### PR TITLE
Alerting: Expect 406s from the remote Alertmanager during the readiness check

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -642,7 +642,7 @@ func (am *Alertmanager) shouldSendConfig(ctx context.Context, config *apimodels.
 	rc, err := am.mimirClient.GetGrafanaAlertmanagerConfig(ctx)
 	if err != nil {
 		// Log the error and return true so we try to upload our config anyway.
-		am.log.Error("Unable to get the remote Alertmanager configuration for comparison", "err", err)
+		am.log.Warn("Unable to get the remote Alertmanager configuration for comparison", "err", err)
 		return true
 	}
 
@@ -669,7 +669,7 @@ func (am *Alertmanager) shouldSendState(ctx context.Context, state string) bool 
 	rs, err := am.mimirClient.GetGrafanaAlertmanagerState(ctx)
 	if err != nil {
 		// Log the error and return true so we try to upload our state anyway.
-		am.log.Error("Unable to get the remote Alertmanager state for comparison", "err", err)
+		am.log.Warn("Unable to get the remote Alertmanager state for comparison", "err", err)
 		return true
 	}
 

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -642,7 +642,7 @@ func (am *Alertmanager) shouldSendConfig(ctx context.Context, config *apimodels.
 	rc, err := am.mimirClient.GetGrafanaAlertmanagerConfig(ctx)
 	if err != nil {
 		// Log the error and return true so we try to upload our config anyway.
-		am.log.Warn("Unable to get the remote Alertmanager configuration for comparison", "err", err)
+		am.log.Warn("Unable to get the remote Alertmanager configuration for comparison, sending the configuration without comparing", "err", err)
 		return true
 	}
 
@@ -669,7 +669,7 @@ func (am *Alertmanager) shouldSendState(ctx context.Context, state string) bool 
 	rs, err := am.mimirClient.GetGrafanaAlertmanagerState(ctx)
 	if err != nil {
 		// Log the error and return true so we try to upload our state anyway.
-		am.log.Warn("Unable to get the remote Alertmanager state for comparison", "err", err)
+		am.log.Warn("Unable to get the remote Alertmanager state for comparison, sending the state without comparing", "err", err)
 		return true
 	}
 


### PR DESCRIPTION
An improvement was recently introduced in Mimir to skip initializing the Alertmanager for a Grafana tenant without a promoted, non-default configuration.

If the Alertmanager is not running for a tenant, requests to the `/alertmanager/-/ready` endpoint will result in `406` status codes. The endpoints to store and retrieve configuration and state will still be usable.

This PR makes the readiness check consider this case.

Note: I also changed the _"Unable to get the remote Alertmanager configuration for comparison"_ log line from _Error_ to _Warn_. We don't return this error, we upload our state/configuration anyway. 