### PR TITLE
K8s search: add legacy id to dashboard response

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -52,6 +52,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -1215,6 +1216,7 @@ func (dr *DashboardServiceImpl) FindDashboards(ctx context.Context, query *dashb
 		finalResults := make([]dashboards.DashboardSearchProjection, len(response.Hits))
 		for i, hit := range response.Hits {
 			finalResults[i] = dashboards.DashboardSearchProjection{
+				ID:        hit.Field.GetNestedInt64(search.DASHBOARD_LEGACY_ID),
 				UID:       hit.Name,
 				OrgID:     query.OrgId,
 				Title:     hit.Title,
@@ -1980,7 +1982,7 @@ func ParseResults(result *resource.ResourceSearchResponse, offset int64) (*v0alp
 	for i, row := range result.Results.Rows {
 		fields := &common.Unstructured{}
 		for colIndex, col := range result.Results.Columns {
-			if _, ok := excludedFields[col.Name]; ok {
+			if _, ok := excludedFields[col.Name]; !ok {
 				val, err := resource.DecodeCell(col, colIndex, row.Cells[colIndex])
 				if err != nil {
 					return nil, err

--- a/pkg/storage/unified/search/dashboard.go
+++ b/pkg/storage/unified/search/dashboard.go
@@ -189,6 +189,11 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 				Filterable: true,
 			},
 		},
+		{
+			Name:        DASHBOARD_LEGACY_ID,
+			Type:        resource.ResourceTableColumnDefinition_INT64,
+			Description: "Deprecated legacy id of the dashboard",
+		},
 	})
 	if namespaced == nil {
 		namespaced = func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
@@ -267,6 +272,7 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 
 	// metadata name is the dashboard uid
 	summary.UID = obj.GetName()
+	summary.ID = obj.GetDeprecatedInternalID() // nolint:staticcheck
 
 	doc := resource.NewIndexableDocument(key, rv, obj)
 	doc.Title = summary.Title
@@ -310,11 +316,9 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	doc.Fields = map[string]any{
 		DASHBOARD_SCHEMA_VERSION: summary.SchemaVersion,
 		DASHBOARD_LINK_COUNT:     summary.LinkCount,
+		DASHBOARD_LEGACY_ID:      summary.ID,
 	}
 
-	if summary.ID > 0 {
-		doc.Fields[DASHBOARD_LEGACY_ID] = summary.ID
-	}
 	if len(panelTypes) > 0 {
 		sort.Strings(panelTypes)
 		doc.Fields[DASHBOARD_PANEL_TYPES] = panelTypes

--- a/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
@@ -16,6 +16,7 @@
     "c"
   ],
   "labels": {
+    "grafana.app/deprecatedInternalID": "141",
     "host": "abc",
     "region": "xyz"
   },

--- a/pkg/storage/unified/search/testdata/doc/dashboard-aaa.json
+++ b/pkg/storage/unified/search/testdata/doc/dashboard-aaa.json
@@ -13,7 +13,8 @@
     },
     "labels": {
        "host": "abc",
-       "region": "xyz"
+       "region": "xyz",
+       "grafana.app/deprecatedInternalID": "141"
     }
   },
   "spec": {

--- a/pkg/storage/unified/search/testdata/manual-dashboard.json
+++ b/pkg/storage/unified/search/testdata/manual-dashboard.json
@@ -168,6 +168,13 @@
       "format": "int64",
       "description": "Total number of views",
       "priority": 0
+    },
+    {
+      "name": "legacy_id",
+      "type": "number",
+      "format": "int64",
+      "description": "Deprecated legacy id of the dashboard",
+      "priority": 0
     }
   ],
   "rows": [
@@ -179,6 +186,7 @@
           "aa"
         ],
         "zzz",
+        null,
         null,
         null,
         null,
@@ -239,6 +247,7 @@
         100,
         null,
         null,
+        null,
         null
       ],
       "object": {
@@ -280,6 +289,7 @@
         null,
         null,
         50,
+        null,
         null,
         null,
         null


### PR DESCRIPTION
This PR adds in the legacy ID to the search response fields, this is needed so we can use search in analytics without having to pull in the entire dashboard body.