### PR TITLE
fix: use home page from configuration if user home not found

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -594,6 +594,10 @@ func (hs *HTTPServer) GetHomeDashboard(c *contextmodel.ReqContext) response.Resp
 			return response.JSON(http.StatusOK, &dashRedirect)
 		}
 		hs.log.Warn("Failed to get slug from database", "err", err)
+		if len(homePage) > 0 {
+			homePageRedirect := dtos.DashboardRedirect{RedirectUri: homePage}
+			return response.JSON(http.StatusOK, &homePageRedirect)
+		}
 	}
 
 	filePath := hs.Cfg.DefaultHomeDashboardPath


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue in which the user is shown the default home dashboard instead of the configured home page when the user's home dashboard is deleted.


**Who is this feature for?**

Instance administrators specifying a custom home page

**Which issue(s) does this PR fix?**:

Related to [this escalation](https://github.com/grafana/support-escalations/issues/14236).


Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
