### PR TITLE
Prometheus: Use the timerange in languageProvider when it's not provided

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -1029,6 +1029,23 @@ describe('PrometheusDatasource', () => {
       expect(interval).toEqual({ text: '15s', value: '15s' });
       expect(intervalMs).toEqual({ text: 15000, value: 15000 });
     });
+
+    it('should use the default time range when no range provided in options', () => {
+      const prometheusDatasource = new PrometheusDatasource(
+        { ...instanceSettings, jsonData: { ...instanceSettings.jsonData, cacheLevel: PrometheusCacheLevel.None } },
+        templateSrvStub
+      );
+      const query = 'query_result(topk(5,rate(http_request_duration_microseconds_count[$__interval])))';
+      prometheusDatasource.metricFindQuery(query);
+
+      // Last 6h
+      const range = replaceMock.mock.calls[1][1].__range;
+      const rangeMs = replaceMock.mock.calls[1][1].__range_ms;
+      const rangeS = replaceMock.mock.calls[1][1].__range_s;
+      expect(range).toEqual({ text: '21600s', value: '21600s' });
+      expect(rangeMs).toEqual({ text: 21600000, value: 21600000 });
+      expect(rangeS).toEqual({ text: 21600, value: 21600 });
+    });
   });
 });
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -456,13 +456,15 @@ export class PrometheusDatasource
       return Promise.resolve([]);
     }
 
+    const timeRange = options?.range ?? this.languageProvider.timeRange ?? getDefaultTimeRange();
+
     const scopedVars = {
       ...this.getIntervalVars(),
-      ...this.getRangeScopedVars(options?.range ?? getDefaultTimeRange()),
+      ...this.getRangeScopedVars(timeRange),
     };
     const interpolated = this.templateSrv.replace(query, scopedVars, this.interpolateQueryExpr);
     const metricFindQuery = new PrometheusMetricFindQuery(this, interpolated);
-    return metricFindQuery.process(options?.range ?? getDefaultTimeRange());
+    return metricFindQuery.process(timeRange);
   }
 
   getIntervalVars() {


### PR DESCRIPTION
**What is this feature?**

When calling `metricFindQuery`, if timeRange is not provided we should get the range from `languageProvider`. Otherwise we fallback to `defaultTimeRange`. Previously we always use the default time range when the range is not provided. 

**Who is this feature for?**

Prometheus data source users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/91101

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
