### PR TITLE
Azure: Fix interface conversion

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -269,12 +269,20 @@ func (e *AzureLogAnalyticsDatasource) buildQuery(ctx context.Context, query back
 func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client, url string) (*backend.DataResponse, error) {
 	// If azureLogAnalyticsSameAs is defined and set to false, return an error
 	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok {
-		val, ok := sameAs.(bool)
+		sameAsValue, ok := sameAs.(bool)
 		if !ok {
-			stringVal := sameAs.(string)
-			val, _ = strconv.ParseBool(stringVal)
+			stringVal, ok := sameAs.(string)
+			if !ok {
+				return nil, backend.DownstreamError(fmt.Errorf("unknown value for Log Analytics credentials. Go to the data source configuration to update Azure Monitor credentials"))
+			}
+
+			var err error
+			sameAsValue, err = strconv.ParseBool(stringVal)
+			if err != nil {
+				return nil, backend.DownstreamError(fmt.Errorf("unknown value for Log Analytics credentials. Go to the data source configuration to update Azure Monitor credentials"))
+			}
 		}
-		if !val {
+		if !sameAsValue {
 			return nil, backend.DownstreamError(fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
 		}
 	}

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -267,8 +268,15 @@ func (e *AzureLogAnalyticsDatasource) buildQuery(ctx context.Context, query back
 
 func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client, url string) (*backend.DataResponse, error) {
 	// If azureLogAnalyticsSameAs is defined and set to false, return an error
-	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok && !sameAs.(bool) {
-		return nil, backend.DownstreamError(fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
+	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok {
+		val, ok := sameAs.(bool)
+		if !ok {
+			stringVal := sameAs.(string)
+			val, _ = strconv.ParseBool(stringVal)
+		}
+		if !val {
+			return nil, backend.DownstreamError(fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
+		}
 	}
 
 	queryJSONModel := dataquery.AzureMonitorQuery{}

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -708,13 +708,26 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 	query := &AzureLogAnalyticsQuery{
 		TimeRange: backend.TimeRange{},
 	}
-	_, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL)
-	if err == nil {
-		t.Fatal("expecting an error")
-	}
-	if !strings.Contains(err.Error(), "credentials for Log Analytics are no longer supported") {
-		t.Error("expecting the error to inform of bad credentials")
-	}
+	t.Run("errors with azureLogAnalyticsSameAs set to false (boolean)", func(t *testing.T) {
+		_, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL)
+		if err == nil {
+			t.Fatal("expecting an error")
+		}
+		if !strings.Contains(err.Error(), "credentials for Log Analytics are no longer supported") {
+			t.Error("expecting the error to inform of bad credentials")
+		}
+	})
+
+	t.Run("errors with azureLogAnalyticsSameAs set to false (boolean)", func(t *testing.T) {
+		dsInfo.JSONData["azureLogAnalyticsSameAs"] = "false"
+		_, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL)
+		if err == nil {
+			t.Fatal("expecting an error")
+		}
+		if !strings.Contains(err.Error(), "credentials for Log Analytics are no longer supported") {
+			t.Error("expecting the error to inform of bad credentials")
+		}
+	})
 }
 
 func Test_exemplarsFeatureToggle(t *testing.T) {


### PR DESCRIPTION
Correctly parse either string or boolean values for the deprecated `azureLogAnalyticsSameAs` property.