### PR TITLE
@grafana/plugin-ui: use fixed version of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@grafana/lezer-logql": "0.2.7",
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.9.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/data": "11.5.0-pre",
-    "@grafana/plugin-ui": "^0.9.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "11.5.0-pre",
     "@grafana/sql": "11.5.0-pre",
     "@grafana/ui": "11.5.0-pre",

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -8,7 +8,7 @@
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.9.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "workspace:*",
     "@grafana/ui": "workspace:*",
     "lodash": "4.17.21",

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/data": "11.5.0-pre",
-    "@grafana/plugin-ui": "^0.9.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "11.5.0-pre",
     "@grafana/sql": "11.5.0-pre",
     "@grafana/ui": "11.5.0-pre",

--- a/public/app/plugins/datasource/zipkin/package.json
+++ b/public/app/plugins/datasource/zipkin/package.json
@@ -8,7 +8,7 @@
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.9.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "workspace:*",
     "@grafana/ui": "workspace:*",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,7 +2773,7 @@ __metadata:
     "@grafana/data": "npm:11.5.0-pre"
     "@grafana/e2e-selectors": "npm:11.5.0-pre"
     "@grafana/plugin-configs": "npm:11.5.0-pre"
-    "@grafana/plugin-ui": "npm:^0.9.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "npm:11.5.0-pre"
     "@grafana/sql": "npm:11.5.0-pre"
     "@grafana/ui": "npm:11.5.0-pre"
@@ -2885,7 +2885,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "workspace:*"
-    "@grafana/plugin-ui": "npm:^0.9.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "workspace:*"
     "@grafana/ui": "workspace:*"
     "@testing-library/dom": "npm:10.4.0"
@@ -2957,7 +2957,7 @@ __metadata:
     "@grafana/data": "npm:11.5.0-pre"
     "@grafana/e2e-selectors": "npm:11.5.0-pre"
     "@grafana/plugin-configs": "npm:11.5.0-pre"
-    "@grafana/plugin-ui": "npm:^0.9.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "npm:11.5.0-pre"
     "@grafana/sql": "npm:11.5.0-pre"
     "@grafana/ui": "npm:11.5.0-pre"
@@ -3127,7 +3127,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "workspace:*"
-    "@grafana/plugin-ui": "npm:^0.9.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "workspace:*"
     "@grafana/ui": "workspace:*"
     "@testing-library/dom": "npm:10.4.0"
@@ -3583,7 +3583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-ui@npm:0.9.6, @grafana/plugin-ui@npm:^0.9.3, @grafana/plugin-ui@npm:^0.9.6":
+"@grafana/plugin-ui@npm:0.9.6, @grafana/plugin-ui@npm:^0.9.3":
   version: 0.9.6
   resolution: "@grafana/plugin-ui@npm:0.9.6"
   dependencies:
@@ -17770,7 +17770,7 @@ __metadata:
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:^1.11.0"
-    "@grafana/plugin-ui": "npm:^0.9.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"


### PR DESCRIPTION
Use `"@grafana/plugin-ui": "0.9.6"` instead of `"@grafana/plugin-ui": "^0.9.6"` everywhere, so we have fixed version as with other dependencies