### PR TITLE
Live: make maximum WebSocket message size configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1797,6 +1797,10 @@ preinstall_disabled = false
 # tuning. 0 disables Live, -1 means unlimited connections.
 max_connections = 100
 
+# message_size_limit is the maximum size in bytes of Websocket messages from clients. Defaults to 64KB.
+# The limit can be disabled by setting it to -1.
+message_size_limit = 65536
+
 # allowed_origins is a comma-separated list of origins that can establish connection with Grafana Live.
 # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
 allowed_origins =

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -269,12 +269,14 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	originGlobs, _ := setting.GetAllowedOriginGlobs(originPatterns) // error already checked on config load.
 	checkOrigin := getCheckOriginFunc(appURL, originPatterns, originGlobs)
 
+	wsCfg := centrifuge.WebsocketConfig{
+		ReadBufferSize:   1024,
+		WriteBufferSize:  1024,
+		CheckOrigin:      checkOrigin,
+		MessageSizeLimit: cfg.LiveMessageSizeLimit,
+	}
 	// Use a pure websocket transport.
-	wsHandler := centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		CheckOrigin:     checkOrigin,
-	})
+	wsHandler := centrifuge.NewWebsocketHandler(node, wsCfg)
 
 	pushWSHandler := pushws.NewHandler(g.ManagedStreamRunner, pushws.Config{
 		ReadBufferSize:  1024,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -434,6 +434,9 @@ type Cfg struct {
 	// LiveAllowedOrigins is a set of origins accepted by Live. If not provided
 	// then Live uses AppURL as the only allowed origin.
 	LiveAllowedOrigins []string
+	// LiveMessageSizeLimit is the maximum size in bytes of Websocket messages
+	// from clients. Defaults to 64KB.
+	LiveMessageSizeLimit int
 
 	// Grafana.com URL, used for OAuth redirect.
 	GrafanaComURL string
@@ -1969,6 +1972,10 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	cfg.LiveMaxConnections = section.Key("max_connections").MustInt(100)
 	if cfg.LiveMaxConnections < -1 {
 		return fmt.Errorf("unexpected value %d for [live] max_connections", cfg.LiveMaxConnections)
+	}
+	cfg.LiveMessageSizeLimit = section.Key("message_size_limit").MustInt(65536)
+	if cfg.LiveMessageSizeLimit < -1 {
+		return fmt.Errorf("unexpected value %d for [live] message_size_limit", cfg.LiveMaxConnections)
 	}
 	cfg.LiveHAEngine = section.Key("ha_engine").MustString("")
 	switch cfg.LiveHAEngine {


### PR DESCRIPTION
This change adds a new configuration option `message_size_limit` to the
`[live]` section of the configuration file, which can be used to set the
maximum allowed size in bytes of WebSocket messages from clients.

The default value comes from the [Centrifuge transport][cf].

Fixes #99349.

Co-authored-by: Chris Marchbanks <chris.marchbanks@grafana.com>

[cf]: https://centrifugal.dev/docs/transports/websocket
