### PR TITLE
DynamicDashboards: Open edit pane on selection if it's collapsed

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.ts
+++ b/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.ts
@@ -82,6 +82,14 @@ export function useSnappingSplitter(options: UseSnappingSplitterOptions) {
     setState({ collapsed: !state.collapsed });
   }, [state.collapsed]);
 
+  const onOpen = useCallback(() => {
+    setState({ collapsed: false, snapSize: 1 - (options.initialSize ?? 0.5) });
+  }, [options.initialSize]);
+
+  const onClose = useCallback(() => {
+    setState({ collapsed: true, snapSize: 0 });
+  }, []);
+
   const { containerProps, primaryProps, secondaryProps, splitterProps } = useSplitter({
     direction: options.direction,
     dragPosition: options.dragPosition,
@@ -110,5 +118,14 @@ export function useSnappingSplitter(options: UseSnappingSplitterOptions) {
     secondaryProps.style.overflow = 'unset';
   }
 
-  return { containerProps, primaryProps, secondaryProps, splitterProps, splitterState: state, onToggleCollapse };
+  return {
+    containerProps,
+    primaryProps,
+    secondaryProps,
+    splitterProps,
+    splitterState: state,
+    onToggleCollapse,
+    onOpen,
+    onClose,
+  };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When making a selection in edit mode, if the edit pane is collapsed by default then making a selection will open the edit pane while the selection exists, returning to collapsed mode when the selection is cleared.

**Why do we need this feature?**

Enhancement around dynamic dashboards

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #99149

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/b43d8834-e32d-4947-9f56-65a42ee84ff3



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
