### PR TITLE
Simplify DOM page structure

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -23,7 +23,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
       MsOverflowStyle: 'scrollbar',
       WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
       boxSizing: 'border-box',
-      height: '100%',
+      // height: '100%',
       fontSize: `${theme.typography.htmlFontSize}px`,
       fontFamily: theme.typography.fontFamily,
       lineHeight: theme.typography.body.lineHeight,
@@ -35,7 +35,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
     },
 
     body: {
-      height: '100%',
+      // height: '100%',
       width: '100%',
       position: 'unset',
       color: theme.colors.text.primary,

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -36,8 +36,8 @@ export function getElementStyles(theme: GrafanaTheme2) {
 
     body: {
       // height: '100%',
-      width: '100%',
-      position: 'unset',
+      // width: '100%',
+      // position: 'unset',
       color: theme.colors.text.primary,
       backgroundColor: theme.colors.background.canvas,
       // react select tries prevent scrolling by setting overflow/padding-right on the body

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -23,7 +23,6 @@ export function getElementStyles(theme: GrafanaTheme2) {
       MsOverflowStyle: 'scrollbar',
       WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
       boxSizing: 'border-box',
-      // height: '100%',
       fontSize: `${theme.typography.htmlFontSize}px`,
       fontFamily: theme.typography.fontFamily,
       lineHeight: theme.typography.body.lineHeight,
@@ -35,9 +34,6 @@ export function getElementStyles(theme: GrafanaTheme2) {
     },
 
     body: {
-      // height: '100%',
-      // width: '100%',
-      // position: 'unset',
       color: theme.colors.text.primary,
       backgroundColor: theme.colors.background.canvas,
       // react select tries prevent scrolling by setting overflow/padding-right on the body

--- a/packages/grafana-ui/src/themes/GlobalStyles/page.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/page.ts
@@ -10,7 +10,7 @@ export function getPageStyles(theme: GrafanaTheme2) {
     '.grafana-app': {
       display: 'flex',
       flexDirection: 'column',
-      height: '100vh',
+      minHeight: '100vh',
     },
 
     '.main-view': {

--- a/packages/grafana-ui/src/themes/GlobalStyles/page.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/page.ts
@@ -7,27 +7,9 @@ export function getPageStyles(theme: GrafanaTheme2) {
     theme.breakpoints.values.xxl + theme.spacing.gridSize * 2 + theme.components.sidemenu.width;
 
   return css({
-    '.grafana-app': {
-      // display: 'flex',
-      // flexDirection: 'column',
-      // minHeight: '100vh',
-    },
-
     '.main-view': {
-      // display: 'flex',
-      // flexDirection: 'column',
-      // flexGrow: 1,
       position: 'relative',
-      // minWidth: 0,
     },
-
-    // '.page-scrollbar-content': {
-    //   display: 'flex',
-    //   minHeight: '100%',
-    //   flexDirection: 'column',
-    //   width: '100%',
-    //   height: '100%',
-    // },
 
     '.page-container': {
       flexGrow: 1,

--- a/packages/grafana-ui/src/themes/GlobalStyles/page.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/page.ts
@@ -8,26 +8,26 @@ export function getPageStyles(theme: GrafanaTheme2) {
 
   return css({
     '.grafana-app': {
-      display: 'flex',
-      flexDirection: 'column',
-      minHeight: '100vh',
+      // display: 'flex',
+      // flexDirection: 'column',
+      // minHeight: '100vh',
     },
 
     '.main-view': {
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
+      // display: 'flex',
+      // flexDirection: 'column',
+      // flexGrow: 1,
       position: 'relative',
-      minWidth: 0,
+      // minWidth: 0,
     },
 
-    '.page-scrollbar-content': {
-      display: 'flex',
-      minHeight: '100%',
-      flexDirection: 'column',
-      width: '100%',
-      height: '100%',
-    },
+    // '.page-scrollbar-content': {
+    //   display: 'flex',
+    //   minHeight: '100%',
+    //   flexDirection: 'column',
+    //   width: '100%',
+    //   height: '100%',
+    // },
 
     '.page-container': {
       flexGrow: 1,

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -118,15 +118,13 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
                   <MaybeTimeRangeProvider>
                     <SidecarContext_EXPERIMENTAL.Provider value={sidecarServiceSingleton_EXPERIMENTAL}>
                       <ExtensionRegistriesProvider registries={pluginExtensionRegistries}>
-                        <div className="grafana-app">
-                          {config.featureToggles.appSidecar ? (
-                            <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />
-                          ) : (
-                            <RouterWrapper {...routerWrapperProps} />
-                          )}
-                          <LiveConnectionWarning />
-                          <PortalContainer />
-                        </div>
+                        {config.featureToggles.appSidecar ? (
+                          <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />
+                        ) : (
+                          <RouterWrapper {...routerWrapperProps} />
+                        )}
+                        <LiveConnectionWarning />
+                        <PortalContainer />
                       </ExtensionRegistriesProvider>
                     </SidecarContext_EXPERIMENTAL.Provider>
                   </MaybeTimeRangeProvider>

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -20,7 +20,6 @@ import { useMegaMenuFocusHelper } from './MegaMenu/utils';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
 import { SingleTopBar } from './TopBar/SingleTopBar';
 import { SingleTopBarActions } from './TopBar/SingleTopBarActions';
-import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
 export interface Props extends PropsWithChildren<{}> {}
 
@@ -129,18 +128,6 @@ export function AppChrome({ children }: Props) {
 
 const getStyles = (theme: GrafanaTheme2, hasActions: boolean) => {
   return {
-    content: css({
-      label: 'AppChrome-Content',
-      display: 'flex',
-      flexDirection: 'column',
-      paddingTop: hasActions ? TOP_BAR_LEVEL_HEIGHT * 2 : TOP_BAR_LEVEL_HEIGHT,
-      flexGrow: 1,
-      height: 'auto',
-    }),
-    contentChromeless: css({
-      label: 'AppChrome-contentChromeless',
-      paddingTop: 0,
-    }),
     dockedMegaMenu: css({
       label: 'AppChrome-dockedMegaMenu',
       background: theme.colors.background.primary,
@@ -155,16 +142,6 @@ const getStyles = (theme: GrafanaTheme2, hasActions: boolean) => {
       [theme.breakpoints.up('xl')]: {
         display: 'block',
       },
-    }),
-    scopesDashboardsContainer: css({
-      label: 'AppChrome-scopesDashboardsContainer',
-      position: 'fixed',
-      height: `calc(100% - ${TOP_BAR_LEVEL_HEIGHT}px)`,
-      zIndex: 1,
-    }),
-    scopesDashboardsContainerDocked: css({
-      label: 'AppChrome-scopesDashboardsContainerDocked',
-      left: MENU_WIDTH,
     }),
 
     topNav: css({
@@ -182,12 +159,6 @@ const getStyles = (theme: GrafanaTheme2, hasActions: boolean) => {
       left: MENU_WIDTH,
     }),
 
-    panes: css({
-      label: 'AppChrome-panes',
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-    }),
     pageContainerMenuDocked: css({
       label: 'AppChrome-pageContainerMenuDocked',
       paddingLeft: MENU_WIDTH,

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -49,42 +49,35 @@ export const Page: PageType = ({
     }
   }, [navModel, pageNav, chrome, layout]);
 
+  // PR TODO: I removed:
+  // - `divId="page-scrollbar"` which is apparently used by the image renderer to scroll through the dashboard
+  // - NativeScrollbar which is used for a page scroll api
+  // - Canvas page background
+
+  if (layout === PageLayoutType.Custom) {
+    return (
+      <div className={cx(styles.wrapper, className)} {...otherProps}>
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
-      {layout === PageLayoutType.Standard && (
-        <NativeScrollbar
-          // This id is used by the image renderer to scroll through the dashboard
-          divId="page-scrollbar"
-          onSetScrollRef={onSetScrollRef}
-        >
-          <div className={styles.pageInner}>
-            {pageHeaderNav && (
-              <PageHeader
-                actions={actions}
-                onEditTitle={onEditTitle}
-                navItem={pageHeaderNav}
-                renderTitle={renderTitle}
-                info={info}
-                subTitle={subTitle}
-              />
-            )}
-            {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
-            <div className={styles.pageContent}>{children}</div>
-          </div>
-        </NativeScrollbar>
+      {pageHeaderNav && (
+        <PageHeader
+          actions={actions}
+          onEditTitle={onEditTitle}
+          navItem={pageHeaderNav}
+          renderTitle={renderTitle}
+          info={info}
+          subTitle={subTitle}
+        />
       )}
 
-      {layout === PageLayoutType.Canvas && (
-        <NativeScrollbar
-          // This id is used by the image renderer to scroll through the dashboard
-          divId="page-scrollbar"
-          onSetScrollRef={onSetScrollRef}
-        >
-          <div className={styles.canvasContent}>{children}</div>
-        </NativeScrollbar>
-      )}
+      {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
 
-      {layout === PageLayoutType.Custom && children}
+      {children}
     </div>
   );
 };
@@ -94,21 +87,29 @@ Page.Contents = PageContents;
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrapper: css({
-      label: 'page-wrapper',
+      label: 'Page-wrapper',
       display: 'flex',
       flex: '1 1 0',
       flexDirection: 'column',
       position: 'relative',
+
+      // originally from pageInner
+      background: theme.colors.background.primary,
+      padding: theme.spacing(2),
+
+      [theme.breakpoints.up('md')]: {
+        padding: theme.spacing(4),
+      },
     }),
     pageContent: css({
-      label: 'page-content',
+      label: 'Page-content',
       flexGrow: 1,
     }),
     primaryBg: css({
       background: theme.colors.background.primary,
     }),
     pageInner: css({
-      label: 'page-inner',
+      label: 'Page-inner',
       padding: theme.spacing(2),
       borderBottom: 'none',
       background: theme.colors.background.primary,
@@ -122,7 +123,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     canvasContent: css({
-      label: 'canvas-content',
+      label: 'Page-canvasContent',
       display: 'flex',
       flexDirection: 'column',
       padding: theme.spacing(2),

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -77,6 +77,7 @@ export const Page: PageType = ({
 
       {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
 
+      {/* PR TODO: will probably put a .pageContent div around this */}
       {children}
     </div>
   );
@@ -100,35 +101,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       [theme.breakpoints.up('md')]: {
         padding: theme.spacing(4),
       },
-    }),
-    pageContent: css({
-      label: 'Page-content',
-      flexGrow: 1,
-    }),
-    primaryBg: css({
-      background: theme.colors.background.primary,
-    }),
-    pageInner: css({
-      label: 'Page-inner',
-      padding: theme.spacing(2),
-      borderBottom: 'none',
-      background: theme.colors.background.primary,
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-      margin: theme.spacing(0, 0, 0, 0),
-
-      [theme.breakpoints.up('md')]: {
-        padding: theme.spacing(4),
-      },
-    }),
-    canvasContent: css({
-      label: 'Page-canvasContent',
-      display: 'flex',
-      flexDirection: 'column',
-      padding: theme.spacing(2),
-      flexBasis: '100%',
-      flexGrow: 1,
     }),
   };
 };

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -48,6 +48,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     topRow: css({
+      label: 'PageHeader-topRow',
       alignItems: 'flex-start',
       display: 'flex',
       flexDirection: 'row',
@@ -70,7 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     titleInfoContainer: css({
       display: 'flex',
-      label: 'title-info-container',
+      label: 'PageHeader-titleInfoContainer',
       flex: 1,
       flexWrap: 'wrap',
       gap: theme.spacing(1, 4),
@@ -79,17 +80,19 @@ const getStyles = (theme: GrafanaTheme2) => {
       minWidth: '200px',
     }),
     pageHeader: css({
-      label: 'page-header',
+      label: 'PageHeader-pageHeader',
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
       marginBottom: theme.spacing(2),
     }),
     subTitle: css({
+      label: 'PageHeader-subTitle',
       position: 'relative',
       color: theme.colors.text.secondary,
     }),
     img: css({
+      label: 'PageHeader-img',
       width: '32px',
       height: '32px',
       marginRight: theme.spacing(2),

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -186,18 +186,20 @@ const BrowseDashboardsPage = memo(() => {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   pageContents: css({
+    label: 'BrowseDashboardsPage-pageContents',
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),
-    height: '100%',
   }),
 
   // AutoSizer needs an element to measure the full height available
   subView: css({
+    label: 'BrowseDashboardsPage-subView',
     height: '100%',
   }),
 
   filters: css({
+    label: 'BrowseDashboardsPage-filters',
     display: 'none',
 
     [theme.breakpoints.up('md')]: {

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -11,11 +11,10 @@ import {
   useChromeHeaderHeight,
   useSidecar_EXPERIMENTAL,
 } from '@grafana/runtime';
-import { GlobalStyles, IconButton, ModalRoot, Stack, useSplitter, useStyles2 } from '@grafana/ui';
+import { GlobalStyles, IconButton, ModalRoot, useSplitter, useStyles2 } from '@grafana/ui';
 
 import { AngularRoot } from '../angular/AngularRoot';
 import { AppChrome } from '../core/components/AppChrome/AppChrome';
-import { AppNotificationList } from '../core/components/AppNotifications/AppNotificationList';
 import { ModalsContextProvider } from '../core/context/ModalsContextProvider';
 import { QueriesDrawerContextProvider } from '../features/explore/QueriesDrawer/QueriesDrawerContext';
 
@@ -33,13 +32,7 @@ export function RouterWrapper(props: RouterWrapperProps) {
             <ModalsContextProvider>
               <AppChrome>
                 <AngularRoot />
-                <AppNotificationList />
-                <Stack gap={0} grow={1} direction="column">
-                  {props.pageBanners.map((Banner, index) => (
-                    <Banner key={index.toString()} />
-                  ))}
-                  {props.routes}
-                </Stack>
+                {props.routes}
                 {props.bodyRenderHooks.map((Hook, index) => (
                   <Hook key={index.toString()} />
                 ))}

--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -1,7 +1,7 @@
 // This is specified in runtime Emotion GlobalStyles but we need them for the preloader styles
 html {
   font-size: $font-size-base;
-  height: 100%;
+  // height: 100%;
 }
 
 // This is specified in runtime Emotion GlobalStyles but we need them for the preloader styles
@@ -11,7 +11,7 @@ body {
   line-height: $line-height-base;
   color: $text-color;
   background-color: $body-bg;
-  height: 100%;
+  // height: 100%;
   width: 100%;
   margin: 0;
   position: absolute;

--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -4,6 +4,8 @@ html {
   // height: 100%;
 }
 
+// PR TODO: this has broken the page loading bounce animation
+
 // This is specified in runtime Emotion GlobalStyles but we need them for the preloader styles
 body {
   font-family: $font-family-sans-serif;
@@ -11,10 +13,7 @@ body {
   line-height: $line-height-base;
   color: $text-color;
   background-color: $body-bg;
-  // height: 100%;
-  width: 100%;
   margin: 0;
-  position: absolute;
 }
 
 // BASE

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -264,7 +264,7 @@
       </script>
     </div>
 
-    <div id="reactRoot"></div>
+    <div id="reactRoot" class="main-view"></div>
 
     <script nonce="[[.Nonce]]">
       window.grafanaBootData = {


### PR DESCRIPTION
This is a brief stab at attempting to simplify our page-level DOM structure and CSS.

Goals:
 - less divs
 - less `height: 100%`
 - html and body elements have the full height of the page
 - App/Page 'content' is not a flex child (no page should put `flexSpan: 1` on their root element)

I doubt this PR itself will be usable, as I've just went to town on gutting elements from the page, and some features (Scopes, AnnouncementBanners) have been (temporarily) lost in the process.