### PR TITLE
DashboardList: Throttle the re-renders

### DIFF
--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -1,4 +1,4 @@
-import { isEqual, take } from 'lodash';
+import { take } from 'lodash';
 import { SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { useThrottle } from 'react-use';
 
@@ -111,9 +111,7 @@ export function DashList(props: PanelProps<Options>) {
 
   useEffect(() => {
     fetchDashboards(props.options, props.replaceVariables).then((dashes) => {
-      if (!isEqual(dashes, dashboards)) {
-        setDashboards(dashes);
-      }
+      setDashboards(dashes);
     });
   }, [dashboards, props.options, props.replaceVariables, throttledRenderCount]);
 

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -1,6 +1,6 @@
-import { take } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
+import { isEqual, take } from 'lodash';
+import { SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import { useThrottle } from 'react-use';
 
 import {
   DataLinkBuiltInVars,
@@ -107,13 +107,17 @@ export function DashList(props: PanelProps<Options>) {
   const dispatch = useDispatch();
   const navIndex = useSelector((state) => state.navIndex);
 
+  const throttledRenderCount = useThrottle(props.renderCounter, 5000);
+
   useEffect(() => {
     fetchDashboards(props.options, props.replaceVariables).then((dashes) => {
-      setDashboards(dashes);
+      if (!isEqual(dashes, dashboards)) {
+        setDashboards(dashes);
+      }
     });
-  }, [props.options, props.replaceVariables, props.renderCounter]);
+  }, [dashboards, props.options, props.replaceVariables, throttledRenderCount]);
 
-  const toggleDashboardStar = async (e: React.SyntheticEvent, dash: Dashboard) => {
+  const toggleDashboardStar = async (e: SyntheticEvent, dash: Dashboard) => {
     const { uid, title, url } = dash;
     e.preventDefault();
     e.stopPropagation();

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -113,7 +113,7 @@ export function DashList(props: PanelProps<Options>) {
     fetchDashboards(props.options, props.replaceVariables).then((dashes) => {
       setDashboards(dashes);
     });
-  }, [dashboards, props.options, props.replaceVariables, throttledRenderCount]);
+  }, [props.options, props.replaceVariables, throttledRenderCount]);
 
   const toggleDashboardStar = async (e: SyntheticEvent, dash: Dashboard) => {
     const { uid, title, url } = dash;


### PR DESCRIPTION
**What is this feature?**

This PR throttles the re-renders of the dashboard list panel.

**Why do we need this feature?**

Enabling live refresh causes the panel to fetch data continuously, blocking dashboard and panel loading.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-
**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
