### PR TITLE
[POC] Canvas: Add support for base64 image source

### DIFF
--- a/public/app/features/dimensions/resource.ts
+++ b/public/app/features/dimensions/resource.ts
@@ -11,6 +11,9 @@ export function getPublicOrAbsoluteUrl(v: string): string {
   if (!v) {
     return '';
   }
+  if (v.startsWith('data:image/')) {
+    return v;
+  }
   return v.indexOf(':/') > 0 ? v : window.__grafana_public_path__ + v;
 }
 


### PR DESCRIPTION
Add support for base64-encoded images for Resource Dimension Editor.

After:
![Jan-23-2025 15-25-06](https://github.com/user-attachments/assets/32fc5ede-1e93-4835-a4a7-98c132881f0e)

