### PR TITLE
Panel inspect: Fix inspect keyboard shortcut when grafana served from subpath

### DIFF
--- a/e2e/dashboards-suite/dashboard-keybindings.spec.ts
+++ b/e2e/dashboards-suite/dashboard-keybindings.spec.ts
@@ -21,4 +21,12 @@ describe('Dashboard keybindings', () => {
     e2e.components.Panels.Panel.title('server = A, pod = Bob').should('be.visible');
     e2e.components.Panels.Panel.title('server = B, pod = Bob').should('be.visible');
   });
+
+  it('should open panel inspect', () => {
+    e2e.flows.openDashboard({ uid: 'edediimbjhdz4b/a-tall-dashboard' });
+    e2e.components.Panels.Panel.title('Panel #1').type('i');
+    e2e.components.PanelInspector.Json.content().should('be.visible');
+    cy.get('body').type('{esc}');
+    e2e.components.PanelInspector.Json.content().should('not.exist');
+  });
 });

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -105,7 +105,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   keybindings.addBinding({
     key: 'i',
     onTrigger: withFocusedPanel(scene, async (vizPanel: VizPanel) => {
-      locationService.push(getInspectUrl(vizPanel));
+      locationService.push(locationUtil.stripBaseFromUrl(getInspectUrl(vizPanel)));
     }),
   });
 


### PR DESCRIPTION
Discovered this accidentally, hasn't been working for a while. 