### PR TITLE
K8s/OpenAPI: Remove /watch/ from the openapi spec

### DIFF
--- a/pkg/registry/apis/alerting/notifications/register.go
+++ b/pkg/registry/apis/alerting/notifications/register.go
@@ -143,11 +143,6 @@ func (t *NotificationsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3
 	delete(oas.Paths.Paths, root+templategroup.ResourceInfo.GroupResource().Resource)
 	delete(oas.Paths.Paths, root+routingtree.ResourceInfo.GroupResource().Resource)
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }
 

--- a/pkg/registry/apis/dashboard/v0alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v0alpha1/register.go
@@ -219,11 +219,6 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 	oas.Paths.Paths[root+"search"] = sub
 	delete(oas.Paths.Paths, root+"search/{name}")
 
-	// The root API discovery list
-	sub = oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }
 

--- a/pkg/registry/apis/dashboard/v1alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v1alpha1/register.go
@@ -209,11 +209,6 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 	delete(oas.Paths.Paths, root+dashboardv1alpha1.DashboardResourceInfo.GroupResource().Resource)
 	delete(oas.Paths.Paths, root+"watch/"+dashboardv1alpha1.DashboardResourceInfo.GroupResource().Resource)
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }
 

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -208,13 +208,7 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 
 	// Hide the ability to list or watch across all tenants
 	delete(oas.Paths.Paths, root+dashboardv2alpha1.DashboardResourceInfo.GroupResource().Resource)
-	delete(oas.Paths.Paths, root+"watch/"+dashboardv2alpha1.DashboardResourceInfo.GroupResource().Resource)
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }
 

--- a/pkg/registry/apis/dashboardsnapshot/register.go
+++ b/pkg/registry/apis/dashboardsnapshot/register.go
@@ -350,10 +350,5 @@ func (b *SnapshotsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Ope
 	// Hide the invalid endpoint to list all snapshots for all orgs
 	delete(oas.Paths.Paths, "/apis/dashboardsnapshot.grafana.app/v0alpha1/dashboardsnapshots")
 
-	// The root API discovery list
-	sub = oas.Paths.Paths["/apis/dashboardsnapshot.grafana.app/v0alpha1/"]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -274,10 +274,5 @@ func (b *DataSourceAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 		QueryDescription: fmt.Sprintf("Query the %s datasources", b.pluginJSON.Name),
 	})
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, err
 }

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -191,13 +191,7 @@ func (b *FolderAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAP
 
 	// Hide the ability to list or watch across all tenants
 	delete(oas.Paths.Paths, root+v0alpha1.FolderResourceInfo.GroupResource().Resource)
-	delete(oas.Paths.Paths, root+"watch/"+v0alpha1.FolderResourceInfo.GroupResource().Resource)
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }
 

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -251,10 +251,5 @@ func (b *QueryAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI
 		return oas, nil
 	}
 
-	// The root API discovery list
-	sub := oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -220,10 +220,5 @@ func (b *ScopeAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI
 		oas.Paths.Paths[root+"namespaces/{namespace}/find/scope_dashboard_bindings"] = findDashboardPath
 	}
 
-	// The root API discovery list
-	sub = oas.Paths.Paths[root]
-	if sub != nil && sub.Get != nil {
-		sub.Get.Tags = []string{"API Discovery"} // sorts first in the list
-	}
 	return oas, nil
 }

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -66,6 +66,20 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 					Paths:        s.Paths,
 				}
 
+				for k := range copy.Paths.Paths {
+					// Remove the deprecated watch URL -- can use list with ?watch=true
+					if strings.HasPrefix(k, prefix+"watch/") {
+						delete(copy.Paths.Paths, k)
+						continue
+					}
+				}
+
+				sub := copy.Paths.Paths[prefix]
+				if sub != nil && sub.Get != nil {
+					sub.Get.Tags = []string{"API Discovery"}
+					sub.Get.Description = "Describe the available kubernetes resources"
+				}
+
 				// Remove the growing list of kinds
 				for k, v := range copy.Components.Schemas {
 					if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") && v.Extensions != nil {

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -7,8 +7,10 @@
   "paths": {
     "/apis/dashboard.grafana.app/v0alpha1/": {
       "get": {
-        "tags": ["API Discovery"],
-        "description": "get available resources",
+        "tags": [
+          "API Discovery"
+        ],
+        "description": "Describe the available kubernetes resources",
         "operationId": "getAPIResources",
         "responses": {
           "200": {
@@ -36,7 +38,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/librarypanels": {
       "get": {
-        "tags": ["LibraryPanel"],
+        "tags": [
+          "LibraryPanel"
+        ],
         "description": "list objects of kind LibraryPanel",
         "operationId": "listLibraryPanelForAllNamespaces",
         "responses": {
@@ -182,7 +186,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards": {
       "get": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "list or watch objects of kind Dashboard",
         "operationId": "listDashboard",
         "parameters": [
@@ -317,7 +323,9 @@
         }
       },
       "post": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "create a Dashboard",
         "operationId": "createDashboard",
         "parameters": [
@@ -429,7 +437,9 @@
         }
       },
       "delete": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "delete collection of Dashboard",
         "operationId": "deletecollectionDashboard",
         "parameters": [
@@ -613,7 +623,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards/{name}": {
       "get": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "read the specified Dashboard",
         "operationId": "getDashboard",
         "responses": {
@@ -646,7 +658,9 @@
         }
       },
       "put": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "replace the specified Dashboard",
         "operationId": "replaceDashboard",
         "parameters": [
@@ -738,7 +752,9 @@
         }
       },
       "delete": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "delete a Dashboard",
         "operationId": "deleteDashboard",
         "parameters": [
@@ -847,7 +863,9 @@
         }
       },
       "patch": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "partially update the specified Dashboard",
         "operationId": "updateDashboard",
         "parameters": [
@@ -996,7 +1014,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards/{name}/dto": {
       "get": {
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "description": "connect GET requests to dto of Dashboard",
         "operationId": "getDashboardDto",
         "responses": {
@@ -1059,7 +1079,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/librarypanels": {
       "get": {
-        "tags": ["LibraryPanel"],
+        "tags": [
+          "LibraryPanel"
+        ],
         "description": "list objects of kind LibraryPanel",
         "operationId": "listLibraryPanel",
         "responses": {
@@ -1215,7 +1237,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/librarypanels/{name}": {
       "get": {
-        "tags": ["LibraryPanel"],
+        "tags": [
+          "LibraryPanel"
+        ],
         "description": "read the specified LibraryPanel",
         "operationId": "getLibraryPanel",
         "responses": {
@@ -1281,7 +1305,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/search": {
       "get": {
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "description": "Dashboard search",
         "parameters": [
           {
@@ -1338,7 +1364,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["totalHits", "hits"],
+                  "required": [
+                    "totalHits",
+                    "hits"
+                  ],
                   "properties": {
                     "apiVersion": {
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1396,7 +1425,9 @@
     },
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/search/sortable": {
       "get": {
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "description": "Get sortable fields",
         "parameters": [
           {
@@ -1416,7 +1447,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["fields"],
+                  "required": [
+                    "fields"
+                  ],
                   "properties": {
                     "apiVersion": {
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1441,329 +1474,7 @@
         }
       }
     },
-    "/apis/dashboard.grafana.app/v0alpha1/search": null,
-    "/apis/dashboard.grafana.app/v0alpha1/watch/namespaces/{namespace}/dashboards": {
-      "get": {
-        "tags": ["Dashboard"],
-        "description": "watch individual changes to a list of Dashboard. deprecated: use the 'watch' parameter with a list operation instead.",
-        "operationId": "watchDashboardList",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/json;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/yaml": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "watchlist",
-        "x-kubernetes-group-version-kind": {
-          "group": "dashboard.grafana.app",
-          "version": "v0alpha1",
-          "kind": "Dashboard"
-        }
-      },
-      "parameters": [
-        {
-          "name": "allowWatchBookmarks",
-          "in": "query",
-          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "continue",
-          "in": "query",
-          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "fieldSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "labelSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "limit",
-          "in": "query",
-          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "pretty",
-          "in": "query",
-          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersion",
-          "in": "query",
-          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersionMatch",
-          "in": "query",
-          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "sendInitialEvents",
-          "in": "query",
-          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "timeoutSeconds",
-          "in": "query",
-          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "watch",
-          "in": "query",
-          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        }
-      ]
-    },
-    "/apis/dashboard.grafana.app/v0alpha1/watch/namespaces/{namespace}/dashboards/{name}": {
-      "get": {
-        "tags": ["Dashboard"],
-        "description": "watch changes to an object of kind Dashboard. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
-        "operationId": "watchDashboard",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/json;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/yaml": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "watch",
-        "x-kubernetes-group-version-kind": {
-          "group": "dashboard.grafana.app",
-          "version": "v0alpha1",
-          "kind": "Dashboard"
-        }
-      },
-      "parameters": [
-        {
-          "name": "allowWatchBookmarks",
-          "in": "query",
-          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "continue",
-          "in": "query",
-          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "fieldSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "labelSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "limit",
-          "in": "query",
-          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "name",
-          "in": "path",
-          "description": "name of the Dashboard",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "pretty",
-          "in": "query",
-          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersion",
-          "in": "query",
-          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersionMatch",
-          "in": "query",
-          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "sendInitialEvents",
-          "in": "query",
-          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "timeoutSeconds",
-          "in": "query",
-          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "watch",
-          "in": "query",
-          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        }
-      ]
-    }
+    "/apis/dashboard.grafana.app/v0alpha1/search": null
   },
   "components": {
     "schemas": {
@@ -1774,7 +1485,9 @@
           "datasource": {
             "description": "The datasource",
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiVersion": {
                 "description": "The apiserver version",
@@ -1814,7 +1527,9 @@
           "resultAssertions": {
             "description": "Optionally define expected query result behavior",
             "type": "object",
-            "required": ["typeVersion"],
+            "required": [
+              "typeVersion"
+            ],
             "properties": {
               "maxFrames": {
                 "description": "Maximum frame count",
@@ -1853,19 +1568,26 @@
           "timeRange": {
             "description": "TimeRange represents the query range\nNOTE: unlike generic /ds/query, we can now send explicit time values in each query\nNOTE: the values for timeRange are not saved in a dashboard, they are constructed on the fly",
             "type": "object",
-            "required": ["from", "to"],
+            "required": [
+              "from",
+              "to"
+            ],
             "properties": {
               "from": {
                 "description": "From is the start time of the query.",
                 "type": "string",
                 "default": "now-6h",
-                "examples": ["now-1h"]
+                "examples": [
+                  "now-1h"
+                ]
               },
               "to": {
                 "description": "To is the end time of the query.",
                 "type": "string",
                 "default": "now",
-                "examples": ["now"]
+                "examples": [
+                  "now"
+                ]
               }
             },
             "additionalProperties": false
@@ -1885,7 +1607,11 @@
       },
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.AnnotationActions": {
         "type": "object",
-        "required": ["canAdd", "canEdit", "canDelete"],
+        "required": [
+          "canAdd",
+          "canEdit",
+          "canDelete"
+        ],
         "properties": {
           "canAdd": {
             "type": "boolean",
@@ -1903,7 +1629,10 @@
       },
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.AnnotationPermission": {
         "type": "object",
-        "required": ["dashboard", "organization"],
+        "required": [
+          "dashboard",
+          "organization"
+        ],
         "properties": {
           "dashboard": {
             "default": {},
@@ -1925,7 +1654,9 @@
       },
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.Dashboard": {
         "type": "object",
-        "required": ["spec"],
+        "required": [
+          "spec"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1964,7 +1695,14 @@
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.DashboardAccess": {
         "description": "Information about how the requesting user can use a given dashboard",
         "type": "object",
-        "required": ["canSave", "canEdit", "canAdmin", "canStar", "canDelete", "annotationsPermissions"],
+        "required": [
+          "canSave",
+          "canEdit",
+          "canAdmin",
+          "canStar",
+          "canDelete",
+          "annotationsPermissions"
+        ],
         "properties": {
           "annotationsPermissions": {
             "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.AnnotationPermission"
@@ -2041,7 +1779,10 @@
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.DashboardWithAccessInfo": {
         "description": "This is like the legacy DTO where access and metadata are all returned in a single call",
         "type": "object",
-        "required": ["spec", "access"],
+        "required": [
+          "spec",
+          "access"
+        ],
         "properties": {
           "access": {
             "default": {},
@@ -2087,7 +1828,9 @@
       },
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.LibraryPanel": {
         "type": "object",
-        "required": ["spec"],
+        "required": [
+          "spec"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -2173,7 +1916,11 @@
       },
       "com.github.grafana.grafana.pkg.apis.dashboard.v0alpha1.LibraryPanelSpec": {
         "type": "object",
-        "required": ["type", "options", "fieldConfig"],
+        "required": [
+          "type",
+          "options",
+          "fieldConfig"
+        ],
         "properties": {
           "datasource": {
             "description": "The default datasource type",
@@ -2250,7 +1997,13 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
-        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
+        "required": [
+          "name",
+          "singularName",
+          "namespaced",
+          "kind",
+          "verbs"
+        ],
         "properties": {
           "categories": {
             "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
@@ -2315,7 +2068,10 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
         "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
         "type": "object",
-        "required": ["groupVersion", "resources"],
+        "required": [
+          "groupVersion",
+          "resources"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -2554,7 +2310,9 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": ["uid"],
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "uid",
             "x-kubernetes-patch-strategy": "merge"
@@ -2576,7 +2334,12 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
         "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
         "type": "object",
-        "required": ["apiVersion", "kind", "name", "uid"],
+        "required": [
+          "apiVersion",
+          "kind",
+          "name",
+          "uid"
+        ],
         "properties": {
           "apiVersion": {
             "description": "API version of the referent.",
@@ -2742,7 +2505,10 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
         "description": "Event represents a single event to a watched resource.",
         "type": "object",
-        "required": ["type", "object"],
+        "required": [
+          "type",
+          "object"
+        ],
         "properties": {
           "object": {
             "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v0alpha1.json
@@ -7,8 +7,10 @@
   "paths": {
     "/apis/folder.grafana.app/v0alpha1/": {
       "get": {
-        "tags": ["API Discovery"],
-        "description": "get available resources",
+        "tags": [
+          "API Discovery"
+        ],
+        "description": "Describe the available kubernetes resources",
         "operationId": "getAPIResources",
         "responses": {
           "200": {
@@ -36,7 +38,9 @@
     },
     "/apis/folder.grafana.app/v0alpha1/namespaces/{namespace}/folders": {
       "get": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "list objects of kind Folder",
         "operationId": "listFolder",
         "parameters": [
@@ -171,7 +175,9 @@
         }
       },
       "post": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "create a Folder",
         "operationId": "createFolder",
         "parameters": [
@@ -283,7 +289,9 @@
         }
       },
       "delete": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "delete collection of Folder",
         "operationId": "deletecollectionFolder",
         "parameters": [
@@ -467,7 +475,9 @@
     },
     "/apis/folder.grafana.app/v0alpha1/namespaces/{namespace}/folders/{name}": {
       "get": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "read the specified Folder",
         "operationId": "getFolder",
         "responses": {
@@ -500,7 +510,9 @@
         }
       },
       "put": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "replace the specified Folder",
         "operationId": "replaceFolder",
         "parameters": [
@@ -592,7 +604,9 @@
         }
       },
       "delete": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "delete a Folder",
         "operationId": "deleteFolder",
         "parameters": [
@@ -701,7 +715,9 @@
         }
       },
       "patch": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "partially update the specified Folder",
         "operationId": "updateFolder",
         "parameters": [
@@ -850,7 +866,9 @@
     },
     "/apis/folder.grafana.app/v0alpha1/namespaces/{namespace}/folders/{name}/access": {
       "get": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "connect GET requests to access of Folder",
         "operationId": "getFolderAccess",
         "responses": {
@@ -897,7 +915,9 @@
     },
     "/apis/folder.grafana.app/v0alpha1/namespaces/{namespace}/folders/{name}/counts": {
       "get": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "connect GET requests to counts of Folder",
         "operationId": "getFolderCounts",
         "responses": {
@@ -944,7 +964,9 @@
     },
     "/apis/folder.grafana.app/v0alpha1/namespaces/{namespace}/folders/{name}/parents": {
       "get": {
-        "tags": ["Folder"],
+        "tags": [
+          "Folder"
+        ],
         "description": "connect GET requests to parents of Folder",
         "operationId": "getFolderParents",
         "responses": {
@@ -994,7 +1016,9 @@
     "schemas": {
       "com.github.grafana.grafana.pkg.apis.folder.v0alpha1.DescendantCounts": {
         "type": "object",
-        "required": ["counts"],
+        "required": [
+          "counts"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1073,7 +1097,12 @@
       "com.github.grafana.grafana.pkg.apis.folder.v0alpha1.FolderAccessInfo": {
         "description": "Access control information for the current user",
         "type": "object",
-        "required": ["canSave", "canEdit", "canAdmin", "canDelete"],
+        "required": [
+          "canSave",
+          "canEdit",
+          "canAdmin",
+          "canDelete"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1116,7 +1145,10 @@
       "com.github.grafana.grafana.pkg.apis.folder.v0alpha1.FolderInfo": {
         "description": "FolderInfo briefly describes a folder -- unlike a folder resource, this is a partial record of the folder metadata used for navigating parents and children",
         "type": "object",
-        "required": ["name", "title"],
+        "required": [
+          "name",
+          "title"
+        ],
         "properties": {
           "description": {
             "description": "The folder description",
@@ -1160,7 +1192,9 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": ["uid"],
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
             "x-kubernetes-list-type": "map"
           },
           "kind": {
@@ -1235,7 +1269,11 @@
       },
       "com.github.grafana.grafana.pkg.apis.folder.v0alpha1.ResourceStats": {
         "type": "object",
-        "required": ["group", "resource", "count"],
+        "required": [
+          "group",
+          "resource",
+          "count"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -1254,7 +1292,9 @@
       },
       "com.github.grafana.grafana.pkg.apis.folder.v0alpha1.Spec": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "description": {
             "description": "Describe the feature toggle",
@@ -1270,7 +1310,13 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
-        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
+        "required": [
+          "name",
+          "singularName",
+          "namespaced",
+          "kind",
+          "verbs"
+        ],
         "properties": {
           "categories": {
             "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
@@ -1335,7 +1381,10 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
         "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
         "type": "object",
-        "required": ["groupVersion", "resources"],
+        "required": [
+          "groupVersion",
+          "resources"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1574,7 +1623,9 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": ["uid"],
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "uid",
             "x-kubernetes-patch-strategy": "merge"
@@ -1596,7 +1647,12 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
         "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
         "type": "object",
-        "required": ["apiVersion", "kind", "name", "uid"],
+        "required": [
+          "apiVersion",
+          "kind",
+          "name",
+          "uid"
+        ],
         "properties": {
           "apiVersion": {
             "description": "API version of the referent.",

--- a/pkg/tests/apis/openapi_snapshots/peakq.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/peakq.grafana.app-v0alpha1.json
@@ -6,7 +6,10 @@
   "paths": {
     "/apis/peakq.grafana.app/v0alpha1/": {
       "get": {
-        "description": "get available resources",
+        "tags": [
+          "API Discovery"
+        ],
+        "description": "Describe the available kubernetes resources",
         "operationId": "getAPIResources",
         "responses": {
           "200": {
@@ -34,7 +37,9 @@
     },
     "/apis/peakq.grafana.app/v0alpha1/namespaces/{namespace}/querytemplates": {
       "get": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "list or watch objects of kind QueryTemplate",
         "operationId": "listQueryTemplate",
         "parameters": [
@@ -169,7 +174,9 @@
         }
       },
       "post": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "create a QueryTemplate",
         "operationId": "createQueryTemplate",
         "parameters": [
@@ -281,7 +288,9 @@
         }
       },
       "delete": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "delete collection of QueryTemplate",
         "operationId": "deletecollectionQueryTemplate",
         "parameters": [
@@ -465,7 +474,9 @@
     },
     "/apis/peakq.grafana.app/v0alpha1/namespaces/{namespace}/querytemplates/{name}": {
       "get": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "read the specified QueryTemplate",
         "operationId": "getQueryTemplate",
         "responses": {
@@ -498,7 +509,9 @@
         }
       },
       "put": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "replace the specified QueryTemplate",
         "operationId": "replaceQueryTemplate",
         "parameters": [
@@ -590,7 +603,9 @@
         }
       },
       "delete": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "delete a QueryTemplate",
         "operationId": "deleteQueryTemplate",
         "parameters": [
@@ -699,7 +714,9 @@
         }
       },
       "patch": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "partially update the specified QueryTemplate",
         "operationId": "updateQueryTemplate",
         "parameters": [
@@ -848,7 +865,9 @@
     },
     "/apis/peakq.grafana.app/v0alpha1/namespaces/{namespace}/querytemplates/{name}/render": {
       "get": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "connect GET requests to render of QueryTemplate",
         "operationId": "getQueryTemplateRender",
         "responses": {
@@ -895,7 +914,9 @@
     },
     "/apis/peakq.grafana.app/v0alpha1/querytemplates": {
       "get": {
-        "tags": ["QueryTemplate"],
+        "tags": [
+          "QueryTemplate"
+        ],
         "description": "list or watch objects of kind QueryTemplate",
         "operationId": "listQueryTemplateForAllNamespaces",
         "responses": {
@@ -1060,8 +1081,13 @@
               }
             },
             "example": {
-              "var-another": ["first", "second"],
-              "var-metricName": ["up"]
+              "var-another": [
+                "first",
+                "second"
+              ],
+              "var-metricName": [
+                "up"
+              ]
             }
           }
         ],
@@ -1077,53 +1103,9 @@
                     "vars": [
                       {
                         "key": "metricName",
-                        "defaultValues": ["down"]
-                      }
-                    ],
-                    "targets": [
-                      {
-                        "variables": {
-                          "metricName": [
-                            {
-                              "path": "$.expr",
-                              "position": {
-                                "start": 0,
-                                "end": 10
-                              }
-                            },
-                            {
-                              "path": "$.expr",
-                              "position": {
-                                "start": 13,
-                                "end": 23
-                              }
-                            }
-                          ]
-                        },
-                        "properties": {
-                          "refId": "A",
-                          "datasource": {
-                            "type": "prometheus",
-                            "uid": "foo"
-                          },
-                          "editorMode": "builder",
-                          "expr": "metricName + metricName + 42",
-                          "instant": true,
-                          "range": false,
-                          "exemplar": false
-                        }
-                      }
-                    ]
-                  }
-                },
-                "test2": {
-                  "summary": "hello2",
-                  "value": {
-                    "title": "Test",
-                    "vars": [
-                      {
-                        "key": "metricName",
-                        "defaultValues": ["down"]
+                        "defaultValues": [
+                          "down"
+                        ]
                       }
                     ],
                     "targets": [
@@ -1157,6 +1139,54 @@
                           "exemplar": false,
                           "editorMode": "builder",
                           "expr": "metricName + metricName + 42"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "test2": {
+                  "summary": "hello2",
+                  "value": {
+                    "title": "Test",
+                    "vars": [
+                      {
+                        "key": "metricName",
+                        "defaultValues": [
+                          "down"
+                        ]
+                      }
+                    ],
+                    "targets": [
+                      {
+                        "variables": {
+                          "metricName": [
+                            {
+                              "path": "$.expr",
+                              "position": {
+                                "start": 0,
+                                "end": 10
+                              }
+                            },
+                            {
+                              "path": "$.expr",
+                              "position": {
+                                "start": 13,
+                                "end": 23
+                              }
+                            }
+                          ]
+                        },
+                        "properties": {
+                          "refId": "A",
+                          "datasource": {
+                            "type": "prometheus",
+                            "uid": "foo"
+                          },
+                          "editorMode": "builder",
+                          "expr": "metricName + metricName + 42",
+                          "instant": true,
+                          "range": false,
+                          "exemplar": false
                         }
                       }
                     ]
@@ -1197,474 +1227,6 @@
           }
         }
       }
-    },
-    "/apis/peakq.grafana.app/v0alpha1/watch/namespaces/{namespace}/querytemplates": {
-      "get": {
-        "tags": ["QueryTemplate"],
-        "description": "watch individual changes to a list of QueryTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
-        "operationId": "watchQueryTemplateList",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/json;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/yaml": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "watchlist",
-        "x-kubernetes-group-version-kind": {
-          "group": "peakq.grafana.app",
-          "version": "v0alpha1",
-          "kind": "QueryTemplate"
-        }
-      },
-      "parameters": [
-        {
-          "name": "allowWatchBookmarks",
-          "in": "query",
-          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "continue",
-          "in": "query",
-          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "fieldSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "labelSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "limit",
-          "in": "query",
-          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "pretty",
-          "in": "query",
-          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersion",
-          "in": "query",
-          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersionMatch",
-          "in": "query",
-          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "sendInitialEvents",
-          "in": "query",
-          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "timeoutSeconds",
-          "in": "query",
-          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "watch",
-          "in": "query",
-          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        }
-      ]
-    },
-    "/apis/peakq.grafana.app/v0alpha1/watch/namespaces/{namespace}/querytemplates/{name}": {
-      "get": {
-        "tags": ["QueryTemplate"],
-        "description": "watch changes to an object of kind QueryTemplate. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
-        "operationId": "watchQueryTemplate",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/json;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/yaml": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "watch",
-        "x-kubernetes-group-version-kind": {
-          "group": "peakq.grafana.app",
-          "version": "v0alpha1",
-          "kind": "QueryTemplate"
-        }
-      },
-      "parameters": [
-        {
-          "name": "allowWatchBookmarks",
-          "in": "query",
-          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "continue",
-          "in": "query",
-          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "fieldSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "labelSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "limit",
-          "in": "query",
-          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "name",
-          "in": "path",
-          "description": "name of the QueryTemplate",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "pretty",
-          "in": "query",
-          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersion",
-          "in": "query",
-          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersionMatch",
-          "in": "query",
-          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "sendInitialEvents",
-          "in": "query",
-          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "timeoutSeconds",
-          "in": "query",
-          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "watch",
-          "in": "query",
-          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        }
-      ]
-    },
-    "/apis/peakq.grafana.app/v0alpha1/watch/querytemplates": {
-      "get": {
-        "tags": ["QueryTemplate"],
-        "description": "watch individual changes to a list of QueryTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
-        "operationId": "watchQueryTemplateListForAllNamespaces",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/json;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/vnd.kubernetes.protobuf;stream=watch": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              },
-              "application/yaml": {
-                "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "watchlist",
-        "x-kubernetes-group-version-kind": {
-          "group": "peakq.grafana.app",
-          "version": "v0alpha1",
-          "kind": "QueryTemplate"
-        }
-      },
-      "parameters": [
-        {
-          "name": "allowWatchBookmarks",
-          "in": "query",
-          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "continue",
-          "in": "query",
-          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "fieldSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "labelSelector",
-          "in": "query",
-          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "limit",
-          "in": "query",
-          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "pretty",
-          "in": "query",
-          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersion",
-          "in": "query",
-          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "resourceVersionMatch",
-          "in": "query",
-          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "sendInitialEvents",
-          "in": "query",
-          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "timeoutSeconds",
-          "in": "query",
-          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
-          "schema": {
-            "type": "integer",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "watch",
-          "in": "query",
-          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
-          "schema": {
-            "type": "boolean",
-            "uniqueItems": true
-          }
-        }
-      ]
     }
   },
   "components": {
@@ -1676,7 +1238,9 @@
           "datasource": {
             "description": "The datasource",
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiVersion": {
                 "description": "The apiserver version",
@@ -1716,7 +1280,9 @@
           "resultAssertions": {
             "description": "Optionally define expected query result behavior",
             "type": "object",
-            "required": ["typeVersion"],
+            "required": [
+              "typeVersion"
+            ],
             "properties": {
               "maxFrames": {
                 "description": "Maximum frame count",
@@ -1755,19 +1321,26 @@
           "timeRange": {
             "description": "TimeRange represents the query range\nNOTE: unlike generic /ds/query, we can now send explicit time values in each query\nNOTE: the values for timeRange are not saved in a dashboard, they are constructed on the fly",
             "type": "object",
-            "required": ["from", "to"],
+            "required": [
+              "from",
+              "to"
+            ],
             "properties": {
               "from": {
                 "description": "From is the start time of the query.",
                 "type": "string",
                 "default": "now-6h",
-                "examples": ["now-1h"]
+                "examples": [
+                  "now-1h"
+                ]
               },
               "to": {
                 "description": "To is the end time of the query.",
                 "type": "string",
                 "default": "now",
-                "examples": ["now"]
+                "examples": [
+                  "now"
+                ]
               }
             },
             "additionalProperties": false
@@ -1859,7 +1432,10 @@
       "com.github.grafana.grafana.pkg.apis.query.v0alpha1.template.Position": {
         "description": "Position is where to do replacement in the targets during render.",
         "type": "object",
-        "required": ["start", "end"],
+        "required": [
+          "start",
+          "end"
+        ],
         "properties": {
           "end": {
             "description": "End is the byte offset of the end of the variable.",
@@ -1877,7 +1453,9 @@
       },
       "com.github.grafana.grafana.pkg.apis.query.v0alpha1.template.QueryTemplate": {
         "type": "object",
-        "required": ["targets"],
+        "required": [
+          "targets"
+        ],
         "properties": {
           "description": {
             "description": "Longer description for why it is interesting",
@@ -1911,14 +1489,19 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": ["key"],
+            "x-kubernetes-list-map-keys": [
+              "key"
+            ],
             "x-kubernetes-list-type": "map"
           }
         }
       },
       "com.github.grafana.grafana.pkg.apis.query.v0alpha1.template.Target": {
         "type": "object",
-        "required": ["variables", "properties"],
+        "required": [
+          "variables",
+          "properties"
+        ],
         "properties": {
           "dataType": {
             "description": "DataType is the returned Dataplane type from the query.",
@@ -1952,7 +1535,9 @@
       "com.github.grafana.grafana.pkg.apis.query.v0alpha1.template.TemplateVariable": {
         "description": "TemplateVariable is the definition of a variable that will be interpolated in targets.",
         "type": "object",
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "properties": {
           "defaultValues": {
             "description": "DefaultValue is the value to be used when there is no selected value during render.",
@@ -1981,12 +1566,21 @@
       "com.github.grafana.grafana.pkg.apis.query.v0alpha1.template.VariableReplacement": {
         "description": "QueryVariable is the definition of a variable that will be interpolated in targets.",
         "type": "object",
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "properties": {
           "format": {
             "description": "How values should be interpolated\n\nPossible enum values:\n - `\"csv\"` Formats variables with multiple values as a comma-separated string.\n - `\"doublequote\"` Formats single- and multi-valued variables into a comma-separated string\n - `\"json\"` Formats variables with multiple values as a comma-separated string.\n - `\"pipe\"` Formats variables with multiple values into a pipe-separated string.\n - `\"raw\"` Formats variables with multiple values into comma-separated string. This is the default behavior when no format is specified\n - `\"singlequote\"` Formats single- and multi-valued variables into a comma-separated string",
             "type": "string",
-            "enum": ["csv", "doublequote", "json", "pipe", "raw", "singlequote"]
+            "enum": [
+              "csv",
+              "doublequote",
+              "json",
+              "pipe",
+              "raw",
+              "singlequote"
+            ]
           },
           "path": {
             "description": "Path is the location of the property within a target. The format for this is not figured out yet (Maybe JSONPath?). Idea: [\"string\", int, \"string\"] where int indicates array offset",
@@ -2006,7 +1600,13 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
-        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
+        "required": [
+          "name",
+          "singularName",
+          "namespaced",
+          "kind",
+          "verbs"
+        ],
         "properties": {
           "categories": {
             "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
@@ -2071,7 +1671,10 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
         "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
         "type": "object",
-        "required": ["groupVersion", "resources"],
+        "required": [
+          "groupVersion",
+          "resources"
+        ],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -2310,7 +1913,9 @@
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": ["uid"],
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "uid",
             "x-kubernetes-patch-strategy": "merge"
@@ -2332,7 +1937,12 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
         "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
         "type": "object",
-        "required": ["apiVersion", "kind", "name", "uid"],
+        "required": [
+          "apiVersion",
+          "kind",
+          "name",
+          "uid"
+        ],
         "properties": {
           "apiVersion": {
             "description": "API version of the referent.",
@@ -2498,7 +2108,10 @@
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
         "description": "Event represents a single event to a watched resource.",
         "type": "object",
-        "required": ["type", "object"],
+        "required": [
+          "type",
+          "object"
+        ],
         "properties": {
           "object": {
             "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",


### PR DESCRIPTION
This PR hides the deprecated `/watch/` endpoints from openapi and sets consistent tags on the root path (that was previously manually copied in many places)
