### PR TITLE
PanelDataPane: Render bottom border on tabs bar

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -80,7 +80,7 @@ function PanelDataPaneRendered({ model }: SceneComponentProps<PanelDataPane>) {
 
   return (
     <div className={styles.dataPane} data-testid={selectors.components.PanelEditor.DataPane.content}>
-      <TabsBar hideBorder={true} className={styles.tabsBar}>
+      <TabsBar className={styles.tabsBar}>
         {tabs.map((t) => t.renderTab({ active: t.tabId === tab, onChangeTab: () => model.onChangeTab(t) }))}
       </TabsBar>
       <ScrollContainer backgroundColor="primary">


### PR DESCRIPTION
### What does this PR do? 📓 

Resolves a UX style issue whereby a user scrolls down in the query editor and the visual distinction between the tabs bar and query editor disappears (same background color). This PR renders a bottom border on the tabs bar to help with the visual distinction by removing the `hideBorder` optional prop passed to `<TabsBar />`.

Fixes https://github.com/grafana/grafana/issues/98837

#### Before 📸 

<img width="820" alt="image" src="https://github.com/user-attachments/assets/55257ae0-499f-42a1-a2d7-5d14a3d7e622" />

#### After 📸 

<img width="826" alt="image" src="https://github.com/user-attachments/assets/c0bf4980-6302-46ea-a4aa-36671841831d" />
