### PR TITLE
Library elements: do not error if dashboard is not found

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -722,6 +722,9 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 			}
 			ds, err := l.dashboardsService.GetDashboardUIDByID(c, &dashboards.GetDashboardRefByIDQuery{ID: connection.ConnectionID})
 			if err != nil {
+				if errors.Is(err, dashboards.ErrDashboardNotFound) {
+					continue
+				}
 				return err
 			}
 			connections = append(connections, model.LibraryElementConnectionDTO{

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -166,6 +166,10 @@ func TestGetLibraryPanelConnections(t *testing.T) {
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
 
+			// add a connection where the dashboard doesn't exist. Shouldn't be returned in the list
+			err = sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, 99999999)
+			require.NoError(t, err)
+
 			var expected = func(res model.LibraryElementConnectionsResponse) model.LibraryElementConnectionsResponse {
 				return model.LibraryElementConnectionsResponse{
 					Result: []model.LibraryElementConnectionDTO{


### PR DESCRIPTION
**What is this feature?**

In [this PR](https://github.com/grafana/grafana/pull/99369), we changed the get connections to use the dashboard service. This made it so we return an error if the dashboard is not found for a connection, which is different than the previous behavior (where it just wouldn't be returned in the dropdown). This PR updates the logic to match the previous behavior.
