### PR TITLE
Alerting: Make pagination token empty if an invalid token is passed

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -334,6 +334,11 @@ func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager
 
 	maxGroups := getInt64WithDefault(opts.Query, "group_limit", -1)
 	nextToken := opts.Query.Get("group_next_token")
+	if nextToken != "" {
+		if _, err := base64.URLEncoding.DecodeString(nextToken); err != nil {
+			nextToken = ""
+		}
+	}
 
 	groupedRules := getGroupedRules(log, ruleList, ruleNamesSet, opts.Namespaces)
 	rulesTotals := make(map[string]int64, len(groupedRules))

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -790,8 +790,8 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			}
 		})
 
-		t.Run("bad token should return no results", func(t *testing.T) {
-			r, err := http.NewRequest("GET", "/api/v1/rules?group_limit=10&group_next_token=foobar", nil)
+		t.Run("bad token should return first group_limit results", func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/api/v1/rules?group_limit=1&group_next_token=foobar", nil)
 			require.NoError(t, err)
 
 			c.Context = &web.Context{Req: r}
@@ -801,7 +801,14 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			result := &apimodels.RuleResponse{}
 			require.NoError(t, json.Unmarshal(resp.Body(), result))
 
-			require.Len(t, result.Data.RuleGroups, 0)
+			require.Len(t, result.Data.RuleGroups, 1)
+			require.Len(t, result.Data.Totals, 0)
+			require.NotEmpty(t, result.Data.NextToken)
+
+			folder, err := api.store.GetNamespaceByUID(context.Background(), "namespace_0", orgID, user)
+			require.NoError(t, err)
+			require.Equal(t, folder.Fullpath, result.Data.RuleGroups[0].File)
+			require.Equal(t, "rule_group_0", result.Data.RuleGroups[0].Name)
 		})
 
 		t.Run("should return nothing when using group_limit=0", func(t *testing.T) {


### PR DESCRIPTION
Small fix to reset token to empty if an invalid base64 encoding is passed. Previous behaviour was undeterministic.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
