### PR TITLE
Revert "Bug: Fix broken ui components when angular is disabled"

### DIFF
--- a/public/app/angular/AngularApp.ts
+++ b/public/app/angular/AngularApp.ts
@@ -2,6 +2,7 @@ import 'angular';
 import 'angular-route';
 import 'angular-sanitize';
 import 'angular-bindonce';
+import 'vendor/bootstrap/bootstrap';
 
 import angular from 'angular'; // eslint-disable-line no-duplicate-imports
 import { extend } from 'lodash';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -4,7 +4,6 @@ import 'regenerator-runtime/runtime';
 import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'file-saver';
 import 'jquery';
-import 'vendor/bootstrap/bootstrap';
 
 import _ from 'lodash'; // eslint-disable-line lodash/import-scope
 import { createElement } from 'react';


### PR DESCRIPTION
Having done a small audit against the vendor'd bootstrap plugins:

```
bootstrap-transition
bootstrap-alert
bootstrap-dropdown
bootstrap-modal
bootstrap-tooltip
bootstrap-tab
bootstrap-typeahead
bootstrap-affix
```

and their [`data-` attribute and js api initialisation methods](https://getbootstrap.com/2.3.2/javascript.html#overview) I cannot find any usage outside the `public/app/angular` folder now so moving the bootstrap import back to angular so we don't load it unnecessarily in HG. It'll all go away when angular is deleted anyhow but every little helps I guess. 😄 

Reverts grafana/grafana#78208