### PR TITLE
Tempo: Add separate options groups

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -1,7 +1,9 @@
+import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { EditorField, EditorRow } from '@grafana/experimental';
-import { AutoSizeInput, RadioButtonGroup } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { EditorField } from '@grafana/experimental';
+import { AutoSizeInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
 import { QueryOptionGroup } from '../_importedDependencies/datasources/prometheus/QueryOptionGroup';
 import { SearchTableType } from '../dataquery.gen';
@@ -28,6 +30,8 @@ const parseIntWithFallback = (val: string, fallback: number) => {
 };
 
 export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, isStreaming }) => {
+  const styles = useStyles2(getStyles);
+
   if (!query.hasOwnProperty('limit')) {
     query.limit = DEFAULT_LIMIT;
   }
@@ -60,85 +64,88 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
   //   }
   // };
 
-  const collapsedInfoList = [
+  const collapsedSearchOptions = [
     `Limit: ${query.limit || DEFAULT_LIMIT}`,
     `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
     `Table Format: ${query.tableType === SearchTableType.Traces ? 'Traces' : 'Spans'}`,
     '|',
-    `Step: ${query.step || 'auto'}`,
-    // `Exemplars: ${query.exemplars !== undefined ? query.exemplars : 'auto'}`,
-    '|',
     `Streaming: ${isStreaming ? 'Enabled' : 'Disabled'}`,
   ];
 
+  const collapsedMetricsOptions = [
+    `Step: ${query.step || 'auto'}`,
+    // `Exemplars: ${query.exemplars !== undefined ? query.exemplars : 'auto'}`,
+  ];
+
   return (
-    <>
-      <EditorRow>
-        <QueryOptionGroup title="Options" collapsedInfo={collapsedInfoList}>
-          <EditorField label="Limit" tooltip="Maximum number of traces to return.">
-            <AutoSizeInput
-              className="width-4"
-              placeholder="auto"
-              type="number"
-              min={1}
-              defaultValue={query.limit || DEFAULT_LIMIT}
-              onCommitChange={onLimitChange}
-              value={query.limit}
-            />
-          </EditorField>
-          <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
-            <AutoSizeInput
-              className="width-4"
-              placeholder="auto"
-              type="number"
-              min={1}
-              defaultValue={query.spss || DEFAULT_SPSS}
-              onCommitChange={onSpssChange}
-              value={query.spss}
-            />
-          </EditorField>
-          <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
-            <RadioButtonGroup
-              options={[
-                { label: 'Traces', value: SearchTableType.Traces },
-                { label: 'Spans', value: SearchTableType.Spans },
-              ]}
-              value={query.tableType}
-              onChange={onTableTypeChange}
-            />
-          </EditorField>
-          <EditorField
-            label="Step"
-            tooltip="Defines the step for metric queries. Use duration notation, for example 30s or 1m"
-          >
-            <AutoSizeInput
-              className="width-4"
-              placeholder="auto"
-              type="string"
-              defaultValue={query.step}
-              onCommitChange={onStepChange}
-              value={query.step}
-            />
-          </EditorField>
-          {/*<EditorField*/}
-          {/*  label="Exemplars"*/}
-          {/*  tooltip="Defines the amount of exemplars to request for metric queries. A value of 0 means no exemplars."*/}
-          {/*>*/}
-          {/*  <AutoSizeInput*/}
-          {/*    className="width-4"*/}
-          {/*    placeholder="auto"*/}
-          {/*    type="string"*/}
-          {/*    defaultValue={query.exemplars}*/}
-          {/*    onCommitChange={onExemplarsChange}*/}
-          {/*    value={query.exemplars}*/}
-          {/*  />*/}
-          {/*</EditorField>*/}
-          <EditorField label="Streaming" tooltip={<StreamingTooltip />} tooltipInteractive>
-            <div>{isStreaming ? 'Enabled' : 'Disabled'}</div>
-          </EditorField>
-        </QueryOptionGroup>
-      </EditorRow>
-    </>
+    <div className={styles.options}>
+      <QueryOptionGroup title="Search Options" collapsedInfo={collapsedSearchOptions}>
+        <EditorField label="Limit" tooltip="Maximum number of traces to return.">
+          <AutoSizeInput
+            className="width-4"
+            placeholder="auto"
+            type="number"
+            min={1}
+            defaultValue={query.limit || DEFAULT_LIMIT}
+            onCommitChange={onLimitChange}
+            value={query.limit}
+          />
+        </EditorField>
+        <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
+          <AutoSizeInput
+            className="width-4"
+            placeholder="auto"
+            type="number"
+            min={1}
+            defaultValue={query.spss || DEFAULT_SPSS}
+            onCommitChange={onSpssChange}
+            value={query.spss}
+          />
+        </EditorField>
+        <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
+          <RadioButtonGroup
+            options={[
+              { label: 'Traces', value: SearchTableType.Traces },
+              { label: 'Spans', value: SearchTableType.Spans },
+            ]}
+            value={query.tableType}
+            onChange={onTableTypeChange}
+          />
+        </EditorField>
+        <EditorField label="Streaming" tooltip={<StreamingTooltip />} tooltipInteractive>
+          <div>{isStreaming ? 'Enabled' : 'Disabled'}</div>
+        </EditorField>
+      </QueryOptionGroup>
+
+      <QueryOptionGroup title="Metrics Options" collapsedInfo={collapsedMetricsOptions}>
+        <EditorField
+          label="Step"
+          tooltip="Defines the step for metric queries. Use duration notation, for example 30s or 1m"
+        >
+          <AutoSizeInput
+            className="width-4"
+            placeholder="auto"
+            type="string"
+            defaultValue={query.step}
+            onCommitChange={onStepChange}
+            value={query.step}
+          />
+        </EditorField>
+        {/*<EditorField*/}
+        {/*  label="Exemplars"*/}
+        {/*  tooltip="Defines the amount of exemplars to request for metric queries. A value of 0 means no exemplars."*/}
+        {/*>*/}
+        {/*  <AutoSizeInput*/}
+        {/*    className="width-4"*/}
+        {/*    placeholder="auto"*/}
+        {/*    type="string"*/}
+        {/*    defaultValue={query.exemplars}*/}
+        {/*    onCommitChange={onExemplarsChange}*/}
+        {/*    value={query.exemplars}*/}
+        {/*  />*/}
+        {/*</EditorField>*/}
+      </QueryOptionGroup>
+    </div>
   );
 });
 
@@ -163,3 +170,17 @@ const StreamingTooltip = () => {
 };
 
 TempoQueryBuilderOptions.displayName = 'TempoQueryBuilderOptions';
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    options: css({
+      display: 'flex',
+      width: '-webkit-fill-available',
+      gap: theme.spacing(1),
+
+      '> div': {
+        width: 'auto',
+      },
+    }),
+  };
+};

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { EditorField } from '@grafana/experimental';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { AutoSizeInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
 import { QueryOptionGroup } from '../_importedDependencies/datasources/prometheus/QueryOptionGroup';
@@ -78,74 +78,76 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
   ];
 
   return (
-    <div className={styles.options}>
-      <QueryOptionGroup title="Search Options" collapsedInfo={collapsedSearchOptions}>
-        <EditorField label="Limit" tooltip="Maximum number of traces to return.">
-          <AutoSizeInput
-            className="width-4"
-            placeholder="auto"
-            type="number"
-            min={1}
-            defaultValue={query.limit || DEFAULT_LIMIT}
-            onCommitChange={onLimitChange}
-            value={query.limit}
-          />
-        </EditorField>
-        <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
-          <AutoSizeInput
-            className="width-4"
-            placeholder="auto"
-            type="number"
-            min={1}
-            defaultValue={query.spss || DEFAULT_SPSS}
-            onCommitChange={onSpssChange}
-            value={query.spss}
-          />
-        </EditorField>
-        <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
-          <RadioButtonGroup
-            options={[
-              { label: 'Traces', value: SearchTableType.Traces },
-              { label: 'Spans', value: SearchTableType.Spans },
-            ]}
-            value={query.tableType}
-            onChange={onTableTypeChange}
-          />
-        </EditorField>
-        <EditorField label="Streaming" tooltip={<StreamingTooltip />} tooltipInteractive>
-          <div>{isStreaming ? 'Enabled' : 'Disabled'}</div>
-        </EditorField>
-      </QueryOptionGroup>
+    <EditorRow>
+      <div className={styles.options}>
+        <QueryOptionGroup title="Search Options" collapsedInfo={collapsedSearchOptions}>
+          <EditorField label="Limit" tooltip="Maximum number of traces to return.">
+            <AutoSizeInput
+              className="width-4"
+              placeholder="auto"
+              type="number"
+              min={1}
+              defaultValue={query.limit || DEFAULT_LIMIT}
+              onCommitChange={onLimitChange}
+              value={query.limit}
+            />
+          </EditorField>
+          <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
+            <AutoSizeInput
+              className="width-4"
+              placeholder="auto"
+              type="number"
+              min={1}
+              defaultValue={query.spss || DEFAULT_SPSS}
+              onCommitChange={onSpssChange}
+              value={query.spss}
+            />
+          </EditorField>
+          <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
+            <RadioButtonGroup
+              options={[
+                { label: 'Traces', value: SearchTableType.Traces },
+                { label: 'Spans', value: SearchTableType.Spans },
+              ]}
+              value={query.tableType}
+              onChange={onTableTypeChange}
+            />
+          </EditorField>
+          <EditorField label="Streaming" tooltip={<StreamingTooltip />} tooltipInteractive>
+            <div>{isStreaming ? 'Enabled' : 'Disabled'}</div>
+          </EditorField>
+        </QueryOptionGroup>
 
-      <QueryOptionGroup title="Metrics Options" collapsedInfo={collapsedMetricsOptions}>
-        <EditorField
-          label="Step"
-          tooltip="Defines the step for metric queries. Use duration notation, for example 30s or 1m"
-        >
-          <AutoSizeInput
-            className="width-4"
-            placeholder="auto"
-            type="string"
-            defaultValue={query.step}
-            onCommitChange={onStepChange}
-            value={query.step}
-          />
-        </EditorField>
-        {/*<EditorField*/}
-        {/*  label="Exemplars"*/}
-        {/*  tooltip="Defines the amount of exemplars to request for metric queries. A value of 0 means no exemplars."*/}
-        {/*>*/}
-        {/*  <AutoSizeInput*/}
-        {/*    className="width-4"*/}
-        {/*    placeholder="auto"*/}
-        {/*    type="string"*/}
-        {/*    defaultValue={query.exemplars}*/}
-        {/*    onCommitChange={onExemplarsChange}*/}
-        {/*    value={query.exemplars}*/}
-        {/*  />*/}
-        {/*</EditorField>*/}
-      </QueryOptionGroup>
-    </div>
+        <QueryOptionGroup title="Metrics Options" collapsedInfo={collapsedMetricsOptions}>
+          <EditorField
+            label="Step"
+            tooltip="Defines the step for metric queries. Use duration notation, for example 30s or 1m"
+          >
+            <AutoSizeInput
+              className="width-4"
+              placeholder="auto"
+              type="string"
+              defaultValue={query.step}
+              onCommitChange={onStepChange}
+              value={query.step}
+            />
+          </EditorField>
+          {/*<EditorField*/}
+          {/*  label="Exemplars"*/}
+          {/*  tooltip="Defines the amount of exemplars to request for metric queries. A value of 0 means no exemplars."*/}
+          {/*>*/}
+          {/*  <AutoSizeInput*/}
+          {/*    className="width-4"*/}
+          {/*    placeholder="auto"*/}
+          {/*    type="string"*/}
+          {/*    defaultValue={query.exemplars}*/}
+          {/*    onCommitChange={onExemplarsChange}*/}
+          {/*    value={query.exemplars}*/}
+          {/*  />*/}
+          {/*</EditorField>*/}
+        </QueryOptionGroup>
+      </div>
+    </EditorRow>
   );
 });
 


### PR DESCRIPTION
**What is this feature?**

Adds separate options groups to the Tempo query editor.

**Why do we need this feature?**

As the functionality for search and metrics queries grows, so does the options and so we need a tidier way to display these options without confusing users.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

![Screenshot 2025-01-21 at 11 27 44](https://github.com/user-attachments/assets/f85cbeed-cfeb-4c66-869b-9473b9caa3fb)
