### PR TITLE
ExploreMetrics: Preinstall metrics drilldown app

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1248,12 +1248,12 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	panelsSection := iniFile.Section("panels")
 	cfg.DisableSanitizeHtml = panelsSection.Key("disable_sanitize_html").MustBool(false)
 
-	if err := cfg.readPluginSettings(iniFile); err != nil {
+	// nolint:staticcheck
+	if err := cfg.readFeatureToggles(iniFile); err != nil {
 		return err
 	}
 
-	// nolint:staticcheck
-	if err := cfg.readFeatureToggles(iniFile); err != nil {
+	if err := cfg.readPluginSettings(iniFile); err != nil {
 		return err
 	}
 

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -26,13 +26,19 @@ func extractPluginSettings(sections []*ini.Section) PluginSettings {
 	return psMap
 }
 
-var (
-	defaultPreinstallPlugins = map[string]InstallPlugin{
+func getDefaultPreinstallPlugins(isFeatureToggleEnabled func(key string) bool) map[string]InstallPlugin {
+	plugins := map[string]InstallPlugin{
 		// Default preinstalled plugins
 		"grafana-lokiexplore-app": {"grafana-lokiexplore-app", "", ""},
 		"grafana-pyroscope-app":   {"grafana-pyroscope-app", "", ""},
 	}
-)
+
+	if isFeatureToggleEnabled("exploreMetricsUseExternalAppPlugin") {
+		plugins["grafana-metricsdrilldown-app"] = InstallPlugin{"grafana-metricsdrilldown-app", "", ""}
+	}
+
+	return plugins
+}
 
 func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	pluginsSection := iniFile.Section("plugins")
@@ -52,7 +58,7 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		rawInstallPlugins := util.SplitString(pluginsSection.Key("preinstall").MustString(""))
 		preinstallPlugins := make(map[string]InstallPlugin)
 		// Add the default preinstalled plugins
-		for _, plugin := range defaultPreinstallPlugins {
+		for _, plugin := range getDefaultPreinstallPlugins(cfg.IsFeatureToggleEnabled) {
 			preinstallPlugins[plugin.ID] = plugin
 		}
 		if cfg.IsFeatureToggleEnabled("grafanaAdvisor") { // Use literal string to avoid circular dependency

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -98,6 +98,8 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 
 	t.Run("when plugins.preinstall is defined", func(t *testing.T) {
+		cfg := NewCfg()
+		defaultPreinstallPlugins := getDefaultPreinstallPlugins(cfg.IsFeatureToggleEnabled)
 		defaultPreinstallPluginsList := make([]InstallPlugin, 0, len(defaultPreinstallPlugins))
 		defaultPreinstallPluginsIDs := []string{}
 		for _, p := range defaultPreinstallPlugins {

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -98,8 +98,6 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 
 	t.Run("when plugins.preinstall is defined", func(t *testing.T) {
-		cfg := NewCfg()
-		defaultPreinstallPlugins := getDefaultPreinstallPlugins(cfg.IsFeatureToggleEnabled)
 		defaultPreinstallPluginsList := make([]InstallPlugin, 0, len(defaultPreinstallPlugins))
 		defaultPreinstallPluginsIDs := []string{}
 		for _, p := range defaultPreinstallPlugins {


### PR DESCRIPTION
## Which issue does this close?

Closes #98991.

## What is this change?

1. This PR ensures that the [`grafana-metricsdrilldown-app`](https://github.com/grafana/metrics-drilldown) is preinstalled when the `exploreMetricsUseExternalAppPlugin` feature toggle is enabled.
2. This PR fixes an issue with the order of operations in `pkg/setting/setting.go`. Previously, we were unable to correctly access feature toggles with `cfg.IsFeatureToggleEnabled("<some-toggle>")` (it would return `false` even if the toggle was enabled). By reading the feature toggles before reading the plugin settings, `cfg.IsFeatureToggleEnabled("<some-toggle>")` works as expected in `cfg.readPluginSettings`.

## Notes to reviewers

- This PR will remain a draft until the `"grafana-metricsdrilldown-app"` app plugin is signed & available in the plugins registry (update: [done](https://grafana.com/grafana/plugins/grafana-metricsdrilldown-app) ✅)
- It's not great that we have to do `isFeatureToggleEnabled("exploreMetricsUseExternalAppPlugin")` instead of `isFeatureToggleEnabled(featuremgmt.FlagExploreMetricsUseExternalAppPlugin)`, but we can't import `featuremgmt` in `pkg/setting/setting_plugins.go` (it'd be a circular import). My hope is that because we intend to promote this feature toggle to GA pretty quickly (and then deprecate it), we'll be able to remove this conditional preinstall soon.

## How to test

1. If you have previously installed `grafana-metricsdrilldown-app` as a local unsigned plugin, please remove it so that we can test that this PR preinstalls `grafana-metricsdrilldown-app` from the plugins catalog. If you used the symlinking strategy described [here](https://github.com/grafana/metrics-drilldown/wiki/Local-development-guide#running-the-metrics-drilldown-app-in-grafanagrafana), you can simply delete the symlink with:

```
rm data/plugins/grafana-metricsdrilldown-app
```

2. Check out the `98991/install-metrics-app-by-default` branch.
3. In `conf/custom.ini`, ensure that the `exploreMetricsUseExternalAppPlugin` feature toggle is enabled.
4. After spinning up Grafana, navigating to [localhost:3000/plugins/grafana-metricsdrilldown-app](http://localhost:3000/plugins/grafana-metricsdrilldown-app) should show that the Grafana Metrics Drilldown app is installed:

![grafana plugins gmd installed](https://github.com/user-attachments/assets/2cab2f82-5d75-4853-a672-70646f6135f4)

5. When clicking **Drilldown** > **Metrics** in the sidebar, this should take you to [localhost:3000/a/grafana-metricsdrilldown-app.](http://localhost:3000/a/grafana-metricsdrilldown-app):

![grafana demo drilldown metrics routes to gmd app](https://github.com/user-attachments/assets/5cde394e-09a9-40aa-a1fa-e9cf444a8b37)
