### PR TITLE
datasources: querier: adjust the query-client

### DIFF
--- a/pkg/registry/apis/query/client.go
+++ b/pkg/registry/apis/query/client.go
@@ -4,18 +4,13 @@ import (
 	"context"
 
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 )
 
-// The query runner interface
-type DataSourceClientSupplier interface {
-	// Get a client for a given datasource
-	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (data.QueryDataClient, error)
-}
-
 type CommonDataSourceClientSupplier struct {
-	Client data.QueryDataClient
+	Client clientapi.QueryDataClient
 }
 
-func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string) (data.QueryDataClient, error) {
+func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string) (clientapi.QueryDataClient, error) {
 	return s.Client, nil
 }

--- a/pkg/registry/apis/query/client/testdata.go
+++ b/pkg/registry/apis/query/client/testdata.go
@@ -3,43 +3,21 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	query "github.com/grafana/grafana/pkg/apis/query/v0alpha1"
-	testdata "github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource"
 )
 
 type testdataDummy struct{}
 
-var _ data.QueryDataClient = (*testdataDummy)(nil)
 var _ query.DataSourceApiServerRegistry = (*testdataDummy)(nil)
-
-// NewTestDataClient creates a runner that only works with testdata
-func NewTestDataClient() data.QueryDataClient {
-	return &testdataDummy{}
-}
 
 // NewTestDataRegistry returns a registry that only knows about testdata
 func NewTestDataRegistry() query.DataSourceApiServerRegistry {
 	return &testdataDummy{}
-}
-
-// ExecuteQueryData implements QueryHelper.
-func (d *testdataDummy) QueryData(ctx context.Context, req data.QueryDataRequest) (int, *backend.QueryDataResponse, error) {
-	queries, _, err := data.ToDataSourceQueries(req)
-	if err != nil {
-		return http.StatusBadRequest, nil, err
-	}
-
-	qdr := &backend.QueryDataRequest{Queries: queries}
-	rsp, err := testdata.ProvideService().QueryData(ctx, qdr)
-	return query.GetResponseCode(rsp), rsp, err
 }
 
 // GetDatasourceAPI implements DataSourceRegistry.

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -1,0 +1,18 @@
+package clientapi
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+)
+
+type QueryDataClient interface {
+	QueryData(ctx context.Context, req data.QueryDataRequest) (*backend.QueryDataResponse, error)
+}
+
+// The query runner interface
+type DataSourceClientSupplier interface {
+	// Get a client for a given datasource
+	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (QueryDataClient, error)
+}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -242,7 +242,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 		return qdr, err
 	}
 
-	code, rsp, err := client.QueryData(ctx, *req.Request)
+	rsp, err := client.QueryData(ctx, *req.Request)
 	if err == nil && rsp != nil {
 		for _, q := range req.Request.Queries {
 			if q.ResultAssertions != nil {
@@ -259,16 +259,6 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 		}
 	}
 
-	// Create a response object with the error when missing (happens for client errors like 404)
-	if rsp == nil && err != nil {
-		rsp = &backend.QueryDataResponse{Responses: make(backend.Responses)}
-		for _, q := range req.Request.Queries {
-			rsp.Responses[q.RefID] = backend.DataResponse{
-				Status: backend.Status(code),
-				Error:  err,
-			}
-		}
-	}
 	return rsp, err
 }
 

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ type mockClient struct {
 	lastCalledWithHeaders *map[string]string
 }
 
-func (m mockClient) GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (data.QueryDataClient, error) {
+func (m mockClient) GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (clientapi.QueryDataClient, error) {
 	*m.lastCalledWithHeaders = headers
 
 	return nil, fmt.Errorf("mock error")

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/registry/apis/query/client"
+	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 	"github.com/grafana/grafana/pkg/registry/apis/query/queryschema"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
@@ -40,14 +41,14 @@ type QueryAPIBuilder struct {
 	tracer     tracing.Tracer
 	metrics    *queryMetrics
 	parser     *queryParser
-	client     DataSourceClientSupplier
+	client     clientapi.DataSourceClientSupplier
 	registry   query.DataSourceApiServerRegistry
 	converter  *expr.ResultConverter
 	queryTypes *query.QueryTypeDefinitionList
 }
 
 func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
-	client DataSourceClientSupplier,
+	client clientapi.DataSourceClientSupplier,
 	registry query.DataSourceApiServerRegistry,
 	legacy service.LegacyDataSourceLookup,
 	registerer prometheus.Registerer,


### PR DESCRIPTION
the `QueryDataClient` is defined in https://github.com/grafana/grafana-plugin-sdk-go/blob/48b049eeb06d88d02a76797c093fea42fd1ac141/experimental/apis/data/v0alpha1/client.go#L19-L21 .

we realised that the first return value (the `int`, usually named `code` ) is not used, so we need to remove it.

but, the interface is only used in `grafana/grafana` and `grafana/grafana-enterprise` (it's also used by a struct in `grafana/grafana-plugin-sdk-go` , but that usage is not called from anywhere, so can be removed).
considering this, it's much simpler to have the interface be defined in `grafana/grafana.

that's what this PR does.
it got moved to `pkg/registry/apis/query/clientapi`. i'm very open to name that folder something different, but it has to be a new folder, otherwise import-cycles can happen.

all the code got adjusted to the new location of `QueryDataClient`.

NOTE: i only did this change, i did not improve the error-handling logic of the querier in this PR. that will come in a later one.