### PR TITLE
Logs: Re-run Loki queries in Explore when direction and sort order are changed

### DIFF
--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -48,16 +48,17 @@ jest.mock('../state/explorePane', () => ({
   changePanelState: (exploreId: string, panel: 'logs', panelState: {} | ExploreLogsPanelState) => {
     return fakeChangePanelState(exploreId, panel, panelState);
   },
-  changeQueries: (args: { queries: DataQuery[]; exploreId: string | undefined }) => {
-    return fakeChangeQueries(args);
-  },
 }));
 
 const fakeChangeQueries = jest.fn().mockReturnValue({ type: 'fakeChangeQueries' });
+const fakeRunQueries = jest.fn().mockReturnValue({ type: 'fakeRunQueries' });
 jest.mock('../state/query', () => ({
   ...jest.requireActual('../state/query'),
   changeQueries: (args: { queries: DataQuery[]; exploreId: string | undefined }) => {
     return fakeChangeQueries(args);
+  },
+  runQueries: (args: { queries: DataQuery[]; exploreId: string | undefined }) => {
+    return fakeRunQueries(args);
   },
 }));
 
@@ -388,6 +389,7 @@ describe('Logs', () => {
     expect(logRows.length).toBe(3);
     expect(logRows[0].textContent).toContain('log message 1');
     expect(logRows[2].textContent).toContain('log message 3');
+    expect(fakeRunQueries).not.toHaveBeenCalled();
   });
 
   it('should sync the query direction when changing the order of loki queries', async () => {
@@ -399,6 +401,7 @@ describe('Logs', () => {
       exploreId: 'left',
       queries: [{ ...query, direction: LokiQueryDirection.Forward }],
     });
+    expect(fakeRunQueries).toHaveBeenCalledWith({ exploreId: 'left' });
   });
 
   it('should not change the query direction when changing the order of non-loki queries', async () => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -73,7 +73,7 @@ import {
 import { useContentOutlineContext } from '../ContentOutline/ContentOutlineContext';
 import { getUrlStateFromPaneState } from '../hooks/useStateSync';
 import { changePanelState } from '../state/explorePane';
-import { changeQueries } from '../state/query';
+import { changeQueries, runQueries } from '../state/query';
 
 import { LogsFeedback } from './LogsFeedback';
 import { LogsMetaRow } from './LogsMetaRow';
@@ -476,12 +476,11 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           if (query.datasource?.type !== 'loki' || !isLokiQuery(query)) {
             return query;
           }
-          hasLokiQueries = true;
-
           if (query.direction === LokiQueryDirection.Scan) {
             // Don't override Scan. When the direction is Scan it means that the user specifically assigned this direction to the query.
             return query;
           }
+          hasLokiQueries = true;
           const newDirection =
             newSortOrder === LogsSortOrder.Ascending ? LokiQueryDirection.Forward : LokiQueryDirection.Backward;
           if (newDirection !== query.direction) {
@@ -492,6 +491,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
         if (hasLokiQueries) {
           dispatch(changeQueries({ exploreId, queries: newQueries }));
+          dispatch(runQueries({ exploreId }));
         }
       }
 


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/98722 we synced query direction and sort order for Loki queries, but a missing piece was re-executing the updated Loki query, analog to how it works in Explore Logs.
