### PR TITLE
Search: fix uid/name filter

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1791,7 +1791,9 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 		request.Options.Fields = append(request.Options.Fields, req...)
 	}
 
-	request.Limit = query.Limit
+	if query.Limit > 0 {
+		request.Limit = query.Limit
+	}
 
 	res, err := dr.k8sclient.getSearcher().Search(ctx, request)
 	if err != nil {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1717,7 +1717,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 
 	if len(query.DashboardUIDs) > 0 {
 		request.Options.Fields = []*resource.Requirement{{
-			Key:      "key.name",
+			Key:      "name",
 			Operator: string(selection.In),
 			Values:   query.DashboardUIDs,
 		}}
@@ -1790,6 +1790,8 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 		}}
 		request.Options.Fields = append(request.Options.Fields, req...)
 	}
+
+	request.Limit = query.Limit
 
 	res, err := dr.k8sclient.getSearcher().Search(ctx, request)
 	if err != nil {


### PR DESCRIPTION
* Set the proper `name` (uid) filter.
* Set the limit

This fixes a few issues:

* Starred Dashboards from the left Nav menu - not filtering on name correctly
Fixes https://github.com/grafana/grafana-org/issues/374
* Starred Dashboards from the Welcome Page:  DashList.tsx - not filtering on name correctly
* Recent Dashboards from the Welcome Page: DashList.tsx - not filtering on name correctly
* Getting Started Page (GettingStarted.tsx) - this search was setting a limit which was being ignored

![image](https://github.com/user-attachments/assets/c5570377-49e5-4a6e-aa22-0790ae40d22b)
![image](https://github.com/user-attachments/assets/0cf41061-fad7-4b0c-9360-38b01ad874a3)


