### PR TITLE
Prometheus: Sort Table format data frames by first field's values

### DIFF
--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -288,11 +288,13 @@ describe('Prometheus Result Transformer', () => {
 
       expect(series.data.length).toEqual(1);
       expect(series.data[0].fields[0].name).toEqual('Time');
+      expect(series.data[0].fields[0].values).toEqual([2,3,4,5,6,7]);
       expect(series.data[0].fields[1].name).toEqual('label1');
       expect(series.data[0].fields[2].name).toEqual('label2');
       expect(series.data[0].fields[3].name).toEqual('label3');
       expect(series.data[0].fields[4].name).toEqual('label4');
       expect(series.data[0].fields[5].name).toEqual('Value');
+      expect(series.data[0].fields[5].values).toEqual([2,3,4,5,6,7]);
       expect(series.data[0].meta?.preferredVisualisationType).toEqual('rawPrometheus' as PreferredVisualisationType);
     });
 

--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -261,11 +261,11 @@ describe('Prometheus Result Transformer', () => {
           createDataFrame({
             refId: 'A',
             fields: [
-              { name: 'time', type: FieldType.time, values: [6, 5, 4] },
+              { name: 'time', type: FieldType.time, values: [4, 5, 6] },
               {
                 name: 'value',
                 type: FieldType.number,
-                values: [6, 5, 4],
+                values: [4, 5, 6],
                 labels: { label1: 'value1', label2: 'value2' },
               },
             ],

--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -288,13 +288,13 @@ describe('Prometheus Result Transformer', () => {
 
       expect(series.data.length).toEqual(1);
       expect(series.data[0].fields[0].name).toEqual('Time');
-      expect(series.data[0].fields[0].values).toEqual([2,3,4,5,6,7]);
+      expect(series.data[0].fields[0].values).toEqual([2, 3, 4, 5, 6, 7]);
       expect(series.data[0].fields[1].name).toEqual('label1');
       expect(series.data[0].fields[2].name).toEqual('label2');
       expect(series.data[0].fields[3].name).toEqual('label3');
       expect(series.data[0].fields[4].name).toEqual('label4');
       expect(series.data[0].fields[5].name).toEqual('Value');
-      expect(series.data[0].fields[5].values).toEqual([2,3,4,5,6,7]);
+      expect(series.data[0].fields[5].values).toEqual([2, 3, 4, 5, 6, 7]);
       expect(series.data[0].meta?.preferredVisualisationType).toEqual('rawPrometheus' as PreferredVisualisationType);
     });
 

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -17,6 +17,7 @@ import {
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
 } from '@grafana/data';
+import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { ExemplarTraceIdDestination, PromMetric, PromQuery, PromValue } from './types';
@@ -236,7 +237,8 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
       length: timeField.values.length,
     };
   });
-  return frames;
+
+  return frames.map((frame) => maybeSortFrame(frame, 0));
 }
 
 function getValueText(responseLength: number, refId = '') {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/14240
(probably)

our x=time panels expect ascending order Time fields. in this case the Prometheus DS frontend was simply concatenating multiple frames together where one frame's timestamps were in the middle of the other frame.

the straightforward fix here was to add a sorting pass.