### PR TITLE
RBAC: Don't check folder access if `annotationPermissionUpdate` FT is enabled

### DIFF
--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -18,7 +18,12 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     const builtInLayer = getBuiltInAnnotationsLayer(dashboard);
 
     // When there is no builtin annotations query we disable the ability to add annotations
-    if (!builtInLayer || !dashboard.canEditDashboard()) {
+    if (!builtInLayer) {
+      return false;
+    }
+
+    // If feature flag is enabled we pass the info of whether annotation can be added through the dashboard permissions
+    if (!config.featureToggles.annotationPermissionUpdate && !dashboard.canEditDashboard()) {
       return false;
     }
 
@@ -29,7 +34,8 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
   context.canEditAnnotations = (dashboardUID?: string) => {
     const dashboard = getDashboardSceneFor(vizPanel);
 
-    if (!dashboard.canEditDashboard()) {
+    // If feature flag is enabled we pass the info of whether annotation can be edited through the dashboard permissions
+    if (!config.featureToggles.annotationPermissionUpdate && !dashboard.canEditDashboard()) {
       return false;
     }
 
@@ -43,7 +49,8 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
   context.canDeleteAnnotations = (dashboardUID?: string) => {
     const dashboard = getDashboardSceneFor(vizPanel);
 
-    if (!dashboard.canEditDashboard()) {
+    // If feature flag is enabled we pass the info of whether annotation can be deleted through the dashboard permissions
+    if (!config.featureToggles.annotationPermissionUpdate && !dashboard.canEditDashboard()) {
       return false;
     }
 


### PR DESCRIPTION
**What is this feature?**

If `annotationPermissionUpdate` feature toggle is enabled, we check whether the user has the needed permissions to add/update/delete annotation on the backend, and pass this info to the frontend through `dashboard.state.meta.annotationsPermissions`, so there's no need to also check if the user can edit the dashboard.

We had already made this change in the frontend code, but it wasn't included in the scenes code (original PR: https://github.com/grafana/grafana/pull/78352).

**Who is this feature for?**

Decouples dashboard and annotation permissions.