### PR TITLE
Add workflow that comments when PRs include the `add to what's new` label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -747,6 +747,7 @@ embed.go @grafana/grafana-as-code
 /.github/pr-checks.json @tolzhabayev
 /.github/pr-commands.json @tolzhabayev
 /.github/renovate.json5 @grafana/frontend-ops
+/.github/workflows/add-to-whats-new.yml @grafana/docs-tooling
 /.github/workflows/auto-triager/ @grafana/plugins-platform-frontend
 /.github/workflows/alerting-swagger-gen.yml @grafana/alerting-backend
 /.github/workflows/auto-milestone.yml @grafana/grafana-developer-enablement-squad

--- a/.github/workflows/add-to-whats-new.yml
+++ b/.github/workflows/add-to-whats-new.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         with:
           message: |
-            Since you've added the `Add to what's new` label, consider drafting a [What's new note](https://admin.grafana.com/content-admin/#/collections/whats-new/) for this feature.
+            Since you've added the `Add to what's new` label, consider drafting a [What's new note](https://admin.grafana.com/content-admin/#/collections/whats-new/new) for this feature.

--- a/.github/workflows/add-to-whats-new.yml
+++ b/.github/workflows/add-to-whats-new.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   add-comment:
-    if: ${{ ! github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'Add to what''s new') }}
+    if: ${{ ! github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'add to what''s new') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/add-to-whats-new.yml
+++ b/.github/workflows/add-to-whats-new.yml
@@ -1,0 +1,16 @@
+name: Add comment about adding a What's new note
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  add-comment:
+    if: ${{ ! github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'Add to what''s new') }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          message: |
+            Since you've added the `Add to what's new` label, consider drafting a [What's new note](https://admin.grafana.com/content-admin/#/collections/whats-new/) for this feature.


### PR DESCRIPTION
**What is this feature?**

When someone adds the `add to what's new` label, nudge them to create a [What's new note](https://admin.grafana.com/content-admin/#/collections/whats-new/).

**Why do we need this feature?**

That label is a clear indicator of intent to announce the feature, this comment makes it easier to start drafting the announcement.

**Who is this feature for?**

Grafana Labs employees.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
