### PR TITLE
TableNG: Fix footer calcs with no reducer

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -423,7 +423,8 @@ export function TableNG(props: TableNGProps) {
         return index === 0 ? `Count: ${filteredRows.length}` : '';
       }
       if (index === 0) {
-        return footerOptions ? fieldReducers.get(footerOptions.reducer[0]).name : '';
+        const footerCalcReducer = footerOptions?.reducer[0];
+        return footerCalcReducer ? fieldReducers.get(footerCalcReducer).name : '';
       }
       return getFooterItemNG(filteredRows, field, footerOptions);
     });


### PR DESCRIPTION
When table footer is on and no reducer is selected, the table was crashing. This checks for that.