### PR TITLE
Search fallback: prevent for now

### DIFF
--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"google.golang.org/grpc"
 )
 
+/* Temporarily disabled search fallback while we add functionality
 func TestSearchFallback(t *testing.T) {
 	t.Run("should hit legacy search handler on mode 0", func(t *testing.T) {
 		mockClient := &MockClient{}
@@ -172,7 +171,7 @@ func TestSearchFallback(t *testing.T) {
 			t.Fatalf("expected Search NOT to be called, but it was")
 		}
 	})
-}
+}*/
 
 func TestSearchHandlerFields(t *testing.T) {
 	// Create a mock client

--- a/pkg/storage/unified/resource/go.mod
+++ b/pkg/storage/unified/resource/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/grafana/grafana v11.4.0-00010101000000-000000000000+incompatible
 	github.com/grafana/grafana-plugin-sdk-go v0.263.0
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250121113133-e747350fee2d
-	github.com/grafana/grafana/pkg/apiserver v0.0.0-20250121113133-e747350fee2d
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/prometheus/client_golang v1.20.5
@@ -121,6 +120,7 @@ require (
 	github.com/grafana/grafana-app-sdk/logging v0.29.0 // indirect
 	github.com/grafana/grafana-aws-sdk v0.31.5 // indirect
 	github.com/grafana/grafana-azure-sdk-go/v2 v2.1.6 // indirect
+	github.com/grafana/grafana/pkg/apiserver v0.0.0-20250121113133-e747350fee2d // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/grafana/sqlds/v4 v4.1.3 // indirect

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -1,17 +1,16 @@
 package resource
 
 import (
-	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 func NewSearchClient(cfg *setting.Cfg, unifiedStorageConfigKey string, unifiedClient ResourceIndexClient, legacyClient ResourceIndexClient) ResourceIndexClient {
-	config, ok := cfg.UnifiedStorage[unifiedStorageConfigKey]
+	/*config, ok := cfg.UnifiedStorage[unifiedStorageConfigKey]
 	if !ok {
 		return legacyClient
 	}
 
-	/*switch config.DualWriterMode {
+	switch config.DualWriterMode {
 	case rest.Mode0, rest.Mode1, rest.Mode2:
 		return legacyClient
 	default:

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -11,10 +11,11 @@ func NewSearchClient(cfg *setting.Cfg, unifiedStorageConfigKey string, unifiedCl
 		return legacyClient
 	}
 
-	switch config.DualWriterMode {
+	/*switch config.DualWriterMode {
 	case rest.Mode0, rest.Mode1, rest.Mode2:
 		return legacyClient
 	default:
 		return unifiedClient
-	}
+	}*/
+	return unifiedClient
 }


### PR DESCRIPTION
Since not all the legacy functionality is there yet, we are unable to test provisioning of folders in mode 1 with the fallback.

This PR temporarily disables the fallback flow