### PR TITLE
Alerting: Add rule title and namespace uid to the error when provisioning API returns 409

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -34,11 +34,12 @@ var (
 	// ErrAlertRuleFailedGenerateUniqueUID is an error for failure to generate alert rule UID
 	ErrAlertRuleFailedGenerateUniqueUID = errors.New("failed to generate alert rule UID")
 	// ErrCannotEditNamespace is an error returned if the user does not have permissions to edit the namespace
-	ErrCannotEditNamespace                = errors.New("user does not have permissions to edit the namespace")
-	ErrRuleGroupNamespaceNotFound         = errors.New("rule group not found under this namespace")
-	ErrAlertRuleFailedValidation          = errors.New("invalid alert rule")
-	ErrAlertRuleUniqueConstraintViolation = errors.New("rule title under the same organisation and folder should be unique")
-	ErrQuotaReached                       = errors.New("quota has been exceeded")
+	ErrCannotEditNamespace                   = errors.New("user does not have permissions to edit the namespace")
+	ErrRuleGroupNamespaceNotFound            = errors.New("rule group not found under this namespace")
+	ErrAlertRuleFailedValidation             = errors.New("invalid alert rule")
+	ErrAlertRuleUniqueConstraintViolation    = errors.New("rule title under the same organisation and folder should be unique")
+	ErrAlertRuleUIDUniqueConstraintViolation = errors.New("rule UID under the same organisation should be unique")
+	ErrQuotaReached                          = errors.New("quota has been exceeded")
 	// ErrNoDashboard is returned when the alert rule does not have a Dashboard UID
 	// in its annotations or the dashboard does not exist.
 	ErrNoDashboard = errors.New("no dashboard")

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -902,6 +902,7 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		_, err = store.InsertAlertRules(context.Background(), &usr, []models.AlertRule{rules[0]})
 		require.ErrorIs(t, err, models.ErrAlertRuleConflictBase)
 	})
+
 	t.Run("fail insert rules with the same title in a folder", func(t *testing.T) {
 		cp := models.CopyRule(&rules[0])
 		cp.UID = cp.UID + "-new"
@@ -915,12 +916,19 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		require.ErrorContains(t, err, rules[0].Title)
 		require.ErrorContains(t, err, rules[0].NamespaceUID)
 	})
+
 	t.Run("should not let insert rules with the same UID", func(t *testing.T) {
 		cp := models.CopyRule(&rules[0])
 		cp.Title = "unique-test-title"
+		cp.NamespaceUID = "unique-namespace-uid"
 		_, err = store.InsertAlertRules(context.Background(), &usr, []models.AlertRule{*cp})
 		require.ErrorIs(t, err, models.ErrAlertRuleConflictBase)
-		require.ErrorContains(t, err, "rule UID under the same organisation should be unique")
+		require.ErrorIs(t, err, models.ErrAlertRuleUIDUniqueConstraintViolation)
+		require.ErrorContains(t, err, cp.UID)
+		require.ErrorContains(t, err, cp.Title)
+		require.ErrorContains(t, err, rules[0].Title)
+		require.ErrorContains(t, err, cp.NamespaceUID)
+		require.ErrorContains(t, err, rules[0].NamespaceUID)
 	})
 
 	t.Run("should emit event when rules are inserted", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This change improves the error messaging when there's a conflict while provisioning alert rules. Currently if the rule with the same UID exists, the returned error looks like this:

```
alert rule [rule_uid: uid-1, title: title-2, namespace_uid: namespace-2]
conflicts with existing [rule_uid: uid-1, title: '', namespace_uid: '']:
rule UID under the same organisation should be unique
```

The `title` and the `namespace_uid` are empty which is confusing. This PR adds them to the error.

With this change the error in the HTTP response is:

```
alert rule [rule_uid: uid-1, title: title-2, namespace_uid: namespace-2]
conflicts with existing [rule_uid: uid-1, title: title-1, namespace_uid: namespace-1]:
rule UID under the same organisation should be unique
```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
