### PR TITLE
PreviewLogRow: fix LogRowMessageDisplayedFields being unnecessarily rendered

### DIFF
--- a/public/app/features/logs/components/PreviewLogRow.tsx
+++ b/public/app/features/logs/components/PreviewLogRow.tsx
@@ -10,7 +10,7 @@ export const PreviewLogRow = ({ row, showDuplicates, showLabels, showTime, displ
       <td></td>
       {showTime && <td>{row.timeEpochMs}</td>}
       {showLabels && row.uniqueLabels && <td></td>}
-      {displayedFields ? (
+      {displayedFields && displayedFields.length > 0 ? (
         <LogRowMessageDisplayedFields
           {...rest}
           row={row}


### PR DESCRIPTION
Originally introduced in https://github.com/grafana/grafana/pull/98025, displayedFields was an empty array, so it was causing unnecessary renders of \<LogRowMessageDisplayedFields\>
