### PR TITLE
chore: Use non-zero version to reference github.com/grafana/grafana Go module

### DIFF
--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -5,7 +5,7 @@ go 1.23.5
 replace github.com/grafana/grafana => ../../..
 
 require (
-	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
+	github.com/grafana/grafana v11.4.0-00010101000000-000000000000+incompatible
 	github.com/grafana/grafana-app-sdk v0.30.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/apiserver v0.32.0

--- a/pkg/storage/unified/apistore/go.mod
+++ b/pkg/storage/unified/apistore/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20250120145936-5f0e28e7a87c
-	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
+	github.com/grafana/grafana v11.4.0-00010101000000-000000000000+incompatible
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250121113133-e747350fee2d
 	github.com/grafana/grafana/pkg/apiserver v0.0.0-20250121113133-e747350fee2d
 	github.com/grafana/grafana/pkg/storage/unified/resource v0.0.0-20250121113133-e747350fee2d

--- a/pkg/storage/unified/resource/go.mod
+++ b/pkg/storage/unified/resource/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grafana/authlib v0.0.0-20250120145936-5f0e28e7a87c
 	github.com/grafana/authlib/types v0.0.0-20250120145936-5f0e28e7a87c
 	github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040
-	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
+	github.com/grafana/grafana v11.4.0-00010101000000-000000000000+incompatible
 	github.com/grafana/grafana-plugin-sdk-go v0.262.0
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250121113133-e747350fee2d
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0


### PR DESCRIPTION
**What is this feature?**

Some vulnerability scanners apparently get confused about this overridden reference to a "v0.0.0-..." version and are marking these modules as vulnerable to CVEs fixed in versions as old as v6. This is an attempt to fix this as I can't actually reproduce this locally.

**Who is this feature for?**

Maintainers