### PR TITLE
fix(search): use the right services when unfied search is enabled for folders

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1892,15 +1892,7 @@ license_path =
 # you can either pass an array of feature you want to enable to the `enable` field or
 # configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
 # will take precedence over toggles in the `enable` list.
-kubernetesCliDashboards = true
-kubernetesFolders = true
-kubernetesFoldersServiceV2 = true
-managedPlugins = false
-ngalert = true
-unifiedStorage = true
-unifiedStorageBigObjectsSupport = false
-unifiedStorageSearch = true
-unifiedStorageSearchUI = true
+
 # enable = feature1,feature2
 enable =
 
@@ -1911,10 +1903,6 @@ enable =
 
 # feature1 = true
 # feature2 = false
-[unified_storage.dashboards.dashboard.grafana.app]
-dualWriterMode = 5
-[unified_storage.folders.folder.grafana.app]
-dualWriterMode = 5
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1892,7 +1892,15 @@ license_path =
 # you can either pass an array of feature you want to enable to the `enable` field or
 # configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
 # will take precedence over toggles in the `enable` list.
-
+kubernetesCliDashboards = true
+kubernetesFolders = true
+kubernetesFoldersServiceV2 = true
+managedPlugins = false
+ngalert = true
+unifiedStorage = true
+unifiedStorageBigObjectsSupport = false
+unifiedStorageSearch = true
+unifiedStorageSearchUI = true
 # enable = feature1,feature2
 enable =
 
@@ -1903,6 +1911,10 @@ enable =
 
 # feature1 = true
 # feature2 = false
+[unified_storage.dashboards.dashboard.grafana.app]
+dualWriterMode = 5
+[unified_storage.folders.folder.grafana.app]
+dualWriterMode = 5
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/public/app/core/components/FolderFilter/FolderFilter.tsx
+++ b/public/app/core/components/FolderFilter/FolderFilter.tsx
@@ -4,9 +4,10 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AsyncMultiSelect, Icon, Button, useStyles2 } from '@grafana/ui';
+import { config } from 'app/core/config';
 import { Trans } from 'app/core/internationalization';
 import { getBackendSrv } from 'app/core/services/backend_srv';
-import { DashboardSearchItemType } from 'app/features/search/types';
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { FolderInfo, PermissionLevelString } from 'app/types';
 
 export interface FolderFilterProps {
@@ -66,22 +67,52 @@ async function getFoldersAsOptions(
 ): Promise<Array<SelectableValue<FolderInfo>>> {
   setLoading(true);
 
-  const params = {
-    query: searchString,
-    type: DashboardSearchItemType.DashFolder,
-    permission: PermissionLevelString.View,
-  };
+  try {
+    if (config.featureToggles.unifiedStorageSearchUI) {
+      const searcher = getGrafanaSearcher();
+      const queryResponse = await searcher.search({
+        query: searchString,
+        kind: ['folder'],
+        limit: 100,
+        permission: PermissionLevelString.View,
+      });
 
-  // FIXME: stop using id from search and use UID instead
-  const searchHits = await getBackendSrv().search(params);
-  const options = searchHits.map((d) => ({ label: d.title, value: { uid: d.uid, title: d.title } }));
-  if (!searchString || 'dashboards'.includes(searchString.toLowerCase())) {
-    options.unshift({ label: 'Dashboards', value: { uid: 'general', title: 'Dashboards' } });
+      const options = queryResponse.view.map((item) => ({
+        label: item.name,
+        value: { uid: item.uid, title: item.name }
+      }));
+
+      if (!searchString || 'dashboards'.includes(searchString.toLowerCase())) {
+        options.unshift({ label: 'Dashboards', value: { uid: 'general', title: 'Dashboards' } });
+      }
+
+      return options;
+    } else {
+      // Use existing backend service search
+      const params = {
+        query: searchString,
+        type: 'folder',
+        permission: PermissionLevelString.View,
+      };
+
+      const searchHits = await getBackendSrv().search(params);
+      const options = searchHits.map((d) => ({ 
+        label: d.title, 
+        value: { uid: d.uid, title: d.title } 
+      }));
+
+      if (!searchString || 'dashboards'.includes(searchString.toLowerCase())) {
+        options.unshift({ label: 'Dashboards', value: { uid: 'general', title: 'Dashboards' } });
+      }
+
+      return options;
+    }
+  } catch (error) {
+    console.error('Failed to fetch folders:', error);
+    return [];
+  } finally {
+    setLoading(false);
   }
-
-  setLoading(false);
-
-  return options;
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -291,7 +291,7 @@ export async function searchFolders(
       isStarred: false,
       folderId: 0,
       folderUid: item.location ?? 'general',
-      folderTitle: item.location || 'General',
+      folderTitle: item.location ?? 'General',
     }));
   }
 

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -1,9 +1,8 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { getBackendSrv, getDataSourceSrv, isFetchError, config } from '@grafana/runtime';
+import { getBackendSrv, getDataSourceSrv, isFetchError } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { browseDashboardsAPI, ImportInputs } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
-import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { PermissionLevelString, SearchQueryType, ThunkResult } from 'app/types';
 
 import {
@@ -14,7 +13,7 @@ import {
 } from '../../dashboard/components/DashExportModal/DashboardExporter';
 import { getLibraryPanel } from '../../library-panels/state/api';
 import { LibraryElementDTO, LibraryElementKind } from '../../library-panels/types';
-import { DashboardSearchHit, DashboardSearchItemType } from '../../search/types';
+import { DashboardSearchHit } from '../../search/types';
 import { DashboardJson } from '../types';
 
 import {
@@ -273,27 +272,6 @@ export async function searchFolders(
   permission?: PermissionLevelString,
   type: SearchQueryType = SearchQueryType.Folder
 ): Promise<DashboardSearchHit[]> {
-  if (config.featureToggles.unifiedStorageSearchUI) {
-    const searcher = getGrafanaSearcher();
-    const queryResponse = await searcher.search({
-      query: query ?? '*',
-      kind: ['folder'],
-      limit: SLICE_FOLDER_RESULTS_TO,
-      permission,
-    });
-
-    return queryResponse.view.map((item) => ({
-      uid: item.uid,
-      title: item.name,
-      url: item.url,
-      type: DashboardSearchItemType.DashFolder,
-      tags: item.tags ?? [],
-      isStarred: false,
-      folderId: 0,
-      folderUid: item.location ?? 'general',
-      folderTitle: item.location ?? 'General',
-    }));
-  }
 
   return getBackendSrv().get('/api/search', {
     query,

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -272,7 +272,6 @@ export async function searchFolders(
   permission?: PermissionLevelString,
   type: SearchQueryType = SearchQueryType.Folder
 ): Promise<DashboardSearchHit[]> {
-
   return getBackendSrv().get('/api/search', {
     query,
     type: type,

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -276,7 +276,7 @@ export async function searchFolders(
   if (config.featureToggles.unifiedStorageSearchUI) {
     const searcher = getGrafanaSearcher();
     const queryResponse = await searcher.search({
-      query: query || '*',
+      query: query ?? '*',
       kind: ['folder'],
       limit: SLICE_FOLDER_RESULTS_TO,
       permission,

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -287,7 +287,7 @@ export async function searchFolders(
       title: item.name,
       url: item.url,
       type: DashboardSearchItemType.DashFolder,
-      tags: item.tags || [],
+      tags: item.tags ?? [],
       isStarred: false,
       folderId: 0,
       folderUid: item.location || 'general',

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -290,7 +290,7 @@ export async function searchFolders(
       tags: item.tags ?? [],
       isStarred: false,
       folderId: 0,
-      folderUid: item.location || 'general',
+      folderUid: item.location ?? 'general',
       folderTitle: item.location || 'General',
     }));
   }


### PR DESCRIPTION
Caution, this is my first frontend PR.

This PR makes sure that we use the new search API for the folder pickers if the unified search feature toggle is enabled. Not sure if this is the state of the art approach to do it, feedback welcome 😄 