### PR TITLE
Dashboards: SchemaV2 - Fix saving dashboards on folder

### DIFF
--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -115,6 +115,11 @@ export class K8sDashboardV2API
 
     // add folder annotation
     if (options.folderUid) {
+      // remove frontend folder annotations
+      delete obj.metadata.annotations?.[AnnoKeyFolderTitle];
+      delete obj.metadata.annotations?.[AnnoKeyFolderUrl];
+      delete obj.metadata.annotations?.[AnnoKeyFolderId];
+
       obj.metadata.annotations = {
         ...obj.metadata.annotations,
         [AnnoKeyFolder]: options.folderUid,


### PR DESCRIPTION
When saving a dashboard in the v2 api, we were sending unnecessary annotations related to folders. That was breaking the request. In this PR, I removed the folder title, url and id. 

Before:

https://github.com/user-attachments/assets/c6a088ec-fdbc-4fec-8cd9-e3fe8d2dbb2a


After:

https://github.com/user-attachments/assets/35fc2cc9-f4fb-4afa-aa11-bac68a635bc5


