### PR TITLE
VizTooltip: Check useragent to perform consistently on all mobile devices

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -108,6 +108,8 @@ const maybeZoomAction = (e?: MouseEvent | null) => e != null && !e.ctrlKey && !e
 
 const getDataLinksFallback: GetDataLinksCallback = () => [];
 
+const userAgentIsMobile = /Android|iPhone|iPad/i.test(navigator.userAgent);
+
 /**
  * @alpha
  */
@@ -666,8 +668,9 @@ export const TooltipPlugin2 = ({
 
       // if not viaSync, re-dispatch real event
       if (event != null) {
-        // we expect to re-dispatch mousemove, but we need to explicitly do it for mobile
-        const isMobile = event.type !== 'mousemove' || /Android|iPhone|iPad/i.test(navigator.userAgent);
+        // we expect to re-dispatch mousemove, but may have a different event type, so create a mousemove event and fire that instead
+        // this doesn't work for every mobile device, so fall back to checking the useragent as well
+        const isMobile = event.type !== 'mousemove' || userAgentIsMobile;
 
         if (isMobile) {
           event = new MouseEvent('mousemove', {

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -666,8 +666,8 @@ export const TooltipPlugin2 = ({
 
       // if not viaSync, re-dispatch real event
       if (event != null) {
-        // we expect to re-dispatch mousemove, but on mobile we'll get mouseup or click
-        const isMobile = event.type !== 'mousemove';
+        // we expect to re-dispatch mousemove, but we need to explicitly do it for mobile
+        const isMobile = event.type !== 'mousemove' || /Android|iPhone|iPad/i.test(navigator.userAgent);
 
         if (isMobile) {
           event = new MouseEvent('mousemove', {


### PR DESCRIPTION
**What is this feature?**

Due to some timing/inconsistency with the iPhone, the offset for tooltips was not being properly calculated for iPhones when initially selecting a data point and showing the tooltip.

This logic keeps the initial check, which that the event didn't fire so we can fire it manually, but also checks the useragent for mobile devices to capture the iPhone's scenario.

Replicated on an iPhone 15 Pro

Before

https://github.com/user-attachments/assets/23511e48-fa1e-4397-a590-66b9b3b8e148

After

https://github.com/user-attachments/assets/d623f4f6-7377-4c97-99ef-bc5dc961a764

**Which issue(s) does this PR fix?**:

Fixes #99240

**Special notes for your reviewer:**

This is actually a special note for any future developer that finds this and wonders what the bug is

<details><summary>Bug breakdown</summary>

Normal correct behavior

1. sizeRef is height and width of 0,0 and _isHovering starts out as false, moves to true, gets changed in the state here https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx#L258
1. the second useLayoutEffect with the isHovering state as a dependency fires immediately, which sets the sizeRef with values https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx#L661
1. These values  turn into the offset in the setCursor hook. Its not 0,0 so there is a valid offset and everything shows up where its supposed to. https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx#L586

iOS behavior

1. Same as above
1. The setCursor hook fires first, with the 0,0 values, so the x offset is not accurate
1. Then the useLayerEffect hook fires and updates after we need it.

</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
