### PR TITLE
Alerting docs: update screenshot (modify NoData/Error state)

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
@@ -87,7 +87,7 @@ In [Configure no data and error handling](ref:no-data-and-error-handling), you c
 
 Note that `No Data` and `Error` states are supported only for Grafana-managed alert rules.
 
-{{< figure src="/media/docs/alerting/alert-rule-configure-no-data-and-error.png" alt="A screenshot of the `Configure no data and error handling` option in Grafana Alerting." max-width="500px" >}}
+{{< figure src="/media/docs/alerting/alert-rule-configure-no-data-and-error-v2.png" alt="A screenshot of the `Configure no data and error handling` option in Grafana Alerting." max-width="500px" >}}
 
 {{< docs/shared lookup="alerts/table-configure-no-data-and-error.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 


### PR DESCRIPTION
The configurable option has been renamed from `Ok` to `Normal`.

This PR updates an outdated screenshot for v11.5.0. 

⭐  [Preview](https://deploy-preview-grafana-99996-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/state-and-health/#modify-the-no-data-or-error-state) ⭐ 




