### PR TITLE
Alerting: Fix getting targets in dag when using classic condition

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -2,10 +2,9 @@ import { Graph } from 'app/core/utils/dag';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {
-  _createDagFromQueries,
   _getDescendants,
   _getOriginsOfRefId,
-  fingerPrintQueries,
+  createDagFromQueries,
   fingerprintGraph,
   parseRefsFromMathExpression,
 } from './dag';
@@ -45,7 +44,7 @@ describe('working with dag', () => {
       },
     ] as AlertQuery[];
 
-    const dag = _createDagFromQueries(queries);
+    const dag = createDagFromQueries(queries);
 
     expect(Object.keys(dag.nodes)).toHaveLength(4);
 
@@ -84,9 +83,9 @@ describe('working with dag', () => {
       },
     ] as AlertQuery[];
 
-    expect(() => _createDagFromQueries(queries)).not.toThrow();
+    expect(() => createDagFromQueries(queries)).not.toThrow();
 
-    const dag = _createDagFromQueries(queries);
+    const dag = createDagFromQueries(queries);
 
     expect(Object.keys(dag.nodes)).toHaveLength(1);
 
@@ -156,37 +155,5 @@ describe('fingerprints', () => {
     graph.link('D', 'B');
 
     expect(fingerprintGraph(graph)).toMatchInlineSnapshot(`"A:B: B:C:A, D C::B D:B:"`);
-  });
-
-  test('Queries fingerprint', () => {
-    const queries = [
-      {
-        refId: 'A',
-        queryType: 'query',
-        model: {
-          refId: 'A',
-          expression: '',
-        },
-      },
-      {
-        refId: 'B',
-        queryType: 'query',
-        model: {
-          refId: 'B',
-          expression: 'A',
-        },
-      },
-      {
-        refId: 'C',
-        queryType: 'query',
-        model: {
-          refId: 'C',
-          expression: '$B > 0',
-          type: 'math',
-        },
-      },
-    ] as AlertQuery[];
-
-    expect(fingerPrintQueries(queries)).toMatchInlineSnapshot(`"Aquery,BAquery,C$B > 0math"`);
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/dag.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.ts
@@ -1,24 +1,15 @@
 import { compact, memoize, uniq } from 'lodash';
-import memoizeOne from 'memoize-one';
 
 import { Edge, Graph, Node } from 'app/core/utils/dag';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { ExpressionQuery } from 'app/features/expressions/types';
+import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
-
-// memoized version of _createDagFromQueries to prevent recreating the DAG if no sources or targets are modified
-export const createDagFromQueries = memoizeOne(
-  _createDagFromQueries,
-  (previous: Parameters<typeof _createDagFromQueries>, next: Parameters<typeof _createDagFromQueries>) => {
-    return fingerPrintQueries(previous[0]) === fingerPrintQueries(next[0]);
-  }
-);
 
 /**
  * Turn the array of alert queries (this means data queries and expressions)
  * in to a DAG, a directed acyclical graph
  */
-export function _createDagFromQueries(queries: AlertQuery[]): Graph {
+export function createDagFromQueries(queries: AlertQuery[]): Graph {
   const graph = new Graph();
 
   const nodes = queries.map((query) => query.refId);
@@ -46,8 +37,8 @@ export function _createDagFromQueries(queries: AlertQuery[]): Graph {
 }
 
 function getTargets(model: ExpressionQuery) {
-  const isMathExpression = model.type === 'math';
-  const isClassicCondition = model.type === 'classic_conditions';
+  const isMathExpression = model.type === ExpressionQueryType.math;
+  const isClassicCondition = model.type === ExpressionQueryType.classic;
 
   if (isMathExpression) {
     return parseRefsFromMathExpression(model.expression ?? '');
@@ -139,14 +130,4 @@ export function fingerprintGraph(graph: Graph) {
       return `${n.name}:${outputEdges}:${inputEdges}`;
     })
     .join(' ');
-}
-
-// create a unique fingerprint of the array of queries
-export function fingerPrintQueries(queries: AlertQuery[]) {
-  return queries
-    .map((query) => {
-      const type = isExpressionQuery(query.model) ? query.model.type : query.queryType;
-      return query.refId + (query.model.expression ?? '') + type;
-    })
-    .join();
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes the DAG targets used in the alert rule form when using a classic condition.
Previously, we were incorrectly using the `model.expression` field as the target.

In this scenario, however, the correct target is a list within the `model.conditions` array.

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

All alerting users.

**Which issue(s) does this PR fix?**:

Related to this [escalation](https://github.com/grafana/support-escalations/issues/14323).

**Special notes for your reviewer:**

Before the fix:

<img width="1785" alt="Screenshot 2025-01-24 at 13 45 58" src="https://github.com/user-attachments/assets/791e888e-5f52-4a0c-8ef7-e87d88d8f60e" />

After the fix:


<img width="1790" alt="Screenshot 2025-01-24 at 13 46 46" src="https://github.com/user-attachments/assets/319b314c-7678-4b02-8a4b-25b56f3b4303" />

## Important

We've decided to remove the query fingerprinting and memoization optimization for the following reasons:
1. the DAG function is probably fast enough for most if not all alert rule definitions.
2. the fingerprinting function was incorrect for some expressions (math, classic) and maintaining it is unnecessary.