### PR TITLE
k8s: Dashboard history: Fix created by

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -287,7 +287,7 @@ func (s *Service) UnstructuredToLegacyDashboardVersion(ctx context.Context, item
 	// by that user
 	if obj.GetUpdatedBy() != "" {
 		updatedBy, err := s.k8sclient.GetUserFromMeta(ctx, obj.GetUpdatedBy())
-		if err == nil {
+		if err == nil && updatedBy != nil {
 			createdBy = updatedBy
 		}
 	}

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -283,6 +283,15 @@ func (s *Service) UnstructuredToLegacyDashboardVersion(ctx context.Context, item
 		return nil, err
 	}
 
+	// if updated by is set, then this version of the dashboard was "created"
+	// by that user
+	if obj.GetUpdatedBy() != "" {
+		updatedBy, err := s.k8sclient.GetUserFromMeta(ctx, obj.GetUpdatedBy())
+		if err == nil {
+			createdBy = updatedBy
+		}
+	}
+
 	id, err := obj.GetResourceVersionInt64()
 	if err != nil {
 		return nil, err

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -39,7 +39,7 @@ func TestDashboardVersionService(t *testing.T) {
 		require.Equal(t, dashboard.ToDTO("uid"), dashboardVersion)
 	})
 
-	t.Run("Get dashboard version through k8s", func(t *testing.T) {
+	t.Run("Get dashboard version sthrough k8s", func(t *testing.T) {
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardVersionService := Service{dashSvc: dashboardService, features: featuremgmt.WithFeatures()}
 		mockCli := new(client.MockK8sHandler)
@@ -47,7 +47,7 @@ func TestDashboardVersionService(t *testing.T) {
 		dashboardVersionService.features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesCliDashboards)
 		dashboardService.On("GetDashboardUIDByID", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardRefByIDQuery")).Return(&dashboards.DashboardRef{UID: "uid"}, nil)
 
-		mockCli.On("GetUserFromMeta", mock.Anything, mock.Anything).Return(&user.User{}, nil)
+		mockCli.On("GetUserFromMeta", mock.Anything, "user:1").Return(&user.User{ID: 1}, nil)
 		mockCli.On("Get", mock.Anything, "uid", int64(1), v1.GetOptions{ResourceVersion: "10"}, mock.Anything).Return(&unstructured.Unstructured{
 			Object: map[string]any{
 				"metadata": map[string]any{
@@ -55,6 +55,9 @@ func TestDashboardVersionService(t *testing.T) {
 					"resourceVersion": "12",
 					"labels": map[string]any{
 						utils.LabelKeyDeprecatedInternalID: "42", // nolint:staticcheck
+					},
+					"annotations": map[string]any{
+						utils.AnnoKeyCreatedBy: "user:1",
 					},
 				},
 				"spec": map[string]any{
@@ -73,7 +76,42 @@ func TestDashboardVersionService(t *testing.T) {
 			ParentVersion: 9,
 			DashboardID:   42,
 			DashboardUID:  "uid",
+			CreatedBy:     1,
 			Data:          simplejson.NewFromAny(map[string]any{"uid": "uid", "version": int64(10)}),
+		})
+
+		mockCli.On("GetUserFromMeta", mock.Anything, "user:2").Return(&user.User{ID: 2}, nil)
+		mockCli.On("Get", mock.Anything, "uid", int64(1), v1.GetOptions{ResourceVersion: "11"}, mock.Anything).Return(&unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":            "uid",
+					"resourceVersion": "11",
+					"labels": map[string]any{
+						utils.LabelKeyDeprecatedInternalID: "42", // nolint:staticcheck
+					},
+					"annotations": map[string]any{
+						utils.AnnoKeyCreatedBy: "user:1",
+						utils.AnnoKeyUpdatedBy: "user:2", // if updated by is set, that is the version creator
+					},
+				},
+				"spec": map[string]any{
+					"version": int64(11),
+				},
+			}}, nil).Once()
+		res, err = dashboardVersionService.Get(context.Background(), &dashver.GetDashboardVersionQuery{
+			DashboardID: 42,
+			OrgID:       1,
+			Version:     11,
+		})
+		require.Nil(t, err)
+		require.Equal(t, res, &dashver.DashboardVersionDTO{
+			ID:            11, // RV should be used
+			Version:       11,
+			ParentVersion: 10,
+			DashboardID:   42,
+			DashboardUID:  "uid",
+			CreatedBy:     2,
+			Data:          simplejson.NewFromAny(map[string]any{"uid": "uid", "version": int64(11)}),
 		})
 	})
 }

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -39,7 +39,7 @@ func TestDashboardVersionService(t *testing.T) {
 		require.Equal(t, dashboard.ToDTO("uid"), dashboardVersion)
 	})
 
-	t.Run("Get dashboard version sthrough k8s", func(t *testing.T) {
+	t.Run("Get dashboard versions through k8s", func(t *testing.T) {
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardVersionService := Service{dashSvc: dashboardService, features: featuremgmt.WithFeatures()}
 		mockCli := new(client.MockK8sHandler)


### PR DESCRIPTION
**What is this feature?**

In the first pass at dashboard history going through unistore, I incorrectly set the "created by" as the creator of the dashboard, but it should be the creator of that dashboard version. So, if updated by is set, we should use that.

<img width="585" alt="Screenshot 2025-01-28 at 2 18 11 PM" src="https://github.com/user-attachments/assets/f0ff4dc9-91a1-4097-bb08-1a8b1fb356a9" />
