### PR TITLE
[DO NOT MERGE] Folders: Remove dependency on dashboard store for default permissions

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -468,7 +468,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 		features, tracing.InitializeTracerForTest(), zanzana.NewNoopClient(), sc.db, permreg.ProvidePermissionRegistry(), nil, folderServiceWithFlagOn,
 	)
 	folderPermissions, err := ossaccesscontrol.ProvideFolderPermissions(
-		cfg, features, routing.NewRouteRegister(), sc.db, ac, license, &dashboards.FakeDashboardStore{}, folderServiceWithFlagOn, acSvc, sc.teamSvc, sc.userSvc, actionSets)
+		cfg, features, routing.NewRouteRegister(), sc.db, ac, license, folderServiceWithFlagOn, acSvc, sc.teamSvc, sc.userSvc, actionSets)
 	require.NoError(b, err)
 	dashboardSvc, err := dashboardservice.ProvideDashboardServiceImpl(
 		sc.cfg, dashStore, folderStore,

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
@@ -88,7 +87,6 @@ func ProvideFolderPermissions(
 		sqlStore,
 		ac,
 		license,
-		&dashboards.FakeDashboardStore{},
 		fService,
 		acSvc,
 		teamSvc,

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -293,9 +293,7 @@ func (s *Service) SetPermissions(
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetPermissions")
 	defer span.End()
 
-	// permissions have not yet been set - validate the resource with a service account
-	identityCtx, _ := identity.WithServiceIdentitiy(ctx, orgID)
-	if err := s.validateResource(identityCtx, orgID, resourceID); err != nil {
+	if err := s.validateResource(ctx, orgID, resourceID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -293,7 +293,9 @@ func (s *Service) SetPermissions(
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetPermissions")
 	defer span.End()
 
-	if err := s.validateResource(ctx, orgID, resourceID); err != nil {
+	// permissions have not yet been set - validate the resource with a service account
+	identityCtx, _ := identity.WithServiceIdentitiy(ctx, orgID)
+	if err := s.validateResource(identityCtx, orgID, resourceID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR removes the dependency on the dashboard store for the folders default permissions, and instead it grabs the folder from the folder service.

Note: this PR is blocked by https://github.com/grafana/grafana/pull/99709 / having a solution for that. If we merge this PR in as-is, it will break the editor flow on main.

**Why do we need this feature?**

As we move folders to app platform, they will no longer be stored in the dashboard table for retrieval. We also need to go through the service so it will either be routed to the folder table or unified storage, depending on what the source of truth is.