### PR TITLE
Azure: Improve resource request error handling

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -33,11 +33,12 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(statusCode)
 
+	// Set error response to initial error message
+	errorBody := map[string]string{"error": message}
+
 	// Attempt to locate JSON portion in error message
 	re := regexp.MustCompile(`\{.*?\}`)
 	jsonPart := re.FindString(message)
-	errorBody := map[string]string{"error": message}
-
 	if jsonPart != "" {
 		var jsonData map[string]interface{}
 		if unmarshalErr := json.Unmarshal([]byte(jsonPart), &jsonData); unmarshalErr != nil {

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -36,27 +36,27 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 	// Attempt to locate JSON portion in error message
 	re := regexp.MustCompile(`\{.*?\}`)
 	jsonPart := re.FindString(message)
+	errorBody := map[string]string{"error": message}
 
-	var jsonData map[string]interface{}
-	if unmarshalErr := json.Unmarshal([]byte(jsonPart), &jsonData); unmarshalErr != nil {
-		errorMsg, _ := json.Marshal(map[string]string{"error": "Invalid JSON format in error message"})
-		_, err := rw.Write(errorMsg)
-		if err != nil {
-			return fmt.Errorf("unable to write HTTP response: %v", err)
+	if jsonPart != "" {
+		var jsonData map[string]interface{}
+		if unmarshalErr := json.Unmarshal([]byte(jsonPart), &jsonData); unmarshalErr != nil {
+			errorBody["error"] = fmt.Sprintf("Invalid JSON format in error message. Raw error: %s", message)
+			s.logger.Error("failed to unmarshal JSON error message", "error", unmarshalErr)
+		} else {
+			// Extract relevant fields for a formatted error message
+			errorType, _ := jsonData["error"].(string)
+			errorDescription, _ := jsonData["error_description"].(string)
+			if errorType == "" {
+				errorType = "UnknownError"
+			}
+
+			errorBody["error"] = fmt.Sprintf("%s: %s", errorType, errorDescription)
 		}
-		return unmarshalErr
 	}
 
-	// Extract relevant fields for a formatted error message
-	errorType, _ := jsonData["error"].(string)
-	errorDescription, _ := jsonData["error_description"].(string)
-	if errorType == "" {
-		errorType = "UnknownError"
-	}
-	formattedError := fmt.Sprintf("%s: %s", errorType, errorDescription)
-
-	errorMsg, _ := json.Marshal(map[string]string{"error": formattedError})
-	_, err := rw.Write(errorMsg)
+	jsonRes, _ := json.Marshal(errorBody)
+	_, err := rw.Write(jsonRes)
 	if err != nil {
 		return fmt.Errorf("unable to write HTTP response: %v", err)
 	}
@@ -117,7 +117,7 @@ func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (types.DatasourceI
 }
 
 func writeErrorResponse(rw http.ResponseWriter, code int, msg string) {
-	rw.WriteHeader(http.StatusBadRequest)
+	rw.WriteHeader(code)
 	errorBody := map[string]string{
 		"error": msg,
 	}
@@ -154,9 +154,11 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 		req.URL.Host = serviceURL.Host
 		req.URL.Scheme = serviceURL.Scheme
 
-		rw, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
+		_, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
 		if err != nil {
-			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+			// The ResourceRequest function should handle writing the error response
+			// We log the error here to ensure it's captured
+			s.logger.Error("error in resource request", "error", err)
 			return
 		}
 	}

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -47,7 +47,12 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 		} else {
 			// Extract relevant fields for a formatted error message
 			errorType, _ := jsonData["error"].(string)
-			errorDescription, _ := jsonData["error_description"].(string)
+			errorDescription, ok := jsonData["error_description"].(string)
+			if !ok {
+				s.logger.Error("unable to convert error_description to string", "rawError", jsonData["error_description"])
+				// Attempt to just format the error as a string
+				errorDescription = fmt.Sprintf("%v", jsonData["error_description"])
+			}
 			if errorType == "" {
 				errorType = "UnknownError"
 			}


### PR DESCRIPTION
Some minor fixes on the back of #73652 and #96004.

The changes in the first PR began returning the response writer. The changes in the second PR then changed the behavior of request execution to write the response if it failed rather than returning an error which would then be written.

The change in behaviour causes a panic as the response has already been written for a failed request, leading to the response writer being `nil`. This change will ensure that an error in the request is written in the `Do` method and we do not attempt to reuse the response writer.

List of improvements:
- Correctly parse JSON responses
- Log erroneous failures in JSON marshalling/unmarshalling
- Correctly set response status code
- Do not attempt to use the response writer as it will be nil
