### PR TITLE
Graphite: Fix issue where duplicated panels share same query object

### DIFF
--- a/public/app/plugins/datasource/graphite/state/context.tsx
+++ b/public/app/plugins/datasource/graphite/state/context.tsx
@@ -88,7 +88,7 @@ export const GraphiteQueryEditorContext = ({
   if (!state) {
     dispatch(
       actions.init({
-        target: query,
+        target: { ...query },
         datasource: datasource,
         range: range,
         templateSrv: getTemplateSrv(),


### PR DESCRIPTION
Fixes an issue where changes made to a duplicated panel containing a graphite query also affected the original panel.
This is an issue that also needs to be fixed for the Google Cloud Monitoring datasource.

Context:
https://github.com/grafana/scenes/pull/967#issuecomment-2476417763
https://github.com/grafana/support-escalations/issues/14182