### PR TITLE
[Provisioning] Patch instead of Update in Controller

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -199,19 +199,6 @@ func (s *jobStore) Next(ctx context.Context) *provisioning.Job {
 	return nil
 }
 
-// Get the status for a job
-func (s *jobStore) Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	for _, job := range s.jobs {
-		if job.Name == name && job.Namespace == namespace {
-			return job.Status.DeepCopy()
-		}
-	}
-	return nil
-}
-
 // Complete implements JobQueue.
 func (s *jobStore) Update(ctx context.Context, namespace string, name string, status provisioning.JobStatus) error {
 	s.mutex.Lock()

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -8,9 +8,7 @@ import (
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
 
-var (
-	_ JobQueue = (*jobStore)(nil)
-)
+var _ JobQueue = (*jobStore)(nil)
 
 // Basic job queue infrastructure
 type JobQueue interface {
@@ -21,9 +19,6 @@ type JobQueue interface {
 
 	// Get the next job we should process
 	Next(ctx context.Context) *provisioning.Job
-
-	// Get the status for a job
-	Status(ctx context.Context, namespace string, name string) *provisioning.JobStatus
 
 	// Update the status on a given job
 	// This is only valid if current job is not finished

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -786,44 +786,34 @@ func (r *githubRepository) deleteWebhook(ctx context.Context) error {
 	return nil
 }
 
-func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.RepositoryStatus, error) {
+func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error) {
 	ctx, _ = r.logger(ctx, "")
 	hook, err := r.createWebhook(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	status := r.config.Status.DeepCopy()
-	status.Webhook = &provisioning.WebhookStatus{
+	return &provisioning.WebhookStatus{
 		ID:               hook.ID,
 		URL:              hook.URL,
 		Secret:           hook.Secret,
 		SubscribedEvents: hook.Events,
-	}
-
-	return status, nil
+	}, nil
 }
 
-func (r *githubRepository) OnUpdate(ctx context.Context) (*provisioning.RepositoryStatus, error) {
+func (r *githubRepository) OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error) {
 	ctx, _ = r.logger(ctx, "")
-	hook, updated, err := r.updateWebhook(ctx)
+	hook, _, err := r.updateWebhook(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if !updated {
-		return nil, nil
-	}
-
-	status := r.config.Status.DeepCopy()
-	status.Webhook = &provisioning.WebhookStatus{
+	return &provisioning.WebhookStatus{
 		ID:               hook.ID,
 		URL:              hook.URL,
 		Secret:           hook.Secret,
 		SubscribedEvents: hook.Events,
-	}
-
-	return status, nil
+	}, nil
 }
 
 func (r *githubRepository) OnDelete(ctx context.Context) error {

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -111,8 +111,8 @@ type Repository interface {
 
 // Hooks called after the repository has been created, updated or deleted
 type RepositoryHooks interface {
-	OnCreate(ctx context.Context) (*provisioning.RepositoryStatus, error)
-	OnUpdate(ctx context.Context) (*provisioning.RepositoryStatus, error)
+	OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error)
+	OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnDelete(ctx context.Context) error
 }
 


### PR DESCRIPTION
# Why? 

The controller triggers a bunch of changes in the status which interfere with each other depending on the order and lead to conflict responses from k8s APIs. 

Apart from that, the code in controller is getting unmanageable. So many pointers, conditions, etc. If we manage to use path, then we will be much happy thereafter. Less pointer hunt, less conflicts and we will be able to create small and isolated functions or delegate some logic to other packages. 

# How? 

- Use `PATCH` instead of UPDATE and avoid using pointers. 
- The patch in the controller will only update the `observedGeneration` if the spec changes (and the webhook status for now). 
- Controller won't update sync status. That will be responsibility of the sync job.  
- Controller will update health status independently of other operations. 