### PR TITLE
Zanzana: Add migration for mysql

### DIFF
--- a/pkg/services/authz/zanzana/store/migration/migrator.go
+++ b/pkg/services/authz/zanzana/store/migration/migrator.go
@@ -12,7 +12,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func Run(cfg *setting.Cfg, typ, connStr string, fs embed.FS, path string) error {
+type Location struct {
+	FS   embed.FS
+	Path string
+}
+
+func Run(cfg *setting.Cfg, typ, connStr string, locations []Location) error {
 	engine, err := xorm.NewEngine(typ, connStr)
 	if err != nil {
 		return fmt.Errorf("failed to create db engine: %w", err)
@@ -21,17 +26,22 @@ func Run(cfg *setting.Cfg, typ, connStr string, fs embed.FS, path string) error 
 	m := migrator.NewMigrator(engine, cfg)
 	m.AddCreateMigration()
 
-	if err := RunWithMigrator(m, cfg, fs, path); err != nil {
+	if err := RunWithMigrator(m, cfg, locations); err != nil {
 		return err
 	}
 
 	return engine.Close()
 }
 
-func RunWithMigrator(m *migrator.Migrator, cfg *setting.Cfg, fs embed.FS, path string) error {
-	migrations, err := getMigrations(fs, path)
-	if err != nil {
-		return err
+func RunWithMigrator(m *migrator.Migrator, cfg *setting.Cfg, locations []Location) error {
+	var migrations []migration
+
+	for _, loc := range locations {
+		parsed, err := parseMigrations(loc.FS, loc.Path)
+		if err != nil {
+			return err
+		}
+		migrations = append(migrations, parsed...)
 	}
 
 	for _, mig := range migrations {
@@ -50,7 +60,7 @@ type migration struct {
 	migration migrator.Migration
 }
 
-func getMigrations(fs embed.FS, path string) ([]migration, error) {
+func parseMigrations(fs embed.FS, path string) ([]migration, error) {
 	entries, err := fs.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read migration dir: %w", err)

--- a/pkg/services/authz/zanzana/store/migrations/mysql/006_alter_object_id.sql
+++ b/pkg/services/authz/zanzana/store/migrations/mysql/006_alter_object_id.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE tuple MODIFY COLUMN object_id varchar(256);
+
+-- +goose Down
+ALTER TABLE tuple MODIFY COLUMN object_id varchar(128);

--- a/pkg/services/authz/zanzana/store/store.go
+++ b/pkg/services/authz/zanzana/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"embed"
 	"fmt"
 	"strings"
 	"time"
@@ -22,6 +23,13 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/store/migration"
 )
 
+const (
+	mysqlMigrationDir = "migrations/mysql"
+)
+
+//go:embed migrations/*
+var embedMigrations embed.FS
+
 func NewStore(cfg *setting.Cfg, logger log.Logger) (storage.OpenFGADatastore, error) {
 	grafanaDBCfg, zanzanaDBCfg, err := parseConfig(cfg, logger)
 	if err != nil {
@@ -31,7 +39,7 @@ func NewStore(cfg *setting.Cfg, logger log.Logger) (storage.OpenFGADatastore, er
 	switch grafanaDBCfg.Type {
 	case migrator.SQLite:
 		connStr := sqliteConnectionString(grafanaDBCfg.ConnectionString)
-		if err := migration.Run(cfg, migrator.SQLite, connStr, assets.EmbedMigrations, assets.SqliteMigrationDir); err != nil {
+		if err := migration.Run(cfg, migrator.SQLite, connStr, getSQLiteMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
@@ -39,14 +47,14 @@ func NewStore(cfg *setting.Cfg, logger log.Logger) (storage.OpenFGADatastore, er
 	case migrator.MySQL:
 		// For mysql we need to pass parseTime parameter in connection string
 		connStr := grafanaDBCfg.ConnectionString + "&parseTime=true"
-		if err := migration.Run(cfg, migrator.MySQL, connStr, assets.EmbedMigrations, assets.MySQLMigrationDir); err != nil {
+		if err := migration.Run(cfg, migrator.MySQL, connStr, getMySQLMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
 		return mysql.New(connStr, zanzanaDBCfg)
 	case migrator.Postgres:
 		connStr := grafanaDBCfg.ConnectionString
-		if err := migration.Run(cfg, migrator.Postgres, connStr, assets.EmbedMigrations, assets.PostgresMigrationDir); err != nil {
+		if err := migration.Run(cfg, migrator.Postgres, connStr, getPostgresMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
@@ -66,14 +74,14 @@ func NewEmbeddedStore(cfg *setting.Cfg, db db.DB, logger log.Logger) (storage.Op
 	switch grafanaDBCfg.Type {
 	case migrator.SQLite:
 		grafanaDBCfg.ConnectionString = sqliteConnectionString(grafanaDBCfg.ConnectionString)
-		if err := migration.Run(cfg, migrator.SQLite, grafanaDBCfg.ConnectionString, assets.EmbedMigrations, assets.SqliteMigrationDir); err != nil {
+		if err := migration.Run(cfg, migrator.SQLite, grafanaDBCfg.ConnectionString, getSQLiteMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
 		return sqlite.New(grafanaDBCfg.ConnectionString, zanzanaDBCfg)
 	case migrator.MySQL:
 		m := migrator.NewMigrator(db.GetEngine(), cfg)
-		if err := migration.RunWithMigrator(m, cfg, assets.EmbedMigrations, assets.MySQLMigrationDir); err != nil {
+		if err := migration.RunWithMigrator(m, cfg, getMySQLMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
@@ -81,7 +89,7 @@ func NewEmbeddedStore(cfg *setting.Cfg, db db.DB, logger log.Logger) (storage.Op
 		return mysql.New(grafanaDBCfg.ConnectionString+"&parseTime=true", zanzanaDBCfg)
 	case migrator.Postgres:
 		m := migrator.NewMigrator(db.GetEngine(), cfg)
-		if err := migration.RunWithMigrator(m, cfg, assets.EmbedMigrations, assets.PostgresMigrationDir); err != nil {
+		if err := migration.RunWithMigrator(m, cfg, getPostgresMigrationLocations()); err != nil {
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
@@ -122,4 +130,35 @@ func sqliteConnectionString(v string) string {
 
 	// hardcode zanzana.db for now
 	return v[0:strings.LastIndex(v, "/")+1] + "zanzana.db"
+}
+
+func getMySQLMigrationLocations() []migration.Location {
+	return []migration.Location{
+		{
+			FS:   assets.EmbedMigrations,
+			Path: assets.MySQLMigrationDir,
+		},
+		{
+			FS:   embedMigrations,
+			Path: mysqlMigrationDir,
+		},
+	}
+}
+
+func getSQLiteMigrationLocations() []migration.Location {
+	return []migration.Location{
+		{
+			FS:   assets.EmbedMigrations,
+			Path: assets.SqliteMigrationDir,
+		},
+	}
+}
+
+func getPostgresMigrationLocations() []migration.Location {
+	return []migration.Location{
+		{
+			FS:   assets.EmbedMigrations,
+			Path: assets.PostgresMigrationDir,
+		},
+	}
 }


### PR DESCRIPTION
**What is this feature?**
openFGA uses text column types for most things on postgres and sqlite. But for mysql there are some restrictions that prevents it. Our object_id can be longer than the current limit so I added a migration to increased it to the maximum value that is allowed.

openFGA issue - https://github.com/openfga/openfga/issues/2233

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1092

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.