### PR TITLE
ExploreMetrics: Disable the Overview tab by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -230,7 +230,7 @@ export interface FeatureToggles {
   playlistsReconciler?: boolean;
   passwordlessMagicLinkAuthentication?: boolean;
   exploreMetricsRelatedLogs?: boolean;
-  exploreMetricsRemoveOverviewTab?: boolean;
+  exploreMetricsEnableLegacyOverviewTab?: boolean;
   prometheusSpecialCharsInLabelValues?: boolean;
   enableExtensionsAdminPage?: boolean;
   zipkinBackendMigration?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1592,8 +1592,8 @@ var (
 			HideFromDocs: true,
 		},
 		{
-			Name:         "exploreMetricsRemoveOverviewTab",
-			Description:  "Remove overview tab from selected metric view.",
+			Name:         "exploreMetricsEnableLegacyOverviewTab",
+			Description:  "Enables the Overview tab in the selected metric view.",
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaObservabilityMetricsSquad,
 			FrontendOnly: true,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -211,7 +211,7 @@ preinstallAutoUpdate,GA,@grafana/plugins-platform-backend,false,false,false
 playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false
 exploreMetricsRelatedLogs,experimental,@grafana/observability-metrics,false,false,true
-exploreMetricsRemoveOverviewTab,experimental,@grafana/observability-metrics,false,false,true
+exploreMetricsEnableLegacyOverviewTab,experimental,@grafana/observability-metrics,false,false,true
 prometheusSpecialCharsInLabelValues,experimental,@grafana/oss-big-tent,false,false,true
 enableExtensionsAdminPage,experimental,@grafana/plugins-platform-backend,false,true,false
 zipkinBackendMigration,GA,@grafana/oss-big-tent,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -855,9 +855,9 @@ const (
 	// Display Related Logs in Explore Metrics
 	FlagExploreMetricsRelatedLogs = "exploreMetricsRelatedLogs"
 
-	// FlagExploreMetricsRemoveOverviewTab
-	// Remove overview tab from selected metric view.
-	FlagExploreMetricsRemoveOverviewTab = "exploreMetricsRemoveOverviewTab"
+	// FlagExploreMetricsEnableLegacyOverviewTab
+	// Enables the Overview tab in the selected metric view.
+	FlagExploreMetricsEnableLegacyOverviewTab = "exploreMetricsEnableLegacyOverviewTab"
 
 	// FlagPrometheusSpecialCharsInLabelValues
 	// Adds support for quotes and special characters in label values for Prometheus queries

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1430,6 +1430,20 @@
     },
     {
       "metadata": {
+        "name": "exploreMetricsEnableLegacyOverviewTab",
+        "resourceVersion": "1736892559600",
+        "creationTimestamp": "2025-01-14T22:09:19Z"
+      },
+      "spec": {
+        "description": "Enables the Overview tab in the selected metric view.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "exploreMetricsRelatedLogs",
         "resourceVersion": "1730125602673",
         "creationTimestamp": "2024-10-28T14:26:42Z"
@@ -1445,15 +1459,20 @@
     {
       "metadata": {
         "name": "exploreMetricsRemoveOverviewTab",
-        "resourceVersion": "1732715340262",
-        "creationTimestamp": "2024-11-27T13:49:00Z"
+        "resourceVersion": "1736892148934",
+        "creationTimestamp": "2024-11-27T13:49:00Z",
+        "deletionTimestamp": "2025-01-14T22:09:19Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-01-14 22:02:28.934237 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Remove overview tab from selected metric view.",
         "stage": "experimental",
         "codeowner": "@grafana/observability-metrics",
         "frontend": true,
-        "hideFromDocs": true
+        "hideFromDocs": true,
+        "expression": "true"
       }
     },
     {

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -39,7 +39,7 @@ import {
 } from './shared';
 import { getDataSource, getTrailFor, getUrlForTrail } from './utils';
 
-const { exploreMetricsRelatedLogs, exploreMetricsRemoveOverviewTab } = config.featureToggles;
+const { exploreMetricsRelatedLogs, exploreMetricsEnableLegacyOverviewTab } = config.featureToggles;
 
 export interface MetricSceneState extends SceneObjectState {
   body: MetricGraphScene;
@@ -68,7 +68,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
 
   private _onActivate() {
     if (this.state.actionView === undefined) {
-      this.setActionView(exploreMetricsRemoveOverviewTab ? 'breakdown' : 'overview');
+      this.setActionView(exploreMetricsEnableLegacyOverviewTab ? 'overview' : 'breakdown');
     }
 
     if (config.featureToggles.enableScopesInMetricsExplore) {
@@ -132,7 +132,7 @@ const actionViewsDefinitions: ActionViewDefinition[] = [
   },
 ];
 
-if (!exploreMetricsRemoveOverviewTab) {
+if (exploreMetricsEnableLegacyOverviewTab) {
   actionViewsDefinitions.unshift({
     displayName: 'Overview',
     value: 'overview',


### PR DESCRIPTION
## Goal

This PR complements #97118. It intends to remove the Explore Metrics Overview tab by default.

## Context

When @itsmylife and I discussed removing the Overview tab by default, we originally intended to set `Expression: "true"` for the `exploreMetricsRemoveOverviewTab` feature toggle introduced by #97118. But we can't do that with experimental feature toggles. Running `make gen-feature-toggles` leads to:

```
toggles_gen_test.go:176: only FeatureStageGeneralAvailability or FeatureStageDeprecated features can be enabled by default.  See: exploreMetricsRemoveOverviewTab
```

To achieve the goal of removing the Overview tab by default, we can invert the behavior of the feature toggle and change its name to reflect its intent.

## Demo

With no feature toggle set, the overview tab is removed:

https://github.com/user-attachments/assets/3ffe0cb1-eefb-4dc1-a01c-2a2128ad425b

With the new/renamed `exploreMetricsEnableLegacyOverviewTab` feature toggle enabled, the overview tab is present:

https://github.com/user-attachments/assets/9e52d69c-b720-46c0-946d-7ed05815cf8c

