### PR TITLE
[v11.3.x] DashboardScenes: Fix issue where relative time does not pass properly

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.test.tsx
@@ -47,6 +47,19 @@ describe('PanelTimeRange', () => {
     expect(panelTime.state.value.from.toISOString()).toBe('2019-02-11T15:00:00.000Z');
     expect(panelTime.state.timeInfo).toBe('Last 2 hours timeshift -2h');
   });
+
+  it('should update panelTimeRange from/to based on scene timeRange on activate', () => {
+    const panelTime = new PanelTimeRange({});
+    const panel = new SceneCanvasText({ text: 'Hello', $timeRange: panelTime });
+    const scene = new SceneFlexLayout({
+      $timeRange: new SceneTimeRange({ from: 'now-12h', to: 'now-2h' }),
+      children: [new SceneFlexItem({ body: panel })],
+    });
+    activateFullSceneTree(scene);
+
+    expect(panelTime.state.from).toBe('now-12h');
+    expect(panelTime.state.to).toBe('now-2h');
+  });
 });
 
 function buildAndActivateSceneFor(panelTime: PanelTimeRange) {

--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
@@ -43,6 +43,15 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
         }
       })
     );
+
+    const { timeRange } = this.getTimeOverride(this.getAncestorTimeRange().state.value);
+
+    // set initial values on activate
+    this.setState({
+      value: timeRange,
+      from: timeRange.raw.from.toString(),
+      to: timeRange.raw.to.toString(),
+    });
   }
   protected ancestorTimeRangeChanged(timeRange: SceneTimeRangeState): void {
     const overrideResult = this.getTimeOverride(timeRange.value);


### PR DESCRIPTION
Backport bf1a0837af29c4eb50697235eb7afbce937acc1d from #99282

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue where some properties of the local `PanelTimeRange` would not update properly based on dashboard timerange and time overrides, but would instead maintain the placeholder values set in the constructor.

**Why do we need this feature?**

Fixes issues where datasources would use those properties which were not updated (specifically the raw from/to values in `PanelTimeRange`) and cause issues by using wrong values.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
