### PR TITLE
RBAC: only query folder service when fetching parent folders

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -468,7 +468,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 		features, tracing.InitializeTracerForTest(), zanzana.NewNoopClient(), sc.db, permreg.ProvidePermissionRegistry(), nil, folderServiceWithFlagOn,
 	)
 	folderPermissions, err := ossaccesscontrol.ProvideFolderPermissions(
-		cfg, features, routing.NewRouteRegister(), sc.db, ac, license, &dashboards.FakeDashboardStore{}, folderServiceWithFlagOn, acSvc, sc.teamSvc, sc.userSvc, actionSets)
+		cfg, features, routing.NewRouteRegister(), sc.db, ac, license, folderServiceWithFlagOn, acSvc, sc.teamSvc, sc.userSvc, actionSets)
 	require.NoError(b, err)
 	dashboardSvc, err := dashboardservice.ProvideDashboardServiceImpl(
 		sc.cfg, dashStore, folderStore,

--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -131,7 +131,6 @@ func ProvideDashboardPermissions(
 			return nil
 		},
 		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
-
 			ctx, _ = identity.WithServiceIdentitiy(ctx, orgID)
 			dashboard, err := getDashboard(ctx, orgID, resourceID)
 			if err != nil {
@@ -141,7 +140,6 @@ func ProvideDashboardPermissions(
 			scopes := []string(accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix))
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.AccessControl).Inc()
 			if dashboard.FolderUID != "" {
-
 				nestedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderService)
 				if err != nil {
 					return nil, err

--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -139,19 +139,12 @@ func ProvideDashboardPermissions(
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.AccessControl).Inc()
 			// nolint:staticcheck
 			if dashboard.FolderUID != "" {
-				query := &dashboards.GetDashboardQuery{UID: dashboard.FolderUID, OrgID: orgID}
-				queryResult, err := dashboardService.GetDashboard(ctx, query)
-				if err != nil {
-					return nil, err
-				}
-				parentScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(queryResult.UID)
-
-				nestedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, queryResult.UID, folderService)
+				nestedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderService)
 				if err != nil {
 					return nil, err
 				}
 
-				scopes = append(scopes, parentScope)
+				scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashboard.FolderUID))
 				scopes = append(scopes, nestedScopes...)
 				return scopes, nil
 			}

--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -137,7 +137,6 @@ func ProvideDashboardPermissions(
 				return nil, err
 			}
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.AccessControl).Inc()
-			// nolint:staticcheck
 			if dashboard.FolderUID != "" {
 				nestedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderService)
 				if err != nil {
@@ -148,6 +147,7 @@ func ProvideDashboardPermissions(
 				scopes = append(scopes, nestedScopes...)
 				return scopes, nil
 			}
+
 			return append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)), nil
 		},
 		Assignments: resourcepermissions.Assignments{

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -84,7 +84,7 @@ func registerFolderRoles(cfg *setting.Cfg, features featuremgmt.FeatureToggles, 
 
 func ProvideFolderPermissions(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, accesscontrol accesscontrol.AccessControl,
-	license licensing.Licensing, dashboardStore dashboards.Store, folderService folder.Service, service accesscontrol.Service,
+	license licensing.Licensing, folderService folder.Service, service accesscontrol.Service,
 	teamService team.Service, userService user.Service, actionSetService resourcepermissions.ActionSetService,
 ) (*FolderPermissionsService, error) {
 	if err := registerFolderRoles(cfg, features, service); err != nil {

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -98,12 +98,8 @@ func ProvideFolderPermissions(
 			ctx, span := tracer.Start(ctx, "accesscontrol.ossaccesscontrol.ProvideFolderPermissions.ResourceValidator")
 			defer span.End()
 
-			ident, err := identity.GetRequester(ctx)
-			if err != nil {
-				return err
-			}
-
-			_, err = folderService.Get(ctx, &folder.GetFolderQuery{
+			ctx, ident := identity.WithServiceIdentitiy(ctx, orgID)
+			_, err := folderService.Get(ctx, &folder.GetFolderQuery{
 				UID:          &resourceID,
 				OrgID:        orgID,
 				SignedInUser: ident,
@@ -116,6 +112,7 @@ func ProvideFolderPermissions(
 			return nil
 		},
 		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
+			ctx, _ = identity.WithServiceIdentitiy(ctx, orgID)
 			return dashboards.GetInheritedScopes(ctx, orgID, resourceID, folderService)
 		},
 		Assignments: resourcepermissions.Assignments{

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
@@ -88,7 +87,6 @@ func ProvideFolderPermissions(
 		sqlStore,
 		ac,
 		license,
-		&dashboards.FakeDashboardStore{},
 		fService,
 		acSvc,
 		teamSvc,


### PR DESCRIPTION
**What is this feature?**
When running with `kubernetesCliDashboards` we cannot fetch permissions. Previously all folders used to be stored in both dashboard and folder table and we did not used to have `FolderUID` on dashboard only `FolderID` so we had to do this to resolve the relationship.

But since we have `FolderUID` we don't have do do this call anymore and can just use `folderService`. This also fixes the issue when using flags to query unified storage for both folder and dashboard.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
