### PR TITLE
Alerting: Update design of rule details tab and add `updated by`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2238,9 +2238,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/GrafanaFolderAndLabelsStep.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2485,19 +2483,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
-    ],
-    "public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
     ],
     "public/app/features/alerting/unified/components/rule-viewer/tabs/Query.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1637,10 +1637,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
-    "public/app/features/alerting/unified/components/InfoPausedRule.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
-    ],
     "public/app/features/alerting/unified/components/InvalidIntervalWarning.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],

--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { Trans } from '../../../src/utils/i18n';
+import { t } from '../../../src/utils/i18n';
 import { useStyles2 } from '../../themes';
 import { Button, ButtonProps } from '../Button';
 import { Icon } from '../Icon/Icon';
@@ -28,6 +28,7 @@ export function ClipboardButton({
   getText,
   icon,
   variant,
+  'aria-label': ariaLabel,
   ...buttonProps
 }: Props) {
   const styles = useStyles2(getStyles);
@@ -60,11 +61,12 @@ export function ClipboardButton({
     }
   }, [getText, onClipboardCopy, onClipboardError]);
 
+  const copiedText = t('clipboard-button.inline-toast.success', 'Copied');
   return (
     <>
       {showCopySuccess && (
         <InlineToast placement="top" referenceElement={buttonRef.current}>
-          <Trans i18nKey="clipboard-button.inline-toast.success">Copied</Trans>
+          {copiedText}
         </InlineToast>
       )}
 
@@ -72,7 +74,7 @@ export function ClipboardButton({
         onClick={copyTextCallback}
         icon={icon}
         variant={showCopySuccess ? 'success' : variant}
-        aria-label={showCopySuccess ? 'Copied' : undefined}
+        aria-label={showCopySuccess ? copiedText : ariaLabel}
         {...buttonProps}
         className={cx(styles.button, showCopySuccess && styles.successButton, buttonProps.className)}
         ref={buttonRef}

--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -28,7 +28,6 @@ export function ClipboardButton({
   getText,
   icon,
   variant,
-  'aria-label': ariaLabel,
   ...buttonProps
 }: Props) {
   const styles = useStyles2(getStyles);
@@ -74,7 +73,7 @@ export function ClipboardButton({
         onClick={copyTextCallback}
         icon={icon}
         variant={showCopySuccess ? 'success' : variant}
-        aria-label={showCopySuccess ? copiedText : ariaLabel}
+        aria-label={showCopySuccess ? copiedText : undefined}
         {...buttonProps}
         className={cx(styles.button, showCopySuccess && styles.successButton, buttonProps.className)}
         ref={buttonRef}

--- a/public/app/features/alerting/unified/components/InfoPausedRule.tsx
+++ b/public/app/features/alerting/unified/components/InfoPausedRule.tsx
@@ -1,10 +1,12 @@
 import { Alert } from '@grafana/ui';
-import { t } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 
 const InfoPausedRule = () => {
   return (
     <Alert severity="info" title={t('alerting.alert.evaluation-paused', 'Alert evaluation currently paused')}>
-      Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.
+      <Trans i18nKey="alerting.alert.evaluation-paused-description">
+        Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.
+      </Trans>
     </Alert>
   );
 };

--- a/public/app/features/alerting/unified/components/InfoPausedRule.tsx
+++ b/public/app/features/alerting/unified/components/InfoPausedRule.tsx
@@ -1,8 +1,9 @@
 import { Alert } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 
 const InfoPausedRule = () => {
   return (
-    <Alert severity="info" title="Alert evaluation currently paused">
+    <Alert severity="info" title={t('alerting.alert.evaluation-paused', 'Alert evaluation currently paused')}>
       Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.
     </Alert>
   );

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -36,7 +36,7 @@ export const DetailText = ({
 }: DetailTextProps) => {
   const copyToClipboardLabel = t('alerting.copy-to-clipboard', 'Copy "{{label}}" to clipboard', { label });
   return (
-    <Box paddingBottom={2}>
+    <Box>
       <Stack direction="column" gap={0}>
         <Text color="secondary" id={id}>
           {label}

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -3,6 +3,7 @@ import { Box, ClipboardButton, Stack, Text, Tooltip } from '@grafana/ui';
 import ConditionalWrap from '../ConditionalWrap';
 
 type DetailTextProps = {
+  id: string;
   label: string;
   value: string | JSX.Element | null;
   /** Should the value be displayed using monospace font family? */
@@ -23,12 +24,22 @@ type DetailTextProps = {
   | { showCopyButton?: never; copyValue?: never }
 );
 
-export const DetailText = ({ label, value, monospace, showCopyButton, copyValue, tooltipValue }: DetailTextProps) => {
+export const DetailText = ({
+  id,
+  label,
+  value,
+  monospace,
+  showCopyButton,
+  copyValue,
+  tooltipValue,
+}: DetailTextProps) => {
   return (
     <Box paddingBottom={2}>
       <Stack direction="column" gap={0}>
-        <Text color="secondary">{label}</Text>
-        <Text color="primary" variant={monospace ? 'code' : 'body'}>
+        <Text color="secondary" id={id}>
+          {label}
+        </Text>
+        <Text aria-labelledby={id} color="primary" variant={monospace ? 'code' : 'body'}>
           <ConditionalWrap
             shouldWrap={Boolean(tooltipValue)}
             wrap={(children) => <Tooltip content={tooltipValue!}>{children}</Tooltip>}

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -11,9 +11,11 @@ type DetailTextProps = {
   monospace?: boolean;
   /** Optional string to display in a tooltip on hover of the value */
   tooltipValue?: string;
-} & (
+} & ConditionalProps;
+
+type ConditionalProps =
+  // Require either both copy props or neither
   | {
-      // Require either both copy props or neither
       /** Should we show a button for copying the value to clipboard? */
       showCopyButton: boolean;
       /**
@@ -22,8 +24,7 @@ type DetailTextProps = {
        */
       copyValue: string;
     }
-  | { showCopyButton?: never; copyValue?: never }
-);
+  | { showCopyButton?: never; copyValue?: never };
 
 export const DetailText = ({
   id,

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -1,0 +1,45 @@
+import { Box, ClipboardButton, Stack, Text, Tooltip } from '@grafana/ui';
+
+import ConditionalWrap from '../ConditionalWrap';
+
+type DetailTextProps = {
+  label: string;
+  value: string | JSX.Element | null;
+  /** Should the value be displayed using monospace font family? */
+  monospace?: boolean;
+  /** Optional string to display in a tooltip on hover of the value */
+  tooltipValue?: string;
+} & (
+  | {
+      // Require either both copy props or neither
+      /** Should we show a button for copying the value to clipboard? */
+      showCopyButton: boolean;
+      /**
+       * Value to use for copying to clipboard, when enabled.
+       * Needed as the value could be an element
+       */
+      copyValue: string;
+    }
+  | { showCopyButton?: never; copyValue?: never }
+);
+
+export const DetailText = ({ label, value, monospace, showCopyButton, copyValue, tooltipValue }: DetailTextProps) => {
+  return (
+    <Box paddingBottom={2}>
+      <Stack direction="column" gap={0}>
+        <Text color="secondary">{label}</Text>
+        <Text color="primary" variant={monospace ? 'code' : 'body'}>
+          <ConditionalWrap
+            shouldWrap={Boolean(tooltipValue)}
+            wrap={(children) => <Tooltip content={tooltipValue!}>{children}</Tooltip>}
+          >
+            <span>{value}</span>
+          </ConditionalWrap>
+          {showCopyButton && (
+            <ClipboardButton fill="text" variant="secondary" icon="copy" size="sm" getText={() => copyValue} />
+          )}
+        </Text>
+      </Stack>
+    </Box>
+  );
+};

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -1,4 +1,5 @@
 import { Box, ClipboardButton, Stack, Text, Tooltip } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 
 import ConditionalWrap from '../ConditionalWrap';
 
@@ -33,6 +34,7 @@ export const DetailText = ({
   copyValue,
   tooltipValue,
 }: DetailTextProps) => {
+  const copyToClipboardLabel = t('alerting.copy-to-clipboard', 'Copy "{{label}}" to clipboard', { label });
   return (
     <Box paddingBottom={2}>
       <Stack direction="column" gap={0}>
@@ -47,7 +49,14 @@ export const DetailText = ({
             <span>{value}</span>
           </ConditionalWrap>
           {showCopyButton && (
-            <ClipboardButton fill="text" variant="secondary" icon="copy" size="sm" getText={() => copyValue} />
+            <ClipboardButton
+              aria-label={copyToClipboardLabel}
+              fill="text"
+              variant="secondary"
+              icon="copy"
+              size="sm"
+              getText={() => copyValue}
+            />
           )}
         </Text>
       </Stack>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -363,7 +363,10 @@ export function GrafanaEvaluationBehaviorStep({
           {showErrorHandling && (
             <>
               <NeedHelpInfoForConfigureNoDataError />
-              <Field htmlFor="no-data-state-input" label="Alert state if no data or all values are null">
+              <Field
+                htmlFor="no-data-state-input"
+                label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
+              >
                 <Controller
                   render={({ field: { onChange, ref, ...field } }) => (
                     <GrafanaAlertStatePicker
@@ -378,7 +381,10 @@ export function GrafanaEvaluationBehaviorStep({
                   name="noDataState"
                 />
               </Field>
-              <Field htmlFor="exec-err-state-input" label="Alert state if execution error or timeout">
+              <Field
+                htmlFor="exec-err-state-input"
+                label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
+              >
                 <Controller
                   render={({ field: { onChange, ref, ...field } }) => (
                     <GrafanaAlertStatePicker

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -1,6 +1,6 @@
 import { within } from '@testing-library/react';
 import { render, screen, userEvent, waitFor } from 'test/test-utils';
-import { byRole, byText } from 'testing-library-selector';
+import { byLabelText, byRole, byText } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
@@ -40,7 +40,7 @@ const ELEMENTS = {
     label: ([key, value]: [string, string]) => byRole('listitem', { name: `${key}: ${value}` }),
   },
   details: {
-    pendingPeriod: byText(/Pending period/i),
+    pendingPeriod: byLabelText(/Pending period/i),
   },
   actions: {
     edit: byRole('link', { name: 'Edit' }),
@@ -107,6 +107,10 @@ const dataSources = {
 };
 
 describe('RuleViewer', () => {
+  beforeEach(() => {
+    setupDataSources(...Object.values(dataSources));
+  });
+
   describe('Grafana managed alert rule', () => {
     const mockRule = getGrafanaRule(
       {
@@ -211,10 +215,6 @@ describe('RuleViewer', () => {
       ]);
     });
 
-    beforeEach(() => {
-      setupDataSources(...Object.values(dataSources));
-    });
-
     it('should render a data source managed alert rule', () => {
       renderRuleViewer(mockRule, mockRuleIdentifier);
 
@@ -291,7 +291,7 @@ describe('RuleViewer', () => {
       // One summary is rendered by the Title component, and the other by the DetailsTab component
       expect(ELEMENTS.metadata.summary(mockRule.annotations[Annotation.summary]).getAll()).toHaveLength(2);
 
-      expect(within(ELEMENTS.details.pendingPeriod.get()).getByText(/15m/i)).toBeInTheDocument();
+      expect(ELEMENTS.details.pendingPeriod.get()).toHaveTextContent(/15m/i);
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
@@ -67,19 +67,25 @@ export const Details = ({ rule }: DetailsProps) => {
     <div className={styles.metadata}>
       <Box>
         <DetailHeading label={t('alerting.alert.rule', 'Rule')} />
-        <DetailText label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
+        <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
         {isGrafanaRulerRule(rule.rulerRule) && (
           <>
             <DetailText
+              id="rule-type"
               label={t('alerting.alert.rule-identifier', 'Rule identifier')}
               value={rule.rulerRule.grafana_alert.uid}
               monospace
               showCopyButton
               copyValue={rule.rulerRule.grafana_alert.uid}
             />
-            <DetailText label={t('alerting.alert.last-updated-by', 'Last updated by')} value={lastUpdatedBy} />
+            <DetailText
+              id="last-updated-by"
+              label={t('alerting.alert.last-updated-by', 'Last updated by')}
+              value={lastUpdatedBy}
+            />
             {updated && (
               <DetailText
+                id="date-of-last-update"
                 label={t('alerting.alert.last-updated-date', 'Date of last update')}
                 value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
               />
@@ -92,6 +98,7 @@ export const Details = ({ rule }: DetailsProps) => {
         <DetailHeading label={t('alerting.alert.evaluation', 'Evaluation')} />
         {evaluationTimestamp && (
           <DetailText
+            id="last-evaluated"
             label={t('alerting.alert.last-evaluated', 'Last evaluated')}
             value={formatDistanceToNowStrict(new Date(evaluationTimestamp), { addSuffix: true })}
             tooltipValue={dateTimeFormat(evaluationTimestamp)}
@@ -99,12 +106,17 @@ export const Details = ({ rule }: DetailsProps) => {
         )}
         {hasEvaluationDuration && (
           <DetailText
+            id="last-evaluation-duration"
             label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
             value={`${evaluationDuration} ms`}
           />
         )}
         {pendingPeriod && (
-          <DetailText label={t('alerting.alert.pending-period', 'Pending period')} value={pendingPeriod} />
+          <DetailText
+            id="pending-period"
+            label={t('alerting.alert.pending-period', 'Pending period')}
+            value={pendingPeriod}
+          />
         )}
       </Box>
 
@@ -116,12 +128,14 @@ export const Details = ({ rule }: DetailsProps) => {
             <DetailHeading label={t('alerting.alert.alert-state', 'Alert state')} />
             {hasEvaluationDuration && (
               <DetailText
+                id="alert-state-no-data"
                 label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
                 value={rule.rulerRule.grafana_alert.no_data_state}
               />
             )}
             {pendingPeriod && (
               <DetailText
+                id="alert-state-exec-err"
                 label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
                 value={rule.rulerRule.grafana_alert.exec_err_state}
               />
@@ -139,9 +153,10 @@ export const Details = ({ rule }: DetailsProps) => {
               </Text>
             </div>
           ) : (
-            Object.entries(annotations).map(([name, value]) => (
-              <DetailText key={name} label={name} value={<AnnotationValue value={value} />} />
-            ))
+            Object.entries(annotations).map(([name, value]) => {
+              const id = `annotation-${name.replace(/\s/g, '-')}`;
+              return <DetailText id={id} key={name} label={name} value={<AnnotationValue value={value} />} />;
+            })
           )}
         </Box>
       )}

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns';
 
 import { GrafanaTheme2, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
-import { Box, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Box, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 import { CombinedRule } from 'app/types/unified-alerting';
 
@@ -18,11 +18,7 @@ enum RuleType {
   CloudRecordingRule = 'Cloud recording rule',
 }
 
-const DetailHeading = ({ label }: { label: string }) => (
-  <Box paddingBottom={1}>
-    <Text variant="h4">{label}</Text>
-  </Box>
-);
+const DetailHeading = ({ label }: { label: string }) => <Text variant="h4">{label}</Text>;
 
 interface DetailsProps {
   rule: CombinedRule;
@@ -67,57 +63,60 @@ export const Details = ({ rule }: DetailsProps) => {
     <div className={styles.metadata}>
       <Box>
         <DetailHeading label={t('alerting.alert.rule', 'Rule')} />
-        <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
-        {isGrafanaRulerRule(rule.rulerRule) && (
-          <>
-            <DetailText
-              id="rule-type"
-              label={t('alerting.alert.rule-identifier', 'Rule identifier')}
-              value={rule.rulerRule.grafana_alert.uid}
-              monospace
-              showCopyButton
-              copyValue={rule.rulerRule.grafana_alert.uid}
-            />
-            <DetailText
-              id="last-updated-by"
-              label={t('alerting.alert.last-updated-by', 'Last updated by')}
-              value={lastUpdatedBy}
-            />
-            {updated && (
+        <Stack direction="column" gap={2}>
+          <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
+          {isGrafanaRulerRule(rule.rulerRule) && (
+            <>
               <DetailText
-                id="date-of-last-update"
-                label={t('alerting.alert.last-updated-date', 'Date of last update')}
-                value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
+                id="rule-type"
+                label={t('alerting.alert.rule-identifier', 'Rule identifier')}
+                value={rule.rulerRule.grafana_alert.uid}
+                monospace
+                showCopyButton
+                copyValue={rule.rulerRule.grafana_alert.uid}
               />
-            )}
-          </>
-        )}
+              <DetailText
+                id="last-updated-by"
+                label={t('alerting.alert.last-updated-by', 'Last updated by')}
+                value={lastUpdatedBy}
+              />
+              {updated && (
+                <DetailText
+                  id="date-of-last-update"
+                  label={t('alerting.alert.last-updated-at', 'Last updated at')}
+                  value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
+                />
+              )}
+            </>
+          )}
+        </Stack>
       </Box>
-
       <Box>
         <DetailHeading label={t('alerting.alert.evaluation', 'Evaluation')} />
-        {evaluationTimestamp && (
-          <DetailText
-            id="last-evaluated"
-            label={t('alerting.alert.last-evaluated', 'Last evaluated')}
-            value={formatDistanceToNowStrict(new Date(evaluationTimestamp), { addSuffix: true })}
-            tooltipValue={dateTimeFormat(evaluationTimestamp)}
-          />
-        )}
-        {hasEvaluationDuration && (
-          <DetailText
-            id="last-evaluation-duration"
-            label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
-            value={`${evaluationDuration} ms`}
-          />
-        )}
-        {pendingPeriod && (
-          <DetailText
-            id="pending-period"
-            label={t('alerting.alert.pending-period', 'Pending period')}
-            value={pendingPeriod}
-          />
-        )}
+        <Stack direction="column" gap={2}>
+          {evaluationTimestamp && (
+            <DetailText
+              id="last-evaluated"
+              label={t('alerting.alert.last-evaluated', 'Last evaluated')}
+              value={formatDistanceToNowStrict(new Date(evaluationTimestamp), { addSuffix: true })}
+              tooltipValue={dateTimeFormat(evaluationTimestamp)}
+            />
+          )}
+          {hasEvaluationDuration && (
+            <DetailText
+              id="last-evaluation-duration"
+              label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
+              value={`${evaluationDuration} ms`}
+            />
+          )}
+          {pendingPeriod && (
+            <DetailText
+              id="pending-period"
+              label={t('alerting.alert.pending-period', 'Pending period')}
+              value={pendingPeriod}
+            />
+          )}
+        </Stack>
       </Box>
 
       {isGrafanaRulerRule(rule.rulerRule) &&
@@ -126,38 +125,42 @@ export const Details = ({ rule }: DetailsProps) => {
         rule.rulerRule.grafana_alert.exec_err_state && (
           <Box>
             <DetailHeading label={t('alerting.alert.alert-state', 'Alert state')} />
-            {hasEvaluationDuration && (
-              <DetailText
-                id="alert-state-no-data"
-                label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
-                value={rule.rulerRule.grafana_alert.no_data_state}
-              />
-            )}
-            {pendingPeriod && (
-              <DetailText
-                id="alert-state-exec-err"
-                label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
-                value={rule.rulerRule.grafana_alert.exec_err_state}
-              />
-            )}
+            <Stack direction="column" gap={2}>
+              {hasEvaluationDuration && (
+                <DetailText
+                  id="alert-state-no-data"
+                  label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
+                  value={rule.rulerRule.grafana_alert.no_data_state}
+                />
+              )}
+              {pendingPeriod && (
+                <DetailText
+                  id="alert-state-exec-err"
+                  label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
+                  value={rule.rulerRule.grafana_alert.exec_err_state}
+                />
+              )}
+            </Stack>
           </Box>
         )}
 
       {annotations && (
         <Box>
           <DetailHeading label={t('alerting.alert.annotations', 'Annotations')} />
-          {Object.keys(annotations).length === 0 ? (
-            <div>
-              <Text color="secondary" italic>
-                <Trans i18nKey="alerting.alert.no-annotations">No annotations</Trans>
-              </Text>
-            </div>
-          ) : (
-            Object.entries(annotations).map(([name, value]) => {
-              const id = `annotation-${name.replace(/\s/g, '-')}`;
-              return <DetailText id={id} key={name} label={name} value={<AnnotationValue value={value} />} />;
-            })
-          )}
+          <Stack direction="column" gap={2}>
+            {Object.keys(annotations).length === 0 ? (
+              <div>
+                <Text color="secondary" italic>
+                  <Trans i18nKey="alerting.alert.no-annotations">No annotations</Trans>
+                </Text>
+              </div>
+            ) : (
+              Object.entries(annotations).map(([name, value]) => {
+                const id = `annotation-${name.replace(/\s/g, '-')}`;
+                return <DetailText id={id} key={name} label={name} value={<AnnotationValue value={value} />} />;
+              })
+            )}
+          </Stack>
         </Box>
       )}
     </div>

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
@@ -2,12 +2,19 @@ import { css } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns';
 
 import { GrafanaTheme2, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
-import { Box, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Icon, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 import { CombinedRule } from 'app/types/unified-alerting';
 
 import { usePendingPeriod } from '../../../hooks/rules/usePendingPeriod';
-import { getAnnotations, isGrafanaRecordingRule, isGrafanaRulerRule, isRecordingRulerRule } from '../../../utils/rules';
+import {
+  getAnnotations,
+  isGrafanaAlertingRule,
+  isGrafanaRecordingRule,
+  isGrafanaRulerRule,
+  isRecordingRulerRule,
+} from '../../../utils/rules';
+import { isNullDate } from '../../../utils/time';
 import { Tokenize } from '../../Tokenize';
 import { DetailText } from '../../common/DetailText';
 
@@ -18,7 +25,16 @@ enum RuleType {
   CloudRecordingRule = 'Cloud recording rule',
 }
 
-const DetailHeading = ({ label }: { label: string }) => <Text variant="h4">{label}</Text>;
+const DetailGroup = ({ title, children }: { title: string; children: React.ReactNode }) => {
+  return (
+    <Stack direction="column" gap={1}>
+      <Text variant="h4">{title}</Text>
+      <Stack direction="column" gap={2}>
+        {children}
+      </Stack>
+    </Stack>
+  );
+};
 
 interface DetailsProps {
   rule: CombinedRule;
@@ -58,110 +74,120 @@ export const Details = ({ rule }: DetailsProps) => {
   })();
 
   const updated = isGrafanaRulerRule(rule.rulerRule) ? rule.rulerRule.grafana_alert.updated : undefined;
-
+  const isPaused = isGrafanaAlertingRule(rule.rulerRule) && rule.rulerRule.grafana_alert.is_paused;
+  const pausedIcon = (
+    <Stack>
+      <Text color="warning">
+        <Icon name="pause-circle" />
+      </Text>
+      <Text>
+        <Trans i18nKey="alerting.alert.evaluation-paused">Alert evaluation currently paused</Trans>
+      </Text>
+    </Stack>
+  );
   return (
     <div className={styles.metadata}>
-      <Box>
-        <DetailHeading label={t('alerting.alert.rule', 'Rule')} />
-        <Stack direction="column" gap={2}>
-          <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
-          {isGrafanaRulerRule(rule.rulerRule) && (
-            <>
+      <DetailGroup title={t('alerting.alert.rule', 'Rule')}>
+        <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={ruleType} />
+        {isGrafanaRulerRule(rule.rulerRule) && (
+          <>
+            <DetailText
+              id="rule-type"
+              label={t('alerting.alert.rule-identifier', 'Rule identifier')}
+              value={rule.rulerRule.grafana_alert.uid}
+              monospace
+              showCopyButton
+              copyValue={rule.rulerRule.grafana_alert.uid}
+            />
+            <DetailText
+              id="last-updated-by"
+              label={t('alerting.alert.last-updated-by', 'Last updated by')}
+              value={lastUpdatedBy}
+            />
+            {updated && (
               <DetailText
-                id="rule-type"
-                label={t('alerting.alert.rule-identifier', 'Rule identifier')}
-                value={rule.rulerRule.grafana_alert.uid}
-                monospace
-                showCopyButton
-                copyValue={rule.rulerRule.grafana_alert.uid}
+                id="date-of-last-update"
+                label={t('alerting.alert.last-updated-at', 'Last updated at')}
+                value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
               />
+            )}
+          </>
+        )}
+      </DetailGroup>
+
+      <DetailGroup title={t('alerting.alert.evaluation', 'Evaluation')}>
+        {isPaused ? (
+          pausedIcon
+        ) : (
+          <>
+            {hasEvaluationDuration && evaluationTimestamp && (
               <DetailText
-                id="last-updated-by"
-                label={t('alerting.alert.last-updated-by', 'Last updated by')}
-                value={lastUpdatedBy}
+                id="last-evaluated"
+                label={t('alerting.alert.last-evaluated', 'Last evaluated')}
+                value={
+                  !isNullDate(evaluationTimestamp)
+                    ? formatDistanceToNowStrict(new Date(evaluationTimestamp), { addSuffix: true })
+                    : '-'
+                }
+                tooltipValue={!isNullDate(evaluationTimestamp) ? dateTimeFormat(evaluationTimestamp) : undefined}
               />
-              {updated && (
-                <DetailText
-                  id="date-of-last-update"
-                  label={t('alerting.alert.last-updated-at', 'Last updated at')}
-                  value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
-                />
-              )}
-            </>
-          )}
-        </Stack>
-      </Box>
-      <Box>
-        <DetailHeading label={t('alerting.alert.evaluation', 'Evaluation')} />
-        <Stack direction="column" gap={2}>
-          {evaluationTimestamp && (
-            <DetailText
-              id="last-evaluated"
-              label={t('alerting.alert.last-evaluated', 'Last evaluated')}
-              value={formatDistanceToNowStrict(new Date(evaluationTimestamp), { addSuffix: true })}
-              tooltipValue={dateTimeFormat(evaluationTimestamp)}
-            />
-          )}
-          {hasEvaluationDuration && (
-            <DetailText
-              id="last-evaluation-duration"
-              label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
-              value={`${evaluationDuration} ms`}
-            />
-          )}
-          {pendingPeriod && (
-            <DetailText
-              id="pending-period"
-              label={t('alerting.alert.pending-period', 'Pending period')}
-              value={pendingPeriod}
-            />
-          )}
-        </Stack>
-      </Box>
+            )}
+            {hasEvaluationDuration && (
+              <DetailText
+                id="last-evaluation-duration"
+                label={t('alerting.alert.last-evaluation-duration', 'Last evaluation duration')}
+                value={isPaused ? pausedIcon : `${evaluationDuration} ms`}
+              />
+            )}
+          </>
+        )}
+
+        {pendingPeriod && (
+          <DetailText
+            id="pending-period"
+            label={t('alerting.alert.pending-period', 'Pending period')}
+            value={pendingPeriod}
+          />
+        )}
+      </DetailGroup>
 
       {isGrafanaRulerRule(rule.rulerRule) &&
         // grafana recording rules don't have these fields
         rule.rulerRule.grafana_alert.no_data_state &&
         rule.rulerRule.grafana_alert.exec_err_state && (
-          <Box>
-            <DetailHeading label={t('alerting.alert.alert-state', 'Alert state')} />
-            <Stack direction="column" gap={2}>
-              {hasEvaluationDuration && (
-                <DetailText
-                  id="alert-state-no-data"
-                  label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
-                  value={rule.rulerRule.grafana_alert.no_data_state}
-                />
-              )}
-              {pendingPeriod && (
-                <DetailText
-                  id="alert-state-exec-err"
-                  label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
-                  value={rule.rulerRule.grafana_alert.exec_err_state}
-                />
-              )}
-            </Stack>
-          </Box>
+          <DetailGroup title={t('alerting.alert.alert-state', 'Alert state')}>
+            {hasEvaluationDuration && (
+              <DetailText
+                id="alert-state-no-data"
+                label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
+                value={rule.rulerRule.grafana_alert.no_data_state}
+              />
+            )}
+            {pendingPeriod && (
+              <DetailText
+                id="alert-state-exec-err"
+                label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
+                value={rule.rulerRule.grafana_alert.exec_err_state}
+              />
+            )}
+          </DetailGroup>
         )}
 
       {annotations && (
-        <Box>
-          <DetailHeading label={t('alerting.alert.annotations', 'Annotations')} />
-          <Stack direction="column" gap={2}>
-            {Object.keys(annotations).length === 0 ? (
-              <div>
-                <Text color="secondary" italic>
-                  <Trans i18nKey="alerting.alert.no-annotations">No annotations</Trans>
-                </Text>
-              </div>
-            ) : (
-              Object.entries(annotations).map(([name, value]) => {
-                const id = `annotation-${name.replace(/\s/g, '-')}`;
-                return <DetailText id={id} key={name} label={name} value={<AnnotationValue value={value} />} />;
-              })
-            )}
-          </Stack>
-        </Box>
+        <DetailGroup title={t('alerting.alert.annotations', 'Annotations')}>
+          {Object.keys(annotations).length === 0 ? (
+            <div>
+              <Text color="secondary" italic>
+                <Trans i18nKey="alerting.alert.no-annotations">No annotations</Trans>
+              </Text>
+            </div>
+          ) : (
+            Object.entries(annotations).map(([name, value]) => {
+              const id = `annotation-${name.replace(/\s/g, '-')}`;
+              return <DetailText id={id} key={name} label={name} value={<AnnotationValue value={value} />} />;
+            })
+          )}
+        </DetailGroup>
       )}
     </div>
   );
@@ -189,7 +215,7 @@ export function AnnotationValue({ value }: AnnotationValueProps) {
 const getStyles = (theme: GrafanaTheme2) => ({
   metadata: css({
     display: 'grid',
-    gap: theme.spacing(2),
+    gap: theme.spacing(4),
     gridTemplateColumns: '1fr 1fr 1fr',
 
     [theme.breakpoints.down('lg')]: {

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -265,6 +265,11 @@ export interface GrafanaRuleDefinition extends PostableGrafanaRuleDefinition {
   namespace_uid: string;
   rule_group: string;
   provenance?: string;
+  updated_by?: {
+    uid: string;
+    name?: string;
+  };
+  updated?: string;
 }
 
 export interface RulerGrafanaRuleDTO<T = GrafanaRuleDefinition> {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -179,6 +179,7 @@
       "annotations": "Annotations",
       "evaluation": "Evaluation",
       "evaluation-paused": "Alert evaluation currently paused",
+      "evaluation-paused-description": "Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.",
       "last-evaluated": "Last evaluated",
       "last-evaluation-duration": "Last evaluation duration",
       "last-updated-at": "Last updated at",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -174,6 +174,22 @@
     }
   },
   "alerting": {
+    "alert": {
+      "alert-state": "Alert state",
+      "annotations": "Annotations",
+      "evaluation": "Evaluation",
+      "last-evaluated": "Last evaluated",
+      "last-evaluation-duration": "Last evaluation duration",
+      "last-updated-by": "Last updated by",
+      "last-updated-date": "Date of last update",
+      "no-annotations": "No annotations",
+      "pending-period": "Pending period",
+      "rule": "Rule",
+      "rule-identifier": "Rule identifier",
+      "rule-type": "Rule type",
+      "state-error-timeout": "Alert state if execution error or timeout",
+      "state-no-data": "Alert state if no data or all values are null"
+    },
     "alert-recording-rule-form": {
       "evaluation-behaviour": {
         "description": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -178,6 +178,7 @@
       "alert-state": "Alert state",
       "annotations": "Annotations",
       "evaluation": "Evaluation",
+      "evaluation-paused": "Alert evaluation currently paused",
       "last-evaluated": "Last evaluated",
       "last-evaluation-duration": "Last evaluation duration",
       "last-updated-at": "Last updated at",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -180,8 +180,8 @@
       "evaluation": "Evaluation",
       "last-evaluated": "Last evaluated",
       "last-evaluation-duration": "Last evaluation duration",
+      "last-updated-at": "Last updated at",
       "last-updated-by": "Last updated by",
-      "last-updated-date": "Date of last update",
       "no-annotations": "No annotations",
       "pending-period": "Pending period",
       "rule": "Rule",
@@ -299,7 +299,7 @@
     "contactPointFilter": {
       "label": "Contact point"
     },
-    "copy-to-clipboard": "Copy {{label}} to clipboard",
+    "copy-to-clipboard": "Copy \"{{label}}\" to clipboard",
     "export": {
       "subtitle": {
         "formats": "Select the format and download the file or copy the contents to clipboard",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -299,6 +299,7 @@
     "contactPointFilter": {
       "label": "Contact point"
     },
+    "copy-to-clipboard": "Copy {{label}} to clipboard",
     "export": {
       "subtitle": {
         "formats": "Select the format and download the file or copy the contents to clipboard",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -180,8 +180,8 @@
       "evaluation": "Ēväľūäŧįőŉ",
       "last-evaluated": "Ŀäşŧ ęväľūäŧęđ",
       "last-evaluation-duration": "Ŀäşŧ ęväľūäŧįőŉ đūřäŧįőŉ",
+      "last-updated-at": "Ŀäşŧ ūpđäŧęđ äŧ",
       "last-updated-by": "Ŀäşŧ ūpđäŧęđ þy",
-      "last-updated-date": "Đäŧę őƒ ľäşŧ ūpđäŧę",
       "no-annotations": "Ńő äŉŉőŧäŧįőŉş",
       "pending-period": "Pęŉđįŉģ pęřįőđ",
       "rule": "Ŗūľę",
@@ -299,7 +299,7 @@
     "contactPointFilter": {
       "label": "Cőŉŧäčŧ pőįŉŧ"
     },
-    "copy-to-clipboard": "Cőpy {{label}} ŧő čľįpþőäřđ",
+    "copy-to-clipboard": "Cőpy \"{{label}}\" ŧő čľįpþőäřđ",
     "export": {
       "subtitle": {
         "formats": "Ŝęľęčŧ ŧĥę ƒőřmäŧ äŉđ đőŵŉľőäđ ŧĥę ƒįľę őř čőpy ŧĥę čőŉŧęŉŧş ŧő čľįpþőäřđ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -174,6 +174,22 @@
     }
   },
   "alerting": {
+    "alert": {
+      "alert-state": "Åľęřŧ şŧäŧę",
+      "annotations": "Åŉŉőŧäŧįőŉş",
+      "evaluation": "Ēväľūäŧįőŉ",
+      "last-evaluated": "Ŀäşŧ ęväľūäŧęđ",
+      "last-evaluation-duration": "Ŀäşŧ ęväľūäŧįőŉ đūřäŧįőŉ",
+      "last-updated-by": "Ŀäşŧ ūpđäŧęđ þy",
+      "last-updated-date": "Đäŧę őƒ ľäşŧ ūpđäŧę",
+      "no-annotations": "Ńő äŉŉőŧäŧįőŉş",
+      "pending-period": "Pęŉđįŉģ pęřįőđ",
+      "rule": "Ŗūľę",
+      "rule-identifier": "Ŗūľę įđęŉŧįƒįęř",
+      "rule-type": "Ŗūľę ŧypę",
+      "state-error-timeout": "Åľęřŧ şŧäŧę įƒ ęχęčūŧįőŉ ęřřőř őř ŧįmęőūŧ",
+      "state-no-data": "Åľęřŧ şŧäŧę įƒ ŉő đäŧä őř äľľ väľūęş äřę ŉūľľ"
+    },
     "alert-recording-rule-form": {
       "evaluation-behaviour": {
         "description": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -299,6 +299,7 @@
     "contactPointFilter": {
       "label": "Cőŉŧäčŧ pőįŉŧ"
     },
+    "copy-to-clipboard": "Cőpy {{label}} ŧő čľįpþőäřđ",
     "export": {
       "subtitle": {
         "formats": "Ŝęľęčŧ ŧĥę ƒőřmäŧ äŉđ đőŵŉľőäđ ŧĥę ƒįľę őř čőpy ŧĥę čőŉŧęŉŧş ŧő čľįpþőäřđ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -178,6 +178,7 @@
       "alert-state": "Åľęřŧ şŧäŧę",
       "annotations": "Åŉŉőŧäŧįőŉş",
       "evaluation": "Ēväľūäŧįőŉ",
+      "evaluation-paused": "Åľęřŧ ęväľūäŧįőŉ čūřřęŉŧľy päūşęđ",
       "last-evaluated": "Ŀäşŧ ęväľūäŧęđ",
       "last-evaluation-duration": "Ŀäşŧ ęväľūäŧįőŉ đūřäŧįőŉ",
       "last-updated-at": "Ŀäşŧ ūpđäŧęđ äŧ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -179,6 +179,7 @@
       "annotations": "Åŉŉőŧäŧįőŉş",
       "evaluation": "Ēväľūäŧįőŉ",
       "evaluation-paused": "Åľęřŧ ęväľūäŧįőŉ čūřřęŉŧľy päūşęđ",
+      "evaluation-paused-description": "Ńőŧįƒįčäŧįőŉş ƒőř ŧĥįş řūľę ŵįľľ ŉőŧ ƒįřę äŉđ ŉő äľęřŧ įŉşŧäŉčęş ŵįľľ þę čřęäŧęđ ūŉŧįľ ŧĥę řūľę įş ūŉ-päūşęđ.",
       "last-evaluated": "Ŀäşŧ ęväľūäŧęđ",
       "last-evaluation-duration": "Ŀäşŧ ęväľūäŧįőŉ đūřäŧįőŉ",
       "last-updated-at": "Ŀäşŧ ūpđäŧęđ äŧ",


### PR DESCRIPTION
**What is this feature?**
Updates design of the rule details view, and adds `updated`/`updated by` to the list of fields
Before:
![image](https://github.com/user-attachments/assets/308f5463-a639-4b61-873d-927efcf2e0da)

After:
![image](https://github.com/user-attachments/assets/75deeb54-e4c4-41a2-8f76-3da3236379b3)


**Why do we need this feature?**
To improve readability of the page + for consistency with rule version history implementation

**Who is this feature for?**
Alerting users
