### PR TITLE
CloudMigrations: save snapshot of alert rule groups

### DIFF
--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -127,6 +127,7 @@ const (
 	FolderDataType           MigrateDataType = "FOLDER"
 	LibraryElementDataType   MigrateDataType = "LIBRARY_ELEMENT"
 	AlertRuleType            MigrateDataType = "ALERT_RULE"
+	AlertRuleGroupType       MigrateDataType = "ALERT_RULE_GROUP"
 	ContactPointType         MigrateDataType = "CONTACT_POINT"
 	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
 	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -821,8 +821,11 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool, cfgOverrides ...conf
 	secretsService := secretsfakes.NewFakeSecretsService()
 	rr := routing.NewRouteRegister()
 	tracer := tracing.InitializeTracerForTest()
+
+	fakeFolder := &folder.Folder{UID: "folderUID", Title: "Folder"}
 	mockFolder := &foldertest.FakeService{
-		ExpectedFolder: &folder.Folder{UID: "folderUID", Title: "Folder"},
+		ExpectedFolders: []*folder.Folder{fakeFolder},
+		ExpectedFolder:  fakeFolder,
 	}
 
 	cfg := setting.NewCfg()

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -43,6 +43,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.NotificationTemplateType,
 	cloudmigration.ContactPointType,
 	cloudmigration.NotificationPolicyType,
+	cloudmigration.AlertRuleGroupType,
 	cloudmigration.AlertRuleType,
 	cloudmigration.PluginDataType,
 }
@@ -103,6 +104,13 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	notificationPolicies, err := s.getNotificationPolicies(ctx, signedInUser)
 	if err != nil {
 		s.log.Error("Failed to get alert notification policies", "err", err)
+		return nil, err
+	}
+
+	// Alerts: Alert Rule Groups
+	alertRuleGroups, err := s.getAlertRuleGroups(ctx, signedInUser)
+	if err != nil {
+		s.log.Error("Failed to get alert rule groups", "err", err)
 		return nil, err
 	}
 
@@ -206,6 +214,15 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 			RefID: notificationPolicies.Name, // no UID available
 			Name:  notificationPolicies.Name,
 			Data:  notificationPolicies.Routes,
+		})
+	}
+
+	for _, alertRuleGroup := range alertRuleGroups {
+		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+			Type:  cloudmigration.AlertRuleGroupType,
+			RefID: alertRuleGroup.Title, // no UID available
+			Name:  alertRuleGroup.Title,
+			Data:  alertRuleGroup,
 		})
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -180,3 +180,61 @@ func (s *Service) getAlertRules(ctx context.Context, signedInUser *user.SignedIn
 
 	return provisionedAlertRules, nil
 }
+
+type alertRuleGroup struct {
+	Title     string      `json:"title"`
+	FolderUID string      `json:"folderUid"`
+	Interval  int64       `json:"interval"`
+	Rules     []alertRule `json:"rules"`
+}
+
+func (s *Service) getAlertRuleGroups(ctx context.Context, signedInUser *user.SignedInUser) ([]alertRuleGroup, error) {
+	alertRuleGroupsWithFolder, err := s.ngAlert.Api.AlertRules.GetAlertGroupsWithFolderFullpath(ctx, signedInUser, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching alert rule groups with folders: %w", err)
+	}
+
+	settingAlertRulesPaused := s.cfg.CloudMigration.AlertRulesState == setting.GMSAlertRulesPaused
+
+	alertRuleGroups := make([]alertRuleGroup, 0, len(alertRuleGroupsWithFolder))
+
+	for _, ruleGroup := range alertRuleGroupsWithFolder {
+		provisionedAlertRules := make([]alertRule, 0, len(ruleGroup.Rules))
+
+		for _, rule := range ruleGroup.Rules {
+			isPaused := rule.IsPaused
+			if settingAlertRulesPaused {
+				isPaused = true
+			}
+
+			provisionedAlertRules = append(provisionedAlertRules, alertRule{
+				ID:                   rule.ID,
+				UID:                  rule.UID,
+				OrgID:                rule.OrgID,
+				FolderUID:            rule.NamespaceUID,
+				RuleGroup:            rule.RuleGroup,
+				Title:                rule.Title,
+				For:                  model.Duration(rule.For),
+				Condition:            rule.Condition,
+				Data:                 ngalertapi.ApiAlertQueriesFromAlertQueries(rule.Data),
+				Updated:              rule.Updated,
+				NoDataState:          rule.NoDataState.String(),
+				ExecErrState:         rule.ExecErrState.String(),
+				Annotations:          rule.Annotations,
+				Labels:               rule.Labels,
+				IsPaused:             isPaused,
+				NotificationSettings: ngalertapi.AlertRuleNotificationSettingsFromNotificationSettings(rule.NotificationSettings),
+				Record:               ngalertapi.ApiRecordFromModelRecord(rule.Record),
+			})
+		}
+
+		alertRuleGroups = append(alertRuleGroups, alertRuleGroup{
+			Title:     ruleGroup.Title,
+			FolderUID: ruleGroup.FolderUID,
+			Interval:  ruleGroup.Interval,
+			Rules:     provisionedAlertRules,
+		})
+	}
+
+	return alertRuleGroups, nil
+}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -121,7 +121,7 @@ func TestGetAlertRules(t *testing.T) {
 
 		user := &user.SignedInUser{OrgID: 1}
 
-		alertRule := createAlertRule(t, ctx, s, user, false)
+		alertRule := createAlertRule(t, ctx, s, user, false, "")
 
 		alertRules, err := s.getAlertRules(ctx, user)
 		require.NoError(t, err)
@@ -138,10 +138,10 @@ func TestGetAlertRules(t *testing.T) {
 
 		user := &user.SignedInUser{OrgID: 1}
 
-		alertRulePaused := createAlertRule(t, ctx, s, user, true)
+		alertRulePaused := createAlertRule(t, ctx, s, user, true, "")
 		require.True(t, alertRulePaused.IsPaused)
 
-		alertRuleUnpaused := createAlertRule(t, ctx, s, user, false)
+		alertRuleUnpaused := createAlertRule(t, ctx, s, user, false, "")
 		require.False(t, alertRuleUnpaused.IsPaused)
 
 		alertRules, err := s.getAlertRules(ctx, user)
@@ -149,6 +149,83 @@ func TestGetAlertRules(t *testing.T) {
 		require.Len(t, alertRules, 2)
 		require.True(t, alertRules[0].IsPaused)
 		require.True(t, alertRules[1].IsPaused)
+	})
+}
+
+func TestGetAlertRuleGroups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("it returns the alert rule groups", func(t *testing.T) {
+		s := setUpServiceTest(t, false).(*Service)
+
+		user := &user.SignedInUser{OrgID: 1}
+
+		ruleGroupTitle := "ruleGroupTitle"
+
+		alertRule1 := createAlertRule(t, ctx, s, user, true, ruleGroupTitle)
+		alertRule2 := createAlertRule(t, ctx, s, user, false, ruleGroupTitle)
+		alertRule3 := createAlertRule(t, ctx, s, user, false, "anotherRuleGroup")
+
+		createAlertRuleGroup(t, ctx, s, user, ruleGroupTitle, []models.AlertRule{alertRule1, alertRule2})
+
+		ruleGroups, err := s.getAlertRuleGroups(ctx, user)
+		require.NoError(t, err)
+		require.Len(t, ruleGroups, 2)
+
+		for _, ruleGroup := range ruleGroups {
+			alertRuleUIDs := make([]string, 0)
+			for _, alertRule := range ruleGroup.Rules {
+				alertRuleUIDs = append(alertRuleUIDs, alertRule.UID)
+			}
+
+			if ruleGroup.Title == ruleGroupTitle {
+				require.Len(t, ruleGroup.Rules, 2)
+				require.ElementsMatch(t, []string{alertRule1.UID, alertRule2.UID}, alertRuleUIDs)
+			} else {
+				require.Len(t, ruleGroup.Rules, 1)
+				require.ElementsMatch(t, []string{alertRule3.UID}, alertRuleUIDs)
+			}
+		}
+	})
+
+	t.Run("with the alert rules state set to paused, it returns the alert rule groups with alert rules paused", func(t *testing.T) {
+		alertRulesState := func(c *setting.Cfg) {
+			c.CloudMigration.AlertRulesState = setting.GMSAlertRulesPaused
+		}
+
+		s := setUpServiceTest(t, false, alertRulesState).(*Service)
+
+		user := &user.SignedInUser{OrgID: 1}
+
+		ruleGroupTitle := "ruleGroupTitle"
+
+		alertRule1 := createAlertRule(t, ctx, s, user, true, ruleGroupTitle)
+		alertRule2 := createAlertRule(t, ctx, s, user, false, ruleGroupTitle)
+		alertRule3 := createAlertRule(t, ctx, s, user, false, "anotherRuleGroup")
+
+		createAlertRuleGroup(t, ctx, s, user, ruleGroupTitle, []models.AlertRule{alertRule1, alertRule2})
+
+		ruleGroups, err := s.getAlertRuleGroups(ctx, user)
+		require.NoError(t, err)
+		require.Len(t, ruleGroups, 2)
+
+		for _, ruleGroup := range ruleGroups {
+			alertRuleUIDs := make([]string, 0)
+			for _, alertRule := range ruleGroup.Rules {
+				alertRuleUIDs = append(alertRuleUIDs, alertRule.UID)
+
+				require.True(t, alertRule.IsPaused)
+			}
+
+			if ruleGroup.Title == ruleGroupTitle {
+				require.Len(t, ruleGroup.Rules, 2)
+				require.ElementsMatch(t, []string{alertRule1.UID, alertRule2.UID}, alertRuleUIDs)
+			} else {
+				require.Len(t, ruleGroup.Rules, 1)
+				require.ElementsMatch(t, []string{alertRule3.UID}, alertRuleUIDs)
+			}
+		}
 	})
 }
 
@@ -267,12 +344,12 @@ func updateNotificationPolicyTree(t *testing.T, ctx context.Context, service *Se
 	require.NoError(t, err)
 }
 
-func createAlertRule(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser, isPaused bool) models.AlertRule {
+func createAlertRule(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser, isPaused bool, ruleGroup string) models.AlertRule {
 	t.Helper()
 
 	rule := models.AlertRule{
 		OrgID:        user.GetOrgID(),
-		Title:        fmt.Sprintf("Alert Rule SLO (Paused: %v)", isPaused),
+		Title:        fmt.Sprintf("Alert Rule SLO (Paused: %v) - %v", isPaused, ruleGroup),
 		NamespaceUID: "folderUID",
 		Condition:    "A",
 		Data: []models.AlertQuery{
@@ -286,7 +363,7 @@ func createAlertRule(t *testing.T, ctx context.Context, service *Service, user *
 			},
 		},
 		IsPaused:        isPaused,
-		RuleGroup:       "ruleGroup",
+		RuleGroup:       ruleGroup,
 		For:             time.Minute,
 		IntervalSeconds: 60,
 		NoDataState:     models.OK,
@@ -297,4 +374,20 @@ func createAlertRule(t *testing.T, ctx context.Context, service *Service, user *
 	require.NoError(t, err)
 
 	return createdRule
+}
+
+func createAlertRuleGroup(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser, title string, rules []models.AlertRule) models.AlertRuleGroup {
+	t.Helper()
+
+	group := models.AlertRuleGroup{
+		Title:     title,
+		FolderUID: "folderUID",
+		Interval:  300,
+		Rules:     rules,
+	}
+
+	err := service.ngAlert.Api.AlertRules.ReplaceRuleGroup(ctx, user, group, "")
+	require.NoError(t, err)
+
+	return group
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -88,6 +88,7 @@ const (
 	FolderDataType           MigrateDataType = "FOLDER"
 	LibraryElementDataType   MigrateDataType = "LIBRARY_ELEMENT"
 	AlertRuleType            MigrateDataType = "ALERT_RULE"
+	AlertRuleGroupType       MigrateDataType = "ALERT_RULE_GROUP"
 	ContactPointType         MigrateDataType = "CONTACT_POINT"
 	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
 	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -5670,6 +5670,7 @@
             "FOLDER",
             "LIBRARY_ELEMENT",
             "ALERT_RULE",
+            "ALERT_RULE_GROUP",
             "CONTACT_POINT",
             "NOTIFICATION_POLICY",
             "NOTIFICATION_TEMPLATE",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -17190,6 +17190,7 @@
             "FOLDER",
             "LIBRARY_ELEMENT",
             "ALERT_RULE",
+            "ALERT_RULE_GROUP",
             "CONTACT_POINT",
             "NOTIFICATION_POLICY",
             "NOTIFICATION_TEMPLATE",

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -194,6 +194,7 @@ export type MigrateDataResponseItemDto = {
     | 'FOLDER'
     | 'LIBRARY_ELEMENT'
     | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
     | 'CONTACT_POINT'
     | 'NOTIFICATION_POLICY'
     | 'NOTIFICATION_TEMPLATE'

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -231,6 +231,8 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
       return <Icon size="xl" name="bell" />;
     case 'ALERT_RULE':
       return <Icon size="xl" name="bell" />;
+    case 'ALERT_RULE_GROUP':
+      return <Icon size="xl" name="bell" />;
     case 'PLUGIN':
       if (pluginLogo) {
         return <img className={styles.icon} src={pluginLogo} alt="" />;

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -23,6 +23,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.notification_policy', 'Notification Policy');
     case 'ALERT_RULE':
       return t('migrate-to-cloud.resource-type.alert_rule', 'Alert Rule');
+    case 'ALERT_RULE_GROUP':
+      return t('migrate-to-cloud.resource-type.alert_rule_group', 'Alert Rule Group');
     case 'PLUGIN':
       return t('migrate-to-cloud.resource-type.plugin', 'Plugin');
     default:

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -62,6 +62,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.notification_policies', 'notification policies'));
     } else if (type === 'ALERT_RULE') {
       types.push(t('migrate-to-cloud.migrated-counts.alert_rules', 'alert rules'));
+    } else if (type === 'ALERT_RULE_GROUP') {
+      types.push(t('migrate-to-cloud.migrated-counts.alert_rule_groups', 'alert rule groups'));
     } else if (type === 'PLUGIN') {
       types.push(t('migrate-to-cloud.migrated-counts.plugins', 'plugins'));
     }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1981,6 +1981,7 @@
       "title": "Let us help you migrate to this stack"
     },
     "migrated-counts": {
+      "alert_rule_groups": "alert rule groups",
       "alert_rules": "alert rules",
       "contact_points": "contact points",
       "dashboards": "dashboards",
@@ -2087,6 +2088,7 @@
     },
     "resource-type": {
       "alert_rule": "Alert Rule",
+      "alert_rule_group": "Alert Rule Group",
       "contact_point": "Contact Point",
       "dashboard": "Dashboard",
       "datasource": "Data source",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1981,6 +1981,7 @@
       "title": "Ŀęŧ ūş ĥęľp yőū mįģřäŧę ŧő ŧĥįş şŧäčĸ"
     },
     "migrated-counts": {
+      "alert_rule_groups": "äľęřŧ řūľę ģřőūpş",
       "alert_rules": "äľęřŧ řūľęş",
       "contact_points": "čőŉŧäčŧ pőįŉŧş",
       "dashboards": "đäşĥþőäřđş",
@@ -2087,6 +2088,7 @@
     },
     "resource-type": {
       "alert_rule": "Åľęřŧ Ŗūľę",
+      "alert_rule_group": "Åľęřŧ Ŗūľę Ğřőūp",
       "contact_point": "Cőŉŧäčŧ Pőįŉŧ",
       "dashboard": "Đäşĥþőäřđ",
       "datasource": "Đäŧä şőūřčę",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7258,6 +7258,7 @@
               "FOLDER",
               "LIBRARY_ELEMENT",
               "ALERT_RULE",
+              "ALERT_RULE_GROUP",
               "CONTACT_POINT",
               "NOTIFICATION_POLICY",
               "NOTIFICATION_TEMPLATE",


### PR DESCRIPTION
**What is this feature?**

We now create snapshots of alert rule groups, which was missing from the alerts-related resources.

We also need to backport it to v11.5.x as v11.5.0 was the first version with Alerts support in the migration assistant.

![Screenshot 2025-02-05 at 11 02 03](https://github.com/user-attachments/assets/75b5d150-db67-4d61-b0d6-18e3846ec920)
![Screenshot 2025-02-05 at 11 02 25](https://github.com/user-attachments/assets/212fb950-99f3-49f3-8c77-fefc30066ac8)


**Why do we need this feature?**

This fixes an issue where alert rules with non-default evaluation intervals (!= 1min) would not be migrated properly, because we were not migrating their alert rule group definitions which contained the interval information.

**Who is this feature for?**

Cloud Migration Assistant users.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1168

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
