### PR TITLE
Explore metrics: Add metadata heuristic for native histograms

### DIFF
--- a/public/app/features/trails/helpers/MetricDataSourceHelper.test.ts
+++ b/public/app/features/trails/helpers/MetricDataSourceHelper.test.ts
@@ -41,5 +41,21 @@ describe('MetricDatasourceHelper', () => {
       const result = await metricDatasourceHelper.isNativeHistogram('non_histogram_metric');
       expect(result).toBe(false);
     });
+
+    it('should return false if metric is a classic histogram', async () => {
+      const result = await metricDatasourceHelper.isNativeHistogram('test_metric_bucket');
+      expect(result).toBe(false);
+    });
+
+    it('should return true if metric is a native histogram and has metadata but does not have a classic histogram to compare to', async () => {
+      metricDatasourceHelper._metricsMetadata = {
+        solo_native_histogram: {
+          type: 'histogram',
+          help: 'test',
+        },
+      };
+      const result = await metricDatasourceHelper.isNativeHistogram('solo_native_histogram');
+      expect(result).toBe(true);
+    });
   });
 });

--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -40,8 +40,8 @@ export class MetricDatasourceHelper {
     const ds = await this._datasource;
     return ds;
   }
-
-  _metricsMetadata?: Promise<PromMetricsMetadata | undefined>;
+  // store metadata in a more easily accessible form
+  _metricsMetadata?: PromMetricsMetadata | undefined;
 
   private async _getMetricsMetadata() {
     const ds = await this.getDatasource();
@@ -61,7 +61,7 @@ export class MetricDatasourceHelper {
       return undefined;
     }
     if (!this._metricsMetadata) {
-      this._metricsMetadata = this._getMetricsMetadata();
+      this._metricsMetadata = await this._getMetricsMetadata();
     }
 
     const metadata = await this._metricsMetadata;
@@ -74,9 +74,12 @@ export class MetricDatasourceHelper {
   public listNativeHistograms() {
     return this._nativeHistograms;
   }
+
   /**
-   * Identify native histograms by querying classic histograms and all metrics,
+   * Identify native histograms by 2 strategies.
+   * 1. querying classic histograms and all metrics,
    * then comparing the results and build the collection of native histograms.
+   * 2. querying all metrics and checking if the metric is a histogram type and dies not have the bucket suffix.
    *
    * classic histogram = test_metric_bucket
    * native histogram = test_metric
@@ -93,6 +96,13 @@ export class MetricDatasourceHelper {
         this._classicHistograms[m.text] = 1;
       });
 
+      if (ds.languageProvider instanceof PromQlLanguageProvider) {
+        if (!this._metricsMetadata && !ds.languageProvider.metricsMetadata) {
+          await ds.languageProvider.loadMetricsMetadata();
+          this._metricsMetadata = ds.languageProvider.metricsMetadata;
+        }
+      }
+
       allMetrics.forEach((m) => {
         if (this.isNativeHistogram(m.text)) {
           // Build the collection of native histograms.
@@ -103,19 +113,33 @@ export class MetricDatasourceHelper {
   }
 
   /**
-   *
-   * If a metric name + _bucket exists in the classic histograms, then it is a native histogram
+   * Identify native histograms by 2 strategies.
+   * 1. querying classic histograms and all metrics,
+   * then comparing the results and build the collection of native histograms.
+   * 2. querying all metrics and checking if the metric is a histogram type and dies not have the bucket suffix.
    *
    * classic histogram = test_metric_bucket
    * native histogram = test_metric
+   *
    * @param metric
-   * @returns
+   * @returns boolean
    */
   public isNativeHistogram(metric: string): boolean {
     if (!metric) {
       return false;
     }
 
+    // check when fully migrated, we only have metadata, and there are no more classic histograms
+    const metadata = this._metricsMetadata;
+    // suffix is not 'bucket' and type is histogram
+    const suffix: string = metric.split('_').pop() ?? '';
+    // the string is not equal to bucket
+    const notClassic = suffix !== 'bucket';
+    if (metadata && metadata[metric] && metadata[metric].type === 'histogram' && notClassic) {
+      return true;
+    }
+
+    // check for comparison when there is overlap between native and classic histograms
     if (this._classicHistograms[`${metric}_bucket`]) {
       return true;
     }


### PR DESCRIPTION
Check that a metric is a native histogram with metadata present.

![Screenshot 2025-01-21 at 6 04 05 PM](https://github.com/user-attachments/assets/6d6ffb0a-b034-4026-ac3b-1e3b80e2256f)


A native histogram has a type of 'histogram' and does not have the suffix 'bucket.'

Notes for reviewers:

It can be challenging to find a Prometheus data source that has native histograms with the type defined. Please contact @bohandley and I have credentials to a data source that has a type defined for a native histogram.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
