### PR TITLE
Sandbox: Add SRI validation for CDN assets loaded in the sandbox

### DIFF
--- a/public/app/features/plugins/sandbox/types.ts
+++ b/public/app/features/plugins/sandbox/types.ts
@@ -11,4 +11,4 @@ export type SandboxedPluginObject = {
 
 export type SandboxEnvironment = ReturnType<typeof createVirtualEnvironment>;
 
-export type SandboxPluginMeta = Pick<PluginMeta, 'id' | 'type' | 'module'>;
+export type SandboxPluginMeta = Pick<PluginMeta, 'id' | 'type' | 'module' | 'moduleHash'>;


### PR DESCRIPTION
**What is this feature?**

Adds [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) validation to plugins loaded inside the sandbox when the necessary feature toggles are enabled and information is available.

**Why do we need this feature?**

To keep the frontend security in pair with the system js loading method

**Who is this feature for?**

All users of the plugins frontend sandbox

**Which issue(s) does this PR fix?**:
