### PR TITLE
Alerting: Escape back slashes in mute timing name edit page

### DIFF
--- a/public/app/features/alerting/unified/components/mute-timings/EditMuteTiming.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/EditMuteTiming.tsx
@@ -5,6 +5,7 @@ import { useGetMuteTiming } from 'app/features/alerting/unified/components/mute-
 import { useURLSearchParams } from 'app/features/alerting/unified/hooks/useURLSearchParams';
 
 import { useAlertmanager } from '../../state/AlertmanagerContext';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 
 import MuteTimingForm from './MuteTimingForm';
@@ -12,7 +13,11 @@ import MuteTimingForm from './MuteTimingForm';
 const EditTimingRoute = () => {
   const [queryParams] = useURLSearchParams();
   const { selectedAlertmanager } = useAlertmanager();
-  const name = queryParams.get('muteName')!;
+  // we need to replace all backslashes with double backslashes, otherwise the rule will not be found
+  const name =
+    selectedAlertmanager === GRAFANA_RULES_SOURCE_NAME
+      ? queryParams.get('muteName')!.replace(/\\/g, '\\\\')
+      : queryParams.get('muteName')!;
 
   const {
     isLoading,


### PR DESCRIPTION
**What is this feature?**

This PR fixes the edit page for mute timings in case the name contains back slashes.

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Related to this [escalation](https://github.com/grafana/support-escalations/issues/14370).

**Special notes for your reviewer:**

you can test it in : https://ephemeral1511182199680soniaag.grafana-dev.net/alerting/routes?tab=mute_timings 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
