### PR TITLE
fix: set repository name in jobs

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -470,7 +470,8 @@ func (r *githubRepository) parsePushEvent(event *github.PushEvent) (*provisionin
 	return &provisioning.WebhookResponse{
 		Code: http.StatusAccepted,
 		Job: &provisioning.JobSpec{
-			Action: provisioning.JobActionSync,
+			Repository: r.Config().GetName(),
+			Action:     provisioning.JobActionSync,
 		},
 	}, nil
 }
@@ -519,11 +520,12 @@ func (r *githubRepository) parsePullRequestEvent(event *github.PullRequestEvent)
 		Code:    http.StatusAccepted, // Nothing needed
 		Message: fmt.Sprintf("pull request: %s", action),
 		Job: &provisioning.JobSpec{
-			Action: provisioning.JobActionPullRequest,
-			URL:    pr.GetHTMLURL(),
-			PR:     pr.GetNumber(),
-			Ref:    pr.GetHead().GetRef(),
-			Hash:   pr.GetHead().GetSHA(),
+			Repository: r.Config().GetName(),
+			Action:     provisioning.JobActionPullRequest,
+			URL:        pr.GetHTMLURL(),
+			PR:         pr.GetNumber(),
+			Ref:        pr.GetHead().GetRef(),
+			Hash:       pr.GetHead().GetSHA(),
 		},
 	}, nil
 }

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
@@ -65,11 +66,12 @@ func TestParseWebhooks(t *testing.T) {
 		{"pull_request", "opened", provisioning.WebhookResponse{
 			Code: http.StatusAccepted, // 202
 			Job: &provisioning.JobSpec{
-				Action: provisioning.JobActionPullRequest,
-				Ref:    "dashboard/1733653266690",
-				Hash:   "ab5446a53df9e5f8bdeed52250f51fad08e822bc",
-				PR:     12,
-				URL:    "https://github.com/grafana/git-ui-sync-demo/pull/12",
+				Repository: "unit-test-repo",
+				Action:     provisioning.JobActionPullRequest,
+				Ref:        "dashboard/1733653266690",
+				Hash:       "ab5446a53df9e5f8bdeed52250f51fad08e822bc",
+				PR:         12,
+				URL:        "https://github.com/grafana/git-ui-sync-demo/pull/12",
 			},
 		}},
 		{"push", "different_branch", provisioning.WebhookResponse{
@@ -78,13 +80,15 @@ func TestParseWebhooks(t *testing.T) {
 		{"push", "nothing_relevant", provisioning.WebhookResponse{
 			Code: http.StatusAccepted,
 			Job: &provisioning.JobSpec{ // we want to always push a sync job
-				Action: provisioning.JobActionSync,
+				Repository: "unit-test-repo",
+				Action:     provisioning.JobActionSync,
 			},
 		}},
 		{"push", "nested", provisioning.WebhookResponse{
 			Code: http.StatusAccepted,
 			Job: &provisioning.JobSpec{
-				Action: provisioning.JobActionSync,
+				Repository: "unit-test-repo",
+				Action:     provisioning.JobActionSync,
 			},
 		}},
 		{"issue_comment", "created", provisioning.WebhookResponse{
@@ -94,6 +98,9 @@ func TestParseWebhooks(t *testing.T) {
 
 	gh := &githubRepository{
 		config: &provisioning.Repository{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "unit-test-repo",
+			},
 			Spec: provisioning.RepositorySpec{
 				GitHub: &provisioning.GitHubRepositoryConfig{
 					Repository: "git-ui-sync-demo",

--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -346,7 +346,8 @@ func (r *localRepository) Webhook(ctx context.Context, req *http.Request) (*prov
 	return &provisioning.WebhookResponse{
 		Code: http.StatusAccepted,
 		Job: &provisioning.JobSpec{
-			Action: provisioning.JobActionSync, // sync the latest changes
+			Repository: r.Config().GetName(),
+			Action:     provisioning.JobActionSync, // sync the latest changes
 		},
 	}, nil
 }

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -349,7 +349,8 @@ func (rc *RepositoryController) process(item *queueItem) error {
 			},
 		},
 		Spec: provisioning.JobSpec{
-			Action: provisioning.JobActionSync,
+			Repository: cachedRepo.GetName(),
+			Action:     provisioning.JobActionSync,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
We now require the repo name in jobs. Let's actually set it, too...