### PR TITLE
LibraryPanels: Prevent double-escaping of dashboard name in OpenLibraryPanelModal

### DIFF
--- a/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
@@ -77,7 +77,10 @@ export function OpenLibraryPanelModal({ libraryPanel, onDismiss }: OpenLibraryPa
         </Button>
         <Button onClick={onViewPanel} disabled={!Boolean(option)}>
           {option
-            ? t('library-panels.modal.button-view-panel1', 'View panel in {{label}}...', { label: option?.label })
+            ? t('library-panels.modal.button-view-panel1', 'View panel in {{label}}...', {
+                label: option?.label,
+                interpolation: { escapeValue: false },
+              })
             : t('library-panels.modal.button-view-panel2', 'View panel in dashboard...')}
         </Button>
       </Modal.ButtonRow>


### PR DESCRIPTION
The i18n `t` function escapes strings by default, but so does react, resulting in dashboards titles like "Bob's Dashboard" being rendered as "Bob\&#39;s Dashboard". This PR fixes the issue.
