### PR TITLE
Alerting docs: add Admonitions to Link Doc pages with practical Tutorials

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/_index.md
+++ b/docs/sources/alerting/alerting-rules/templates/_index.md
@@ -218,3 +218,7 @@ For further details on how to template alert rules, refer to:
 
 - [Annotation and label template reference](ref:alert-rule-template-reference)
 - [Annotation and label examples](ref:alert-rule-template-examples)
+
+{{< admonition type="tip" >}}
+For a practical example of templating, refer to our [Getting Started with Templating tutorial](https://grafana.com/tutorials/alerting-get-started-pt4/).
+{{< /admonition  >}}

--- a/docs/sources/alerting/configure-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/_index.md
@@ -108,3 +108,7 @@ For further details on how to write notification templates, refer to:
 - [Select, create, and preview a notification template](ref:manage-notification-templates)
 - [Notification template reference](ref:reference)
 - [Notification template examples](ref:examples)
+
+{{< admonition type="tip" >}}
+For a practical example of templating, refer to our [Getting Started with Templating tutorial](https://grafana.com/tutorials/alerting-get-started-pt4/).
+{{< /admonition  >}}

--- a/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
+++ b/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
@@ -35,6 +35,10 @@ refs:
 
 Grouping in Grafana Alerting allows you to batch relevant alerts together into a smaller number of notifications. This is particularly important if notifications are delivered to first-responders, such as engineers on-call, where receiving lots of notifications in a short period of time can be overwhelming. In some cases, it can negatively impact a first-responders ability to respond to an incident. For example, consider a large outage where many of your systems are down. In this case, grouping can be the difference between receiving 1 phone call and 100 phone calls.
 
+{{< admonition type="tip" >}}
+For a practical example of grouping, refer to our [Getting Started with Grouping tutorial](https://grafana.com/tutorials/alerting-get-started-pt3/).
+{{< /admonition  >}}
+
 ## Group notifications
 
 Grouping combines similar alert instances within a specific period into a single notification, reducing alert noise.

--- a/docs/sources/alerting/fundamentals/notifications/notification-policies.md
+++ b/docs/sources/alerting/fundamentals/notifications/notification-policies.md
@@ -75,6 +75,10 @@ Each policy consists of a set of label matchers (0 or more) that specify which a
 
 {{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Matching alert instances with notification policies" alt="Example of a notification policy tree" >}}
 
+{{< admonition type="tip" >}}
+For a practical example of routing with notification policies, refer to our [Getting Started with Alert Instances and Notification Routing tutorial](https://grafana.com/tutorials/alerting-get-started-pt4/).
+{{< /admonition  >}}
+
 ## Routing
 
 To determine which notification policies handle an alert instance, the system looks for matching policies starting from the top of the tree—beginning with the default notification policy.

--- a/docs/sources/alerting/fundamentals/templates.md
+++ b/docs/sources/alerting/fundamentals/templates.md
@@ -69,6 +69,10 @@ In Grafana, you have various options to template your alert notification message
    - Template notifications when you want to customize the appearance and information of your notifications.
    - Avoid using notification templates to add extra information to alert instances—use annotations instead.
 
+{{< admonition type="tip" >}}
+For a practical example of templating, refer to our [Getting Started with Templating tutorial](https://grafana.com/tutorials/alerting-get-started-pt4/).
+{{< /admonition  >}}
+
 This diagram illustrates the entire templating process, from querying labels and templating the alert summary and notification to the final alert notification message.
 
 {{< figure src="/media/docs/alerting/how-notification-templates-works.png" max-width="1200px" caption="How templating works" >}}


### PR DESCRIPTION
With the launch of our new Alerting tutorials, this PR adds admonitions in the respective documentation pages to guide readers to their related tutorials for better discoverability. 

![Screenshot 2025-01-21 at 13 44 23](https://github.com/user-attachments/assets/baf2de94-e8b9-4ef5-bd89-b02ff6e7b836)

![Screenshot 2025-01-21 at 13 44 15](https://github.com/user-attachments/assets/2456aa1e-ad9c-4487-bdbb-dc34b3084e13)

![Screenshot 2025-01-21 at 13 44 10](https://github.com/user-attachments/assets/9df0af12-c758-429c-924d-5e93cc61ee44)



