### PR TITLE
Explore metrics: Show the native histogram banner once

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -469,6 +469,16 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     }
   }
 
+  bannerHasBeenShown() {
+    return localStorage.getItem('nativeHistogramBanner') ?? false;
+  }
+
+  setBannerHasBeenShown() {
+    if (this.state.histogramsLoaded && this.state.nativeHistograms.length > 0) {
+      localStorage.setItem('nativeHistogramBanner', 'true');
+    }
+  }
+
   resetOtelExperience(hasOtelResources?: boolean, nonPromotedResources?: string[]) {
     const otelResourcesVariable = sceneGraph.lookupVariable(VAR_OTEL_RESOURCES, this);
     const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
@@ -598,9 +608,16 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       reportOtelExperience.current = true;
     }
 
+    // do not show the native histogram banner more than once
+    useEffect(() => {
+      return () => {
+        model.setBannerHasBeenShown();
+      };
+    }, [model]);
+
     return (
       <div className={styles.container}>
-        {NativeHistogramBanner({ histogramsLoaded, nativeHistograms, trail: model })}
+        {!model.bannerHasBeenShown() && NativeHistogramBanner({ histogramsLoaded, nativeHistograms, trail: model })}
         {showHeaderForFirstTimeUsers && <MetricsHeader />}
         <history.Component model={history} />
         {controls && (

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -469,16 +469,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
     }
   }
 
-  bannerHasBeenShown() {
-    return localStorage.getItem('nativeHistogramBanner') ?? false;
-  }
-
-  setBannerHasBeenShown() {
-    if (this.state.histogramsLoaded && this.state.nativeHistograms.length > 0) {
-      localStorage.setItem('nativeHistogramBanner', 'true');
-    }
-  }
-
   resetOtelExperience(hasOtelResources?: boolean, nonPromotedResources?: string[]) {
     const otelResourcesVariable = sceneGraph.lookupVariable(VAR_OTEL_RESOURCES, this);
     const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
@@ -608,16 +598,9 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
       reportOtelExperience.current = true;
     }
 
-    // do not show the native histogram banner more than once
-    useEffect(() => {
-      return () => {
-        model.setBannerHasBeenShown();
-      };
-    }, [model]);
-
     return (
       <div className={styles.container}>
-        {!model.bannerHasBeenShown() && NativeHistogramBanner({ histogramsLoaded, nativeHistograms, trail: model })}
+        {NativeHistogramBanner({ histogramsLoaded, nativeHistograms, trail: model })}
         {showHeaderForFirstTimeUsers && <MetricsHeader />}
         <history.Component model={history} />
         {controls && (

--- a/public/app/features/trails/banners/NativeHistogramBanner.test.tsx
+++ b/public/app/features/trails/banners/NativeHistogramBanner.test.tsx
@@ -51,4 +51,11 @@ describe('NativeHistogramBanner', () => {
     fireEvent.click(histogramButton);
     expect(mockTrail.publishEvent).toHaveBeenCalledWith(new MetricSelectedEvent('histogram1'), true);
   });
+
+  test('Set that the banner has been shown in local storage when a user closes the banner', () => {
+    render(<NativeHistogramBanner {...mockProps} />);
+    // click the button with aria label "Close alert"
+    fireEvent.click(screen.getByLabelText('Close alert'));
+    expect(localStorage.getItem('nativeHistogramBanner')).toBe('true');
+  });
 });

--- a/public/app/features/trails/banners/NativeHistogramBanner.tsx
+++ b/public/app/features/trails/banners/NativeHistogramBanner.tsx
@@ -21,7 +21,7 @@ export function NativeHistogramBanner(props: NativeHistogramInfoProps) {
   const [showHistogramExamples, setShowHistogramExamples] = useState(false);
   const styles = useStyles2(getStyles, 0);
 
-  if (!histogramsLoaded || nativeHistograms.length === 0 || !histogramMessage) {
+  if (bannerHasBeenShown() || !histogramsLoaded || nativeHistograms.length === 0 || !histogramMessage) {
     return null;
   }
 
@@ -32,6 +32,8 @@ export function NativeHistogramBanner(props: NativeHistogramInfoProps) {
           title={'Native Histogram Support'}
           severity={'info'}
           onRemove={() => {
+            // when a user explicitly closes the banner, save that it has been closed in local storage to not show again
+            setBannerHasBeenShown();
             setHistogramMessage(false);
           }}
           className={styles.banner}
@@ -274,4 +276,12 @@ function getStyles(theme: GrafanaTheme2, _chromeHeaderHeight: number) {
       paddingLeft: '16px',
     }),
   };
+}
+
+export function setBannerHasBeenShown() {
+  localStorage.setItem('nativeHistogramBanner', 'true');
+}
+
+export function bannerHasBeenShown() {
+  return localStorage.getItem('nativeHistogramBanner') ?? false;
 }


### PR DESCRIPTION
![Screenshot 2025-02-10 at 3 42 04 PM](https://github.com/user-attachments/assets/ace445da-e82d-4e78-a980-10eafa906d86)

This is a fix to show the native histogram banner once for users, so that on future Explore metrics usage, they will not see the banner.

Once a user has selected a data source that contains native histograms, the banner will be shown. When a user clicks the 'X' to close the banner, in all future explore metrics interactions the banner will not be shown.

https://github.com/user-attachments/assets/06cab869-7ecc-434f-85a8-9eba5383c8b2

This is done by setting a flag in local storage since we do not have a backend for Explore metrics.

![Screenshot 2025-01-30 at 6 54 57 PM](https://github.com/user-attachments/assets/989d3abc-43a6-4b72-9989-19e5a79bc670)

To test:
1. Select a data source that has native histograms. Dev-cortex or OTel demo app prometheus both have native histograms.
2. See the banner in Explore metrics.
3. Close the banner by clicking 'X'.
4. See that that `nativeHistogramBanner` has been set to true in local storage.
5. Start a new metric exploration with a data source that contains native histograms.
6. See that the banner is not shown for a data source with native histograms.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
