### PR TITLE
K8s: Dashboards: use title sort field instead

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1689,9 +1689,9 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	// but is currently not needed by other services in the backend
 	if query.Title != "" {
 		req := []*resource.Requirement{{
-			Key:      resource.SEARCH_FIELD_TITLE,
+			Key:      resource.SEARCH_FIELD_TITLE_SORT, // use title sort to prevent issues with `-` in the title & how bleve searches
 			Operator: string(selection.In),
-			Values:   []string{query.Title},
+			Values:   []string{strings.ToLower(query.Title)},
 		}}
 		request.Options.Fields = append(request.Options.Fields, req...)
 	}


### PR DESCRIPTION
This ensures we can search by title even if there are dashes in it. From [slack](https://raintank-corp.slack.com/archives/C07L5BQHY5U/p1738092652438829?thread_ts=1738089496.546719&cid=C07L5BQHY5U); `SEARCH_FIELD_TITLE_SORT uses the keyword analyzer so it won't get broken up into separate terms when including dashes`