### PR TITLE
K8s: Dashboards: Set message as annotation

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -2234,13 +2234,17 @@ func LegacySaveCommandToUnstructured(cmd *dashboards.SaveDashboardCommand, names
 	finalObj.SetNamespace(namespace)
 	finalObj.SetGroupVersionKind(v0alpha1.DashboardResourceInfo.GroupVersionKind())
 
-	if cmd.FolderUID != "" {
-		meta, err := utils.MetaAccessor(&finalObj)
-		if err != nil {
-			return finalObj, err
-		}
+	meta, err := utils.MetaAccessor(&finalObj)
+	if err != nil {
+		return finalObj, err
+	}
 
+	if cmd.FolderUID != "" {
 		meta.SetFolder(cmd.FolderUID)
+	}
+
+	if cmd.Message != "" {
+		meta.SetMessage(cmd.Message)
 	}
 
 	return finalObj, nil

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1871,6 +1871,7 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 	t.Run("successfully converts save command to unstructured", func(t *testing.T) {
 		cmd := &dashboards.SaveDashboardCommand{
 			FolderUID: "folder-uid",
+			Message:   "saving this dashboard",
 			Dashboard: simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "test-uid"}),
 		}
 
@@ -1881,7 +1882,7 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 		assert.Equal(t, "test-namespace", result.GetNamespace())
 		spec := result.Object["spec"].(map[string]any)
 		assert.Equal(t, spec["version"], 1)
-		assert.Equal(t, result.GetAnnotations(), map[string]string{utils.AnnoKeyFolder: "folder-uid"})
+		assert.Equal(t, result.GetAnnotations(), map[string]string{utils.AnnoKeyFolder: "folder-uid", utils.AnnoKeyMessage: "saving this dashboard"})
 	})
 
 	t.Run("should increase version when called", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This PR sets the dashboard save message as an annotation on the dashboard (the max length of this will be introduced in https://github.com/grafana/grafana/pull/99229).

![Screenshot 2025-01-19 at 12 40 59 PM](https://github.com/user-attachments/assets/9315dad7-5a90-40b4-a806-89a11fb96569)

**Why do we need this feature?**

So we can support dashboard version messages in app platform

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/app-platform-wg/issues/192
