### PR TITLE
feat: Expose theme color variables as CSS variables on :root

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -4,6 +4,8 @@ import { GrafanaTheme2, ThemeTypographyVariant } from '@grafana/data';
 
 import { getFocusStyles } from '../mixins';
 
+import { createGlobalCssVars } from './globalCssVariables';
+
 export function getElementStyles(theme: GrafanaTheme2) {
   return css({
     '*, *::before, *::after': {
@@ -32,6 +34,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
 
     ':root': {
       colorScheme: theme.colors.mode,
+      ...createGlobalCssVars(theme),
     },
 
     body: {

--- a/packages/grafana-ui/src/themes/GlobalStyles/globalCssVariables.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/globalCssVariables.ts
@@ -1,0 +1,55 @@
+import { GrafanaTheme2 } from '@grafana/data';
+
+const richColors = ['primary', 'secondary', 'info', 'error', 'success', 'warning'] as const;
+/**
+ * Creates CSS variables from the active Grafana theme.
+ * @param theme The Grafana theme to extract variables from
+ * @returns Object containing CSS variable declarations
+ */
+export function createGlobalCssVars(theme: GrafanaTheme2) {
+  const vars: {
+    [key: `--grafana-${'color' | 'gradient'}-${string}`]: string;
+  } = {};
+
+  // Process rich colors (primary, secondary, info, etc)
+  for (const colorName of richColors) {
+    const color = theme.colors[colorName];
+    vars[`--grafana-color-${colorName}-main`] = color.main;
+    vars[`--grafana-color-${colorName}-text`] = color.text;
+    vars[`--grafana-color-${colorName}-border`] = color.border;
+    vars[`--grafana-color-${colorName}-shade`] = color.shade;
+    vars[`--grafana-color-${colorName}-transparent`] = color.transparent;
+    vars[`--grafana-color-${colorName}-border-transparent`] = color.borderTransparent;
+    vars[`--grafana-color-${colorName}-contrast-text`] = color.contrastText;
+  }
+
+  for (const [key, value] of Object.entries(theme.colors.text)) {
+    vars[`--grafana-color-text-${key}`] = value;
+  }
+
+  for (const [key, value] of Object.entries(theme.colors.background)) {
+    vars[`--grafana-color-bg-${key}`] = value;
+  }
+
+  for (const [key, value] of Object.entries(theme.colors.border)) {
+    vars[`--grafana-color-border-${key}`] = value;
+  }
+
+  for (const [key, value] of Object.entries(theme.colors.action)) {
+    if (typeof value === 'string') {
+      vars[`--grafana-color-action-${key}`] = value;
+    } else if (typeof value === 'number') {
+      vars[`--grafana-color-action-${key}`] = value.toString();
+    }
+  }
+
+  for (const [key, value] of Object.entries(theme.colors.gradients)) {
+    vars[`--grafana-gradient-${key}`] = value;
+  }
+
+  vars['--grafana-color-hover-factor'] = theme.colors.hoverFactor.toString();
+  vars['--grafana-color-contrast-threshold'] = theme.colors.contrastThreshold.toString();
+  vars['--grafana-color-tonal-offset'] = theme.colors.tonalOffset.toString();
+
+  return vars;
+}


### PR DESCRIPTION
**What is this feature?**

To use Grafana's theme colors, one must access the Theme2 context in order to be responsive to light/dark changes.

This feature exposes all Grafana Theme2 color variables as CSS variables, and updates them as the theme changes. 

This means less re-renders during theme changes, and allows front-end developers to take advantage of css-only color
features in CSS Colors Level 4 and 5, such as `color-mix`, color spaces, hue interpolation, and more.

Notably, this has no effect on any rendering on it's own.

<img width="441" alt="Screenshot 2025-01-16 at 11 09 13 AM" src="https://github.com/user-attachments/assets/cc327048-2bb4-4ad4-a40f-43030ddce438" />

**Why do we need this feature?**

There are performance implications to doing color processing in javascript, and CSS is quickly becoming the best place
to perform color transformations. Exposing our theme to CSS means we can begin incrementally adopting these features 
only where they are required without a big refactor in how we deal with color.

**Who is this feature for?**

Grafana core and plugin authors will benefit from simpler theme-responsive styling. If adopted widely
this approach will reduce the bundle size and compile time, as typescript across the application will 
no longer have to import `useTheme2` et al. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
