### PR TITLE
Alerting: Use exponential backoff in the remote Alertmanager readiness check

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -232,19 +232,15 @@ func (am *Alertmanager) ApplyConfig(ctx context.Context, config *models.AlertCon
 }
 
 func (am *Alertmanager) checkReadiness(ctx context.Context) error {
-	ready, err := am.amClient.IsReadyWithBackoff(ctx)
+	err := am.amClient.IsReadyWithBackoff(ctx)
 	if err != nil {
 		return err
 	}
 
-	if ready {
-		am.log.Debug("Alertmanager readiness check successful")
-		am.metrics.LastReadinessCheck.SetToCurrentTime()
-		am.ready = true
-		return nil
-	}
-
-	return notifier.ErrAlertmanagerNotReady
+	am.log.Debug("Alertmanager readiness check successful")
+	am.metrics.LastReadinessCheck.SetToCurrentTime()
+	am.ready = true
+	return nil
 }
 
 // CompareAndSendConfiguration checks whether a given configuration is being used by the remote Alertmanager.

--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -116,7 +116,7 @@ func (am *Alertmanager) exponentialReadinessCheck(ctx context.Context, c chan<- 
 			}
 
 			if status >= 400 && status < 500 {
-				c <- fmt.Errorf("Readiness check failed on attempt %d with non-retriable status code %d", attempt, status)
+				c <- fmt.Errorf("readiness check failed on attempt %d with non-retriable status code %d", attempt, status)
 				return
 			}
 

--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -73,13 +73,11 @@ func (am *Alertmanager) IsReadyWithBackoff(ctx context.Context) error {
 
 	c := make(chan error)
 	go am.exponentialReadinessCheck(ctx, c)
-	for {
-		select {
-		case err := <-c:
-			return err
-		case <-ctx.Done():
-			return fmt.Errorf("readiness check timed out")
-		}
+	select {
+	case err := <-c:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("readiness check timed out")
 	}
 }
 


### PR DESCRIPTION
This PR adds exponential backoff to the remote Alertmanager readiness check, multiplying 100ms by $2^n$, where $n$ is the number of failed attempts. This results in at most 7 attempts before the check hits the 10s timeout.