### PR TITLE
Alerting: Use stack_id instead of id in cloud failures panel in the Insights page

### DIFF
--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getAlertsByStateScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum by (state) (grafanacloud_instance_alertmanager_alerts{id="${INSTANCE_ID}"})`
+    ? `sum by (state) (grafanacloud_instance_alertmanager_alerts{stack_id="${INSTANCE_ID}"})`
     : `sum by (state) (grafanacloud_instance_alertmanager_alerts)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getInvalidConfigScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config{id="${INSTANCE_ID}"})`
+    ? `sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config{stack_id="${INSTANCE_ID}"})`
     : `sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -6,11 +6,11 @@ import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getNotificationsScene(datasource: DataSourceRef, panelTitle: string) {
   const exprA = INSTANCE_ID
-    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second{id="${INSTANCE_ID}"}) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{id="${INSTANCE_ID}"})`
+    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second{stack_id="${INSTANCE_ID}"}) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{stack_id="${INSTANCE_ID}"})`
     : `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)`;
 
   const exprB = INSTANCE_ID
-    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{id="${INSTANCE_ID}"})`
+    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{stack_id="${INSTANCE_ID}"})`
     : `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getSilencesScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum by (state) (grafanacloud_instance_alertmanager_silences{id="${INSTANCE_ID}"})`
+    ? `sum by (state) (grafanacloud_instance_alertmanager_silences{stack_id="${INSTANCE_ID}"})`
     : `sum by (state) (grafanacloud_instance_alertmanager_silences)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRuleGroupEvaluationDurationIntervalRatioScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", stack_id="${INSTANCE_ID}"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", stack_id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRuleGroupEvaluationDurationScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", stack_id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -6,11 +6,11 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRuleGroupEvaluationsScene(datasource: DataSourceRef, panelTitle: string) {
   const exprA = INSTANCE_ID
-    ? `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group", id="${INSTANCE_ID}"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", id="${INSTANCE_ID}"}`
+    ? `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group", stack_id="${INSTANCE_ID}"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", stack_id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
 
   const exprB = INSTANCE_ID
-    ? `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", id="${INSTANCE_ID}"}`
+    ? `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", stack_id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRuleGroupIntervalScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
+    ? `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", stack_id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRulesPerGroupScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group", id="${INSTANCE_ID}"})`
+    ? `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group", stack_id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -6,11 +6,11 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getEvalSuccessVsFailuresScene(datasource: DataSourceRef, panelTitle: string) {
   const exprA = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_evaluations_total:rate5m{id="${INSTANCE_ID}"}) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID}"})`
+    ? `sum(grafanacloud_instance_rule_evaluations_total:rate5m{stack_id="${INSTANCE_ID}"}) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{stack_id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_evaluations_total:rate5m) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)`;
 
   const exprB = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID}"})`
+    ? `sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{stack_id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -6,7 +6,7 @@ import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID}"})`
+    ? `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m{stack_id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)`;
 
   const query = new SceneQueryRunner({


### PR DESCRIPTION
**What is this feature?**

This PR fixes Mimir-managed panel not showing data because we were using id instead of stack_id in the query

<img width="835" alt="Screenshot 2025-01-23 at 11 20 27" src="https://github.com/user-attachments/assets/423af668-553f-4d84-92b0-5da0b942cd9a" />

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

All alerting users.


**Special notes for your reviewer:**



Please check that:


- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
