### PR TITLE
POC/Provisioning: Show banner on dashboards from external source

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3404,8 +3404,13 @@ exports[`better eslint`] = {
     ],
     "public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -78,7 +78,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
 
   return (
     <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true} createBrowserHistorySteps={true}>
-      <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} slug={slug} path={path} />
+      <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} path={path} />
       <dashboard.Component model={dashboard} key={dashboard.state.key} />
       <DashboardPrompt dashboard={dashboard} />
     </UrlSyncContextProvider>

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -26,7 +26,6 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
   const { type, slug, uid } = params;
   const path = params['*'];
-
   const prevMatch = usePrevious({ params });
   const stateManager = config.featureToggles.useV2DashboardsAPI
     ? getDashboardScenePageStateManager('v2')

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -26,6 +26,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
   const { type, slug, uid } = params;
   const path = params['*'];
+
   const prevMatch = usePrevious({ params });
   const stateManager = config.featureToggles.useV2DashboardsAPI
     ? getDashboardScenePageStateManager('v2')
@@ -78,7 +79,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
 
   return (
     <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true} createBrowserHistorySteps={true}>
-      <DashboardPreviewBanner queryParams={queryParams} />
+      <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} slug={slug} path={path} />
       <dashboard.Component model={dashboard} key={dashboard.state.key} />
       <DashboardPrompt dashboard={dashboard} />
     </UrlSyncContextProvider>

--- a/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
@@ -1,15 +1,53 @@
 import { Alert, Icon, Stack } from '@grafana/ui';
 import { DashboardPageRouteSearchParams } from 'app/features/dashboard/containers/types';
+import { DashboardRoutes } from 'app/types';
 
 interface DashboardPreviewBannerProps {
   queryParams: DashboardPageRouteSearchParams;
+  route?: string;
+  slug?: string;
+  path?: string;
 }
-export function DashboardPreviewBanner({ queryParams }: DashboardPreviewBannerProps) {
+export function DashboardPreviewBanner({ queryParams, route, slug, path }: DashboardPreviewBannerProps) {
+  console.log('DashboardScenePage X', { queryParams, route, slug, path });
+
+  // Do not show a banner when rendering the previews
+  if ('kiosk' in queryParams) {
+    return null;
+  }
+  const hasPrLink = Boolean(queryParams.prLink);
+
+  if (route === DashboardRoutes.Provisioning && path) {
+    return (
+      <Alert
+        title={'This dashboard is loaded from an external repository'}
+        severity={'info'}
+        style={{ flex: 0 }}
+        buttonContent={
+          hasPrLink && (
+            <Stack alignItems={'center'}>
+              <span>View pull request in GitHub</span>
+              <Icon name="external-link-alt" />
+            </Stack>
+          )
+        }
+        onRemove={
+          hasPrLink
+            ? () => {
+                window.open(queryParams.prLink, '_blank');
+              }
+            : undefined
+        }
+      >
+        The value is <b>not</b> saved in the grafana database.
+      </Alert>
+    );
+  }
+
   if (!queryParams.isPreview) {
     return null;
   }
 
-  const hasPrLink = Boolean(queryParams.prLink);
   return (
     <Alert
       title={'Dashboard preview'}

--- a/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
@@ -5,69 +5,39 @@ import { DashboardRoutes } from 'app/types';
 interface DashboardPreviewBannerProps {
   queryParams: DashboardPageRouteSearchParams;
   route?: string;
-  slug?: string;
   path?: string;
 }
-export function DashboardPreviewBanner({ queryParams, route, slug, path }: DashboardPreviewBannerProps) {
-  // Do not show a banner when rendering the previews
-  if ('kiosk' in queryParams) {
+
+export function DashboardPreviewBanner({ queryParams, route, path }: DashboardPreviewBannerProps) {
+  if ('kiosk' in queryParams || !queryParams.isPreview) {
     return null;
   }
+
   const hasPrLink = Boolean(queryParams.prLink);
-
-  if (route === DashboardRoutes.Provisioning && path) {
-    return (
-      <Alert
-        title={'This dashboard is loaded from an external repository'}
-        severity={'info'}
-        style={{ flex: 0 }}
-        buttonContent={
-          hasPrLink && (
-            <Stack alignItems={'center'}>
-              <span>View pull request in GitHub</span>
-              <Icon name="external-link-alt" />
-            </Stack>
-          )
-        }
-        onRemove={
-          hasPrLink
-            ? () => {
-                window.open(queryParams.prLink, '_blank');
-              }
-            : undefined
-        }
-      >
-        The value is <b>not</b> saved in the grafana database.
-      </Alert>
-    );
-  }
-
-  if (!queryParams.isPreview) {
-    return null;
-  }
+  const isProvisioned = route === DashboardRoutes.Provisioning && path;
 
   return (
     <Alert
-      title={'Dashboard preview'}
-      severity={'success'}
+      title={isProvisioned ? 'This dashboard is loaded from an external repository' : 'Dashboard preview'}
+      severity={isProvisioned ? 'info' : 'success'}
       style={{ flex: 0 }}
       buttonContent={
         hasPrLink && (
           <Stack alignItems={'center'}>
-            <span>Open pull request in GitHub</span>
+            <span>{isProvisioned ? 'View' : 'Open'} pull request in GitHub</span>
             <Icon name="external-link-alt" />
           </Stack>
         )
       }
-      onRemove={
-        hasPrLink
-          ? () => {
-              window.open(queryParams.prLink, '_blank');
-            }
-          : undefined
-      }
+      onRemove={hasPrLink ? () => window.open(queryParams.prLink, '_blank') : undefined}
     >
-      {queryParams.prLink && <>Branch successfully created.</>}
+      {isProvisioned ? (
+        <>
+          The value is <strong>not</strong> saved in the grafana database.
+        </>
+      ) : (
+        queryParams.prLink && <>Branch successfully created.</>
+      )}
     </Alert>
   );
 }

--- a/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
@@ -9,8 +9,6 @@ interface DashboardPreviewBannerProps {
   path?: string;
 }
 export function DashboardPreviewBanner({ queryParams, route, slug, path }: DashboardPreviewBannerProps) {
-  console.log('DashboardScenePage X', { queryParams, route, slug, path });
-
   // Do not show a banner when rendering the previews
   if ('kiosk' in queryParams) {
     return null;

--- a/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/DashboardPreviewBanner.tsx
@@ -9,12 +9,12 @@ interface DashboardPreviewBannerProps {
 }
 
 export function DashboardPreviewBanner({ queryParams, route, path }: DashboardPreviewBannerProps) {
-  if ('kiosk' in queryParams || !queryParams.isPreview) {
-    return null;
-  }
-
   const hasPrLink = Boolean(queryParams.prLink);
   const isProvisioned = route === DashboardRoutes.Provisioning && path;
+
+  if ('kiosk' in queryParams || (!queryParams.isPreview && !isProvisioned)) {
+    return null;
+  }
 
   return (
     <Alert


### PR DESCRIPTION
Show a banner on the pages that are not in our database...  
<img width="868" alt="image" src="https://github.com/user-attachments/assets/921c8ca5-955e-4c19-992c-c3c1018243bc" />

We can eventually show more data in that banner -- but for now it just seems important to make sure people know it is not saved in grafana.

This is the URL that github PRs will link to