### PR TITLE
Chore: Export some more from index for explore metrics

### DIFF
--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -88,8 +88,8 @@ export { PrometheusVariableSupport } from './variables';
 
 // For explore metrics
 export * from './language_provider';
-export {getPrometheusTime} from './language_utils';
-export {isValidLegacyName, utf8Support, wrapUtf8Filters} from './utf8_support';
-export {buildVisualQueryFromString} from './querybuilder/parsing';
-export {PromQueryModeller} from './querybuilder/PromQueryModeller';
-export {type QueryBuilderLabelFilter} from './querybuilder/shared/types';
+export { getPrometheusTime } from './language_utils';
+export { isValidLegacyName, utf8Support, wrapUtf8Filters } from './utf8_support';
+export { buildVisualQueryFromString } from './querybuilder/parsing';
+export { PromQueryModeller } from './querybuilder/PromQueryModeller';
+export { type QueryBuilderLabelFilter } from './querybuilder/shared/types';

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -85,3 +85,11 @@ export {
   type StandardPromVariableQuery,
 } from './types';
 export { PrometheusVariableSupport } from './variables';
+
+// For explore metrics
+export * from './language_provider';
+export {getPrometheusTime} from './language_utils';
+export {isValidLegacyName, utf8Support, wrapUtf8Filters} from './utf8_support';
+export {buildVisualQueryFromString} from './querybuilder/parsing';
+export {PromQueryModeller} from './querybuilder/PromQueryModeller';
+export {type QueryBuilderLabelFilter} from './querybuilder/shared/types';

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -87,7 +87,7 @@ export {
 export { PrometheusVariableSupport } from './variables';
 
 // For explore metrics
-export * from './language_provider';
+export { default } from './language_provider';
 export { getPrometheusTime } from './language_utils';
 export { isValidLegacyName, utf8Support, wrapUtf8Filters } from './utf8_support';
 export { buildVisualQueryFromString } from './querybuilder/parsing';

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -87,7 +87,7 @@ export {
 export { PrometheusVariableSupport } from './variables';
 
 // For explore metrics
-export { default } from './language_provider';
+export { default as PromQlLanguageProvider } from './language_provider';
 export { getPrometheusTime } from './language_utils';
 export { isValidLegacyName, utf8Support, wrapUtf8Filters } from './utf8_support';
 export { buildVisualQueryFromString } from './querybuilder/parsing';

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
-import { PromMetricsMetadataItem } from '@grafana/prometheus';
-import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
+import { isValidLegacyName, PromMetricsMetadataItem } from '@grafana/prometheus';
 import {
   QueryVariable,
   SceneComponentProps,

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -4,7 +4,7 @@ import { isNumber, max, min, throttle } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import { DataFrame, FieldType, GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
-import { isValidLegacyName, utf8Support } from '@grafana/prometheus/src/utf8_support';
+import { isValidLegacyName, utf8Support } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
 import {
   ConstantVariable,

--- a/public/app/features/trails/Integrations/getQueryMetrics.ts
+++ b/public/app/features/trails/Integrations/getQueryMetrics.ts
@@ -1,5 +1,4 @@
-import { buildVisualQueryFromString } from '@grafana/prometheus/src/querybuilder/parsing';
-import { QueryBuilderLabelFilter } from '@grafana/prometheus/src/querybuilder/shared/types';
+import { buildVisualQueryFromString, QueryBuilderLabelFilter } from '@grafana/prometheus';
 
 import { isEquals } from './utils';
 

--- a/public/app/features/trails/Integrations/utils.ts
+++ b/public/app/features/trails/Integrations/utils.ts
@@ -1,4 +1,4 @@
-import { QueryBuilderLabelFilter } from '@grafana/prometheus/src/querybuilder/shared/types';
+import { QueryBuilderLabelFilter } from '@grafana/prometheus';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 import { QueryMetric } from './getQueryMetrics'; // We only support label filters with the '=' operator

--- a/public/app/features/trails/MetricSelect/api.ts
+++ b/public/app/features/trails/MetricSelect/api.ts
@@ -1,7 +1,5 @@
 import { AdHocVariableFilter, RawTimeRange, Scope } from '@grafana/data';
-import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
-import { PromQueryModeller } from '@grafana/prometheus/src/querybuilder/PromQueryModeller';
-import { utf8Support } from '@grafana/prometheus/src/utf8_support';
+import { getPrometheusTime, PromQueryModeller, utf8Support } from '@grafana/prometheus';
 import { config, getBackendSrv } from '@grafana/runtime';
 
 import { limitOtelMatchTerms } from '../otel/util';

--- a/public/app/features/trails/autoQuery/getAutoQueriesForMetric.ts
+++ b/public/app/features/trails/autoQuery/getAutoQueriesForMetric.ts
@@ -1,4 +1,4 @@
-import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
+import { isValidLegacyName } from '@grafana/prometheus';
 
 import { createDefaultMetricQueryDefs } from './queryGenerators/default';
 import { createHistogramMetricQueryDefs } from './queryGenerators/histogram';

--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -4,10 +4,11 @@ import {
   DataSourceGetTagValuesOptions,
   MetricFindValue,
 } from '@grafana/data';
-import PromQlLanguageProvider, {
+import {
   PrometheusDatasource,
   PromMetricsMetadata,
   PromMetricsMetadataItem,
+  PromQlLanguageProvider,
   PromQuery,
 } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';

--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -4,8 +4,12 @@ import {
   DataSourceGetTagValuesOptions,
   MetricFindValue,
 } from '@grafana/data';
-import { PrometheusDatasource, PromMetricsMetadata, PromMetricsMetadataItem, PromQuery } from '@grafana/prometheus';
-import PromQlLanguageProvider from '@grafana/prometheus/src/language_provider';
+import PromQlLanguageProvider, {
+  PrometheusDatasource,
+  PromMetricsMetadata,
+  PromMetricsMetadataItem,
+  PromQuery,
+} from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { DataTrail } from '../DataTrail';

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -1,6 +1,5 @@
 import { RawTimeRange, Scope } from '@grafana/data';
-import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
-import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
+import { getPrometheusTime, isValidLegacyName } from '@grafana/prometheus';
 import { config, getBackendSrv } from '@grafana/runtime';
 
 import { callSuggestionsApi } from '../utils';

--- a/public/app/features/trails/otel/util.ts
+++ b/public/app/features/trails/otel/util.ts
@@ -1,5 +1,5 @@
 import { AdHocVariableFilter, MetricFindValue, RawTimeRange, VariableHide } from '@grafana/data';
-import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
+import { isValidLegacyName } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
 import { AdHocFiltersVariable, ConstantVariable, sceneGraph, SceneObject } from '@grafana/scenes';
 

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -10,7 +10,7 @@ import {
   ScopeSpecFilter,
   urlUtil,
 } from '@grafana/data';
-import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
+import { getPrometheusTime } from '@grafana/prometheus';
 import { config, FetchResponse, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,


### PR DESCRIPTION
**What is this feature?**

For the externalization work of explore metrics some of the components and types has to be exported from root in order to be used in externalized package. I know this is against the idea of not-using-barrel-files. But soon I'll have another PR that handles this and makes the `@grafana/prometheus` package an esmodule.

**Why do we need this feature?**

For explore metrics externalization

**Who is this feature for?**

Explore Metrics Developers

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/98976

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
