### PR TITLE
Provisioning: Move openapi setup to core

### DIFF
--- a/openapi/provisioning.grafana.app-v0alpha1.json
+++ b/openapi/provisioning.grafana.app-v0alpha1.json
@@ -7,9 +7,7 @@
   "paths": {
     "/apis/provisioning.grafana.app/v0alpha1/": {
       "get": {
-        "tags": [
-          "API Discovery"
-        ],
+        "tags": ["API Discovery"],
         "description": "get available resources",
         "operationId": "getAPIResources",
         "responses": {
@@ -38,9 +36,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/jobs": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "list or watch objects of kind Job",
         "operationId": "listJobForAllNamespaces",
         "responses": {
@@ -78,8 +74,8 @@
         "x-kubernetes-action": "list",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -186,9 +182,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/jobs": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "list or watch objects of kind Job",
         "operationId": "listJob",
         "responses": {
@@ -226,8 +220,8 @@
         "x-kubernetes-action": "list",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -344,9 +338,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/jobs/{name}": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "read the specified Job",
         "operationId": "getJob",
         "responses": {
@@ -374,8 +366,8 @@
         "x-kubernetes-action": "get",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -412,9 +404,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "list or watch objects of kind Repository",
         "operationId": "listRepository",
         "parameters": [
@@ -544,14 +534,12 @@
         "x-kubernetes-action": "list",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "create a Repository",
         "operationId": "createRepository",
         "parameters": [
@@ -658,14 +646,12 @@
         "x-kubernetes-action": "post",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "delete": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "delete collection of Repository",
         "operationId": "deletecollectionRepository",
         "parameters": [
@@ -821,8 +807,8 @@
         "x-kubernetes-action": "deletecollection",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -849,9 +835,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "read the specified Repository",
         "operationId": "getRepository",
         "responses": {
@@ -879,14 +863,12 @@
         "x-kubernetes-action": "get",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "put": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "replace the specified Repository",
         "operationId": "replaceRepository",
         "parameters": [
@@ -973,14 +955,12 @@
         "x-kubernetes-action": "put",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "delete": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "delete a Repository",
         "operationId": "deleteRepository",
         "parameters": [
@@ -1084,14 +1064,12 @@
         "x-kubernetes-action": "delete",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "patch": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "partially update the specified Repository",
         "operationId": "updateRepository",
         "parameters": [
@@ -1202,8 +1180,8 @@
         "x-kubernetes-action": "patch",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -1240,9 +1218,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/export": {
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Export from grafana into the remote repository",
         "operationId": "createRepositoryExport",
         "requestBody": {
@@ -1270,9 +1246,9 @@
                 }
               },
               "example": {
-                "branch": "target-branch",
                 "folder": "grafan-folder-ref",
                 "history": true,
+                "branch": "target-branch",
                 "prefix": "prefix/in/repo/tree"
               }
             }
@@ -1293,8 +1269,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -1322,9 +1298,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/files/": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "summary": "File listing",
         "description": "Get the files and content hash",
         "operationId": "getRepositoryFiles",
@@ -1386,8 +1360,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceWrapper",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceWrapper"
         }
       },
       "parameters": [
@@ -1415,9 +1389,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/files/{path}": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Read value from upstream repository",
         "operationId": "getRepositoryFilesWithPath",
         "parameters": [
@@ -1458,14 +1430,12 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceWrapper",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceWrapper"
         }
       },
       "put": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "connect PUT requests to files of Repository",
         "operationId": "replaceRepositoryFilesWithPath",
         "parameters": [
@@ -1554,14 +1524,12 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceWrapper",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceWrapper"
         }
       },
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "connect POST requests to files of Repository",
         "operationId": "createRepositoryFilesWithPath",
         "parameters": [
@@ -1650,14 +1618,12 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceWrapper",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceWrapper"
         }
       },
       "delete": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "connect DELETE requests to files of Repository",
         "operationId": "deleteRepositoryFilesWithPath",
         "parameters": [
@@ -1706,8 +1672,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceWrapper",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceWrapper"
         }
       },
       "parameters": [
@@ -1745,9 +1711,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/history": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Get the history of the repository",
         "operationId": "getRepositoryHistory",
         "parameters": [
@@ -1788,8 +1752,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "HistoryList",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "HistoryList"
         }
       },
       "parameters": [
@@ -1817,9 +1781,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/history/{path}": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Get the history of a path",
         "operationId": "getRepositoryHistoryWithPath",
         "parameters": [
@@ -1860,8 +1822,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "HistoryList",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "HistoryList"
         }
       },
       "parameters": [
@@ -1899,9 +1861,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/resources": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "connect GET requests to resources of Repository",
         "operationId": "getRepositoryResources",
         "responses": {
@@ -1919,8 +1879,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "ResourceList",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "ResourceList"
         }
       },
       "parameters": [
@@ -1948,9 +1908,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/status": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "read status of the specified Repository",
         "operationId": "getRepositoryStatus",
         "responses": {
@@ -1978,14 +1936,12 @@
         "x-kubernetes-action": "get",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "put": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "replace status of the specified Repository",
         "operationId": "replaceRepositoryStatus",
         "parameters": [
@@ -2072,14 +2028,12 @@
         "x-kubernetes-action": "put",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "patch": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "partially update status of the specified Repository",
         "operationId": "updateRepositoryStatus",
         "parameters": [
@@ -2190,8 +2144,8 @@
         "x-kubernetes-action": "patch",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -2228,9 +2182,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/sync": {
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Sync from repository into Grafana",
         "operationId": "createRepositorySync",
         "requestBody": {
@@ -2266,8 +2218,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -2295,9 +2247,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/test": {
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Check if the configuration is valid",
         "operationId": "createRepositoryTest",
         "requestBody": {
@@ -2344,8 +2294,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "TestResults",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "TestResults"
         }
       },
       "parameters": [
@@ -2373,9 +2323,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/webhook": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "connect GET requests to webhook of Repository",
         "operationId": "getRepositoryWebhook",
         "responses": {
@@ -2393,14 +2341,12 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "WebhookResponse",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "WebhookResponse"
         }
       },
       "post": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Currently only supports github webhooks",
         "operationId": "createRepositoryWebhook",
         "responses": {
@@ -2418,8 +2364,8 @@
         "x-kubernetes-action": "connect",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "WebhookResponse",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "WebhookResponse"
         }
       },
       "parameters": [
@@ -2447,9 +2393,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/stats": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "Get resource stats for this namespace",
         "operationId": "getResourceStats",
         "parameters": [
@@ -2499,9 +2443,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/repositories": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "list or watch objects of kind Repository",
         "operationId": "listRepositoryForAllNamespaces",
         "responses": {
@@ -2539,8 +2481,8 @@
         "x-kubernetes-action": "list",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -2647,9 +2589,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/jobs": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
         "operationId": "watchJobListForAllNamespaces",
         "responses": {
@@ -2687,8 +2627,8 @@
         "x-kubernetes-action": "watchlist",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -2795,9 +2735,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/namespaces/{namespace}/jobs": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
         "operationId": "watchJobList",
         "responses": {
@@ -2835,8 +2773,8 @@
         "x-kubernetes-action": "watchlist",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -2953,9 +2891,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/namespaces/{namespace}/jobs/{name}": {
       "get": {
-        "tags": [
-          "Job"
-        ],
+        "tags": ["Job"],
         "description": "watch changes to an object of kind Job. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
         "operationId": "watchJob",
         "responses": {
@@ -2993,8 +2929,8 @@
         "x-kubernetes-action": "watch",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Job",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Job"
         }
       },
       "parameters": [
@@ -3121,9 +3057,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/namespaces/{namespace}/repositories": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "watch individual changes to a list of Repository. deprecated: use the 'watch' parameter with a list operation instead.",
         "operationId": "watchRepositoryList",
         "responses": {
@@ -3161,8 +3095,8 @@
         "x-kubernetes-action": "watchlist",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -3279,9 +3213,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/namespaces/{namespace}/repositories/{name}": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "watch changes to an object of kind Repository. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
         "operationId": "watchRepository",
         "responses": {
@@ -3319,8 +3251,8 @@
         "x-kubernetes-action": "watch",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -3447,9 +3379,7 @@
     },
     "/apis/provisioning.grafana.app/v0alpha1/watch/repositories": {
       "get": {
-        "tags": [
-          "Repository"
-        ],
+        "tags": ["Repository"],
         "description": "watch individual changes to a list of Repository. deprecated: use the 'watch' parameter with a list operation instead.",
         "operationId": "watchRepositoryListForAllNamespaces",
         "responses": {
@@ -3487,8 +3417,8 @@
         "x-kubernetes-action": "watchlist",
         "x-kubernetes-group-version-kind": {
           "group": "provisioning.grafana.app",
-          "kind": "Repository",
-          "version": "v0alpha1"
+          "version": "v0alpha1",
+          "kind": "Repository"
         }
       },
       "parameters": [
@@ -3603,11 +3533,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.EditingOptions": {
         "type": "object",
-        "required": [
-          "create",
-          "update",
-          "delete"
-        ],
+        "required": ["create", "update", "delete"],
         "properties": {
           "create": {
             "description": "End users can create new files in the remote file system",
@@ -3682,9 +3608,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.HealthStatus": {
         "type": "object",
-        "required": [
-          "healthy"
-        ],
+        "required": ["healthy"],
         "properties": {
           "checked": {
             "description": "When the health was checked last time",
@@ -3838,20 +3762,13 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.JobSpec": {
         "type": "object",
-        "required": [
-          "action",
-          "repository"
-        ],
+        "required": ["action", "repository"],
         "properties": {
           "action": {
             "description": "Possible enum values:\n - `\"export\"` Export from grafana into the remote repository\n - `\"pr\"` Update a pull request -- send preview images, links etc\n - `\"sync\"` Sync the remote branch with the grafana instance",
             "type": "string",
             "default": "",
-            "enum": [
-              "export",
-              "pr",
-              "sync"
-            ]
+            "enum": ["export", "pr", "sync"]
           },
           "export": {
             "description": "Required when the action is `export`",
@@ -3914,12 +3831,7 @@
           "state": {
             "description": "Possible enum values:\n - `\"error\"` Finished with errors\n - `\"pending\"` Job has been submitted, but not processed yet\n - `\"success\"` Finished with success\n - `\"working\"` The job is running",
             "type": "string",
-            "enum": [
-              "error",
-              "pending",
-              "success",
-              "working"
-            ]
+            "enum": ["error", "pending", "success", "working"]
           },
           "summary": {
             "description": "Summary of processed actions",
@@ -3937,11 +3849,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.LintIssue": {
         "type": "object",
-        "required": [
-          "severity",
-          "rule",
-          "message"
-        ],
+        "required": ["severity", "rule", "message"],
         "properties": {
           "message": {
             "type": "string",
@@ -3955,13 +3863,7 @@
             "description": "Possible enum values:\n - `\"error\"`\n - `\"exclude\"`\n - `\"fixed\"`\n - `\"quiet\"`\n - `\"warning\"`",
             "type": "string",
             "default": "",
-            "enum": [
-              "error",
-              "exclude",
-              "fixed",
-              "quiet",
-              "warning"
-            ]
+            "enum": ["error", "exclude", "fixed", "quiet", "warning"]
           }
         }
       },
@@ -4090,12 +3992,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.RepositorySpec": {
         "type": "object",
-        "required": [
-          "title",
-          "editing",
-          "deletePolicy",
-          "type"
-        ],
+        "required": ["title", "editing", "deletePolicy", "type"],
         "properties": {
           "deletePolicy": {
             "description": "DeletePolicy options within the repository",
@@ -4156,23 +4053,14 @@
             "description": "The repository type.  When selected oneOf the values below should be non-nil\n\nPossible enum values:\n - `\"github\"`\n - `\"local\"`\n - `\"s3\"`",
             "type": "string",
             "default": "",
-            "enum": [
-              "github",
-              "local",
-              "s3"
-            ]
+            "enum": ["github", "local", "s3"]
           }
         }
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.RepositoryStatus": {
         "description": "The status of a Repository. This is expected never to be created by a kubectl call or similar, and is expected to rarely (if ever) be edited manually. As such, it is also a little less well structured than the spec, such as conditional-but-ever-present fields.",
         "type": "object",
-        "required": [
-          "observedGeneration",
-          "health",
-          "sync",
-          "webhook"
-        ],
+        "required": ["observedGeneration", "health", "sync", "webhook"],
         "properties": {
           "health": {
             "description": "This will get updated with the current health status (and updated periodically)",
@@ -4222,11 +4110,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.ResourceCount": {
         "type": "object",
-        "required": [
-          "group",
-          "resource",
-          "count"
-        ],
+        "required": ["group", "resource", "count"],
         "properties": {
           "count": {
             "type": "integer",
@@ -4293,13 +4177,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.ResourceListItem": {
         "type": "object",
-        "required": [
-          "path",
-          "group",
-          "resource",
-          "name",
-          "hash"
-        ],
+        "required": ["path", "group", "resource", "name", "hash"],
         "properties": {
           "folder": {
             "type": "string"
@@ -4336,18 +4214,12 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.ResourceObjects": {
         "type": "object",
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "action": {
             "description": "The action required/used for dryRun\n\nPossible enum values:\n - `\"create\"`\n - `\"delete\"`\n - `\"update\"`",
             "type": "string",
-            "enum": [
-              "create",
-              "delete",
-              "update"
-            ]
+            "enum": ["create", "delete", "update"]
           },
           "dryRun": {
             "description": "The value returned from a dryRun request",
@@ -4390,12 +4262,7 @@
           "classic": {
             "description": "For non-k8s native formats, what did this start as\n\nPossible enum values:\n - `\"access-control\"` Access control https://github.com/grafana/grafana/blob/v11.3.1/conf/provisioning/access-control/sample.yaml\n - `\"alerting\"` Alert configuration https://github.com/grafana/grafana/blob/v11.3.1/conf/provisioning/alerting/sample.yaml\n - `\"dashboard\"` Dashboard JSON\n - `\"datasources\"` Datasource definitions eg: https://github.com/grafana/grafana/blob/v11.3.1/conf/provisioning/datasources/sample.yaml",
             "type": "string",
-            "enum": [
-              "access-control",
-              "alerting",
-              "dashboard",
-              "datasources"
-            ]
+            "enum": ["access-control", "alerting", "dashboard", "datasources"]
           },
           "group": {
             "type": "string"
@@ -4414,9 +4281,7 @@
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.ResourceWrapper": {
         "description": "This is a container type for any resource type",
         "type": "object",
-        "required": [
-          "resource"
-        ],
+        "required": ["resource"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -4511,9 +4376,7 @@
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.SyncStatus": {
         "type": "object",
-        "required": [
-          "state"
-        ],
+        "required": ["state"],
         "properties": {
           "finished": {
             "description": "When the sync job finished",
@@ -4550,22 +4413,14 @@
             "description": "pending, running, success, error\n\nPossible enum values:\n - `\"error\"` Finished with errors\n - `\"pending\"` Job has been submitted, but not processed yet\n - `\"success\"` Finished with success\n - `\"working\"` The job is running",
             "type": "string",
             "default": "",
-            "enum": [
-              "error",
-              "pending",
-              "success",
-              "working"
-            ]
+            "enum": ["error", "pending", "success", "working"]
           }
         }
       },
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.TestResults": {
         "description": "HistoryList is a list of versions of a resource",
         "type": "object",
-        "required": [
-          "code",
-          "success"
-        ],
+        "required": ["code", "success"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -4683,13 +4538,7 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
-        "required": [
-          "name",
-          "singularName",
-          "namespaced",
-          "kind",
-          "verbs"
-        ],
+        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
         "properties": {
           "categories": {
             "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
@@ -4754,10 +4603,7 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
         "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
         "type": "object",
-        "required": [
-          "groupVersion",
-          "resources"
-        ],
+        "required": ["groupVersion", "resources"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -4996,9 +4842,7 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": [
-              "uid"
-            ],
+            "x-kubernetes-list-map-keys": ["uid"],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "uid",
             "x-kubernetes-patch-strategy": "merge"
@@ -5020,12 +4864,7 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
         "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
         "type": "object",
-        "required": [
-          "apiVersion",
-          "kind",
-          "name",
-          "uid"
-        ],
+        "required": ["apiVersion", "kind", "name", "uid"],
         "properties": {
           "apiVersion": {
             "description": "API version of the referent.",
@@ -5191,10 +5030,7 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
         "description": "Event represents a single event to a watched resource.",
         "type": "object",
-        "required": [
-          "type",
-          "object"
-        ],
+        "required": ["type", "object"],
         "properties": {
           "object": {
             "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",

--- a/pkg/tests/apis/core/openapi_test.go
+++ b/pkg/tests/apis/core/openapi_test.go
@@ -10,12 +10,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/version"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tests/apis"
@@ -39,6 +38,9 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 		Group:   "folder.grafana.app",
 		Version: "v0alpha1",
 	}, {
+		Group:   "provisioning.grafana.app",
+		Version: "v0alpha1",
+	}, {
 		Group:   "peakq.grafana.app",
 		Version: "v0alpha1",
 	}}
@@ -48,6 +50,7 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagKubernetesFoldersServiceV2, // Will be default on by G12
 			featuremgmt.FlagQueryService,               // Query Library
+			featuremgmt.FlagProvisioning,
 		},
 	})
 

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -242,11 +242,6 @@ func TestIntegrationProvisioning(t *testing.T) {
 				}
 			]
 		}`, string(v1Disco))
-
-		// also verify the openapi
-		helper.VerifyStaticOpenAPISpec(schema.GroupVersion{
-			Group: "provisioning.grafana.app", Version: "v0alpha1",
-		}, "testdata/openapi.json")
 	})
 
 	t.Run("Check basic create and get", func(t *testing.T) {

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -38,7 +38,7 @@ const config: ConfigFile = {
     },
     '../public/app/features/provisioning/api/endpoints.gen.ts': {
       apiFile: '../public/app/features/provisioning/api/baseAPI.ts',
-      schemaFile: '../pkg/tests/apis/provisioning/testdata/openapi.json',
+      schemaFile: '../openapi/provisioning.grafana.app-v0alpha1.json',
       apiImport: 'baseAPI',
       filterEndpoints,
       argSuffix: 'Arg',


### PR DESCRIPTION
This shifts our openapi generation to use the same pattern as https://github.com/grafana/grafana/pull/99561