### PR TITLE
Logs Volume: Do not throw when fields are missing

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -303,7 +303,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         }
       });
     }
-  }, [hiddenLogLevels, logsVolumeData, logsVolumeEnabled, register, unregisterAllChildren]);
+  }, [logsVolumeData, unregisterAllChildren, logsVolumeEnabled, hiddenLogLevels, register, toggleLegendRef]);
 
   useEffect(() => {
     if (getPinnedLogsCount() === PINNED_LOGS_LIMIT) {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -246,11 +246,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   }, [outlineItems]);
 
   const registerLogLevelsWithContentOutline = useCallback(() => {
-    if (!logsVolumeData) {
-      return;
-    }
     const levelsArr = Object.keys(LogLevelColor);
-    const logVolumeDataFrames = new Set(logsVolumeData.data);
+    const logVolumeDataFrames = new Set(logsVolumeData?.data);
     // TODO remove this once filtering multiple log volumes is supported
     const logVolData = logsVolumeData?.data.filter(
       (frame: DataFrame) => frame.meta?.dataTopic !== DataTopic.Annotations
@@ -269,7 +266,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     // check if we have dataFrames that return the same level
     const logLevelsArray: Array<{ levelStr: string; logLevel: LogLevel }> = [];
     logVolumeDataFrames.forEach((dataFrame) => {
-      const { level } = getLogLevelInfo(dataFrame, logsVolumeData.data);
+      const { level } = getLogLevelInfo(dataFrame, logsVolumeData?.data ?? []);
       logLevelsArray.push({ levelStr: level, logLevel: getLogLevel(level) });
     });
 
@@ -303,7 +300,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         }
       });
     }
-  }, [logsVolumeData, unregisterAllChildren, logsVolumeEnabled, hiddenLogLevels, register, toggleLegendRef]);
+  }, [logsVolumeData?.data, unregisterAllChildren, logsVolumeEnabled, hiddenLogLevels, register, toggleLegendRef]);
 
   useEffect(() => {
     if (getPinnedLogsCount() === PINNED_LOGS_LIMIT) {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -246,8 +246,11 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   }, [outlineItems]);
 
   const registerLogLevelsWithContentOutline = useCallback(() => {
+    if (!logsVolumeData) {
+      return;
+    }
     const levelsArr = Object.keys(LogLevelColor);
-    const logVolumeDataFrames = new Set(logsVolumeData?.data);
+    const logVolumeDataFrames = new Set(logsVolumeData.data);
     // TODO remove this once filtering multiple log volumes is supported
     const logVolData = logsVolumeData?.data.filter(
       (frame: DataFrame) => frame.meta?.dataTopic !== DataTopic.Annotations
@@ -266,7 +269,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     // check if we have dataFrames that return the same level
     const logLevelsArray: Array<{ levelStr: string; logLevel: LogLevel }> = [];
     logVolumeDataFrames.forEach((dataFrame) => {
-      const { level } = getLogLevelInfo(dataFrame);
+      const { level } = getLogLevelInfo(dataFrame, logsVolumeData.data);
       logLevelsArray.push({ levelStr: level, logLevel: getLogLevel(level) });
     });
 
@@ -300,7 +303,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         }
       });
     }
-  }, [logsVolumeData?.data, unregisterAllChildren, logsVolumeEnabled, hiddenLogLevels, register, toggleLegendRef]);
+  }, [hiddenLogLevels, logsVolumeData, logsVolumeEnabled, register, unregisterAllChildren]);
 
   useEffect(() => {
     if (getPinnedLogsCount() === PINNED_LOGS_LIMIT) {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -300,7 +300,7 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
 
 export function getLogLevelInfo(dataFrame: DataFrame) {
   const fieldCache = new FieldCache(dataFrame);
-  const timeField = undefined;
+  const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -314,7 +314,7 @@ export function getLogLevelInfo(dataFrame: DataFrame) {
     console.error('Value field missing in data frame');
   }
 
-  const level = valueField?.config.displayNameFromDS || dataFrame.name || 'logs';
+  const level = valueField?.config.displayNameFromDS ?? dataFrame.name ?? 'logs';
   const length = valueField?.values.length ?? 0;
   return { level, valueField, timeField, length };
 }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -218,15 +218,16 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
   dataFrames.forEach((dataFrame) => {
     const { level, valueField, timeField, length } = getLogLevelInfo(dataFrame);
 
+    if (!timeField || !valueField) {
+      return;
+    }
+
     configs[level] = {
       meta: dataFrame.meta,
       valueFieldConfig: valueField?.config ?? {},
       timeFieldConfig: timeField?.config ?? {},
     };
 
-    if (!timeField || !valueField) {
-      return;
-    }
     for (let pointIndex = 0; pointIndex < length; pointIndex++) {
       const time: number = timeField.values[pointIndex];
       const value: number = valueField.values[pointIndex];

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -14,6 +14,7 @@ import {
   QueryResultMeta,
   LogsVolumeType,
   NumericLogLevel,
+  getFieldDisplayName,
 } from '@grafana/data';
 
 import { getDataframeFields } from './components/logParser';
@@ -216,7 +217,7 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
 
   // collect and aggregate into aggregated object
   dataFrames.forEach((dataFrame) => {
-    const { level, valueField, timeField } = getLogLevelInfo(dataFrame);
+    const { level, valueField, timeField } = getLogLevelInfo(dataFrame, dataFrames);
 
     if (!timeField || !valueField) {
       return;
@@ -302,7 +303,7 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
   }
 };
 
-export function getLogLevelInfo(dataFrame: DataFrame) {
+export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]) {
   const fieldCache = new FieldCache(dataFrame);
   const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
@@ -314,7 +315,7 @@ export function getLogLevelInfo(dataFrame: DataFrame) {
     console.error('Value field missing in data frame');
   }
 
-  const level = valueField?.config.displayNameFromDS ?? dataFrame.name ?? 'logs';
+  const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';
   return { level, valueField, timeField };
 }
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -220,18 +220,20 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
 
     configs[level] = {
       meta: dataFrame.meta,
-      valueFieldConfig: valueField.config,
-      timeFieldConfig: timeField.config,
+      valueFieldConfig: valueField?.config ?? {},
+      timeFieldConfig: timeField?.config ?? {},
     };
 
-    for (let pointIndex = 0; pointIndex < length; pointIndex++) {
-      const time: number = timeField.values[pointIndex];
-      const value: number = valueField.values[pointIndex];
-      aggregated[level] ??= {};
-      aggregated[level][time] = (aggregated[level][time] || 0) + value;
+    if (timeField && valueField) {
+      for (let pointIndex = 0; pointIndex < length; pointIndex++) {
+        const time: number = timeField.values[pointIndex];
+        const value: number = valueField.values[pointIndex];
+        aggregated[level] ??= {};
+        aggregated[level][time] = (aggregated[level][time] || 0) + value;
 
-      totals[time] = (totals[time] || 0) + value;
-      maximumValue = Math.max(totals[time], maximumValue);
+        totals[time] = (totals[time] || 0) + value;
+        maximumValue = Math.max(totals[time], maximumValue);
+      }
     }
   });
 
@@ -298,18 +300,18 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
 
 export function getLogLevelInfo(dataFrame: DataFrame) {
   const fieldCache = new FieldCache(dataFrame);
-  const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
+  const timeField = undefined;
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    throw new Error('Missing time field');
+    console.error('Time field missing in data frame');
   }
   if (!valueField) {
-    throw new Error('Missing value field');
+    console.error('Value field missing in data frame');
   }
 
-  const level = valueField.config.displayNameFromDS || dataFrame.name || 'logs';
-  const length = valueField.values.length;
+  const level = valueField?.config.displayNameFromDS || dataFrame.name || 'logs';
+  const length = valueField?.values.length ?? 0;
   return { level, valueField, timeField, length };
 }
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -224,17 +224,18 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
       timeFieldConfig: timeField?.config ?? {},
     };
 
-    if (timeField && valueField) {
-      for (let pointIndex = 0; pointIndex < length; pointIndex++) {
-        const time: number = timeField.values[pointIndex];
-        const value: number = valueField.values[pointIndex];
-        aggregated[level] ??= {};
-        aggregated[level][time] = (aggregated[level][time] || 0) + value;
+    if (!timeField || !valueField) {
+      return;
+    }
+    for (let pointIndex = 0; pointIndex < length; pointIndex++) {
+      const time: number = timeField.values[pointIndex];
+      const value: number = valueField.values[pointIndex];
+      aggregated[level] ??= {};
+      aggregated[level][time] = (aggregated[level][time] || 0) + value;
 
-        totals[time] = (totals[time] || 0) + value;
-        if (totals[time] > maximumValue) {
-          maximumValue = totals[time];
-        }
+      totals[time] = (totals[time] || 0) + value;
+      if (totals[time] > maximumValue) {
+        maximumValue = totals[time];
       }
     }
   });

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -216,7 +216,7 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
 
   // collect and aggregate into aggregated object
   dataFrames.forEach((dataFrame) => {
-    const { level, valueField, timeField, length } = getLogLevelInfo(dataFrame);
+    const { level, valueField, timeField } = getLogLevelInfo(dataFrame);
 
     if (!timeField || !valueField) {
       return;
@@ -228,7 +228,7 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
       timeFieldConfig: timeField?.config ?? {},
     };
 
-    for (let pointIndex = 0; pointIndex < length; pointIndex++) {
+    for (let pointIndex = 0; pointIndex < dataFrame.length; pointIndex++) {
       const time: number = timeField.values[pointIndex];
       const value: number = valueField.values[pointIndex];
       aggregated[level] ??= {};
@@ -315,8 +315,7 @@ export function getLogLevelInfo(dataFrame: DataFrame) {
   }
 
   const level = valueField?.config.displayNameFromDS ?? dataFrame.name ?? 'logs';
-  const length = valueField?.values.length ?? 0;
-  return { level, valueField, timeField, length };
+  return { level, valueField, timeField };
 }
 
 export function targetIsElement(target: EventTarget | null): target is Element {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -232,7 +232,9 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
         aggregated[level][time] = (aggregated[level][time] || 0) + value;
 
         totals[time] = (totals[time] || 0) + value;
-        maximumValue = Math.max(totals[time], maximumValue);
+        if (totals[time] > maximumValue) {
+          maximumValue = totals[time];
+        }
       }
     }
   });


### PR DESCRIPTION
Missing fields would cause exceptions when processing logs volume frames. After these changes, the panel will show no data and will output an error to the console.

![Volume](https://github.com/user-attachments/assets/d7216896-a396-4980-a42c-e48f9839cff2)

![Console](https://github.com/user-attachments/assets/c2d633fb-f279-49ca-b525-e9dd83405806)

This allows for a more graceful handling of incorrect data, without breaking the UI for the user.