### PR TITLE
Chore: Change jsonMarkup.js to esm

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/jsonMarkup.js
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/jsonMarkup.js
@@ -67,7 +67,7 @@ function escape(str) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-module.exports = function (doc, styleFile) {
+export default function jsonMarkup(doc, styleFile) {
   let indent = '';
   const style = Stylize(styleFile);
 
@@ -130,4 +130,4 @@ module.exports = function (doc, styleFile) {
   }
 
   return '<div ' + style('json-markup') + '>' + visit(doc) + '</div>';
-};
+}


### PR DESCRIPTION
Slight change to jsonMarkup.js from the Explore Trace View to make it an ES Module.

Would love a hand from @grafana/observability-traces-and-profiling in testing this to double check this doesn't have unexpected side effects.

For https://github.com/grafana/grafana/issues/87308 