### PR TITLE
#84658 Add DisableUiUpdate on http call to mark a dashboard as provisioned

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -606,7 +606,7 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 		provisioningData = data
 	}
 
-	allowUiUpdate := true
+	allowUiUpdate := !cmd.DisableUiUpdate
 	if provisioningData != nil {
 		allowUiUpdate = hs.ProvisioningService.GetAllowUIUpdatesFromConfig(provisioningData.Name)
 	}

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -203,9 +203,10 @@ type SaveDashboardCommand struct {
 	RestoredFrom int              `json:"-"`
 	PluginID     string           `json:"-" xorm:"plugin_id"`
 	// Deprecated: use FolderUID instead
-	FolderID  int64  `json:"folderId" xorm:"folder_id"`
-	FolderUID string `json:"folderUid" xorm:"folder_uid"`
-	IsFolder  bool   `json:"isFolder"`
+	FolderID        int64  `json:"folderId" xorm:"folder_id"`
+	FolderUID       string `json:"folderUid" xorm:"folder_uid"`
+	IsFolder        bool   `json:"isFolder"`
+	DisableUiUpdate bool   `json:"disableUiUpdate"`
 
 	UpdatedAt time.Time
 }


### PR DESCRIPTION
**What is this feature?**

Add a flag in the create dashboard api to disable the UI update button.

**Why do we need this feature?**

The Grafana operator uses the rest api to provision dashboards but only from a file the update button can be disabled.

This probably applies for ansible, terrafrom, polumni etc.

**Who is this feature for?**

For developers which provision there dashboards using the HTTP API.

**Which issue(s) does this PR fix?**:

Fixes #84658

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
