### PR TITLE
Dashboard: Add ScopeMeta to DashboardModel

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -34,7 +34,7 @@ import store from 'app/core/store';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { SaveDashboardAsOptions } from 'app/features/dashboard/components/SaveDashboard/types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
-import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import { DashboardModel, ScopeMeta } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { getClosestScopesFacade, ScopesFacade } from 'app/features/scopes';
@@ -99,6 +99,8 @@ export interface DashboardSceneState extends SceneObjectState {
   preload?: boolean;
   /** A uid when saved */
   uid?: string;
+  /** @experimental */
+  scopeMeta?: ScopeMeta;
   /** @deprecated */
   id?: number | null;
   /** Layout of panels */

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -248,6 +248,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     title: oldModel.title,
     uid: oldModel.uid,
     version: oldModel.version,
+    scopeMeta: oldModel.scopesMeta,
     body: new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         isLazy: !(dto.preload || contextSrv.user.authenticatedBy === 'render'),

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -278,8 +278,13 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     }),
   });
 
-  if (config.featureToggles.scopeFilters) {
-    dashboardScene.setState({ scopeMeta: oldModel.scopeMeta });
+  if (config.featureToggles.scopeFilters && oldModel.scopeMeta) {
+    dashboardScene.setState({
+      scopeMeta: {
+        trait: oldModel.scopeMeta.trait,
+        groups: oldModel.scopeMeta.groups,
+      },
+    });
   }
 
   return dashboardScene;

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -248,7 +248,6 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     title: oldModel.title,
     uid: oldModel.uid,
     version: oldModel.version,
-    scopeMeta: oldModel.scopesMeta,
     body: new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         isLazy: !(dto.preload || contextSrv.user.authenticatedBy === 'render'),
@@ -278,6 +277,10 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
       hideTimeControls: oldModel.timepicker.hidden,
     }),
   });
+
+  if (config.featureToggles.scopeFilters) {
+    dashboardScene.setState({ scopeMeta: oldModel.scopeMeta });
+  }
 
   return dashboardScene;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -216,6 +216,14 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     });
   }
 
+  const scopeMeta =
+    config.featureToggles.scopeFilters && oldModel.scopeMeta
+      ? {
+          trait: oldModel.scopeMeta.trait,
+          groups: oldModel.scopeMeta.groups,
+        }
+      : undefined;
+
   const behaviorList: SceneObjectState['$behaviors'] = [
     new behaviors.CursorSync({
       sync: oldModel.graphTooltip,
@@ -248,6 +256,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
     title: oldModel.title,
     uid: oldModel.uid,
     version: oldModel.version,
+    scopeMeta,
     body: new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         isLazy: !(dto.preload || contextSrv.user.authenticatedBy === 'render'),
@@ -277,15 +286,6 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
       hideTimeControls: oldModel.timepicker.hidden,
     }),
   });
-
-  if (config.featureToggles.scopeFilters && oldModel.scopeMeta) {
-    dashboardScene.setState({
-      scopeMeta: {
-        trait: oldModel.scopeMeta.trait,
-        groups: oldModel.scopeMeta.groups,
-      },
-    });
-  }
 
   return dashboardScene;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -140,6 +140,8 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
     liveNow,
     schemaVersion: DASHBOARD_SCHEMA_VERSION,
     refresh: refreshPicker?.state.refresh,
+    // @ts-expect-error not in dashboard schema because it's experimental
+    scopeMeta: state.scopeMeta,
   };
 
   return sortedDeepCloneWithoutNulls(dashboard);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -93,7 +93,7 @@ export class DashboardModel implements TimeModel {
   panelInEdit?: PanelModel;
   panelInView?: PanelModel;
   fiscalYearStartMonth?: number;
-  scopesMeta?: ScopeMeta;
+  scopeMeta?: ScopeMeta;
   private panelsAffectedByVariableChange: number[] | null;
   private appEventsSubscription: Subscription;
   private lastRefresh: number;
@@ -162,9 +162,8 @@ export class DashboardModel implements TimeModel {
     this.links = data.links ?? [];
     this.gnetId = data.gnetId || null;
     this.panels = map(data.panels ?? [], (panelData) => new PanelModel(panelData));
-    // @ts-expect-error - experimental so it's not included in the schema
-    // but the backend will still return this field
-    this.scopesMeta = data.scopeMeta;
+    // @ts-expect-error - experimental and it's not included in the schema
+    this.scopeMeta = data.scopeMeta;
     // Deep clone original dashboard to avoid mutations by object reference
     this.originalDashboard = cloneDeep(data);
     this.originalTemplating = cloneDeep(this.templating);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -56,6 +56,12 @@ export interface CloneOptions {
 
 export type DashboardLinkType = 'link' | 'dashboards';
 
+/** @experimental */
+export interface ScopeMeta {
+  trait: string;
+  groups: string[];
+}
+
 export class DashboardModel implements TimeModel {
   /** @deprecated use UID */
   id: any;
@@ -87,6 +93,7 @@ export class DashboardModel implements TimeModel {
   panelInEdit?: PanelModel;
   panelInView?: PanelModel;
   fiscalYearStartMonth?: number;
+  scopesMeta?: ScopeMeta;
   private panelsAffectedByVariableChange: number[] | null;
   private appEventsSubscription: Subscription;
   private lastRefresh: number;
@@ -155,6 +162,9 @@ export class DashboardModel implements TimeModel {
     this.links = data.links ?? [];
     this.gnetId = data.gnetId || null;
     this.panels = map(data.panels ?? [], (panelData) => new PanelModel(panelData));
+    // @ts-expect-error - experimental so it's not included in the schema
+    // but the backend will still return this field
+    this.scopesMeta = data.scopeMeta;
     // Deep clone original dashboard to avoid mutations by object reference
     this.originalDashboard = cloneDeep(data);
     this.originalTemplating = cloneDeep(this.templating);


### PR DESCRIPTION
Adds experimental ScopeMeta prop to DashboardModel so this field can be added in JSON editor and then persisted in db.

> These fields would be used by an external controller that creates links between scopes and dashboards based on those fields. Eventually, they should be configurable somewhere under dashboard settings, but for now, just adding them in the dashboard JSON is good enough since it enables us to dogfood. @bergquist

I didn't add them to the schema because Foundation SDK will pick it up and then create a lot of ripple effects. This approach still works because the current backend will accept any json and will persist it to the database. 


