### PR TITLE
fix(indexer): reduce cardinality of indexer metric

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -72,7 +72,7 @@ func NewIndexMetrics(indexDir string, searchBackend SearchBackend) *BleveIndexMe
 				Namespace: "index_server",
 				Name:      "index_tenants",
 				Help:      "Number of tenants in the index",
-			}, []string{"namespace", "index_storage"}), // index_storage is either "file" or "memory"
+			}, []string{"index_storage"}), // index_storage is either "file" or "memory"
 		}
 	})
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/grafana/authlib/authz"
+
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
@@ -138,10 +139,10 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 			index, err = bleve.New(dir, mapper)
 		}
 
-		resource.IndexMetrics.IndexTenants.WithLabelValues(key.Namespace, "file").Inc()
+		resource.IndexMetrics.IndexTenants.WithLabelValues("file").Inc()
 	} else {
 		index, err = bleve.NewMemOnly(mapper)
-		resource.IndexMetrics.IndexTenants.WithLabelValues(key.Namespace, "memory").Inc()
+		resource.IndexMetrics.IndexTenants.WithLabelValues("memory").Inc()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reduces the cardinality of the metric by removing the tenant. In this case the metric will return the total number of tenants for each index type (`memory`, `file`).