### PR TITLE
ExploreMetrics: Use redirect to route traffic to metrics drilldown app

### DIFF
--- a/public/app/features/trails/RedirectToDrilldownApp.tsx
+++ b/public/app/features/trails/RedirectToDrilldownApp.tsx
@@ -1,0 +1,17 @@
+import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+
+import { getRouteForAppPlugin } from 'app/features/plugins/routes';
+
+/**
+ * Navigate to the drilldown app with the remaining path parameters and search params
+ */
+const RedirectToDrilldownApp = () => {
+  const { '*': remainingPath } = useParams();
+  const location = useLocation();
+  const appPath = getRouteForAppPlugin('grafana-metricsdrilldown-app').path.replace('*', '');
+  const newPath = `${appPath}${remainingPath}${location.search}`;
+
+  return <Navigate replace to={newPath} />;
+};
+
+export default RedirectToDrilldownApp;

--- a/public/app/features/trails/RedirectToDrilldownApp.tsx
+++ b/public/app/features/trails/RedirectToDrilldownApp.tsx
@@ -8,7 +8,7 @@ import { getRouteForAppPlugin } from 'app/features/plugins/routes';
 const RedirectToDrilldownApp = () => {
   const { '*': remainingPath } = useParams();
   const location = useLocation();
-  const appPath = getRouteForAppPlugin('grafana-metricsdrilldown-app').path.replace('*', '');
+  const appPath = getRouteForAppPlugin('grafana-metricsdrilldown-app').path.replaceAll('*', '');
   const newPath = `${appPath}${remainingPath}${location.search}`;
 
   return <Navigate replace to={newPath} />;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -15,7 +15,7 @@ import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { ConfigureIRM } from 'app/features/gops/configuration-tracker/components/ConfigureIRM';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
-import { getAppPluginRoutes, getRouteForAppPlugin } from 'app/features/plugins/routes';
+import { getAppPluginRoutes } from 'app/features/plugins/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';
 import { AccessControlAction, DashboardRoutes } from 'app/types';
 
@@ -518,7 +518,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       roles: () => contextSrv.evaluatePermission([AccessControlAction.DataSourcesExplore]),
       ...(config.featureToggles.exploreMetricsUseExternalAppPlugin
         ? {
-            component: getRouteForAppPlugin('grafana-metricsdrilldown-app').component,
+            component: SafeDynamicImport(
+              () =>
+                import(/* webpackChunkName: "MetricsDrilldownRedirect"*/ 'app/features/trails/RedirectToDrilldownApp')
+            ),
           }
         : {
             chromeless: false,


### PR DESCRIPTION
## Which issue does this fix?

Fixes #100096.

## What is this PR doing?

This PR updates the routing of `/explore/metrics/*` traffic when the `exploreMetricsUseExternalAppPlugin` feature toggle is enabled. Before, when the `exploreMetricsUseExternalAppPlugin` feature toggle was enabled, we kept the `/explore/metrics` URL but used the external app's `component`. As described in #100096, this can make it confusing to know at a glance whether you're in `public/app/features/trails` or if you're actually in the Metrics Drilldown app.

Now, when the `exploreMetricsUseExternalAppPlugin` feature toggle is enabled, we instead redirect `/explore/metrics/*` traffic to the equivalent `/a/grafana-metricsdrilldown-app` route.

## Demo

### Before

You can see another issue here...when we open the sidebar, it doesn't indicate that the **Explore > Metrics** route is the active route (because it's technically not!).

https://github.com/user-attachments/assets/e661c01b-85d8-44e8-b9e7-8c9b8280fbe0

### After

https://github.com/user-attachments/assets/da4fd713-ca83-4a57-a2fe-e7b426d98ab4

## How to test

1. If you haven't set up the `grafana-metricsdrilldown-app` yet, please follow these steps: https://github.com/grafana/metrics-drilldown/wiki/Developing-the-unsigned-app-plugin#running-the-metrics-drilldown-app-in-grafanagrafana.
2. With the `exploreMetricsUseExternalAppPlugin` feature toggle disabled, visit Explore Metrics, select a metric (try adding filters!), and then copy the URL.
3. Enable the `exploreMetricsUseExternalAppPlugin` feature toggle, then visit the URL you copied in the previous step (the path should start with `/explore/metrics`). You should see the same metric page contents you saw before, but the path should begin with `/a/grafana-metricsdrilldown-app` instead of `/explore/metrics`.