### PR TITLE
Selectors: Add selectors for alert rule steps

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -661,6 +661,9 @@ export const versionedComponents = {
     newEvaluationGroupCreate: {
       '11.1.0': 'data-testid alert-rule new-evaluation-group-create-button',
     },
+    step: {
+      '11.5.0': (stepNo: string) => `data-testid alert-rule step-no-${stepNo}`,
+    },
   },
   Alert: {
     alertV2: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -662,7 +662,10 @@ export const versionedComponents = {
       '11.1.0': 'data-testid alert-rule new-evaluation-group-create-button',
     },
     step: {
-      '11.5.0': (stepNo: string) => `data-testid alert-rule step-no-${stepNo}`,
+      '11.5.0': (stepNo: string) => `data-testid alert-rule step-${stepNo}`,
+    },
+    stepAdvancedModeSwitch: {
+      '11.5.0': (stepNo: string) => `data-testid advanced-mode-switch step-${stepNo}`,
     },
   },
   Alert: {

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ReactElement } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { FieldSet, InlineSwitch, Stack, Text, useStyles2 } from '@grafana/ui';
 
 export interface RuleEditorSectionProps {
@@ -26,7 +27,7 @@ export const RuleEditorSection = ({
 }: React.PropsWithChildren<RuleEditorSectionProps>) => {
   const styles = useStyles2(getStyles);
   return (
-    <div className={styles.parent}>
+    <div className={styles.parent} data-testid={selectors.components.AlertRules.step(stepNo.toString())}>
       <FieldSet
         className={cx(fullWidth && styles.fullWidth)}
         label={

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -26,8 +26,9 @@ export const RuleEditorSection = ({
   switchMode,
 }: React.PropsWithChildren<RuleEditorSectionProps>) => {
   const styles = useStyles2(getStyles);
+  const AlertRuleSelectors = selectors.components.AlertRules;
   return (
-    <div className={styles.parent} data-testid={selectors.components.AlertRules.step(stepNo.toString())}>
+    <div className={styles.parent} data-testid={AlertRuleSelectors.step(stepNo.toString())}>
       <FieldSet
         className={cx(fullWidth && styles.fullWidth)}
         label={
@@ -38,10 +39,7 @@ export const RuleEditorSection = ({
             {switchMode && (
               <Text variant="bodySmall">
                 <InlineSwitch
-                  id={`advanced-switch-${stepNo}`}
-                  data-testid={
-                    switchMode.isAdvancedMode ? `advanced-switch-${stepNo}-advanced` : `advanced-switch-${stepNo}-basic`
-                  }
+                  data-testid={AlertRuleSelectors.stepAdvancedModeSwitch(stepNo.toString())}
                   value={switchMode.isAdvancedMode}
                   onChange={(event) => {
                     switchMode.setAdvancedMode(event.currentTarget.checked);

--- a/public/test/helpers/alertingRuleEditor.tsx
+++ b/public/test/helpers/alertingRuleEditor.tsx
@@ -31,8 +31,10 @@ export const ui = {
       contactPoint: byTestId('contact-point-picker'),
       routingOptions: byText(/muting, grouping and timings \(optional\)/i),
     },
-    switchModeBasic: (stepNo: GrafanaRuleFormStep) => byTestId(`advanced-switch-${stepNo}-basic`),
-    switchModeAdvanced: (stepNo: GrafanaRuleFormStep) => byTestId(`advanced-switch-${stepNo}-advanced`),
+    switchModeBasic: (stepNo: GrafanaRuleFormStep) =>
+      byTestId(selectors.components.AlertRules.stepAdvancedModeSwitch(stepNo.toString())),
+    switchModeAdvanced: (stepNo: GrafanaRuleFormStep) =>
+      byTestId(selectors.components.AlertRules.stepAdvancedModeSwitch(stepNo.toString())),
   },
   buttons: {
     saveAndExit: byRole('button', { name: 'Save rule and exit' }),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds e2e selectors for alert rule steps so that they can be accessed safely inside e2e tests. Also refactoring the advanced mode switch so that the selector is moved to the e2e selectors package. 

**Why do we need this feature?**

To be able to fix issues in plugin-e2e. 
https://github.com/grafana/plugin-tools/issues/1480

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
