### PR TITLE
K8s: Dashboards: fix in folder count

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1401,6 +1401,18 @@ func (dr *DashboardServiceImpl) GetDashboardTags(ctx context.Context, query *das
 }
 
 func (dr DashboardServiceImpl) CountInFolders(ctx context.Context, orgID int64, folderUIDs []string, u identity.Requester) (int64, error) {
+	if dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesCliDashboards) {
+		dashs, err := dr.searchDashboardsThroughK8s(ctx, &dashboards.FindPersistedDashboardsQuery{
+			OrgId:      orgID,
+			FolderUIDs: folderUIDs,
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		return int64(len(dashs)), nil
+	}
+
 	return dr.dashboardStore.CountDashboardsInFolders(ctx, &dashboards.CountDashboardsInFolderRequest{FolderUIDs: folderUIDs, OrgID: orgID})
 }
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes the `CountInFolders` function that folders calls for the number of dashboards in a folder, by using search when the feature flag is on to get the number of dashboards in a given folder

**Why do we need this feature?**

If we do not have this, and delete the dashboard table, we get this result:

![Screenshot 2025-01-27 at 8 13 45 PM](https://github.com/user-attachments/assets/721e1f5c-4156-4f86-8b7a-b0d29e2cc074)
