### PR TITLE
K8s Dashboards: Fix creating a dashboard inside a folder

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -85,6 +85,8 @@ func dashboardGuardianResponse(err error) response.Response {
 // 403: forbiddenError
 // 404: notFoundError
 // 500: internalServerError
+//
+//nolint:gocyclo
 func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response {
 	ctx, span := tracer.Start(c.Req.Context(), "api.GetDashboard")
 	defer span.End()
@@ -181,7 +183,6 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		Version:                dash.Version,
 		HasACL:                 dash.HasACL,
 		IsFolder:               dash.IsFolder,
-		FolderUid:              dash.FolderUID,
 		FolderId:               dash.FolderID, // nolint:staticcheck
 		Url:                    dash.GetURL(),
 		FolderTitle:            "General",
@@ -190,7 +191,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 	}
 	metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetDashboard).Inc()
 	// lookup folder title & url
-	if dash.FolderUID != "" {
+	if dash.FolderUID != "" && hs.Features.IsEnabledGlobally(featuremgmt.FlagKubernetesFoldersServiceV2) {
 		queryResult, err := hs.folderService.Get(ctx, &folder.GetFolderQuery{
 			OrgID:        c.SignedInUser.GetOrgID(),
 			UID:          &dash.FolderUID,

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
@@ -180,6 +181,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		Version:                dash.Version,
 		HasACL:                 dash.HasACL,
 		IsFolder:               dash.IsFolder,
+		FolderUid:              dash.FolderUID,
 		FolderId:               dash.FolderID, // nolint:staticcheck
 		Url:                    dash.GetURL(),
 		FolderTitle:            "General",
@@ -187,11 +189,23 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		PublicDashboardEnabled: publicDashboardEnabled,
 	}
 	metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetDashboard).Inc()
-	// lookup folder title
-	// nolint:staticcheck
-	if dash.FolderID > 0 {
-		// nolint:staticcheck
-		query := dashboards.GetDashboardQuery{ID: dash.FolderID, OrgID: c.SignedInUser.GetOrgID()}
+	// lookup folder title & url
+	if dash.FolderUID != "" {
+		queryResult, err := hs.folderService.Get(ctx, &folder.GetFolderQuery{
+			OrgID:        c.SignedInUser.GetOrgID(),
+			UID:          &dash.FolderUID,
+			SignedInUser: c.SignedInUser,
+		})
+		if errors.Is(err, dashboards.ErrFolderNotFound) {
+			return response.Error(http.StatusNotFound, "Folder not found", err)
+		}
+		meta.FolderUid = queryResult.UID
+		meta.FolderTitle = queryResult.Title
+		meta.FolderId = queryResult.ID // nolint:staticcheck
+		queryResult = queryResult.WithURL()
+		meta.FolderUrl = queryResult.URL
+	} else if dash.FolderID > 0 { // nolint:staticcheck
+		query := dashboards.GetDashboardQuery{ID: dash.FolderID, OrgID: c.SignedInUser.GetOrgID()} // nolint:staticcheck
 		metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetDashboard).Inc()
 		queryResult, err := hs.DashboardService.GetDashboard(ctx, &query)
 		if err != nil {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -370,15 +370,17 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	// Validate folder
 	if dash.FolderUID != "" {
-		if !dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesFoldersServiceV2) {
-			folder, err := dr.folderStore.GetFolderByUID(ctx, dash.OrgID, dash.FolderUID)
-			if err != nil {
-				return nil, err
-			}
-			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
-			// nolint:staticcheck
-			dash.FolderID = folder.ID
+		folder, err := dr.folderService.Get(ctx, &folder.GetFolderQuery{
+			OrgID:        dash.OrgID,
+			UID:          &dash.FolderUID,
+			SignedInUser: dto.User,
+		})
+		if err != nil {
+			return nil, err
 		}
+		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
+		// nolint:staticcheck
+		dash.FolderID = folder.ID
 	} else if dash.FolderID != 0 { // nolint:staticcheck
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
 		// nolint:staticcheck
@@ -2166,6 +2168,15 @@ func LegacySaveCommandToUnstructured(cmd *dashboards.SaveDashboardCommand, names
 	finalObj.SetName(uid)
 	finalObj.SetNamespace(namespace)
 	finalObj.SetGroupVersionKind(v0alpha1.DashboardResourceInfo.GroupVersionKind())
+
+	if cmd.FolderUID != "" {
+		meta, err := utils.MetaAccessor(&finalObj)
+		if err != nil {
+			return finalObj, err
+		}
+
+		meta.SetFolder(cmd.FolderUID)
+	}
 
 	return finalObj, nil
 }

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -40,7 +40,6 @@ func TestDashboardService(t *testing.T) {
 		defer fakeStore.AssertExpectations(t)
 
 		folderSvc := foldertest.NewFakeService()
-
 		service := &DashboardServiceImpl{
 			cfg:            setting.NewCfg(),
 			log:            log.New("test.logger"),
@@ -48,6 +47,9 @@ func TestDashboardService(t *testing.T) {
 			folderService:  folderSvc,
 			features:       featuremgmt.WithFeatures(),
 		}
+		folderStore := foldertest.FakeFolderStore{}
+		folderStore.On("GetFolderByUID", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).Return(nil, dashboards.ErrFolderNotFound).Once()
+		service.folderStore = &folderStore
 
 		origNewDashboardGuardian := guardian.New
 		defer func() { guardian.New = origNewDashboardGuardian }()

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1835,6 +1835,7 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 	namespace := "test-namespace"
 	t.Run("successfully converts save command to unstructured", func(t *testing.T) {
 		cmd := &dashboards.SaveDashboardCommand{
+			FolderUID: "folder-uid",
 			Dashboard: simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "test-uid"}),
 		}
 
@@ -1845,6 +1846,7 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 		assert.Equal(t, "test-namespace", result.GetNamespace())
 		spec := result.Object["spec"].(map[string]any)
 		assert.Equal(t, spec["version"], 1)
+		assert.Equal(t, result.GetAnnotations(), map[string]string{utils.AnnoKeyFolder: "folder-uid"})
 	})
 
 	t.Run("should increase version when called", func(t *testing.T) {
@@ -1856,6 +1858,8 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 		assert.NotNil(t, result)
 		spec := result.Object["spec"].(map[string]any)
 		assert.Equal(t, spec["version"], float64(2))
+		// folder annotation should not be set if not inside a folder
+		assert.Equal(t, result.GetAnnotations(), map[string]string(nil))
 	})
 }
 

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -102,9 +102,8 @@ func TestDashboardService(t *testing.T) {
 			t.Run("Should return validation error if a folder that is specified can't be found", func(t *testing.T) {
 				dto.Dashboard = dashboards.NewDashboard("Dash")
 				dto.Dashboard.FolderUID = "non-existing-folder"
-				folderStore := foldertest.FakeFolderStore{}
-				folderStore.On("GetFolderByUID", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).Return(nil, dashboards.ErrFolderNotFound).Once()
-				service.folderStore = &folderStore
+				folderSvc := foldertest.FakeService{ExpectedError: dashboards.ErrFolderNotFound}
+				service.folderService = &folderSvc
 				_, err := service.SaveDashboard(context.Background(), dto, false)
 				require.Equal(t, err, dashboards.ErrFolderNotFound)
 			})

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -303,10 +303,14 @@ func createDashboard(t *testing.T, sqlStore db.DB, user user.SignedInUser, dash 
 	dashboardPermissions := acmock.NewMockedPermissionsService()
 	dashboardPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
+	var expectedFolder *folder.Folder
+	if dash.FolderUID != "" || dash.FolderID != 0 { // nolint:staticcheck
+		expectedFolder = &folder.Folder{ID: folderID, UID: folderUID}
+	}
 	service, err := dashboardservice.ProvideDashboardServiceImpl(
 		cfg, dashboardStore, folderStore,
 		features, folderPermissions, dashboardPermissions, ac,
-		foldertest.NewFakeService(),
+		&foldertest.FakeService{ExpectedFolder: expectedFolder},
 		folder.NewFakeStore(),
 		nil,
 		nil,


### PR DESCRIPTION
**What is this feature?**

This PR fixes creating dashboards in folders when both folders and dashboards are stored in unified storage. For that, we need to ensure we are using the folders service, not the folder table.

We also need to set the folder annotation on dashboard save.

Custom.ini:
```
[feature_toggles]
grafanaAPIServerWithExperimentalAPIs = true
kubernetesFolders = true
kubernetesFoldersServiceV2 = true
unifiedStorage = true
unifiedStorageSearch = true
kubernetesCliDashboards = true

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 4

[unified_storage.folders.folder.grafana.app]
dualWriterMode = 4

[grafana-apiserver]
address = 127.0.0.1:10000
storage_type = unified-grpc
```

![Screenshot 2025-01-14 at 12 46 44 PM](https://github.com/user-attachments/assets/3be45cbe-5d23-425e-ada3-45e40b875f36)
![Screenshot 2025-01-14 at 12 46 52 PM](https://github.com/user-attachments/assets/cf75b759-c71b-4790-9e11-2990ad9e752f)

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/211
