### PR TITLE
TableNG: Update renderHeaderCell with filter dep

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -430,7 +430,7 @@ export function TableNG(props: TableNGProps) {
     });
   }, [filteredRows, props.data.fields, footerOptions, isCountRowsSet]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const columns = useMemo(() => mapFrameToDataGrid(props.data, calcsRef), [props.data, calcsRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  const columns = useMemo(() => mapFrameToDataGrid(props.data, calcsRef), [props.data, calcsRef, filter]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {


### PR DESCRIPTION
Fixes an issue where changing filter was not updating renderHeaderCell. By adding filter as a dep for the columns useMemo, the behavior acts as expected. Might be a more optimal way to do this, but for now this unblocks any filter work.

Before:
![Jan-23-2025 13-24-32](https://github.com/user-attachments/assets/d98ea925-02b1-45d8-9aa1-2a84822e0e44)

After:
![Jan-23-2025 13-23-58](https://github.com/user-attachments/assets/13c13126-4cd0-44d6-9f49-f4b84e50118b)

