### PR TITLE
Explore metrics: fix flexGrow issue with native histograms banner

### DIFF
--- a/public/app/features/trails/banners/NativeHistogramBanner.tsx
+++ b/public/app/features/trails/banners/NativeHistogramBanner.tsx
@@ -34,6 +34,7 @@ export function NativeHistogramBanner(props: NativeHistogramInfoProps) {
           onRemove={() => {
             setHistogramMessage(false);
           }}
+          className={styles.banner}
         >
           <div className={styles.histogramRow}>
             <div className={styles.histogramSentence}>
@@ -231,6 +232,9 @@ const NativeHistogramExamples = ({ trail, nativeHistograms, setHistogramMessage 
 
 function getStyles(theme: GrafanaTheme2, _chromeHeaderHeight: number) {
   return {
+    banner: css({
+      flexGrow: 0,
+    }),
     histogramRow: css({
       display: 'flex',
       flexDirection: 'row',


### PR DESCRIPTION
Fix to set the flexGrow property at 0 which is automatically applied to banners. The space between the banner and the app will not grow now.

![Screenshot 2025-01-21 at 4 02 45 PM](https://github.com/user-attachments/assets/c7519dbc-cb62-4af1-ba1d-c19009ffa453)


Bug shown here:

https://github.com/user-attachments/assets/bfdd55bb-2ffc-46a6-ab1d-abfe2fb25ec4

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
