### PR TITLE
Remove @grafana/experimental in @grafana/o11y-ds-frontend and @grafana/sql

### DIFF
--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -20,7 +20,7 @@
     "@emotion/css": "11.13.5",
     "@grafana/data": "11.5.0-pre",
     "@grafana/e2e-selectors": "11.5.0-pre",
-    "@grafana/experimental": "2.1.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "11.5.0-pre",
     "@grafana/schema": "11.5.0-pre",
     "@grafana/ui": "11.5.0-pre",

--- a/packages/grafana-o11y-ds-frontend/src/NodeGraph/NodeGraphSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/NodeGraph/NodeGraphSettings.tsx
@@ -7,7 +7,7 @@ import {
   GrafanaTheme2,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
 
 export interface NodeGraphOptions {

--- a/packages/grafana-o11y-ds-frontend/src/SpanBar/SpanBarSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/SpanBar/SpanBarSettings.tsx
@@ -7,7 +7,7 @@ import {
   toOption,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { InlineField, InlineFieldRow, Input, Select, useStyles2 } from '@grafana/ui';
 
 export interface SpanBarOptions {

--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 
 import { DataSourceJsonData, DataSourceInstanceSettings, DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSection } from '@grafana/plugin-ui';
 import { DataSourcePicker } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Input, InlineSwitch } from '@grafana/ui';
 

--- a/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -7,7 +7,7 @@ import {
   GrafanaTheme2,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSection } from '@grafana/plugin-ui';
 import { DataSourcePicker } from '@grafana/runtime';
 import { Button, InlineField, InlineFieldRow, Input, useStyles2 } from '@grafana/ui';
 

--- a/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
@@ -9,7 +9,7 @@ import {
   DataSourcePluginOptionsEditorProps,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSection } from '@grafana/plugin-ui';
 import { DataSourcePicker, DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Input, InlineSwitch } from '@grafana/ui';
 

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -17,7 +17,7 @@
     "@emotion/css": "11.13.5",
     "@grafana/data": "11.5.0-pre",
     "@grafana/e2e-selectors": "11.5.0-pre",
-    "@grafana/experimental": "2.1.6",
+    "@grafana/plugin-ui": "0.9.6",
     "@grafana/runtime": "11.5.0-pre",
     "@grafana/ui": "11.5.0-pre",
     "@react-awesome-query-builder/ui": "6.6.4",

--- a/packages/grafana-sql/src/components/QueryEditor.tsx
+++ b/packages/grafana-sql/src/components/QueryEditor.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { QueryEditorProps } from '@grafana/data';
-import { EditorMode } from '@grafana/experimental';
+import { EditorMode } from '@grafana/plugin-ui';
 import { Space } from '@grafana/ui';
 
 import { SqlDatasource } from '../datasource/SqlDatasource';

--- a/packages/grafana-sql/src/components/QueryHeader.tsx
+++ b/packages/grafana-sql/src/components/QueryHeader.tsx
@@ -3,7 +3,7 @@ import { useCopyToClipboard } from 'react-use';
 
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { EditorField, EditorHeader, EditorMode, EditorRow, FlexItem, InlineSelect } from '@grafana/experimental';
+import { EditorField, EditorHeader, EditorMode, EditorRow, FlexItem, InlineSelect } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, InlineSwitch, RadioButtonGroup, Tooltip, Space } from '@grafana/ui';
 

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -1,5 +1,5 @@
 import { DataSourceSettings } from '@grafana/data';
-import { ConfigSubSection, Stack } from '@grafana/experimental';
+import { ConfigSubSection, Stack } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Field, Icon, InlineLabel, Label, Switch, Tooltip } from '@grafana/ui';
 

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -1,7 +1,7 @@
 import { DataSourceSettings } from '@grafana/data';
-import { ConfigSubSection, Stack } from '@grafana/plugin-ui';
+import { ConfigSubSection } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
-import { Field, Icon, InlineLabel, Label, Switch, Tooltip } from '@grafana/ui';
+import { Field, Icon, InlineLabel, Label, Stack, Switch, Tooltip } from '@grafana/ui';
 
 import { SQLConnectionLimits, SQLOptions } from '../../types';
 

--- a/packages/grafana-sql/src/components/query-editor-raw/QueryEditorRaw.tsx
+++ b/packages/grafana-sql/src/components/query-editor-raw/QueryEditorRaw.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import * as React from 'react';
 
-import { LanguageDefinition, SQLEditor } from '@grafana/experimental';
+import { LanguageDefinition, SQLEditor } from '@grafana/plugin-ui';
 
 import { SQLQuery } from '../../types';
 

--- a/packages/grafana-sql/src/components/visual-query-builder/GroupByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/GroupByRow.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { AccessoryButton, EditorList, InputGroup } from '@grafana/experimental';
+import { AccessoryButton, EditorList, InputGroup } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
 import { QueryEditorGroupByExpression } from '../../expressions';

--- a/packages/grafana-sql/src/components/visual-query-builder/OrderByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/OrderByRow.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import * as React from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { EditorField, InputGroup } from '@grafana/experimental';
+import { EditorField, InputGroup } from '@grafana/plugin-ui';
 import { Input, RadioButtonGroup, Select, Space } from '@grafana/ui';
 
 import { SQLExpression } from '../../types';

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectColumn.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectColumn.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { EditorField } from '@grafana/experimental';
+import { EditorField } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
 interface Props {

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectFunctionParameters.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectFunctionParameters.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useId, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { EditorField } from '@grafana/experimental';
+import { EditorField } from '@grafana/plugin-ui';
 import { InlineLabel, Input, Select, Stack, useStyles2 } from '@grafana/ui';
 
 import { QueryEditorExpressionType } from '../../expressions';

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectRow.test.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectRow.test.tsx
@@ -12,6 +12,7 @@ import { SelectRow } from './SelectRow';
 
 // Mock featureToggle sqlQuerybuilderFunctionParameters
 jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
   config: {
     featureToggles: {
       sqlQuerybuilderFunctionParameters: true,

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { EditorField } from '@grafana/experimental';
+import { EditorField } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Button, Select, Stack, useStyles2 } from '@grafana/ui';
 

--- a/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
@@ -1,6 +1,6 @@
 import { useAsync } from 'react-use';
 
-import { EditorRows, EditorRow, EditorField } from '@grafana/experimental';
+import { EditorRows, EditorRow, EditorField } from '@grafana/plugin-ui';
 
 import { DB, QueryEditorProps, QueryRowFilter } from '../../types';
 import { QueryToolbox } from '../query-editor-raw/QueryToolbox';

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -17,7 +17,7 @@ import {
   VariableWithMultiSupport,
   TimeRange,
 } from '@grafana/data';
-import { EditorMode } from '@grafana/experimental';
+import { EditorMode } from '@grafana/plugin-ui';
 import {
   BackendDataSourceResponse,
   DataSourceWithBackend,

--- a/packages/grafana-sql/src/defaults.ts
+++ b/packages/grafana-sql/src/defaults.ts
@@ -1,4 +1,4 @@
-import { EditorMode } from '@grafana/experimental';
+import { EditorMode } from '@grafana/plugin-ui';
 
 import { QueryFormat, SQLQuery } from './types';
 import { createFunctionField, setGroupByField } from './utils/sql.utils';

--- a/packages/grafana-sql/src/types.ts
+++ b/packages/grafana-sql/src/types.ts
@@ -9,7 +9,7 @@ import {
   TimeRange,
   toOption as toOptionFromData,
 } from '@grafana/data';
-import { CompletionItemKind, EditorMode, LanguageDefinition } from '@grafana/experimental';
+import { CompletionItemKind, EditorMode, LanguageDefinition } from '@grafana/plugin-ui';
 
 import { QueryWithDefaults } from './defaults';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,7 +3519,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@grafana/data": "npm:11.5.0-pre"
     "@grafana/e2e-selectors": "npm:11.5.0-pre"
-    "@grafana/experimental": "npm:2.1.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "npm:11.5.0-pre"
     "@grafana/schema": "npm:11.5.0-pre"
     "@grafana/tsconfig": "npm:^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,7 +3897,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@grafana/data": "npm:11.5.0-pre"
     "@grafana/e2e-selectors": "npm:11.5.0-pre"
-    "@grafana/experimental": "npm:2.1.6"
+    "@grafana/plugin-ui": "npm:0.9.6"
     "@grafana/runtime": "npm:11.5.0-pre"
     "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:11.5.0-pre"


### PR DESCRIPTION
`@grafana/experimental` has been deprecated and archived and components have been moved to `@grafana/plugin-ui`. This PR replaces `@grafana/experimental`  with `@grafana/plugin-ui` in packages:
- @grafana/o11y-ds-frontend 
- @grafana/sql

Manually verified at couple of places that these changes work:
<img width="968" alt="image" src="https://github.com/user-attachments/assets/39d34723-d901-42d0-a6c9-c78af49a77a9" />

<img width="990" alt="image" src="https://github.com/user-attachments/assets/8e83cd48-d082-4271-82ad-58e8af7d26d8" />

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/fdae0233-dcd0-48b5-8fa2-08e270b3ec3d" />

<img width="988" alt="image" src="https://github.com/user-attachments/assets/316b0bfe-e78f-42b3-a081-0854a29c0f35" />

