### PR TITLE
GrafanaUI: Fix error handling from rejected promises in Combobox

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.ts
+++ b/packages/grafana-ui/src/components/Combobox/useLatestAsyncCall.ts
@@ -15,14 +15,16 @@ export function useLatestAsyncCall<T, V>(fn: AsyncFn<T, V>): AsyncFn<T, V> {
       const requestCount = latestValueCount.current;
 
       return new Promise<V>((resolve, reject) => {
-        fn(value).then((result) => {
-          // Only resolve if the value is still the latest
-          if (requestCount === latestValueCount.current) {
-            resolve(result);
-          } else {
-            reject(new StaleResultError());
-          }
-        });
+        fn(value)
+          .then((result) => {
+            // Only resolve if the value is still the latest
+            if (requestCount === latestValueCount.current) {
+              resolve(result);
+            } else {
+              reject(new StaleResultError());
+            }
+          })
+          .catch(reject);
       });
     },
     [fn]


### PR DESCRIPTION
If the async options function returns a rejected promise, the rejection is just silently swallowed inside `useLatestAsyncCall`.

This PR catches and and pops it up to be handled as normal.