### PR TITLE
Zanzana: Add grpc health and readiness checks for standalone zanzana

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -154,12 +155,12 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return fmt.Errorf("failed to initilize zanana store: %w", err)
 	}
 
-	openfga, err := zanzana.NewOpenFGAServer(z.cfg.ZanzanaServer, store, z.logger)
+	openfgaServer, err := zanzana.NewOpenFGAServer(z.cfg.ZanzanaServer, store, z.logger)
 	if err != nil {
 		return fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	srv, err := zanzana.NewServer(z.cfg.ZanzanaServer, openfga, z.logger)
+	zanzanaServer, err := zanzana.NewServer(z.cfg.ZanzanaServer, openfgaServer, z.logger)
 	if err != nil {
 		return fmt.Errorf("failed to start zanzana: %w", err)
 	}
@@ -203,10 +204,14 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return fmt.Errorf("failed to create zanzana grpc server: %w", err)
 	}
 
-	s := z.handle.GetServer()
-	openfgav1.RegisterOpenFGAServiceServer(s, openfga)
-	authzv1.RegisterAuthzServiceServer(s, srv)
-	authzextv1.RegisterAuthzExtentionServiceServer(s, srv)
+	grpcServer := z.handle.GetServer()
+	openfgav1.RegisterOpenFGAServiceServer(grpcServer, openfgaServer)
+	authzv1.RegisterAuthzServiceServer(grpcServer, zanzanaServer)
+	authzextv1.RegisterAuthzExtentionServiceServer(grpcServer, zanzanaServer)
+
+	// register grpc health server
+	healthServer := zanzana.NewHealthServer(zanzanaServer)
+	healthv1pb.RegisterHealthServer(grpcServer, healthServer)
 
 	if _, err := grpcserver.ProvideReflectionService(z.cfg, z.handle); err != nil {
 		return fmt.Errorf("failed to register reflection for zanzana: %w", err)

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -3,7 +3,6 @@ package zanzana
 import (
 	"net/http"
 
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	openfgaserver "github.com/openfga/openfga/pkg/server"
 	openfgastorage "github.com/openfga/openfga/pkg/storage"
 
@@ -13,8 +12,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func NewServer(cfg setting.ZanzanaServerSettings, openfga openfgav1.OpenFGAServiceServer, logger log.Logger) (*server.Server, error) {
+func NewServer(cfg setting.ZanzanaServerSettings, openfga server.OpenFGAServer, logger log.Logger) (*server.Server, error) {
 	return server.NewServer(cfg, openfga, logger)
+}
+
+func NewHealthServer(target server.DiagnosticServer) *server.HealthServer {
+	return server.NewHealthServer(target)
 }
 
 func NewOpenFGAServer(cfg setting.ZanzanaServerSettings, store openfgastorage.OpenFGADatastore, logger log.Logger) (*openfgaserver.Server, error) {

--- a/pkg/services/authz/zanzana/server/health.go
+++ b/pkg/services/authz/zanzana/server/health.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type DiagnosticServer interface {
+	IsHealthy(ctx context.Context) (bool, error)
+}
+
+func NewHealthServer(target DiagnosticServer) *HealthServer {
+	return &HealthServer{target: target}
+}
+
+type HealthServer struct {
+	healthv1pb.UnimplementedHealthServer
+	target DiagnosticServer
+}
+
+var _ grpcauth.ServiceAuthFuncOverride = (*HealthServer)(nil)
+
+func (s *HealthServer) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s *HealthServer) Check(ctx context.Context, req *healthv1pb.HealthCheckRequest) (*healthv1pb.HealthCheckResponse, error) {
+	healthy, err := s.target.IsHealthy(ctx)
+	if err != nil || !healthy {
+		return &healthv1pb.HealthCheckResponse{Status: healthv1pb.HealthCheckResponse_NOT_SERVING}, err
+	}
+	return &healthv1pb.HealthCheckResponse{Status: healthv1pb.HealthCheckResponse_SERVING}, nil
+}
+
+func (s *HealthServer) Watch(req *healthv1pb.HealthCheckRequest, stream healthv1pb.Health_WatchServer) error {
+	res, err := s.Check(stream.Context(), &healthv1pb.HealthCheckRequest{})
+	if err != nil {
+		return err
+	}
+
+	err = stream.Send(res)
+	if err != nil {
+		return err
+	}
+
+	prevStatus := res.GetStatus()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			res, err := s.Check(stream.Context(), &healthv1pb.HealthCheckRequest{})
+			if err != nil {
+				return err
+			}
+
+			// if health status has not changed, continue
+			if res.GetStatus() == prevStatus {
+				continue
+			}
+
+			prevStatus = res.GetStatus()
+			err = stream.Send(res)
+			if err != nil {
+				return err
+			}
+
+		case <-stream.Context().Done():
+			return errors.New("stream closed, context cancelled")
+		}
+	}
+}


### PR DESCRIPTION
**What is this feature?**
Implement and register grpc health server for standalone zanana according to https://github.com/grpc/grpc/blob/master/doc/health-checking.md


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1113

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
