### PR TITLE
Dashboards: Update `POST /api/dashboards/db` docs

### DIFF
--- a/docs/sources/developers/http_api/dashboard.md
+++ b/docs/sources/developers/http_api/dashboard.md
@@ -139,7 +139,6 @@ The **412** status code is used for explaining that you cannot create the dashbo
 There can be different reasons for this:
 
 - The dashboard has been changed by someone else, `status=version-mismatch`
-- A dashboard with the same name in the folder already exists, `status=name-exists`
 - A dashboard with the same uid already exists, `status=name-exists`
 - The dashboard belongs to plugin `<plugin title>`, `status=plugin-dashboard`
 
@@ -155,8 +154,6 @@ Content-Length: 97
   "status": "version-mismatch"
 }
 ```
-
-In case of title already exists the `status` property will be `name-exists`.
 
 ## Get dashboard by uid
 


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/97011 and https://github.com/grafana/grafana/pull/90687

We no longer have the dashboard name unique constraint - this part of docs was no longer valid