### PR TITLE
MultiCombobox: Refactor open state

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -142,18 +142,10 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     inputValue,
     selectedItem: null,
     stateReducer: (state, actionAndChanges) => {
-      if (state.isOpen === true && actionAndChanges.changes.isOpen === false) {
-        console.log('downshiftDebug', actionAndChanges.type, 'downshift wants to close the menu', {
-          state,
-          changes: actionAndChanges.changes,
-        });
-      }
-
       const { changes, type } = actionAndChanges;
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-          console.log('  downshiftDebug - ItemClick, keeping menu open');
           return {
             ...changes,
             isOpen: true,


### PR DESCRIPTION
Refactors MultiCombobox to remove the `[menuIsOpen, setMenuisOpen] = useState()`, relying on MultiCombobox to manage this itself.

As detailed in the comments in the code, it works around an issue where clicking a selected item in the menu can close the menu if that item is last in the `value` list by overriding some of the keyboard focus (?) logic.