### PR TITLE
Dashboard: Simplify repeating logic and panel menu interaction

### DIFF
--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
@@ -16,9 +16,10 @@ import {
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { activateFullSceneTree } from '../utils/test-utils';
+import { isReadOnlyClone } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
-import { panelMenuBehavior, repeatPanelMenuBehavior } from './PanelMenuBehavior';
+import { panelMenuBehavior } from './PanelMenuBehavior';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { DashboardGridItem, RepeatDirection } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
@@ -67,6 +68,13 @@ describe('RowRepeaterBehavior', () => {
       // Should give repeated panels unique keys
       const gridItem = row2.state.children[0] as SceneGridItem;
       expect(gridItem.state.body?.state.key).toBe('canvas-1-clone-B1');
+    });
+
+    it('Repeated rows should be read only', () => {
+      const row1 = grid.state.children[1] as SceneGridRow;
+      const row2 = grid.state.children[2] as SceneGridRow;
+      expect(isReadOnlyClone(row1)).toBe(false);
+      expect(isReadOnlyClone(row2)).toBe(true);
     });
 
     it('Should update all rows when a panel is added to a clone', async () => {
@@ -165,50 +173,6 @@ describe('RowRepeaterBehavior', () => {
       expect(notifyPanelsSpy).toHaveBeenCalledTimes(1);
 
       notifyPanelsSpy.mockRestore();
-    });
-  });
-
-  describe('Given scene with DashboardGridItem', () => {
-    let scene: DashboardScene;
-    let grid: SceneGridLayout;
-    let rowToRepeat: SceneGridRow;
-
-    beforeEach(async () => {
-      const menu = new VizPanelMenu({
-        $behaviors: [panelMenuBehavior],
-      });
-
-      ({ scene, grid, rowToRepeat } = buildScene({ variableQueryTime: 0 }));
-      const panel = new VizPanel({ pluginId: 'text', menu });
-      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
-
-      rowToRepeat.setState({
-        children: [
-          new DashboardGridItem({
-            body: panel,
-          }),
-        ],
-      });
-
-      activateFullSceneTree(scene);
-      await new Promise((r) => setTimeout(r, 1));
-    });
-
-    it('Should set repeat specific panel menu for repeated rows but not original one', () => {
-      const row1 = grid.state.children[1] as SceneGridRow;
-      const row2 = grid.state.children[2] as SceneGridRow;
-      const panelMenuBehaviorOriginal = (
-        ((row1.state.children[0] as DashboardGridItem).state.body as VizPanel).state.menu as VizPanelMenu
-      ).state.$behaviors;
-      const panelMenuBehaviorClone = (
-        ((row2.state.children[0] as DashboardGridItem).state.body as VizPanel).state.menu as VizPanelMenu
-      ).state.$behaviors;
-
-      expect(panelMenuBehaviorOriginal).toBeDefined();
-      expect(panelMenuBehaviorOriginal![0]).toBe(panelMenuBehavior);
-
-      expect(panelMenuBehaviorClone).toBeDefined();
-      expect(panelMenuBehaviorClone![0]).toBe(repeatPanelMenuBehavior);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
@@ -10,8 +10,6 @@ import {
   SceneVariableSet,
   TestVariable,
   VariableValueOption,
-  VizPanel,
-  VizPanelMenu,
 } from '@grafana/scenes';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
@@ -19,9 +17,8 @@ import { activateFullSceneTree } from '../utils/test-utils';
 import { isReadOnlyClone } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
-import { panelMenuBehavior } from './PanelMenuBehavior';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
-import { DashboardGridItem, RepeatDirection } from './layout-default/DashboardGridItem';
+import { RepeatDirection } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { RowActions } from './row-actions/RowActions';
 

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
@@ -13,12 +13,10 @@ import {
   SceneVariableSet,
   VariableDependencyConfig,
   VariableValueSingle,
-  VizPanelMenu,
 } from '@grafana/scenes';
 
 import { getMultiVariableValues, getQueryRunnerFor } from '../utils/utils';
 
-import { repeatPanelMenuBehavior } from './PanelMenuBehavior';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DashboardRepeatsProcessedEvent } from './types';
 
@@ -192,15 +190,7 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
 
           //disallow clones to be dragged around or out of the row
           if (itemClone instanceof DashboardGridItem) {
-            itemClone.setState({
-              isDraggable: false,
-            });
-
-            itemClone.state.body.setState({
-              menu: new VizPanelMenu({
-                $behaviors: [repeatPanelMenuBehavior],
-              }),
-            });
+            itemClone.setState({ isDraggable: false });
           }
         }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
@@ -5,6 +5,7 @@ import { SceneGridLayout, SceneVariableSet, TestVariable, VizPanel } from '@graf
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { activateFullSceneTree, buildPanelRepeaterScene } from '../../utils/test-utils';
+import { isReadOnlyClone } from '../../utils/utils';
 import { DashboardScene } from '../DashboardScene';
 
 import { DashboardGridItem, DashboardGridItemState } from './DashboardGridItem';
@@ -41,6 +42,9 @@ describe('PanelRepeaterGridItem', () => {
     expect(panel1.state.$variables?.state.variables[0].getValue()).toBe('1');
     expect(panel1.state.$variables?.state.variables[0].getValueText?.()).toBe('A');
     expect(panel2.state.$variables?.state.variables[0].getValue()).toBe('2');
+
+    expect(isReadOnlyClone(panel1)).toBe(false);
+    expect(isReadOnlyClone(panel2)).toBe(true);
   });
 
   it('Should wait for variable to load', async () => {

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -15,7 +15,6 @@ import {
   MultiValueVariable,
   LocalValueVariable,
   CustomVariable,
-  VizPanelMenu,
   VizPanelState,
   VariableValueSingle,
   SceneVariable,
@@ -25,7 +24,6 @@ import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
 import { getMultiVariableValues, getQueryRunnerFor } from '../../utils/utils';
-import { repeatPanelMenuBehavior } from '../PanelMenuBehavior';
 import { DashboardLayoutItem, DashboardRepeatsProcessedEvent } from '../types';
 
 import { getDashboardGridItemOptions } from './DashboardGridItemEditor';
@@ -142,11 +140,6 @@ export class DashboardGridItem
         }),
         key: `${panelToRepeat.state.key}-clone-${index}`,
       };
-      if (index > 0) {
-        cloneState.menu = new VizPanelMenu({
-          $behaviors: [repeatPanelMenuBehavior],
-        });
-      }
       const clone = panelToRepeat.clone(cloneState);
       repeatedPanels.push(clone);
     }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -236,11 +236,6 @@ export function isReadOnlyClone(sceneObject: SceneObject): boolean {
   return false;
 }
 
-/**
- * Just a behavior that does nothing, used to mark an object as read only clone
- */
-export function readOnlyCloneBehavior(sceneObject: SceneObject) {}
-
 export function getDefaultVizPanel(): VizPanel {
   return new VizPanel({
     title: 'Panel Title',

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -216,6 +216,31 @@ export function isPanelClone(key: string) {
   return key.includes('clone');
 }
 
+/**
+ * Recursivly check the scene graph up until it finds a read only clone.
+ * If the key contains clone-0 it is the reference object and can be edited
+ */
+export function isReadOnlyClone(sceneObject: SceneObject): boolean {
+  const key = sceneObject.state.key!;
+
+  // Regular expression to match 'clone-' followed by a number, but not 'clone-0' as the is the reference object
+  const pattern = /clone-(?!0)/;
+  if (pattern.test(key)) {
+    return true;
+  }
+
+  if (sceneObject.parent) {
+    return isReadOnlyClone(sceneObject.parent);
+  }
+
+  return false;
+}
+
+/**
+ * Just a behavior that does nothing, used to mark an object as read only clone
+ */
+export function readOnlyCloneBehavior(sceneObject: SceneObject) {}
+
 export function getDefaultVizPanel(): VizPanel {
   return new VizPanel({
     title: 'Panel Title',


### PR DESCRIPTION
Was reviewing https://github.com/grafana/grafana/pull/99300 and the repeat logic for the new RowItem and found the need to know about the row's internal layout (to modify panels and add repeatPanelMenuBehavior). This felt unnecessary, the panel should be able to figure out if it's below a read-only repeated object without having a special behavior by just walking up the scene graph and checking for a repeated panel or row. 

 https://github.com/grafana/grafana/pull/99300/files#diff-4a6f6aedde9bf74d72afe2d25ccae721551aeb31f9f7f3ba8c5d22837f18db27R112 