### PR TITLE
Revert "Remove dependency on dashboards table to get library element and library element connection"

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -29,7 +29,7 @@ import (
 const (
 	selectLibraryElementDTOWithMeta = `
 SELECT DISTINCT
-	le.name, le.id, le.org_id, le.folder_id, le.folder_uid, le.uid, le.kind, le.type, le.description, le.model, le.created, le.created_by, le.updated, le.updated_by, le.version
+	le.name, le.id, le.org_id, le.folder_id, le.uid, le.kind, le.type, le.description, le.model, le.created, le.created_by, le.updated, le.updated_by, le.version
 	, u1.login AS created_by_name
 	, u1.email AS created_by_email
 	, u2.login AS updated_by_name
@@ -93,7 +93,10 @@ func syncFieldsWithModel(libraryElement *model.LibraryElement) error {
 func GetLibraryElement(dialect migrator.Dialect, session *db.Session, uid string, orgID int64) (model.LibraryElementWithMeta, error) {
 	elements := make([]model.LibraryElementWithMeta, 0)
 	sql := selectLibraryElementDTOWithMeta +
+		", coalesce(dashboard.title, 'General') AS folder_name" +
+		", coalesce(dashboard.uid, '') AS folder_uid" +
 		getFromLibraryElementDTOWithMeta(dialect) +
+		" LEFT JOIN dashboard AS dashboard ON dashboard.id = le.folder_id" +
 		" WHERE le.uid=? AND le.org_id=?"
 	sess := session.SQL(sql, uid, orgID)
 	err := sess.Find(&elements)
@@ -105,15 +108,6 @@ func GetLibraryElement(dialect migrator.Dialect, session *db.Session, uid string
 	}
 	if len(elements) > 1 {
 		return model.LibraryElementWithMeta{}, fmt.Errorf("found %d elements, while expecting at most one", len(elements))
-	}
-
-	for _, el := range elements {
-		if el.FolderName == "" {
-			el.FolderName = dashboards.RootFolderName
-		}
-		if el.FolderUID == "" {
-			el.FolderUID = ac.GeneralFolderUID
-		}
 	}
 
 	return elements[0], nil
@@ -684,12 +678,12 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 		if err != nil {
 			return err
 		}
-
 		var libraryElementConnections []model.LibraryElementConnectionWithMeta
 		builder := db.NewSqlBuilder(l.Cfg, l.features, l.SQLStore.GetDialect(), recursiveQueriesAreSupported)
-		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email")
+		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email, dashboard.uid AS connection_uid")
 		builder.Write(" FROM " + model.LibraryElementConnectionTableName + " AS lec")
 		builder.Write(" LEFT JOIN " + l.SQLStore.GetDialect().Quote("user") + " AS u1 ON lec.created_by = u1.id")
+		builder.Write(" INNER JOIN dashboard AS dashboard on lec.connection_id = dashboard.id")
 		builder.Write(` WHERE lec.element_id=?`, element.ID)
 		if signedInUser.GetOrgRole() != org.RoleAdmin {
 			builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, "")
@@ -700,11 +694,12 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 
 		for _, connection := range libraryElementConnections {
 			connections = append(connections, model.LibraryElementConnectionDTO{
-				ID:           connection.ID,
-				Kind:         connection.Kind,
-				ElementID:    connection.ElementID,
-				ConnectionID: connection.ConnectionID,
-				Created:      connection.Created,
+				ID:            connection.ID,
+				Kind:          connection.Kind,
+				ElementID:     connection.ElementID,
+				ConnectionID:  connection.ConnectionID,
+				ConnectionUID: connection.ConnectionUID,
+				Created:       connection.Created,
 				CreatedBy: librarypanel.LibraryElementDTOMetaUser{
 					Id:        connection.CreatedBy,
 					Name:      connection.CreatedByName,

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -116,13 +116,11 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
-				result.Result.FolderUID = "general"
 				result.Result.Meta.CreatedBy.Name = userInDbName
 				result.Result.Meta.CreatedBy.AvatarUrl = userInDbAvatar
 				result.Result.Meta.UpdatedBy.Name = userInDbName
 				result.Result.Meta.UpdatedBy.AvatarUrl = userInDbAvatar
 				result.Result.Meta.FolderName = "General"
-				result.Result.Meta.FolderUID = "general"
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				resp = sc.service.getAllHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -171,11 +171,12 @@ func TestGetLibraryPanelConnections(t *testing.T) {
 				return model.LibraryElementConnectionsResponse{
 					Result: []model.LibraryElementConnectionDTO{
 						{
-							ID:           sc.initialResult.Result.ID,
-							Kind:         sc.initialResult.Result.Kind,
-							ElementID:    1,
-							ConnectionID: dashInDB.ID,
-							Created:      res.Result[0].Created,
+							ID:            sc.initialResult.Result.ID,
+							Kind:          sc.initialResult.Result.Kind,
+							ElementID:     1,
+							ConnectionID:  dashInDB.ID,
+							ConnectionUID: dashInDB.UID,
+							Created:       res.Result[0].Created,
 							CreatedBy: librarypanel.LibraryElementDTOMetaUser{
 								Id:        1,
 								Name:      userInDbName,


### PR DESCRIPTION
Reverts grafana/grafana#98941

In the PR, the connection.UID was removed, which is then used to search for the dashboards:

This results in the dropdown showing nothing:
<img width="765" alt="Screenshot 2025-01-17 at 12 24 04 PM" src="https://github.com/user-attachments/assets/3476fe61-f400-4978-a689-a57843a57ae1" />