### PR TITLE
Add E2E smoke tests for Jaeger, PostgreSQL, Zipkin

### DIFF
--- a/e2e/plugin-e2e/jaeger/jaeger.spec.ts
+++ b/e2e/plugin-e2e/jaeger/jaeger.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Smoke test: plugin loads', async ({ createDataSourceConfigPage, page }) => {
+  await createDataSourceConfigPage({ type: 'jaeger' });
+
+  await expect(await page.getByText('Type: Jaeger', { exact: true })).toBeVisible();
+  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+});

--- a/e2e/plugin-e2e/postgres/postgres.spec.ts
+++ b/e2e/plugin-e2e/postgres/postgres.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Smoke test: plugin loads', async ({ createDataSourceConfigPage, page }) => {
+  await createDataSourceConfigPage({ type: 'grafana-postgresql-datasource' });
+
+  await expect(await page.getByText('Type: PostgreSQL', { exact: true })).toBeVisible();
+  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+});

--- a/e2e/plugin-e2e/zipkin/zipkin.spec.ts
+++ b/e2e/plugin-e2e/zipkin/zipkin.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Smoke test: plugin loads', async ({ createDataSourceConfigPage, page }) => {
+  await createDataSourceConfigPage({ type: 'zipkin' });
+
+  await expect(await page.getByText('Type: Zipkin', { exact: true })).toBeVisible();
+  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -160,5 +160,32 @@ export default defineConfig<PluginOptions>({
       },
       dependencies: ['authenticate'],
     },
+    {
+      name: 'jaeger',
+      testDir: path.join(testDirRoot, '/jaeger'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
+    {
+      name: 'grafana-postgresql-datasource',
+      testDir: path.join(testDirRoot, '/grafana-postgresql-datasource'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
+    {
+      name: 'zipkin',
+      testDir: path.join(testDirRoot, '/zipkin'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
   ],
 });


### PR DESCRIPTION
Closes https://github.com/grafana/data-sources/issues/198, https://github.com/grafana/data-sources/issues/199, https://github.com/grafana/data-sources/issues/200. This PR adds basic E2E smoke tests for the Jaeger, PostgreSQL, Zipkin datasources that run with Playwright.