### PR TITLE
Alerting: Support retry with backoff in alert rule evaluation

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1412,10 +1412,25 @@ execute_alerts = true
 # The timeout string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 evaluation_timeout = 30s
 
-# Number of times we'll attempt to evaluate an alert rule before giving up on that evaluation. The default value is 3.
+# Total number of evaluation attempts for an alert rule before giving up (including the initial attempt). The default value is 3.
+# The retry mechanism will stop if this number is reached or if the rule's evaluation interval is exceeded.
+# NOTE: For rules with short evaluation intervals, it's recommended to keep this value low and ensure that
+# retry delays are shorter than the rule's evaluation interval to avoid resource contention.
 max_attempts = 3
 
-# Minimum interval to enforce between rule evaluations. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as we'll schedule fewer evaluations over time.
+# The initial delay before retrying a failed alert evaluation. This is the starting point for exponential backoff.
+initial_retry_delay = 1s
+
+# The maximum delay between retries during exponential backoff. Once this delay is reached, all subsequent retries will use this fixed interval.
+# For optimal performance, ensure the total time of all retries is less than the rule's evaluation interval to prevent retry attempts from overlapping with scheduled evaluations.
+max_retry_delay = 4s
+
+# The randomization factor for exponential backoff retries. This adds jitter to retry delays to prevent thundering herd problems when multiple rules fail simultaneously.
+# Value must be between 0 and 1. With factor F, the actual delay will be randomly chosen
+# from [current_delay*(1-F), current_delay*(1+F)] where current_delay grows exponentially.
+# Default is 0.1.
+randomization_factor = 0.1
+
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 min_interval = 10s
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1389,10 +1389,25 @@
 # The timeout string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;evaluation_timeout = 30s
 
-# Number of times we'll attempt to evaluate an alert rule before giving up on that evaluation. The default value is 3.
+# Total number of evaluation attempts for an alert rule before giving up (including the initial attempt). The default value is 3.
+# The retry mechanism will stop if this number is reached or if the rule's evaluation interval is exceeded.
+# NOTE: For rules with short evaluation intervals, it's recommended to keep this value low and ensure that
+# retry delays are shorter than the rule's evaluation interval to avoid resource contention.
 ;max_attempts = 3
 
-# Minimum interval to enforce between rule evaluations. Rules will be adjusted if they are less than this value  or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as we'll schedule fewer evaluations over time.
+# The initial delay before retrying a failed alert evaluation. This is the starting point for exponential backoff.
+;initial_retry_delay = 1s
+
+# The maximum delay between retries during exponential backoff. Once this delay is reached, all subsequent retries will use this fixed interval.
+# For optimal performance, ensure the total time of all retries is less than the rule's evaluation interval to prevent retry attempts from overlapping with scheduled evaluations.
+;max_retry_delay = 4s
+
+# The randomization factor for exponential backoff retries. This adds jitter to retry delays to prevent thundering herd problems when multiple rules fail simultaneously.
+# Value must be between 0 and 1. With factor F, the actual delay will be randomly chosen
+# from [current_delay*(1-F), current_delay*(1+F)] where current_delay grows exponentially.
+# Default is 0.1.
+;randomization_factor = 0.1
+
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;min_interval = 10s
 

--- a/go.mod
+++ b/go.mod
@@ -366,7 +366,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/caio/go-tdigest v3.1.0+incompatible // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // @grafana/alerting-backend
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/centrifugal/protocol v0.16.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -321,7 +321,12 @@ func (ng *AlertNG) init() error {
 	ng.RecordingWriter = recordingWriter
 
 	schedCfg := schedule.SchedulerCfg{
-		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
+		RetryConfig: schedule.RetryConfig{
+			MaxAttempts:         ng.Cfg.UnifiedAlerting.MaxAttempts,
+			InitialRetryDelay:   ng.Cfg.UnifiedAlerting.InitialRetryDelay,
+			MaxRetryDelay:       ng.Cfg.UnifiedAlerting.MaxRetryDelay,
+			RandomizationFactor: ng.Cfg.UnifiedAlerting.RandomizationFactor,
+		},
 		C:                    clk,
 		BaseInterval:         ng.Cfg.UnifiedAlerting.BaseInterval,
 		MinRuleInterval:      ng.Cfg.UnifiedAlerting.MinInterval,

--- a/pkg/services/ngalert/schedule/retry.go
+++ b/pkg/services/ngalert/schedule/retry.go
@@ -1,0 +1,37 @@
+package schedule
+
+import (
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/cenkalti/backoff/v4"
+)
+
+const retryStop = backoff.Stop
+
+type exponentialBackoffRetryer struct {
+	backoff.BackOff
+}
+
+func newExponentialBackoffRetryer(
+	maxRetries int64,
+	initialRetryDelay time.Duration,
+	maxRetryDelay time.Duration,
+	randomizationFactor float64,
+	clock clock.Clock,
+) *exponentialBackoffRetryer {
+	b := backoff.NewExponentialBackOff(
+		backoff.WithClockProvider(clock),
+		backoff.WithMaxInterval(maxRetryDelay),
+		backoff.WithInitialInterval(initialRetryDelay),
+		backoff.WithRandomizationFactor(randomizationFactor),
+	)
+
+	return &exponentialBackoffRetryer{
+		BackOff: backoff.WithMaxRetries(b, uint64(maxRetries)),
+	}
+}
+
+func (b *exponentialBackoffRetryer) NextAttemptIn() time.Duration {
+	return b.NextBackOff()
+}

--- a/pkg/services/ngalert/schedule/retry_test.go
+++ b/pkg/services/ngalert/schedule/retry_test.go
@@ -1,0 +1,73 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExponentialBackoffRetryProvider_New(t *testing.T) {
+	testClock := clock.NewMock()
+
+	maxRetries := int64(5)
+	initialDelay := 100 * time.Millisecond
+	maxDelay := 1 * time.Second
+
+	retry := newExponentialBackoffRetryer(maxRetries, initialDelay, maxDelay, 0, testClock)
+	require.NotNil(t, retry, "Retry instance should not be nil")
+
+	for i := int64(0); i < maxRetries; i++ {
+		delay := retry.NextAttemptIn()
+		require.GreaterOrEqual(t, delay, initialDelay, "Delay should be at least the initial delay")
+		require.LessOrEqual(t, delay, maxDelay, "Delay should not exceed the max delay")
+
+		testClock.Add(delay)
+	}
+
+	delay := retry.NextAttemptIn()
+	require.Equal(t, backoff.Stop, delay, "Delay should be backoff.Stop after max retries")
+}
+
+func TestExponentialBackoffRetryProvider_MaxRetries(t *testing.T) {
+	testClock := clock.NewMock()
+
+	t.Run("max retries is zero", func(t *testing.T) {
+		retry := newExponentialBackoffRetryer(0, 100*time.Millisecond, 1*time.Second, 0, testClock)
+		require.NotNil(t, retry, "Retry instance should not be nil")
+		delay := retry.NextAttemptIn()
+		require.Equal(t, backoff.Stop, delay, "Should immediately stop when maxRetries is 0")
+	})
+
+	t.Run("max retries is not zero", func(t *testing.T) {
+		maxRetries := int64(10)
+		retry := newExponentialBackoffRetryer(maxRetries, 10*time.Millisecond, 1*time.Second, 0, testClock)
+		for i := int64(0); i < maxRetries; i++ {
+			delay := retry.NextAttemptIn()
+			require.NotEqual(t, backoff.Stop, delay, "Should not stop before reaching max retries")
+			testClock.Add(delay)
+		}
+
+		delay := retry.NextAttemptIn()
+		require.Equal(t, backoff.Stop, delay, "Should stop after reaching maxRetries")
+	})
+}
+
+func TestExponentialBackoffRetryProvider_DelaysWithinBounds(t *testing.T) {
+	testClock := clock.NewMock()
+
+	initialDelay := 200 * time.Millisecond
+	maxDelay := 2 * time.Second
+	maxRetries := int64(10)
+
+	retry := newExponentialBackoffRetryer(maxRetries, initialDelay, maxDelay, 0, testClock)
+
+	for i := int64(0); i < maxRetries; i++ {
+		delay := retry.NextAttemptIn()
+		require.GreaterOrEqual(t, delay, initialDelay, "Delay should not be less than initial delay")
+		require.LessOrEqual(t, delay, maxDelay, "Delay should not exceed max delay")
+		testClock.Add(delay)
+	}
+}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -31,9 +31,6 @@ type ScheduleService interface {
 	Run(context.Context) error
 }
 
-// retryDelay represents how long to wait between each failed rule evaluation.
-const retryDelay = 1 * time.Second
-
 // AlertsSender is an interface for a service that is responsible for sending notifications to the end-user.
 //
 //go:generate mockery --name AlertsSender --structname AlertsSenderMock --inpackage --filename alerts_sender_mock.go --with-expecter
@@ -67,7 +64,7 @@ type schedule struct {
 	// each rule gets its own channel and routine
 	registry ruleRegistry
 
-	maxAttempts int64
+	retryConfig RetryConfig
 
 	clock clock.Clock
 
@@ -112,9 +109,17 @@ type schedule struct {
 	recordingWriter RecordingWriter
 }
 
+// RetryConfig configures the exponential backoff for alert rule and recording rule evaluations.
+type RetryConfig struct {
+	MaxAttempts         int64
+	InitialRetryDelay   time.Duration
+	MaxRetryDelay       time.Duration
+	RandomizationFactor float64
+}
+
 // SchedulerCfg is the scheduler configuration.
 type SchedulerCfg struct {
-	MaxAttempts            int64
+	RetryConfig            RetryConfig
 	BaseInterval           time.Duration
 	C                      clock.Clock
 	MinRuleInterval        time.Duration
@@ -136,14 +141,14 @@ type SchedulerCfg struct {
 // NewScheduler returns a new scheduler.
 func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 	const minMaxAttempts = int64(1)
-	if cfg.MaxAttempts < minMaxAttempts {
-		cfg.Log.Warn("Invalid scheduler maxAttempts, using a safe minimum", "configured", cfg.MaxAttempts, "actual", minMaxAttempts)
-		cfg.MaxAttempts = minMaxAttempts
+	if cfg.RetryConfig.MaxAttempts < minMaxAttempts {
+		cfg.Log.Warn("Invalid scheduler maxAttempts, using a safe minimum", "configured", cfg.RetryConfig.MaxAttempts, "actual", minMaxAttempts)
+		cfg.RetryConfig.MaxAttempts = minMaxAttempts
 	}
 
 	sch := schedule{
 		registry:               newRuleRegistry(),
-		maxAttempts:            cfg.MaxAttempts,
+		retryConfig:            cfg.RetryConfig,
 		clock:                  cfg.C,
 		baseInterval:           cfg.BaseInterval,
 		log:                    cfg.Log,
@@ -168,7 +173,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 }
 
 func (sch *schedule) Run(ctx context.Context) error {
-	sch.log.Info("Starting scheduler", "tickInterval", sch.baseInterval, "maxAttempts", sch.maxAttempts)
+	sch.log.Info("Starting scheduler", "tickInterval", sch.baseInterval, "maxAttempts", sch.retryConfig.MaxAttempts)
 	t := ticker.New(sch.clock, sch.baseInterval, sch.metrics.Ticker, sch.log)
 	defer t.Stop()
 
@@ -296,10 +301,11 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 	updatedRules := make([]ngmodels.AlertRuleKeyWithVersion, 0, len(updated)) // this is needed for tests only
 	restartedRules := make([]Rule, 0)
 	missingFolder := make(map[string][]string)
+
 	ruleFactory := newRuleFactory(
 		sch.appURL,
 		sch.disableGrafanaFolder,
-		sch.maxAttempts,
+		sch.retryConfig,
 		sch.alertsSender,
 		sch.stateManager,
 		sch.evaluatorFactory,

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -51,6 +51,9 @@ const (
 	schedulerDefaultAdminConfigPollInterval = time.Minute
 	schedulerDefaultExecuteAlerts           = true
 	schedulerDefaultMaxAttempts             = 3
+	schedulerDefaultInitialRetryDelay       = 1 * time.Second
+	schedulerDefaultMaxRetryDelay           = 4 * time.Second
+	schedulerDefaultRandomizationFactor     = 0.1
 	schedulerDefaultLegacyMinInterval       = 1
 	screenshotsDefaultCapture               = false
 	screenshotsDefaultCaptureTimeout        = 10 * time.Second
@@ -106,6 +109,9 @@ type UnifiedAlertingSettings struct {
 	HARedisTLSConfig                dstls.ClientConfig
 	InitializationTimeout           time.Duration
 	MaxAttempts                     int64
+	InitialRetryDelay               time.Duration
+	MaxRetryDelay                   time.Duration
+	RandomizationFactor             float64
 	MinInterval                     time.Duration
 	EvaluationTimeout               time.Duration
 	EvaluationResultLimit           int
@@ -362,6 +368,27 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.EvaluationTimeout = uaEvaluationTimeout
 
 	uaCfg.MaxAttempts = ua.Key("max_attempts").MustInt64(schedulerDefaultMaxAttempts)
+
+	uaInitialRetryDelay, err := gtime.ParseDuration(valueAsString(ua, "initial_retry_delay", schedulerDefaultInitialRetryDelay.String()))
+	if err != nil {
+		cfg.Logger.Warn("failed to parse setting 'initial_retry_delay' as duration, falling back to the default value", "error", err, "default", schedulerDefaultInitialRetryDelay)
+		uaInitialRetryDelay = schedulerDefaultInitialRetryDelay
+	}
+	uaCfg.InitialRetryDelay = uaInitialRetryDelay
+
+	uaMaxRetryDelay, err := gtime.ParseDuration(valueAsString(ua, "max_retry_delay", schedulerDefaultMaxRetryDelay.String()))
+	if err != nil {
+		cfg.Logger.Warn("failed to parse setting 'max_retry_delay' as duration, falling back to the default value", "error", err, "default", schedulerDefaultMaxRetryDelay)
+		uaMaxRetryDelay = schedulerDefaultMaxRetryDelay
+	}
+	uaCfg.MaxRetryDelay = uaMaxRetryDelay
+
+	uaRandomizationFactor := ua.Key("randomization_factor").MustFloat64(schedulerDefaultRandomizationFactor)
+	if uaRandomizationFactor < 0 || uaRandomizationFactor > 1 {
+		cfg.Logger.Warn("randomization_factor must be between 0 and 1, falling back to the default value", "value", uaRandomizationFactor, "default", schedulerDefaultRandomizationFactor)
+		uaRandomizationFactor = schedulerDefaultRandomizationFactor
+	}
+	uaCfg.RandomizationFactor = uaRandomizationFactor
 
 	uaCfg.BaseInterval = SchedulerBaseInterval
 


### PR DESCRIPTION
**What is this feature?**

This feature introduces a retry mechanism with exponential backoff for alert rule evaluations in Grafana Alerting. When an alert rule evaluation fails due to a retryable error, it will be retried with increasing delay intervals until a maximum number of attempts is reached:

```ini
[unified_alerting]
initial_retry_delay = 1s
max_retry_delay = 20s
randomization_factor = 0.1
```

**Why do we need this feature?**

Currently, failed alert rule evaluations are retried a fixed number of times without any delay control (it's hardcoded to 1s). This feature allows to manage load to data sources by spacing out retries using exponential backoff.

For rules with very short evaluation intervals and long retry intervals, retries could overlap with the next scheduled evaluation, same as now. This PR doesn't add any automatic checks for these cases.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
