### PR TITLE
Only run documentation linter on branches that target `main`

### DIFF
--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -1,6 +1,7 @@
 name: Documentation CI
 on:
   pull_request:
+    branches: ["main"]
     paths: ["docs/sources/**"]
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
We don't want to lint other branches because we'd prefer those fixes are made to `main` and backported