### PR TITLE
LogsPanel: do not re-render while data is loading

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -518,6 +518,22 @@ describe('LogsPanel', () => {
       expect(await screen.findByRole('row')).toBeInTheDocument();
       expect(jest.mocked(styles.getLogRowStyles).mock.calls.length).toBeGreaterThan(3);
     });
+
+    it('does not re-render when data is loading', async () => {
+      const { rerender, props } = setup({
+        data: {
+          ...defaultProps.data,
+          series,
+        },
+      });
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+
+      rerender(<LogsPanel {...props} data={{ ...props.data, state: LoadingState.Loading }} />);
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+      expect(styles.getLogRowStyles).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('Filters', () => {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -28,6 +28,7 @@ import {
   toUtc,
   urlUtil,
   LogSortOrderChangeEvent,
+  LoadingState,
 } from '@grafana/data';
 import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -133,7 +134,6 @@ export const LogsPanel = ({
   const style = useStyles2(getStyles);
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const [contextRow, setContextRow] = useState<LogRowModel | null>(null);
-  const dataSourcesMap = useDatasourcesFromTargets(data.request?.targets);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   const [displayedFields, setDisplayedFields] = useState<string[]>(options.displayedFields ?? []);
   // Loading state to be passed as a prop to the <InfiniteScroll> component
@@ -141,6 +141,7 @@ export const LogsPanel = ({
   // Loading ref to prevent firing multiple requests
   const loadingRef = useRef(false);
   const [panelData, setPanelData] = useState(data);
+  const dataSourcesMap = useDatasourcesFromTargets(panelData.request?.targets);
   // Prevents the scroll position to change when new data from infinite scrolling is received
   const keepScrollPositionRef = useRef(false);
   let closeCallback = useRef<() => void>();
@@ -194,9 +195,9 @@ export const LogsPanel = ({
         !row.dataFrame.refId ||
         !dataSourcesMap ||
         (!showLogContextToggle &&
-          data.request?.app !== CoreApp.Dashboard &&
-          data.request?.app !== CoreApp.PanelEditor &&
-          data.request?.app !== CoreApp.PanelViewer)
+          panelData.request?.app !== CoreApp.Dashboard &&
+          panelData.request?.app !== CoreApp.PanelEditor &&
+          panelData.request?.app !== CoreApp.PanelViewer)
       ) {
         return false;
       }
@@ -204,16 +205,16 @@ export const LogsPanel = ({
       const dataSource = dataSourcesMap.get(row.dataFrame.refId);
       return hasLogsContextSupport(dataSource);
     },
-    [dataSourcesMap, showLogContextToggle, data.request?.app]
+    [dataSourcesMap, showLogContextToggle, panelData.request?.app]
   );
 
   const showPermaLink = useCallback(() => {
     return !(
-      data.request?.app !== CoreApp.Dashboard &&
-      data.request?.app !== CoreApp.PanelEditor &&
-      data.request?.app !== CoreApp.PanelViewer
+      panelData.request?.app !== CoreApp.Dashboard &&
+      panelData.request?.app !== CoreApp.PanelEditor &&
+      panelData.request?.app !== CoreApp.PanelViewer
     );
-  }, [data.request?.app]);
+  }, [panelData.request?.app]);
 
   const getLogRowContext = useCallback(
     async (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions): Promise<DataQueryResponse> => {
@@ -221,7 +222,7 @@ export const LogsPanel = ({
         return Promise.resolve({ data: [] });
       }
 
-      const query = data.request?.targets[0];
+      const query = panelData.request?.targets[0];
       if (!query) {
         return Promise.resolve({ data: [] });
       }
@@ -233,7 +234,7 @@ export const LogsPanel = ({
 
       return dataSource.getLogRowContext(row, options, query);
     },
-    [data.request?.targets, dataSourcesMap]
+    [panelData.request?.targets, dataSourcesMap]
   );
 
   const getLogRowContextUi = useCallback(
@@ -242,7 +243,7 @@ export const LogsPanel = ({
         return <></>;
       }
 
-      const query = data.request?.targets[0];
+      const query = panelData.request?.targets[0];
       if (!query) {
         return <></>;
       }
@@ -258,29 +259,31 @@ export const LogsPanel = ({
 
       return dataSource.getLogRowContextUi(origRow, runContextQuery, query);
     },
-    [data.request?.targets, dataSourcesMap]
+    [panelData.request?.targets, dataSourcesMap]
   );
 
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
     const logs = panelData
-      ? dataFrameToLogsModel(panelData.series, data.request?.intervalMs, undefined, data.request?.targets)
+      ? dataFrameToLogsModel(panelData.series, panelData.request?.intervalMs, undefined, panelData.request?.targets)
       : null;
     const logRows = logs?.rows || [];
     const commonLabels = logs?.meta?.find((m) => m.label === COMMON_LABELS);
     const deduplicatedRows = dedupLogRows(logRows, dedupStrategy);
     return [logRows, deduplicatedRows, commonLabels];
-  }, [data.request?.intervalMs, data.request?.targets, dedupStrategy, panelData]);
+  }, [dedupStrategy, panelData]);
 
   const onPermalinkClick = useCallback(
     async (row: LogRowModel) => {
-      return await copyDashboardUrl(row, logRows, data.timeRange);
+      return await copyDashboardUrl(row, logRows, panelData.timeRange);
     },
-    [data.timeRange, logRows]
+    [panelData.timeRange, logRows]
   );
 
   useEffect(() => {
-    setPanelData(data);
+    if (data.state !== LoadingState.Loading) {
+      setPanelData(data);
+    }
   }, [data]);
 
   useLayoutEffect(() => {
@@ -292,16 +295,16 @@ export const LogsPanel = ({
      * In dashboards, users with newest logs at the bottom have the expectation of keeping the scroll at the bottom
      * when new data is received. See https://github.com/grafana/grafana/pull/37634
      */
-    if (data.request?.app === CoreApp.Dashboard || data.request?.app === CoreApp.PanelEditor) {
+    if (panelData.request?.app === CoreApp.Dashboard || panelData.request?.app === CoreApp.PanelEditor) {
       scrollElement.scrollTo(0, isAscending ? logsContainerRef.current.scrollHeight : 0);
     }
-  }, [data.request?.app, isAscending, scrollElement, logRows]);
+  }, [panelData.request?.app, isAscending, scrollElement, logRows]);
 
   const getFieldLinks = useCallback(
     (field: Field, rowIndex: number) => {
-      return getFieldLinksForExplore({ field, rowIndex, range: data.timeRange });
+      return getFieldLinksForExplore({ field, rowIndex, range: panelData.timeRange });
     },
-    [data]
+    [panelData]
   );
 
   /**


### PR DESCRIPTION
Found while working on https://github.com/grafana/grafana/issues/99075 .

When infinite scrolling was introduced to the logs panel, we started holding and updating the panel data in the `panelData` state variable, which holds what the panel is supposed to render and is synced with `data` updates. As many things depends on the information in `data`, any updates to `data` will cause unnecesary re-renders, like re-rendering 2 or 3 times the log rows while the panel is updating.

To improve that, 2 changes were made:
- Anything that depended on data now depends on `panelData`, as it should originally have been when it was introduced.
- We sync `panelData` with `data` when the state is not `loading`.

Before:

https://github.com/user-attachments/assets/eead982f-80bf-4c37-8261-0a6e9451c86b

After:

https://github.com/user-attachments/assets/a82c1300-8eff-4d2d-a933-8b9cffe92236

Regression:
![regression](https://github.com/user-attachments/assets/fa2e858e-3399-4d4c-8df3-03f9ad13bdba)

