### PR TITLE
[v11.3.x] Alerting: k8s receivers api encrypt existing unencrypted secureFields on update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.13.0 // @grafana/grafana-backend-group
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20240930154843-22cee00b280e // @grafana/alerting-backend
+	github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0 // @grafana/alerting-backend
 	github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 // @grafana/identity-access-team
 	github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd // @grafana/identity-access-team
 	github.com/grafana/codejen v0.0.3 // @grafana/dataviz-squad

--- a/go.sum
+++ b/go.sum
@@ -2254,6 +2254,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20240930154843-22cee00b280e h1:RttFYx5+RTNuMPlaftx8i9f91kwUi9LdxsoPLHnticU=
 github.com/grafana/alerting v0.0.0-20240930154843-22cee00b280e/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
+github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0 h1:6C4sCdsM/TPKNom1tlR0wFBiFfSbEmSTEKS6q7MeqpU=
+github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 h1:zYF/RBulpvMqPYR3gbzJZ8t/j/Eymn5FNidSYkueNCA=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564/go.mod h1:PFzXbCrn0GIpN4KwT6NP1l5Z1CPLfmKHnYx8rZzQcyY=
 github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd h1:sIlR7n38/MnZvX2qxDEszywXdI5soCwQ78aTDSARvus=

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -267,7 +267,7 @@ type ThreemaIntegration struct {
 type VictoropsIntegration struct {
 	DisableResolveMessage *bool `json:"-" yaml:"-" hcl:"disable_resolve_message"`
 
-	URL string `json:"url" yaml:"url" hcl:"url"`
+	URL Secret `json:"url" yaml:"url" hcl:"url"`
 
 	MessageType *string `json:"messageType,omitempty" yaml:"messageType,omitempty" hcl:"message_type"`
 	Title       *string `json:"title,omitempty" yaml:"title,omitempty" hcl:"title"`

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -388,6 +388,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Placeholder:  "VictorOps url",
 					PropertyName: "url",
 					Required:     true,
+					Secure:       true,
 				},
 				{ // New in 8.0.
 					Label:        "Message Type",

--- a/pkg/services/ngalert/notifier/channels_config/available_channels_test.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels_test.go
@@ -15,7 +15,7 @@ func TestGetSecretKeysForContactPointType(t *testing.T) {
 		{receiverType: "kafka", expectedSecretFields: []string{"password"}},
 		{receiverType: "email", expectedSecretFields: []string{}},
 		{receiverType: "pagerduty", expectedSecretFields: []string{"integrationKey"}},
-		{receiverType: "victorops", expectedSecretFields: []string{}},
+		{receiverType: "victorops", expectedSecretFields: []string{"url"}},
 		{receiverType: "oncall", expectedSecretFields: []string{"password", "authorization_credentials"}},
 		{receiverType: "pushover", expectedSecretFields: []string{"apiToken", "userKey"}},
 		{receiverType: "slack", expectedSecretFields: []string{"token", "url"}},


### PR DESCRIPTION
Backport 70073427041e15c353e0d467b714527584765aea from #99784

---

What is this feature?

Ensures the new pre-GA k8s receivers API behind alertingApiServer feature flag can handle encrypting incorrectly encrypted secrets stored in settings when passed in via secureFields.

Why do we need this feature?

Incorrectly stored secrets saved to settings will be correctly encrypted when sent in settings field, but the UI will send them as a secureFields boolean if they are unchanged. Currently, this will fail to store the field as the API will not find the secret in secureSettings when trying to patch.
