### PR TITLE
CI: Backport to release branches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -755,7 +755,8 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/bump-version.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/close-milestone.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/release-pr.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/release-comms.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/migrate-prs.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/greate-next-release-branch.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/codeowners-validator.yml @tolzhabayev
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -757,7 +757,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/release-pr.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/release-comms.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/migrate-prs.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/greate-next-release-branch.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/create-next-release-branch.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/codeowners-validator.yml @tolzhabayev
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -755,6 +755,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/bump-version.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/close-milestone.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/release-pr.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/release-comms.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/migrate-prs.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/greate-next-release-branch.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/codeowners-validator.yml @tolzhabayev

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,11 +10,8 @@ jobs:
     if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
           ref: main
       - name: "Generate token"
         id: generate_token
@@ -24,8 +21,8 @@ jobs:
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - run: git config --global user.email '132647405+grafana-delivery-bot[bot]@users.noreply.github.com'
       - run: git config --global user.name 'grafana-delivery-bot[bot]'
-      - run: git remote set-url origin https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/grafana.git
+      - run: git remote set-url origin "https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/grafana.git"
       - name: Run backport
-        uses: ./actions/backport
+        uses: grafana/grafana-github-actions-go/backport@main
         with:
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,8 +23,8 @@ jobs:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - run: git config --global user.email '132647405+grafana-delivery-bot[bot]@users.noreply.github.com'
-      - run: git config --global user.name 'grafana-delivery-bot[bot]
-      - run: git remote set-url origin https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/backport-testing.git
+      - run: git config --global user.name 'grafana-delivery-bot[bot]'
+      - run: git remote set-url origin https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/grafana.git
       - name: Run backport
         uses: ./actions/backport
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,18 +16,16 @@ jobs:
           repository: "grafana/grafana-github-actions"
           path: ./actions
           ref: main
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
       - name: "Generate token"
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - run: git config --global user.email '132647405+grafana-delivery-bot[bot]@users.noreply.github.com'
+      - run: git config --global user.name 'grafana-delivery-bot[bot]
+      - run: git remote set-url origin https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/backport-testing.git
       - name: Run backport
         uses: ./actions/backport
         with:
-          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{ steps.generate_token.outputs.token }}
-          labelsToAdd: "backport"
-          title: "[{{base}}] {{originalTitle}}"

--- a/.github/workflows/create-next-release-branch.yml
+++ b/.github/workflows/create-next-release-branch.yml
@@ -2,30 +2,42 @@ name: Create next release branch
 on:
   workflow_call:
     inputs:
+      ownerRepo:
+        type: string
+        description: Owner/repo of the repository where the branch is created (e.g. 'grafana/grafana')
+        required: true
       source:
         description: The release branch to increment (eg providing `release-11.2.3` will result in `release-11.2.4` being created)
         type: string
         required: true
+    secrets:
+      token:
+        required: true
+    outputs:
+      branch:
+        description: The new branch that was created
+        value: ${{ jobs.main.outputs.branch }}
   workflow_dispatch:
     inputs:
+      ownerRepo:
+        description: Owner/repo of the repository where the branch is created (e.g. 'grafana/grafana')
       source:
         description: The release branch to increment (eg providing `release-11.2.3` will result in `release-11.2.4` being created)
         type: string
         required: true
-
+    secrets:
+      token:
+        required: true
 jobs:
   main:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-      - name: Bump release branch
+      - name: Create release branch
+        id: branch
         uses: grafana/grafana-github-actions-go/bump-release@main
         with:
-          token: ${{ steps.generate_token.outputs.token }}
-          ownerRepo: 'grafana/grafana'
+          ownerRepo: ${{ inputs.ownerRepo }}
           source: ${{ inputs.source }}
+          token: ${{ secrets.token }}

--- a/.github/workflows/create-next-release-branch.yml
+++ b/.github/workflows/create-next-release-branch.yml
@@ -1,0 +1,31 @@
+name: Create next release branch
+on:
+  workflow_call:
+    inputs:
+      source:
+        description: The release branch to increment (eg providing `release-11.2.3` will result in `release-11.2.4` being created)
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      source:
+        description: The release branch to increment (eg providing `release-11.2.3` will result in `release-11.2.4` being created)
+        type: string
+        required: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: Bump release branch
+        uses: grafana/grafana-github-actions-go/bump-release@main
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          ownerRepo: 'grafana/grafana'
+          source: ${{ inputs.source }}

--- a/.github/workflows/migrate-prs.yml
+++ b/.github/workflows/migrate-prs.yml
@@ -1,0 +1,50 @@
+name: Migrate open PRs
+# Migrate open PRs from a superseded release branch to the current release branch and notify authors
+on: 
+  workflow_call:
+    inputs:
+      from:
+        description: 'The base branch to check for open PRs'
+        required: true
+        type: string
+      to:
+        description: 'The base branch to migrate open PRs to'
+        required: true
+        type: string
+      ownerRepo:
+        description: Owner/repo of the repository where the branch is created (e.g. 'grafana/grafana')
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+  workflow_dispatch:
+    inputs:
+      from:
+        description: 'The base branch to check for open PRs'
+        required: true
+        type: string
+      to:
+        description: 'The base branch to migrate open PRs to'
+        required: true
+        type: string
+      ownerRepo:
+        description: Owner/repo of the repository where the branch is created (e.g. 'grafana/grafana')
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Migrate PRs
+        uses: grafana/grafana-github-actions-go/migrate-open-prs@main
+        with:
+          token: ${{ secrets.token }}
+          ownerRepo: ${{ inputs.ownerRepo }}
+          from: ${{ inputs.from }}
+          to: ${{ inputs.to }}
+          binary_release_tag: 'dev'

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -3,7 +3,7 @@ name: publish-technical-documentation-release
 on:
   push:
     branches:
-      - v[0-9]+.[0-9]+.x
+      - release-v[0-9]+.[0-9]+.[0-9]+
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
     paths:
@@ -23,7 +23,7 @@ jobs:
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
           release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
-          release_branch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.x$"
-          release_branch_with_patch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_with_patch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           website_directory: content/docs/grafana
           version_suffix: ""

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -27,10 +27,18 @@ jobs:
     name: Setup and establish latest
     outputs:
       version: ${{ steps.output.outputs.version }}
+      release_branch: ${{ steps.output.outputs.release_branch }}
       dry_run: ${{ steps.output.outputs.dry_run }}
       latest: ${{ steps.output.outputs.latest }}
+      token: ${{ steps.output.outputs.token }}
     runs-on: ubuntu-latest
     steps:
+    - name: "Generate token"
+      id: generate_token
+      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+      with:
+        app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+        private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       # The github-release action expects a `LATEST` value of a string of either '1' or '0'
     - if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
@@ -49,24 +57,51 @@ jobs:
         echo "latest: $LATEST"
         echo "version: $VERSION"
 
+        echo "release_branch=$(echo $VERSION | sed -s 's/^v/release-/g')" >> "$GITHUB_OUTPUT"
+        echo "token=${{ steps.generate_token.outputs.token }}" >> "$GITHUB_OUTPUT"
         echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
         echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-  create_next_release_branch:
+  create_next_release_branch_grafana:
+    name: Create next release branch (Grafana)
     needs: setup
     uses: ./.github/workflows/create-next-release-branch.yml
+    with:
+      ownerRepo: 'grafana/grafana'
+      source: ${{ needs.setup.outputs.release_branch }}
     secrets:
-      GRAFANA_DELIVERY_BOT_APP_ID: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-      GRAFANA_DELIVERY_BOT_APP_PEM: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-  migrate_prs:
-    needs: create_next_release_branch
+      token: ${{ needs.setup.outputs.token }}
+  create_next_release_branch_enterprise:
+    name: Create next release branch (Grafana Enterprise)
+    needs: setup
+    uses: ./.github/workflows/create-next-release-branch.yml
+    with:
+      ownerRepo: 'grafana/grafana'
+      source: ${{ needs.setup.outputs.release_branch }}
+    secrets:
+      token: ${{ needs.setup.outputs.token }}
+  migrate_prs_grafana:
+    needs:
+      - setup
+      - create_next_release_branch_grafana
     uses: ./.github/workflows/migrate-prs.yml
     with:
-      from:
-      to: 
+      ownerRepo: 'grafana/grafana'
+      from: ${{ needs.setup.outputs.release_branch }}
+      to: ${{ needs.create_next_release_branch_grafana.outputs.branch }}
     secrets:
-      GRAFANA_DELIVERY_BOT_APP_ID: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-      GRAFANA_DELIVERY_BOT_APP_PEM: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      token: ${{ needs.setup.outputs.token }}
+  migrate_prs_enterprise:
+    needs:
+      - setup
+      - create_next_release_branch_enterprise
+    uses: ./.github/workflows/migrate-prs.yml
+    with:
+      ownerRepo: 'grafana/grafana-enterprise'
+      from: ${{ needs.setup.outputs.release_branch }}
+      to: ${{ needs.create_next_release_branch_enterprise.outputs.branch }}
+    secrets:
+      token: ${{ needs.setup.outputs.token }}
   post_changelog_on_forum:
     needs: setup
     uses: ./.github/workflows/community-release.yml

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -52,6 +52,21 @@ jobs:
         echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
         echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  create_next_release_branch:
+    needs: setup
+    uses: ./.github/workflows/create-next-release-branch.yml
+    secrets:
+      GRAFANA_DELIVERY_BOT_APP_ID: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+      GRAFANA_DELIVERY_BOT_APP_PEM: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+  migrate_prs:
+    needs: create_next_release_branch
+    uses: ./.github/workflows/migrate-prs.yml
+    with:
+      from:
+      to: 
+    secrets:
+      GRAFANA_DELIVERY_BOT_APP_ID: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+      GRAFANA_DELIVERY_BOT_APP_PEM: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
   post_changelog_on_forum:
     needs: setup
     uses: ./.github/workflows/community-release.yml

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,7 +19,7 @@ on:
       target:
         required: true
         type: string
-        description: The base branch that these changes are being merged into
+        description: The release branch pattern (eg v9.5.x) that these changes are being merged into
       backport:
         required: false
         type: string
@@ -61,10 +61,17 @@ jobs:
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: Get release branch
+        id: branch
+        uses: grafana/grafana-github-actions-go/latest-release-branch@main
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          ownerRepo: 'grafana/grafana'
+          pattern: ${{ inputs.target }}
       - name: Checkout Grafana
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target }}
+          ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
           fetch-tags: true
       - name: Checkout Grafana (main)
@@ -124,7 +131,6 @@ jobs:
           rm -f CHANGELOG.part changelog_items.md
 
           git diff CHANGELOG.md
-          
       - name: "Prettify CHANGELOG.md"
         run: npx prettier --write CHANGELOG.md
       - name: Commit CHANGELOG.md changes
@@ -151,7 +157,7 @@ jobs:
             $( [ "x${{ inputs.latest }}" == "xtrue" ] && printf %s '-l "release/latest"') \
             -l "no-changelog" \
             --dry-run=${{ inputs.dry_run }} \
-            -B "${{ inputs.target }}" \
+            -B "${{ steps.branch.outputs.branch }}" \
             --title "Release: ${{ inputs.version }}" \
             --body "These code changes must be merged after a release is complete"
         env:
@@ -165,7 +171,7 @@ jobs:
             -l "product-approved" \
             -l "no-changelog" \
             --dry-run=${{ inputs.dry_run }} \
-            -B "${{ inputs.target }}" \
+            -B "${{ steps.branch.outputs.branch }}" \
             --title "Release: ${{ inputs.version }}" \
             --body "These code changes must be merged after a release is complete"
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -4,7 +4,7 @@
 # Please refrain from including any processes that do not result in code changes in this workflow. Instead, they should
 # either be triggered in the release promotion process or in the release comms process (that is triggered by merging
 # this PR).
-name: Complete a Grafana release
+name: Grafana Release PR
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This PR:

1. Changes backports so that they automatically go to the latest release branch (e.g. `release-11.2.3` instead of `11.2.x`)
2. Automatically creates new release branches after a release is done (When the "release PR" is merged)
3. Adds a workflow which changes the base branch of open PRs from the old release branch to the newest one/
4. Changes the branches that trigger docs updates from `next` branches to `release` branches.
5. Changes the release PR, which updates the package.json and changelog, to target `release` branches instead of the `next` branches.