### PR TITLE
Use tags for `documentation-ci` actions

### DIFF
--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -10,10 +10,10 @@ jobs:
     container:
       image: grafana/vale:latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/vale-action@13205961f20ad13843505a9b84fdf032f911a3f4 # vale-action/v1.1.0
+      - uses: grafana/writers-toolkit/vale-action@vale-action/v1
         with:
           filter: '.Name in ["Grafana.WordList", "Grafana.Spelling", "Grafana.ProductPossessives"]'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trade off a bit of security for a lot of convenience until we have something like Renovate or Dependabot in place
