### PR TITLE
Folders/K8s: Fix createdBy and updatedBy fields in response

### DIFF
--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -54,6 +54,9 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	if updater.UID == "" {
+		updater = creator
+	}
 
 	return &folder.Folder{
 		UID:         uid,
@@ -73,7 +76,7 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 	}, nil
 }
 
-func (ss *FolderUnifiedStoreImpl) getUserFromMeta(ctx context.Context, userMeta string) (*user.User, error) { //
+func (ss *FolderUnifiedStoreImpl) getUserFromMeta(ctx context.Context, userMeta string) (*user.User, error) {
 	if userMeta == "" || toUID(userMeta) == "" {
 		return &user.User{}, nil
 	}

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(item *unstructured.Unstructured) (*folder.Folder, error) {
+func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context, item *unstructured.Unstructured) (*folder.Folder, error) {
 	meta, err := utils.MetaAccessor(item)
 	if err != nil {
 		return nil, err

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -64,14 +64,12 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 		Version:     int(meta.GetGeneration()),
 		Repository:  meta.GetRepositoryName(),
 
-		URL:          url,
-		Created:      created,
-		Updated:      *updated,
-		OrgID:        info.OrgID,
-		CreatedBy:    creator.ID,
-		CreatedByUID: creator.UID,
-		UpdatedBy:    updater.ID,
-		UpdatedByUID: updater.UID,
+		URL:       url,
+		Created:   created,
+		Updated:   *updated,
+		OrgID:     info.OrgID,
+		CreatedBy: creator.ID,
+		UpdatedBy: updater.ID,
 	}, nil
 }
 

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-	"time"
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -101,15 +100,4 @@ func toUID(rawIdentifier string) string {
 		return ""
 	}
 	return parts[1]
-}
-
-func getCreated(meta utils.GrafanaMetaAccessor) (*time.Time, error) {
-	created := meta.GetCreationTimestamp().Time
-	return &created, nil
-}
-
-func getURL(meta utils.GrafanaMetaAccessor, title string) string {
-	slug := slugify.Slugify(title)
-	uid := meta.GetName()
-	return dashboards.GetFolderURL(uid, slug)
 }

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -1,0 +1,101 @@
+package folderimpl
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/slugify"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(item *unstructured.Unstructured) (*folder.Folder, error) {
+	meta, err := utils.MetaAccessor(item)
+	if err != nil {
+		return nil, err
+	}
+
+	info, _ := authlib.ParseNamespace(meta.GetNamespace())
+	if info.OrgID < 0 {
+		info.OrgID = 1 // This resolves all test cases that assume org 1
+	}
+
+	title, _, _ := unstructured.NestedString(item.Object, "spec", "title")
+	description, _, _ := unstructured.NestedString(item.Object, "spec", "description")
+
+	uid := meta.GetName()
+	url := ""
+	if uid != folder.RootFolder.UID {
+		slug := slugify.Slugify(title)
+		url = dashboards.GetFolderURL(uid, slug)
+	}
+
+	created := meta.GetCreationTimestamp().Time.UTC()
+	updated, _ := meta.GetUpdatedTimestamp()
+	if updated == nil {
+		updated = &created
+	} else {
+		tmp := updated.UTC()
+		updated = &tmp
+	}
+
+	return &folder.Folder{
+		UID:         uid,
+		Title:       title,
+		Description: description,
+		ID:          meta.GetDeprecatedInternalID(), // nolint:staticcheck
+		ParentUID:   meta.GetFolder(),
+		Version:     int(meta.GetGeneration()),
+		Repository:  meta.GetRepositoryName(),
+
+		URL:     url,
+		Created: created,
+		Updated: *updated,
+		OrgID:   info.OrgID,
+	}, nil
+}
+
+func (ss *FolderUnifiedStoreImpl) getUserFromMeta(ctx context.Context, userMeta string) (*user.User, error) { //
+	if userMeta == "" || toUID(userMeta) == "" {
+		return &user.User{}, nil
+	}
+	usr, err := ss.getUser(ctx, toUID(userMeta))
+	if err != nil && errors.Is(err, user.ErrUserNotFound) {
+		return &user.User{}, nil
+	}
+	return usr, err
+}
+
+func (ss *FolderUnifiedStoreImpl) getUser(ctx context.Context, uid string) (*user.User, error) {
+	userId, err := strconv.ParseInt(uid, 10, 64)
+	if err == nil {
+		return ss.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userId})
+	}
+	return ss.userService.GetByUID(ctx, &user.GetUserByUIDQuery{UID: uid})
+}
+
+func toUID(rawIdentifier string) string {
+	parts := strings.Split(rawIdentifier, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func getCreated(meta utils.GrafanaMetaAccessor) (*time.Time, error) {
+	created := meta.GetCreationTimestamp().Time
+	return &created, nil
+}
+
+func getURL(meta utils.GrafanaMetaAccessor, title string) string {
+	slug := slugify.Slugify(title)
+	uid := meta.GetName()
+	return dashboards.GetFolderURL(uid, slug)
+}

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -46,6 +46,16 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 		updated = &tmp
 	}
 
+	creator, err := ss.getUserFromMeta(ctx, meta.GetCreatedBy())
+	if err != nil {
+		return nil, err
+	}
+
+	updater, err := ss.getUserFromMeta(ctx, meta.GetUpdatedBy())
+	if err != nil {
+		return nil, err
+	}
+
 	return &folder.Folder{
 		UID:         uid,
 		Title:       title,
@@ -55,10 +65,14 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 		Version:     int(meta.GetGeneration()),
 		Repository:  meta.GetRepositoryName(),
 
-		URL:     url,
-		Created: created,
-		Updated: *updated,
-		OrgID:   info.OrgID,
+		URL:          url,
+		Created:      created,
+		Updated:      *updated,
+		OrgID:        info.OrgID,
+		CreatedBy:    creator.ID,
+		CreatedByUID: creator.UID,
+		UpdatedBy:    updater.ID,
+		UpdatedByUID: updater.UID,
 	}, nil
 }
 

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -88,9 +88,9 @@ func (ss *FolderUnifiedStoreImpl) getUserFromMeta(ctx context.Context, userMeta 
 }
 
 func (ss *FolderUnifiedStoreImpl) getUser(ctx context.Context, uid string) (*user.User, error) {
-	userId, err := strconv.ParseInt(uid, 10, 64)
+	userID, err := strconv.ParseInt(uid, 10, 64)
 	if err == nil {
-		return ss.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userId})
+		return ss.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
 	}
 	return ss.userService.GetByUID(ctx, &user.GetUserByUIDQuery{UID: uid})
 }

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -1,4 +1,4 @@
-package folders
+package folderimpl
 
 import (
 	"testing"

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -55,20 +55,18 @@ func TestFolderConversions(t *testing.T) {
 	converted, err := fs.UnstructuredToLegacyFolder(context.Background(), input)
 	require.NoError(t, err)
 	require.Equal(t, folder.Folder{
-		ID:           234,
-		OrgID:        1,
-		Version:      4,
-		UID:          "be79sztagf20wd",
-		ParentUID:    "parent-folder-name",
-		Title:        "test folder",
-		Description:  "Something set in the file",
-		URL:          "/dashboards/f/be79sztagf20wd/test-folder",
-		Repository:   "example-repo",
-		Created:      created,
-		Updated:      created.Add(time.Hour * 5),
-		CreatedBy:    10,
-		CreatedByUID: "useruid",
-		UpdatedBy:    10,
-		UpdatedByUID: "useruid",
+		ID:          234,
+		OrgID:       1,
+		Version:     4,
+		UID:         "be79sztagf20wd",
+		ParentUID:   "parent-folder-name",
+		Title:       "test folder",
+		Description: "Something set in the file",
+		URL:         "/dashboards/f/be79sztagf20wd/test-folder",
+		Repository:  "example-repo",
+		Created:     created,
+		Updated:     created.Add(time.Hour * 5),
+		CreatedBy:   10,
+		UpdatedBy:   10,
 	}, *converted)
 }

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -1,6 +1,7 @@
 package folderimpl
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 )
 
 func TestFolderConversions(t *testing.T) {
@@ -44,7 +47,14 @@ func TestFolderConversions(t *testing.T) {
 	created = created.UTC()
 	require.NoError(t, err)
 
-	converted, err := UnstructuredToLegacyFolder(input)
+	userService := &usertest.FakeUserService{
+		ExpectedUser: &user.User{},
+	}
+
+	// #TODO implement this properly
+	fs := ProvideUnifiedStore(nil, userService)
+
+	converted, err := fs.UnstructuredToLegacyFolder(context.Background(), input)
 	require.NoError(t, err)
 	require.Equal(t, folder.Folder{
 		ID:          234,

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -32,8 +32,8 @@ func TestFolderConversions(t *testing.T) {
           "grafana.app/folder": "parent-folder-name",
           "grafana.app/updatedTimestamp": "2022-12-02T07:02:02Z",
           "grafana.app/repoName": "example-repo",
-          "grafana.app/createdBy": "user:abc",
-          "grafana.app/updatedBy": "service:xyz"
+          "grafana.app/createdBy": "user:useruid",
+          "grafana.app/updatedBy": "user:useruid"
         }
       },
       "spec": {
@@ -47,26 +47,28 @@ func TestFolderConversions(t *testing.T) {
 	created = created.UTC()
 	require.NoError(t, err)
 
-	userService := &usertest.FakeUserService{
-		ExpectedUser: &user.User{},
-	}
+	fake := usertest.NewUserServiceFake()
+	fake.ExpectedUser = &user.User{ID: 10, UID: "useruid"}
 
-	// #TODO implement this properly
-	fs := ProvideUnifiedStore(nil, userService)
+	fs := ProvideUnifiedStore(nil, fake)
 
 	converted, err := fs.UnstructuredToLegacyFolder(context.Background(), input)
 	require.NoError(t, err)
 	require.Equal(t, folder.Folder{
-		ID:          234,
-		OrgID:       1,
-		Version:     4,
-		UID:         "be79sztagf20wd",
-		ParentUID:   "parent-folder-name",
-		Title:       "test folder",
-		Description: "Something set in the file",
-		URL:         "/dashboards/f/be79sztagf20wd/test-folder",
-		Repository:  "example-repo",
-		Created:     created,
-		Updated:     created.Add(time.Hour * 5),
+		ID:           234,
+		OrgID:        1,
+		Version:      4,
+		UID:          "be79sztagf20wd",
+		ParentUID:    "parent-folder-name",
+		Title:        "test folder",
+		Description:  "Something set in the file",
+		URL:          "/dashboards/f/be79sztagf20wd/test-folder",
+		Repository:   "example-repo",
+		Created:      created,
+		Updated:      created.Add(time.Hour * 5),
+		CreatedBy:    10,
+		CreatedByUID: "useruid",
+		UpdatedBy:    10,
+		UpdatedByUID: "useruid",
 	}, *converted)
 }

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -88,7 +88,6 @@ func ProvideService(
 		dashboardStore:         dashboardStore,
 		dashboardFolderStore:   folderStore,
 		store:                  store,
-		userService:            userService, // #TODO remove from the struct
 		features:               features,
 		accessControl:          ac,
 		bus:                    bus,

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -88,7 +88,7 @@ func ProvideService(
 		dashboardStore:         dashboardStore,
 		dashboardFolderStore:   folderStore,
 		store:                  store,
-		userService:            userService,
+		userService:            userService, // #TODO remove from the struct
 		features:               features,
 		accessControl:          ac,
 		bus:                    bus,
@@ -114,7 +114,7 @@ func ProvideService(
 			recourceClientProvider: unified.GetResourceClient,
 		}
 
-		unifiedStore := ProvideUnifiedStore(k8sHandler)
+		unifiedStore := ProvideUnifiedStore(k8sHandler, userService)
 
 		srv.unifiedStore = unifiedStore
 		srv.k8sclient = k8sHandler

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -53,7 +53,6 @@ type Service struct {
 	log                    *slog.Logger
 	dashboardStore         dashboards.Store
 	dashboardFolderStore   folder.FolderStore
-	userService            user.Service
 	features               featuremgmt.FeatureToggles
 	accessControl          accesscontrol.AccessControl
 	k8sclient              folderK8sHandler

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -181,7 +181,8 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		recourceClientProvider: f,
 	}
 
-	unifiedStore := ProvideUnifiedStore(k8sHandler)
+	// #TODO figure out what to do about passing in user service here
+	unifiedStore := ProvideUnifiedStore(k8sHandler, nil)
 
 	ctx := context.Background()
 	usr := &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
@@ -181,8 +182,11 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		recourceClientProvider: f,
 	}
 
-	// #TODO figure out what to do about passing in user service here
-	unifiedStore := ProvideUnifiedStore(k8sHandler, nil)
+	userService := &usertest.FakeUserService{
+		ExpectedUser: &user.User{},
+	}
+
+	unifiedStore := ProvideUnifiedStore(k8sHandler, userService)
 
 	ctx := context.Background()
 	usr := &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -68,8 +68,6 @@ func (ss *FolderUnifiedStoreImpl) Create(ctx context.Context, cmd folder.CreateF
 		return nil, err
 	}
 
-	folder.UpdatedBy = folder.CreatedBy
-
 	return folder, err
 }
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -68,6 +68,8 @@ func (ss *FolderUnifiedStoreImpl) Create(ctx context.Context, cmd folder.CreateF
 		return nil, err
 	}
 
+	folder.UpdatedBy = folder.CreatedBy
+
 	return folder, err
 }
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -63,7 +63,7 @@ func (ss *FolderUnifiedStoreImpl) Create(ctx context.Context, cmd folder.CreateF
 		return nil, err
 	}
 
-	folder, err := ss.UnstructuredToLegacyFolder(out)
+	folder, err := ss.UnstructuredToLegacyFolder(ctx, out)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (ss *FolderUnifiedStoreImpl) Update(ctx context.Context, cmd folder.UpdateF
 		return nil, err
 	}
 
-	return ss.UnstructuredToLegacyFolder(out)
+	return ss.UnstructuredToLegacyFolder(ctx, out)
 }
 
 // If WithFullpath is true it computes also the full path of a folder.
@@ -181,7 +181,7 @@ func (ss *FolderUnifiedStoreImpl) Get(ctx context.Context, q folder.GetFolderQue
 		return nil, dashboards.ErrFolderNotFound
 	}
 
-	return ss.UnstructuredToLegacyFolder(out)
+	return ss.UnstructuredToLegacyFolder(ctx, out)
 }
 
 func (ss *FolderUnifiedStoreImpl) GetParents(ctx context.Context, q folder.GetParentsQuery) ([]*folder.Folder, error) {
@@ -209,7 +209,7 @@ func (ss *FolderUnifiedStoreImpl) GetParents(ctx context.Context, q folder.GetPa
 			return nil, err
 		}
 
-		folder, err := ss.UnstructuredToLegacyFolder(out)
+		folder, err := ss.UnstructuredToLegacyFolder(ctx, out)
 		if err != nil {
 			return nil, err
 		}
@@ -248,7 +248,7 @@ func (ss *FolderUnifiedStoreImpl) GetChildren(ctx context.Context, q folder.GetC
 	hits := make([]*folder.Folder, 0)
 	for _, item := range out.Items {
 		// convert item to legacy folder format
-		f, err := ss.UnstructuredToLegacyFolder(&item)
+		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
 			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
 		}
@@ -348,7 +348,7 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 	m := map[string]*folder.Folder{}
 	for _, item := range out.Items {
 		// convert item to legacy folder format
-		f, err := ss.UnstructuredToLegacyFolder(&item)
+		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
 			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
 		}
@@ -408,7 +408,7 @@ func (ss *FolderUnifiedStoreImpl) GetDescendants(ctx context.Context, orgID int6
 	nodes := map[string]*folder.Folder{}
 	for _, item := range out.Items {
 		// convert item to legacy folder format
-		f, err := ss.UnstructuredToLegacyFolder(&item)
+		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
 			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
 		}

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -250,7 +250,7 @@ func (ss *FolderUnifiedStoreImpl) GetChildren(ctx context.Context, q folder.GetC
 		// convert item to legacy folder format
 		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
-			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
+			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
 
 		// it we are at root level, skip subfolder
@@ -350,7 +350,7 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 		// convert item to legacy folder format
 		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
-			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
+			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
 
 		m[f.UID] = f
@@ -410,7 +410,7 @@ func (ss *FolderUnifiedStoreImpl) GetDescendants(ctx context.Context, orgID int6
 		// convert item to legacy folder format
 		f, err := ss.UnstructuredToLegacyFolder(ctx, &item)
 		if f == nil {
-			return nil, fmt.Errorf("unable covert unstructured item to legacy folder %w", err)
+			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
 
 		nodes[f.UID] = f

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -20,21 +20,24 @@ import (
 	internalfolders "github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 type FolderUnifiedStoreImpl struct {
-	log       log.Logger
-	k8sclient folderK8sHandler
+	log         log.Logger
+	k8sclient   folderK8sHandler
+	userService user.Service
 }
 
 // sqlStore implements the store interface.
 var _ folder.Store = (*FolderUnifiedStoreImpl)(nil)
 
-func ProvideUnifiedStore(k8sHandler *foldk8sHandler) *FolderUnifiedStoreImpl {
+func ProvideUnifiedStore(k8sHandler *foldk8sHandler, userService user.Service) *FolderUnifiedStoreImpl {
 	return &FolderUnifiedStoreImpl{
-		k8sclient: k8sHandler,
-		log:       log.New("folder-store"),
+		k8sclient:   k8sHandler,
+		log:         log.New("folder-store"),
+		userService: userService,
 	}
 }
 

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -75,7 +75,7 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		return nil, err
 	}
 	obj.SetRepositoryInfo(repo)
-	obj.SetUpdatedBy(user.GetUID())
+	obj.SetUpdatedBy("")
 	obj.SetUpdatedTimestamp(nil)
 	obj.SetCreatedBy(user.GetUID())
 

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -75,7 +75,7 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		return nil, err
 	}
 	obj.SetRepositoryInfo(repo)
-	obj.SetUpdatedBy("")
+	obj.SetUpdatedBy(user.GetUID())
 	obj.SetUpdatedTimestamp(nil)
 	obj.SetCreatedBy(user.GetUID())
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Stop returning "Anonymous" for createdBy and updatedBy fields in folder Get and Create responses if the user info exists. Modelled the test after the one for the [dashboard test](https://github.com/grafana/grafana/blob/suntala/fix-user-login-2/pkg/services/dashboards/service/dashboard_service_test.go#L1619) counterpart.

**Why do we need this feature?**

The createdBy and updatedBy fields returned by the folder API when k8s is enabled needs to match legacy behavior.

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partial https://github.com/grafana/search-and-storage-team/issues/178

**Special notes for your reviewer:**

We are going to start populating createdBy / updatedBy where legacy doesn't do so. Are we ok with this? For example legacy Get doesn't populate these fields. See issue ticket for more details.

The orgID issue will be done in a separate PR if required.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
