### PR TITLE
K8s/Unstructured: Avoid panic in DeepCopy

### DIFF
--- a/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
@@ -1,0 +1,30 @@
+package v0alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	obj := &Unstructured{
+		Object: map[string]interface{}{
+			"int":    int(2),
+			"int16":  int16(2),
+			"int32":  int32(2),
+			"uint64": uint64(2),
+			"ref": &ObjectReference{
+				Resource: "x",
+			},
+		},
+	}
+	before, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	clone := obj.DeepCopy()
+	after, err := json.Marshal(clone)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(before), string(after))
+}

--- a/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeepCopyJSON(t *testing.T) {
@@ -17,10 +18,18 @@ func TestDeepCopyJSON(t *testing.T) {
 			"ref": &ObjectReference{
 				Resource: "x",
 			},
-			"string": map[string]any{
+			"array": []any{
+				int(1), int64(2), "hello",
+			},
+			"string": "hello",
+			"bool":   true,
+			"map": map[string]any{
 				"x": &ObjectReference{
 					Resource: "x",
 				},
+			},
+			"object": &v1.APIGroup{
+				Name: "HELLO",
 			},
 		},
 	}

--- a/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/unstructured_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidate(t *testing.T) {
+func TestDeepCopyJSON(t *testing.T) {
 	obj := &Unstructured{
 		Object: map[string]interface{}{
 			"int":    int(2),
@@ -16,6 +16,11 @@ func TestValidate(t *testing.T) {
 			"uint64": uint64(2),
 			"ref": &ObjectReference{
 				Resource: "x",
+			},
+			"string": map[string]any{
+				"x": &ObjectReference{
+					Resource: "x",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
While testing git provisioning, I am periodically hitting a panic like this:

```
panic: cannot deep copy int

goroutine 32640 [running]:
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x109c66140?, 0x10ff92a40?})
	/Users/ryan/go/pkg/mod/k8s.io/apimachinery@v0.32.0/pkg/runtime/converter.go:639 +0x248
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x10a0bc640?, 0x14006937ce0})
	/Users/ryan/go/pkg/mod/k8s.io/apimachinery@v0.32.0/pkg/runtime/converter.go:623 +0x27c
k8s.io/apimachinery/pkg/runtime.DeepCopyJSON(...)
	/Users/ryan/go/pkg/mod/k8s.io/apimachinery@v0.32.0/pkg/runtime/converter.go:608
github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1.(*Unstructured).DeepCopy(0x14005fe0358)
	/Users/ryan/workspace/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1/unstructured.go:66 +0x60
github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1.(*Unstructured).DeepCopyInto(...)
	/Users/ryan/workspace/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1/unstructured.go:71
github.com/grafana/grafana/pkg/apis/dashboard/v1alpha1.(*DashboardSpec).DeepCopyInto(0x14005fe0260?, 0x14003c6f9c8)
	/Users/ryan/workspace/grafana/grafana/pkg/apis/dashboard/v1alpha1/zz_generated.deepcopy.go:133 +0x64
github.com/grafana/grafana/pkg/apis/dashboard/v1alpha1.(*Dashboard).DeepCopyInto(0x14005fe0240, 0x14003c6f8c0)
	/Users/ryan/workspace/grafana/grafana/pkg/apis/dashboard/v1alpha1/zz_generated.deepcopy.go:54 +0xd8
github.com/grafana/grafana/pkg/apis/dashboard/v1alpha1.(*Dashboard).DeepCopy(...)
```

The DeepCopy function as implemented calls `runtime.DeepCopyJSON(u.Object)` that will panic for any non-json value... this changes things to try harder, and then fallback to reflect copy