### PR TITLE
Storybook: Support an arbitrary number of themes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,6 @@
     "slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
     "@types/slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
     "@types/slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
-    "storybook-dark-mode", // 4.0.2 causes storybook 8.4 to break with react hooks errors
     // Temporarily pause updating lerna and nx until we resolve build issues
     "lerna",
     "nx"

--- a/packages/grafana-ui/.storybook/main.ts
+++ b/packages/grafana-ui/.storybook/main.ts
@@ -43,7 +43,6 @@ const mainConfig: StorybookConfig = {
       },
     },
     getAbsolutePath('@storybook/addon-storysource'),
-    getAbsolutePath('storybook-dark-mode'),
     getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
   ],
   framework: {

--- a/packages/grafana-ui/.storybook/manager.ts
+++ b/packages/grafana-ui/.storybook/manager.ts
@@ -1,6 +1,8 @@
 import { addons } from '@storybook/manager-api';
-import { GrafanaDark } from './storybookTheme';
+import { getThemeById } from '@grafana/data';
+import { createStorybookTheme } from './storybookTheme';
 
+const darkTheme = getThemeById('debug');
 addons.setConfig({
   isFullscreen: false,
   panelPosition: 'right',
@@ -10,5 +12,5 @@ addons.setConfig({
   sidebar: {
     showRoots: true,
   },
-  theme: GrafanaDark,
+  theme: createStorybookTheme(darkTheme),
 });

--- a/packages/grafana-ui/.storybook/manager.ts
+++ b/packages/grafana-ui/.storybook/manager.ts
@@ -2,7 +2,7 @@ import { addons } from '@storybook/manager-api';
 import { getThemeById } from '@grafana/data';
 import { createStorybookTheme } from './storybookTheme';
 
-const darkTheme = getThemeById('dark');
+const systemTheme = getThemeById('system');
 addons.setConfig({
   isFullscreen: false,
   panelPosition: 'right',
@@ -12,5 +12,5 @@ addons.setConfig({
   sidebar: {
     showRoots: true,
   },
-  theme: createStorybookTheme(darkTheme),
+  theme: createStorybookTheme(systemTheme),
 });

--- a/packages/grafana-ui/.storybook/manager.ts
+++ b/packages/grafana-ui/.storybook/manager.ts
@@ -2,7 +2,7 @@ import { addons } from '@storybook/manager-api';
 import { getThemeById } from '@grafana/data';
 import { createStorybookTheme } from './storybookTheme';
 
-const darkTheme = getThemeById('debug');
+const darkTheme = getThemeById('dark');
 addons.setConfig({
   isFullscreen: false,
   panelPosition: 'right',

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -66,7 +66,7 @@ const preview: Preview = {
     theme: {
       name: 'Theme',
       description: 'Global theme for components',
-      defaultValue: 'dark',
+      defaultValue: 'system',
       toolbar: {
         icon: 'paintbrush',
         items: getBuiltInThemes(true).map((theme) => ({

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import { Preview } from '@storybook/react';
 import 'jquery';
-import { getTimeZone, getTimeZones } from '@grafana/data';
+import { getBuiltInThemes, getTimeZone, getTimeZones, GrafanaTheme2 } from '@grafana/data';
 
 import '../../../public/vendor/flot/jquery.flot.js';
 import '../../../public/vendor/flot/jquery.flot.selection';
@@ -20,10 +20,9 @@ import { ThemedDocsContainer } from '../src/utils/storybook/ThemedDocsContainer'
 import lightTheme from '../../../public/sass/grafana.light.scss';
 // @ts-ignore
 import darkTheme from '../../../public/sass/grafana.dark.scss';
-import { GrafanaDark, GrafanaLight } from './storybookTheme';
 
-const handleThemeChange = (theme: any) => {
-  if (theme !== 'light') {
+const handleThemeChange = (theme: GrafanaTheme2) => {
+  if (theme.colors.mode !== 'light') {
     lightTheme.unuse();
     darkTheme.use();
   } else {
@@ -36,10 +35,6 @@ const preview: Preview = {
   decorators: [withTheme(handleThemeChange), withTimeZone()],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
-    darkMode: {
-      dark: GrafanaDark,
-      light: GrafanaLight,
-    },
     docs: {
       container: ThemedDocsContainer,
     },
@@ -68,6 +63,19 @@ const preview: Preview = {
     },
   },
   globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'paintbrush',
+        items: getBuiltInThemes(['debug']).map((theme) => ({
+          value: theme.id,
+          title: theme.name,
+        })),
+        showName: true,
+      },
+    },
     timeZone: {
       description: 'Set the timezone for the storybook preview',
       defaultValue: getTimeZone(),

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -31,6 +31,8 @@ const handleThemeChange = (theme: GrafanaTheme2) => {
   }
 };
 
+const showExtraThemes = process.env.NODE_ENV === 'development';
+
 const preview: Preview = {
   decorators: [withTheme(handleThemeChange), withTimeZone()],
   parameters: {
@@ -69,7 +71,7 @@ const preview: Preview = {
       defaultValue: 'system',
       toolbar: {
         icon: 'paintbrush',
-        items: getBuiltInThemes(true).map((theme) => ({
+        items: getBuiltInThemes(showExtraThemes).map((theme) => ({
           value: theme.id,
           title: theme.name,
         })),

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -69,7 +69,7 @@ const preview: Preview = {
       defaultValue: 'dark',
       toolbar: {
         icon: 'paintbrush',
-        items: getBuiltInThemes(['debug']).map((theme) => ({
+        items: getBuiltInThemes(true).map((theme) => ({
           value: theme.id,
           title: theme.name,
         })),

--- a/packages/grafana-ui/.storybook/storybookTheme.ts
+++ b/packages/grafana-ui/.storybook/storybookTheme.ts
@@ -1,8 +1,7 @@
-import { GrafanaTheme2, createTheme } from '@grafana/data';
-//@ts-ignore
+import { GrafanaTheme2 } from '@grafana/data';
 import { create } from '@storybook/theming';
 
-const createStorybookTheme = (theme: GrafanaTheme2) => {
+export const createStorybookTheme = (theme: GrafanaTheme2) => {
   return create({
     base: theme.colors.mode,
     colorPrimary: theme.colors.primary.main,
@@ -38,8 +37,3 @@ const createStorybookTheme = (theme: GrafanaTheme2) => {
     brandImage: `public/img/grafana_text_logo-${theme.colors.mode}.svg`,
   });
 };
-
-const GrafanaLight = createStorybookTheme(createTheme({ colors: { mode: 'light' } }));
-const GrafanaDark = createStorybookTheme(createTheme({ colors: { mode: 'dark' } }));
-
-export { GrafanaLight, GrafanaDark };

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -180,7 +180,6 @@
     "rollup-plugin-svg-import": "3.0.0",
     "sass-loader": "16.0.4",
     "storybook": "^8.4.2",
-    "storybook-dark-mode": "4.0.1",
     "style-loader": "4.0.0",
     "typescript": "5.7.3",
     "webpack": "5.97.1"

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -13,10 +13,12 @@ type Props = {
 };
 
 export const ThemedDocsContainer = ({ children, context }: Props) => {
-  // TODO figure out how to make this work for docs not attached to stories (e.g. Intro)
-  const story = context.storyById();
-  const { globals } = context.getStoryContext(story);
-  const { theme: themeId } = globals;
+  let themeId = 'system';
+  if (context.componentStories().length > 0) {
+    const story = context.storyById();
+    const { globals } = context.getStoryContext(story);
+    themeId = globals.theme;
+  }
   const theme = getThemeById(themeId);
 
   return (

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -13,9 +13,10 @@ type Props = {
 };
 
 export const ThemedDocsContainer = ({ children, context }: Props) => {
-  console.log(context);
-  // const [{theme: themeId}] = useGlobals();
-  const theme = getThemeById('');
+  const story = context.storyById();
+  const { globals } = context.getStoryContext(story);
+  const { theme: themeId } = globals;
+  const theme = getThemeById(themeId);
 
   return (
     <DocsContainer theme={createStorybookTheme(theme)} context={context}>

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -13,6 +13,8 @@ type Props = {
 };
 
 export const ThemedDocsContainer = ({ children, context }: Props) => {
+  // Default to system theme for pages that don't have associated stories
+  // Currently this is only the case for the docs `Intro` page
   let themeId = 'system';
   if (context.componentStories().length > 0) {
     const story = context.storyById();

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -1,9 +1,10 @@
-// Wrap the DocsContainer for storybook-dark-mode theme switching support.
+// Wrap the DocsContainer for theme switching support.
 import { DocsContainer, DocsContextProps } from '@storybook/addon-docs';
 import * as React from 'react';
-import { useDarkMode } from 'storybook-dark-mode';
 
-import { GrafanaLight, GrafanaDark } from '../../../.storybook/storybookTheme';
+import { getThemeById } from '@grafana/data';
+
+import { createStorybookTheme } from '../../../.storybook/storybookTheme';
 import { GlobalStyles } from '../../themes';
 
 type Props = {
@@ -12,10 +13,12 @@ type Props = {
 };
 
 export const ThemedDocsContainer = ({ children, context }: Props) => {
-  const dark = useDarkMode();
+  console.log(context);
+  // const [{theme: themeId}] = useGlobals();
+  const theme = getThemeById('');
 
   return (
-    <DocsContainer theme={dark ? GrafanaDark : GrafanaLight} context={context}>
+    <DocsContainer theme={createStorybookTheme(theme)} context={context}>
       <GlobalStyles />
       {children}
     </DocsContainer>

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -13,6 +13,7 @@ type Props = {
 };
 
 export const ThemedDocsContainer = ({ children, context }: Props) => {
+  // TODO figure out how to make this work for docs not attached to stories (e.g. Intro)
   const story = context.storyById();
   const { globals } = context.getStoryContext(story);
   const { theme: themeId } = globals;

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -1,17 +1,17 @@
 import { Decorator } from '@storybook/react';
 import * as React from 'react';
-import { useDarkMode } from 'storybook-dark-mode';
 
-import { createTheme, GrafanaTheme2, ThemeContext } from '@grafana/data';
+import { getThemeById, GrafanaTheme2, ThemeContext } from '@grafana/data';
 
 import { GlobalStyles } from '../../themes/GlobalStyles/GlobalStyles';
 
 type SassThemeChangeHandler = (theme: GrafanaTheme2) => void;
-const ThemeableStory = ({
-  children,
-  handleSassThemeChange,
-}: React.PropsWithChildren<{ handleSassThemeChange: SassThemeChangeHandler }>) => {
-  const theme = createTheme({ colors: { mode: useDarkMode() ? 'dark' : 'light' } });
+interface ThemeableStoryProps {
+  themeId: string;
+  handleSassThemeChange: SassThemeChangeHandler;
+}
+const ThemeableStory = ({ children, handleSassThemeChange, themeId }: React.PropsWithChildren<ThemeableStoryProps>) => {
+  const theme = getThemeById(themeId);
 
   handleSassThemeChange(theme);
 
@@ -38,4 +38,8 @@ const ThemeableStory = ({
 export const withTheme =
   (handleSassThemeChange: SassThemeChangeHandler): Decorator =>
   // eslint-disable-next-line react/display-name
-  (story) => <ThemeableStory handleSassThemeChange={handleSassThemeChange}>{story()}</ThemeableStory>;
+  (story, context) => (
+    <ThemeableStory themeId={context.globals.theme} handleSassThemeChange={handleSassThemeChange}>
+      {story()}
+    </ThemeableStory>
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,7 +4129,6 @@ __metadata:
     slate-plain-serializer: "npm:0.7.13"
     slate-react: "npm:0.22.10"
     storybook: "npm:^8.4.2"
-    storybook-dark-mode: "npm:4.0.1"
     style-loader: "npm:4.0.0"
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.8.1"
@@ -7524,7 +7523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:8.4.4, @storybook/components@npm:^8.0.0, @storybook/components@npm:^8.4.2":
+"@storybook/components@npm:8.4.4, @storybook/components@npm:^8.4.2":
   version: 8.4.4
   resolution: "@storybook/components@npm:8.4.4"
   peerDependencies:
@@ -7533,7 +7532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:^8.0.0, @storybook/core-events@npm:^8.4.2":
+"@storybook/core-events@npm:^8.4.2":
   version: 8.4.4
   resolution: "@storybook/core-events@npm:8.4.4"
   peerDependencies:
@@ -7605,7 +7604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/icons@npm:^1.2.12, @storybook/icons@npm:^1.2.5":
+"@storybook/icons@npm:^1.2.12":
   version: 1.2.12
   resolution: "@storybook/icons@npm:1.2.12"
   peerDependencies:
@@ -7615,7 +7614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-api@npm:8.4.4, @storybook/manager-api@npm:^8.0.0, @storybook/manager-api@npm:^8.4.2":
+"@storybook/manager-api@npm:8.4.4, @storybook/manager-api@npm:^8.4.2":
   version: 8.4.4
   resolution: "@storybook/manager-api@npm:8.4.4"
   peerDependencies:
@@ -7766,7 +7765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:8.4.4, @storybook/theming@npm:^8.0.0, @storybook/theming@npm:^8.4.2":
+"@storybook/theming@npm:8.4.4, @storybook/theming@npm:^8.4.2":
   version: 8.4.4
   resolution: "@storybook/theming@npm:8.4.4"
   peerDependencies:
@@ -28883,22 +28882,6 @@ __metadata:
   version: 3.7.0
   resolution: "std-env@npm:3.7.0"
   checksum: 10/6ee0cca1add3fd84656b0002cfbc5bfa20340389d9ba4720569840f1caa34bce74322aef4c93f046391583e50649d0cf81a5f8fe1d411e50b659571690a45f12
-  languageName: node
-  linkType: hard
-
-"storybook-dark-mode@npm:4.0.1":
-  version: 4.0.1
-  resolution: "storybook-dark-mode@npm:4.0.1"
-  dependencies:
-    "@storybook/components": "npm:^8.0.0"
-    "@storybook/core-events": "npm:^8.0.0"
-    "@storybook/global": "npm:^5.0.0"
-    "@storybook/icons": "npm:^1.2.5"
-    "@storybook/manager-api": "npm:^8.0.0"
-    "@storybook/theming": "npm:^8.0.0"
-    fast-deep-equal: "npm:^3.1.3"
-    memoizerific: "npm:^1.11.3"
-  checksum: 10/3225e5bdaba0ea76b65d642202d9712d7de234e3b5673fb46e444892ab114be207dd287778e2002b662ec35bb8153d2624ff280ce51c5299fb13c711431dad40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes `storybook-dark-mode`
- adds a storybook global, `theme`
  - this defaults to `system`
  - this shows extra themes when running in development, but only `system`, `dark` + `light` in production
- there are 2 downsides i can't figure out how to workaround:
  - this does not change the _storybook manager ui theme_ (this stays as `system`)
  - this does not change the _theme for docs pages with no associated story_ (this stays as `system`)
    - the only occurrence of this is the `Intro` page, which doesn't render any components anyway
  - i don't think either of these are that important tbh, but if we could find a way to handle them properly that would be even better 😄 

**Why do we need this feature?**

- support for more themes in storybook

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
