### PR TITLE
Tempo: Support TraceQL instant metrics queries

### DIFF
--- a/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
@@ -31,6 +31,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   maxDuration?: string;
   /**
+   * For metric queries, whether to run instant or range queries
+   */
+  metricsQueryType?: MetricsQueryType;
+  /**
    * @deprecated Define the minimum duration to select traces. Use duration format, for example: 1.2s, 100ms
    */
   minDuration?: string;
@@ -78,6 +82,11 @@ export const defaultTempoQuery: Partial<TempoQuery> = {
 };
 
 export type TempoQueryType = ('traceql' | 'traceqlSearch' | 'serviceMap' | 'upload' | 'nativeSearch' | 'traceId' | 'clear');
+
+export enum MetricsQueryType {
+  Instant = 'instant',
+  Range = 'range',
+}
 
 /**
  * The state of the TraceQL streaming search query

--- a/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
@@ -54,13 +54,15 @@ type TempoQuery struct {
 	TableType *SearchTableType `json:"tableType,omitempty"`
 	// For metric queries, the step size to use
 	Step *string `json:"step,omitempty"`
+	// For metric queries, how many exemplars to request, 0 means no exemplars
+	Exemplars *int64 `json:"exemplars,omitempty"`
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
 	Datasource any `json:"datasource,omitempty"`
-	// For metric queries, how many exemplars to request, 0 means no exemplars
-	Exemplars *int64 `json:"exemplars,omitempty"`
+	// For metric queries, whether to run instant or range queries
+	MetricsQueryType *MetricsQueryType `json:"metricsQueryType,omitempty"`
 }
 
 // NewTempoQuery creates a new TempoQuery object.
@@ -78,6 +80,13 @@ const (
 	TempoQueryTypeNativeSearch  TempoQueryType = "nativeSearch"
 	TempoQueryTypeTraceId       TempoQueryType = "traceId"
 	TempoQueryTypeClear         TempoQueryType = "clear"
+)
+
+type MetricsQueryType string
+
+const (
+	MetricsQueryTypeRange   MetricsQueryType = "range"
+	MetricsQueryTypeInstant MetricsQueryType = "instant"
 )
 
 // The state of the TraceQL streaming search query

--- a/pkg/tsdb/tempo/traceql/metrics_test.go
+++ b/pkg/tsdb/tempo/traceql/metrics_test.go
@@ -122,3 +122,47 @@ func TestTransformMetricsResponse_MultipleSeries(t *testing.T) {
 	assert.Equal(t, time.UnixMilli(1638316800000), frames[1].Fields[0].At(0))
 	assert.Equal(t, 4.56, frames[1].Fields[1].At(0))
 }
+
+func TestTransformInstantMetricsResponse(t *testing.T) {
+	query := &dataquery.TempoQuery{}
+	resp := tempopb.QueryInstantResponse{
+		Series: []*tempopb.InstantSeries{
+			{
+				Labels: []v1.KeyValue{
+					{
+						Key:   "label",
+						Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "value"}},
+					},
+				},
+				Value:      123.45,
+				PromLabels: "label=\"value\"",
+			},
+		},
+	}
+
+	frames := TransformInstantMetricsResponse(query, resp)
+
+	assert.Len(t, frames, 1)
+	frame := frames[0]
+
+	assert.Equal(t, "value", frame.RefID)
+	assert.Equal(t, "value", frame.Name)
+	assert.Len(t, frame.Fields, 3)
+
+	timeField := frame.Fields[0]
+	assert.Equal(t, "time", timeField.Name)
+	assert.Equal(t, 1, timeField.Len())
+	assert.IsType(t, time.Time{}, timeField.At(0))
+
+	labelField := frame.Fields[1]
+	assert.Equal(t, "label", labelField.Name)
+	assert.Equal(t, 1, labelField.Len())
+	assert.IsType(t, "", labelField.At(0))
+	assert.Equal(t, "value", labelField.At(0))
+
+	valueField := frame.Fields[2]
+	assert.Equal(t, "value", valueField.Name)
+	assert.Equal(t, 1, valueField.Len())
+	assert.IsType(t, 0.0, valueField.At(0))
+	assert.Equal(t, 123.45, valueField.At(0).(float64))
+}

--- a/pkg/tsdb/tempo/traceql_query.go
+++ b/pkg/tsdb/tempo/traceql_query.go
@@ -14,6 +14,7 @@ import (
 	//nolint:all
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/tempo/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/tempo/traceql"
@@ -86,21 +87,40 @@ func (s *Service) runTraceQlQueryMetrics(ctx context.Context, pCtx backend.Plugi
 		return result, nil
 	}
 
-	var queryResponse tempopb.QueryRangeResponse
-	err = jsonpb.Unmarshal(bytes.NewReader(responseBody), &queryResponse)
+	if isInstantQuery(tempoQuery.MetricsQueryType) {
+		var queryResponse tempopb.QueryInstantResponse
+		err = jsonpb.Unmarshal(bytes.NewReader(responseBody), &queryResponse)
 
+		if res, err := handleConversionError(ctxLogger, span, err); err != nil {
+			return res, err
+		}
+
+		frames := traceql.TransformInstantMetricsResponse(tempoQuery, queryResponse)
+		result.Frames = frames
+	} else {
+		var queryResponse tempopb.QueryRangeResponse
+		err = jsonpb.Unmarshal(bytes.NewReader(responseBody), &queryResponse)
+
+		if res, err := handleConversionError(ctxLogger, span, err); err != nil {
+			return res, err
+		}
+
+		frames := traceql.TransformMetricsResponse(tempoQuery, queryResponse)
+		result.Frames = frames
+	}
+
+	ctxLogger.Debug("Successfully performed TraceQL query", "function", logEntrypoint())
+	return result, nil
+}
+
+func handleConversionError(ctxLogger log.Logger, span trace.Span, err error) (*backend.DataResponse, error) {
 	if err != nil {
 		ctxLogger.Error("Failed to convert response to type", "error", err, "function", logEntrypoint())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return &backend.DataResponse{}, fmt.Errorf("failed to convert response to type: %w", err)
 	}
-
-	frames := traceql.TransformMetricsResponse(tempoQuery, queryResponse)
-
-	result.Frames = frames
-	ctxLogger.Debug("Successfully performed TraceQL query", "function", logEntrypoint())
-	return result, nil
+	return nil, nil
 }
 
 func (s *Service) performMetricsQuery(ctx context.Context, dsInfo *Datasource, model *dataquery.TempoQuery, query backend.DataQuery, span trace.Span) (*http.Response, []byte, error) {
@@ -133,7 +153,12 @@ func (s *Service) performMetricsQuery(ctx context.Context, dsInfo *Datasource, m
 func (s *Service) createMetricsQuery(ctx context.Context, dsInfo *Datasource, query *dataquery.TempoQuery, start int64, end int64) (*http.Request, error) {
 	ctxLogger := s.logger.FromContext(ctx)
 
-	rawUrl := fmt.Sprintf("%s/api/metrics/query_range", dsInfo.URL)
+	queryType := "query_range"
+	if isInstantQuery(query.MetricsQueryType) {
+		queryType = "query"
+	}
+
+	rawUrl := fmt.Sprintf("%s/api/metrics/%s", dsInfo.URL, queryType)
 	searchUrl, err := url.Parse(rawUrl)
 	if err != nil {
 		ctxLogger.Error("Failed to parse URL", "url", rawUrl, "error", err, "function", logEntrypoint())
@@ -165,6 +190,13 @@ func (s *Service) createMetricsQuery(ctx context.Context, dsInfo *Datasource, qu
 
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+func isInstantQuery(metricQueryType *dataquery.MetricsQueryType) bool {
+	if metricQueryType == nil {
+		return false
+	}
+	return *metricQueryType == dataquery.MetricsQueryTypeInstant
 }
 
 func isMetricsQuery(query string) bool {

--- a/public/app/plugins/datasource/tempo/dataquery.cue
+++ b/public/app/plugins/datasource/tempo/dataquery.cue
@@ -55,9 +55,13 @@ composableKinds: DataQuery: {
 					step?: string
 					// For metric queries, how many exemplars to request, 0 means no exemplars
 					exemplars?: int64
+					// For metric queries, whether to run instant or range queries
+					metricsQueryType?: #MetricsQueryType
 				} @cuetsy(kind="interface") @grafana(TSVeneer="type")
 
 				#TempoQueryType: "traceql" | "traceqlSearch" | "serviceMap" | "upload" | "nativeSearch" | "traceId" | "clear" @cuetsy(kind="type")
+
+				#MetricsQueryType: "range" | "instant" @cuetsy(kind="enum")
 
 				// The state of the TraceQL streaming search query
 				#SearchStreamingState: "pending" | "streaming" | "done" | "error" @cuetsy(kind="enum")

--- a/public/app/plugins/datasource/tempo/dataquery.gen.ts
+++ b/public/app/plugins/datasource/tempo/dataquery.gen.ts
@@ -29,6 +29,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   maxDuration?: string;
   /**
+   * For metric queries, whether to run instant or range queries
+   */
+  metricsQueryType?: MetricsQueryType;
+  /**
    * @deprecated Define the minimum duration to select traces. Use duration format, for example: 1.2s, 100ms
    */
   minDuration?: string;
@@ -76,6 +80,11 @@ export const defaultTempoQuery: Partial<TempoQuery> = {
 };
 
 export type TempoQueryType = ('traceql' | 'traceqlSearch' | 'serviceMap' | 'upload' | 'nativeSearch' | 'traceId' | 'clear');
+
+export enum MetricsQueryType {
+  Instant = 'instant',
+  Range = 'range',
+}
 
 /**
  * The state of the TraceQL streaming search query

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -6,7 +6,7 @@ import { EditorField, EditorRow } from '@grafana/experimental';
 import { AutoSizeInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 
 import { QueryOptionGroup } from '../_importedDependencies/datasources/prometheus/QueryOptionGroup';
-import { SearchTableType } from '../dataquery.gen';
+import { SearchTableType, MetricsQueryType } from '../dataquery.gen';
 import { DEFAULT_LIMIT, DEFAULT_SPSS } from '../datasource';
 import { TempoQuery } from '../types';
 
@@ -40,6 +40,10 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
     query.tableType = SearchTableType.Traces;
   }
 
+  if (!query.hasOwnProperty('metricsQueryType')) {
+    query.metricsQueryType = MetricsQueryType.Range;
+  }
+
   const onLimitChange = (e: React.FormEvent<HTMLInputElement>) => {
     onChange({ ...query, limit: parseIntWithFallback(e.currentTarget.value, DEFAULT_LIMIT) });
   };
@@ -48,6 +52,9 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
   };
   const onTableTypeChange = (val: SearchTableType) => {
     onChange({ ...query, tableType: val });
+  };
+  const onMetricsQueryTypeChange = (val: MetricsQueryType) => {
+    onChange({ ...query, metricsQueryType: val });
   };
   const onStepChange = (e: React.FormEvent<HTMLInputElement>) => {
     onChange({ ...query, step: e.currentTarget.value });
@@ -74,6 +81,7 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
 
   const collapsedMetricsOptions = [
     `Step: ${query.step || 'auto'}`,
+    `Type: ${query.metricsQueryType === MetricsQueryType.Range ? 'Range' : 'Instant'}`,
     // `Exemplars: ${query.exemplars !== undefined ? query.exemplars : 'auto'}`,
   ];
 
@@ -130,6 +138,16 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
               defaultValue={query.step}
               onCommitChange={onStepChange}
               value={query.step}
+            />
+          </EditorField>
+          <EditorField label="Type" tooltip="Type of metrics query to run">
+            <RadioButtonGroup
+              options={[
+                { label: 'Range', value: MetricsQueryType.Range },
+                { label: 'Instant', value: MetricsQueryType.Instant },
+              ]}
+              value={query.metricsQueryType}
+              onChange={onMetricsQueryTypeChange}
             />
           </EditorField>
           {/*<EditorField*/}


### PR DESCRIPTION
**What is this feature?**

Support [TraceQL instant metrics](https://grafana.com/docs/tempo/latest/api_docs/#instant) queries in Tempo which return a single result instead of a series data.

**Why do we need this feature?**

It is more performant to run an instant metrics query instead of a range query where we do not require series data. Additionally, instant metrics results support different use cases for users.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/99134

**Special notes for your reviewer:**

![Screenshot 2025-01-29 at 09 23 57](https://github.com/user-attachments/assets/f017cc26-35ed-442c-a2c7-eb0df59beac8)
