### PR TITLE
Authn: use authenticator for grpc

### DIFF
--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -133,7 +133,7 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 			Namespace: o.GrpcClientAuthenticationTokenNamespace,
 		},
 	}
-	unified, err := resource.NewCloudResourceClient(tracer, conn, authCfg, o.GrpcClientAuthenticationAllowInsecure)
+	unified, err := resource.NewRemoteResourceClient(tracer, conn, authCfg, o.GrpcClientAuthenticationAllowInsecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/authn/grpcutils/config.go
+++ b/pkg/services/authn/grpcutils/config.go
@@ -1,32 +1,14 @@
 package grpcutils
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
 
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type Mode string
-
-func (s Mode) IsValid() bool {
-	switch s {
-	case ModeOnPrem, ModeCloud:
-		return true
-	}
-	return false
-}
-
-const (
-	ModeOnPrem Mode = "on-prem"
-	ModeCloud  Mode = "cloud"
-)
-
 type GrpcServerConfig struct {
 	SigningKeysURL   string
 	AllowedAudiences []string
-	Mode             Mode
 	LegacyFallback   bool
 	AllowInsecure    bool
 }
@@ -35,21 +17,15 @@ func (c *GrpcServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.SigningKeysURL, "grpc-server-authentication.signing-keys-url", "", "gRPC server authentication signing keys URL")
 }
 
-func ReadGrpcServerConfig(cfg *setting.Cfg) (*GrpcServerConfig, error) {
+func ReadGrpcServerConfig(cfg *setting.Cfg) *GrpcServerConfig {
 	section := cfg.SectionWithEnvOverrides("grpc_server_authentication")
-
-	mode := Mode(section.Key("mode").MustString(string(ModeOnPrem)))
-	if !mode.IsValid() {
-		return nil, fmt.Errorf("grpc_server_authentication: invalid mode %q", mode)
-	}
 
 	return &GrpcServerConfig{
 		SigningKeysURL:   section.Key("signing_keys_url").MustString(""),
 		AllowedAudiences: section.Key("allowed_audiences").Strings(","),
-		Mode:             mode,
 		LegacyFallback:   section.Key("legacy_fallback").MustBool(true),
 		AllowInsecure:    cfg.Env == setting.Dev,
-	}, nil
+	}
 }
 
 type GrpcClientConfig struct {

--- a/pkg/services/authn/grpcutils/grpc_authenticator.go
+++ b/pkg/services/authn/grpcutils/grpc_authenticator.go
@@ -19,15 +19,48 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var once sync.Once
-
 func NewInProcGrpcAuthenticator() interceptors.Authenticator {
+	return newAuthenticator(
+		authn.NewDefaultAuthenticator(
+			authn.NewUnsafeAccessTokenVerifier(authn.VerifierConfig{}),
+			authn.NewUnsafeIDTokenVerifier(authn.VerifierConfig{}),
+		),
+		tracing.NewNoopTracerService(),
+	)
+}
+
+func NewAuthenticator(cfg *GrpcServerConfig, tracer tracing.Tracer) interceptors.Authenticator {
+	client := http.DefaultClient
+	if cfg.AllowInsecure {
+		client = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	}
+
+	kr := authn.NewKeyRetriever(authn.KeyRetrieverConfig{
+		SigningKeysURL: cfg.SigningKeysURL,
+	}, authn.WithHTTPClientKeyRetrieverOpt(client))
+
 	auth := authn.NewDefaultAuthenticator(
-		authn.NewUnsafeAccessTokenVerifier(authn.VerifierConfig{}),
-		authn.NewUnsafeIDTokenVerifier(authn.VerifierConfig{}),
+		authn.NewAccessTokenVerifier(authn.VerifierConfig{AllowedAudiences: cfg.AllowedAudiences}, kr),
+		authn.NewIDTokenVerifier(authn.VerifierConfig{}, kr),
 	)
 
+	return newAuthenticator(auth, tracer)
+}
+
+func NewAuthenticatorWithFallback(cfg *setting.Cfg, reg prometheus.Registerer, tracer tracing.Tracer, fallback interceptors.Authenticator) interceptors.Authenticator {
+	return &authenticatorWithFallback{
+		authenticator: NewAuthenticator(ReadGrpcServerConfig(cfg), tracer),
+		fallback:      fallback,
+		tracer:        tracer,
+		metrics:       newMetrics(reg),
+	}
+}
+
+func newAuthenticator(auth authn.Authenticator, tracer tracing.Tracer) interceptors.Authenticator {
 	return interceptors.AuthenticatorFunc(func(ctx context.Context) (context.Context, error) {
+		ctx, span := tracer.Start(ctx, "grpcutils.Authenticate")
+		defer span.End()
+
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			return nil, errors.New("missing metedata in context")
@@ -35,85 +68,30 @@ func NewInProcGrpcAuthenticator() interceptors.Authenticator {
 
 		info, err := auth.Authenticate(ctx, authn.NewGRPCTokenProvider(md))
 		if err != nil {
+			span.RecordError(err)
 			return ctx, err
 		}
 
+		span.SetAttributes(attribute.String("subject", info.GetUID()))
+		span.SetAttributes(attribute.Bool("service", types.IsIdentityType(info.GetIdentityType(), types.TypeAccessPolicy)))
 		return types.WithAuthInfo(ctx, info), nil
 	})
 }
 
-func NewGrpcAuthenticator(authCfg *GrpcServerConfig, tracer tracing.Tracer) (*authn.GrpcAuthenticator, error) {
-	grpcAuthCfg := authn.GrpcAuthenticatorConfig{
-		KeyRetrieverConfig: authn.KeyRetrieverConfig{
-			SigningKeysURL: authCfg.SigningKeysURL,
-		},
-		VerifierConfig: authn.VerifierConfig{
-			AllowedAudiences: authCfg.AllowedAudiences,
-		},
-	}
-
-	client := http.DefaultClient
-	if authCfg.AllowInsecure {
-		// allow insecure connections in development mode to facilitate testing
-		client = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
-	}
-	keyRetriever := authn.NewKeyRetriever(grpcAuthCfg.KeyRetrieverConfig, authn.WithHTTPClientKeyRetrieverOpt(client))
-
-	grpcOpts := []authn.GrpcAuthenticatorOption{
-		authn.WithKeyRetrieverOption(keyRetriever),
-		authn.WithTracerAuthOption(tracer),
-		authn.WithIDTokenAuthOption(false),
-	}
-
-	if authCfg.Mode == ModeOnPrem {
-		grpcOpts = append(grpcOpts,
-			// Access token are not yet available on-prem
-			authn.WithDisableAccessTokenAuthOption(),
-		)
-	}
-	return authn.NewGrpcAuthenticator(
-		&grpcAuthCfg,
-		grpcOpts...,
-	)
-}
-
-type contextFallbackKey struct{}
-
-type AuthenticatorWithFallback struct {
-	authenticator *authn.GrpcAuthenticator
+type authenticatorWithFallback struct {
+	authenticator interceptors.Authenticator
 	fallback      interceptors.Authenticator
 	metrics       *metrics
 	tracer        tracing.Tracer
 }
 
-func NewGrpcAuthenticatorWithFallback(cfg *setting.Cfg, reg prometheus.Registerer, tracer tracing.Tracer, fallback interceptors.Authenticator) (interceptors.Authenticator, error) {
-	authCfg, err := ReadGrpcServerConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	authenticator, err := NewGrpcAuthenticator(authCfg, tracer)
-	if err != nil {
-		return nil, err
-	}
-
-	if !authCfg.LegacyFallback {
-		return authenticator, nil
-	}
-
-	return &AuthenticatorWithFallback{
-		authenticator: authenticator,
-		fallback:      fallback,
-		metrics:       newMetrics(reg),
-		tracer:        tracer,
-	}, nil
-}
+type contextFallbackKey struct{}
 
 func FallbackUsed(ctx context.Context) bool {
 	return ctx.Value(contextFallbackKey{}) != nil
 }
 
-func (f *AuthenticatorWithFallback) Authenticate(ctx context.Context) (context.Context, error) {
+func (f *authenticatorWithFallback) Authenticate(ctx context.Context) (context.Context, error) {
 	ctx, span := f.tracer.Start(ctx, "grpcutils.AuthenticatorWithFallback.Authenticate")
 	defer span.End()
 
@@ -144,6 +122,8 @@ const (
 type metrics struct {
 	requestsTotal *prometheus.CounterVec
 }
+
+var once sync.Once
 
 func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -146,5 +146,5 @@ func newResourceClient(conn *grpc.ClientConn, cfg *setting.Cfg, features feature
 	if !features.IsEnabledGlobally(featuremgmt.FlagAppPlatformGrpcClientAuth) {
 		return resource.NewLegacyResourceClient(conn), nil
 	}
-	return resource.NewCloudResourceClient(tracer, conn, clientCfgMapping(grpcutils.ReadGrpcClientConfig(cfg)), cfg.Env == setting.Dev)
+	return resource.NewRemoteResourceClient(tracer, conn, clientCfgMapping(grpcutils.ReadGrpcClientConfig(cfg)), cfg.Env == setting.Dev)
 }

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -146,11 +146,5 @@ func newResourceClient(conn *grpc.ClientConn, cfg *setting.Cfg, features feature
 	if !features.IsEnabledGlobally(featuremgmt.FlagAppPlatformGrpcClientAuth) {
 		return resource.NewLegacyResourceClient(conn), nil
 	}
-	if cfg.StackID == "" {
-		return resource.NewGRPCResourceClient(tracer, conn)
-	}
-
-	grpcClientCfg := grpcutils.ReadGrpcClientConfig(cfg)
-
-	return resource.NewCloudResourceClient(tracer, conn, clientCfgMapping(grpcClientCfg), cfg.Env == setting.Dev)
+	return resource.NewCloudResourceClient(tracer, conn, clientCfgMapping(grpcutils.ReadGrpcClientConfig(cfg)), cfg.Env == setting.Dev)
 }

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -92,31 +92,7 @@ func NewLocalResourceClient(server ResourceServer) ResourceClient {
 	}
 }
 
-func NewGRPCResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn) (ResourceClient, error) {
-	// scenario: remote on-prem
-	clientInt, err := authnlib.NewGrpcClientInterceptor(
-		&authnlib.GrpcClientConfig{},
-		authnlib.WithDisableAccessTokenOption(),
-		authnlib.WithIDTokenExtractorOption(idTokenExtractor),
-		authnlib.WithTracerOption(tracer),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	cc := grpchan.InterceptClientConn(conn, clientInt.UnaryClientInterceptor, clientInt.StreamClientInterceptor)
-	return &resourceClient{
-		ResourceStoreClient:   NewResourceStoreClient(cc),
-		ResourceIndexClient:   NewResourceIndexClient(cc),
-		BlobStoreClient:       NewBlobStoreClient(cc),
-		BatchStoreClient:      NewBatchStoreClient(cc),
-		RepositoryIndexClient: NewRepositoryIndexClient(cc),
-		DiagnosticsClient:     NewDiagnosticsClient(cc),
-	}, nil
-}
-
 func NewCloudResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn, cfg authnlib.GrpcClientConfig, allowInsecure bool) (ResourceClient, error) {
-	// scenario: remote cloud
 	opts := []authnlib.GrpcClientInterceptorOption{
 		authnlib.WithIDTokenExtractorOption(idTokenExtractor),
 		authnlib.WithTracerOption(tracer),

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -92,7 +92,7 @@ func NewLocalResourceClient(server ResourceServer) ResourceClient {
 	}
 }
 
-func NewCloudResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn, cfg authnlib.GrpcClientConfig, allowInsecure bool) (ResourceClient, error) {
+func NewRemoteResourceClient(tracer tracing.Tracer, conn *grpc.ClientConn, cfg authnlib.GrpcClientConfig, allowInsecure bool) (ResourceClient, error) {
 	opts := []authnlib.GrpcClientInterceptorOption{
 		authnlib.WithIDTokenExtractorOption(idTokenExtractor),
 		authnlib.WithTracerOption(tracer),

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -80,11 +80,7 @@ func ProvideUnifiedStorageGrpcService(
 
 	// FIXME: This is a temporary solution while we are migrating to the new authn interceptor
 	// grpcutils.NewGrpcAuthenticator should be used instead.
-	fallback := &grpc.Authenticator{Tracer: tracing}
-	authn, err := grpcutils.NewGrpcAuthenticatorWithFallback(cfg, reg, tracing, fallback)
-	if err != nil {
-		return nil, err
-	}
+	authn := grpcutils.NewAuthenticatorWithFallback(cfg, reg, tracing, &grpc.Authenticator{Tracer: tracing})
 
 	s := &service{
 		cfg:           cfg,

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -512,7 +512,7 @@ func TestClientServer(t *testing.T) {
 	t.Run("Create a client", func(t *testing.T) {
 		conn, err := grpc.NewClient(svc.GetAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		require.NoError(t, err)
-		client, err = resource.NewGRPCResourceClient(tracing.NewNoopTracerService(), conn)
+		client, err = resource.NewRemoteResourceClient(tracing.NewNoopTracerService(), conn, authn.GrpcClientConfig{}, true)
 		require.NoError(t, err)
 	})
 

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -191,7 +191,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		doPlaylistTests(t, apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    false,
 			DisableAnonymous:     true,
-			APIServerStorageType: options.StorageTypeUnifiedGrpc, // start a real grpc server
+			APIServerStorageType: options.StorageTypeUnified,
 			EnableFeatureToggles: []string{},
 		}))
 	})
@@ -200,7 +200,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		doPlaylistTests(t, apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    false, // required for  unified storage
 			DisableAnonymous:     true,
-			APIServerStorageType: "unified", // use the entity api tables
+			APIServerStorageType: options.StorageTypeUnified, // use the entity api tables
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -216,7 +216,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		doPlaylistTests(t, apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    false, // required for  unified storage
 			DisableAnonymous:     true,
-			APIServerStorageType: "unified", // use the entity api tables
+			APIServerStorageType: options.StorageTypeUnified, // use the entity api tables
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -232,7 +232,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		doPlaylistTests(t, apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    false, // required for  unified storage
 			DisableAnonymous:     true,
-			APIServerStorageType: "unified", // use the entity api tables
+			APIServerStorageType: options.StorageTypeUnified, // use the entity api tables
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -251,7 +251,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
-			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
+			APIServerStorageType: options.StorageTypeEtcd, // requires etcd running on localhost:2379
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 				RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode0,
@@ -280,7 +280,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
-			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
+			APIServerStorageType: options.StorageTypeEtcd, // requires etcd running on localhost:2379
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -309,7 +309,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
-			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
+			APIServerStorageType: options.StorageTypeEtcd, // requires etcd running on localhost:2379
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -338,7 +338,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
-			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
+			APIServerStorageType: options.StorageTypeEtcd, // requires etcd running on localhost:2379
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
@@ -367,7 +367,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
-			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
+			APIServerStorageType: options.StorageTypeEtcd, // requires etcd running on localhost:2379
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},


### PR DESCRIPTION
**What is this feature?**
Follow up to https://github.com/grafana/grafana/pull/99550

Use https://github.com/grafana/authlib/blob/main/authn/authenticator.go#L98  for authentication. Also removed the ability to distinguish between cloud and grpc. The grpc mode was unauthenticate so we should instead work towards making that one work properly on-prem. 


**Which issue(s) does this PR fix?**:
Part of https://github.com/grafana/identity-access-team/issues/1128

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
