### PR TITLE
Alerting: Use BE filter for labels in ash page

### DIFF
--- a/public/app/features/alerting/unified/api/stateHistoryApi.ts
+++ b/public/app/features/alerting/unified/api/stateHistoryApi.ts
@@ -1,5 +1,7 @@
 import { DataFrameJSON } from '@grafana/data';
 
+import { parsePromQLStyleMatcherLoose } from '../utils/matchers';
+
 import { alertingApi } from './alertingApi';
 
 export const LABELS_PREFIX = 'labels_';
@@ -9,18 +11,16 @@ export function labelsDtoFromLabelsAsString(labels?: string): Record<string, str
   if (!labels) {
     return {};
   }
-  const result = labels
-    .replace(/[{()}]/g, '')
-    .split(',')
-    .reduce(
-      (acc, label) => {
-        const [key, value] = label.split('=');
-        acc[`${LABELS_PREFIX}${key.trim()}`] = value;
-        return acc;
-      },
-      // eslint-disable-next-line
-      {} as Record<string, string>
-    );
+
+  const matchers = parsePromQLStyleMatcherLoose(labels);
+  const result = matchers.reduce(
+    (acc, matcher) => {
+      acc[`${LABELS_PREFIX}${matcher.name}`] = matcher.value;
+      return acc;
+    },
+    // eslint-disable-next-line
+    {} as Record<string, string>
+  );
 
   return result;
 }

--- a/public/app/features/alerting/unified/api/stateHistoryApi.ts
+++ b/public/app/features/alerting/unified/api/stateHistoryApi.ts
@@ -2,12 +2,38 @@ import { DataFrameJSON } from '@grafana/data';
 
 import { alertingApi } from './alertingApi';
 
+export const LABELS_PREFIX = 'labels_';
+
+export function labelsDtoFromLabelsAsString(labels?: string): Record<string, string> {
+  // convert "{ke1=val1,key2=val2}" to { labels_key1: val1, labels_key2: val2 }
+  if (!labels) {
+    return {};
+  }
+  const result = labels
+    .replace(/[{()}]/g, '')
+    .split(',')
+    .reduce(
+      (acc, label) => {
+        const [key, value] = label.split('=');
+        acc[`${LABELS_PREFIX}${key.trim()}`] = value;
+        return acc;
+      },
+      // eslint-disable-next-line
+      {} as Record<string, string>
+    );
+
+  return result;
+}
+
 export const stateHistoryApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    getRuleHistory: build.query<DataFrameJSON, { ruleUid?: string; from?: number; to?: number; limit?: number }>({
-      query: ({ ruleUid, from, to, limit = 100 }) => ({
+    getRuleHistory: build.query<
+      DataFrameJSON,
+      { ruleUid?: string; from?: number; to?: number; limit?: number; labels?: string }
+    >({
+      query: ({ ruleUid, from, to, limit = 100, labels }) => ({
         url: '/api/v1/rules/history',
-        params: { ruleUID: ruleUid, from, to, limit },
+        params: { ruleUID: ruleUid, from, to, limit, ...labelsDtoFromLabelsAsString(labels) },
       }),
     }),
   }),

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -63,7 +63,7 @@ class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
     const stateTo = templateSrv.replace(query.stateTo ?? '', request.scopedVars);
     const stateFrom = templateSrv.replace(query.stateFrom ?? '', request.scopedVars);
 
-    const historyResult = await getHistory(from, to);
+    const historyResult = await getHistory(from, to, labels);
 
     return {
       data: historyResultToDataFrame(historyResult, { stateTo, stateFrom, labels }),
@@ -81,13 +81,14 @@ class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
  * @param to the end time
  * @returns the history events only filtered by time
  */
-export const getHistory = (from: number, to: number) => {
+export const getHistory = (from: number, to: number, labels?: string) => {
   return dispatch(
     stateHistoryApi.endpoints.getRuleHistory.initiate(
       {
         from: from,
         to: to,
         limit: LIMIT_EVENTS,
+        labels,
       },
       {
         forceRefetch: Boolean(getTimeSrv().getAutoRefreshInteval().interval), // force refetch in case we are using the refresh option

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -73,6 +73,7 @@ export const HistoryEventsList = ({
     from: from,
     to: to,
     limit: LIMIT_EVENTS,
+    labels: valueInLabelFilter.toString(),
   });
 
   const { historyRecords: historyRecordsNotSorted } = useRuleHistoryRecords(stateHistory, {

--- a/public/app/features/alerting/unified/components/rules/central-state-history/useRuleHistoryRecords.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/useRuleHistoryRecords.ts
@@ -3,8 +3,6 @@ import { useMemo } from 'react';
 import { DataFrameJSON } from '@grafana/data';
 import { mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
-import { labelsMatchMatchers } from '../../../utils/alertmanager';
-import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { LogRecord } from '../state-history/common';
 import { isLine, isNumbers } from '../state-history/useRuleHistoryRecords';
 
@@ -29,13 +27,11 @@ export function useRuleHistoryRecords(stateHistory?: DataFrameJSON, filters = em
 }
 
 export function ruleHistoryToRecords(stateHistory?: DataFrameJSON, filters = emptyFilters) {
-  const { labels, stateFrom, stateTo } = filters;
+  const { stateFrom, stateTo } = filters;
 
   if (!stateHistory?.data) {
     return { historyRecords: [] };
   }
-
-  const filterMatchers = labels ? parsePromQLStyleMatcherLooseSafe(labels) : [];
 
   const [tsValues, lines] = stateHistory.data.values;
   const timestamps = isNumbers(tsValues) ? tsValues : [];
@@ -47,12 +43,11 @@ export function ruleHistoryToRecords(stateHistory?: DataFrameJSON, filters = emp
       return acc;
     }
     // values property can be undefined for some instance states (e.g. NoData)
-    const filterMatch = line.labels && labelsMatchMatchers(line.labels, filterMatchers);
     const baseStateTo = mapStateWithReasonToBaseState(line.current);
     const baseStateFrom = mapStateWithReasonToBaseState(line.previous);
     const stateToMatch = stateTo !== StateFilterValues.all ? stateTo === baseStateTo : true;
     const stateFromMatch = stateFrom !== StateFilterValues.all ? stateFrom === baseStateFrom : true;
-    if (filterMatch && stateToMatch && stateFromMatch) {
+    if (stateToMatch && stateFromMatch) {
       acc.push({ timestamp, line });
     }
 


### PR DESCRIPTION
**What is this feature?**

This PR moves the labels filter in the alert state history page to the BE side.

Note: We need the history endpoint to support any type of expressions in the labels filter (not only equality) to move this forward. See https://github.com/grafana/grafana/issues/100065 

**Why do we need this feature?**

Due to the limit we have in the history response from Loki (5000 events) , using the filter in the BE side, we can get more results.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/100060

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
