### PR TITLE
Dashboad: Edit variables in modal

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
@@ -1,12 +1,17 @@
+import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { Input, TextArea } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { sceneGraph, SceneVariable } from '@grafana/scenes';
+import { Button, Input, Stack, TextArea, Text, Box, useStyles2 } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { useLayoutCategory } from '../scene/layouts-shared/DashboardLayoutSelector';
 import { EditableDashboardElement } from '../scene/types';
+
+import { VariableEditDrawer } from './VariableEditDrawer';
 
 export class DashboardEditableElement implements EditableDashboardElement {
   public isEditableDashboardElement: true = true;
@@ -19,8 +24,8 @@ export class DashboardEditableElement implements EditableDashboardElement {
     // When layout changes we need to update options list
     const { body } = dashboard.useState();
 
-    const dashboardOptions = useMemo(() => {
-      return new OptionsPaneCategoryDescriptor({
+    const categories = useMemo(() => {
+      const topLevelOptions = new OptionsPaneCategoryDescriptor({
         title: 'Dashboard options',
         id: 'dashboard-options',
         isOpenDefault: true,
@@ -41,11 +46,27 @@ export class DashboardEditableElement implements EditableDashboardElement {
             },
           })
         );
+
+      const variablesCategory = new OptionsPaneCategoryDescriptor({
+        title: 'Variables',
+        id: 'variables',
+        isOpenDefault: false,
+      }).addItem(
+        new OptionsPaneItemDescriptor({
+          title: '',
+          skipField: true,
+          render: function variablesList() {
+            return <VariablesList dashboard={dashboard} />;
+          },
+        })
+      );
+
+      return [topLevelOptions, variablesCategory];
     }, [dashboard]);
 
     const layoutCategory = useLayoutCategory(body);
 
-    return [dashboardOptions, layoutCategory];
+    return [...categories, layoutCategory];
   }
 
   public getTypeName(): string {
@@ -63,4 +84,53 @@ export function DashboardDescriptionInput({ dashboard }: { dashboard: DashboardS
   const { description } = dashboard.useState();
 
   return <TextArea value={description} onChange={(e) => dashboard.setState({ title: e.currentTarget.value })} />;
+}
+
+interface VariablesListProps {
+  dashboard: DashboardScene;
+}
+
+function VariablesList({ dashboard }: VariablesListProps) {
+  const varSet = sceneGraph.getVariables(dashboard);
+  const { variables } = varSet.useState();
+  const styles = useStyles2(getStyles);
+
+  const onEditVariable = (variable: SceneVariable) => {
+    dashboard.showModal(new VariableEditDrawer({ variableRef: variable.getRef() }));
+  };
+
+  return (
+    <Stack direction="column" gap={0}>
+      {variables.map((variable) => (
+        <div className={styles.variableItem} key={variable.state.name} onClick={() => onEditVariable(variable)}>
+          <Text>${variable.state.name}</Text>
+          <Button variant="secondary" size="sm" onClick={() => onEditVariable(variable)}>
+            Edit
+          </Button>
+        </div>
+      ))}
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    variableItem: css({
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1),
+      padding: theme.spacing(0.5),
+      borderRadius: theme.shape.radius.default,
+      cursor: 'pointer',
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['color'], {
+          duration: theme.transitions.duration.short,
+        }),
+      },
+      '&:hover': {
+        color: theme.colors.text.link,
+      },
+    }),
+  };
 }

--- a/public/app/features/dashboard-scene/edit-pane/VariableEditDrawer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VariableEditDrawer.tsx
@@ -1,0 +1,80 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import {
+  SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectRef,
+  SceneObjectState,
+  SceneVariable,
+  SceneVariables,
+} from '@grafana/scenes';
+import { Drawer, Modal, useStyles2 } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+
+import { VariableEditorForm } from '../settings/variables/VariableEditorForm';
+import { RESERVED_GLOBAL_VARIABLE_NAME_REGEX, WORD_CHARACTERS_REGEX } from '../settings/variables/utils';
+import { getDashboardSceneFor } from '../utils/utils';
+
+export interface VariableEditDrawerState extends SceneObjectState {
+  variableRef: SceneObjectRef<SceneVariable>;
+}
+
+export class VariableEditDrawer extends SceneObjectBase<VariableEditDrawerState> {
+  public onClose = () => {
+    getDashboardSceneFor(this).closeModal();
+  };
+
+  public onValidateVariableName = (name: string, key: string | undefined): [true, string] | [false, null] => {
+    let errorText = null;
+    if (!RESERVED_GLOBAL_VARIABLE_NAME_REGEX.test(name)) {
+      errorText = "Template names cannot begin with '__', that's reserved for Grafana's global variables";
+    }
+
+    if (!WORD_CHARACTERS_REGEX.test(name)) {
+      errorText = 'Only word characters are allowed in variable names';
+    }
+
+    const variable = this.getVariableSet().getByName(name)?.state;
+
+    if (variable && variable.key !== key) {
+      errorText = 'Variable with the same name already exists';
+    }
+
+    if (errorText) {
+      return [true, errorText];
+    }
+
+    return [false, null];
+  };
+
+  public getVariableSet(): SceneVariables {
+    return sceneGraph.getVariables(this);
+  }
+
+  static Component = ({ model }: SceneComponentProps<VariableEditDrawer>) => {
+    const variable = model.state.variableRef?.resolve();
+    const styles = useStyles2(getStyles);
+
+    return (
+      <Modal title={`Edit variable`} onDismiss={model.onClose} isOpen={true} className={styles.modal}>
+        <VariableEditorForm
+          variable={variable}
+          onTypeChange={() => {}}
+          onGoBack={model.onClose}
+          onDelete={() => {}}
+          onValidateVariableName={model.onValidateVariableName}
+        />
+      </Modal>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    modal: css({
+      width: '80%',
+    }),
+  };
+}


### PR DESCRIPTION
Quick POC for showing list of variables in edit pane and clicking on one opens the edit variable from in a modal:

[variables_edit_modal.webm](https://github.com/user-attachments/assets/4b19ddd1-e92b-4a47-bd8f-66c625db0319)

obviously there should be some interaction where you can click on the variable label to open the edit pane as well. Question is what should the interaction look like, cursor poiner, any icon or hover state change, tooltip etc. 

Challanges

* Ideally the modal I think should not cover the edit pane itself but only the cavas part of the view (a bit tricky to calculate this without changing the edit pane sizing to pixels and passing that along) 
* Modal buttons should always be visible right now you need to scroll down to view them, so we need to fork/change the form layout to make modal scroll body but not buttons 
* Changing a variable so that it changes it's value will trigger queries for all panels on the dashboard (as they are active / mounted). Possible solutions 
  *  A) Hide the canvas body layout (deactivates all panels) and show a new type of "canvas modal" that unmounts all panels 
  *  B) Somehow prevent panel queries from being executed 
  *  C) Ignore issue 