### PR TITLE
Zanzana: Disable broken OpenFGA health check

### DIFF
--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -75,10 +75,7 @@ func (s *Server) IsHealthy(ctx context.Context) (bool, error) {
 	_, err := s.openfga.ListStores(ctx, &openfgav1.ListStoresRequest{
 		PageSize: wrapperspb.Int32(1),
 	})
-	if err != nil {
-		return false, nil
-	}
-	return true, nil
+	return err == nil, nil
 }
 
 func (s *Server) getContextuals(ctx context.Context, subject string) (*openfgav1.ContextualTupleKeys, error) {

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -10,6 +10,7 @@ import (
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	dashboardalpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v2alpha1"
 	"github.com/grafana/grafana/pkg/infra/localcache"
@@ -69,7 +70,15 @@ func NewServer(cfg setting.ZanzanaServerSettings, openfga OpenFGAServer, logger 
 }
 
 func (s *Server) IsHealthy(ctx context.Context) (bool, error) {
-	return s.openfga.IsReady(ctx)
+	// FIXME: get back to openfga.IsReady() when issue is fixed
+	// https://github.com/openfga/openfga/issues/2251
+	_, err := s.openfga.ListStores(ctx, &openfgav1.ListStoresRequest{
+		PageSize: wrapperspb.Int32(1),
+	})
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (s *Server) getContextuals(ctx context.Context, subject string) (*openfgav1.ContextualTupleKeys, error) {


### PR DESCRIPTION
**What is this feature?**

Temporary disable broken OpenFGA `IsReady()` health check and replace it with simple store listing.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

Related to https://github.com/grafana/identity-access-team/issues/1130

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
