### PR TITLE
K8s: Folders: Fix get command

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -361,12 +361,22 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	// Validate folder
 	if dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesFoldersServiceV2) {
-		folder, err := dr.folderService.Get(ctx, &folder.GetFolderQuery{
+		query := &folder.GetFolderQuery{
 			OrgID:        dash.OrgID,
-			UID:          &dash.FolderUID,
-			ID:           &dash.FolderID, // nolint:staticcheck
 			SignedInUser: dto.User,
-		})
+		}
+
+		switch {
+		case dash.FolderUID != "":
+			query.UID = &dash.FolderUID
+		case dash.FolderID != 0:
+			query.ID = &dash.FolderID // nolint:staticcheck
+		default:
+			// return the default folder if no folder information is set
+			query.UID = &dash.FolderUID
+		}
+
+		folder, err := dr.folderService.Get(ctx, query)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -363,17 +363,9 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 	if dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesFoldersServiceV2) {
 		query := &folder.GetFolderQuery{
 			OrgID:        dash.OrgID,
+			UID:          &dash.FolderUID,
+			ID:           &dash.FolderID,
 			SignedInUser: dto.User,
-		}
-
-		switch {
-		case dash.FolderUID != "":
-			query.UID = &dash.FolderUID
-		case dash.FolderID != 0:
-			query.ID = &dash.FolderID // nolint:staticcheck
-		default:
-			// return the default folder if no folder information is set
-			query.UID = &dash.FolderUID
 		}
 
 		folder, err := dr.folderService.Get(ctx, query)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -369,7 +369,7 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 		switch {
 		case dash.FolderUID != "":
 			query.UID = &dash.FolderUID
-		case dash.FolderID != 0:
+		case dash.FolderID != 0: // nolint:staticcheck
 			query.ID = &dash.FolderID // nolint:staticcheck
 		default:
 			// return the default folder if no folder information is set

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -364,7 +364,7 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 		folder, err := dr.folderService.Get(ctx, &folder.GetFolderQuery{
 			OrgID:        dash.OrgID,
 			UID:          &dash.FolderUID,
-			ID:           &dash.FolderID,
+			ID:           &dash.FolderID, // nolint:staticcheck
 			SignedInUser: dto.User,
 		})
 		if err != nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -106,27 +106,24 @@ func (s *Service) getFromApiServer(ctx context.Context, q *folder.GetFolderQuery
 	var dashFolder *folder.Folder
 	var err error
 	switch {
-	case q.UID != nil:
-		if *q.UID == "" {
-			return &folder.GeneralFolder, nil
-		}
+	case q.UID != nil && *q.UID != "":
 		dashFolder, err = s.unifiedStore.Get(ctx, *q)
 		if err != nil {
 			return nil, toFolderError(err)
 		}
 	// nolint:staticcheck
-	case q.ID != nil:
+	case q.ID != nil && *q.ID != 0:
 		dashFolder, err = s.getFolderByIDFromApiServer(ctx, *q.ID, q.OrgID)
 		if err != nil {
 			return nil, toFolderError(err)
 		}
-	case q.Title != nil:
+	case q.Title != nil && *q.Title != "":
 		dashFolder, err = s.getFolderByTitleFromApiServer(ctx, q.OrgID, *q.Title, q.ParentUID)
 		if err != nil {
 			return nil, toFolderError(err)
 		}
 	default:
-		return nil, folder.ErrBadRequest.Errorf("either on of UID, ID, Title fields must be present")
+		return &folder.GeneralFolder, nil
 	}
 
 	if dashFolder.IsGeneral() {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -424,9 +424,11 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			t.Run("When get folder by ID should return folder", func(t *testing.T) {
+			t.Run("When get folder by ID and uid is an empty string should return folder by id", func(t *testing.T) {
 				id := int64(123)
+				emptyString := ""
 				query := &folder.GetFolderQuery{
+					UID:          &emptyString,
 					ID:           &id,
 					OrgID:        1,
 					SignedInUser: usr,
@@ -482,10 +484,13 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		})
 
 		t.Run("Returns root folder", func(t *testing.T) {
-			t.Run("When the folder UID is blank should return the root folder", func(t *testing.T) {
+			t.Run("When the folder UID and title are blank, and id is 0, should return the root folder", func(t *testing.T) {
 				emptyString := ""
+				idZero := int64(0)
 				actual, err := folderService.Get(ctx, &folder.GetFolderQuery{
 					UID:          &emptyString,
+					ID:           &idZero,
+					Title:        &emptyString,
 					OrgID:        1,
 					SignedInUser: usr,
 				})


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue where if the ID is passed in but not the UID, we evaluate the UID as the general folder.
