### PR TITLE
Remove dependecy on dashboard table when getting a library element

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -295,7 +295,7 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		} else if cmd.Name != "" {
 			builder.Write(` AND le.name=?`, cmd.Name)
 		} else {
-			builder.Write(` AND (le.folder_uid="" OR le.folder_uid IS NULL OR le.folder_uid="General OR le.folder_id = 0")`)
+			builder.Write(` AND (le.folder_uid="" OR le.folder_uid IS NULL OR le.folder_uid="General" OR le.folder_id = 0)`)
 		}
 		if err := session.SQL(builder.GetSQLString(), builder.GetParams()...).Find(&libraryElements); err != nil {
 			return err

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -287,18 +287,16 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 	err = store.WithDbSession(c, func(session *db.Session) error {
 		builder := db.NewSqlBuilder(cfg, features, store.GetDialect(), recursiveQueriesAreSupported)
 		builder.Write(selectLibraryElementDTOWithMeta)
-		builder.Write(", ? as folder_name ", cmd.FolderName)
 		builder.Write(getFromLibraryElementDTOWithMeta(store.GetDialect()))
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
-		// nolint:staticcheck
-		writeParamSelectorSQL(&builder, append(params, Pair{"folder_id", cmd.FolderID})...)
-		builder.Write(" UNION ")
-		builder.Write(selectLibraryElementDTOWithMeta)
-		builder.Write(", dashboard.title as folder_name ")
-		builder.Write(getFromLibraryElementDTOWithMeta(store.GetDialect()))
-		builder.Write(" INNER JOIN dashboard AS dashboard on le.folder_id = dashboard.id AND le.folder_id <> 0")
-		writeParamSelectorSQL(&builder, params...)
-		builder.Write(` OR dashboard.id=0`)
+		builder.Write(`WHERE le.org_id=?`, signedInUser.GetOrgID())
+		if cmd.UID != "" {
+			builder.Write(` AND le.uid=?`, cmd.UID)
+		} else if cmd.Name != "" {
+			builder.Write(` AND le.name=?`, cmd.Name)
+		} else {
+			builder.Write(` AND (le.folder_uid="" OR le.folder_uid IS NULL OR le.folder_uid="General OR le.folder_id = 0")`)
+		}
 		if err := session.SQL(builder.GetSQLString(), builder.GetParams()...).Find(&libraryElements); err != nil {
 			return err
 		}
@@ -385,6 +383,7 @@ func (l *LibraryElementService) getLibraryElementsByName(c context.Context, sign
 	return l.getLibraryElements(c, l.SQLStore, l.Cfg, signedInUser, []Pair{{"org_id", signedInUser.GetOrgID()}, {"name", name}}, l.features,
 		model.GetLibraryElementCommand{
 			FolderName: dashboards.RootFolderName,
+			Name:       name,
 		})
 }
 

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -214,6 +214,7 @@ type GetLibraryElementCommand struct {
 	// Deprecated: use FolderUID instead
 	FolderID int64
 	UID      string
+	Name     string
 }
 
 // SearchLibraryElementsQuery is the query used for searching for Elements

--- a/pkg/services/libraryelements/writers.go
+++ b/pkg/services/libraryelements/writers.go
@@ -16,23 +16,6 @@ type Pair struct {
 	value any
 }
 
-func selectLibraryElementByParam(params []Pair) (string, []any) {
-	conditions := make([]string, 0, len(params))
-	values := make([]any, 0, len(params))
-	for _, p := range params {
-		conditions = append(conditions, "le."+p.key+"=?")
-		values = append(values, p.value)
-	}
-	return ` WHERE ` + strings.Join(conditions, " AND "), values
-}
-
-func writeParamSelectorSQL(builder *db.SQLBuilder, params ...Pair) {
-	if len(params) > 0 {
-		conditionString, paramValues := selectLibraryElementByParam(params)
-		builder.Write(conditionString, paramValues...)
-	}
-}
-
 func writePerPageSQL(query model.SearchLibraryElementsQuery, sqlStore db.DB, builder *db.SQLBuilder) {
 	if query.PerPage != 0 {
 		offset := query.PerPage * (query.Page - 1)


### PR DESCRIPTION
**What is this feature?**

De-duplicastes query when getting library elements and removes the dependency on dashboards table when fetching a library element.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/search-and-storage-team/issues/167

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
