### PR TITLE
ExemplarMarker: Fix exemplar tooltip box shadow

### DIFF
--- a/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
+++ b/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
@@ -60,7 +60,6 @@ const getStyles = (theme: GrafanaTheme2, padding = 0) => {
       borderRadius: theme.shape.radius.default,
       background: theme.colors.background.primary,
       border: `1px solid ${theme.colors.border.weak}`,
-      boxShadow: `0 4px 8px ${theme.colors.background.primary}`,
     }),
     exemplarHeader: css({
       display: 'flex',

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
@@ -285,6 +285,7 @@ const getExemplarMarkerStyles = (theme: GrafanaTheme2) => {
       padding: 0,
       overflowY: 'auto',
       maxHeight: '95vh',
+      boxShadow: theme.shadows.z2,
     }),
     header: css({
       background: headerBg,


### PR DESCRIPTION
### What does this PR do? 📓 

The tooltip for exemplar markers is missing the `box-shadow` css property. It's currently set within the `ExemplarHoverView` file on the `exemplarWrapper`, however these styles need to be applied at a higher level on the element in the DOM. 

The fix: removing `box-shadow` on the `exemplarWrapper` and instead applying it on the `tooltip` style in `ExemplarMarker`.

Fixes https://github.com/grafana/grafana/issues/99388

#### Before 📸 

<img width="633" alt="image" src="https://github.com/user-attachments/assets/43af037c-598a-4544-a542-f2267e017284" />

#### After 📸 

<img width="675" alt="image" src="https://github.com/user-attachments/assets/bc6741bc-8c34-4e44-95da-9775b7ea9a00" />
