### PR TITLE
Adds johnny as codeowner for alerting docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 
 /docs/sources/                                                                    @irenerl24
 
-/docs/sources/alerting/                                                           @brendamuir
+/docs/sources/alerting/                                                           @JohnnyK-Grafana
 /docs/sources/dashboards/                                                         @imatwawana
 /docs/sources/datasources/                                                        @lwandz13
 /docs/sources/panels-visualizations/                                              @imatwawana

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,4 +8,4 @@
   - @davkal
 - Docs:
   - @chri2547
-  - @brendamuir
+  - @JohnnyK-Grafana


### PR DESCRIPTION
Johnny is replacing Brenda as tech writer on the alerting squad.