### PR TITLE
[Onboarding] Fix import all from Github into Root

### DIFF
--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -490,6 +490,10 @@ func (r *Replicator) fetchRepoFolderTree(ctx context.Context) (*folderTree, erro
 }
 
 func (r *Replicator) ensureRepositoryFolderExists(ctx context.Context) error {
+	if r.repository.Config().Spec.Folder == "" {
+		return nil
+	}
+
 	_, err := r.folders.Get(ctx, r.repository.Config().Spec.Folder, metav1.GetOptions{})
 	if err == nil {
 		return nil

--- a/public/app/features/provisioning/SetupWarnings.tsx
+++ b/public/app/features/provisioning/SetupWarnings.tsx
@@ -6,8 +6,6 @@ const requiredFeatureToggles: Array<keyof FeatureToggles> = [
   'kubernetesDashboards',
   'kubernetesFoldersServiceV2',
   'kubernetesDashboards',
-  'grafanaAPIServerWithExperimentalAPIs',
-  // 'unifiedStorage', // FIXME: not assignable to keyof FeatureToggles
   'unifiedStorageSearch',
   'unifiedStorageSearchUI',
   'kubernetesCliDashboards',

--- a/public/app/features/provisioning/SetupWarnings.tsx
+++ b/public/app/features/provisioning/SetupWarnings.tsx
@@ -3,9 +3,14 @@ import { config } from '@grafana/runtime';
 import { Alert, Text } from '@grafana/ui';
 
 const requiredFeatureToggles: Array<keyof FeatureToggles> = [
-  'kubernetesFolders',
   'kubernetesDashboards',
+  'kubernetesFoldersServiceV2',
+  'kubernetesDashboards',
+  'grafanaAPIServerWithExperimentalAPIs',
+  // 'unifiedStorage', // FIXME: not assignable to keyof FeatureToggles
   'unifiedStorageSearch',
+  'unifiedStorageSearchUI',
+  'kubernetesCliDashboards',
 ];
 
 export function SetupWarnings() {


### PR DESCRIPTION
Fixes: https://github.com/grafana/git-ui-sync-project/issues/76


- I fixed the code to allow users to use root folder. 
- (extra) I fixed the list of feature flags necessary to run the prototype. 


<img width="1254" alt="image" src="https://github.com/user-attachments/assets/cd77c782-6710-48f7-9fc8-47b9dbca5822" />

```bash
.
├── README.md
├── first-dashboard.json
├── nested
│   └── second-dashboard.json
└── new-dashboard-1737371197670.json

2 directories, 4 files
```