### PR TITLE
Alerting: Expose updated_by in rules GET APIs

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -12,6 +12,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -43,11 +48,8 @@ import (
 	secretsfakes "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretskv "github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_NoopServiceDoesNothing(t *testing.T) {
@@ -874,7 +876,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool, cfgOverrides ...conf
 		cfg, featureToggles, nil, nil, rr, sqlStore, kvStore, nil, nil, quotatest.New(false, nil),
 		secretsService, nil, alertMetrics, mockFolder, fakeAccessControl, dashboardService, nil, bus, fakeAccessControlService,
 		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore,
-		httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
+		httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -78,6 +79,7 @@ type API struct {
 	Historian            Historian
 	Tracer               tracing.Tracer
 	AppUrl               *url.URL
+	UserService          user.Service
 
 	// Hooks can be used to replace API handlers for specific paths.
 	Hooks *Hooks
@@ -135,6 +137,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 			amConfigStore:      api.AlertingStore,
 			amRefresher:        api.MultiOrgAlertmanager,
 			featureManager:     api.FeatureManager,
+			userService:        api.UserService,
 		},
 	), m)
 	api.RegisterTestingApiEndpoints(NewTestingApi(

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -741,7 +741,7 @@ func (srv RulerSrv) resolveUserIdToNameFn(ctx context.Context) userIDToUserInfoF
 		})
 		var result string
 		if err != nil {
-			srv.log.FromContext(ctx).Warn("Failed to get user by uid. Use empty name", "uid", id, "error", err)
+			srv.log.FromContext(ctx).Warn("Failed to get user by uid. Defaulting to an empty name", "uid", id, "error", err)
 		}
 		if u != nil {
 			result = u.NameOrFallback()

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -53,6 +54,7 @@ type RulerSrv struct {
 	cfg                *setting.UnifiedAlertingSettings
 	conditionValidator ConditionValidator
 	authz              RuleAccessControlService
+	userService        user.Service
 
 	amConfigStore  AMConfigStore
 	amRefresher    AMRefresher
@@ -211,7 +213,7 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *contextmodel.ReqContext, nam
 	result := apimodels.NamespaceConfigResponse{}
 
 	for groupKey, rules := range ruleGroups {
-		result[namespace.Fullpath] = append(result[namespace.Fullpath], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, provenanceRecords))
+		result[namespace.Fullpath] = append(result[namespace.Fullpath], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, provenanceRecords, srv.resolveUserIdToNameFn(c.Req.Context())))
 	}
 
 	return response.JSON(http.StatusAccepted, result)
@@ -246,7 +248,7 @@ func (srv RulerSrv) RouteGetRulesGroupConfig(c *contextmodel.ReqContext, namespa
 
 	result := apimodels.RuleGroupConfigResponse{
 		// nolint:staticcheck
-		GettableRuleGroupConfig: toGettableRuleGroupConfig(finalRuleGroup, rules, provenanceRecords),
+		GettableRuleGroupConfig: toGettableRuleGroupConfig(finalRuleGroup, rules, provenanceRecords, srv.resolveUserIdToNameFn(c.Req.Context())),
 	}
 	return response.JSON(http.StatusAccepted, result)
 }
@@ -300,7 +302,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Res
 			srv.log.Error("Namespace not visible to the user", "user", id, "userNamespace", userNamespace, "namespace", groupKey.NamespaceUID)
 			continue
 		}
-		result[folder.Fullpath] = append(result[folder.Fullpath], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, provenanceRecords))
+		result[folder.Fullpath] = append(result[folder.Fullpath], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, provenanceRecords, srv.resolveUserIdToNameFn(c.Req.Context())))
 	}
 	return response.JSON(http.StatusOK, result)
 }
@@ -323,7 +325,7 @@ func (srv RulerSrv) RouteGetRuleByUID(c *contextmodel.ReqContext, ruleUID string
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get rule provenance", err)
 	}
 
-	result := toGettableExtendedRuleNode(rule, map[string]ngmodels.Provenance{rule.ResourceID(): provenance})
+	result := toGettableExtendedRuleNode(rule, map[string]ngmodels.Provenance{rule.ResourceID(): provenance}, srv.resolveUserIdToNameFn(ctx))
 
 	return response.JSON(http.StatusOK, result)
 }
@@ -533,7 +535,7 @@ func changesToResponse(finalChanges *store.GroupDelta) response.Response {
 	return response.JSON(http.StatusAccepted, body)
 }
 
-func toGettableRuleGroupConfig(groupName string, rules ngmodels.RulesGroup, provenanceRecords map[string]ngmodels.Provenance) apimodels.GettableRuleGroupConfig {
+func toGettableRuleGroupConfig(groupName string, rules ngmodels.RulesGroup, provenanceRecords map[string]ngmodels.Provenance, userIdToName userIDToUserInfoFn) apimodels.GettableRuleGroupConfig {
 	rules.SortByGroupIndex()
 	ruleNodes := make([]apimodels.GettableExtendedRuleNode, 0, len(rules))
 	var interval time.Duration
@@ -541,7 +543,7 @@ func toGettableRuleGroupConfig(groupName string, rules ngmodels.RulesGroup, prov
 		interval = time.Duration(rules[0].IntervalSeconds) * time.Second
 	}
 	for _, r := range rules {
-		ruleNodes = append(ruleNodes, toGettableExtendedRuleNode(*r, provenanceRecords))
+		ruleNodes = append(ruleNodes, toGettableExtendedRuleNode(*r, provenanceRecords, userIdToName))
 	}
 	return apimodels.GettableRuleGroupConfig{
 		Name:     groupName,
@@ -550,7 +552,7 @@ func toGettableRuleGroupConfig(groupName string, rules ngmodels.RulesGroup, prov
 	}
 }
 
-func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[string]ngmodels.Provenance) apimodels.GettableExtendedRuleNode {
+func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[string]ngmodels.Provenance, userIdToName userIDToUserInfoFn) apimodels.GettableExtendedRuleNode {
 	provenance := ngmodels.ProvenanceNone
 	if prov, exists := provenanceRecords[r.ResourceID()]; exists {
 		provenance = prov
@@ -564,6 +566,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			Condition:            r.Condition,
 			Data:                 ApiAlertQueriesFromAlertQueries(r.Data),
 			Updated:              r.Updated,
+			UpdatedBy:            userIdToName(r.UpdatedBy),
 			IntervalSeconds:      r.IntervalSeconds,
 			Version:              r.Version,
 			UID:                  r.UID,
@@ -723,4 +726,29 @@ func (srv RulerSrv) searchAuthorizedAlertRules(ctx context.Context, q authorized
 		}
 	}
 	return byGroupKey, totalGroups, nil
+}
+
+type userIDToUserInfoFn func(id *ngmodels.UserUID) *apimodels.UserInfo
+
+// getIdentityName returns name of either user or service account
+func (srv RulerSrv) resolveUserIdToNameFn(ctx context.Context) userIDToUserInfoFn {
+	return func(id *ngmodels.UserUID) *apimodels.UserInfo {
+		if id == nil {
+			return nil
+		}
+		u, err := srv.userService.GetByUID(ctx, &user.GetUserByUIDQuery{
+			UID: string(*id),
+		})
+		var result string
+		if err != nil {
+			srv.log.FromContext(ctx).Warn("Failed to get user by uid. Use empty name", "uid", id, "error", err)
+		}
+		if u != nil {
+			result = u.NameOrFallback()
+		}
+		return &apimodels.UserInfo{
+			UID:  string(*id),
+			Name: result,
+		}
+	}
 }

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -32,7 +32,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/cmputil"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -357,6 +359,72 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		require.Equal(t, expectedRule.Title, result.GrafanaManagedAlert.Title)
 		require.True(t, result.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
 		require.True(t, result.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection)
+
+		t.Run("should resolve Updated_by with user service", func(t *testing.T) {
+			testcases := []struct {
+				desc             string
+				UpdatedBy        *models.UserUID
+				User             *user.User
+				UserServiceError error
+				Expected         *apimodels.UserInfo
+			}{
+				{
+					desc:             "nil if UpdatedBy is nil",
+					UpdatedBy:        nil,
+					User:             nil,
+					UserServiceError: nil,
+					Expected:         nil,
+				},
+				{
+					desc:             "just UID if user is not found",
+					UpdatedBy:        util.Pointer(models.UserUID("test-uid")),
+					User:             nil,
+					UserServiceError: nil,
+					Expected: &apimodels.UserInfo{
+						UID: "test-uid",
+					},
+				},
+				{
+					desc:             "just UID if error",
+					UpdatedBy:        util.Pointer(models.UserUID("test-uid")),
+					UserServiceError: errors.New("error"),
+					Expected: &apimodels.UserInfo{
+						UID: "test-uid",
+					},
+				},
+				{
+					desc:      "login if it's known user",
+					UpdatedBy: util.Pointer(models.UserUID("test-uid")),
+					User: &user.User{
+						Login: "Test",
+					},
+					UserServiceError: nil,
+					Expected: &apimodels.UserInfo{
+						UID:  "test-uid",
+						Name: "Test",
+					},
+				},
+			}
+			for _, tc := range testcases {
+				t.Run(tc.desc, func(t *testing.T) {
+					expectedRule.UpdatedBy = tc.UpdatedBy
+					svc := createService(ruleStore)
+					usvc := usertest.NewUserServiceFake()
+					usvc.ExpectedUser = tc.User
+					usvc.ExpectedError = tc.UserServiceError
+					svc.userService = usvc
+
+					response := svc.RouteGetRuleByUID(req, expectedRule.UID)
+
+					require.Equal(t, http.StatusOK, response.Status())
+					result := &apimodels.GettableExtendedRuleNode{}
+					require.NoError(t, json.Unmarshal(response.Body(), result))
+					require.NotNil(t, result)
+
+					require.Equal(t, tc.Expected, result.GrafanaManagedAlert.UpdatedBy)
+				})
+			}
+		})
 	})
 
 	t.Run("error when fetching rule with non-existent UID", func(t *testing.T) {
@@ -659,6 +727,7 @@ func createService(store *fakes.RuleStore) *RulerSrv {
 		amConfigStore:  &fakeAMRefresher{},
 		amRefresher:    &fakeAMRefresher{},
 		featureManager: featuremgmt.WithFeatures(featuremgmt.FlagGrafanaManagedRecordingRules),
+		userService:    usertest.NewUserServiceFake(),
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -364,7 +364,7 @@ const (
 type PostableExtendedRuleNode struct {
 	// note: this works with yaml v3 but not v2 (the inline tag isn't accepted on pointers in v2)
 	*ApiRuleNode `yaml:",inline"`
-	//GrafanaManagedAlert yaml.Node `yaml:"grafana_alert,omitempty"`
+	// GrafanaManagedAlert yaml.Node `yaml:"grafana_alert,omitempty"`
 	GrafanaManagedAlert *PostableGrafanaRule `yaml:"grafana_alert,omitempty" json:"grafana_alert,omitempty"`
 }
 
@@ -401,7 +401,7 @@ func (n *PostableExtendedRuleNode) validate() error {
 type GettableExtendedRuleNode struct {
 	// note: this works with yaml v3 but not v2 (the inline tag isn't accepted on pointers in v2)
 	*ApiRuleNode `yaml:",inline"`
-	//GrafanaManagedAlert yaml.Node `yaml:"grafana_alert,omitempty"`
+	// GrafanaManagedAlert yaml.Node `yaml:"grafana_alert,omitempty"`
 	GrafanaManagedAlert *GettableGrafanaRule `yaml:"grafana_alert,omitempty" json:"grafana_alert,omitempty"`
 }
 
@@ -541,6 +541,7 @@ type GettableGrafanaRule struct {
 	Condition            string                         `json:"condition" yaml:"condition"`
 	Data                 []AlertQuery                   `json:"data" yaml:"data"`
 	Updated              time.Time                      `json:"updated" yaml:"updated"`
+	UpdatedBy            *UserInfo                      `json:"updated_by" yaml:"updated_by"`
 	IntervalSeconds      int64                          `json:"intervalSeconds" yaml:"intervalSeconds"`
 	Version              int64                          `json:"version" yaml:"version"`
 	UID                  string                         `json:"uid" yaml:"uid"`
@@ -553,6 +554,12 @@ type GettableGrafanaRule struct {
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings,omitempty" yaml:"notification_settings,omitempty"`
 	Record               *Record                        `json:"record,omitempty" yaml:"record,omitempty"`
 	Metadata             *AlertRuleMetadata             `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+// UserInfo represents user-related information, including a unique identifier and a name.
+type UserInfo struct {
+	UID  string `json:"uid"`
+	Name string `json:"name"`
 }
 
 // AlertQuery represents a single query associated with an alert definition.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -49,6 +49,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -78,6 +79,7 @@ func ProvideService(
 	ruleStore *store.DBstore,
 	httpClientProvider httpclient.Provider,
 	resourcePermissions accesscontrol.ReceiverPermissionsService,
+	userService user.Service,
 ) (*AlertNG, error) {
 	ng := &AlertNG{
 		Cfg:                  cfg,
@@ -106,6 +108,7 @@ func ProvideService(
 		store:                ruleStore,
 		httpClientProvider:   httpClientProvider,
 		ResourcePermissions:  resourcePermissions,
+		userService:          userService,
 	}
 
 	if ng.IsDisabled() {
@@ -153,6 +156,7 @@ type AlertNG struct {
 	ResourcePermissions  accesscontrol.ReceiverPermissionsService
 	annotationsRepo      annotations.Repository
 	store                *store.DBstore
+	userService          user.Service
 
 	bus          bus.Bus
 	pluginsStore pluginstore.Store
@@ -497,6 +501,7 @@ func (ng *AlertNG) init() error {
 		Historian:            history,
 		Hooks:                api.NewHooks(ng.Log),
 		Tracer:               ng.tracer,
+		UserService:          ng.userService,
 	}
 	ng.Api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -37,6 +37,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets/database"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -71,7 +72,7 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration) (*ngalert.AlertNG, 
 	ng, err := ngalert.ProvideService(
 		cfg, features, nil, nil, routing.NewRouteRegister(), sqlStore, kvstore.NewFakeKVStore(), nil, nil, quotatest.New(false, nil),
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac,
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(tb, err)
 	return ng, &store.DBstore{

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -512,7 +513,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	_, err = ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, ngalertfakes.NewFakeKVStore(t), nil, nil, quotaService,
 		secretsService, nil, m, &foldertest.FakeService{}, &acmock.Mock{}, &dashboards.FakeDashboardService{}, nil, b, &acmock.Mock{},
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(t, err)
 	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), cfg, quotaService, storesrv.ProvideSystemUsersService())

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -3130,6 +3130,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 							 }
 						  ],
 						  "updated":"2021-02-21T01:10:30Z",
+						  "updated_by": {
+							"uid": "uid",	
+							"name": "grafana"
+						  },
 						  "intervalSeconds":60,
 						  "is_paused": false,
 						  "version":1,
@@ -3172,6 +3176,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 							 }
 						  ],
 						  "updated":"2021-02-21T01:10:30Z",
+						  "updated_by": {
+							"uid": "uid",	
+							"name": "grafana"
+						  },
 						  "intervalSeconds":60,
 						  "is_paused": false,
 						  "version":1,
@@ -3486,6 +3494,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                     }
 		                  ],
 		                  "updated":"2021-02-21T01:10:30Z",
+                          "updated_by": {
+							"uid": "uid",	
+							"name": "grafana"
+						  },
 		                  "intervalSeconds":60,
 		                  "is_paused": false,
 		                  "version":2,
@@ -3601,6 +3613,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					     }
 					  ],
 					  "updated":"2021-02-21T01:10:30Z",
+					  "updated_by": {
+						"uid": "uid",	
+						"name": "grafana"
+					  },
 					  "intervalSeconds":60,
 					  "is_paused":false,
 					  "version":3,
@@ -3695,6 +3711,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					     }
 					  ],
 					  "updated":"2021-02-21T01:10:30Z",
+                      "updated_by": {
+						"uid": "uid",	
+						"name": "grafana"
+                      },
 					  "intervalSeconds":60,
 					  "is_paused":false,
 					  "version":3,

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -1529,7 +1529,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 						},
 						Annotations: map[string]string{
 							"Προμηθέας": "prom",      // Prometheus in Greek
-							"犬":         "Shiba Inu", // Dog in Japanese
+							"犬":        "Shiba Inu", // Dog in Japanese
 						},
 					},
 					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -1528,8 +1528,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 							"_bar1": "baz🙂",
 						},
 						Annotations: map[string]string{
-							"Προμηθέας": "prom",      // Prometheus in Greek
-							"犬":        "Shiba Inu", // Dog in Japanese
+							"Προμηθέας": "prom", // Prometheus in Greek
 						},
 					},
 					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
@@ -1562,8 +1561,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 							"_bar1": "baz🙂",
 						},
 						Annotations: map[string]string{
-							"Προμηθέας": "prom",      // Prometheus in Greek
-							"犬":        "Shiba Inu", // Dog in Japanese
+							"Προμηθέας": "prom", // Prometheus in Greek
 						},
 					},
 					GrafanaManagedAlert: &apimodels.GettableGrafanaRule{


### PR DESCRIPTION
**What is this feature?**
This is a follow-up for https://github.com/grafana/grafana/pull/99395 updated alert rule logic to store information about user that last updated a rule. 
This PR exposes this information in Ruler API: a new field `updated_by` is added to model `GettableGrafanaRule`, and the value is an object 
```
{
   "uid": "user_uid",
   "name": "login or name or email"
}
```
Note: 
1. The property is optional. It can be null in two cases:
   a. changes made before the migration to the version of Grafana that populates the field
   b. changes are made by the system, for example, when user renames a contact point (or a time interval) that is referred by alert rules.
2. Field `name` could be empty when user could not be found by the UID. 

The field is deliberately not exposed in provisioning API because I do not see any useful reason to do that.

**Why do we need this feature?**
This is to show information about who changed the rule last.

**Who is this feature for?**
UI
