### PR TITLE
Authenticator: Return gRPC errors

### DIFF
--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
-	"github.com/grafana/authlib/authn"
 	authClaims "github.com/grafana/authlib/claims"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -27,7 +28,7 @@ const (
 // var _ interceptors.Authenticator = (*Authenticator)(nil)
 
 type Authenticator struct {
-	IDTokenVerifier authn.Verifier[authn.IDTokenClaims]
+	// IDTokenVerifier authn.Verifier[authn.IDTokenClaims]
 }
 
 func (f *Authenticator) Authenticate(ctx context.Context) (context.Context, error) {
@@ -57,20 +58,10 @@ func (f *Authenticator) decodeMetadata(ctx context.Context, meta metadata.MD) (i
 		return ""
 	}
 
-	// First try the token
-	token := getter(mdToken)
-	if token != "" && f.IDTokenVerifier != nil {
-		claims, err := f.IDTokenVerifier.Verify(ctx, token)
-		if err != nil {
-			return nil, err
-		}
-		fmt.Printf("TODO, convert CLAIMS to an identity %+v\n", claims)
-	}
-
 	user := &identity.StaticRequester{}
 	user.Login = getter(mdLogin)
 	if user.Login == "" {
-		return nil, fmt.Errorf("no login found in grpc metadata")
+		return nil, status.Error(codes.Unauthenticated, "no login found in grpc metadata")
 	}
 
 	// The namespaced versions have a "-" in the key
@@ -80,34 +71,34 @@ func (f *Authenticator) decodeMetadata(ctx context.Context, meta metadata.MD) (i
 		user.Type = authClaims.TypeUser
 		user.UserID, err = strconv.ParseInt(getter("grafana-userid"), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid user id: %w", err)
+			return nil, status.Error(codes.Unauthenticated, "invalid user id")
 		}
 		user.OrgID, err = strconv.ParseInt(getter("grafana-orgid"), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid org id: %w", err)
+			return nil, status.Error(codes.Unauthenticated, "invalid org id")
 		}
 		return user, nil
 	}
 
 	typ, id, err := authClaims.ParseTypeID(getter(mdUserID))
 	if err != nil {
-		return nil, fmt.Errorf("invalid user id: %w", err)
+		return nil, status.Error(codes.Unauthenticated, "invalid user id")
 	}
 	user.Type = typ
 	user.UserID, err = strconv.ParseInt(id, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("invalid user id: %w", err)
+		return nil, status.Error(codes.Unauthenticated, "invalid user id")
 	}
 
-	_, id, err = authClaims.ParseTypeID(getter(mdUserUID))
+	_, uid, err := authClaims.ParseTypeID(getter(mdUserUID))
 	if err != nil {
-		return nil, fmt.Errorf("invalid user id: %w", err)
+		return nil, status.Error(codes.Unauthenticated, "invalid user uid")
 	}
-	user.UserUID = id
+	user.UserUID = uid
 
 	user.OrgID, err = strconv.ParseInt(getter(mdOrgID), 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("invalid org id: %w", err)
+		return nil, status.Error(codes.Unauthenticated, "invalid org id")
 	}
 	user.OrgRole = identity.RoleType(getter(mdOrgRole))
 	return user, nil

--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"google.golang.org/grpc"
@@ -39,16 +38,16 @@ func (f *Authenticator) Authenticate(ctx context.Context) (context.Context, erro
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, fmt.Errorf("no metadata found")
+		return nil, status.Error(codes.Unauthenticated, "no metadata found in grpc context")
 	}
-	user, err := f.decodeMetadata(ctx, md)
+	user, err := f.decodeMetadata(md)
 	if err != nil {
 		return nil, err
 	}
 	return identity.WithRequester(ctx, user), nil
 }
 
-func (f *Authenticator) decodeMetadata(ctx context.Context, meta metadata.MD) (identity.Requester, error) {
+func (f *Authenticator) decodeMetadata(meta metadata.MD) (identity.Requester, error) {
 	// Avoid NPE/panic with getting keys
 	getter := func(key string) string {
 		v := meta.Get(key)

--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -32,7 +32,7 @@ type Authenticator struct {
 }
 
 func (f *Authenticator) Authenticate(ctx context.Context) (context.Context, error) {
-	ctx, span := f.Tracer.Start(ctx, "grpc.Authenticator.Authenticate")
+	ctx, span := f.Tracer.Start(ctx, "legacy.grpc.Authenticator.Authenticate")
 	defer span.End()
 
 	r, err := identity.GetRequester(ctx)

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -1,17 +1,12 @@
 package grpc
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/authn"
-	"github.com/grafana/grafana/pkg/services/login"
-	"github.com/grafana/grafana/pkg/services/org"
 )
 
 func TestBasicEncodeDecode(t *testing.T) {
@@ -27,32 +22,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 	auth := &Authenticator{}
 
 	md := encodeIdentityInMetadata(before)
-	after, err := auth.decodeMetadata(context.Background(), md)
-	require.NoError(t, err)
-	require.Equal(t, before.GetID(), after.GetID())
-	require.Equal(t, before.GetUID(), after.GetUID())
-	require.Equal(t, before.GetIdentityType(), after.GetIdentityType())
-	require.Equal(t, before.GetLogin(), after.GetLogin())
-	require.Equal(t, before.GetOrgID(), after.GetOrgID())
-	require.Equal(t, before.GetOrgName(), after.GetOrgName())
-	require.Equal(t, before.GetOrgRole(), after.GetOrgRole())
-}
-
-func TestRenderEncodeDecode(t *testing.T) {
-	before := &authn.Identity{
-		ID:              "0",
-		Type:            claims.TypeRenderService,
-		OrgID:           1,
-		OrgRoles:        map[int64]org.RoleType{1: identity.RoleEditor},
-		ClientParams:    authn.ClientParams{SyncPermissions: true},
-		LastSeenAt:      time.Now(),
-		AuthenticatedBy: login.RenderModule,
-	}
-
-	auth := &Authenticator{}
-
-	md := encodeIdentityInMetadata(before)
-	after, err := auth.decodeMetadata(context.Background(), md)
+	after, err := auth.decodeMetadata(md)
 	require.NoError(t, err)
 	require.Equal(t, before.GetID(), after.GetID())
 	require.Equal(t, before.GetUID(), after.GetUID())

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 func TestBasicEncodeDecode(t *testing.T) {
@@ -19,7 +20,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 		OrgRole: identity.RoleAdmin,
 	}
 
-	auth := &Authenticator{}
+	auth := &Authenticator{Tracer: tracing.NewNoopTracerService()}
 
 	md := encodeIdentityInMetadata(before)
 	after, err := auth.decodeMetadata(md)

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -3,11 +3,15 @@ package grpc
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/org"
 )
 
 func TestBasicEncodeDecode(t *testing.T) {
@@ -18,6 +22,31 @@ func TestBasicEncodeDecode(t *testing.T) {
 		Type:    claims.TypeUser,
 		OrgID:   456,
 		OrgRole: identity.RoleAdmin,
+	}
+
+	auth := &Authenticator{}
+
+	md := encodeIdentityInMetadata(before)
+	after, err := auth.decodeMetadata(context.Background(), md)
+	require.NoError(t, err)
+	require.Equal(t, before.GetID(), after.GetID())
+	require.Equal(t, before.GetUID(), after.GetUID())
+	require.Equal(t, before.GetIdentityType(), after.GetIdentityType())
+	require.Equal(t, before.GetLogin(), after.GetLogin())
+	require.Equal(t, before.GetOrgID(), after.GetOrgID())
+	require.Equal(t, before.GetOrgName(), after.GetOrgName())
+	require.Equal(t, before.GetOrgRole(), after.GetOrgRole())
+}
+
+func TestRenderEncodeDecode(t *testing.T) {
+	before := &authn.Identity{
+		ID:              "0",
+		Type:            claims.TypeRenderService,
+		OrgID:           1,
+		OrgRoles:        map[int64]org.RoleType{1: identity.RoleEditor},
+		ClientParams:    authn.ClientParams{SyncPermissions: true},
+		LastSeenAt:      time.Now(),
+		AuthenticatedBy: login.RenderModule,
 	}
 
 	auth := &Authenticator{}

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -80,7 +80,8 @@ func ProvideUnifiedStorageGrpcService(
 
 	// FIXME: This is a temporary solution while we are migrating to the new authn interceptor
 	// grpcutils.NewGrpcAuthenticator should be used instead.
-	authn, err := grpcutils.NewGrpcAuthenticatorWithFallback(cfg, reg, tracing, &grpc.Authenticator{})
+	fallback := &grpc.Authenticator{Tracer: tracing}
+	authn, err := grpcutils.NewGrpcAuthenticatorWithFallback(cfg, reg, tracing, fallback)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR modifies the legacy authenticator to return coherent grpc codes and help debugging with traces.