### PR TITLE
[Prometheus]: Mark ALERTS synthetic metric as a gauge

### DIFF
--- a/packages/grafana-prometheus/src/language_utils.test.ts
+++ b/packages/grafana-prometheus/src/language_utils.test.ts
@@ -91,7 +91,7 @@ describe('parseSelector()', () => {
 describe('fixSummariesMetadata', () => {
   const synthetics = {
     ALERTS: {
-      type: 'counter',
+      type: 'gauge',
       help: 'Time series showing pending and firing alerts. The sample value is set to 1 as long as the alert is in the indicated active (pending or firing) state.',
     },
   };

--- a/packages/grafana-prometheus/src/language_utils.ts
+++ b/packages/grafana-prometheus/src/language_utils.ts
@@ -323,7 +323,7 @@ export function fixSummariesMetadata(metadata: { [metric: string]: PromMetricsMe
   // Synthetic series
   const syntheticMetadata: PromMetricsMetadata = {};
   syntheticMetadata['ALERTS'] = {
-    type: 'counter',
+    type: 'gauge',
     help: 'Time series showing pending and firing alerts. The sample value is set to 1 as long as the alert is in the indicated active (pending or firing) state.',
   };
 


### PR DESCRIPTION
It's not a counter. It can go down in value, but counters cannot


I'm using the `ALERTS` metric, and I'm seeing a message:
```
Selected metric is a counter. Consider calculating rate of counter by adding rate().
```
I'm kinda confused - why is this a `counter`? Shouldn't it be a `gauge`? It moves to `1` when a specific alert (with a specific set of labels) start to fire, and then back to `0` when that alert stops firing. Don't counters always go up, and never down?

![image (11)](https://github.com/user-attachments/assets/9ba345bb-af06-4986-8c9c-941eb104a0e4)
