### PR TITLE
Folders API: Return orgID in response

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -412,6 +412,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		return dtos.Folder{
 			ID:            f.ID, // nolint:staticcheck
 			UID:           f.UID,
+			OrgID:         f.OrgID,
 			Title:         f.Title,
 			URL:           f.URL,
 			HasACL:        f.HasACL,


### PR DESCRIPTION
**What is this feature?**

This PR fixes a current bug on main where we are not setting the orgID in the folders api response, so it is always saying orgID 0.

Before:
<img width="622" alt="Screenshot 2025-01-28 at 6 28 12 PM" src="https://github.com/user-attachments/assets/13876521-3ac4-459f-84cf-b4f7ec408668" />


After:
<img width="604" alt="Screenshot 2025-01-28 at 6 27 23 PM" src="https://github.com/user-attachments/assets/3622d99d-5e4e-4ae3-9b1b-bdd7c7b8db17" />
