### PR TITLE
Chore: Add vscode config for zanzana server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,7 @@
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": {},
       "cwd": "${workspaceFolder}",
-      "args": [
-        "server", 
-        "--homepath", "${workspaceFolder}", 
-        "--packaging", "dev", 
-        "cfg:app_mode=development",
-      ]
+      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev", "cfg:app_mode=development"]
     },
     {
       "name": "Attach to Test Process",
@@ -23,7 +18,7 @@
       "mode": "remote",
       "host": "127.0.0.1",
       "port": 50480,
-      "apiVersion": 2,
+      "apiVersion": 2
     },
     {
       "name": "Run API Server (testdata)",
@@ -69,6 +64,16 @@
       "mode": "auto",
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": { "GF_DEFAULT_TARGET": "storage-server", "GF_SERVER_HTTP_PORT": "3001" },
+      "cwd": "${workspaceFolder}",
+      "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    },
+    {
+      "name": "Run Authz server",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
+      "env": { "GF_DEFAULT_TARGET": "zanzana-server", "GF_SERVER_HTTP_PORT": "3001" },
       "cwd": "${workspaceFolder}",
       "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },


### PR DESCRIPTION
**What is this feature?**

VSCode config for debugging zanzana as a standalone server.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
