### PR TITLE
Explore: Prevent hidden queries from being run as supplementary query

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -353,6 +353,20 @@ describe('ElasticDatasource', () => {
       ).toEqual(undefined);
     });
 
+    it('does not return logs volume query for hidden query', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume },
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1' }],
+            query: 'foo="bar"',
+            hide: true,
+          }
+        )
+      ).toEqual(undefined);
+    });
+
     it('returns logs volume query for log query', () => {
       expect(
         ds.getSupplementaryQuery(
@@ -417,6 +431,20 @@ describe('ElasticDatasource', () => {
         metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
       });
     });
+
+    it('does not return logs samples for hidden time series queries', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsSample, limit: 100 },
+          {
+            refId: 'A',
+            query: '',
+            bucketAggs: [{ type: 'date_histogram', id: '1' }],
+            hide: true,
+          }
+        )
+      ).toEqual(undefined);
+    });
   });
 
   describe('getDataProvider', () => {
@@ -432,6 +460,21 @@ describe('ElasticDatasource', () => {
       };
 
       expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
+    });
+
+    it('does not create a logs volume provider for hidden queries', () => {
+      const options: DataQueryRequest<ElasticsearchQuery> = {
+        ...dataQueryDefaults,
+        targets: [
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
+            hide: true,
+          },
+        ],
+      };
+
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
     });
 
     it('does create a logs sample provider for time series query', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -595,6 +595,10 @@ export class ElasticDatasource
   getSupplementaryQuery(options: SupplementaryQueryOptions, query: ElasticsearchQuery): ElasticsearchQuery | undefined {
     let isQuerySuitable = false;
 
+    if (query.hide) {
+      return undefined;
+    }
+
     switch (options.type) {
       case SupplementaryQueryType.LogsVolume:
         // it has to be a logs-producing range-query

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1414,6 +1414,15 @@ describe('LokiDatasource', () => {
       expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
     });
 
+    it('does not create provider for hidden logs query', () => {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
+        targets: [{ expr: '{label="value"}', refId: 'A', queryType: LokiQueryType.Range, hide: true }],
+      };
+
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
+    });
+
     it('does not create provider for metrics query', () => {
       const options: DataQueryRequest<LokiQuery> = {
         ...baseRequestOptions,
@@ -1526,7 +1535,21 @@ describe('LokiDatasource', () => {
         });
       });
 
-      it('does return logs volume query for instant log query', () => {
+      it('does not return logs volume query for hidden log query', () => {
+        expect(
+          ds.getSupplementaryQuery(
+            { type: SupplementaryQueryType.LogsVolume },
+            {
+              expr: '{label="value"}',
+              queryType: LokiQueryType.Range,
+              refId: 'A',
+              hide: true,
+            }
+          )
+        ).toEqual(undefined);
+      });
+
+      it('returns logs volume query for instant log query', () => {
         // we changed logic to automatically run logs queries as range queries, thus there's a volume query now
         expect(
           ds.getSupplementaryQuery(
@@ -1603,6 +1626,20 @@ describe('LokiDatasource', () => {
           maxLines: 20,
           supportingQueryType: SupportingQueryType.LogsSample,
         });
+      });
+
+      it('does not return logs sample query for hidden query', () => {
+        expect(
+          ds.getSupplementaryQuery(
+            { type: SupplementaryQueryType.LogsSample },
+            {
+              expr: 'rate({label="value"}[5m]',
+              queryType: LokiQueryType.Range,
+              refId: 'A',
+              hide: true,
+            }
+          )
+        ).toEqual(undefined);
       });
 
       it('returns logs sample query for instant metric query', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -206,6 +206,10 @@ export class LokiDatasource
    * @returns A supplemented Loki query or undefined if unsupported.
    */
   getSupplementaryQuery(options: SupplementaryQueryOptions, query: LokiQuery): LokiQuery | undefined {
+    if (query.hide) {
+      return undefined;
+    }
+
     const normalizedQuery = getNormalizedLokiQuery(query);
     let expr = removeCommentsFromQuery(normalizedQuery.expr);
     let isQuerySuitable = false;


### PR DESCRIPTION
**What is this feature?**

When using mixed data source, hidden queries are not excluded from supplementary queries:
https://play.grafana.org/explore?schemaVersion=1&panes=%7B%226zp%22:%7B%22datasource%22:%22--%20Mixed%20--%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcluster%3D%5C%22do-nyc1-demo-infra%5C%22%7D%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22uid%22:%22grafanacloud-demoinfra-logs%22,%22type%22:%22loki%22%7D,%22editorMode%22:%22code%22,%22direction%22:%22forward%22,%22hide%22:true%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%7Bcluster%3D%5C%22eu-west-1%5C%22%7D%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22ddhr3fttaw8aod%22%7D,%22editorMode%22:%22code%22,%22direction%22:%22forward%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22visualisationType%22:%22logs%22%7D%7D%7D%7D&orgId=1

![image](https://github.com/user-attachments/assets/f1277a21-479e-4b96-a43b-339ce47cd690)

This PR filters supplementary queries that are hidden in Elasticsearch and Loki.