### PR TITLE
Alerting: Add EmbeddedContents as alternative embedding in smtp

### DIFF
--- a/pkg/services/notifications/email.go
+++ b/pkg/services/notifications/email.go
@@ -1,8 +1,6 @@
 package notifications
 
 import (
-	"io"
-
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -13,18 +11,24 @@ type AttachedFile struct {
 	Content []byte
 }
 
+// EmbeddedContent struct represents an embedded file.
+type EmbeddedContent struct {
+	Name    string
+	Content []byte
+}
+
 // Message is representation of the email message.
 type Message struct {
-	To              []string
-	SingleEmail     bool
-	From            string
-	Subject         string
-	Body            map[string]string
-	Info            string
-	ReplyTo         []string
-	EmbeddedFiles   []string
-	EmbeddedReaders map[string]io.Reader
-	AttachedFiles   []*AttachedFile
+	To               []string
+	SingleEmail      bool
+	From             string
+	Subject          string
+	Body             map[string]string
+	Info             string
+	ReplyTo          []string
+	EmbeddedFiles    []string
+	EmbeddedContents []EmbeddedContent
+	AttachedFiles    []*AttachedFile
 }
 
 func setDefaultTemplateData(cfg *setting.Cfg, data map[string]any, u *user.User) {

--- a/pkg/services/notifications/email.go
+++ b/pkg/services/notifications/email.go
@@ -1,6 +1,8 @@
 package notifications
 
 import (
+	"io"
+
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -13,15 +15,16 @@ type AttachedFile struct {
 
 // Message is representation of the email message.
 type Message struct {
-	To            []string
-	SingleEmail   bool
-	From          string
-	Subject       string
-	Body          map[string]string
-	Info          string
-	ReplyTo       []string
-	EmbeddedFiles []string
-	AttachedFiles []*AttachedFile
+	To              []string
+	SingleEmail     bool
+	From            string
+	Subject         string
+	Body            map[string]string
+	Info            string
+	ReplyTo         []string
+	EmbeddedFiles   []string
+	EmbeddedReaders map[string]io.Reader
+	AttachedFiles   []*AttachedFile
 }
 
 func setDefaultTemplateData(cfg *setting.Cfg, data map[string]any, u *user.User) {

--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -112,14 +112,15 @@ func (ns *NotificationService) buildEmailMessage(cmd *SendEmailCommand) (*Messag
 
 	addr := mail.Address{Name: ns.Cfg.Smtp.FromName, Address: ns.Cfg.Smtp.FromAddress}
 	return &Message{
-		To:            cmd.To,
-		SingleEmail:   cmd.SingleEmail,
-		From:          addr.String(),
-		Subject:       subject,
-		Body:          body,
-		EmbeddedFiles: cmd.EmbeddedFiles,
-		AttachedFiles: buildAttachedFiles(cmd.AttachedFiles),
-		ReplyTo:       cmd.ReplyTo,
+		To:              cmd.To,
+		SingleEmail:     cmd.SingleEmail,
+		From:            addr.String(),
+		Subject:         subject,
+		Body:            body,
+		EmbeddedFiles:   cmd.EmbeddedFiles,
+		EmbeddedReaders: cmd.EmbeddedReaders,
+		AttachedFiles:   buildAttachedFiles(cmd.AttachedFiles),
+		ReplyTo:         cmd.ReplyTo,
 	}, nil
 }
 

--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -112,15 +112,15 @@ func (ns *NotificationService) buildEmailMessage(cmd *SendEmailCommand) (*Messag
 
 	addr := mail.Address{Name: ns.Cfg.Smtp.FromName, Address: ns.Cfg.Smtp.FromAddress}
 	return &Message{
-		To:              cmd.To,
-		SingleEmail:     cmd.SingleEmail,
-		From:            addr.String(),
-		Subject:         subject,
-		Body:            body,
-		EmbeddedFiles:   cmd.EmbeddedFiles,
-		EmbeddedReaders: cmd.EmbeddedReaders,
-		AttachedFiles:   buildAttachedFiles(cmd.AttachedFiles),
-		ReplyTo:         cmd.ReplyTo,
+		To:               cmd.To,
+		SingleEmail:      cmd.SingleEmail,
+		From:             addr.String(),
+		Subject:          subject,
+		Body:             body,
+		EmbeddedFiles:    cmd.EmbeddedFiles,
+		EmbeddedContents: cmd.EmbeddedContents,
+		AttachedFiles:    buildAttachedFiles(cmd.AttachedFiles),
+		ReplyTo:          cmd.ReplyTo,
 	}, nil
 }
 

--- a/pkg/services/notifications/models.go
+++ b/pkg/services/notifications/models.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"crypto/tls"
 	"errors"
+	"io"
 
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -18,15 +19,16 @@ type SendEmailAttachFile struct {
 
 // SendEmailCommand is the command for sending emails
 type SendEmailCommand struct {
-	To            []string
-	SingleEmail   bool
-	Template      string
-	Subject       string
-	Data          map[string]any
-	Info          string
-	ReplyTo       []string
-	EmbeddedFiles []string
-	AttachedFiles []*SendEmailAttachFile
+	To              []string
+	SingleEmail     bool
+	Template        string
+	Subject         string
+	Data            map[string]any
+	Info            string
+	ReplyTo         []string
+	EmbeddedFiles   []string
+	EmbeddedReaders map[string]io.Reader
+	AttachedFiles   []*SendEmailAttachFile
 }
 
 // SendEmailCommandSync is the command for sending emails synchronously

--- a/pkg/services/notifications/models.go
+++ b/pkg/services/notifications/models.go
@@ -3,7 +3,6 @@ package notifications
 import (
 	"crypto/tls"
 	"errors"
-	"io"
 
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -19,16 +18,16 @@ type SendEmailAttachFile struct {
 
 // SendEmailCommand is the command for sending emails
 type SendEmailCommand struct {
-	To              []string
-	SingleEmail     bool
-	Template        string
-	Subject         string
-	Data            map[string]any
-	Info            string
-	ReplyTo         []string
-	EmbeddedFiles   []string
-	EmbeddedReaders map[string]io.Reader
-	AttachedFiles   []*SendEmailAttachFile
+	To               []string
+	SingleEmail      bool
+	Template         string
+	Subject          string
+	Data             map[string]any
+	Info             string
+	ReplyTo          []string
+	EmbeddedFiles    []string
+	EmbeddedContents []EmbeddedContent
+	AttachedFiles    []*SendEmailAttachFile
 }
 
 // SendEmailCommandSync is the command for sending emails synchronously

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -201,16 +201,16 @@ func __dangerouslyInjectHTML(s string) template.HTML {
 
 func (ns *NotificationService) SendEmailCommandHandlerSync(ctx context.Context, cmd *SendEmailCommandSync) error {
 	message, err := ns.buildEmailMessage(&SendEmailCommand{
-		Data:            cmd.Data,
-		Info:            cmd.Info,
-		Template:        cmd.Template,
-		To:              cmd.To,
-		SingleEmail:     cmd.SingleEmail,
-		EmbeddedFiles:   cmd.EmbeddedFiles,
-		EmbeddedReaders: cmd.EmbeddedReaders,
-		AttachedFiles:   cmd.AttachedFiles,
-		Subject:         cmd.Subject,
-		ReplyTo:         cmd.ReplyTo,
+		Data:             cmd.Data,
+		Info:             cmd.Info,
+		Template:         cmd.Template,
+		To:               cmd.To,
+		SingleEmail:      cmd.SingleEmail,
+		EmbeddedFiles:    cmd.EmbeddedFiles,
+		EmbeddedContents: cmd.EmbeddedContents,
+		AttachedFiles:    cmd.AttachedFiles,
+		Subject:          cmd.Subject,
+		ReplyTo:          cmd.ReplyTo,
 	})
 	if err != nil {
 		return err

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -201,15 +201,16 @@ func __dangerouslyInjectHTML(s string) template.HTML {
 
 func (ns *NotificationService) SendEmailCommandHandlerSync(ctx context.Context, cmd *SendEmailCommandSync) error {
 	message, err := ns.buildEmailMessage(&SendEmailCommand{
-		Data:          cmd.Data,
-		Info:          cmd.Info,
-		Template:      cmd.Template,
-		To:            cmd.To,
-		SingleEmail:   cmd.SingleEmail,
-		EmbeddedFiles: cmd.EmbeddedFiles,
-		AttachedFiles: cmd.AttachedFiles,
-		Subject:       cmd.Subject,
-		ReplyTo:       cmd.ReplyTo,
+		Data:            cmd.Data,
+		Info:            cmd.Info,
+		Template:        cmd.Template,
+		To:              cmd.To,
+		SingleEmail:     cmd.SingleEmail,
+		EmbeddedFiles:   cmd.EmbeddedFiles,
+		EmbeddedReaders: cmd.EmbeddedReaders,
+		AttachedFiles:   cmd.AttachedFiles,
+		Subject:         cmd.Subject,
+		ReplyTo:         cmd.ReplyTo,
 	})
 	if err != nil {
 		return err

--- a/pkg/services/notifications/notifications_test.go
+++ b/pkg/services/notifications/notifications_test.go
@@ -2,9 +2,7 @@ package notifications
 
 import (
 	"context"
-	"io"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -142,8 +140,8 @@ func TestSendEmailSync(t *testing.T) {
 				To:          []string{"asdf@grafana.com"},
 				SingleEmail: true,
 				Template:    "welcome_on_signup",
-				EmbeddedReaders: map[string]io.Reader{
-					"embed.jpg": strings.NewReader("image content"),
+				EmbeddedContents: []EmbeddedContent{
+					{Name: "embed.jpg", Content: []byte("image content")},
 				},
 			},
 		}
@@ -153,10 +151,10 @@ func TestSendEmailSync(t *testing.T) {
 
 		require.NotEmpty(t, mailer.Sent)
 		sent := mailer.Sent[len(mailer.Sent)-1]
-		require.Len(t, sent.EmbeddedReaders, 1)
-		contents, err := io.ReadAll(sent.EmbeddedReaders["embed.jpg"])
-		require.NoError(t, err)
-		require.Equal(t, "image content", string(contents))
+		require.Len(t, sent.EmbeddedContents, 1)
+		f := sent.EmbeddedContents[0]
+		require.Equal(t, "embed.jpg", f.Name)
+		require.Equal(t, "image content", string(f.Content))
 	})
 
 	t.Run("When SMTP disabled in configuration", func(t *testing.T) {

--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -142,8 +142,11 @@ func (sc *SmtpClient) setFiles(
 		m.Embed(file)
 	}
 
-	for name, contents := range msg.EmbeddedReaders {
-		m.EmbedReader(name, contents)
+	for _, file := range msg.EmbeddedContents {
+		m.Embed(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
+			_, err := writer.Write(file.Content)
+			return err
+		}))
 	}
 
 	for _, file := range msg.AttachedFiles {

--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -142,6 +142,10 @@ func (sc *SmtpClient) setFiles(
 		m.Embed(file)
 	}
 
+	for name, contents := range msg.EmbeddedReaders {
+		m.EmbedReader(name, contents)
+	}
+
 	for _, file := range msg.AttachedFiles {
 		file := file
 		m.Attach(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {


### PR DESCRIPTION
**What is this feature?**

Adds support for embedding `[]byte` in `SmtpClient`instead of filenames. This is backwards compatible as it uses a new field `EmbeddedContents` to add an alternative to the existing `EmbeddedFiles` which takes filenames.

**Why do we need this feature?**

Planned work in alertmanager email notifier relating to remote Alertmanager screenshots requires it to handle `[]byte` instead of passing around filenames.