### PR TITLE
Elasticsearch: Replace term size dropdown with text input

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.test.tsx
@@ -1,11 +1,14 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 
+import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { renderWithESProvider } from '../../../../test-helpers/render';
 import { ElasticsearchQuery, Terms, Average, Derivative, TopMetrics } from '../../../../types';
 import { describeMetric } from '../../../../utils';
 
 import { TermsSettingsEditor } from './TermsSettingsEditor';
+
+jest.mock('../../../../hooks/useStatelessReducer');
 
 describe('Terms Settings Editor', () => {
   it('Pipeline aggregations should not be in "order by" options', () => {
@@ -36,5 +39,39 @@ describe('Terms Settings Editor', () => {
     expect(screen.queryByText(describeMetric(topMetrics))).not.toBeInTheDocument();
     // All other metric aggregations can be used in order by
     expect(screen.getByText(describeMetric(avg))).toBeInTheDocument();
+  });
+
+  describe('Handling change', () => {
+    let dispatch = jest.fn();
+    beforeEach(() => {
+      dispatch.mockClear();
+      jest.mocked(useDispatch).mockReturnValue(dispatch);
+    });
+
+    test('updating size', async () => {
+      const termsAgg: Terms = {
+        id: '1',
+        type: 'terms',
+      };
+      const avg: Average = { id: '2', type: 'avg', field: '@value' };
+      const derivative: Derivative = { id: '3', field: avg.id, type: 'derivative' };
+      const topMetrics: TopMetrics = { id: '4', type: 'top_metrics' };
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        query: '',
+        bucketAggs: [termsAgg],
+        metrics: [avg, derivative, topMetrics],
+      };
+
+      renderWithESProvider(<TermsSettingsEditor bucketAgg={termsAgg} />, { providerProps: { query } });
+
+      const sizeInput = screen.getByLabelText('Size');
+      fireEvent.change(sizeInput, { target: { value: '30' } });
+      fireEvent.blur(sizeInput);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0][0].payload.settingName).toBe('size');
+      expect(dispatch.mock.calls[0][0].payload.newValue).toBe('30');
+    });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/TermsSettingsEditor.tsx
@@ -7,11 +7,10 @@ import { InlineField, Select, Input } from '@grafana/ui';
 import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { MetricAggregation, Percentiles, ExtendedStatMetaType, ExtendedStats, Terms } from '../../../../types';
 import { describeMetric } from '../../../../utils';
-import { useCreatableSelectPersistedBehaviour } from '../../../hooks/useCreatableSelectPersistedBehaviour';
 import { useQuery } from '../../ElasticsearchQueryContext';
 import { isPipelineAggregation } from '../../MetricAggregationsEditor/aggregations';
 import { changeBucketAggregationSetting } from '../state/actions';
-import { bucketAggregationConfig, orderByOptions, orderOptions, sizeOptions } from '../utils';
+import { bucketAggregationConfig, orderByOptions, orderOptions } from '../utils';
 
 import { inlineFieldProps } from '.';
 
@@ -23,6 +22,12 @@ export const TermsSettingsEditor = ({ bucketAgg }: Props) => {
   const { metrics } = useQuery();
   const orderBy = createOrderByOptions(metrics);
   const { current: baseId } = useRef(uniqueId('es-terms-'));
+  let size = bucketAgg.settings?.size || bucketAggregationConfig.terms.defaultSettings?.size;
+  if (!size || size === '') {
+    size = '10';
+  } else if (size === '0') {
+    size = '500';
+  }
 
   const dispatch = useDispatch();
 
@@ -40,16 +45,12 @@ export const TermsSettingsEditor = ({ bucketAgg }: Props) => {
       </InlineField>
 
       <InlineField label="Size" {...inlineFieldProps}>
-        <Select
-          inputId={`${baseId}-size`}
-          // TODO: isValidNewOption should only allow numbers & template variables
-          {...useCreatableSelectPersistedBehaviour({
-            options: sizeOptions,
-            value: bucketAgg.settings?.size || bucketAggregationConfig.terms.defaultSettings?.size,
-            onChange({ value }) {
-              dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'size', newValue: value }));
-            },
-          })}
+        <Input
+          id={`${baseId}-size`}
+          onBlur={(e) =>
+            dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'size', newValue: e.target.value }))
+          }
+          defaultValue={size}
         />
       </InlineField>
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -64,14 +64,3 @@ export const orderOptions: Array<SelectableValue<string>> = [
   { label: 'Top', value: 'desc' },
   { label: 'Bottom', value: 'asc' },
 ];
-
-export const sizeOptions = [
-  { label: 'No limit', value: '0' },
-  { label: '1', value: '1' },
-  { label: '2', value: '2' },
-  { label: '3', value: '3' },
-  { label: '5', value: '5' },
-  { label: '10', value: '10' },
-  { label: '15', value: '15' },
-  { label: '20', value: '20' },
-];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Updates the size input for terms to be a text box and automatically displays 500 for old "no limit" queries (which were limited to 500).

**Why do we need this feature?**
The current options are confusing and this makes it clearer to users that they can use template variables.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #15870 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
