### PR TITLE
Explore metrics: Fix otel bug

### DIFF
--- a/public/app/features/trails/otel/util.ts
+++ b/public/app/features/trails/otel/util.ts
@@ -522,6 +522,7 @@ export async function updateOtelData(
       resettingOtel: false,
       afterFirstOtelCheck: true,
       isUpdatingOtel: false,
+      nonPromotedOtelResources,
     });
   }
 }


### PR DESCRIPTION
Fixes an OTel bug where changing resource attributes variable didn't update the variable because the nonPromotedResources collection had not been set, due to only setting it on the first check. Recently we had made the first check default to OTel off, so the nonPromotedResources collection were never being set. Fixed!

**Special notes for your reviewer:**
1. Select an OTel Prometheus data source
2. See the deployment env variable is selected.
3. Change the deployment environment variable.
4. See that the metrics change. If they do not, continue with steps.
5. Select a metric
6. Click open in explore
7. See that the deployment environment variable has been changed in the query.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
