### PR TITLE
Modify guardian to query folders from folder service

### DIFF
--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -40,7 +40,7 @@ func TestHTTPServer_DeleteDashboardSnapshot(t *testing.T) {
 			hs.DashboardService = svc
 
 			hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
-			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService, hs.folderService)
 		})
 	}
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -151,7 +151,7 @@ func TestHTTPServer_GetDashboard_AccessControl(t *testing.T) {
 			hs.starService = startest.NewStarServiceFake()
 			hs.dashboardProvisioningService = mockDashboardProvisioningService{}
 
-			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService, hs.folderService)
 		})
 	}
 
@@ -279,7 +279,7 @@ func TestHTTPServer_DeleteDashboardByUID_AccessControl(t *testing.T) {
 			license.On("FeatureEnabled", publicdashboardModels.FeaturePublicDashboardsEmailSharing).Return(false)
 			hs.PublicDashboardsApi = api.ProvideApi(pubDashService, nil, hs.AccessControl, featuremgmt.WithFeatures(), middleware, hs.Cfg, license)
 
-			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService, hs.folderService)
 		})
 	}
 	deleteDashboard := func(server *webtest.Server, permissions []accesscontrol.Permission) (*http.Response, error) {
@@ -330,7 +330,7 @@ func TestHTTPServer_GetDashboardVersions_AccessControl(t *testing.T) {
 				ExpectedDashboardVersion:     &dashver.DashboardVersionDTO{},
 			}
 
-			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService, hs.folderService)
 		})
 	}
 

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -496,7 +496,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 	}
 
 	hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
-	guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+	guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService, hs.folderService)
 
 	m.Get("/api/folders", hs.GetFolders)
 	m.Get("/api/search", hs.Search)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -632,7 +632,7 @@ func getGuardianForSavePermissionCheck(ctx context.Context, d *dashboards.Dashbo
 		// if it's a new dashboard/folder check the parent folder permissions
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
 		// nolint:staticcheck
-		guard, err := guardian.New(ctx, d.FolderID, d.OrgID, user)
+		guard, err := guardian.NewByFolder(ctx, &folder.Folder{ID: d.FolderID}, d.OrgID, user)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -896,7 +896,7 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 			nil,
 		)
 		require.NoError(t, err)
-		guardian.InitAccessControlGuardian(cfg, ac, dashboardService)
+		guardian.InitAccessControlGuardian(cfg, ac, dashboardService, folderService)
 
 		savedFolder := saveTestFolder(t, "Saved folder", testOrgID, sqlStore)
 		savedDashInFolder := saveTestDashboard(t, "Saved dash in folder", testOrgID, savedFolder.UID, sqlStore)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -1410,7 +1410,7 @@ func getGuardianForSavePermissionCheck(ctx context.Context, d *dashboards.Dashbo
 		// if it's a new dashboard/folder check the parent folder permissions
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Folder).Inc()
 		// nolint:staticcheck
-		guard, err := guardian.New(ctx, d.FolderID, d.OrgID, user)
+		guard, err := guardian.NewByFolder(ctx, &folder.Folder{ID: d.FolderID}, d.OrgID, user)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -18,6 +18,7 @@ var _ DashboardGuardian = new(accessControlDashboardGuardian)
 func NewAccessControlDashboardGuardian(
 	ctx context.Context, cfg *setting.Cfg, dashboardId int64, user identity.Requester,
 	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	folderService folder.Service,
 ) (DashboardGuardian, error) {
 	var dashboard *dashboards.Dashboard
 	if dashboardId != 0 {
@@ -58,6 +59,7 @@ func NewAccessControlDashboardGuardian(
 			user:             user,
 			ac:               ac,
 			dashboardService: dashboardService,
+			folderService:    folderService,
 		},
 		dashboard: dashboard,
 	}, nil
@@ -171,6 +173,7 @@ type accessControlBaseGuardian struct {
 	user             identity.Requester
 	ac               accesscontrol.AccessControl
 	dashboardService dashboards.DashboardService
+	folderService    folder.Service
 }
 
 type accessControlDashboardGuardian struct {
@@ -353,24 +356,24 @@ func (a *accessControlFolderGuardian) evaluate(evaluator accesscontrol.Evaluator
 	return ok, err
 }
 
-func (a *accessControlDashboardGuardian) loadParentFolder(folderID int64) (*dashboards.Dashboard, error) {
+func (a *accessControlDashboardGuardian) loadParentFolder(folderID int64) (*folder.Folder, error) {
 	if folderID == 0 {
-		return &dashboards.Dashboard{UID: accesscontrol.GeneralFolderUID}, nil
+		return &folder.Folder{UID: accesscontrol.GeneralFolderUID}, nil
 	}
-	folderQuery := &dashboards.GetDashboardQuery{ID: folderID, OrgID: a.user.GetOrgID()}
-	folderQueryResult, err := a.dashboardService.GetDashboard(a.ctx, folderQuery)
+	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID()}
+	folderQueryResult, err := a.folderService.Get(a.ctx, folderQuery)
 	if err != nil {
 		return nil, err
 	}
 	return folderQueryResult, nil
 }
 
-func (a *accessControlFolderGuardian) loadParentFolder(folderID int64) (*dashboards.Dashboard, error) {
+func (a *accessControlFolderGuardian) loadParentFolder(folderID int64) (*folder.Folder, error) {
 	if folderID == 0 {
-		return &dashboards.Dashboard{UID: accesscontrol.GeneralFolderUID}, nil
+		return &folder.Folder{UID: accesscontrol.GeneralFolderUID}, nil
 	}
-	folderQuery := &dashboards.GetDashboardQuery{ID: folderID, OrgID: a.user.GetOrgID()}
-	folderQueryResult, err := a.dashboardService.GetDashboard(a.ctx, folderQuery)
+	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID()}
+	folderQueryResult, err := a.folderService.Get(a.ctx, folderQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -46,6 +46,7 @@ func NewAccessControlDashboardGuardian(
 				user:             user,
 				ac:               ac,
 				dashboardService: dashboardService,
+				folderService:    folderService,
 			},
 			folder: dashboards.FromDashboard(dashboard),
 		}, nil
@@ -68,7 +69,7 @@ func NewAccessControlDashboardGuardian(
 // NewAccessControlDashboardGuardianByDashboard creates a dashboard guardian by the provided dashboardUID.
 func NewAccessControlDashboardGuardianByUID(
 	ctx context.Context, cfg *setting.Cfg, dashboardUID string, user identity.Requester,
-	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, folderService folder.Service,
 ) (DashboardGuardian, error) {
 	var dashboard *dashboards.Dashboard
 	if dashboardUID != "" {
@@ -96,6 +97,7 @@ func NewAccessControlDashboardGuardianByUID(
 				user:             user,
 				ac:               ac,
 				dashboardService: dashboardService,
+				folderService:    folderService,
 			},
 			folder: dashboards.FromDashboard(dashboard),
 		}, nil
@@ -109,6 +111,7 @@ func NewAccessControlDashboardGuardianByUID(
 			user:             user,
 			ac:               ac,
 			dashboardService: dashboardService,
+			folderService:    folderService,
 		},
 		dashboard: dashboard,
 	}, nil
@@ -119,7 +122,7 @@ func NewAccessControlDashboardGuardianByUID(
 // since it avoids querying the database for fetching the dashboard.
 func NewAccessControlDashboardGuardianByDashboard(
 	ctx context.Context, cfg *setting.Cfg, dashboard *dashboards.Dashboard, user identity.Requester,
-	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, folderService folder.Service,
 ) (DashboardGuardian, error) {
 	if dashboard != nil && dashboard.IsFolder {
 		return &accessControlFolderGuardian{
@@ -130,6 +133,7 @@ func NewAccessControlDashboardGuardianByDashboard(
 				user:             user,
 				ac:               ac,
 				dashboardService: dashboardService,
+				folderService:    folderService,
 			},
 			folder: dashboards.FromDashboard(dashboard),
 		}, nil
@@ -143,6 +147,7 @@ func NewAccessControlDashboardGuardianByDashboard(
 			user:             user,
 			ac:               ac,
 			dashboardService: dashboardService,
+			folderService:    folderService,
 		},
 		dashboard: dashboard,
 	}, nil
@@ -151,7 +156,7 @@ func NewAccessControlDashboardGuardianByDashboard(
 // NewAccessControlFolderGuardian creates a folder guardian by the provided folder.
 func NewAccessControlFolderGuardian(
 	ctx context.Context, cfg *setting.Cfg, f *folder.Folder, user identity.Requester,
-	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, folderService folder.Service,
 ) (DashboardGuardian, error) {
 	return &accessControlFolderGuardian{
 		accessControlBaseGuardian: accessControlBaseGuardian{
@@ -161,6 +166,7 @@ func NewAccessControlFolderGuardian(
 			user:             user,
 			ac:               ac,
 			dashboardService: dashboardService,
+			folderService:    folderService,
 		},
 		folder: f,
 	}, nil
@@ -360,7 +366,7 @@ func (a *accessControlDashboardGuardian) loadParentFolder(folderID int64) (*fold
 	if folderID == 0 {
 		return &folder.Folder{UID: accesscontrol.GeneralFolderUID}, nil
 	}
-	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID()}
+	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID(), SignedInUser: a.user}
 	folderQueryResult, err := a.folderService.Get(a.ctx, folderQuery)
 	if err != nil {
 		return nil, err
@@ -372,7 +378,7 @@ func (a *accessControlFolderGuardian) loadParentFolder(folderID int64) (*folder.
 	if folderID == 0 {
 		return &folder.Folder{UID: accesscontrol.GeneralFolderUID}, nil
 	}
-	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID()}
+	folderQuery := &folder.GetFolderQuery{ID: &folderID, OrgID: a.user.GetOrgID(), SignedInUser: a.user}
 	folderQueryResult, err := a.folderService.Get(a.ctx, folderQuery)
 	if err != nil {
 		return nil, err

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -976,7 +976,7 @@ func setupAccessControlGuardianTest(
 		userPermissions[orgID][p.Action] = append(userPermissions[orgID][p.Action], p.Scope)
 	}
 
-	g, err := NewAccessControlDashboardGuardianByDashboard(context.Background(), cfg, d, &user.SignedInUser{OrgID: orgID, Permissions: userPermissions}, ac, fakeDashboardService)
+	g, err := NewAccessControlDashboardGuardianByDashboard(context.Background(), cfg, d, &user.SignedInUser{OrgID: orgID, Permissions: userPermissions}, ac, fakeDashboardService, folderSvc)
 	require.NoError(t, err)
 	return g
 }

--- a/pkg/services/guardian/provider.go
+++ b/pkg/services/guardian/provider.go
@@ -15,18 +15,18 @@ type Provider struct{}
 
 func ProvideService(
 	cfg *setting.Cfg, ac accesscontrol.AccessControl,
-	dashboardService dashboards.DashboardService, teamService team.Service,
+	dashboardService dashboards.DashboardService, folderService folder.Service, teamService team.Service,
 ) *Provider {
 	// TODO: Fix this hack, see https://github.com/grafana/grafana-enterprise/issues/2935
-	InitAccessControlGuardian(cfg, ac, dashboardService)
+	InitAccessControlGuardian(cfg, ac, dashboardService, folderService)
 	return &Provider{}
 }
 
 func InitAccessControlGuardian(
-	cfg *setting.Cfg, ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	cfg *setting.Cfg, ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, folderService folder.Service,
 ) {
 	New = func(ctx context.Context, dashId int64, orgId int64, user identity.Requester) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, ac, dashboardService)
+		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, ac, dashboardService, folderService)
 	}
 
 	NewByUID = func(ctx context.Context, dashUID string, orgId int64, user identity.Requester) (DashboardGuardian, error) {

--- a/pkg/services/guardian/provider.go
+++ b/pkg/services/guardian/provider.go
@@ -30,14 +30,14 @@ func InitAccessControlGuardian(
 	}
 
 	NewByUID = func(ctx context.Context, dashUID string, orgId int64, user identity.Requester) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, ac, dashboardService)
+		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, ac, dashboardService, folderService)
 	}
 
 	NewByDashboard = func(ctx context.Context, dash *dashboards.Dashboard, orgId int64, user identity.Requester) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, ac, dashboardService)
+		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, ac, dashboardService, folderService)
 	}
 
 	NewByFolder = func(ctx context.Context, f *folder.Folder, orgId int64, user identity.Requester) (DashboardGuardian, error) {
-		return NewAccessControlFolderGuardian(ctx, cfg, f, user, ac, dashboardService)
+		return NewAccessControlFolderGuardian(ctx, cfg, f, user, ac, dashboardService, folderService)
 	}
 }

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -832,7 +832,6 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			nil, nil, nil, nil, quotaService, nil,
 		)
 		require.NoError(t, err)
-		guardian.InitAccessControlGuardian(cfg, ac, dashService)
 
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
 		require.NoError(t, err)
@@ -840,6 +839,8 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 
 		folderService := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore, folderStore, sqlStore,
 			features, supportbundlestest.NewFakeBundleService(), cfg, nil, tracing.InitializeTracerForTest())
+
+		guardian.InitAccessControlGuardian(cfg, ac, dashService, folderService)
 
 		elementService := libraryelements.ProvideService(cfg, sqlStore, routing.NewRouteRegister(), folderService, features, ac)
 		service := LibraryPanelService{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR modifies the `guardian` methods to query folders via Folder service.

**Why do we need this feature?**

When running on Unified Storage, we can't query folders via the dashboard service. Instead we need to get folder from Folder service.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana-org/issues/378

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
