### PR TITLE
Explore: Add `hide_logs_download` and hide button to download logs

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1572,7 +1572,7 @@ enabled = true
 defaultTimeOffset = 1h
 
 # hides the download logs button in Explore
-disableLogsDownload = false
+hide_logs_download = false
 
 #################################### Help #############################
 [help]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1571,6 +1571,9 @@ enabled = true
 # set the default offset for the time picker
 defaultTimeOffset = 1h
 
+# hides the download logs button in Explore
+disableLogsDownload = false
+
 #################################### Help #############################
 [help]
 # Enable the Help section

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1934,6 +1934,10 @@ Enable or disable the Explore section. Default is `enabled`.
 Set a default time offset from now on the time picker. Default is 1 hour.
 This setting should be expressed as a duration. Examples: 1h (hour), 1d (day), 1w (week), 1M (month).
 
+#### `disableLogsDownload`
+
+Enable or disable the download logs button in Explore. Default is `false`, so that the button will be visible.
+
 ### `[help]`
 
 Configures the help section.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1934,9 +1934,9 @@ Enable or disable the Explore section. Default is `enabled`.
 Set a default time offset from now on the time picker. Default is 1 hour.
 This setting should be expressed as a duration. Examples: 1h (hour), 1d (day), 1w (week), 1M (month).
 
-#### `disableLogsDownload`
+#### `hide_logs_download`
 
-Enable or disable the button to download logs in Explore. Default is `false`, so that the button will be visible.
+Show or hide the button to download logs in Explore. Default is `false`, so that the button will be visible.
 
 ### `[help]`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1936,7 +1936,7 @@ This setting should be expressed as a duration. Examples: 1h (hour), 1d (day), 1
 
 #### `disableLogsDownload`
 
-Enable or disable the download logs button in Explore. Default is `false`, so that the button will be visible.
+Enable or disable the button to download logs in Explore. Default is `false`, so that the button will be visible.
 
 ### `[help]`
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -237,6 +237,7 @@ export interface GrafanaConfig {
   listScopesEndpoint?: string;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset?: string;
+  exploreDisableLogsDownload?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -237,7 +237,7 @@ export interface GrafanaConfig {
   listScopesEndpoint?: string;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset?: string;
-  ExploreHideLogsDownload?: boolean;
+  exploreHideLogsDownload?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -237,7 +237,7 @@ export interface GrafanaConfig {
   listScopesEndpoint?: string;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset?: string;
-  exploreDisableLogsDownload?: boolean;
+  ExploreHideLogsDownload?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -202,6 +202,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   cloudMigrationPollIntervalMs = 2000;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset = '1h';
+  exploreDisableLogsDownload: boolean | undefined;
 
   /**
    * Language used in Grafana's UI. This is after the user's preference (or deteceted locale) is resolved to one of

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -202,7 +202,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   cloudMigrationPollIntervalMs = 2000;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset = '1h';
-  exploreDisableLogsDownload: boolean | undefined;
+  ExploreHideLogsDownload: boolean | undefined;
 
   /**
    * Language used in Grafana's UI. This is after the user's preference (or deteceted locale) is resolved to one of

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -202,7 +202,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   cloudMigrationPollIntervalMs = 2000;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset = '1h';
-  ExploreHideLogsDownload: boolean | undefined;
+  exploreHideLogsDownload: boolean | undefined;
 
   /**
    * Language used in Grafana's UI. This is after the user's preference (or deteceted locale) is resolved to one of

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -210,7 +210,7 @@ type FrontendSettingsDTO struct {
 	CSPReportOnlyEnabled                bool     `json:"cspReportOnlyEnabled"`
 	EnableFrontendSandboxForPlugins     []string `json:"enableFrontendSandboxForPlugins"`
 	ExploreDefaultTimeOffset            string   `json:"exploreDefaultTimeOffset"`
-	ExploreDisableLogsDownload          bool     `json:"exploreDisableLogsDownload"`
+	ExploreHideLogsDownload             bool     `json:"ExploreHideLogsDownload"`
 
 	Auth FrontendSettingsAuthDTO `json:"auth"`
 

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -210,6 +210,7 @@ type FrontendSettingsDTO struct {
 	CSPReportOnlyEnabled                bool     `json:"cspReportOnlyEnabled"`
 	EnableFrontendSandboxForPlugins     []string `json:"enableFrontendSandboxForPlugins"`
 	ExploreDefaultTimeOffset            string   `json:"exploreDefaultTimeOffset"`
+	ExploreDisableLogsDownload          bool     `json:"exploreDisableLogsDownload"`
 
 	Auth FrontendSettingsAuthDTO `json:"auth"`
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -246,6 +246,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,
 		ReportingStaticContext:              hs.Cfg.ReportingStaticContext,
 		ExploreDefaultTimeOffset:            hs.Cfg.ExploreDefaultTimeOffset,
+		ExploreDisableLogsDownload:          hs.Cfg.ExploreDisableLogsDownload,
 
 		DefaultDatasourceManageAlertsUIToggle: hs.Cfg.DefaultDatasourceManageAlertsUIToggle,
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -246,7 +246,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,
 		ReportingStaticContext:              hs.Cfg.ReportingStaticContext,
 		ExploreDefaultTimeOffset:            hs.Cfg.ExploreDefaultTimeOffset,
-		ExploreDisableLogsDownload:          hs.Cfg.ExploreDisableLogsDownload,
+		ExploreHideLogsDownload:             hs.Cfg.ExploreHideLogsDownload,
 
 		DefaultDatasourceManageAlertsUIToggle: hs.Cfg.DefaultDatasourceManageAlertsUIToggle,
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -508,9 +508,9 @@ type Cfg struct {
 	AlertingMinInterval         int64
 
 	// Explore UI
-	ExploreEnabled             bool
-	ExploreDefaultTimeOffset   string
-	ExploreDisableLogsDownload bool
+	ExploreEnabled           bool
+	ExploreDefaultTimeOffset string
+	ExploreHideLogsDownload  bool
 
 	// Help UI
 	HelpEnabled bool
@@ -1211,7 +1211,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	} else {
 		cfg.ExploreDefaultTimeOffset = exploreDefaultTimeOffset
 	}
-	cfg.ExploreDisableLogsDownload = explore.Key("disableLogsDownload").MustBool(false)
+	cfg.ExploreHideLogsDownload = explore.Key("hide_logs_download").MustBool(false)
 
 	help := iniFile.Section("help")
 	cfg.HelpEnabled = help.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -508,8 +508,9 @@ type Cfg struct {
 	AlertingMinInterval         int64
 
 	// Explore UI
-	ExploreEnabled           bool
-	ExploreDefaultTimeOffset string
+	ExploreEnabled             bool
+	ExploreDefaultTimeOffset   string
+	ExploreDisableLogsDownload bool
 
 	// Help UI
 	HelpEnabled bool
@@ -1210,6 +1211,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	} else {
 		cfg.ExploreDefaultTimeOffset = exploreDefaultTimeOffset
 	}
+	cfg.ExploreDisableLogsDownload = explore.Key("disableLogsDownload").MustBool(false)
 
 	help := iniFile.Section("help")
 	cfg.HelpEnabled = help.Key("enabled").MustBool(true)

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -5,13 +5,13 @@ import { ComponentProps } from 'react';
 
 import { FieldType, LogLevel, LogsDedupStrategy, standardTransformersRegistry, toDataFrame } from '@grafana/data';
 import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
+import { config } from '@grafana/runtime';
 
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';
 import { logRowsToReadableJson } from '../../logs/utils';
 import { extractFieldsTransformer } from '../../transformers/extractFields/extractFields';
 
 import { LogsMetaRow } from './LogsMetaRow';
-import { config } from '@grafana/runtime';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -38,7 +38,7 @@ const setup = (propOverrides?: object, disableDownload = false) => {
     ...defaultProps,
     ...propOverrides,
   };
-  config.exploreDisableLogsDownload = disableDownload;
+  config.ExploreHideLogsDownload = disableDownload;
 
   return render(<LogsMetaRow {...props} />);
 };

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -38,7 +38,7 @@ const setup = (propOverrides?: object, disableDownload = false) => {
     ...defaultProps,
     ...propOverrides,
   };
-  config.ExploreHideLogsDownload = disableDownload;
+  config.exploreHideLogsDownload = disableDownload;
 
   return render(<LogsMetaRow {...props} />);
 };

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -11,6 +11,7 @@ import { logRowsToReadableJson } from '../../logs/utils';
 import { extractFieldsTransformer } from '../../transformers/extractFields/extractFields';
 
 import { LogsMetaRow } from './LogsMetaRow';
+import { config } from '@grafana/runtime';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -32,11 +33,12 @@ const defaultProps: LogsMetaRowProps = {
   clearDetectedFields: jest.fn(),
 };
 
-const setup = (propOverrides?: object) => {
+const setup = (propOverrides?: object, disableDownload = false) => {
   const props = {
     ...defaultProps,
     ...propOverrides,
   };
+  config.exploreDisableLogsDownload = disableDownload;
 
   return render(<LogsMetaRow {...props} />);
 };
@@ -119,6 +121,11 @@ describe('LogsMetaRow', () => {
   it('renders a button to show the download menu', () => {
     setup();
     expect(screen.getByText('Download').closest('button')).toBeInTheDocument();
+  });
+
+  it('does not render a button to show the download menu if disabled', async () => {
+    setup({}, true);
+    expect(screen.queryByText('Download')).toBeNull();
   });
 
   it('renders a button to show the download menu', async () => {

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -182,7 +182,7 @@ export const LogsMetaRow = memo(
                 };
               })}
             />
-            {!config.ExploreHideLogsDownload && (
+            {!config.exploreHideLogsDownload && (
               <Dropdown overlay={downloadMenu}>
                 <ToolbarButton isOpen={false} variant="canvas" icon="download-alt">
                   Download

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -16,7 +16,7 @@ import {
   Labels,
 } from '@grafana/data';
 import { DataFrame } from '@grafana/data/';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../../inspector/utils/download';
@@ -182,11 +182,13 @@ export const LogsMetaRow = memo(
                 };
               })}
             />
-            <Dropdown overlay={downloadMenu}>
-              <ToolbarButton isOpen={false} variant="canvas" icon="download-alt">
-                Download
-              </ToolbarButton>
-            </Dropdown>
+            {!config.exploreDisableLogsDownload && (
+              <Dropdown overlay={downloadMenu}>
+                <ToolbarButton isOpen={false} variant="canvas" icon="download-alt">
+                  Download
+                </ToolbarButton>
+              </Dropdown>
+            )}
           </div>
         )}
       </>

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -182,7 +182,7 @@ export const LogsMetaRow = memo(
                 };
               })}
             />
-            {!config.exploreDisableLogsDownload && (
+            {!config.ExploreHideLogsDownload && (
               <Dropdown overlay={downloadMenu}>
                 <ToolbarButton isOpen={false} variant="canvas" icon="download-alt">
                   Download

--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -4,9 +4,9 @@ import { ComponentProps } from 'react';
 import { Props } from 'react-virtualized-auto-sizer';
 
 import { DataFrame, FieldType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { InspectDataTab } from './InspectDataTab';
-import { config } from '@grafana/runtime';
 
 jest.mock('react-virtualized-auto-sizer', () => {
   return ({ children }: Props) =>

--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -6,6 +6,7 @@ import { Props } from 'react-virtualized-auto-sizer';
 import { DataFrame, FieldType } from '@grafana/data';
 
 import { InspectDataTab } from './InspectDataTab';
+import { config } from '@grafana/runtime';
 
 jest.mock('react-virtualized-auto-sizer', () => {
   return ({ children }: Props) =>
@@ -75,6 +76,8 @@ describe('InspectDataTab', () => {
       expect(screen.getByText(/Second data frame/i)).toBeInTheDocument();
     });
     it('should show download logs button if logs data', () => {
+      const oldConfig = config.exploreHideLogsDownload;
+      config.exploreHideLogsDownload = false;
       const dataWithLogs = [
         {
           name: 'Data frame with logs',
@@ -91,6 +94,28 @@ describe('InspectDataTab', () => {
       ] as unknown as DataFrame[];
       render(<InspectDataTab {...createProps({ data: dataWithLogs })} />);
       expect(screen.getByText(/Download logs/i)).toBeInTheDocument();
+      config.exploreHideLogsDownload = oldConfig;
+    });
+    it('should not show download logs button if logs data but config disabled', () => {
+      const oldConfig = config.exploreHideLogsDownload;
+      config.exploreHideLogsDownload = true;
+      const dataWithLogs = [
+        {
+          name: 'Data frame with logs',
+          fields: [
+            { name: 'time', type: FieldType.time, values: [100, 200, 300], config: {} },
+            { name: 'name', type: FieldType.string, values: ['uniqueA', 'b', 'c'], config: {} },
+            { name: 'value', type: FieldType.number, values: [1, 2, 3], config: {} },
+          ],
+          length: 3,
+          meta: {
+            preferredVisualisationType: 'logs',
+          },
+        },
+      ] as unknown as DataFrame[];
+      render(<InspectDataTab {...createProps({ data: dataWithLogs })} />);
+      expect(screen.queryByText(/Download logs/i)).not.toBeInTheDocument();
+      config.exploreHideLogsDownload = oldConfig;
     });
     it('should not show download logs button if no logs data', () => {
       render(<InspectDataTab {...createProps()} />);

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -223,7 +223,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
         <Button variant="primary" onClick={() => this.exportCsv(dataFrames, hasLogs)} size="sm">
           <Trans i18nKey="dashboard.inspect-data.download-csv">Download CSV</Trans>
         </Button>
-        {hasLogs && (
+        {hasLogs && !config.exploreHideLogsDownload && (
           <Button variant="primary" onClick={this.onExportLogsAsTxt} size="sm">
             <Trans i18nKey="dashboard.inspect-data.download-logs">Download logs</Trans>
           </Button>


### PR DESCRIPTION
**What is this feature?**

Adds a configuration option called `hide_logs_download ` in the `explore` section that hides the `Download` button from Explore when logs are rendered. The default value will be `false`, so the `Download` button will be shown by default.

With `hide_logs_download = false`:
![image](https://github.com/user-attachments/assets/c4f546a8-1006-49b7-91f1-00cd809e8e3d)

With `hide_logs_download = true`:
![image](https://github.com/user-attachments/assets/6cf29f03-d7c6-4020-8539-10de1456c4bc)
