### PR TITLE
TableNG: Updated styles for demo

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -12,7 +12,7 @@ import { SparklineCell } from './SparklineCell';
 // }
 
 export function TableCellNG(props: any) {
-  const { field, value, theme, timeRange, height, rowIdx, justifyContent, shouldTextOverflow } = props;
+  const { defaultPadding, field, value, theme, timeRange, height, rowIdx, justifyContent, shouldTextOverflow } = props;
   const { config: fieldConfig } = field;
   const { type: cellType } = fieldConfig.custom.cellOptions;
 
@@ -37,7 +37,12 @@ export function TableCellNG(props: any) {
     case TableCellDisplayMode.BasicGauge:
     case TableCellDisplayMode.GradientGauge:
     case TableCellDisplayMode.LcdGauge:
-      cell = <BarGaugeCell value={value} field={field} theme={theme} timeRange={timeRange} height={height} />;
+      // The gauge cell is just inheriting the 36px height of the cell, so when padding is applied
+      // the cell doesn't adhere to the padding.
+      const paddingOffsetHeight = height - defaultPadding;
+      cell = (
+        <BarGaugeCell value={value} field={field} theme={theme} timeRange={timeRange} height={paddingOffsetHeight} />
+      );
       break;
     case TableCellDisplayMode.Auto:
     default:

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -12,7 +12,7 @@ import { SparklineCell } from './SparklineCell';
 // }
 
 export function TableCellNG(props: any) {
-  const { defaultPadding, field, value, theme, timeRange, height, rowIdx, justifyContent, shouldTextOverflow } = props;
+  const { field, value, theme, timeRange, height, rowIdx, justifyContent, shouldTextOverflow } = props;
   const { config: fieldConfig } = field;
   const { type: cellType } = fieldConfig.custom.cellOptions;
 
@@ -37,12 +37,7 @@ export function TableCellNG(props: any) {
     case TableCellDisplayMode.BasicGauge:
     case TableCellDisplayMode.GradientGauge:
     case TableCellDisplayMode.LcdGauge:
-      // The gauge cell is just inheriting the 36px height of the cell, so when padding is applied
-      // the cell doesn't adhere to the padding.
-      const paddingOffsetHeight = height - defaultPadding;
-      cell = (
-        <BarGaugeCell value={value} field={field} theme={theme} timeRange={timeRange} height={paddingOffsetHeight} />
-      );
+      cell = <BarGaugeCell value={value} field={field} theme={theme} timeRange={timeRange} height={height} />;
       break;
     case TableCellDisplayMode.Auto:
     default:

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -27,7 +27,7 @@ import { TableCellNG } from './Cells/TableCellNG';
 import { Filter } from './Filter/Filter';
 import { getRowHeight, shouldTextOverflow, getFooterItemNG } from './utils';
 
-const DEFAULT_CELL_PADDING = 6;
+const DEFAULT_CELL_PADDING = 8;
 const COLUMN_MIN_WIDTH = 150;
 
 type TableRow = Record<string, unknown>;
@@ -311,6 +311,7 @@ export function TableNG(props: TableNGProps) {
               theme={theme}
               timeRange={timeRange}
               height={defaultRowHeight}
+              defaultPadding={DEFAULT_CELL_PADDING}
               justifyContent={justifyColumnContent}
               rowIdx={rowIdx}
               shouldTextOverflow={() =>
@@ -455,6 +456,7 @@ export function TableNG(props: TableNGProps) {
   return (
     <>
       <DataGrid
+        className={styles.dataGrid}
         key={`DataGrid${revId}`}
         rows={filteredRows}
         columns={columns}
@@ -553,6 +555,20 @@ function getComparator(sortColumnType: string): Comparator {
 }
 
 const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
+  dataGrid: css({
+    '--rdg-background-color': theme.colors.background.primary,
+    '--rdg-header-background-color': theme.colors.background.primary,
+    '--rdg-border-color': theme.colors.border.medium,
+    '--rdg-color': theme.colors.text.primary,
+
+    '.rdg-cell': {
+      padding: theme.spacing(0.5),
+    },
+
+    '&:hover': {
+      '--rdg-row-hover-background-color': theme.colors.action.hover,
+    },
+  }),
   menuItem: css({
     maxWidth: '200px',
   }),
@@ -582,6 +598,11 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     wordWrap: 'break-word',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+
+    '&:hover': {
+      border: `1px solid ${theme.colors.text.link}`,
+      backgroundColor: theme.colors.background.primary,
+    },
   }),
 });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -27,7 +27,7 @@ import { TableCellNG } from './Cells/TableCellNG';
 import { Filter } from './Filter/Filter';
 import { getRowHeight, shouldTextOverflow, getFooterItemNG } from './utils';
 
-const DEFAULT_CELL_PADDING = 8;
+const DEFAULT_CELL_PADDING = 6;
 const COLUMN_MIN_WIDTH = 150;
 
 type TableRow = Record<string, unknown>;
@@ -311,7 +311,6 @@ export function TableNG(props: TableNGProps) {
               theme={theme}
               timeRange={timeRange}
               height={defaultRowHeight}
-              defaultPadding={DEFAULT_CELL_PADDING}
               justifyContent={justifyColumnContent}
               rowIdx={rowIdx}
               shouldTextOverflow={() =>
@@ -560,10 +559,6 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     '--rdg-header-background-color': theme.colors.background.primary,
     '--rdg-border-color': theme.colors.border.medium,
     '--rdg-color': theme.colors.text.primary,
-
-    '.rdg-cell': {
-      padding: theme.spacing(0.5),
-    },
 
     '&:hover': {
       '--rdg-row-hover-background-color': theme.colors.action.hover,


### PR DESCRIPTION
#### What does this PR do? 📓 

This PR adds specific styles to TableNG to try to narrow style parity between TableV1 and TableNG. 

- Updates background, header background, border, text , and hover colors to use semantic theme tokens. This way it'll work in dark and light mode 🚀 
- Added cell-specific hover styling

**Bug noticed**

When we switch between dark/light mode using keyboard shortcut c+t, some of the semantic color tokens don't appear to update.


https://github.com/user-attachments/assets/015b5364-2351-4647-ae80-4db323b0d46a