### PR TITLE
MultiCombobox: Async options

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -162,15 +162,15 @@ export const AsyncOptionsWithLabels: Story = {
 
     return (
       <Field
-        label='Asynbc options fn returns objects like { label: "Option 69", value: "69" }'
+        label='Async options fn returns objects like { label: "Option 69", value: "69" }'
         description="Search for 'break' to see an error"
       >
         <Combobox
           {...args}
           {...dynamicArgs}
-          onChange={(val: ComboboxOption | null) => {
-            onChangeAction(val);
-            setArgs({ value: val });
+          onChange={(value: ComboboxOption | null) => {
+            onChangeAction(value);
+            setArgs({ value });
           }}
         />
       </Field>
@@ -205,7 +205,7 @@ export const AsyncOptionsWithOnlyValues: Story = {
           {...dynamicArgs}
           onChange={(value: ComboboxOption | null) => {
             onChangeAction(value);
-            setArgs({ value: value });
+            setArgs({ value });
           }}
         />
       </Field>

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -1,20 +1,20 @@
 import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import React, { ComponentProps, useCallback, useEffect, useState } from 'react';
-
-import { SelectableValue } from '@grafana/data';
+import React, { useEffect, useState } from 'react';
 
 import { Alert } from '../Alert/Alert';
 import { Field } from '../Forms/Field';
-import { AsyncSelect } from '../Select/Select';
 
-import { Combobox } from './Combobox';
+import { Combobox, ComboboxProps } from './Combobox';
 import mdx from './Combobox.mdx';
+import { fakeSearchAPI, generateOptions } from './storyUtils';
 import { ComboboxOption } from './types';
 
-type PropsAndCustomArgs<T extends string | number = string> = ComponentProps<typeof Combobox<T>> & {
+type PropsAndCustomArgs<T extends string | number = string> = ComboboxProps<T> & {
   numberOfOptions: number;
 };
+type Story<T extends string | number = string> = StoryObj<PropsAndCustomArgs<T>>;
 
 const meta: Meta<PropsAndCustomArgs> = {
   title: 'Forms/Combobox',
@@ -64,256 +64,199 @@ const meta: Meta<PropsAndCustomArgs> = {
     ],
     value: 'banana',
   },
-
-  render: (args) => <BasicWithState {...args} />,
   decorators: [InDevDecorator],
 };
+export default meta;
 
-const BasicWithState: StoryFn<PropsAndCustomArgs> = (args) => {
-  const [value, setValue] = useState<string | null>();
+const loadOptionsAction = action('options called');
+const onChangeAction = action('onChange called');
+
+const BaseCombobox: StoryFn<PropsAndCustomArgs> = (args) => {
+  const [dynamicArgs, setArgs] = useArgs();
+
   return (
     <Field label="Test input" description="Input with a few options">
       <Combobox
         id="test-combobox"
         {...args}
-        value={value}
-        onChange={(val: ComboboxOption | null) => {
-          // TODO: Figure out how to update value on args
-          setValue(val?.value || null);
-          action('onChange')(val);
+        {...dynamicArgs}
+        onChange={(value: ComboboxOption | null) => {
+          setArgs({ value: value?.value || null });
+          onChangeAction(value);
         }}
       />
     </Field>
   );
 };
 
-type Story = StoryObj<typeof Combobox>;
-
-export const Basic: Story = {};
-
-export async function generateOptions(amount: number): Promise<ComboboxOption[]> {
-  return Array.from({ length: amount }, (_, index) => ({
-    label: 'Option ' + index,
-    value: index.toString(),
-  }));
-}
-
-const ManyOptionsStory: StoryFn<PropsAndCustomArgs<string>> = ({ numberOfOptions, ...args }) => {
-  const [value, setValue] = useState<string | null>(null);
-  const [options, setOptions] = useState<ComboboxOption[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    setTimeout(() => {
-      generateOptions(numberOfOptions).then((options) => {
-        setIsLoading(false);
-        setOptions(options);
-        setValue(options[5].value);
-      });
-    }, 1000);
-  }, [numberOfOptions]);
-
-  const { onChange, ...rest } = args;
-  return (
-    <Combobox
-      {...rest}
-      loading={isLoading}
-      options={options}
-      value={value}
-      onChange={(opt: ComboboxOption | null) => {
-        setValue(opt?.value || null);
-        action('onChange')(opt);
-      }}
-    />
-  );
+export const Basic: Story = {
+  render: BaseCombobox,
 };
 
-export const AutoSize: StoryObj<PropsAndCustomArgs> = {
+export const AutoSize: Story = {
   args: {
     width: 'auto',
     minWidth: 5,
     maxWidth: 200,
   },
+  render: BaseCombobox,
 };
 
-export const ManyOptions: StoryObj<PropsAndCustomArgs> = {
+export const CustomValue: Story = {
+  args: {
+    createCustomValue: true,
+  },
+  render: BaseCombobox,
+};
+
+export const ManyOptions: Story = {
   args: {
     numberOfOptions: 1e5,
     options: undefined,
     value: undefined,
   },
-  render: ManyOptionsStory,
-};
+  render: ({ numberOfOptions, ...args }: PropsAndCustomArgs) => {
+    const [dynamicArgs, setArgs] = useArgs();
+    const [options, setOptions] = useState<ComboboxOption[]>([]);
 
-export const CustomValue: StoryObj<PropsAndCustomArgs> = {
-  args: {
-    createCustomValue: true,
+    useEffect(() => {
+      setTimeout(() => {
+        generateOptions(numberOfOptions).then((options) => {
+          setOptions(options);
+          setArgs({ value: options[5].value });
+        });
+      }, 1000);
+    }, [numberOfOptions, setArgs]);
+
+    const { onChange, ...rest } = args;
+    return (
+      <Field label="Test input" description={options.length ? 'Input with a few options' : 'Preparing options...'}>
+        <Combobox
+          {...rest}
+          {...dynamicArgs}
+          options={options}
+          onChange={(value: ComboboxOption | null) => {
+            setArgs({ value: value?.value || null });
+            onChangeAction(value);
+          }}
+        />
+      </Field>
+    );
   },
 };
 
-const loadOptionsAction = action('loadOptions called');
-const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
-  // Combobox
-  const [selectedOption, setSelectedOption] = useState<ComboboxOption<string> | null>(null);
+function loadOptionsWithLabels(inputValue: string) {
+  loadOptionsAction(inputValue);
+  return fakeSearchAPI(`http://example.com/search?errorOnQuery=break&query=${inputValue}`);
+}
 
-  // AsyncSelect
-  const [asyncSelectValue, setAsyncSelectValue] = useState<SelectableValue<string> | null>(null);
+export const AsyncOptionsWithLabels: Story = {
+  name: 'Async - values + labels',
+  args: {
+    options: loadOptionsWithLabels,
+    value: { label: 'Option 69', value: '69' },
+    placeholder: 'Select an option',
+  },
+  render: (args: PropsAndCustomArgs) => {
+    const [dynamicArgs, setArgs] = useArgs();
 
-  // This simulates a kind of search API call
-  const loadOptionsWithLabels = useCallback((inputValue: string) => {
-    loadOptionsAction(inputValue);
-    return fakeSearchAPI(`http://example.com/search?query=${inputValue}`);
-  }, []);
-
-  const loadOptionsOnlyValues = useCallback((inputValue: string) => {
-    return fakeSearchAPI(`http://example.com/search?query=${inputValue}`).then((options) =>
-      options.map((opt) => ({ value: opt.label! }))
+    return (
+      <Field
+        label='Asynbc options fn returns objects like { label: "Option 69", value: "69" }'
+        description="Search for 'break' to see an error"
+      >
+        <Combobox
+          {...args}
+          {...dynamicArgs}
+          onChange={(val: ComboboxOption | null) => {
+            onChangeAction(val);
+            setArgs({ value: val });
+          }}
+        />
+      </Field>
     );
-  }, []);
-
-  const loadOptionsWithErrors = useCallback((inputValue: string) => {
-    if (inputValue.length % 2 === 0) {
-      return fakeSearchAPI(`http://example.com/search?query=${inputValue}`);
-    } else {
-      throw new Error('Could not retrieve options');
-    }
-  }, []);
-
-  const { onChange, ...rest } = args;
-
-  return (
-    <>
-      <Field
-        label="Options with labels"
-        description="This tests when options have both a label and a value. Consumers are required to pass in a full ComboboxOption as a value with a label"
-      >
-        <Combobox
-          {...rest}
-          id="test-combobox-one"
-          placeholder="Select an option"
-          options={loadOptionsWithLabels}
-          value={selectedOption}
-          onChange={(val: ComboboxOption | null) => {
-            action('onChange')(val);
-            setSelectedOption(val);
-          }}
-          createCustomValue={args.createCustomValue}
-        />
-      </Field>
-
-      <Field
-        label="Options without labels"
-        description="Or without labels, where consumer can just pass in a raw scalar value Value"
-      >
-        <Combobox
-          {...args}
-          id="test-combobox-two"
-          placeholder="Select an option"
-          options={loadOptionsOnlyValues}
-          value={selectedOption?.value ?? null}
-          onChange={(val: ComboboxOption | null) => {
-            action('onChange')(val);
-            setSelectedOption(val);
-          }}
-          createCustomValue={args.createCustomValue}
-        />
-      </Field>
-
-      <Field label="Async with error" description="An odd number of characters throws an error">
-        <Combobox
-          id="test-combobox-error"
-          placeholder="Select an option"
-          options={loadOptionsWithErrors}
-          value={selectedOption}
-          onChange={(val) => {
-            action('onChange')(val);
-            setSelectedOption(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Compared to AsyncSelect">
-        <AsyncSelect
-          id="test-async-select"
-          placeholder="Select an option"
-          loadOptions={loadOptionsWithLabels}
-          value={asyncSelectValue}
-          defaultOptions
-          onChange={(val) => {
-            action('onChange')(val);
-            setAsyncSelectValue(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Async with error" description="An odd number of characters throws an error">
-        <Combobox
-          {...args}
-          id="test-combobox-error"
-          placeholder="Select an option"
-          options={loadOptionsWithErrors}
-          value={selectedOption}
-          onChange={(val: ComboboxOption | null) => {
-            action('onChange')(val);
-            setSelectedOption(val);
-          }}
-        />
-      </Field>
-    </>
-  );
+  },
 };
 
-export const Async: StoryObj<PropsAndCustomArgs> = {
-  render: AsyncStory,
+function loadOptionsOnlyValues(inputValue: string) {
+  loadOptionsAction(inputValue);
+  return fakeSearchAPI(`http://example.com/search?errorOnQuery=break&query=${inputValue}`).then((options) =>
+    options.map((opt) => ({ value: opt.label! }))
+  );
+}
+
+export const AsyncOptionsWithOnlyValues: Story = {
+  name: 'Async - values only',
+  args: {
+    options: loadOptionsOnlyValues,
+    value: { value: 'Option 69' },
+    placeholder: 'Select an option',
+  },
+  render: (args: PropsAndCustomArgs) => {
+    const [dynamicArgs, setArgs] = useArgs();
+
+    return (
+      <Field
+        label='Async options fn returns objects like { value: "69" }'
+        description="Search for 'break' to see an error"
+      >
+        <Combobox
+          {...args}
+          {...dynamicArgs}
+          onChange={(value: ComboboxOption | null) => {
+            onChangeAction(value);
+            setArgs({ value: value });
+          }}
+        />
+      </Field>
+    );
+  },
 };
 
 const noop = () => {};
-const PositioningTestStory: StoryFn<PropsAndCustomArgs> = (args) => {
-  if (typeof args.options === 'function') {
-    throw new Error('This story does not support async options');
-  }
 
-  function renderColumnOfComboboxes(pos: string) {
+export const PositioningTest: Story = {
+  render: (args: PropsAndCustomArgs) => {
+    if (typeof args.options === 'function') {
+      throw new Error('This story does not support async options');
+    }
+
+    function renderColumnOfComboboxes(pos: string) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            flex: 1,
+          }}
+        >
+          <Combobox {...args} placeholder={`${pos} top`} options={args.options} value={null} onChange={noop} />
+          <Combobox {...args} placeholder={`${pos} middle`} options={args.options} value={null} onChange={noop} />
+          <Combobox {...args} placeholder={`${pos} bottom`} options={args.options} value={null} onChange={noop} />
+        </div>
+      );
+    }
+
     return (
       <div
         style={{
           display: 'flex',
-          flexDirection: 'column',
+          flexDirection: 'row',
+
+          // approx the height of the dev alert, and three margins. exact doesn't matter
+          minHeight: 'calc(100vh - (105px + 16px + 16px + 16px))',
           justifyContent: 'space-between',
-          flex: 1,
+          gap: 32,
         }}
       >
-        <Combobox {...args} placeholder={`${pos} top`} options={args.options} value={null} onChange={noop} />
-        <Combobox {...args} placeholder={`${pos} middle`} options={args.options} value={null} onChange={noop} />
-        <Combobox {...args} placeholder={`${pos} bottom`} options={args.options} value={null} onChange={noop} />
+        {renderColumnOfComboboxes('Left')}
+        {renderColumnOfComboboxes('Middle')}
+        {renderColumnOfComboboxes('Right')}
       </div>
     );
-  }
-
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-
-        // approx the height of the dev alert, and three margins. exact doesn't matter
-        minHeight: 'calc(100vh - (105px + 16px + 16px + 16px))',
-        justifyContent: 'space-between',
-        gap: 32,
-      }}
-    >
-      {renderColumnOfComboboxes('Left')}
-      {renderColumnOfComboboxes('Middle')}
-      {renderColumnOfComboboxes('Right')}
-    </div>
-  );
+  },
 };
-
-export const PositioningTest: StoryObj<PropsAndCustomArgs> = {
-  render: PositioningTestStory,
-};
-
-export default meta;
 
 function InDevDecorator(Story: React.ElementType) {
   return (
@@ -327,29 +270,4 @@ function InDevDecorator(Story: React.ElementType) {
       <Story />
     </div>
   );
-}
-
-let fakeApiOptions: Array<ComboboxOption<string>>;
-async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOption<string>>> {
-  const searchParams = new URL(urlString).searchParams;
-
-  if (!fakeApiOptions) {
-    fakeApiOptions = await generateOptions(1000);
-  }
-
-  const searchQuery = searchParams.get('query')?.toLowerCase();
-
-  if (!searchQuery || searchQuery.length === 0) {
-    return Promise.resolve(fakeApiOptions.slice(0, 10));
-  }
-
-  const filteredOptions = Promise.resolve(
-    fakeApiOptions.filter((opt) => opt.label?.toLowerCase().includes(searchQuery))
-  );
-
-  const delay = searchQuery.length % 2 === 0 ? 200 : 1000;
-
-  return new Promise<Array<ComboboxOption<string>>>((resolve) => {
-    setTimeout(() => resolve(filteredOptions), delay);
-  });
 }

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -1,20 +1,20 @@
 import { action } from '@storybook/addon-actions';
-import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import React, { useEffect, useState } from 'react';
+import React, { ComponentProps, useCallback, useEffect, useState } from 'react';
+
+import { SelectableValue } from '@grafana/data';
 
 import { Alert } from '../Alert/Alert';
 import { Field } from '../Forms/Field';
+import { AsyncSelect } from '../Select/Select';
 
-import { Combobox, ComboboxProps } from './Combobox';
+import { Combobox } from './Combobox';
 import mdx from './Combobox.mdx';
-import { fakeSearchAPI, generateOptions } from './storyUtils';
 import { ComboboxOption } from './types';
 
-type PropsAndCustomArgs<T extends string | number = string> = ComboboxProps<T> & {
+type PropsAndCustomArgs<T extends string | number = string> = ComponentProps<typeof Combobox<T>> & {
   numberOfOptions: number;
 };
-type Story<T extends string | number = string> = StoryObj<PropsAndCustomArgs<T>>;
 
 const meta: Meta<PropsAndCustomArgs> = {
   title: 'Forms/Combobox',
@@ -64,199 +64,256 @@ const meta: Meta<PropsAndCustomArgs> = {
     ],
     value: 'banana',
   },
+
+  render: (args) => <BasicWithState {...args} />,
   decorators: [InDevDecorator],
 };
-export default meta;
 
-const loadOptionsAction = action('options called');
-const onChangeAction = action('onChange called');
-
-const BaseCombobox: StoryFn<PropsAndCustomArgs> = (args) => {
-  const [dynamicArgs, setArgs] = useArgs();
-
+const BasicWithState: StoryFn<PropsAndCustomArgs> = (args) => {
+  const [value, setValue] = useState<string | null>();
   return (
     <Field label="Test input" description="Input with a few options">
       <Combobox
         id="test-combobox"
         {...args}
-        {...dynamicArgs}
-        onChange={(value: ComboboxOption | null) => {
-          setArgs({ value: value?.value || null });
-          onChangeAction(value);
+        value={value}
+        onChange={(val: ComboboxOption | null) => {
+          // TODO: Figure out how to update value on args
+          setValue(val?.value || null);
+          action('onChange')(val);
         }}
       />
     </Field>
   );
 };
 
-export const Basic: Story = {
-  render: BaseCombobox,
+type Story = StoryObj<typeof Combobox>;
+
+export const Basic: Story = {};
+
+export async function generateOptions(amount: number): Promise<ComboboxOption[]> {
+  return Array.from({ length: amount }, (_, index) => ({
+    label: 'Option ' + index,
+    value: index.toString(),
+  }));
+}
+
+const ManyOptionsStory: StoryFn<PropsAndCustomArgs<string>> = ({ numberOfOptions, ...args }) => {
+  const [value, setValue] = useState<string | null>(null);
+  const [options, setOptions] = useState<ComboboxOption[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      generateOptions(numberOfOptions).then((options) => {
+        setIsLoading(false);
+        setOptions(options);
+        setValue(options[5].value);
+      });
+    }, 1000);
+  }, [numberOfOptions]);
+
+  const { onChange, ...rest } = args;
+  return (
+    <Combobox
+      {...rest}
+      loading={isLoading}
+      options={options}
+      value={value}
+      onChange={(opt: ComboboxOption | null) => {
+        setValue(opt?.value || null);
+        action('onChange')(opt);
+      }}
+    />
+  );
 };
 
-export const AutoSize: Story = {
+export const AutoSize: StoryObj<PropsAndCustomArgs> = {
   args: {
     width: 'auto',
     minWidth: 5,
     maxWidth: 200,
   },
-  render: BaseCombobox,
 };
 
-export const CustomValue: Story = {
-  args: {
-    createCustomValue: true,
-  },
-  render: BaseCombobox,
-};
-
-export const ManyOptions: Story = {
+export const ManyOptions: StoryObj<PropsAndCustomArgs> = {
   args: {
     numberOfOptions: 1e5,
     options: undefined,
     value: undefined,
   },
-  render: ({ numberOfOptions, ...args }: PropsAndCustomArgs) => {
-    const [dynamicArgs, setArgs] = useArgs();
-    const [options, setOptions] = useState<ComboboxOption[]>([]);
+  render: ManyOptionsStory,
+};
 
-    useEffect(() => {
-      setTimeout(() => {
-        generateOptions(numberOfOptions).then((options) => {
-          setOptions(options);
-          setArgs({ value: options[5].value });
-        });
-      }, 1000);
-    }, [numberOfOptions, setArgs]);
+export const CustomValue: StoryObj<PropsAndCustomArgs> = {
+  args: {
+    createCustomValue: true,
+  },
+};
 
-    const { onChange, ...rest } = args;
-    return (
-      <Field label="Test input" description={options.length ? 'Input with a few options' : 'Preparing options...'}>
+const loadOptionsAction = action('loadOptions called');
+const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
+  // Combobox
+  const [selectedOption, setSelectedOption] = useState<ComboboxOption<string> | null>(null);
+
+  // AsyncSelect
+  const [asyncSelectValue, setAsyncSelectValue] = useState<SelectableValue<string> | null>(null);
+
+  // This simulates a kind of search API call
+  const loadOptionsWithLabels = useCallback((inputValue: string) => {
+    loadOptionsAction(inputValue);
+    return fakeSearchAPI(`http://example.com/search?query=${inputValue}`);
+  }, []);
+
+  const loadOptionsOnlyValues = useCallback((inputValue: string) => {
+    return fakeSearchAPI(`http://example.com/search?query=${inputValue}`).then((options) =>
+      options.map((opt) => ({ value: opt.label! }))
+    );
+  }, []);
+
+  const loadOptionsWithErrors = useCallback((inputValue: string) => {
+    if (inputValue.length % 2 === 0) {
+      return fakeSearchAPI(`http://example.com/search?query=${inputValue}`);
+    } else {
+      throw new Error('Could not retrieve options');
+    }
+  }, []);
+
+  const { onChange, ...rest } = args;
+
+  return (
+    <>
+      <Field
+        label="Options with labels"
+        description="This tests when options have both a label and a value. Consumers are required to pass in a full ComboboxOption as a value with a label"
+      >
         <Combobox
           {...rest}
-          {...dynamicArgs}
-          options={options}
-          onChange={(value: ComboboxOption | null) => {
-            setArgs({ value: value?.value || null });
-            onChangeAction(value);
-          }}
-        />
-      </Field>
-    );
-  },
-};
-
-function loadOptionsWithLabels(inputValue: string) {
-  loadOptionsAction(inputValue);
-  return fakeSearchAPI(`http://example.com/search?errorOnQuery=break&query=${inputValue}`);
-}
-
-export const AsyncOptionsWithLabels: Story = {
-  name: 'Async - values + labels',
-  args: {
-    options: loadOptionsWithLabels,
-    value: { label: 'Option 69', value: '69' },
-    placeholder: 'Select an option',
-  },
-  render: (args: PropsAndCustomArgs) => {
-    const [dynamicArgs, setArgs] = useArgs();
-
-    return (
-      <Field
-        label='Asynbc options fn returns objects like { label: "Option 69", value: "69" }'
-        description="Search for 'break' to see an error"
-      >
-        <Combobox
-          {...args}
-          {...dynamicArgs}
+          id="test-combobox-one"
+          placeholder="Select an option"
+          options={loadOptionsWithLabels}
+          value={selectedOption}
           onChange={(val: ComboboxOption | null) => {
-            onChangeAction(val);
-            setArgs({ value: val });
+            action('onChange')(val);
+            setSelectedOption(val);
           }}
+          createCustomValue={args.createCustomValue}
         />
       </Field>
-    );
-  },
-};
 
-function loadOptionsOnlyValues(inputValue: string) {
-  loadOptionsAction(inputValue);
-  return fakeSearchAPI(`http://example.com/search?errorOnQuery=break&query=${inputValue}`).then((options) =>
-    options.map((opt) => ({ value: opt.label! }))
-  );
-}
-
-export const AsyncOptionsWithOnlyValues: Story = {
-  name: 'Async - values only',
-  args: {
-    options: loadOptionsOnlyValues,
-    value: { value: 'Option 69' },
-    placeholder: 'Select an option',
-  },
-  render: (args: PropsAndCustomArgs) => {
-    const [dynamicArgs, setArgs] = useArgs();
-
-    return (
       <Field
-        label='Async options fn returns objects like { value: "69" }'
-        description="Search for 'break' to see an error"
+        label="Options without labels"
+        description="Or without labels, where consumer can just pass in a raw scalar value Value"
       >
         <Combobox
           {...args}
-          {...dynamicArgs}
-          onChange={(value: ComboboxOption | null) => {
-            onChangeAction(value);
-            setArgs({ value: value });
+          id="test-combobox-two"
+          placeholder="Select an option"
+          options={loadOptionsOnlyValues}
+          value={selectedOption?.value ?? null}
+          onChange={(val: ComboboxOption | null) => {
+            action('onChange')(val);
+            setSelectedOption(val);
+          }}
+          createCustomValue={args.createCustomValue}
+        />
+      </Field>
+
+      <Field label="Async with error" description="An odd number of characters throws an error">
+        <Combobox
+          id="test-combobox-error"
+          placeholder="Select an option"
+          options={loadOptionsWithErrors}
+          value={selectedOption}
+          onChange={(val) => {
+            action('onChange')(val);
+            setSelectedOption(val);
           }}
         />
       </Field>
-    );
-  },
+
+      <Field label="Compared to AsyncSelect">
+        <AsyncSelect
+          id="test-async-select"
+          placeholder="Select an option"
+          loadOptions={loadOptionsWithLabels}
+          value={asyncSelectValue}
+          defaultOptions
+          onChange={(val) => {
+            action('onChange')(val);
+            setAsyncSelectValue(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Async with error" description="An odd number of characters throws an error">
+        <Combobox
+          {...args}
+          id="test-combobox-error"
+          placeholder="Select an option"
+          options={loadOptionsWithErrors}
+          value={selectedOption}
+          onChange={(val: ComboboxOption | null) => {
+            action('onChange')(val);
+            setSelectedOption(val);
+          }}
+        />
+      </Field>
+    </>
+  );
+};
+
+export const Async: StoryObj<PropsAndCustomArgs> = {
+  render: AsyncStory,
 };
 
 const noop = () => {};
+const PositioningTestStory: StoryFn<PropsAndCustomArgs> = (args) => {
+  if (typeof args.options === 'function') {
+    throw new Error('This story does not support async options');
+  }
 
-export const PositioningTest: Story = {
-  render: (args: PropsAndCustomArgs) => {
-    if (typeof args.options === 'function') {
-      throw new Error('This story does not support async options');
-    }
-
-    function renderColumnOfComboboxes(pos: string) {
-      return (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            flex: 1,
-          }}
-        >
-          <Combobox {...args} placeholder={`${pos} top`} options={args.options} value={null} onChange={noop} />
-          <Combobox {...args} placeholder={`${pos} middle`} options={args.options} value={null} onChange={noop} />
-          <Combobox {...args} placeholder={`${pos} bottom`} options={args.options} value={null} onChange={noop} />
-        </div>
-      );
-    }
-
+  function renderColumnOfComboboxes(pos: string) {
     return (
       <div
         style={{
           display: 'flex',
-          flexDirection: 'row',
-
-          // approx the height of the dev alert, and three margins. exact doesn't matter
-          minHeight: 'calc(100vh - (105px + 16px + 16px + 16px))',
+          flexDirection: 'column',
           justifyContent: 'space-between',
-          gap: 32,
+          flex: 1,
         }}
       >
-        {renderColumnOfComboboxes('Left')}
-        {renderColumnOfComboboxes('Middle')}
-        {renderColumnOfComboboxes('Right')}
+        <Combobox {...args} placeholder={`${pos} top`} options={args.options} value={null} onChange={noop} />
+        <Combobox {...args} placeholder={`${pos} middle`} options={args.options} value={null} onChange={noop} />
+        <Combobox {...args} placeholder={`${pos} bottom`} options={args.options} value={null} onChange={noop} />
       </div>
     );
-  },
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+
+        // approx the height of the dev alert, and three margins. exact doesn't matter
+        minHeight: 'calc(100vh - (105px + 16px + 16px + 16px))',
+        justifyContent: 'space-between',
+        gap: 32,
+      }}
+    >
+      {renderColumnOfComboboxes('Left')}
+      {renderColumnOfComboboxes('Middle')}
+      {renderColumnOfComboboxes('Right')}
+    </div>
+  );
 };
+
+export const PositioningTest: StoryObj<PropsAndCustomArgs> = {
+  render: PositioningTestStory,
+};
+
+export default meta;
 
 function InDevDecorator(Story: React.ElementType) {
   return (
@@ -270,4 +327,29 @@ function InDevDecorator(Story: React.ElementType) {
       <Story />
     </div>
   );
+}
+
+let fakeApiOptions: Array<ComboboxOption<string>>;
+async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOption<string>>> {
+  const searchParams = new URL(urlString).searchParams;
+
+  if (!fakeApiOptions) {
+    fakeApiOptions = await generateOptions(1000);
+  }
+
+  const searchQuery = searchParams.get('query')?.toLowerCase();
+
+  if (!searchQuery || searchQuery.length === 0) {
+    return Promise.resolve(fakeApiOptions.slice(0, 10));
+  }
+
+  const filteredOptions = Promise.resolve(
+    fakeApiOptions.filter((opt) => opt.label?.toLowerCase().includes(searchQuery))
+  );
+
+  const delay = searchQuery.length % 2 === 0 ? 200 : 1000;
+
+  return new Promise<Array<ComboboxOption<string>>>((resolve) => {
+    setTimeout(() => resolve(filteredOptions), delay);
+  });
 }

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.internal.story.tsx
@@ -72,17 +72,14 @@ export const AutoSize: Story = {
 };
 
 const ManyOptionsStory: StoryFn<ManyOptionsArgs> = ({ numberOfOptions = 1e4, ...args }) => {
-  const [value, setValue] = useState<string[]>([]);
+  const [dynamicArgs, setArgs] = useArgs();
+
   const [options, setOptions] = useState<ComboboxOption[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setTimeout(() => {
-      generateOptions(numberOfOptions).then((options) => {
-        setIsLoading(false);
-        setOptions(options);
-        setValue([options[5].value]);
-      });
+    setTimeout(async () => {
+      const options = await generateOptions(numberOfOptions);
+      setOptions(options);
     }, 1000);
   }, [numberOfOptions]);
 
@@ -90,11 +87,10 @@ const ManyOptionsStory: StoryFn<ManyOptionsArgs> = ({ numberOfOptions = 1e4, ...
   return (
     <MultiCombobox
       {...rest}
-      loading={isLoading}
+      {...dynamicArgs}
       options={options}
-      value={value}
       onChange={(opts) => {
-        setValue(opts || []);
+        setArgs({ value: opts });
         onChangeAction(opts);
       }}
     />

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.internal.story.tsx
@@ -1,9 +1,10 @@
 import { action } from '@storybook/addon-actions';
 import { useArgs, useEffect, useState } from '@storybook/preview-api';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { useCallback } from 'react';
 
 import { MultiCombobox } from './MultiCombobox';
-import { generateOptions } from './storyUtils';
+import { generateOptions, fakeSearchAPI } from './storyUtils';
 import { ComboboxOption } from './types';
 
 const meta: Meta<typeof MultiCombobox> = {
@@ -103,4 +104,37 @@ export const ManyOptions: StoryObj<ManyOptionsArgs> = {
     value: undefined,
   },
   render: ManyOptionsStory,
+};
+
+const loadOptionsAction = action('loadOptions called');
+const AsyncStory: StoryFn = (args) => {
+  // Combobox
+  const [selectedOption, setSelectedOption] = useState<Array<ComboboxOption<string>> | undefined>([]);
+
+  // This simulates a kind of search API call
+  const loadOptionsWithLabels = useCallback((inputValue: string) => {
+    loadOptionsAction(inputValue);
+    return fakeSearchAPI(`http://example.com/search?query=${inputValue}`);
+  }, []);
+
+  const { onChange, ...rest } = args;
+
+  return (
+    <MultiCombobox
+      {...rest}
+      id="test-combobox-one"
+      placeholder="Select an option"
+      options={loadOptionsWithLabels}
+      value={selectedOption}
+      onChange={(val: any[] | undefined) => {
+        action('onChange')(val);
+        setSelectedOption(val);
+      }}
+      createCustomValue={args.createCustomValue}
+    />
+  );
+};
+
+export const Async: StoryObj = {
+  render: AsyncStory,
 };

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -2,8 +2,8 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import React from 'react';
 
-import { ComboboxOption } from './Combobox';
 import { MultiCombobox, MultiComboboxProps } from './MultiCombobox';
+import { ComboboxOption } from './types';
 
 describe('MultiCombobox', () => {
   beforeAll(() => {

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -18,13 +18,14 @@ import { NotFoundError } from './MessageRows';
 import { OptionListItem } from './OptionListItem';
 import { SuffixIcon } from './SuffixIcon';
 import { ValuePill } from './ValuePill';
-import { itemFilter, itemToString } from './filter';
+import { itemToString } from './filter';
 import { getComboboxStyles, MENU_OPTION_HEIGHT, MENU_OPTION_HEIGHT_DESCRIPTION } from './getComboboxStyles';
 import { getMultiComboboxStyles } from './getMultiComboboxStyles';
 import { ALL_OPTION_VALUE, ComboboxOption } from './types';
 import { useComboboxFloat } from './useComboboxFloat';
 import { MAX_SHOWN_ITEMS, useMeasureMulti } from './useMeasureMulti';
 import { useMultiInputAutoSize } from './useMultiInputAutoSize';
+import { useOptions } from './useOptions';
 
 interface MultiComboboxBaseProps<T extends string | number> extends Omit<ComboboxBaseProps<T>, 'value' | 'onChange'> {
   value?: T[] | Array<ComboboxOption<T>>;
@@ -34,71 +35,9 @@ interface MultiComboboxBaseProps<T extends string | number> extends Omit<Combobo
 
 export type MultiComboboxProps<T extends string | number> = MultiComboboxBaseProps<T> & AutoSizeConditionals;
 
-// A hook to handle sync or async options
-// intended to be used by both MultiCombobox and Combobox
-function useOptions<T extends string | number>(options: MultiComboboxBaseProps<T>['options']) {
-  const isAsync = typeof options === 'function';
-  const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);
-  const [asyncLoading, setAsyncLoading] = useState(false);
-  const [asyncError, setAsyncError] = useState(false);
-
-  // This hook keeps its own inputValue state (rather than accepting it as an arg) because it needs to be
-  // told it for async options loading anyway.
-  const [userTypedSearch, setUserTypedSearch] = useState('');
-
-  const loadOptionsWhenUserTypes = useCallback(
-    (inputValue: string) => {
-      console.log('loadOptionsWhenUserTypes', inputValue);
-      if (!isAsync) {
-        setUserTypedSearch(inputValue);
-        return;
-      }
-
-      setAsyncLoading(true);
-
-      options(inputValue)
-        .then((options) => {
-          setAsyncOptions(options);
-          setAsyncLoading(false);
-          setAsyncError(false);
-        })
-        .catch((error) => {
-          setAsyncError(true);
-          setAsyncLoading(false);
-
-          if (error) {
-            console.error('Error loading async options for Combobox', error);
-          }
-        });
-    },
-    [options, isAsync]
-  );
-
-  const finalOptions = useMemo(() => {
-    if (isAsync) {
-      return asyncOptions;
-    } else {
-      return options.filter(itemFilter(userTypedSearch));
-    }
-  }, [options, asyncOptions, isAsync, userTypedSearch]);
-
-  return { options: finalOptions, loadOptionsWhenUserTypes, asyncLoading, asyncError };
-}
-
 export const MultiCombobox = <T extends string | number>(props: MultiComboboxProps<T>) => {
-  const {
-    options,
-    placeholder,
-    onChange,
-    value,
-    width,
-    enableAllOption,
-    invalid,
-    loading,
-    disabled,
-    minWidth,
-    maxWidth,
-  } = props;
+  const { placeholder, onChange, value, width, enableAllOption, invalid, loading, disabled, minWidth, maxWidth } =
+    props;
 
   const { options: newOptions, loadOptionsWhenUserTypes /*, asyncLoading, asyncError */ } = useOptions(props.options);
 

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -36,8 +36,7 @@ interface MultiComboboxBaseProps<T extends string | number> extends Omit<Combobo
 export type MultiComboboxProps<T extends string | number> = MultiComboboxBaseProps<T> & AutoSizeConditionals;
 
 export const MultiCombobox = <T extends string | number>(props: MultiComboboxProps<T>) => {
-  const { placeholder, onChange, value, width, enableAllOption, invalid, loading, disabled, minWidth, maxWidth } =
-    props;
+  const { placeholder, onChange, value, width, enableAllOption, invalid, disabled, minWidth, maxWidth } = props;
 
   const styles = useStyles2(getComboboxStyles);
   const [inputValue, setInputValue] = useState('');
@@ -54,12 +53,13 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
   }, [inputValue]);
 
   // Handle async options and the 'All' option
-  const { options: baseOptions, updateOptions } = useOptions(props.options);
+  const { options: baseOptions, updateOptions, asyncLoading } = useOptions(props.options);
   const options = useMemo(() => {
     // Only add the 'All' option if there's more than 1 option
     const addAllOption = enableAllOption && baseOptions.length > 1;
     return addAllOption ? [allOptionItem, ...baseOptions] : baseOptions;
   }, [baseOptions, enableAllOption, allOptionItem]);
+  const loading = props.loading || asyncLoading;
 
   const selectedItems = useMemo(() => {
     if (!value) {
@@ -91,10 +91,8 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
           case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
           case useMultipleSelection.stateChangeTypes.FunctionAddSelectedItem:
           case useMultipleSelection.stateChangeTypes.FunctionSetSelectedItems:
-            console.log('useMultipleSelection has new items', newSelectedItems);
             // TODO: i don't like multiple breaks
             if (!newSelectedItems) {
-              console.warn('newSelectedItems is undefined, but should it ever be?');
               break;
             }
 
@@ -184,7 +182,6 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     },
 
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
-      console.log('state change', type);
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -91,12 +91,8 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
           case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
           case useMultipleSelection.stateChangeTypes.FunctionAddSelectedItem:
           case useMultipleSelection.stateChangeTypes.FunctionSetSelectedItems:
-            // TODO: i don't like multiple breaks
-            if (!newSelectedItems) {
-              break;
-            }
-
-            onChange(newSelectedItems);
+            // Unclear why newSelectedItems would be undefined, but this seems logical
+            onChange(newSelectedItems ?? []);
             break;
 
           default:
@@ -146,7 +142,6 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
       const { type } = actionAndChanges;
       let { changes } = actionAndChanges;
       const menuBeingOpened = state.isOpen === false && changes.isOpen === true;
-      // const menuBeingClosed = state.isOpen === true && changes.isOpen === false;
 
       // Reset the input value when the menu is opened. If the menu is opened due to an input change
       // then make sure we keep that.
@@ -157,8 +152,6 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
           inputValue: '',
         };
       }
-
-      // TODO: handle menuBeingClosed?
 
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
@@ -185,22 +178,15 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-          // TODO: i don't like multiple breaks
-          if (!newSelectedItem) {
-            break;
-          }
-
           // Handle All functionality
           if (newSelectedItem?.value === ALL_OPTION_VALUE) {
-            // Get the 'real options', excluding the ALL_OPTION_VALUE
-            const realOptions = options.slice(1);
-
             // TODO: fix bug where if the search filtered items list is the
             // same length, but different, than the selected items (ask tobias)
             const isAllFilteredSelected = selectedItems.length === options.length - 1;
 
             // if every option is already selected, clear the selection.
             // otherwise, select all the options (excluding the first ALL_OTION)
+            const realOptions = options.slice(1);
             let newSelectedItems = isAllFilteredSelected && inputValue === '' ? [] : realOptions;
 
             if (!isAllFilteredSelected && inputValue !== '') {
@@ -215,9 +201,9 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
             }
 
             setSelectedItems(newSelectedItems);
-          } else if (isOptionSelected(newSelectedItem)) {
+          } else if (newSelectedItem && isOptionSelected(newSelectedItem)) {
             removeSelectedItem(newSelectedItem);
-          } else {
+          } else if (newSelectedItem) {
             addSelectedItem(newSelectedItem);
           }
 

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,0 +1,66 @@
+import { useState, useCallback, useMemo } from 'react';
+
+import { ComboboxOption } from './Combobox';
+import { itemFilter } from './filter';
+
+type AsyncOptions<T extends string | number> =
+  | Array<ComboboxOption<T>>
+  | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
+
+/**
+ * Abstracts away sync/async options for MultiCombobox (and later Combobox).
+ * It also filters options based on the user's input.
+ *
+ * Returns:
+ *  - options either filtered by user's input, or from async options fn
+ *  - function to call when user types (to filter, or call async fn)
+ *  - loading and error states
+ */
+export function useOptions<T extends string | number>(options: AsyncOptions<T>) {
+  const isAsync = typeof options === 'function';
+  const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);
+  const [asyncLoading, setAsyncLoading] = useState(false);
+  const [asyncError, setAsyncError] = useState(false);
+
+  // This hook keeps its own inputValue state (rather than accepting it as an arg) because it needs to be
+  // told it for async options loading anyway.
+  const [userTypedSearch, setUserTypedSearch] = useState('');
+
+  const loadOptionsWhenUserTypes = useCallback(
+    (inputValue: string) => {
+      console.log('loadOptionsWhenUserTypes', inputValue);
+      if (!isAsync) {
+        setUserTypedSearch(inputValue);
+        return;
+      }
+
+      setAsyncLoading(true);
+
+      options(inputValue)
+        .then((options) => {
+          setAsyncOptions(options);
+          setAsyncLoading(false);
+          setAsyncError(false);
+        })
+        .catch((error) => {
+          setAsyncError(true);
+          setAsyncLoading(false);
+
+          if (error) {
+            console.error('Error loading async options for Combobox', error);
+          }
+        });
+    },
+    [options, isAsync]
+  );
+
+  const finalOptions = useMemo(() => {
+    if (isAsync) {
+      return asyncOptions;
+    } else {
+      return options.filter(itemFilter(userTypedSearch));
+    }
+  }, [options, asyncOptions, isAsync, userTypedSearch]);
+
+  return { options: finalOptions, loadOptionsWhenUserTypes, asyncLoading, asyncError };
+}

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 
-import { ComboboxOption } from './Combobox';
 import { itemFilter } from './filter';
+import { ComboboxOption } from './types';
 
 type AsyncOptions<T extends string | number> =
   | Array<ComboboxOption<T>>

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -53,10 +53,10 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
           if (!(error instanceof StaleResultError)) {
             setAsyncError(true);
             setAsyncLoading(false);
-          }
 
-          if (error) {
-            console.error('Error loading async options for Combobox', error);
+            if (error) {
+              console.error('Error loading async options for Combobox', error);
+            }
           }
         });
     },


### PR DESCRIPTION
Adds Async options loading to MultiCombobox.

Abstracts this away into a `useOptions` hook that lets the rest of the component not worry about whether the options are async or not. Goal is to move Combobox to use this as well.

Fixes https://github.com/grafana/grafana/issues/96114 