### PR TITLE
Explore: Fix casing for `exploreHideLogsDownload` setting

### DIFF
--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -212,7 +212,7 @@ type FrontendSettingsDTO struct {
 	CSPReportOnlyEnabled                bool     `json:"cspReportOnlyEnabled"`
 	EnableFrontendSandboxForPlugins     []string `json:"enableFrontendSandboxForPlugins"`
 	ExploreDefaultTimeOffset            string   `json:"exploreDefaultTimeOffset"`
-	ExploreHideLogsDownload             bool     `json:"ExploreHideLogsDownload"`
+	ExploreHideLogsDownload             bool     `json:"exploreHideLogsDownload"`
 
 	Auth FrontendSettingsAuthDTO `json:"auth"`
 


### PR DESCRIPTION
**What is this feature?**

Fixing a silly casing mistake that breaks #99512