### PR TITLE
AuzerAD: Handle empty `client_authentication` case

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -373,7 +373,7 @@ func validateClientAuthentication(info *social.OAuthInfo, requester identity.Req
 		}
 		return nil
 
-	case social.ClientSecretPost:
+	case social.ClientSecretPost, "":
 		if info.ClientSecret == "" {
 			return ssosettings.ErrInvalidOAuthConfig("Client secret is required for Client secret authentication.")
 		}


### PR DESCRIPTION
**What is this feature?**
To solve https://github.com/grafana/terraform-provider-grafana/issues/1990 for now we can handle the case when `client_authentication` is an empty string. It gets validated the same way we do for `client_secret_post`,

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
