### PR TITLE
Dashboard: Prevent panel selection on drag and items click

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -327,8 +327,12 @@ export function PanelChrome({
           }}
           onPointerUp={(evt) => {
             evt.stopPropagation();
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            if (pointerDownEvt.current && !(evt.target as HTMLElement).closest(`.${dragClassCancel}`)) {
+            if (
+              pointerDownEvt.current &&
+              dragClassCancel &&
+              evt.target instanceof HTMLElement &&
+              !evt.target.closest(`.${dragClassCancel}`)
+            ) {
               onSelect?.(pointerDownEvt.current);
               pointerDownEvt.current = null;
             }


### PR DESCRIPTION
**What is this feature?**

Prevent panel selection on panel dragging and panel header items clicks.

**Why do we need this feature?**

Refine the experience for panel selection.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #99140
Fixes #99141

**Special notes for your reviewer:**

I know it's not the most elegant solution and i'm not keen merging this. I'd love to find an alternative solution from an UX perspective (maybe an edit button? I don't know)


https://github.com/user-attachments/assets/91485e34-eab6-4bab-a294-40fe01e4e725



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
