### PR TITLE
Folders: Validator: add temporary fix

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -2,6 +2,7 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -106,6 +107,17 @@ func ProvideFolderPermissions(
 			})
 
 			if err != nil {
+				// if the folder is not found, this may be on the create path,
+				// where the write path to legacy will then go through the read
+				// path and try to read from both legacy & unified before it exists on both
+				if features.IsEnabledGlobally(featuremgmt.FlagKubernetesFoldersServiceV2) && errors.Is(err, dashboards.ErrFolderNotFound) {
+					_, err = folderService.GetLegacy(ctx, &folder.GetFolderQuery{
+						UID:          &resourceID,
+						OrgID:        orgID,
+						SignedInUser: ident,
+					})
+					return err
+				}
 				return err
 			}
 


### PR DESCRIPTION
**What is this feature?**

Once we started using the folder service for the resource validation, we run into an interesting issue with the dual writer. The flow ends up like:

1. Create a folder
2. The create request goes to the folder service
3. The folder service takes the create request and goes to the api server.
4. This goes to the dual writer, which first writes to legacy db
5. The write to the legacy db will then create the folder in the database
6. Then, it will try to create default permissions. But this will send a get request to the folder service
7. The folder service will then send it to the api server / dual writer
8. The dual writer will then try to read from both the legacy & unified dbs, and then fail because it is not yet created in unified.

This is a temporary fix. We will come up with a more elegant solution after this, but this unblocks us for now.