### PR TITLE
[search] fix dashboard list default sort

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -348,7 +348,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(searchRequest.SortBy) == 0 {
+	if parsedResults != nil && len(searchRequest.SortBy) == 0 {
 		// default sort by resource descending ( folders then dashboards ) then title
 		sort.Slice(parsedResults.Hits, func(i, j int) bool {
 			return parsedResults.Hits[i].Resource > parsedResults.Hits[j].Resource ||

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -199,6 +199,7 @@ func (s *SearchHandler) DoSortable(w http.ResponseWriter, r *http.Request) {
 
 const rootFolder = "general"
 
+//nolint:gocyclo
 func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.tracer.Start(r.Context(), "dashboard.search")
 	defer span.End()

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -344,6 +345,14 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errhttp.Write(ctx, err, w)
 		return
+	}
+
+	if len(searchRequest.SortBy) == 0 {
+		// default sort by resource descending ( folders then dashboards ) then title
+		sort.Slice(parsedResults.Hits, func(i, j int) bool {
+			return parsedResults.Hits[i].Resource > parsedResults.Hits[j].Resource ||
+				(parsedResults.Hits[i].Resource == parsedResults.Hits[j].Resource && strings.ToLower(parsedResults.Hits[i].Title) < strings.ToLower(parsedResults.Hits[j].Title))
+		})
 	}
 
 	s.write(w, parsedResults)

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -180,7 +180,7 @@ func TestSearchFallback(t *testing.T) {
 }
 */
 
-func TestSearchHandlerFields(t *testing.T) {
+func TestSearchHandler(t *testing.T) {
 	// Create a mock client
 	mockClient := &MockClient{}
 
@@ -239,6 +239,19 @@ func TestSearchHandlerFields(t *testing.T) {
 		expectedFields := []string{"title", "folder", "tags"}
 		if fmt.Sprintf("%v", mockClient.LastSearchRequest.Fields) != fmt.Sprintf("%v", expectedFields) {
 			t.Errorf("expected fields %v, got %v", expectedFields, mockClient.LastSearchRequest.Fields)
+		}
+	})
+
+	t.Run("Sort - default sort by resource then title", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/search", nil)
+		req.Header.Add("content-type", "application/json")
+		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test"}))
+
+		searchHandler.DoSearch(rr, req)
+
+		if mockClient.LastSearchRequest == nil {
+			t.Fatalf("expected Search to be called, but it was not")
 		}
 
 		resp := rr.Result()

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -255,7 +255,11 @@ func TestSearchHandler(t *testing.T) {
 		}
 
 		resp := rr.Result()
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
 
 		p := &v0alpha1.SearchResults{}
 		err := json.NewDecoder(resp.Body).Decode(p)

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -263,9 +264,7 @@ func TestSearchHandler(t *testing.T) {
 
 		p := &v0alpha1.SearchResults{}
 		err := json.NewDecoder(resp.Body).Decode(p)
-		if err != nil {
-			t.Fail()
-		}
+		require.NoError(t, err)
 		assert.Equal(t, len(mockResults), len(p.Hits))
 		assert.Equal(t, mockResults[3].Value, p.Hits[0].Title)
 		assert.Equal(t, mockResults[1].Value, p.Hits[3].Title)

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -262,7 +262,7 @@ func TestSearchHandler(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		assert.Equal(t, 4, len(p.Hits))
+		assert.Equal(t, len(mockResults), len(p.Hits))
 		assert.Equal(t, mockResults[3].Value, p.Hits[0].Title)
 		assert.Equal(t, mockResults[1].Value, p.Hits[3].Title)
 	})


### PR DESCRIPTION
Default sort dashboard list by resource descending ( folder then dashboards ), then by title

Fixes https://github.com/grafana/search-and-storage-team/issues/186

![Screenshot 2025-01-30 at 9 58 56 AM](https://github.com/user-attachments/assets/7aa1bc22-9b63-4195-a408-940234409b99)
