### PR TITLE
AutoSizeInput: Improve performance when typing

### DIFF
--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -113,7 +113,6 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
     top: 0,
     zIndex: 1,
     display: 'flex',
-    width: width ? theme.spacing(width) : '100%', // Not used in Input, as this causes performance issues with auto sizing
     alignItems: 'center',
     justifyContent: 'center',
     flexGrow: 0,
@@ -131,6 +130,7 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       css({
         label: 'input-wrapper',
         display: 'flex',
+        width: width ? theme.spacing(width) : '100%', // Not used in Input, as this causes performance issues with auto sizing
         height: theme.spacing(theme.components.height.md),
         borderRadius: theme.shape.radius.default,
         '&:hover': {

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -64,6 +64,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   const theme = useTheme2();
 
+  // Don't pass the width prop, as this causes an unnecessary amount of Emotion calls when auto sizing
   const styles = getInputStyles({ theme, invalid: !!invalid });
 
   const suffix = suffixProp || (loading && <Spinner inline={true} />);
@@ -71,7 +72,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
   return (
     <div
       className={cx(styles.wrapper, className)}
-      style={{ width: finalWidth ? theme.spacing(finalWidth) : '100%' }}
+      style={{ width: finalWidth ? theme.spacing(finalWidth) : '100%' }} // Override emotion styles for the width prop
       data-testid="input-wrapper"
     >
       {!!addonBefore && <div className={styles.addon}>{addonBefore}</div>}
@@ -105,13 +106,14 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
 
 Input.displayName = 'Input';
 
-export const getInputStyles = stylesFactory(({ theme, invalid = false }: StyleDeps) => {
+export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: StyleDeps) => {
   const prefixSuffixStaticWidth = '28px';
   const prefixSuffix = css({
     position: 'absolute',
     top: 0,
     zIndex: 1,
     display: 'flex',
+    width: width ? theme.spacing(width) : '100%', // Not used in Input, as this causes performance issues with auto sizing
     alignItems: 'center',
     justifyContent: 'center',
     flexGrow: 0,

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -64,12 +64,16 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   const theme = useTheme2();
 
-  const styles = getInputStyles({ theme, invalid: !!invalid, width: finalWidth });
+  const styles = getInputStyles({ theme, invalid: !!invalid });
 
   const suffix = suffixProp || (loading && <Spinner inline={true} />);
 
   return (
-    <div className={cx(styles.wrapper, className)} data-testid="input-wrapper">
+    <div
+      className={cx(styles.wrapper, className)}
+      style={{ width: finalWidth ? theme.spacing(finalWidth) : '100%' }}
+      data-testid="input-wrapper"
+    >
       {!!addonBefore && <div className={styles.addon}>{addonBefore}</div>}
       <div className={styles.inputWrapper}>
         {prefix && (
@@ -101,7 +105,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
 
 Input.displayName = 'Input';
 
-export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: StyleDeps) => {
+export const getInputStyles = stylesFactory(({ theme, invalid = false }: StyleDeps) => {
   const prefixSuffixStaticWidth = '28px';
   const prefixSuffix = css({
     position: 'absolute',
@@ -125,7 +129,6 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       css({
         label: 'input-wrapper',
         display: 'flex',
-        width: width ? theme.spacing(width) : '100%',
         height: theme.spacing(theme.components.height.md),
         borderRadius: theme.shape.radius.default,
         '&:hover': {


### PR DESCRIPTION
Repeated calls to Emotion caused this to be an issue. Width is now set directly with the `style` prop. This was most notable when running dev build.


**Before**

https://github.com/user-attachments/assets/6e49110a-d179-4090-b560-f4d7438d770a



**After**

https://github.com/user-attachments/assets/84853b5d-e11e-4433-a7f0-d171853fca83


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
