### PR TITLE
Auth: Fix AzureAD public client configuration

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -199,7 +199,7 @@ func (s *SocialAzureAD) Exchange(ctx context.Context, code string, authOptions .
 	case social.ClientSecretPost:
 		// Default behavior for ClientSecretPost, no additional setup needed
 	default:
-		s.log.Debug("ClientAuthentication is not set. Using default client authentication method")
+		s.log.Debug("ClientAuthentication is not set. Using default client authentication method: none")
 	}
 
 	// Default token exchange
@@ -377,6 +377,9 @@ func validateClientAuthentication(info *social.OAuthInfo, requester identity.Req
 		if info.ClientSecret == "" {
 			return ssosettings.ErrInvalidOAuthConfig("Client secret is required for Client secret authentication.")
 		}
+		return nil
+
+	case social.None:
 		return nil
 
 	default:

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -16,6 +16,7 @@ const (
 
 	// Values for ClientAuthentication under OAuthInfo (based on oidc spec)
 	ClientSecretPost = "client_secret_post"
+	None             = "none"
 	// Azure AD
 	ManagedIdentity = "managed_identity"
 	// Other providers...

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -258,7 +258,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       description: 'The client authentication method used to authenticate to the token endpoint.',
       multi: false,
       options: clientAuthenticationOptions(provider),
-      defaultValue: { value: 'client_secret_post', label: 'Client secret' },
+      defaultValue: { value: 'none', label: 'None' },
       validation: {
         required: true,
         message: 'This field is required',
@@ -683,11 +683,15 @@ function clientAuthenticationOptions(provider: string): Array<SelectableValue<st
   switch (provider) {
     case 'azuread':
       return [
+        { value: 'none', label: 'None' },
         { value: 'client_secret_post', label: 'Client secret' },
         { value: 'managed_identity', label: 'Managed identity' },
       ];
     // Other providers ...
     default:
-      return [{ value: 'client_secret_post', label: 'Client secret' }];
+      return [
+        { value: 'none', label: 'None' },
+        { value: 'client_secret_post', label: 'Client secret' },
+      ];
   }
 }


### PR DESCRIPTION
**What is this feature?**
Add 'none' to client authentication methods for AzureAD to ensure that public clients (without `client_secret`) are configurable from the UI.

**Why do we need this feature?**

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
