### PR TITLE
Azure: Correctly set instance settings based on new credentials

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/datasource.ts
@@ -60,15 +60,17 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
 
     this.variables = new VariableSupport(this);
 
-    this.currentUserAuth = instanceSettings.jsonData.azureAuthType === 'currentuser';
     const credentials = instanceSettings.jsonData.azureCredentials;
     if (credentials && instanceOfAzureCredential<AadCurrentUserCredentials>('currentuser', credentials)) {
+      this.currentUserAuth = true;
       if (!credentials.serviceCredentials) {
         this.currentUserAuthFallbackAvailable = false;
       } else {
         this.currentUserAuthFallbackAvailable = isCredentialsComplete(credentials.serviceCredentials, true);
       }
     } else {
+      // Handle legacy credentials case
+      this.currentUserAuth = instanceSettings.jsonData.azureAuthType === 'currentuser';
       this.currentUserAuthFallbackAvailable = false;
     }
   }


### PR DESCRIPTION
- Correctly set the data source `currentUserAuth` property based on the new credentials format.

Fixes a minor bug introduced in #95354 