### PR TITLE
setDashboardPanelContext: Allow to add filters from the table with the same key

### DIFF
--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -130,11 +130,16 @@ describe('setDashboardPanelContext', () => {
     it('Should add new filter set', () => {
       const { scene, context } = buildTestScene({});
 
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '=' });
+      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
+      context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '!=' });
 
       const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
 
-      expect(variable.state.filters).toEqual([{ key: 'hello', value: 'world', operator: '=' }]);
+      expect(variable.state.filters).toEqual([
+        { key: 'hello', value: 'world', operator: '!=' },
+        { key: 'hello', value: 'world2', operator: '!=' },
+        ,
+      ]);
     });
 
     it('Should update and add filter to existing set', () => {
@@ -149,23 +154,9 @@ describe('setDashboardPanelContext', () => {
       expect(variable.state.filters.length).toBe(2);
 
       // Can update existing filter value without adding a new filter
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '=' });
-      // Verify existing filter value updated
-      expect(variable.state.filters[1].value).toBe('world2');
-    });
-
-    it('Should always add on top existing filter key for elastic search', () => {
-      const { scene, context } = buildTestScene({ datasourceType: 'elasticsearch' });
-
       context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
-      context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '!=' });
-
-      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
-
-      expect(variable.state.filters).toEqual([
-        { key: 'hello', value: 'world', operator: '!=' },
-        { key: 'hello', value: 'world2', operator: '!=' },
-      ]);
+      // Verify existing filter value updated
+      expect(variable.state.filters[1].operator).toBe('!=');
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -169,7 +169,6 @@ interface SceneOptions {
   canDelete?: boolean;
   orgCanEdit?: boolean;
   existingFilterVariable?: boolean;
-  datasourceType?: string;
 }
 
 function buildTestScene(options: SceneOptions) {
@@ -199,7 +198,7 @@ function buildTestScene(options: SceneOptions) {
         {
           type: 'timeseries',
           id: 4,
-          datasource: { uid: 'my-ds-uid', type: options.datasourceType ?? 'prometheus' },
+          datasource: { uid: 'my-ds-uid', type: 'prometheus' },
           targets: [],
         },
       ],

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -153,6 +153,20 @@ describe('setDashboardPanelContext', () => {
       // Verify existing filter value updated
       expect(variable.state.filters[1].value).toBe('world2');
     });
+
+    it('Should always add on top existing filter key for elastic search', () => {
+      const { scene, context } = buildTestScene({ datasourceType: 'elasticsearch' });
+
+      context.onAddAdHocFilter!({ key: 'hello', value: 'world', operator: '!=' });
+      context.onAddAdHocFilter!({ key: 'hello', value: 'world2', operator: '!=' });
+
+      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+
+      expect(variable.state.filters).toEqual([
+        { key: 'hello', value: 'world', operator: '!=' },
+        { key: 'hello', value: 'world2', operator: '!=' },
+      ]);
+    });
   });
 });
 
@@ -164,6 +178,7 @@ interface SceneOptions {
   canDelete?: boolean;
   orgCanEdit?: boolean;
   existingFilterVariable?: boolean;
+  datasourceType?: string;
 }
 
 function buildTestScene(options: SceneOptions) {
@@ -193,7 +208,7 @@ function buildTestScene(options: SceneOptions) {
         {
           type: 'timeseries',
           id: 4,
-          datasource: { uid: 'my-ds-uid', type: 'prometheus' },
+          datasource: { uid: 'my-ds-uid', type: options.datasourceType ?? 'prometheus' },
           targets: [],
         },
       ],

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -114,7 +114,11 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     }
 
     const filterVar = getAdHocFilterVariableFor(dashboard, queryRunner.state.datasource);
-    updateAdHocFilterVariable(filterVar, newFilter);
+    if (queryRunner.state.datasource?.type === 'elasticsearch') {
+      addAdHocFilterVariable(filterVar, newFilter);
+    } else {
+      updateAdHocFilterVariable(filterVar, newFilter);
+    }
   };
 
   context.onUpdateData = (frames: DataFrame[]): Promise<boolean> => {
@@ -191,6 +195,10 @@ function updateAdHocFilterVariable(filterVar: AdHocFiltersVariable, newFilter: A
   }
 
   // Add new filter
+  addAdHocFilterVariable(filterVar, newFilter);
+}
+
+function addAdHocFilterVariable(filterVar: AdHocFiltersVariable, newFilter: AdHocFilterItem) {
   filterVar.setState({
     filters: [...filterVar.state.filters, newFilter],
   });

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -180,14 +180,14 @@ function updateAdHocFilterVariable(filterVar: AdHocFiltersVariable, newFilter: A
 
   // Update is only required when we change operator and keep key and value the same
   //   key1 = value1 -> key1 != value1
-  const updateIndex = filterVar.state.filters.findIndex(
+  const filterToReplaceIndex = filterVar.state.filters.findIndex(
     (filter) =>
       filter.key === newFilter.key && filter.value === newFilter.value && filter.operator !== newFilter.operator
   );
 
-  if (updateIndex >= 0) {
+  if (filterToReplaceIndex >= 0) {
     const updatedFilters = filterVar.state.filters.slice();
-    updatedFilters.splice(updateIndex, 1, newFilter);
+    updatedFilters.splice(filterToReplaceIndex, 1, newFilter);
     filterVar.updateFilters(updatedFilters);
     return;
   }


### PR DESCRIPTION
 Before scenes, adding ad hoc filter from table cell with elastic search datasource would add filters on top instead of replacing if the key already exists. As far as I am aware only elastic supports duplicate keys in filters, but if there are other use cases then let me know.

Fixes https://github.com/grafana/support-escalations/issues/14215

Behaviour in old arch:

https://github.com/user-attachments/assets/d6e4e133-5d60-4aa8-9d53-d682b1c8f0ca



Current behaviour with scenes:

https://github.com/user-attachments/assets/a6735fe1-368e-48d0-b7e7-bde885b79a3c



Behaviour with scenes after this fix:

https://github.com/user-attachments/assets/9592fd89-486a-4942-b33b-bff7db2240c9



