### PR TITLE
Folder: delete from folder table after children

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -1246,7 +1246,7 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 	for _, f := range descendants {
 		descendantUIDs = append(descendantUIDs, f.UID)
 	}
-	s.log.InfoContext(ctx, "deleting folder and its descendants", "org_id", cmd.OrgID, "uid", cmd.UID)
+	s.log.InfoContext(ctx, "deleting folder descendants", "org_id", cmd.OrgID, "uid", cmd.UID)
 
 	err = s.store.Delete(ctx, descendantUIDs, cmd.OrgID)
 	if err != nil {

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -992,6 +992,12 @@ func (s *Service) DeleteLegacy(ctx context.Context, cmd *folder.DeleteFolderComm
 			}
 		}
 
+		err = s.store.Delete(ctx, []string{cmd.UID}, cmd.OrgID)
+		if err != nil {
+			s.log.InfoContext(ctx, "failed deleting folder", "org_id", cmd.OrgID, "uid", cmd.UID, "err", err)
+			return err
+		}
+
 		if err = s.legacyDelete(ctx, cmd, folders); err != nil {
 			return err
 		}
@@ -1241,10 +1247,10 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 		descendantUIDs = append(descendantUIDs, f.UID)
 	}
 	s.log.InfoContext(ctx, "deleting folder and its descendants", "org_id", cmd.OrgID, "uid", cmd.UID)
-	toDelete := append(descendantUIDs, cmd.UID)
-	err = s.store.Delete(ctx, toDelete, cmd.OrgID)
+
+	err = s.store.Delete(ctx, descendantUIDs, cmd.OrgID)
 	if err != nil {
-		s.log.InfoContext(ctx, "failed deleting folder", "org_id", cmd.OrgID, "uid", cmd.UID, "err", err)
+		s.log.InfoContext(ctx, "failed deleting descendants", "org_id", cmd.OrgID, "parent_uid", cmd.UID, "err", err)
 		return descendantUIDs, err
 	}
 	return descendantUIDs, nil


### PR DESCRIPTION
**What is this feature?**

This PR changes the flow of the deletion logic when deleting a folder. Currently, it first deletes the folder from the folder table, along with its decedents. It then proceeds to delete children (such as alert rules & library elements) that are registered to be deleted alongside the folder (if the flag is passed in), and finally deletes the folders from the dashboard table.

The children deletes currently work with the guardian, because the guardian is checking the dashboard table for the folder row, rather than the folder table. But, we need to change the guardian to check the folders instead, [see here](https://github.com/grafana/grafana/pull/99339/files). However, with the current flow, this will fails because the folder has already been deleted from the folder table (but still exists in the dashboard table). This PR moves the deletion logic to be in-line with how the folder is being deleted in the dashboard table, to delete it last as well.

**Why do we need this feature?**

As we move folders to app platform, we need to be able to get the folders through the folder service in the guardian, rather than through the dashboard table, as they will eventually stop being saved there. 