### PR TITLE
ImportDashboards: Use NestedFolderPicker

### DIFF
--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -4,7 +4,7 @@ import { Controller, FieldErrors, UseFormReturn } from 'react-hook-form';
 import { selectors } from '@grafana/e2e-selectors';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { Button, Field, FormFieldErrors, FormsOnSubmit, Stack, Input, Legend } from '@grafana/ui';
-import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
+import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import {
@@ -21,7 +21,6 @@ import { ImportDashboardLibraryPanelsList } from './ImportDashboardLibraryPanels
 interface Props extends Pick<UseFormReturn<ImportDashboardDTO>, 'register' | 'control' | 'getValues' | 'watch'> {
   uidReset: boolean;
   inputs: DashboardInputs;
-  initialFolderUid: string;
   errors: FieldErrors<ImportDashboardDTO>;
   onCancel: () => void;
   onUidReset: () => void;
@@ -35,7 +34,6 @@ export const ImportDashboardForm = ({
   getValues,
   uidReset,
   inputs,
-  initialFolderUid,
   onUidReset,
   onCancel,
   onSubmit,
@@ -72,8 +70,8 @@ export const ImportDashboardForm = ({
       </Field>
       <Field label="Folder">
         <Controller
-          render={({ field: { ref, ...field } }) => (
-            <OldFolderPicker {...field} enableCreateNew initialFolderUid={initialFolderUid} />
+          render={({ field: { ref, value, onChange, ...field } }) => (
+            <FolderPicker {...field} onChange={(uid, title) => onChange({ uid, title })} value={value.uid} />
           )}
           name="folder"
           control={control}

--- a/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx
@@ -112,7 +112,6 @@ class ImportDashboardOverviewUnConnected extends PureComponent<Props, State> {
               onUidReset={this.onUidReset}
               onSubmit={this.onSubmit}
               watch={watch}
-              initialFolderUid={folder.uid}
             />
           )}
         </Form>


### PR DESCRIPTION
Updates Import Dashboard form to use the NestedFolderPicker

![image](https://github.com/user-attachments/assets/363dd8ee-6896-4226-9ff4-453eddbcc6da)

This is to make sure it uses the correct latest APIs, is aware of nested folders, and is consistent with the rest of Grafana.