### PR TITLE
Explore metrics: Do not show otel switch in related metrics tab

### DIFF
--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -512,7 +512,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
 
     const [warningDismissed, dismissWarning] = useReducer(() => true, false);
 
-    const { metricSearch, useOtelExperience, hasOtelResources, isStandardOtel } = trail.useState();
+    const { metricSearch, useOtelExperience, hasOtelResources, isStandardOtel, metric } = trail.useState();
 
     const tooStrict = children.length === 0 && metricSearch;
     const noMetrics = !metricNamesLoading && metricNames && metricNames.length === 0;
@@ -573,7 +573,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
               ]}
             />
           </Field>
-          {hasOtelResources && (
+          {!metric && hasOtelResources && (
             <Field
               label={
                 <>


### PR DESCRIPTION
**What is this?**
Do not show the OTel experience switch in related metrics tab. The switch should only be shown in the metric select scene.
 
For the related metrics scene, we re-use the metric select scene. But because we are showing related metrics, there is a metric chosen. So, when there is a metric in the state, we don't show the otel switch.

Old version
![Screenshot 2025-01-15 at 9 43 11 PM](https://github.com/user-attachments/assets/44f56038-3395-482b-a015-5f24dbb60a56)

Related metrics without the OTel switch
![Screenshot 2025-01-15 at 9 42 31 PM](https://github.com/user-attachments/assets/a52d3002-c94d-48c8-9303-aa3f87446df7)

**For reviewers:**

Make sure you select a data source that has OTel resources and the OTel switch shows on the main page. Select a metric and click the related metrics tab. You should not see the OTel switch in the related metrics tab.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
