### PR TITLE
Explore metrics: Update copy for missing metrics message when OTel is on

### DIFF
--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -291,7 +291,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
       }
 
       if (response.missingOtelTargets) {
-        metricNamesWarning = `${metricNamesWarning ?? ''} The list of metrics is not complete. Please add or change your OTel resource attributes filters. When the OTel experience is turned on, we only show metrics that match target_info on job and instance labels. The resource call to retrieve these metrics accepts only a limited amount of job and instance labels to match for metrics because it is a GET request.`;
+        metricNamesWarning = `${metricNamesWarning ?? ''} There are no metrics found. Please add or update your filters based on your OTel resource attributes.`;
       }
 
       let bodyLayout = this.state.body;

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -291,7 +291,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
       }
 
       if (response.missingOtelTargets) {
-        metricNamesWarning = `${metricNamesWarning ?? ''} The list of metrics is not complete. Select more OTel resource attributes to see a full list of metrics.`;
+        metricNamesWarning = `${metricNamesWarning ?? ''} The list of metrics is not complete. Please add or change your OTel resource attributes filters. When the OTel experience is turned on, we only show metrics that match target_info on job and instance labels. The resource call to retrieve these metrics accepts only a limited amount of job and instance labels to match for metrics because it is a GET request.`;
       }
 
       let bodyLayout = this.state.body;

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -69,6 +69,7 @@ export interface MetricSelectSceneState extends SceneObjectState {
   metricNamesLoading?: boolean;
   metricNamesError?: string;
   metricNamesWarning?: string;
+  missingOtelTargets?: boolean;
 }
 
 const ROW_PREVIEW_HEIGHT = '175px';
@@ -290,10 +291,6 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
         metricNamesWarning = undefined;
       }
 
-      if (response.missingOtelTargets) {
-        metricNamesWarning = `${metricNamesWarning ?? ''} There are no metrics found. Please add or update your filters based on your OTel resource attributes.`;
-      }
-
       let bodyLayout = this.state.body;
 
       // generate groups based on the search metrics input
@@ -306,6 +303,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
         metricNamesLoading: false,
         metricNamesWarning,
         metricNamesError: response.error,
+        missingOtelTargets: response.missingOtelTargets,
       });
     } catch (err: unknown) {
       let error = 'Unknown error';
@@ -504,8 +502,16 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
   };
 
   public static Component = ({ model }: SceneComponentProps<MetricSelectScene>) => {
-    const { body, metricNames, metricNamesError, metricNamesLoading, metricNamesWarning, rootGroup, metricPrefix } =
-      model.useState();
+    const {
+      body,
+      metricNames,
+      metricNamesError,
+      metricNamesLoading,
+      metricNamesWarning,
+      rootGroup,
+      metricPrefix,
+      missingOtelTargets,
+    } = model.useState();
     const { children } = body.useState();
     const trail = getTrailFor(model);
     const styles = useStyles2(getStyles);
@@ -521,9 +527,11 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
 
     const blockingMessage = isLoading
       ? undefined
-      : (noMetrics && 'There are no results found. Try a different time range or a different data source.') ||
-        (tooStrict && 'There are no results found. Try adjusting your search or filters.') ||
-        undefined;
+      : missingOtelTargets
+        ? 'There are no metrics found. Please adjust your filters based on your OTel resource attributes.'
+        : (noMetrics && 'There are no results found. Try a different time range or a different data source.') ||
+          (tooStrict && 'There are no results found. Try adjusting your search or filters.') ||
+          undefined;
 
     const metricNamesWarningIcon = metricNamesWarning ? (
       <Tooltip

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -617,7 +617,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
                 <InlineSwitch
                   disabled={!isStandardOtel}
                   showLabel={true}
-                  label="Otel experience"
+                  label="OTel experience"
                   value={useOtelExperience}
                   onChange={model.onToggleOtelExperience}
                 />


### PR DESCRIPTION
This PR does the following
- moves the OTel missing metrics messsage into the blocking message in the panel (out of the warning banner)
- Adds new copy explaining why some OTel data sources may be missing metrics when OTel experience is turned on. 

```
There are no metrics found. Please adjust your filters based on your OTel resource attributes.
```

![Screenshot 2025-01-16 at 4 54 59 PM](https://github.com/user-attachments/assets/cc4665ae-6c32-471e-9d38-3195aa9d412b)



Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
