### PR TITLE
Remove console.log from correlations service

### DIFF
--- a/packages/grafana-runtime/src/services/CorrelationsService.ts
+++ b/packages/grafana-runtime/src/services/CorrelationsService.ts
@@ -112,7 +112,6 @@ let singletonInstance: CorrelationsService;
  * @internal
  */
 export function setCorrelationsService(instance: CorrelationsService) {
-  console.log('setCorrelationsService', instance);
   singletonInstance = instance;
 }
 


### PR DESCRIPTION
Removing accidental `console.log`