### PR TITLE
Alerting: Clear the state cache when the alert routine stops

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -242,7 +242,7 @@ func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 	logger := st.log.FromContext(ctx)
 	logger.Debug("Resetting state of the rule")
 
-	states := st.cache.removeByRuleUID(ruleKey.OrgID, ruleKey.UID)
+	states := st.ForgetStateByRuleUID(ctx, ruleKey)
 
 	if len(states) == 0 {
 		return nil
@@ -280,9 +280,17 @@ func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 			logger.Error("Failed to delete states that belong to a rule from database", "error", err)
 		}
 	}
+
 	logger.Info("Rules state was reset", "states", len(states))
 
 	return transitions
+}
+
+func (st *Manager) ForgetStateByRuleUID(ctx context.Context, ruleKey ngModels.AlertRuleKeyWithGroup) []*State {
+	logger := st.log.FromContext(ctx)
+	logger.Debug("Removing rule state from cache")
+
+	return st.cache.removeByRuleUID(ruleKey.OrgID, ruleKey.UID)
 }
 
 // ResetStateByRuleUID removes the rule instances from cache and instanceStore and saves state history. If the state


### PR DESCRIPTION
**What is this feature?**

When an alert routine stops, this change ensures the rule's state is cleared from the cache regardless of the stopping reason, not just when the reason is "rule deleted".

Background:
- Originally, this was the default behaviour
- It was modified in #53919 to [clear state on rule deletion](https://github.com/grafana/grafana/pull/53919/files#diff-1fe393768892c6c76a43e1ac0ea9ca69ec72d2124d6d80abbede394dd49077aeR402) because Grafana used to dump all rule states to the database on shutdown. This change was added to prevent fix the dump to the database.
- Later, in #55504, the database dump functionality was removed entirely


This PR restores the original behavior: the alert rule state is cleared from the cache whenever the alert routine stops, regardless of the reason.