### PR TITLE
Tempo: Fix devenv

### DIFF
--- a/devenv/docker/blocks/tempo/tempo.yaml
+++ b/devenv/docker/blocks/tempo/tempo.yaml
@@ -6,15 +6,23 @@ distributor:
     jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
       protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
         thrift_http:                   #
-        grpc:                          # for a production deployment you should only enable the receivers you need!
+          endpoint: "tempo:14268"      # for a production deployment you should only enable the receivers you need!
+        grpc:
+          endpoint: "tempo:14250"
         thrift_binary:
+          endpoint: "tempo:6832"
         thrift_compact:
+          endpoint: "tempo:6831"
     zipkin:
+      endpoint: "tempo:9411"
     otlp:
       protocols:
-        http:
         grpc:
+          endpoint: "tempo:4317"
+        http:
+          endpoint: "tempo:4318"
     opencensus:
+      endpoint: "tempo:55678"
 
 compactor:
   compaction:


### PR DESCRIPTION
**What is this feature?**

Fixes the Tempo devenv.

**Why do we need this feature?**

The Tempo devenv was broken after a change in the Tempo docker image which upgraded the use of OTEL. 

**Who is this feature for?**

Tempo users.