### PR TITLE
Share: Fix short links when root_url is different from the browser URL

### DIFF
--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -70,7 +70,7 @@ export const createDashboardShareUrl = (dashboard: DashboardScene, opts: ShareLi
     slug: dashboard.state.meta.slug,
     currentQueryParams: location.search,
     updateQuery: urlParamsUpdate,
-    absolute: true,
+    absolute: !opts.useShortUrl,
   });
 };
 


### PR DESCRIPTION
**What is this feature?**

This PR removes an operation when generating short links. We first requested an absolute dashboard URL to then make it relative, this directly requests a relative dashboard URL.

**Why do we need this feature?**

As the function that creates the absolute URL and the one that makes it relative are not using the same URL path, this was causing issues in certain use cases when `root_url` in `.ini` doesn't match the URL that is actually used in the user browser (see more information in [the issue](https://github.com/grafana/grafana/issues/97838)).

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/97838