### PR TITLE
fix(unified-storage): initialize blob storage when using grpc

### DIFF
--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -101,6 +101,7 @@ func NewGRPCResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn) (Resour
 	return &resourceClient{
 		ResourceStoreClient: NewResourceStoreClient(cc),
 		ResourceIndexClient: NewResourceIndexClient(cc),
+		BlobStoreClient:     NewBlobStoreClient(cc),
 		DiagnosticsClient:   NewDiagnosticsClient(cc),
 	}, nil
 }
@@ -125,6 +126,7 @@ func NewCloudResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn, cfg au
 	return &resourceClient{
 		ResourceStoreClient: NewResourceStoreClient(cc),
 		ResourceIndexClient: NewResourceIndexClient(cc),
+		BlobStoreClient:     NewBlobStoreClient(cc),
 		DiagnosticsClient:   NewDiagnosticsClient(cc),
 	}, nil
 }


### PR DESCRIPTION
This PR fixes a nil pointer that occurs when `FlagAppPlatformGrpcClientAuth` is enabled and we use gRPC. The gRPC implementation was not initializing the blob storage.