### PR TITLE
Keeper: validate no SecureValue reference before deletion

### DIFF
--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -191,6 +191,11 @@ func (s *KeeperRest) Delete(ctx context.Context, name string, deleteValidation r
 	}
 
 	if err := s.storage.Delete(ctx, nn); err != nil {
+		var kErr xkube.ErrorLister
+		if errors.As(err, &kErr) {
+			return nil, false, apierrors.NewInvalid(s.resource.GroupVersionKind().GroupKind(), name, kErr.ErrorList())
+		}
+
 		return nil, false, fmt.Errorf("failed to delete keeper: %w", err)
 	}
 

--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -317,8 +317,8 @@ func TestIntegrationKeeper(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
-			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
-			require.NoError(t, clientOrg2.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, keeperOrg2.GetName(), metav1.DeleteOptions{}))
+			require.NoError(t, clientOrg2.Resource.Delete(ctx, keeperOrg1.GetName(), metav1.DeleteOptions{}))
 		})
 
 		// Read

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -237,8 +237,8 @@ func TestIntegrationSecureValue(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
-			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
-			require.NoError(t, clientOrg2.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, secureValueOrg2.GetName(), metav1.DeleteOptions{}))
+			require.NoError(t, clientOrg2.Resource.Delete(ctx, secureValueOrg1.GetName(), metav1.DeleteOptions{}))
 		})
 
 		// Read


### PR DESCRIPTION
Before deleting a `Keeper`, we check if any `SecureValues` are referencing it by `name` (within the same `namespace`).
