### PR TITLE
Dashboard: Show hidden elements

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -39,7 +39,10 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> {
   }
 
   public disableSelection() {
-    this.setState({ selectionContext: { ...this.state.selectionContext, enabled: false } });
+    this.setState({
+      selectionContext: { ...this.state.selectionContext, selected: [], enabled: false },
+      selectedObject: undefined,
+    });
   }
 
   private selectElement(element: ElementSelectionContextItem, multi?: boolean) {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -109,6 +109,8 @@ export interface DashboardSceneState extends SceneObjectState {
   controls?: DashboardControls;
   /** True when editing */
   isEditing?: boolean;
+  /** Controls the visibility of hidden elements like row headers */
+  showHiddenElements?: boolean;
   /** True when user made a change */
   isDirty?: boolean;
   /** meta flags */
@@ -257,7 +259,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     this._initialUrlState = locationService.getLocation();
 
     // Switch to edit mode
-    this.setState({ isEditing: true });
+    this.setState({ isEditing: true, showHiddenElements: true });
 
     // Propagate change edit mode change to children
     this.state.body.editModeChanged(true);
@@ -338,10 +340,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
     if (restoreInitialState) {
       //  Restore initial state and disable editing
-      this.setState({ ...this._initialState, isEditing: false });
+      this.setState({ ...this._initialState, isEditing: false, showHiddenElements: false });
     } else {
       // Do not restore
-      this.setState({ isEditing: false });
+      this.setState({ isEditing: false, showHiddenElements: false });
     }
 
     // if we are in edit panel, we need to onDiscard()
@@ -353,11 +355,16 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
     // Disable grid dragging
     this.state.body.editModeChanged(false);
+
+    // Clear selection upon exiting edit mode
+    this.state.editPane.clearSelection();
   }
 
   public canDiscard() {
     return this._initialState !== undefined;
   }
+
+  public onToggleHiddenElements = () => this.setState({ showHiddenElements: !this.state.showHiddenElements });
 
   public pauseTrackingChanges() {
     this._changeTracker.stopTrackingChanges();

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -355,9 +355,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
     // Disable grid dragging
     this.state.body.editModeChanged(false);
-
-    // Clear selection upon exiting edit mode
-    this.state.editPane.clearSelection();
   }
 
   public canDiscard() {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -11,8 +11,10 @@ import {
   ButtonGroup,
   Dropdown,
   Icon,
+  InlineLabel,
   Menu,
   Stack,
+  Switch,
   ToolbarButton,
   ToolbarButtonRow,
   useStyles2,
@@ -54,7 +56,8 @@ NavToolbarActions.displayName = 'NavToolbarActions';
  * This part is split into a separate component to help test this
  */
 export function ToolbarActions({ dashboard }: Props) {
-  const { isEditing, viewPanelScene, isDirty, uid, meta, editview, editPanel, editable } = dashboard.useState();
+  const { isEditing, showHiddenElements, viewPanelScene, isDirty, uid, meta, editview, editPanel, editable } =
+    dashboard.useState();
 
   const { isPlaying } = playlistSrv.useState();
   const [isAddPanelMenuOpen, setIsAddPanelMenuOpen] = useState(false);
@@ -213,6 +216,25 @@ export function ToolbarActions({ dashboard }: Props) {
         >
           Import
         </Button>
+      ),
+    });
+    leftActions.push({
+      group: 'hidden-elements',
+      condition: isEditingAndShowingDashboard,
+      render: () => (
+        <InlineLabel key="toggle-hidden-elements" transparent={true} className={styles.hiddenElementsContainer}>
+          <Switch
+            value={showHiddenElements}
+            onChange={(evt) => {
+              evt.stopPropagation();
+              dashboard.onToggleHiddenElements();
+            }}
+            data-testid={selectors.components.PageToolbar.itemButton('toggle_hidden_elements')}
+          />
+          <span>
+            <Trans i18nKey="dashboard.toolbar.show-hidden-elements">Show hidden</Trans>
+          </span>
+        </InlineLabel>
       ),
     });
   } else {
@@ -741,6 +763,12 @@ interface ToolbarAction {
 
 function getStyles(theme: GrafanaTheme2) {
   return {
+    hiddenElementsContainer: css({
+      display: 'flex',
+      padding: 0,
+      gap: theme.spacing(1),
+      whiteSpace: 'nowrap',
+    }),
     buttonWithExtraMargin: css({
       margin: theme.spacing(0, 0.5),
     }),

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -95,8 +95,8 @@ export class RowItem extends SceneObjectBase<RowItemState> implements LayoutPare
   };
 
   public static Component = ({ model }: SceneComponentProps<RowItem>) => {
-    const { layout, title, isCollapsed, height = 'expand' } = model.useState();
-    const { isEditing } = getDashboardSceneFor(model).useState();
+    const { layout, title, isCollapsed, height = 'expand', isHeaderHidden } = model.useState();
+    const { isEditing, showHiddenElements } = getDashboardSceneFor(model).useState();
     const styles = useStyles2(getStyles);
     const titleInterpolated = sceneGraph.interpolate(model, title, undefined, 'text');
     const ref = useRef<HTMLDivElement>(null);
@@ -113,22 +113,24 @@ export class RowItem extends SceneObjectBase<RowItemState> implements LayoutPare
         )}
         ref={ref}
       >
-        <div className={styles.rowHeader}>
-          <button
-            onClick={model.onCollapseToggle}
-            className={styles.rowTitleButton}
-            aria-label={isCollapsed ? 'Expand row' : 'Collapse row'}
-            data-testid={selectors.components.DashboardRow.title(titleInterpolated)}
-          >
-            <Icon name={isCollapsed ? 'angle-right' : 'angle-down'} />
-            <span className={styles.rowTitle} role="heading">
-              {titleInterpolated}
-            </span>
-          </button>
-          {isEditing && (
-            <Button icon="pen" variant="secondary" size="sm" fill="text" onPointerDown={(evt) => onSelect?.(evt)} />
-          )}
-        </div>
+        {(!isHeaderHidden || showHiddenElements) && (
+          <div className={styles.rowHeader}>
+            <button
+              onClick={model.onCollapseToggle}
+              className={styles.rowTitleButton}
+              aria-label={isCollapsed ? 'Expand row' : 'Collapse row'}
+              data-testid={selectors.components.DashboardRow.title(titleInterpolated)}
+            >
+              <Icon name={isCollapsed ? 'angle-right' : 'angle-down'} />
+              <span className={styles.rowTitle} role="heading">
+                {titleInterpolated}
+              </span>
+            </button>
+            {isEditing && (
+              <Button icon="pen" variant="secondary" size="sm" fill="text" onPointerDown={(evt) => onSelect?.(evt)} />
+            )}
+          </div>
+        )}
         {!isCollapsed && <layout.Component model={layout} />}
       </div>
     );
@@ -201,7 +203,7 @@ export function RowTitleInput({ row }: { row: RowItem }) {
 }
 
 export function RowHeaderSwitch({ row }: { row: RowItem }) {
-  const { isHeaderHidden } = row.useState();
+  const { isHeaderHidden = false } = row.useState();
 
   return (
     <Switch

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -113,7 +113,7 @@ export class RowItem extends SceneObjectBase<RowItemState> implements LayoutPare
         )}
         ref={ref}
       >
-        {(!isHeaderHidden || showHiddenElements) && (
+        {(!isHeaderHidden || (isEditing && showHiddenElements)) && (
           <div className={styles.rowHeader}>
             <button
               onClick={model.onCollapseToggle}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -957,6 +957,7 @@
       "settings": "Dashboard settings",
       "share": "Share dashboard",
       "share-button": "Share",
+      "show-hidden-elements": "Show hidden",
       "unmark-favorite": "Unmark as favorite"
     },
     "validation": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -957,6 +957,7 @@
       "settings": "Đäşĥþőäřđ şęŧŧįŉģş",
       "share": "Ŝĥäřę đäşĥþőäřđ",
       "share-button": "Ŝĥäřę",
+      "show-hidden-elements": "Ŝĥőŵ ĥįđđęŉ",
       "unmark-favorite": "Ůŉmäřĸ äş ƒävőřįŧę"
     },
     "validation": {


### PR DESCRIPTION
**What is this feature?**

Implement the `show hidden` button to show the hidden elements while in edit mode. For the time being this applies to rows headers.

I also introduced a minor bugfix for exiting edit mode with a selection already made (selection was still visible in view mode).

**Why do we need this feature?**

-

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #99148
Fixes #99150

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
