### PR TITLE
Docker: Use our own glibc 2.40 binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_IMAGE=golang:1.23.5-alpine
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder
 
-FROM --platform=${JS_PLATFORM} ${JS_IMAGE} as js-builder
+FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
 
 ENV NODE_OPTIONS=--max_old_space_size=8000
 
@@ -32,7 +32,7 @@ COPY emails emails
 ENV NODE_ENV=production
 RUN yarn build
 
-FROM ${GO_IMAGE} as go-builder
+FROM ${GO_IMAGE} AS go-builder
 
 ARG COMMIT_SHA=""
 ARG BUILD_BRANCH=""
@@ -41,13 +41,13 @@ ARG WIRE_TAGS="oss"
 ARG BINGO="true"
 
 RUN if grep -i -q alpine /etc/issue; then \
-      apk add --no-cache \
-          # This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
-          binutils-gold \
-          bash \
-          # Install build dependencies
-          gcc g++ make git; \
-    fi
+  apk add --no-cache \
+  # This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
+  binutils-gold \
+  bash \
+  # Install build dependencies
+  gcc g++ make git; \
+  fi
 
 WORKDIR /tmp/grafana
 
@@ -76,9 +76,9 @@ COPY pkg/plugins/codegen/go.* pkg/plugins/codegen/
 
 RUN go mod download
 RUN if [[ "$BINGO" = "true" ]]; then \
-      go install github.com/bwplotka/bingo@latest && \
-      bingo get -v; \
-    fi
+  go install github.com/bwplotka/bingo@latest && \
+  bingo get -v; \
+  fi
 
 COPY embed.go Makefile build.go package.json ./
 COPY cue.mod cue.mod
@@ -97,7 +97,7 @@ ENV BUILD_BRANCH=${BUILD_BRANCH}
 
 RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 
-FROM ${BASE_IMAGE} as tgz-builder
+FROM ${BASE_IMAGE} AS tgz-builder
 
 WORKDIR /tmp/grafana
 
@@ -109,8 +109,8 @@ COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 RUN tar x -z -f /tmp/grafana.tar.gz --strip-components=1
 
 # helpers for COPY --from
-FROM ${GO_SRC} as go-src
-FROM ${JS_SRC} as js-src
+FROM ${GO_SRC} AS go-src
+FROM ${JS_SRC} AS js-src
 
 # Final stage
 FROM ${BASE_IMAGE}
@@ -121,74 +121,74 @@ ARG GF_UID="472"
 ARG GF_GID="0"
 
 ENV PATH="/usr/share/grafana/bin:$PATH" \
-    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
-    GF_PATHS_DATA="/var/lib/grafana" \
-    GF_PATHS_HOME="/usr/share/grafana" \
-    GF_PATHS_LOGS="/var/log/grafana" \
-    GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
-    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+  GF_PATHS_DATA="/var/lib/grafana" \
+  GF_PATHS_HOME="/usr/share/grafana" \
+  GF_PATHS_LOGS="/var/log/grafana" \
+  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
 RUN if grep -i -q alpine /etc/issue; then \
-      apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
-      apk info -vv | sort; \
-    elif grep -i -q ubuntu /etc/issue; then \
-      DEBIAN_FRONTEND=noninteractive && \
-      apt-get update && \
-      apt-get install -y ca-certificates curl tzdata musl && \
-      apt-get autoremove -y && \
-      rm -rf /var/lib/apt/lists/*; \
-    else \
-      echo 'ERROR: Unsupported base image' && /bin/false; \
-    fi
+  apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
+  apk info -vv | sort; \
+  elif grep -i -q ubuntu /etc/issue; then \
+  DEBIAN_FRONTEND=noninteractive && \
+  apt-get update && \
+  apt-get install -y ca-certificates curl tzdata musl && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*; \
+  else \
+  echo 'ERROR: Unsupported base image' && /bin/false; \
+  fi
 
 # glibc support for alpine x86_64 only
+# docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
+ARG GLIBC_VERSION=2.40
+
 RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
-      wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
-        -O /tmp/glibc-2.35-r0.apk && \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk \
-        -O /tmp/glibc-bin-2.35-r0.apk && \
-      apk add --force-overwrite --no-cache /tmp/glibc-2.35-r0.apk /tmp/glibc-bin-2.35-r0.apk && \
-      rm -f /lib64/ld-linux-x86-64.so.2 && \
-      ln -s /usr/glibc-compat/lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 && \
-      rm -f /tmp/glibc-2.35-r0.apk && \
-      rm -f /tmp/glibc-bin-2.35-r0.apk && \
-      rm -f /lib/ld-linux-x86-64.so.2 && \
-      rm -f /etc/ld.so.cache; \
-    fi
+  wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
+  usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
+  usr/glibc-compat/lib/libc.so.6 \
+  usr/glibc-compat/lib/libdl.so.2 \
+  usr/glibc-compat/lib/libm.so.6 \
+  usr/glibc-compat/lib/libpthread.so.0 \
+  usr/glibc-compat/lib/librt.so.1 && \
+  mkdir /lib64 && \
+  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
+  fi
 
 COPY --from=go-src /tmp/grafana/conf ./conf
 
 RUN if [ ! $(getent group "$GF_GID") ]; then \
-      if grep -i -q alpine /etc/issue; then \
-        addgroup -S -g $GF_GID grafana; \
-      else \
-        addgroup --system --gid $GF_GID grafana; \
-      fi; \
-    fi && \
-    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
-    mkdir -p "$GF_PATHS_HOME/.aws" && \
-    if grep -i -q alpine /etc/issue; then \
-      adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
-    else \
-      adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
-    fi && \
-    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
-             "$GF_PATHS_PROVISIONING/dashboards" \
-             "$GF_PATHS_PROVISIONING/notifiers" \
-             "$GF_PATHS_PROVISIONING/plugins" \
-             "$GF_PATHS_PROVISIONING/access-control" \
-             "$GF_PATHS_PROVISIONING/alerting" \
-             "$GF_PATHS_LOGS" \
-             "$GF_PATHS_PLUGINS" \
-             "$GF_PATHS_DATA" && \
-    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
-    cp conf/ldap.toml /etc/grafana/ldap.toml && \
-    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+  if grep -i -q alpine /etc/issue; then \
+  addgroup -S -g $GF_GID grafana; \
+  else \
+  addgroup --system --gid $GF_GID grafana; \
+  fi; \
+  fi && \
+  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+  mkdir -p "$GF_PATHS_HOME/.aws" && \
+  if grep -i -q alpine /etc/issue; then \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
+  else \
+  adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
+  fi && \
+  mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+  "$GF_PATHS_PROVISIONING/dashboards" \
+  "$GF_PATHS_PROVISIONING/notifiers" \
+  "$GF_PATHS_PROVISIONING/plugins" \
+  "$GF_PATHS_PROVISIONING/access-control" \
+  "$GF_PATHS_PROVISIONING/alerting" \
+  "$GF_PATHS_LOGS" \
+  "$GF_PATHS_PLUGINS" \
+  "$GF_PATHS_DATA" && \
+  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+  cp conf/ldap.toml /etc/grafana/ldap.toml && \
+  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
 COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
+# syntax=docker/dockerfile:1
+
+# to maintain formatting of multiline commands in vscode, add the following to settings.json:
+# "docker.languageserver.formatter.ignoreMultilineInstructions": true
 
 ARG BASE_IMAGE=alpine:3.20
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.23.5-alpine
 
+# Default to building locally
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder
 
+# Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
 
 ENV NODE_OPTIONS=--max_old_space_size=8000
@@ -32,6 +38,7 @@ COPY emails emails
 ENV NODE_ENV=production
 RUN yarn build
 
+# Golang build stage
 FROM ${GO_IMAGE} AS go-builder
 
 ARG COMMIT_SHA=""
@@ -41,13 +48,13 @@ ARG WIRE_TAGS="oss"
 ARG BINGO="true"
 
 RUN if grep -i -q alpine /etc/issue; then \
-  apk add --no-cache \
-  # This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
-  binutils-gold \
-  bash \
-  # Install build dependencies
-  gcc g++ make git; \
-  fi
+      apk add --no-cache \
+          # This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
+          binutils-gold \
+          bash \
+          # Install build dependencies
+          gcc g++ make git; \
+    fi
 
 WORKDIR /tmp/grafana
 
@@ -76,9 +83,9 @@ COPY pkg/plugins/codegen/go.* pkg/plugins/codegen/
 
 RUN go mod download
 RUN if [[ "$BINGO" = "true" ]]; then \
-  go install github.com/bwplotka/bingo@latest && \
-  bingo get -v; \
-  fi
+      go install github.com/bwplotka/bingo@latest && \
+      bingo get -v; \
+    fi
 
 COPY embed.go Makefile build.go package.json ./
 COPY cue.mod cue.mod
@@ -97,6 +104,7 @@ ENV BUILD_BRANCH=${BUILD_BRANCH}
 
 RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 
+# From-tarball build stage
 FROM ${BASE_IMAGE} AS tgz-builder
 
 WORKDIR /tmp/grafana
@@ -121,74 +129,74 @@ ARG GF_UID="472"
 ARG GF_GID="0"
 
 ENV PATH="/usr/share/grafana/bin:$PATH" \
-  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
-  GF_PATHS_DATA="/var/lib/grafana" \
-  GF_PATHS_HOME="/usr/share/grafana" \
-  GF_PATHS_LOGS="/var/log/grafana" \
-  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
-  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+    GF_PATHS_DATA="/var/lib/grafana" \
+    GF_PATHS_HOME="/usr/share/grafana" \
+    GF_PATHS_LOGS="/var/log/grafana" \
+    GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
 RUN if grep -i -q alpine /etc/issue; then \
-  apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
-  apk info -vv | sort; \
-  elif grep -i -q ubuntu /etc/issue; then \
-  DEBIAN_FRONTEND=noninteractive && \
-  apt-get update && \
-  apt-get install -y ca-certificates curl tzdata musl && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*; \
-  else \
-  echo 'ERROR: Unsupported base image' && /bin/false; \
-  fi
+      apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
+      apk info -vv | sort; \
+    elif grep -i -q ubuntu /etc/issue; then \
+      DEBIAN_FRONTEND=noninteractive && \
+      apt-get update && \
+      apt-get install -y ca-certificates curl tzdata musl && \
+      apt-get autoremove -y && \
+      rm -rf /var/lib/apt/lists/*; \
+    else \
+      echo 'ERROR: Unsupported base image' && /bin/false; \
+    fi
 
 # glibc support for alpine x86_64 only
 # docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
 ARG GLIBC_VERSION=2.40
 
 RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
-  wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
-  usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
-  usr/glibc-compat/lib/libc.so.6 \
-  usr/glibc-compat/lib/libdl.so.2 \
-  usr/glibc-compat/lib/libm.so.6 \
-  usr/glibc-compat/lib/libpthread.so.0 \
-  usr/glibc-compat/lib/librt.so.1 && \
-  mkdir /lib64 && \
-  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
-  fi
+      wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
+        usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
+        usr/glibc-compat/lib/libc.so.6 \
+        usr/glibc-compat/lib/libdl.so.2 \
+        usr/glibc-compat/lib/libm.so.6 \
+        usr/glibc-compat/lib/libpthread.so.0 \
+        usr/glibc-compat/lib/librt.so.1 && \
+      mkdir /lib64 && \
+      ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
+    fi
 
 COPY --from=go-src /tmp/grafana/conf ./conf
 
 RUN if [ ! $(getent group "$GF_GID") ]; then \
-  if grep -i -q alpine /etc/issue; then \
-  addgroup -S -g $GF_GID grafana; \
-  else \
-  addgroup --system --gid $GF_GID grafana; \
-  fi; \
-  fi && \
-  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
-  mkdir -p "$GF_PATHS_HOME/.aws" && \
-  if grep -i -q alpine /etc/issue; then \
-  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
-  else \
-  adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
-  fi && \
-  mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
-  "$GF_PATHS_PROVISIONING/dashboards" \
-  "$GF_PATHS_PROVISIONING/notifiers" \
-  "$GF_PATHS_PROVISIONING/plugins" \
-  "$GF_PATHS_PROVISIONING/access-control" \
-  "$GF_PATHS_PROVISIONING/alerting" \
-  "$GF_PATHS_LOGS" \
-  "$GF_PATHS_PLUGINS" \
-  "$GF_PATHS_DATA" && \
-  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
-  cp conf/ldap.toml /etc/grafana/ldap.toml && \
-  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+      if grep -i -q alpine /etc/issue; then \
+        addgroup -S -g $GF_GID grafana; \
+      else \
+        addgroup --system --gid $GF_GID grafana; \
+      fi; \
+    fi && \
+    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+    mkdir -p "$GF_PATHS_HOME/.aws" && \
+    if grep -i -q alpine /etc/issue; then \
+      adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
+    else \
+      adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
+    fi && \
+    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+             "$GF_PATHS_PROVISIONING/dashboards" \
+             "$GF_PATHS_PROVISIONING/notifiers" \
+             "$GF_PATHS_PROVISIONING/plugins" \
+             "$GF_PATHS_PROVISIONING/access-control" \
+             "$GF_PATHS_PROVISIONING/alerting" \
+             "$GF_PATHS_LOGS" \
+             "$GF_PATHS_PLUGINS" \
+             "$GF_PATHS_DATA" && \
+    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+    cp conf/ldap.toml /etc/grafana/ldap.toml && \
+    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
 COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public


### PR DESCRIPTION
Currently we use a 3rd-party package to add glibc support into our alpine-based docker images. This has 2 drawbacks; the upstream maintainer has not packaged glibc 2.40 and we embed far more than we actually need to.

This PR switches to directly embedding just the binaries we need (saving some 40+MB) and using our own 2.40 binaries.

The binaries are still built using the same builder image as the previous 2.35 binaries, the command to create the tarball is included as a comment in the Dockerfile.

I did also update the Dockerfile syntax (`as` -> `AS`) to fix some warnings, and let vscode auto-indent the file.