### PR TITLE
ExtractFields: return undefined for invalid json paths to stay consistent with auto behaviour

### DIFF
--- a/devenv/dev-dashboards/transforms/extract-json-paths.json
+++ b/devenv/dev-dashboards/transforms/extract-json-paths.json
@@ -30,24 +30,81 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 83,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
-      "id": 2,
+      "datasource": {
+        "type": "testdata",
+        "uid": "gdev-testdata"
+      },
+      "description": "Some data sources (for example MQTT) might be consuming incomparable metrics packaged in the same JSON payload. We can use this extract fields transformation's JSON option to select the specific fields we want, and alias the values to help classify unlabeled or unstructured data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
-      "type": "table",
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.5.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata",
+            "uid": "gdev-testdata"
+          },
+          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"channel\": \"ds/bHGPS1h4z/1s/test\",\n        \"transformations\": [\"extractFields\", \"extractFields\", \"extractFields\"]\n      },\n      \"fields\": [\n        {\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"config\": {\n            \"custom\": {\n              \"align\": \"auto\",\n              \"displayMode\": \"auto\",\n              \"inspect\": false\n            },\n            \"color\": { \"mode\": \"thresholds\" },\n            \"thresholds\": {\n              \"mode\": \"absolute\",\n              \"steps\": [\n                { \"color\": \"green\", \"value\": null },\n                { \"color\": \"red\", \"value\": 80 }\n              ]\n            }\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"other\",\n          \"config\": {\n            \"custom\": {\n              \"align\": \"auto\",\n              \"displayMode\": \"auto\",\n              \"inspect\": false\n            },\n            \"color\": { \"mode\": \"thresholds\" },\n            \"mappings\": [],\n            \"thresholds\": {\n              \"mode\": \"absolute\",\n              \"steps\": [\n                { \"color\": \"green\", \"value\": null },\n                { \"color\": \"red\", \"value\": 80 }\n              ]\n            }\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [1673543683471, 1673543689063, 1673543695050],\n        [\n          [\n            \"2023-01-12T17:14:44.419Z\",\n            62,\n            141,\n            79,\n            29,\n            79,\n            -29,\n            29,\n            {\n              \"testdata\": {\n                \"source1\": { \"value1\": 9, \"value2\": 18, \"value3\": 73 },\n                \"source2\": [\n                  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],\n                  [7, 11, 13, 17, 19, 23, 27, 29]\n                ]\n              }\n            }\n          ],\n          [\n            \"2023-01-12T17:14:50.050Z\",\n            62,\n            143,\n            81,\n            29,\n            81,\n            -29,\n            29,\n            {\n              \"testdata\": {\n                \"source1\": { \"value1\": 10, \"value2\": 20 },\n                \"source2\": [\n                  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\n                  [11, 13, 17, 19, 23, 27, 29, 31]\n                ]\n              }\n            }\n          ],\n          [\n            \"2023-01-12T17:14:55.050Z\",\n            61,\n            146,\n            80,\n            22,\n            85,\n            -28,\n            28,\n            {\n              \"testdata\": {\n                \"source1\": { \"value1\": 11, \"value2\": 22, \"value3\": 100},\n                \"source2\": [\n                  [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],\n                  [13, 17, 19, 23, 27, 29, 31, 37, 41]\n                ]\n              }\n            }\n          ]\n        ]\n      ]\n    }\n  }\n]\n",
+          "refId": "A",
+          "scenarioId": "raw_frame"
+        }
+      ],
       "title": "Extracting individual values",
       "transformations": [
         {
           "id": "extractFields",
           "options": {
+            "delimiter": ",",
             "format": "json",
             "jsonPaths": [
               {
@@ -57,88 +114,10 @@
               {
                 "alias": "Primes",
                 "path": "[8].testdata.source2[1][3]"
-              }
-            ],
-            "keepTime": true,
-            "replace": true,
-            "source": "Value"
-          }
-        }
-      ],
-      "datasource": {
-        "type": "testdata",
-        "uid": "gdev-testdata"
-      },
-      "pluginVersion": "9.4.0-pre",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
               },
               {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "color": {
-            "mode": "thresholds"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "testdata",
-            "uid": "gdev-testdata"
-          },
-          "rawFrameContent": "[{\"schema\":{\"refId\":\"A\",\"meta\":{\"channel\":\"ds/bHGPS1h4z/1s/test\",\"transformations\":[\"extractFields\",\"extractFields\",\"extractFields\"]},\"fields\":[{\"name\":\"Time\",\"type\":\"time\",\"config\":{\"custom\":{\"align\":\"auto\",\"displayMode\":\"auto\",\"inspect\":false},\"color\":{\"mode\":\"thresholds\"},\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\",\"value\":null},{\"color\":\"red\",\"value\":80}]}}},{\"name\":\"Value\",\"type\":\"other\",\"config\":{\"custom\":{\"align\":\"auto\",\"displayMode\":\"auto\",\"inspect\":false},\"color\":{\"mode\":\"thresholds\"},\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\",\"value\":null},{\"color\":\"red\",\"value\":80}]}}}]},\"data\":{\"values\":[[1673543683471,1673543689063,1673543695050],[[\"2023-01-12T17:14:44.419Z\",62,141,79,29,79,-29,29,{\"testdata\":{\"source1\":{\"value1\":9,\"value2\":18},\"source2\":[[0,1,2,3,4,5,6,7,8,9],[7,11,13,17,19,23,27,29]]}}],[\"2023-01-12T17:14:50.050Z\",62,143,81,29,81,-29,29,{\"testdata\":{\"source1\":{\"value1\":10,\"value2\":20},\"source2\":[[1,2,3,4,5,6,7,8,9,10],[11,13,17,19,23,27,29,31]]}}],[\"2023-01-12T17:14:55.050Z\",61,146,80,22,85,-28,28,{\"testdata\":{\"source1\":{\"value1\":11,\"value2\":22},\"source2\":[[3,4,5,6,7,8,9,10,11,12],[13,17,19,23,27,29,31,37,41]]}}]]]}}]",
-          "refId": "A",
-          "scenarioId": "raw_frame"
-        }
-      ],
-      "description": "Some data sources (for example MQTT) might be consuming incomparable metrics packaged in the same JSON payload. We can use this extract fields transformation's JSON option to select the specific fields we want, and alias the values to help classify unlabeled or unstructured data."
-    },
-    {
-      "id": 3,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "type": "timeseries",
-      "title": "Visualizing extracted JSON",
-      "transformations": [
-        {
-          "id": "extractFields",
-          "options": {
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Temperature",
-                "path": "[8].testdata.source1.value1"
+                "alias": "Ages",
+                "path": "[8].testdata.source1.value3"
               }
             ],
             "keepTime": true,
@@ -147,45 +126,48 @@
           }
         }
       ],
+      "type": "table"
+    },
+    {
       "datasource": {
         "type": "testdata",
         "uid": "gdev-testdata"
       },
-      "pluginVersion": "9.4.0-pre",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "linear",
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
             "barAlignment": 0,
-            "lineWidth": 1,
+            "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "spanNulls": false,
-            "showPoints": "auto",
-            "pointSize": 5,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "axisPlacement": "auto",
-            "axisLabel": "",
-            "axisColorMode": "text",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "axisCenteredZero": false,
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
             }
-          },
-          "color": {
-            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -204,18 +186,26 @@
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
       "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
         "tooltip": {
           "mode": "single",
           "sort": "none"
-        },
-        "legend": {
-          "showLegend": true,
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": []
         }
       },
+      "pluginVersion": "9.4.0-pre",
       "targets": [
         {
           "datasource": {
@@ -227,29 +217,42 @@
           "scenarioId": "raw_frame"
         }
       ],
-      "description": ""
+      "title": "Visualizing extracted JSON",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "jsonPaths": [
+              {
+                "alias": "Temperature",
+                "path": "[8].testdata.source1.value1"
+              }
+            ],
+            "keepTime": true,
+            "replace": true,
+            "source": "Value"
+          }
+        }
+      ],
+      "type": "timeseries"
     },
     {
-      "id": 4,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "type": "table",
-      "title": "Raw data",
-      "transformations": [],
       "datasource": {
         "type": "testdata",
         "uid": "gdev-testdata"
       },
-      "pluginVersion": "9.4.0-pre",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -264,24 +267,29 @@
                 "value": 80
               }
             ]
-          },
-          "color": {
-            "mode": "thresholds"
           }
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
       "options": {
-        "showHeader": true,
         "footer": {
-          "show": false,
+          "countRows": false,
+          "fields": "",
           "reducer": [
             "sum"
           ],
-          "countRows": false,
-          "fields": ""
-        }
+          "show": false
+        },
+        "showHeader": true
       },
+      "pluginVersion": "9.4.0-pre",
       "targets": [
         {
           "datasource": {
@@ -293,11 +301,12 @@
           "scenarioId": "raw_frame"
         }
       ],
-      "description": ""
+      "title": "Raw data",
+      "type": "table"
     }
   ],
-  "revision": 1,
-  "schemaVersion": 37,
+  "preload": false,
+  "schemaVersion": 40,
   "tags": [
     "gdev",
     "transform"
@@ -313,6 +322,6 @@
   "timezone": "",
   "title": "Transforms - Test extractFields JSON",
   "uid": "pD4vPYhVz",
-  "version": 3,
+  "version": 1,
   "weekStart": ""
 }

--- a/public/app/features/transformers/extractFields/components/JSONPathEditor.tsx
+++ b/public/app/features/transformers/extractFields/components/JSONPathEditor.tsx
@@ -94,7 +94,7 @@ const getTooltips = () => {
   return {
     field: (
       <div>
-        A valid path of an json object.
+        A valid path of an json object. Paths that do not exist in some rows will return an undefined value.
         <div>
           <strong>JSON Value:</strong>
         </div>

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -186,9 +186,9 @@ describe('Fields from JSON', () => {
           {
             "config": {},
             "name": "invalid.path",
-            "type": "string",
+            "type": "other",
             "values": [
-              "Not Found",
+              undefined,
             ],
           },
         ],

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -79,7 +79,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
       if (filteredPaths.length > 0) {
         filteredPaths.forEach((path: JSONPath) => {
           const key = path.alias && path.alias.length > 0 ? path.alias : path.path;
-          newObj[key] = get(obj, path.path) ?? 'Not Found';
+          newObj[key] = get(obj, path.path) ?? undefined;
         });
 
         obj = newObj;


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Return undefined value when invalid json path is encountered when extracting fields using json paths.

**Why do we need this feature?**

When multiple rows do not share exactly the same json paths, the data returned will change depending on what options are selected.

If no json field paths are specified, invalid paths return undefined and show in the table as null values, making them easy to drop, filter, or map.

If a json field path is specified, then invalid paths return "Not Found" as a string.

This change makes the behaviour consistent, returned undefined when json paths are used.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

This was raised [here](https://community.grafana.com/t/display-empty-value-instead-of-not-found-if-value-in-json-is-empty/126454)
 last here but never turned into an issue. Solution is mapping "Not Found" to an invisible character


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
