### PR TITLE
Access control: set service account to check resource before setting defaults

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -293,7 +293,9 @@ func (s *Service) SetPermissions(
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetPermissions")
 	defer span.End()
 
-	if err := s.validateResource(ctx, orgID, resourceID); err != nil {
+	// permissions have not yet been set - validate the resource with a service account
+	identityCtx, _ := identity.WithServiceIdentitiy(ctx, orgID)
+	if err := s.validateResource(identityCtx, orgID, resourceID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What is this feature?**

After [we migrated access control to using the dashboard service](https://github.com/grafana/grafana/pull/99053), editors in the k8s flow will have issues when creating new dashboards, because the validate resource call happens prior to the default permissions being set. Note: this does **_not_** impact main, as the permission checks differ in that flow.

This will also be needed by folders here: https://github.com/grafana/grafana/pull/99708

This PR modifies the initial resource validator to use a service identity to check the resource prior to setting the default permissions, but there is probably a better way than this - open to changing it :) 

