### PR TITLE
Alerting: Use org store to read organization IDs

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -616,7 +616,7 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 		// Also note that this runs synchronously to ensure state is loaded
 		// before rule evaluation begins, hence we use ctx and not subCtx.
 		//
-		ng.stateManager.Warm(ctx, ng.store, ng.StartupInstanceReader)
+		ng.stateManager.Warm(ctx, ng.store, ng.store, ng.StartupInstanceReader)
 
 		children.Go(func() error {
 			return ng.schedule.Run(subCtx)

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -254,7 +254,7 @@ func (moa *MultiOrgAlertmanager) Run(ctx context.Context) error {
 func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Context) error {
 	moa.logger.Debug("Synchronizing Alertmanagers for orgs")
 	// First, load all the organizations from the database.
-	orgIDs, err := moa.orgStore.GetOrgs(ctx)
+	orgIDs, err := moa.orgStore.FetchOrgIds(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -127,7 +127,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgsWithFailures(t *testing.T)
 		2: {AlertmanagerConfiguration: brokenConfig, OrgID: orgWithBadConfig},
 	})
 
-	orgs, err := mam.orgStore.GetOrgs(ctx)
+	orgs, err := mam.orgStore.FetchOrgIds(ctx)
 	require.NoError(t, err)
 	// No successfully applied configurations should be found at first.
 	{

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -224,7 +224,7 @@ func NewFakeOrgStore(t *testing.T, orgs []int64) *FakeOrgStore {
 	}
 }
 
-func (f *FakeOrgStore) GetOrgs(_ context.Context) ([]int64, error) {
+func (f *FakeOrgStore) FetchOrgIds(_ context.Context) ([]int64, error) {
 	return f.orgs, nil
 }
 

--- a/pkg/services/ngalert/state/multi_instance_reader.go
+++ b/pkg/services/ngalert/state/multi_instance_reader.go
@@ -3,8 +3,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -26,30 +24,6 @@ func NewMultiInstanceReader(logger log.Logger, r1, r2 InstanceReader) *MultiInst
 		DBReader:      r2,
 		logger:        logger,
 	}
-}
-
-// FetchOrgIds merges org IDs from both readers.
-func (m *MultiInstanceReader) FetchOrgIds(ctx context.Context) ([]int64, error) {
-	orgsOne, err := m.ProtoDBReader.FetchOrgIds(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch org IDs from ProtoDBReader: %w", err)
-	}
-
-	orgsTwo, err := m.DBReader.FetchOrgIds(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch org IDs from DBReader: %w", err)
-	}
-
-	orgsSet := make(map[int64]struct{})
-
-	for _, orgID := range orgsOne {
-		orgsSet[orgID] = struct{}{}
-	}
-	for _, orgID := range orgsTwo {
-		orgsSet[orgID] = struct{}{}
-	}
-
-	return slices.Collect(maps.Keys(orgsSet)), nil
 }
 
 // ListAlertInstances fetches alert instances for a query from both readers,

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -15,7 +15,6 @@ type InstanceStore interface {
 
 // InstanceReader provides methods to fetch alert instances.
 type InstanceReader interface {
-	FetchOrgIds(ctx context.Context) ([]int64, error)
 	ListAlertInstances(ctx context.Context, cmd *models.ListAlertInstancesQuery) ([]*models.AlertInstance, error)
 }
 
@@ -27,6 +26,10 @@ type InstanceWriter interface {
 	SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error
 	FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error
+}
+
+type OrgReader interface {
+	FetchOrgIds(ctx context.Context) ([]int64, error)
 }
 
 // RuleReader represents the ability to fetch alert rules.

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -44,8 +44,6 @@ func (f *FakeInstanceStore) SaveAlertInstance(_ context.Context, q models.AlertI
 	return nil
 }
 
-func (f *FakeInstanceStore) FetchOrgIds(_ context.Context) ([]int64, error) { return []int64{}, nil }
-
 func (f *FakeInstanceStore) DeleteAlertInstances(ctx context.Context, q ...models.AlertInstanceKey) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -96,29 +96,6 @@ func (st InstanceDBStore) SaveAlertInstance(ctx context.Context, alertInstance m
 	})
 }
 
-func (st InstanceDBStore) FetchOrgIds(ctx context.Context) ([]int64, error) {
-	orgIds := []int64{}
-
-	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
-		s := strings.Builder{}
-		params := make([]any, 0)
-
-		addToQuery := func(stmt string, p ...any) {
-			s.WriteString(stmt)
-			params = append(params, p...)
-		}
-
-		addToQuery("SELECT DISTINCT rule_org_id FROM alert_instance")
-
-		if err := sess.SQL(s.String(), params...).Find(&orgIds); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	return orgIds, err
-}
-
 // DeleteAlertInstances deletes instances with the provided keys in a single transaction.
 func (st InstanceDBStore) DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error {
 	if len(keys) == 0 {

--- a/pkg/services/ngalert/store/org.go
+++ b/pkg/services/ngalert/store/org.go
@@ -7,10 +7,10 @@ import (
 )
 
 type OrgStore interface {
-	GetOrgs(ctx context.Context) ([]int64, error)
+	FetchOrgIds(ctx context.Context) ([]int64, error)
 }
 
-func (st DBstore) GetOrgs(ctx context.Context) ([]int64, error) {
+func (st DBstore) FetchOrgIds(ctx context.Context) ([]int64, error) {
 	orgs := make([]int64, 0)
 	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		q := "SELECT id FROM org"

--- a/pkg/services/ngalert/store/org_test.go
+++ b/pkg/services/ngalert/store/org_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/ngalert/testutil"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestFetchOrgIds(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns empty result when no orgs exist", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		store := &DBstore{SQLStore: sqlStore}
+		orgIDs, err := store.FetchOrgIds(ctx)
+		require.NoError(t, err)
+		require.Empty(t, orgIDs)
+	})
+
+	t.Run("returns all org IDs", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		store := &DBstore{SQLStore: sqlStore}
+		orgService, err := testutil.SetupOrgService(t, sqlStore, setting.NewCfg())
+		require.NoError(t, err)
+
+		createdOrgIDs := make([]int64, 3)
+
+		for i := range 3 {
+			require.NoError(t, err)
+			newOrg, err := orgService.CreateWithMember(ctx, &org.CreateOrgCommand{Name: fmt.Sprintf("org-%d", i)})
+			require.NoError(t, err)
+			createdOrgIDs[i] = newOrg.ID
+		}
+
+		orgIDs, err := store.FetchOrgIds(ctx)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, createdOrgIDs, orgIDs)
+	})
+}

--- a/pkg/services/ngalert/store/proto_instance_database.go
+++ b/pkg/services/ngalert/store/proto_instance_database.go
@@ -93,29 +93,6 @@ func (st ProtoInstanceDBStore) SaveAlertInstance(ctx context.Context, alertInsta
 	return errors.New("save alert instance is not implemented for proto instance database store")
 }
 
-func (st ProtoInstanceDBStore) FetchOrgIds(ctx context.Context) ([]int64, error) {
-	orgIds := []int64{}
-
-	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
-		s := strings.Builder{}
-		params := make([]any, 0)
-
-		addToQuery := func(stmt string, p ...any) {
-			s.WriteString(stmt)
-			params = append(params, p...)
-		}
-
-		addToQuery("SELECT DISTINCT org_id FROM alert_rule_state")
-
-		if err := sess.SQL(s.String(), params...).Find(&orgIds); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	return orgIds, err
-}
-
 func (st ProtoInstanceDBStore) DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error {
 	logger := st.Logger.FromContext(ctx)
 	logger.Error("DeleteAlertInstances called and not implemented")

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
@@ -66,4 +68,10 @@ func SetupDashboardService(tb testing.TB, sqlStore db.DB, fs *folderimpl.Dashboa
 	dashboardService.RegisterDashboardPermissions(dashboardPermissions)
 
 	return dashboardService, dashboardStore
+}
+
+func SetupOrgService(tb testing.TB, sqlStore db.DB, cfg *setting.Cfg) (org.Service, error) {
+	tb.Helper()
+	quotaService := quotatest.New(false, nil)
+	return orgimpl.ProvideService(sqlStore, cfg, quotaService)
 }


### PR DESCRIPTION
**What is this feature?**

A refactoring of `InstanceStore`. Before the store had `FetchOrgIds` method that would get unique `org_id` from alert_instance table. At the same time, we also have `OrgStore` that uses the `org` table. This PR removes the `FetchOrgIds` from the instance store and uses `OrgStore` instead.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/7835