### PR TITLE
Loki: Replace deprecated `@grafana/experimental` with `@grafana/plugin-ui`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<!-- 11.0.10 START -->
+
+# 11.0.10 (2025-01-28)
+
+### Features and enhancements
+
+- **Security:** Update to Go 1.22.11 - Backport to v11.0.x [#99127](https://github.com/grafana/grafana/pull/99127), [@Proximyst](https://github.com/Proximyst)
+- **Security:** Update to Go 1.22.11 - Backport to v11.0.x (Enterprise)
+
+### Bug fixes
+
+- **Azure/GCM:** Improve error display [#97592](https://github.com/grafana/grafana/pull/97592), [@aangelisc](https://github.com/aangelisc)
+
+<!-- 11.0.10 END -->
 <!-- 10.4.15 START -->
 
 # 10.4.15 (2025-01-28)

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -51,7 +51,7 @@
     "moment": "2.30.1",
     "moment-timezone": "0.5.46",
     "ol": "7.4.0",
-    "papaparse": "5.5.1",
+    "papaparse": "5.5.2",
     "react-use": "17.6.0",
     "rxjs": "7.8.1",
     "string-hash": "^1.1.3",

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -2,7 +2,7 @@
 import { memo } from 'react';
 
 import { AnnotationQuery } from '@grafana/data';
-import { EditorField, EditorRow } from '@grafana/experimental';
+import { EditorField, EditorRow } from '@grafana/plugin-ui';
 import { Input, Stack } from '@grafana/ui';
 
 // Types

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -3,7 +3,7 @@ import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { dateTime, GrafanaTheme2, LogRowModel, renderMarkdown, SelectableValue } from '@grafana/data';
-import { RawQuery } from '@grafana/experimental';
+import { RawQuery } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import {
   Alert,

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { cloneDeep, defaultsDeep } from 'lodash';
 
 import { CoreApp } from '@grafana/data';
-import { QueryEditorMode } from '@grafana/experimental';
+import { QueryEditorMode } from '@grafana/plugin-ui';
 
 import { createLokiDatasource } from '../__mocks__/datasource';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from '../querybuilder/components/LokiQueryBuilderExplained';

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -11,7 +11,7 @@ import {
   QueryEditorModeToggle,
   QueryHeaderSwitch,
   QueryEditorMode,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, ConfirmModal, Space, Stack } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
+++ b/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
@@ -1,5 +1,5 @@
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { InlineField, InlineSwitch } from '@grafana/ui';
 
 export function AlertingSettings({

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
   Auth,
   convertLegacyAuthProps,
   AdvancedHttpSettings,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Divider, SecureSocksProxySettings, Stack } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback, useState } from 'react';
 
 import { GrafanaTheme2, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
-import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { Button, useTheme2 } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';

--- a/public/app/plugins/datasource/loki/configuration/QuerySettings.tsx
+++ b/public/app/plugins/datasource/loki/configuration/QuerySettings.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/experimental';
+import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Badge, InlineField, InlineFieldRow, Input } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -1,7 +1,7 @@
 import { NodeType, SyntaxNode } from '@lezer/common';
 import { sortBy } from 'lodash';
 
-import { QueryBuilderLabelFilter } from '@grafana/experimental';
+import { QueryBuilderLabelFilter } from '@grafana/plugin-ui';
 import {
   Identifier,
   LabelFilter,

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -1,7 +1,6 @@
 import { NodeType, SyntaxNode } from '@lezer/common';
 import { sortBy } from 'lodash';
 
-import { QueryBuilderLabelFilter } from '@grafana/plugin-ui';
 import {
   Identifier,
   LabelFilter,
@@ -23,6 +22,7 @@ import {
   Expr,
   LabelFormatExpr,
 } from '@grafana/lezer-logql';
+import { QueryBuilderLabelFilter } from '@grafana/plugin-ui';
 
 import { unescapeLabelValue } from './languageUtils';
 import { getNodePositionsFromQuery } from './queryUtils';

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -4,7 +4,7 @@ import {
   VisualQuery,
   QueryBuilderOperation,
   VisualQueryBinary,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 
 import { operationDefinitions } from './operations';
 import { LokiOperationId, LokiQueryPattern, LokiQueryPatternType, LokiVisualQueryOperationCategory } from './types';

--- a/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
@@ -2,7 +2,7 @@ import {
   QueryBuilderOperation,
   QueryBuilderOperationDefinition,
   QueryBuilderOperationParamDef,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 
 import { defaultAddOperationHandler } from './operationUtils';
 import { LokiOperationId, LokiVisualQueryOperationCategory } from './types';

--- a/public/app/plugins/datasource/loki/querybuilder/components/LabelParamEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LabelParamEditor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 
 import { DataSourceApi } from '@grafana/data';
-import { QueryBuilderOperation, QueryBuilderOperationParamDef } from '@grafana/experimental';
+import { QueryBuilderOperation, QueryBuilderOperationParamDef } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 
 import { createLokiDatasource } from '../../__mocks__/datasource';

--- a/public/app/plugins/datasource/loki/querybuilder/components/LabelParamEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LabelParamEditor.tsx
@@ -7,7 +7,7 @@ import {
   QueryBuilderOperationParamValue,
   VisualQuery,
   VisualQueryModeller,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
 import { getOperationParamId } from '../operationUtils';

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -14,7 +14,7 @@ import {
   RawQuery,
   QueryBuilderLabelFilter,
   QueryBuilderOperation,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 
 import { testIds } from '../../components/LokiQueryEditor';

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderExplained.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderExplained.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 
-import { OperationExplainedBox, OperationListExplained, RawQuery } from '@grafana/experimental';
+import { OperationExplainedBox, OperationListExplained, RawQuery } from '@grafana/plugin-ui';
 import { Stack } from '@grafana/ui';
 
 import { lokiGrammar } from '../../syntax';

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -11,7 +11,7 @@ import {
   SelectableValue,
   store,
 } from '@grafana/data';
-import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/experimental';
+import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/plugin-ui';
 import { config, getAppEvents, reportInteraction } from '@grafana/runtime';
 import { Alert, AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/NestedQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/NestedQuery.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { memo } from 'react';
 
 import { GrafanaTheme2, toOption } from '@grafana/data';
-import { EditorRows, FlexItem } from '@grafana/experimental';
+import { EditorRows, FlexItem } from '@grafana/plugin-ui';
 import { AutoSizeInput, IconButton, Select, useStyles2 } from '@grafana/ui';
 
 import { LokiDatasource } from '../../datasource';

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPattern.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPattern.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { RawQuery } from '@grafana/experimental';
+import { RawQuery } from '@grafana/plugin-ui';
 import { Button, Card, useStyles2 } from '@grafana/ui';
 
 import logqlGrammar from '../../syntax';

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -1,4 +1,4 @@
-import { EditorRow, EditorFieldGroup, RawQuery } from '@grafana/experimental';
+import { EditorRow, EditorFieldGroup, RawQuery } from '@grafana/plugin-ui';
 
 import { lokiGrammar } from '../../syntax';
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 
 import { DataFrame, DataSourceApi, FieldType, toDataFrame } from '@grafana/data';
-import { QueryBuilderOperation, QueryBuilderOperationParamDef } from '@grafana/experimental';
+import { QueryBuilderOperation, QueryBuilderOperationParamDef } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 
 import { createLokiDatasource } from '../../__mocks__/datasource';

--- a/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { SelectableValue, getDefaultTimeRange, toOption } from '@grafana/data';
-import { QueryBuilderOperationParamEditorProps, VisualQueryModeller } from '@grafana/experimental';
+import { QueryBuilderOperationParamEditorProps, VisualQueryModeller } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -1,4 +1,4 @@
-import { QueryBuilderOperation, QueryBuilderOperationDefinition } from '@grafana/experimental';
+import { QueryBuilderOperation, QueryBuilderOperationDefinition } from '@grafana/plugin-ui';
 
 import {
   createAggregationOperation,

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -8,7 +8,7 @@ import {
   QueryBuilderOperationParamValue,
   VisualQuery,
   VisualQueryModeller,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 
 import { escapeLabelValueInExactSelector } from '../languageUtils';
 import { FUNCTIONS } from '../syntax';

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -1,4 +1,4 @@
-import { QueryBuilderOperationDefinition, QueryBuilderOperationParamValue } from '@grafana/experimental';
+import { QueryBuilderOperationDefinition, QueryBuilderOperationParamValue } from '@grafana/plugin-ui';
 
 import { binaryScalarOperations } from './binaryScalarOperations';
 import { UnwrapParamEditor } from './components/UnwrapParamEditor';

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -1,6 +1,5 @@
 import { SyntaxNode } from '@lezer/common';
 
-import { QueryBuilderLabelFilter, QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/plugin-ui';
 import {
   And,
   BinOpExpr,
@@ -54,6 +53,7 @@ import {
   OnOrIgnoringModifier,
   OrFilter,
 } from '@grafana/lezer-logql';
+import { QueryBuilderLabelFilter, QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/plugin-ui';
 
 import { binaryScalarDefs } from './binaryScalarOperations';
 import { checkParamsAreValid, getDefinitionById } from './operations';

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -1,6 +1,6 @@
 import { SyntaxNode } from '@lezer/common';
 
-import { QueryBuilderLabelFilter, QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/experimental';
+import { QueryBuilderLabelFilter, QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/plugin-ui';
 import {
   And,
   BinOpExpr,

--- a/public/app/plugins/datasource/loki/querybuilder/parsingUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsingUtils.ts
@@ -1,6 +1,6 @@
 import { SyntaxNode, TreeCursor } from '@lezer/common';
 
-import { QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/experimental';
+import { QueryBuilderOperation, QueryBuilderOperationParamValue } from '@grafana/plugin-ui';
 
 // Although 0 isn't explicitly provided in the @grafana/lezer-logql library as the error node ID, it does appear to be the ID of error nodes within lezer.
 export const ErrorId = 0;

--- a/public/app/plugins/datasource/loki/querybuilder/state.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.test.ts
@@ -1,4 +1,4 @@
-import { QueryEditorMode } from '@grafana/experimental';
+import { QueryEditorMode } from '@grafana/plugin-ui';
 
 import { changeEditorMode, getQueryWithDefaults } from './state';
 

--- a/public/app/plugins/datasource/loki/querybuilder/state.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.ts
@@ -1,4 +1,4 @@
-import { QueryEditorMode } from '@grafana/experimental';
+import { QueryEditorMode } from '@grafana/plugin-ui';
 
 import { LokiQuery, LokiQueryType } from '../types';
 

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -3,7 +3,7 @@ import {
   QueryBuilderLabelFilter,
   QueryBuilderOperation,
   BINARY_OPERATIONS_KEY,
-} from '@grafana/experimental';
+} from '@grafana/plugin-ui';
 
 /**
  * Visual query model

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -1,5 +1,5 @@
 import { CoreApp, DashboardLoadedEvent, DataQueryRequest, dateTime } from '@grafana/data';
-import { QueryEditorMode } from '@grafana/experimental';
+import { QueryEditorMode } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 
 import pluginJson from './plugin.json';

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,5 +1,5 @@
 import { CoreApp, DashboardLoadedEvent, DataQueryRequest, DataQueryResponse } from '@grafana/data';
-import { QueryEditorMode } from '@grafana/experimental';
+import { QueryEditorMode } from '@grafana/plugin-ui';
 import { reportInteraction, config } from '@grafana/runtime';
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,7 +3225,7 @@ __metadata:
     moment: "npm:2.30.1"
     moment-timezone: "npm:0.5.46"
     ol: "npm:7.4.0"
-    papaparse: "npm:5.5.1"
+    papaparse: "npm:5.5.2"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-use: "npm:17.6.0"
@@ -23759,10 +23759,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"papaparse@npm:5.5.1":
-  version: 5.5.1
-  resolution: "papaparse@npm:5.5.1"
-  checksum: 10/6c3b47bd316cf11936641abe5590c6fb1e5b04297d1c594965a44dba89cc0f26b4e4d61eb1933352c538a30c4915d110628d14cf4d60cef0b8245c9a26477602
+"papaparse@npm:5.5.2":
+  version: 5.5.2
+  resolution: "papaparse@npm:5.5.2"
+  checksum: 10/f5d25ccb10b1b9e87a0fe2d2965c7f8a83223cd79ec8963dd7e8766e8e97a6228dc6c20738a78148dfc74f32b2372003de732a7d50593f38b6a2bb5092710bc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@grafana/experimental` has been deprecated and archived and components have been moved to `@grafana/plugin-ui`. This PR replaces `@grafana/experimental`  with `@grafana/plugin-ui` in Loki plugin. 

Manually verified at couple of places that these changes work, but would be great to get also Loki data source maintainers 👀 . 

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/de7fa530-514f-402e-aadd-95dedcd973fc" />

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/84bb6573-d5d9-4b97-bb25-18c556e2f78f" />


<img width="1451" alt="image" src="https://github.com/user-attachments/assets/06e640a3-be41-4141-ac44-11a6bbc4c776" />

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/bb8764c2-465b-45b3-af44-4a1314ca93a9" />
