### PR TITLE
TableNG: Refine styling closer to original table

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -673,9 +673,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "Do not use any type assertions.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
     "packages/grafana-ui/src/components/Table/TableNG/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -355,6 +355,14 @@ export function TableNG(props: TableNGProps) {
         },
         ...(footerOptions?.show && {
           renderSummaryCell() {
+            if (isCountRowsSet && fieldIndex === 0) {
+              return (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span>Count</span>
+                  <span>{calcsRef.current[fieldIndex]}</span>
+                </div>
+              );
+            }
             return <div className={footerStyles.footerCell}>{calcsRef.current[fieldIndex]}</div>;
           },
         }),
@@ -472,7 +480,7 @@ export function TableNG(props: TableNGProps) {
         delete field.state?.calcs;
       }
       if (isCountRowsSet) {
-        return index === 0 ? `Count: ${filteredRows.length}` : '';
+        return index === 0 ? `${filteredRows.length}` : '';
       }
       if (index === 0) {
         const footerCalcReducer = footerOptions?.reducer[0];
@@ -609,11 +617,16 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
   dataGrid: css({
     '--rdg-background-color': theme.colors.background.primary,
     '--rdg-header-background-color': theme.colors.background.primary,
-    '--rdg-border-color': theme.colors.border.medium,
+    '--rdg-border-color': 'transparent',
+    '--rdg-summary-border-color': theme.colors.border.medium,
     '--rdg-color': theme.colors.text.primary,
+    // TODO replace with ScrollContainer
+    overflow: 'hidden',
+    scrollbarWidth: 'thin',
 
     '&:hover': {
       '--rdg-row-hover-background-color': theme.colors.action.hover,
+      overflow: 'scroll',
     },
   }),
   menuItem: css({
@@ -641,6 +654,8 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     marginLeft: theme.spacing(0.5),
   }),
   cell: css({
+    '--rdg-border-color': theme.colors.border.medium,
+    'border-left': 'none',
     whiteSpace: `${textWrap ? 'break-spaces' : 'nowrap'}`,
     wordWrap: 'break-word',
     overflow: 'hidden',


### PR DESCRIPTION
Some styling refinement to get a bit closer to Table OG.

Before:
![image](https://github.com/user-attachments/assets/a877a620-98a0-4564-88dc-e246cdcfaf67)

After:
![image](https://github.com/user-attachments/assets/85d560c3-cd79-4c2f-8dc3-a2359c9b2532)
