### PR TITLE
Recommend mode 5 in Github prototype

### DIFF
--- a/public/app/features/provisioning/SetupWarnings.tsx
+++ b/public/app/features/provisioning/SetupWarnings.tsx
@@ -29,10 +29,10 @@ kubernetesFoldersServiceV2 = true
 grafanaAPIServerEnsureKubectlAccess = true
 
 [unified_storage.dashboards.dashboard.grafana.app]
-dualWriterMode = 3
+dualWriterMode = 5
 
 [unified_storage.folders.folder.grafana.app]
-dualWriterMode = 3
+dualWriterMode = 5
 
 # For Github webhook support, you will need something like:
 [server]


### PR DESCRIPTION
Recommend mode 5 in prototype (unified storage only) as it's the mode we want to make sure that it works well enough to support this Github integration.
