### PR TITLE
[DOC] Add connection URL info to Pyroscope datasource doc

### DIFF
--- a/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
+++ b/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
@@ -95,15 +95,17 @@ The data source connection URL should point to a location of a running Pyroscope
 
 **Grafana Cloud Profiles**
 
-A fully configured data source is automatically provisioned in your Grafana Cloud instance.
+Your Grafana Cloud instance automatically includes a fully provisioned data source.
 
-If you are running a self hosted Grafana instance, or need to configure an additional Pyroscope data source pointing to Grafana Cloud Profiles, you can find the Pyroscope URL under the **Manage your stack** section for your organization.
+If you are running a self-managed Grafana instance or need to configure an additional Pyroscope data source pointing to Grafana Cloud Profiles, you can find the Pyroscope URL under the **Manage your stack** section for your organization.
 
-**Self hosted Pyroscope backend**
+**Self-managed Pyroscope backend**
 
-The connection URL for a self hosted Pyroscope backend depends on how Pyroscope is deployed. Refer to the steps under [Query profiles in Grafana](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/helm/#query-profiles-in-grafana) for more information on how to configure the data source.
+The connection URL for a self-managed Pyroscope backend depends on how Pyroscope is deployed.
+Refer to the steps under [Query profiles in Grafana](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/helm/#query-profiles-in-grafana) for more information on how to configure the data source.
 
-If you plan to use the [Explore Profiles](ref:explore-profiles) application and you are running a self hosted Pyroscope backend in microservices mode, the data source connection URL should point to a gateway or proxy that routes requests to the corresponding Pyroscope service. Refer to the [Helm ingress configuration](https://github.com/grafana/pyroscope/blob/main/operations/pyroscope/helm/pyroscope/templates/ingress.yaml) for specific routing requirements.
+If you plan to use the [Explore Profiles](ref:explore-profiles) application and you are running a self-managed Pyroscope backend in microservices mode, the data source connection URL should point to a gateway or proxy that routes requests to the corresponding Pyroscope service.
+Refer to the [Helm ingress configuration](https://github.com/grafana/pyroscope/blob/main/operations/pyroscope/helm/pyroscope/templates/ingress.yaml) for specific routing requirements.
 
 ## Authentication
 

--- a/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
+++ b/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
@@ -33,11 +33,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/
     - pattern: /docs/grafana-cloud/
       destination: docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/
-  provisioning-data-sources:
+  explore-profiles:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
-    - pattern: /docs/grafana-cloud/provision
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/simplified-exploration/profiles/
 ---
 
 # Configure the Grafana Pyroscope data source
@@ -73,7 +73,7 @@ To configure basic settings for the data source, complete the following steps:
 1. On the **Settings** tab, complete the **Name**, **Connection**, and **Authentication** sections.
 
 - Use the **Name** field to specify the name used for the data source in panels, queries, and Explore. Toggle the **Default** switch for the data source to be pre-selected for new panels.
-- Under **Connection**, enter the **URL** of the Pyroscope instance. For example, `https://example.com:4100`.
+- Under **Connection**, enter the **URL** of the Pyroscope instance. For example, `https://example.com:4100`. Refer to [Connection URL](#connection-url) for more information.
 - Complete the [**Authentication** section](#authentication).
 
 1. Optional: Use **Additional settings** to configure other options.
@@ -88,6 +88,22 @@ To modify an existing Pyroscope data source:
 1. Select the Pyroscope data source you wish to modify.
 1. Optional: Use **Additional settings** to configure or modify other options.
 1. After completing your updates, select **Save & test**.
+
+#### Connection URL
+
+The datasource connection URL should point to a location of a running Pyroscope backend.
+
+**Grafana Cloud Profiles**
+
+A fully configured datasource is automatically provisioned in your Grafana Cloud instance.
+
+If you are running a self hosted Grafana instance, or need to configure an additional Pyroscope datasource pointing to Grafana Cloud Profiles, you can find the Pyroscope URL under the **Manage your stack** section for your organization.
+
+**Self hosted Pyroscope backend**
+
+The connection URL for a self hosted Pyroscope backend depends on how Pyroscope is deployed. Refer to the steps under [Query profiles in Grafana](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/helm/#query-profiles-in-grafana) for more information on how to configure the datasource.
+
+If you plan to use the [Explore Profiles](ref:explore-profiles) application and you are running a self hosted Pyroscope backend in microservices mode, the datasource connection URL should point to a gateway or proxy that routes requests to the corresponding Pyroscope service. Refer to the [Helm ingress configuration](https://github.com/grafana/pyroscope/blob/main/operations/pyroscope/helm/pyroscope/templates/ingress.yaml) for specific routing requirements.
 
 ## Authentication
 

--- a/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
+++ b/docs/sources/datasources/pyroscope/configure-pyroscope-data-source.md
@@ -91,19 +91,19 @@ To modify an existing Pyroscope data source:
 
 #### Connection URL
 
-The datasource connection URL should point to a location of a running Pyroscope backend.
+The data source connection URL should point to a location of a running Pyroscope backend.
 
 **Grafana Cloud Profiles**
 
-A fully configured datasource is automatically provisioned in your Grafana Cloud instance.
+A fully configured data source is automatically provisioned in your Grafana Cloud instance.
 
-If you are running a self hosted Grafana instance, or need to configure an additional Pyroscope datasource pointing to Grafana Cloud Profiles, you can find the Pyroscope URL under the **Manage your stack** section for your organization.
+If you are running a self hosted Grafana instance, or need to configure an additional Pyroscope data source pointing to Grafana Cloud Profiles, you can find the Pyroscope URL under the **Manage your stack** section for your organization.
 
 **Self hosted Pyroscope backend**
 
-The connection URL for a self hosted Pyroscope backend depends on how Pyroscope is deployed. Refer to the steps under [Query profiles in Grafana](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/helm/#query-profiles-in-grafana) for more information on how to configure the datasource.
+The connection URL for a self hosted Pyroscope backend depends on how Pyroscope is deployed. Refer to the steps under [Query profiles in Grafana](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/helm/#query-profiles-in-grafana) for more information on how to configure the data source.
 
-If you plan to use the [Explore Profiles](ref:explore-profiles) application and you are running a self hosted Pyroscope backend in microservices mode, the datasource connection URL should point to a gateway or proxy that routes requests to the corresponding Pyroscope service. Refer to the [Helm ingress configuration](https://github.com/grafana/pyroscope/blob/main/operations/pyroscope/helm/pyroscope/templates/ingress.yaml) for specific routing requirements.
+If you plan to use the [Explore Profiles](ref:explore-profiles) application and you are running a self hosted Pyroscope backend in microservices mode, the data source connection URL should point to a gateway or proxy that routes requests to the corresponding Pyroscope service. Refer to the [Helm ingress configuration](https://github.com/grafana/pyroscope/blob/main/operations/pyroscope/helm/pyroscope/templates/ingress.yaml) for specific routing requirements.
 
 ## Authentication
 

--- a/docs/sources/datasources/pyroscope/query-profile-data.md
+++ b/docs/sources/datasources/pyroscope/query-profile-data.md
@@ -33,7 +33,7 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/simplified-exploration/profiles/
-  explore-profile-install:
+  explore-profiles-install:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/access/
     - pattern: /docs/grafana-cloud/


### PR DESCRIPTION
**What is this feature?**

This change adds a "Connection URL" subsection in the Pyroscope datasource documentation, explaining the different options that exist, depending on what kind of backend the datasource is pointing at.

**Why do we need this feature?**

Some users observe errors when using a custom Pyroscope datasource within Explore Profiles. This doc aims to add some context of what requirements there are, especially when it comes to the connection URL.

**Who is this feature for?**

Pyroscope datasource users.

**Which issue(s) does this PR fix?**:

This doesn't fix a specific issue, it however improves our documentation for cases when users are hit with issues like:
https://github.com/grafana/pyroscope/issues/3507 and https://github.com/grafana/explore-profiles/issues/266

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
