### PR TITLE
[Provisioning] Periodic sync and health check

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -49,9 +49,6 @@ const (
 	// Finished with success
 	JobStateSuccess JobState = "success"
 
-	// JobStatusSkipped is used when a job is skipped
-	JobStateSkipped JobState = "skipped"
-
 	// Finished with errors
 	JobStateError JobState = "error"
 )

--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -49,6 +49,9 @@ const (
 	// Finished with success
 	JobStateSuccess JobState = "success"
 
+	// JobStatusSkipped is used when a job is skipped
+	JobStateSkipped JobState = "skipped"
+
 	// Finished with errors
 	JobStateError JobState = "error"
 )

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -199,19 +199,6 @@ func (s *jobStore) Next(ctx context.Context) *provisioning.Job {
 	return nil
 }
 
-// Get the status for a job
-func (s *jobStore) Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	for _, job := range s.jobs {
-		if job.Name == name && job.Namespace == namespace {
-			return job.Status.DeepCopy()
-		}
-	}
-	return nil
-}
-
 // Complete implements JobQueue.
 func (s *jobStore) Update(ctx context.Context, namespace string, name string, status provisioning.JobStatus) error {
 	s.mutex.Lock()

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -199,6 +199,19 @@ func (s *jobStore) Next(ctx context.Context) *provisioning.Job {
 	return nil
 }
 
+// Get the status for a job
+func (s *jobStore) Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, job := range s.jobs {
+		if job.Name == name && job.Namespace == namespace {
+			return job.Status.DeepCopy()
+		}
+	}
+	return nil
+}
+
 // Complete implements JobQueue.
 func (s *jobStore) Update(ctx context.Context, namespace string, name string, status provisioning.JobStatus) error {
 	s.mutex.Lock()

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -8,7 +8,9 @@ import (
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
 
-var _ JobQueue = (*jobStore)(nil)
+var (
+	_ JobQueue = (*jobStore)(nil)
+)
 
 // Basic job queue infrastructure
 type JobQueue interface {
@@ -19,6 +21,9 @@ type JobQueue interface {
 
 	// Get the next job we should process
 	Next(ctx context.Context) *provisioning.Job
+
+	// Get the status for a job
+	Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus
 
 	// Update the status on a given job
 	// This is only valid if current job is not finished

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -8,9 +8,7 @@ import (
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
 
-var (
-	_ JobQueue = (*jobStore)(nil)
-)
+var _ JobQueue = (*jobStore)(nil)
 
 // Basic job queue infrastructure
 type JobQueue interface {
@@ -21,9 +19,6 @@ type JobQueue interface {
 
 	// Get the next job we should process
 	Next(ctx context.Context) *provisioning.Job
-
-	// Get the status for a job
-	Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus
 
 	// Update the status on a given job
 	// This is only valid if current job is not finished

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -416,7 +416,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			}
 			sharedInformerFactory := informers.NewSharedInformerFactory(
 				c,
-				30*time.Second, // Health and reconciliation interval check interval
+				10*time.Second, // Health and reconciliation interval check interval
 			)
 
 			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -331,7 +331,7 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 	}
 
 	if r.Spec.Sync.IntervalSeconds == 0 {
-		r.Spec.Sync.IntervalSeconds = int64(ResyncInterval / time.Second)
+		r.Spec.Sync.IntervalSeconds = 60
 	}
 
 	if r.Spec.Type == provisioning.GitHubRepositoryType {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -48,9 +48,7 @@ import (
 
 const repoControllerWorkers = 1
 
-var (
-	_ builder.APIGroupBuilder = (*APIBuilder)(nil)
-)
+var _ builder.APIGroupBuilder = (*APIBuilder)(nil)
 
 type APIBuilder struct {
 	urlProvider      func(namespace string) string
@@ -418,7 +416,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			}
 			sharedInformerFactory := informers.NewSharedInformerFactory(
 				c,
-				15*time.Minute, // Health check interval
+				30*time.Second, // Health and reconciliation interval check interval
 			)
 
 			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -331,7 +331,7 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 	}
 
 	if r.Spec.Sync.IntervalSeconds == 0 {
-		r.Spec.Sync.IntervalSeconds = 10
+		r.Spec.Sync.IntervalSeconds = int64(ResyncInterval / time.Second)
 	}
 
 	if r.Spec.Type == provisioning.GitHubRepositoryType {
@@ -420,7 +420,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			}
 			sharedInformerFactory := informers.NewSharedInformerFactory(
 				c,
-				10*time.Second, // Health and reconciliation interval check interval
+				ResyncInterval, // Health and reconciliation interval check interval
 			)
 
 			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -330,6 +330,10 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 		}
 	}
 
+	if r.Spec.Sync.IntervalSeconds == 0 {
+		r.Spec.Sync.IntervalSeconds = 10
+	}
+
 	if r.Spec.Type == provisioning.GitHubRepositoryType {
 		if r.Spec.GitHub == nil {
 			return fmt.Errorf("github configuration is required")

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -786,44 +786,34 @@ func (r *githubRepository) deleteWebhook(ctx context.Context) error {
 	return nil
 }
 
-func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.RepositoryStatus, error) {
+func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error) {
 	ctx, _ = r.logger(ctx, "")
 	hook, err := r.createWebhook(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	status := r.config.Status.DeepCopy()
-	status.Webhook = &provisioning.WebhookStatus{
+	return &provisioning.WebhookStatus{
 		ID:               hook.ID,
 		URL:              hook.URL,
 		Secret:           hook.Secret,
 		SubscribedEvents: hook.Events,
-	}
-
-	return status, nil
+	}, nil
 }
 
-func (r *githubRepository) OnUpdate(ctx context.Context) (*provisioning.RepositoryStatus, error) {
+func (r *githubRepository) OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error) {
 	ctx, _ = r.logger(ctx, "")
-	hook, updated, err := r.updateWebhook(ctx)
+	hook, _, err := r.updateWebhook(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if !updated {
-		return nil, nil
-	}
-
-	status := r.config.Status.DeepCopy()
-	status.Webhook = &provisioning.WebhookStatus{
+	return &provisioning.WebhookStatus{
 		ID:               hook.ID,
 		URL:              hook.URL,
 		Secret:           hook.Secret,
 		SubscribedEvents: hook.Events,
-	}
-
-	return status, nil
+	}, nil
 }
 
 func (r *githubRepository) OnDelete(ctx context.Context) error {

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -111,8 +111,8 @@ type Repository interface {
 
 // Hooks called after the repository has been created, updated or deleted
 type RepositoryHooks interface {
-	OnCreate(ctx context.Context) (*provisioning.RepositoryStatus, error)
-	OnUpdate(ctx context.Context) (*provisioning.RepositoryStatus, error)
+	OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error)
+	OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnDelete(ctx context.Context) error
 }
 

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -345,7 +345,7 @@ func (rc *RepositoryController) process(item *queueItem) error {
 			Spec: provisioning.JobSpec{
 				Repository: obj.GetName(),
 				Action:     provisioning.JobActionSync,
-				Sync:       &provisioning.SyncJobOptions{Complete: true},
+				Sync:       sync,
 			},
 		})
 		if err != nil {

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -28,7 +28,10 @@ import (
 
 const loggerName = "provisioning-repository-controller"
 
-const maxAttempts = 3
+const (
+	maxAttempts    = 3
+	ResyncInterval = 10 * time.Second
+)
 
 type queueItem struct {
 	key      string

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -230,7 +230,7 @@ func (rc *RepositoryController) process(item *queueItem) error {
 	isDelete := obj.DeletionTimestamp != nil
 
 	if !hasSpecChanged && !isDelete && !isFirstTime && !isStale {
-		logger.Info("conditions not met, skip processing", "health_age", healthAge, "has_spec_changed", hasSpecChanged, "deletion_timestamp", obj.DeletionTimestamp)
+		logger.Info("skip processing as conditions are not met", "stale", isStale, "spec_changed", hasSpecChanged)
 		return nil
 	}
 
@@ -281,7 +281,7 @@ func (rc *RepositoryController) process(item *queueItem) error {
 	}
 
 	if !hasHooks && !isStale && !hasSpecChanged {
-		logger.Info("no hooks, stale, or spec changed, skip processing")
+		logger.Info("no hooks, stale, or spec changed, skip processing", "has_hooks", hasHooks, "stale", isStale, "spec_changed", hasSpecChanged)
 		return nil
 	}
 

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"slices"
@@ -167,9 +168,10 @@ func ValidateRepository(repo repository.Repository) field.ErrorList {
 			"The target type is required when sync is enabled"))
 	}
 
-	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.IntervalSeconds < 10 {
+	resyncIntervalSeconds := int64(ResyncInterval / time.Second)
+	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.IntervalSeconds < resyncIntervalSeconds {
 		list = append(list, field.Invalid(field.NewPath("spec", "sync", "intervalSeconds"),
-			cfg.Spec.Sync.IntervalSeconds, "Interval must be at least 10 seconds"))
+			cfg.Spec.Sync.IntervalSeconds, fmt.Sprintf("Interval must be at least %d seconds", resyncIntervalSeconds)))
 	}
 
 	// Reserved names (for now)

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -167,6 +167,11 @@ func ValidateRepository(repo repository.Repository) field.ErrorList {
 			"The target type is required when sync is enabled"))
 	}
 
+	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.IntervalSeconds < 10 {
+		list = append(list, field.Invalid(field.NewPath("spec", "sync", "intervalSeconds"),
+			cfg.Spec.Sync.IntervalSeconds, "Interval must be at least 10 seconds"))
+	}
+
 	// Reserved names (for now)
 	reserved := []string{"classic", "sql", "SQL", "plugins", "legacy", "new", "job", "github", "s3", "gcs", "file", "new", "create", "update", "delete"}
 	if slices.Contains(reserved, cfg.Name) {


### PR DESCRIPTION
- Change informer interval to 10 seconds.
- Use sync interval from repository to limit how often we resync.
- Add mutator and validation to ensure the minimum interval is 10 seconds.
- Add more logging.
- Also skip job triggering if it's in pending state.


## How to test? 
If you go to the listing page, you will see resync triggering every 10 seconds. 


## Remarks
- The health check still doesn't work because the state gets overwritten by the job sync process in our main branch. I will investigate in a separate PR. --> I fix this one by patching the health in the controller. See in-line comment. 