### PR TITLE
Authz: For list collect all folder permisions into items

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -656,8 +656,7 @@ func buildItemList(scopes map[string]bool, tree map[string]FolderNode, prefix st
 	itemSet := make(map[string]struct{}, len(scopes))
 
 	for scope := range scopes {
-		if strings.HasPrefix(scope, "folders:uid:") {
-			identifier := strings.TrimPrefix(scope, "folders:uid:")
+		if identifier, ok := strings.CutPrefix(scope, "folders:uid:"); ok {
 			if _, ok := folderSet[identifier]; ok {
 				continue
 			}

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -678,8 +678,8 @@ func buildItemList(scopes map[string]bool, tree map[string]FolderNode, prefix st
 	}
 
 	return &authzv1.ListResponse{Folders: folderList, Items: itemList}
-
 }
+
 func getChildren(folderMap map[string]FolderNode, folderUID string, folderSet map[string]struct{}) {
 	folder, has := folderMap[folderUID]
 	if !has {

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -619,27 +619,28 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 		}
 	}
 
-	folderSet := make(map[string]struct{}, len(scopeMap))
-
-	prefix := t.prefix()
-	itemSet := make(map[string]struct{}, len(scopeMap))
-	for scope := range scopeMap {
-		if strings.HasPrefix(scope, "folders:uid:") {
-			identifier := strings.TrimPrefix(scope, "folders:uid:")
-			if _, ok := folderSet[identifier]; ok {
-				continue
-			}
-			folderSet[identifier] = struct{}{}
-			getChildren(folderMap, identifier, folderSet)
-		} else {
-			identifier := strings.TrimPrefix(scope, prefix)
-			itemSet[identifier] = struct{}{}
-		}
+	var res *authzv1.ListResponse
+	if strings.HasPrefix(req.Action, "folders:") {
+		res = buildFolderList(scopeMap, folderMap)
+	} else {
+		res = buildItemList(scopeMap, folderMap, t.prefix())
 	}
 
-	folderList := make([]string, 0, len(folderSet))
-	for folder := range folderSet {
-		folderList = append(folderList, folder)
+	span.SetAttributes(attribute.Int("num_folders", len(res.Folders)), attribute.Int("num_items", len(res.Items)))
+	return res, nil
+}
+
+func buildFolderList(scopes map[string]bool, tree map[string]FolderNode) *authzv1.ListResponse {
+	itemSet := make(map[string]struct{}, len(scopes))
+
+	for scope := range scopes {
+		identifier := strings.TrimPrefix(scope, "folders:uid:")
+		if _, ok := itemSet[identifier]; ok {
+			continue
+		}
+
+		itemSet[identifier] = struct{}{}
+		getChildren(tree, identifier, itemSet)
 	}
 
 	itemList := make([]string, 0, len(itemSet))
@@ -647,10 +648,38 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 		itemList = append(itemList, item)
 	}
 
-	span.SetAttributes(attribute.Int("num_folders", len(folderList)), attribute.Int("num_items", len(itemList)))
-	return &authzv1.ListResponse{Folders: folderList, Items: itemList}, nil
+	return &authzv1.ListResponse{Items: itemList}
 }
 
+func buildItemList(scopes map[string]bool, tree map[string]FolderNode, prefix string) *authzv1.ListResponse {
+	folderSet := make(map[string]struct{}, len(scopes))
+	itemSet := make(map[string]struct{}, len(scopes))
+
+	for scope := range scopes {
+		if strings.HasPrefix(scope, "folders:uid:") {
+			identifier := strings.TrimPrefix(scope, "folders:uid:")
+			if _, ok := folderSet[identifier]; ok {
+				continue
+			}
+			folderSet[identifier] = struct{}{}
+			getChildren(tree, identifier, folderSet)
+		} else {
+			identifier := strings.TrimPrefix(scope, prefix)
+			itemSet[identifier] = struct{}{}
+		}
+	}
+	folderList := make([]string, 0, len(folderSet))
+	for folder := range folderSet {
+		folderList = append(folderList, folder)
+	}
+	itemList := make([]string, 0, len(itemSet))
+	for item := range itemSet {
+		itemList = append(itemList, item)
+	}
+
+	return &authzv1.ListResponse{Folders: folderList, Items: itemList}
+
+}
 func getChildren(folderMap map[string]FolderNode, folderUID string, folderSet map[string]struct{}) {
 	folder, has := folderMap[folderUID]
 	if !has {


### PR DESCRIPTION
**What is this feature?**
Extracted from https://github.com/grafana/grafana/pull/99554 to make reviewing changes easier.

Fixed issue I discovered with list request is performed on folder type, with the old code all folder identifiers was put in the Folders list instead of items. Resource store could never verify folders without parents because items was always empty. When listing folders we should always put them in Items, even children that inherit parent permissions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
