### PR TITLE
K8s: Fix search when query is set

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1702,6 +1702,8 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	if query.Title != "" {
 		// allow wildcard search
 		request.Query = "*" + strings.ToLower(query.Title) + "*"
+		// if using query, you need to specify the fields you want
+		request.Fields = dashboardsearch.IncludeFields
 	}
 
 	if len(query.Tags) > 0 {

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -19,6 +19,21 @@ var (
 		resource.SEARCH_FIELD_FOLDER:  "",
 		resource.SEARCH_FIELD_TAGS:    "",
 	}
+
+	IncludeFields = []string{
+		resource.SEARCH_FIELD_TITLE,
+		resource.SEARCH_FIELD_TAGS,
+		resource.SEARCH_FIELD_LABELS,
+		resource.SEARCH_FIELD_FOLDER,
+		resource.SEARCH_FIELD_CREATED,
+		resource.SEARCH_FIELD_CREATED_BY,
+		resource.SEARCH_FIELD_UPDATED,
+		resource.SEARCH_FIELD_UPDATED_BY,
+		resource.SEARCH_FIELD_REPOSITORY_NAME,
+		resource.SEARCH_FIELD_REPOSITORY_PATH,
+		resource.SEARCH_FIELD_REPOSITORY_HASH,
+		resource.SEARCH_FIELD_REPOSITORY_TIME,
+	}
 )
 
 func ParseResults(result *resource.ResourceSearchResponse, offset int64) (*v0alpha1.SearchResults, error) {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -217,6 +217,8 @@ func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.S
 	if query.Title != "" {
 		// allow wildcard search
 		request.Query = "*" + strings.ToLower(query.Title) + "*"
+		// if using query, you need to specify the fields you want
+		request.Fields = dashboardsearch.IncludeFields
 	}
 
 	if query.Limit > 0 {


### PR DESCRIPTION
When we started using wildcard searching in the service, search by title began to fail because we are not setting the fields we want back. This results in only the `_score` being returned, which is then trying to be parsed as the title and ending up like this:

![screenshot_2025-01-29_at_5 26 38___pm](https://github.com/user-attachments/assets/2aaebea3-356f-4a1f-a161-b88acdce7a75)

This PR adds the fields we want when we use the query parameter