### PR TITLE
Alerting: Add NamespaceUID to the rule key with group

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -484,6 +484,7 @@ type AlertRuleKeyWithVersion struct {
 
 type AlertRuleKeyWithGroup struct {
 	RuleGroup    string
+	NamespaceUID string
 	AlertRuleKey `xorm:"extends"`
 }
 
@@ -540,9 +541,13 @@ func (alertRule *AlertRule) GetKey() AlertRuleKey {
 	return AlertRuleKey{OrgID: alertRule.OrgID, UID: alertRule.UID}
 }
 
-// GetKeyWithGroup returns the alert definitions identifier
+// GetKeyWithGroup returns the alert definitions identifier with the group information.
 func (alertRule *AlertRule) GetKeyWithGroup() AlertRuleKeyWithGroup {
-	return AlertRuleKeyWithGroup{AlertRuleKey: alertRule.GetKey(), RuleGroup: alertRule.RuleGroup}
+	return AlertRuleKeyWithGroup{
+		AlertRuleKey: alertRule.GetKey(),
+		RuleGroup:    alertRule.RuleGroup,
+		NamespaceUID: alertRule.NamespaceUID,
+	}
 }
 
 // GetGroupKey returns the identifier of a group the rule belongs to

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -911,10 +911,12 @@ func TestAlertRuleGetKeyWithGroup(t *testing.T) {
 	t.Run("should return correct key", func(t *testing.T) {
 		rule := RuleGen.With(
 			RuleMuts.WithUniqueGroupIndex(),
+			RuleMuts.WithNamespaceUID("some-namespace-uid"),
 		).GenerateRef()
 		expected := AlertRuleKeyWithGroup{
 			AlertRuleKey: rule.GetKey(),
 			RuleGroup:    rule.RuleGroup,
+			NamespaceUID: rule.NamespaceUID,
 		}
 		require.Equal(t, expected, rule.GetKeyWithGroup())
 	})


### PR DESCRIPTION
**What is this feature?**

Adding the namespace UID field (folder UID) to the struct so that the key can now uniquely the rule group of the alert rule. Groups can have the same names if they are in different folders.