### PR TITLE
[search] mimic sql search

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -574,7 +574,12 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resource.Res
 	// Add a text query
 	if req.Query != "" && req.Query != "*" {
 		searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_SCORE)
-		queries = append(queries, bleve.NewFuzzyQuery(req.Query))
+		// mimic the behavior of the sql search
+		query := req.Query
+		if !strings.Contains(query, "*") {
+			query = "*" + query + "*"
+		}
+		queries = append(queries, bleve.NewWildcardQuery(query))
 	}
 
 	switch len(queries) {


### PR DESCRIPTION
FuzzyQuery was producing results that seemed strange in comparison to sql ( maybe we need a fuzzy option in the ui? )

This makes the search behave like sql search.

Fixes https://github.com/grafana/search-and-storage-team/issues/180

**Before**
![Screenshot 2025-01-24 at 3 41 54 PM](https://github.com/user-attachments/assets/0a49da5c-793e-4c20-9529-e4e85084c7e1)
![Screenshot 2025-01-24 at 3 42 49 PM](https://github.com/user-attachments/assets/91be34d3-8862-46d8-9ba6-b5e0317f4a4b)

**After**
![Screenshot 2025-01-24 at 3 40 53 PM](https://github.com/user-attachments/assets/f718d5e2-8392-423e-8c48-da34e8c73c29)
![Screenshot 2025-01-24 at 3 44 14 PM](https://github.com/user-attachments/assets/ea49cd27-1b8c-4423-a7e0-165d69659b7a)


