### PR TITLE
Bar Gauge: Add extra padding for scrollbar

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -56,6 +56,7 @@ function getProps(propOverrides?: Partial<Props>): Props {
     theme,
     orientation: VizOrientation.Horizontal,
     namePlacement: BarGaugeNamePlacement.Auto,
+    isOverflow: false,
   };
 
   Object.assign(props, propOverrides);

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -34,6 +34,7 @@ const MAX_VALUE_WIDTH = 150;
 const TITLE_LINE_HEIGHT = 1.5;
 const VALUE_LINE_HEIGHT = 1;
 const VALUE_LEFT_PADDING = 10;
+const VALUE_RIGHT_OVERFLOW_PADDING = 15;
 
 export interface Props extends Themeable2 {
   height: number;
@@ -52,6 +53,7 @@ export interface Props extends Themeable2 {
   alignmentFactors?: DisplayValueAlignmentFactors;
   valueDisplayMode?: BarGaugeValueMode;
   namePlacement?: BarGaugeNamePlacement;
+  isOverflow: boolean;
 }
 
 export class BarGauge extends PureComponent<Props> {
@@ -73,6 +75,7 @@ export class BarGauge extends PureComponent<Props> {
     },
     itemSpacing: 8,
     showUnfilled: true,
+    isOverflow: false,
   };
 
   render() {
@@ -145,6 +148,7 @@ export class BarGauge extends PureComponent<Props> {
       text,
       valueDisplayMode,
       theme,
+      isOverflow,
     } = this.props;
     const { valueHeight, valueWidth, maxBarHeight, maxBarWidth, wrapperWidth, wrapperHeight } =
       calculateBarAndValueDimensions(this.props);
@@ -160,7 +164,15 @@ export class BarGauge extends PureComponent<Props> {
     const valueColor = getTextValueColor(this.props);
 
     const valueToBaseSizeOn = alignmentFactors ? alignmentFactors : value;
-    const valueStyles = getValueStyles(valueToBaseSizeOn, valueColor, valueWidth, valueHeight, orientation, text);
+    const valueStyles = getValueStyles(
+      valueToBaseSizeOn,
+      valueColor,
+      valueWidth,
+      valueHeight,
+      orientation,
+      isOverflow,
+      text
+    );
 
     const containerStyles: CSSProperties = {
       width: `${wrapperWidth}px`,
@@ -486,7 +498,7 @@ export function getValuePercent(value: number, minValue: number, maxValue: numbe
  * Only exported to for unit test
  */
 export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles {
-  const { displayMode, field, value, alignmentFactors, orientation, theme, text } = props;
+  const { displayMode, field, value, alignmentFactors, orientation, theme, text, isOverflow } = props;
   const { valueWidth, valueHeight, maxBarHeight, maxBarWidth } = calculateBarAndValueDimensions(props);
 
   const minValue = field.min ?? GAUGE_DEFAULT_MINIMUM;
@@ -496,7 +508,15 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   const barColor = value.color ?? FALLBACK_COLOR;
 
   const valueToBaseSizeOn = alignmentFactors ? alignmentFactors : value;
-  const valueStyles = getValueStyles(valueToBaseSizeOn, textColor, valueWidth, valueHeight, orientation, text);
+  const valueStyles = getValueStyles(
+    valueToBaseSizeOn,
+    textColor,
+    valueWidth,
+    valueHeight,
+    orientation,
+    isOverflow,
+    text
+  );
 
   const isBasic = displayMode === 'basic';
   const wrapperStyles: CSSProperties = {
@@ -663,6 +683,7 @@ function getValueStyles(
   width: number,
   height: number,
   orientation: VizOrientation,
+  isOverflow: boolean,
   text?: VizTextDisplayOptions
 ): CSSProperties {
   const styles: CSSProperties = {
@@ -688,7 +709,7 @@ function getValueStyles(
       calculateFontSize(formattedValueString, textWidth - VALUE_LEFT_PADDING * 2, height, VALUE_LINE_HEIGHT);
     styles.justifyContent = `flex-end`;
     styles.paddingLeft = `${VALUE_LEFT_PADDING}px`;
-    styles.paddingRight = `${VALUE_LEFT_PADDING}px`;
+    styles.paddingRight = `${VALUE_LEFT_PADDING + (isOverflow ? VALUE_RIGHT_OVERFLOW_PADDING : 0)}px`;
     // Need to remove the left padding from the text width constraints
     textWidth -= VALUE_LEFT_PADDING;
   }

--- a/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
+++ b/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
@@ -181,6 +181,7 @@ export class VizRepeater<V, D = {}> extends PureComponent<PropsWithDefaults<V, D
         repeaterStyle.flexDirection = 'column';
         repeaterStyle.height = `${height}px`;
         repeaterStyle.overflowX = 'hidden';
+        repeaterStyle.scrollbarWidth = 'thin';
         itemStyles.marginBottom = `${itemSpacing}px`;
         vizWidth = width;
         vizHeight = clamp(defaultVizHeight, minVizHeight ?? 0, maxVizHeight ?? defaultVizHeight);

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -29,6 +29,8 @@ export class BarGaugePanel extends PureComponent<BarGaugePanelProps> {
     const { value, alignmentFactors, orientation, width, height, count } = valueProps;
     const { field, display, view, colIndex } = value;
     const { openMenu, targetClassName } = menuProps;
+    const spacing = this.getItemSpacing();
+    const isOverflow = (height + spacing) * count - spacing > this.props.height;
 
     let processor: DisplayProcessor | undefined = undefined;
     if (view && isNumber(colIndex)) {
@@ -45,7 +47,7 @@ export class BarGaugePanel extends PureComponent<BarGaugePanelProps> {
         text={options.text}
         display={processor}
         theme={config.theme2}
-        itemSpacing={this.getItemSpacing()}
+        itemSpacing={spacing}
         displayMode={options.displayMode}
         onClick={openMenu}
         className={targetClassName}
@@ -53,6 +55,7 @@ export class BarGaugePanel extends PureComponent<BarGaugePanelProps> {
         showUnfilled={options.showUnfilled}
         valueDisplayMode={options.valueMode}
         namePlacement={options.namePlacement}
+        isOverflow={isOverflow}
       />
     );
   };

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -30,6 +30,7 @@ export class BarGaugePanel extends PureComponent<BarGaugePanelProps> {
     const { field, display, view, colIndex } = value;
     const { openMenu, targetClassName } = menuProps;
     const spacing = this.getItemSpacing();
+    // check if the total height is bigger than the visualization height, if so, there will be scrollbars for overflow
     const isOverflow = (height + spacing) * count - spacing > this.props.height;
 
     let processor: DisplayProcessor | undefined = undefined;


### PR DESCRIPTION
**What is this feature?**

Adds more right spacing if there is a scrollbar to accommodate overflow within the panel.

**Why the styling changes are not in VizRepeater**: I opted to calculate the isOverflow and add the padding in the individual bar gauges instead of in the viz repeater to ensure that the spacing of the bars themselves is consistent between panels when some panels are scrollable. 

With the padding in the bar gauge, the bar width is calculated with the extra spacing in mind, and if the panels are the same width, the bars will also be the same width, regardless if a scrollbar exists or not.

Unfortunately I don't think it is possible to calculate `isOverflow` outside the loop unless we want to edit VizRepeater. I also felt that making the universal change that panels using VizRepeater use a thin scrollbar made sense, but let me know if I'm wrong.

Let me know if any of the above isn't prioritizing the right things.

![Screenshot 2025-01-28 at 5 56 32 PM](https://github.com/user-attachments/assets/0aa268e5-d046-4d46-8b9e-e26e6befe92e)

**Which issue(s) does this PR fix?**:

Fixes #89226
Fixes #96897

**Special notes for your reviewer:**

<details><summary>Example dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 269,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 10,
      "options": {
        "displayMode": "gradient",
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": false
        },
        "maxVizHeight": 300,
        "minVizHeight": 16,
        "minVizWidth": 8,
        "namePlacement": "auto",
        "orientation": "horizontal",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "showUnfilled": true,
        "sizing": "auto",
        "valueMode": "color"
      },
      "pluginVersion": "11.5.0-pre",
      "targets": [
        {
          "max": 10,
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 12,
          "spread": 10,
          "startValue": 5
        }
      ],
      "title": "Panel Title",
      "type": "bargauge"
    },
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 12,
        "x": 0,
        "y": 8
      },
      "id": 2,
      "maxDataPoints": 10,
      "options": {
        "displayMode": "gradient",
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": false
        },
        "maxVizHeight": 300,
        "minVizHeight": 16,
        "minVizWidth": 8,
        "namePlacement": "auto",
        "orientation": "horizontal",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "showUnfilled": true,
        "sizing": "auto",
        "valueMode": "color"
      },
      "pluginVersion": "11.5.0-pre",
      "targets": [
        {
          "max": 10,
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 12,
          "spread": 10,
          "startValue": 5
        }
      ],
      "title": "Panel Title",
      "type": "bargauge"
    }
  ],
  "preload": false,
  "refresh": "",
  "schemaVersion": 40,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Bar gauge scroll bug",
  "uid": "eebe64a5yf2f4f",
  "version": 3,
  "weekStart": ""
}
```
</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
