### PR TITLE
GroupingToMatrix: Defensively guard against `null` column name

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -155,6 +155,30 @@ describe('Grouping to Matrix', () => {
     });
   });
 
+  it.only('properly handles null column name values', async () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {
+        columnField: 'Column',
+        rowField: 'Row',
+        valueField: 'Temp',
+      },
+    };
+
+    const seriesA = toDataFrame({
+      name: 'C',
+      fields: [
+        { name: 'Column', type: FieldType.string, values: ['C1', null, 'C2'] },
+        { name: 'Row', type: FieldType.string, values: ['R1', 'R2', 'R1'] },
+        { name: 'Temp', type: FieldType.number, values: [1, 4, 5], config: { units: 'celsius' } },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [seriesA])).toEmitValuesWith((received) => {
+      expect(received[0][0].fields.some(({ name }) => name === null)).toBe(true);
+    });
+  });
+
   it('generates Matrix with multiple fields and value type', async () => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -175,7 +175,54 @@ describe('Grouping to Matrix', () => {
     });
 
     await expect(transformDataFrame([cfg], [seriesA])).toEmitValuesWith((received) => {
-      expect(received[0][0].fields.some(({ name }) => name === null)).toBe(true);
+      const processed = received[0];
+
+      expect(processed[0].fields).toMatchInlineSnapshot(`
+        [
+          {
+            "config": {},
+            "name": "Row\\Column",
+            "type": "string",
+            "values": [
+              "R1",
+              "R2",
+            ],
+          },
+          {
+            "config": {
+              "units": "celsius",
+            },
+            "name": "C1",
+            "type": "number",
+            "values": [
+              1,
+              "",
+            ],
+          },
+          {
+            "config": {
+              "units": "celsius",
+            },
+            "name": null,
+            "type": "number",
+            "values": [
+              "",
+              4,
+            ],
+          },
+          {
+            "config": {
+              "units": "celsius",
+            },
+            "name": "C2",
+            "type": "number",
+            "values": [
+              5,
+              "",
+            ],
+          },
+        ]
+      `);
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -155,7 +155,7 @@ describe('Grouping to Matrix', () => {
     });
   });
 
-  it.only('properly handles null column name values', async () => {
+  it('properly handles null column name values', async () => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,
       options: {

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -127,10 +127,10 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
           }
 
           fields.push({
-            name: columnName.toString(),
-            values: values,
             config: valueField.config,
+            name: columnName?.toString() ?? null,
             type: valueField.type,
+            values: values,
           });
         }
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -127,10 +127,10 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
           }
 
           fields.push({
-            config: valueField.config,
             name: columnName?.toString() ?? null,
-            type: valueField.type,
             values: values,
+            config: valueField.config,
+            type: valueField.type,
           });
         }
 


### PR DESCRIPTION
What does this PR do?

This is a bugfix PR that resolves a `.toString()` bug when using `GroupingToMatrix` and the `columnName` field is `null`.

The expected behavior: `null` field names are still a valid use case in data sources, and we need to adjust the `groupingToMatrix` logic to reflect that as we iterate and generate the fields. In this case, we need to defensively guard against a null column name, and set the default value to `null` using nullish coalescing. 

The output is that the `null` column name appears to default to "Value" (I'm assuming this happens somewhere in the table/charting code elsewhere) in the dashboard panel table/legends. Though, we can always add a "Rename fields by regex" transform to title the field "null" (if that's the desired behavior!). 

Fixes https://github.com/grafana/grafana/issues/81801

#### Before

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/178b9fe7-e58d-4288-a4ad-19a40f9cdc26" />

#### After

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/f4d0fa4f-e3f4-4836-8a08-36d64c2ccb23" />

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
