### PR TITLE
Dashboard Schema V2: Introduce __legacyStringValue and deprecate string type for query prop in QueryVariableSpec

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -637,7 +637,7 @@ QueryVariableSpec: {
   skipUrlSync: bool | *false
   description?: string
   datasource?: DataSourceRef
-  query: DataQueryKind | *""
+  query: DataQueryKind
   regex: string | *""
   sort: VariableSort
   definition?: string

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -637,7 +637,7 @@ QueryVariableSpec: {
   skipUrlSync: bool | *false
   description?: string
   datasource?: DataSourceRef
-  query: string | DataQueryKind | *""
+  query: DataQueryKind | *""
   regex: string | *""
   sort: VariableSort
   definition?: string

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -271,6 +271,7 @@ export const handyTestingSchema: DashboardV2Spec = {
           kind: 'prometheus',
           spec: {
             expr: 'test-query',
+            refId: 'A',
           },
         },
         refresh: 'onDashboardLoad',

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -267,7 +267,12 @@ export const handyTestingSchema: DashboardV2Spec = {
         multi: true,
         name: 'queryVar',
         options: [],
-        query: 'query1',
+        query: {
+          kind: 'prometheus',
+          spec: {
+            expr: 'test-query',
+          },
+        },
         refresh: 'onDashboardLoad',
         regex: 'regex1',
         skipUrlSync: false,

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
@@ -928,7 +928,7 @@ export interface QueryVariableSpec {
 	skipUrlSync: boolean;
 	description?: string;
 	datasource?: DataSourceRef;
-	query: string | DataQueryKind;
+	query: DataQueryKind;
 	regex: string;
 	sort: VariableSort;
 	definition?: string;
@@ -945,7 +945,7 @@ export const defaultQueryVariableSpec = (): QueryVariableSpec => ({
 	hide: "dontHide",
 	refresh: "never",
 	skipUrlSync: false,
-	query: "",
+	query: defaultDataQueryKind(),
 	regex: "",
 	sort: "disabled",
 	options: [],

--- a/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
+++ b/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
@@ -168,7 +168,13 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
         "multi": true,
         "name": "queryVar",
         "options": [],
-        "query": "query1",
+        "query": {
+          "kind": "prometheus",
+          "spec": {
+            "expr": "label_values(node_boot_time_seconds)",
+            "refId": "A",
+          },
+        },
         "refresh": "onDashboardLoad",
         "regex": "regex1",
         "skipUrlSync": false,

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
@@ -775,7 +775,12 @@ describe('sceneVariablesSetToVariables', () => {
         "multi": true,
         "name": "test",
         "options": [],
-        "query": "query",
+        "query": {
+          "kind": "fake-std",
+          "spec": {
+            "__legacyStringValue": "query",
+          },
+        },
         "refresh": "onDashboardLoad",
         "regex": "",
         "skipUrlSync": false,

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -1,3 +1,5 @@
+import { get } from 'lodash';
+
 import { config } from '@grafana/runtime';
 import { MultiValueVariable, SceneVariables, sceneUtils } from '@grafana/scenes';
 import {
@@ -22,7 +24,7 @@ import {
 
 import { getIntervalsQueryFromNewIntervalModel } from '../utils/utils';
 
-import { getDataQuerySpec } from './transformSceneToSaveModelSchemaV2';
+import { getDataQueryKind, getDataQuerySpec } from './transformSceneToSaveModelSchemaV2';
 import {
   transformVariableRefreshToEnum,
   transformVariableHideToEnum,
@@ -270,17 +272,16 @@ export function sceneVariablesSetToSchemaV2Variables(
       if (transformVariableRefreshToEnum(variable.state.refresh) === 'never' || keepQueryOptions) {
         options = variableValueOptionsToVariableOptions(variable.state);
       }
-      //query: DataQueryKind | string;
       const query = variable.state.query;
       let dataQuery: DataQueryKind | string;
       if (typeof query !== 'string') {
         dataQuery = {
-          kind: variable.state.datasource?.type || '',
+          kind: variable.state.datasource?.type ?? getDataQueryKind(query),
           spec: getDataQuerySpec(query),
         };
       } else {
         dataQuery = {
-          kind: variable.state.datasource?.type || '',
+          kind: variable.state.datasource?.type ?? getDataQueryKind(query),
           spec: {
             [LEGACY_STRING_VALUE_KEY]: query,
           },

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -22,7 +22,7 @@ import {
 
 import { getIntervalsQueryFromNewIntervalModel } from '../utils/utils';
 
-import { getDataQueryKind, getDataQuerySpec } from './transformSceneToSaveModelSchemaV2';
+import { getDataQuerySpec } from './transformSceneToSaveModelSchemaV2';
 import {
   transformVariableRefreshToEnum,
   transformVariableHideToEnum,
@@ -275,7 +275,7 @@ export function sceneVariablesSetToSchemaV2Variables(
       let dataQuery: DataQueryKind | string;
       if (typeof query !== 'string') {
         dataQuery = {
-          kind: getDataQueryKind(query),
+          kind: variable.state.datasource?.type || '',
           spec: getDataQuerySpec(query),
         };
       } else {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import { config } from '@grafana/runtime';
 import { MultiValueVariable, SceneVariables, sceneUtils } from '@grafana/scenes';
 import {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -27,6 +27,7 @@ import {
   transformVariableRefreshToEnum,
   transformVariableHideToEnum,
   transformSortVariableToEnum,
+  LEGACY_STRING_VALUE_KEY,
 } from './transformToV2TypesUtils';
 /**
  * Converts a SceneVariables object into an array of VariableModel objects.
@@ -278,7 +279,12 @@ export function sceneVariablesSetToSchemaV2Variables(
           spec: getDataQuerySpec(query),
         };
       } else {
-        dataQuery = query;
+        dataQuery = {
+          kind: variable.state.datasource?.type || '',
+          spec: {
+            [LEGACY_STRING_VALUE_KEY]: query,
+          },
+        };
       }
       const queryVariable: QueryVariableKind = {
         kind: 'QueryVariable',

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -94,6 +94,7 @@ import {
   transformVariableHideToEnumV1,
   transformVariableRefreshToEnumV1,
 } from './transformToV1TypesUtils';
+import { LEGACY_STRING_VALUE_KEY } from './transformToV2TypesUtils';
 
 const DEFAULT_DATASOURCE = 'default';
 
@@ -617,12 +618,12 @@ function createSceneVariableFromVariableModel(variable: TypedVariableModelV2): S
 }
 
 function getDataQueryForVariable(variable: QueryVariableKind) {
-  return typeof variable.spec.query !== 'string'
-    ? {
+  return LEGACY_STRING_VALUE_KEY in variable.spec.query.spec
+    ? (variable.spec.query.spec[LEGACY_STRING_VALUE_KEY] ?? '')
+    : {
         ...variable.spec.query.spec,
         refId: variable.spec.query.spec.refId ?? 'A',
-      }
-    : (variable.spec.query ?? '');
+      };
 }
 
 export function getCurrentValueForOldIntervalModel(variable: IntervalVariableKind, intervals: string[]): string {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -196,7 +196,10 @@ describe('transformSceneToSaveModelSchemaV2', () => {
             hide: VariableHideV1.hideLabel,
             value: 'value1',
             text: 'text1',
-            query: 'query1',
+            query: {
+              expr: 'label_values(node_boot_time_seconds)',
+              refId: 'A',
+            },
             definition: 'definition1',
             datasource: { uid: 'datasource1', type: 'prometheus' },
             sort: VariableSortV1.alphabeticalDesc,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -363,8 +363,11 @@ function getVizPanelQueries(vizPanel: VizPanel): PanelQueryKind[] {
   return queries;
 }
 
-export function getDataQueryKind(query: SceneDataQuery): string {
-  // If the query has a datasource, use the datasource type, otherwise return empty kind
+export function getDataQueryKind(query: SceneDataQuery | string): string {
+  if (typeof query === 'string') {
+    return getDefaultDataSourceRef()?.type ?? '';
+  }
+
   return query.datasource?.type ?? getDefaultDataSourceRef()?.type ?? '';
 }
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -579,19 +579,15 @@ export function getAnnotationQueryKind(annotationQuery: AnnotationQuery): string
   }
 }
 
-export function getDefaultDataSourceRef(): DataSourceRef | undefined {
+export function getDefaultDataSourceRef(): DataSourceRef {
   // we need to return the default datasource configured in the BootConfig
   const defaultDatasource = config.bootData.settings.defaultDatasource;
 
   // get default datasource type
-  const dsList = config.bootData.settings.datasources ?? {};
+  const dsList = config.bootData.settings.datasources;
   const ds = dsList[defaultDatasource];
 
-  if (ds) {
-    return { type: ds.meta.id, uid: ds.name }; // in the datasource list from bootData "id" is the type
-  }
-
-  return undefined;
+  return { type: ds.meta.id, uid: ds.name }; // in the datasource list from bootData "id" is the type
 }
 
 // Function to know if the dashboard transformed is a valid DashboardV2Spec

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -19,6 +19,9 @@ import {
   FieldColorModeId as FieldColorModeIdV2,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
 
+// used for QueryVariableKind's query prop - in schema V2 we've deprecated string type and support only DataQuery
+export const LEGACY_STRING_VALUE_KEY = '__legacyStringValue';
+
 export function transformCursorSynctoEnum(cursorSync?: DashboardCursorSyncV1): DashboardCursorSync {
   switch (cursorSync) {
     case 0:

--- a/public/app/features/dashboard-scene/v2schema/test-helpers.ts
+++ b/public/app/features/dashboard-scene/v2schema/test-helpers.ts
@@ -53,7 +53,7 @@ export function validateVariable<
   }
   if (sceneVariable instanceof QueryVariable && variableKind.kind === 'QueryVariable') {
     expect(sceneVariable?.state.datasource).toBe(variableKind.spec.datasource);
-    expect(sceneVariable?.state.query).toBe(variableKind.spec.query);
+    expect(sceneVariable?.state.query).toEqual(variableKind.spec.query.spec);
   }
   if (sceneVariable instanceof CustomVariable && variableKind.kind === 'CustomVariable') {
     expect(sceneVariable?.state.query).toBe(variableKind.spec.query);

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'app/features/apiserver/types';
 import { getDefaultDataSourceRef } from 'app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2';
 import {
+  LEGACY_STRING_VALUE_KEY,
   transformVariableHideToEnum,
   transformVariableRefreshToEnum,
 } from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
@@ -799,7 +800,7 @@ describe('ResponseTransformers', () => {
       expect(v2.spec.datasource).toEqual(v1.datasource);
 
       if (typeof v1.query === 'string') {
-        expect(v2.spec.query).toEqual(v1.query);
+        expect(v2.spec.query.spec[LEGACY_STRING_VALUE_KEY]).toEqual(v1.query);
       } else {
         expect(v2.spec.query).toEqual({
           kind: v1.datasource?.type,

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -56,6 +56,7 @@ import {
   transformVariableRefreshToEnumV1,
 } from 'app/features/dashboard-scene/serialization/transformToV1TypesUtils';
 import {
+  LEGACY_STRING_VALUE_KEY,
   transformCursorSynctoEnum,
   transformDataTopic,
   transformSortVariableToEnum,
@@ -434,8 +435,12 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.error('Query variable query is a string. It needs to extend DataQuery.');
-          query = {};
+          console.warn(
+            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
+          );
+          query = {
+            [LEGACY_STRING_VALUE_KEY]: query,
+          };
         }
 
         const qv: QueryVariableKind = {
@@ -457,7 +462,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
             query: {
               kind: v.datasource?.type || getDefaultDatasourceType(),
               spec: {
-                ...query,
+                ...v.query,
               },
             },
           },
@@ -638,7 +643,10 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
           ...commonProperties,
           current: v.spec.current,
           options: v.spec.options,
-          query: typeof v.spec.query === 'string' ? v.spec.query : v.spec.query.spec,
+          query:
+            LEGACY_STRING_VALUE_KEY in v.spec.query.spec
+              ? v.spec.query.spec[LEGACY_STRING_VALUE_KEY]
+              : v.spec.query.spec,
           datasource: v.spec.datasource,
           sort: transformSortVariableToEnumV1(v.spec.sort),
           refresh: transformVariableRefreshToEnumV1(v.spec.refresh),


### PR DESCRIPTION
Deprecates `string` for `query` prop from `QueryVariableSpec` for schema V2, and introduces `__legacyStringValue` to support old dashboards and legacy queries. 

Fixes: https://github.com/grafana/grafana-org/issues/380
  