### PR TITLE
Azure: Correctly set application insights resource values

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -528,7 +528,12 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 	}
 
 	if query.AppInsightsQuery {
-		body["applications"] = []string{query.Resources[0]}
+		// If the query type is traces then we only need the first resource as the rest are specified in the query
+		if query.QueryType == dataquery.AzureQueryTypeAzureTraces {
+			body["applications"] = []string{query.Resources[0]}
+		} else {
+			body["applications"] = query.Resources
+		}
 	}
 
 	jsonValue, err := json.Marshal(body)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -692,6 +692,24 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 			t.Errorf("Unexpected Body: %v", cmp.Diff(string(body), expectedBody))
 		}
 	})
+
+	t.Run("correctly passes multiple application insights resources in a logs query", func(t *testing.T) {
+		ds := AzureLogAnalyticsDatasource{}
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
+			Resources:        []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/components/r2"},
+			Query:            "Perf",
+			QueryType:        dataquery.AzureQueryTypeLogAnalytics,
+			AppInsightsQuery: true,
+			DashboardTime:    false,
+		})
+		require.NoError(t, err)
+		expectedBody := `{"applications":["/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/components/r1","/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/components/r2"],"query":"Perf"}`
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		if !cmp.Equal(string(body), expectedBody) {
+			t.Errorf("Unexpected Body: %v", cmp.Diff(string(body), expectedBody))
+		}
+	})
 }
 
 func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {


### PR DESCRIPTION
When the query type is traces we only need the first application insights resource as the rest are specified in the query. Otherwise, we should use all the application insights resources in the API request.

Fixes a bug I introduced in #95156.

Fixes grafana/support-escalations#14036