### PR TITLE
Return max depth folder reached instead of a generic error

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -44,7 +44,7 @@ func ToFolderErrorResponse(err error) response.Response {
 		return response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrFolderVersionMismatch.Error()})
 	}
 
-	// folder errors are wrapped in an errot util, so this is the only way of comparing errors
+	// folder errors are wrapped in an error util, so this is the only way of comparing errors
 	if err.Error() == folder.ErrMaximumDepthReached.Error() {
 		return response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": "Maximum nested folder depth reached"})
 	}

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -41,6 +42,11 @@ func ToFolderErrorResponse(err error) response.Response {
 
 	if errors.Is(err, dashboards.ErrFolderVersionMismatch) {
 		return response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrFolderVersionMismatch.Error()})
+	}
+
+	// folder errors are wrapped in an errot util, so this is the only way of comparing errors
+	if err.Error() == folder.ErrMaximumDepthReached.Error() {
+		return response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": "Maximum nested folder depth reached"})
 	}
 
 	return response.ErrOrFallback(http.StatusInternalServerError, "Folder API error", err)

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -1,0 +1,86 @@
+package apierrors
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToFolderErrorResponse(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name  string
+		input error
+		want  response.Response
+	}{
+		{
+			name:  "dashboard error",
+			input: dashboards.DashboardErr{StatusCode: 400, Reason: "Dashboard Error", Status: "error"},
+			want:  response.Error(400, "Dashboard Error", dashboards.DashboardErr{StatusCode: 400, Reason: "Dashboard Error", Status: "error"}),
+		},
+		{
+			name:  "folder title empty",
+			input: dashboards.ErrFolderTitleEmpty,
+			want:  response.Error(400, "folder title cannot be empty", nil),
+		},
+		{
+			name:  "dashboard type mismatch",
+			input: dashboards.ErrDashboardTypeMismatch,
+			want:  response.Error(400, "Dashboard cannot be changed to a folder", dashboards.ErrDashboardTypeMismatch),
+		},
+		{
+			name:  "dashboard invalid uid",
+			input: dashboards.ErrDashboardInvalidUid,
+			want:  response.Error(400, "uid contains illegal characters", dashboards.ErrDashboardInvalidUid),
+		},
+		{
+			name:  "dashboard uid too long",
+			input: dashboards.ErrDashboardUidTooLong,
+			want:  response.Error(400, "uid too long, max 40 characters", dashboards.ErrDashboardUidTooLong),
+		},
+		{
+			name:  "folder access denied",
+			input: dashboards.ErrFolderAccessDenied,
+			want:  response.Error(http.StatusForbidden, "Access denied", dashboards.ErrFolderAccessDenied),
+		},
+		{
+			name:  "folder not found",
+			input: dashboards.ErrFolderNotFound,
+			want:  response.JSON(http.StatusNotFound, util.DynMap{"status": "not-found", "message": dashboards.ErrFolderNotFound.Error()}),
+		},
+		{
+			name:  "folder with same uid exists",
+			input: dashboards.ErrFolderWithSameUIDExists,
+			want:  response.Error(http.StatusConflict, dashboards.ErrFolderWithSameUIDExists.Error(), nil),
+		},
+		{
+			name:  "folder version mismatch",
+			input: dashboards.ErrFolderVersionMismatch,
+			want:  response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrFolderVersionMismatch.Error()}),
+		},
+		{
+			name:  "folder max depth reached",
+			input: folder.ErrMaximumDepthReached,
+			want:  response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": "Maximum nested folder depth reached"}),
+		},
+		{
+			name:  "fallback error",
+			input: errors.New("some error"),
+			want:  response.ErrOrFallback(http.StatusInternalServerError, "Folder API error", errors.New("some error")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := ToFolderErrorResponse(tt.input)
+			require.Equal(t, tt.want, resp)
+		})
+	}
+}

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestToFolderErrorResponse(t *testing.T) {
-	type args struct {
-		err error
-	}
 	tests := []struct {
 		name  string
 		input error


### PR DESCRIPTION
**What is this feature?**

Sends the same error message as legacy is sending to the FE when creating a folder is not possible due to max depth being reached.

<img width="1487" alt="Screenshot 2025-01-30 at 13 26 30" src="https://github.com/user-attachments/assets/7a89048d-3848-4f17-a668-6ed8a8b2f123" />


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/187

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
