### PR TITLE
Escape database names in MSSQL datasource

### DIFF
--- a/public/app/plugins/datasource/mssql/MSSqlMetaQuery.test.ts
+++ b/public/app/plugins/datasource/mssql/MSSqlMetaQuery.test.ts
@@ -1,0 +1,10 @@
+import { getSchema } from './MSSqlMetaQuery';
+
+describe('getSchema', () => {
+  const database = 'foo';
+  const table = 'bar';
+  const schema = getSchema(database, table);
+  it('should escapte database names', () => {
+    expect(schema).toContain(`USE [${database}]`);
+  });
+});

--- a/public/app/plugins/datasource/mssql/MSSqlMetaQuery.ts
+++ b/public/app/plugins/datasource/mssql/MSSqlMetaQuery.ts
@@ -10,7 +10,7 @@ export function getSchemaAndName(database?: string) {
 
 export function getSchema(database?: string, table?: string) {
   return `
-   USE ${database}
+   USE [${database}]
    SELECT COLUMN_NAME as 'column',DATA_TYPE as 'type'
    FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='${table}';`;
 }

--- a/public/app/plugins/datasource/mssql/sqlUtil.test.ts
+++ b/public/app/plugins/datasource/mssql/sqlUtil.test.ts
@@ -1,0 +1,18 @@
+import { SQLQuery, QueryEditorExpressionType } from '@grafana/sql';
+
+import { toRawSql } from './sqlUtil';
+
+describe('toRawSql should escape database names', () => {
+  const query: SQLQuery = {
+    dataset: 'foo',
+    sql: {
+      columns: [{ name: 'a', alias: 'lol', type: QueryEditorExpressionType.Function }],
+    },
+    refId: 'lolsob',
+    table: 'table',
+  };
+  const queryString = toRawSql(query);
+  it('should escapte database names', () => {
+    expect(queryString).toContain(`FROM [${query.dataset}].${query.table}`);
+  });
+});

--- a/public/app/plugins/datasource/mssql/sqlUtil.ts
+++ b/public/app/plugins/datasource/mssql/sqlUtil.ts
@@ -89,7 +89,7 @@ export function toRawSql({ sql, dataset, table }: SQLQuery): string {
   rawQuery += createSelectClause(sql.columns, sql.limit);
 
   if (dataset && table) {
-    rawQuery += `FROM ${dataset}.${table} `;
+    rawQuery += `FROM [${dataset}].${table} `;
   }
 
   if (sql.whereString) {


### PR DESCRIPTION
Valid MSSQL database names can contain characters like `-`, which need to be escaped when used in queries.

This PR wraps database names in `[]`, fixing queries that contain databases with special characters.

Fixes #58757.