### PR TITLE
chore: use types rather than claims

### DIFF
--- a/pkg/storage/secret/keeper_store.go
+++ b/pkg/storage/secret/keeper_store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/authlib/claims"
+	claims "github.com/grafana/authlib/types"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
@@ -31,7 +31,7 @@ type keeperStorage struct {
 }
 
 func (s *keeperStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error) {
-	authInfo, ok := claims.From(ctx)
+	authInfo, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -65,7 +65,7 @@ func (s *keeperStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keepe
 }
 
 func (s *keeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error) {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -96,7 +96,7 @@ func (s *keeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secr
 }
 
 func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error) {
-	authInfo, ok := claims.From(ctx)
+	authInfo, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -147,7 +147,7 @@ func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Ke
 }
 
 func (s *keeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
 	}
@@ -168,7 +168,7 @@ func (s *keeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) erro
 }
 
 func (s *keeperStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}

--- a/pkg/storage/secret/secure_value_store.go
+++ b/pkg/storage/secret/secure_value_store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/authlib/claims"
+	claims "github.com/grafana/authlib/types"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
@@ -35,7 +35,7 @@ type secureValueStorage struct {
 }
 
 func (s *secureValueStorage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
-	authInfo, ok := claims.From(ctx)
+	authInfo, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -95,7 +95,7 @@ func (s *secureValueStorage) Read(ctx context.Context, nn xkube.NameNamespace) (
 }
 
 func (s *secureValueStorage) Update(ctx context.Context, newSecureValue *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
-	authInfo, ok := claims.From(ctx)
+	authInfo, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -153,7 +153,7 @@ func (s *secureValueStorage) Update(ctx context.Context, newSecureValue *secretv
 }
 
 func (s *secureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
 	}
@@ -179,7 +179,7 @@ func (s *secureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace)
 }
 
 func (s *secureValueStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error) {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
@@ -223,7 +223,7 @@ func (s *secureValueStorage) List(ctx context.Context, namespace xkube.Namespace
 }
 
 func (s *secureValueStorage) readInternal(ctx context.Context, nn xkube.NameNamespace) (*secureValueDB, error) {
-	_, ok := claims.From(ctx)
+	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}


### PR DESCRIPTION
Fix a merge issue since the authlib claims package has been changed to types, including the method needed to be used.