### PR TITLE
Docs: Updated unsupported and unconfirmed lists

### DIFF
--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -190,6 +190,7 @@ guaranteed because plugin developers can override this functionality. The follow
   <tr>
     <td>
       <ul>
+        <li>DynamoDB</li>
         <li>Dynatrace</li>
         <li>Graphite</li>
         <li>Google Sheets</li>
@@ -222,7 +223,6 @@ guaranteed because plugin developers can override this functionality. The follow
     </td>
     <td>
       <ul>
-        <li>DynamoDB</li>
         <li>GitHub</li>
         <li>Google BigQuery</li>
         <li>Grafana for YNAB</li>

--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -190,6 +190,7 @@ guaranteed because plugin developers can override this functionality. The follow
   <tr>
     <td>
       <ul>
+        <li>Dynatrace</li>
         <li>Graphite</li>
         <li>Google Sheets</li>
       </ul>
@@ -221,7 +222,7 @@ guaranteed because plugin developers can override this functionality. The follow
     </td>
     <td>
       <ul>
-        <li>Dynatrace</li>
+        <li>DynamoDB</li>
         <li>GitHub</li>
         <li>Google BigQuery</li>
         <li>Grafana for YNAB</li>


### PR DESCRIPTION
Follow up to [PR 99087](https://github.com/grafana/grafana/pull/99087). Opening PR manually in v11.4 and older releases because docs have been restructured in 11.5.
This edit fixes https://github.com/grafana/support-escalations/issues/14246

Also adds update from [PR 97744](https://github.com/grafana/grafana/pull/97744).