### PR TITLE
Advisor: Fix Healtcheck check

### DIFF
--- a/apps/advisor/pkg/app/checkregistry/checkregistry.go
+++ b/apps/advisor/pkg/app/checkregistry/checkregistry.go
@@ -6,9 +6,9 @@ import (
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks/plugincheck"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/repo"
-	"github.com/grafana/grafana/pkg/registry/apis/datasource"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/managedplugins"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugincontext"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugininstaller"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 )
@@ -20,7 +20,7 @@ type CheckService interface {
 type Service struct {
 	datasourceSvc         datasources.DataSourceService
 	pluginStore           pluginstore.Store
-	pluginContextProvider datasource.PluginContextWrapper
+	pluginContextProvider *plugincontext.Provider
 	pluginClient          plugins.Client
 	pluginRepo            repo.Service
 	pluginPreinstall      plugininstaller.Preinstall
@@ -28,7 +28,7 @@ type Service struct {
 }
 
 func ProvideService(datasourceSvc datasources.DataSourceService, pluginStore pluginstore.Store,
-	pluginContextProvider datasource.PluginContextWrapper, pluginClient plugins.Client,
+	pluginContextProvider *plugincontext.Provider, pluginClient plugins.Client,
 	pluginRepo repo.Service, pluginPreinstall plugininstaller.Preinstall, managedPlugins managedplugins.Manager) *Service {
 	return &Service{
 		datasourceSvc:         datasourceSvc,

--- a/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	advisor "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/registry/apis/datasource"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +30,8 @@ func TestCheck_Run(t *testing.T) {
 			PluginClient:          mockPluginClient,
 		}
 
-		report, err := check.Run(context.Background(), &advisor.CheckSpec{})
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+		report, err := check.Run(ctx, &advisor.CheckSpec{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, int64(2), report.Count)
@@ -51,7 +53,8 @@ func TestCheck_Run(t *testing.T) {
 			PluginClient:          mockPluginClient,
 		}
 
-		report, err := check.Run(context.Background(), &advisor.CheckSpec{})
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+		report, err := check.Run(ctx, &advisor.CheckSpec{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), report.Count)
@@ -74,7 +77,8 @@ func TestCheck_Run(t *testing.T) {
 			PluginClient:          mockPluginClient,
 		}
 
-		report, err := check.Run(context.Background(), &advisor.CheckSpec{})
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+		report, err := check.Run(ctx, &advisor.CheckSpec{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), report.Count)
@@ -94,12 +98,10 @@ func (m *MockDatasourceSvc) GetAllDataSources(ctx context.Context, query *dataso
 }
 
 type MockPluginContextProvider struct {
-	datasource.PluginContextWrapper
-
 	pCtx backend.PluginContext
 }
 
-func (m *MockPluginContextProvider) PluginContextForDataSource(ctx context.Context, datasourceSettings *backend.DataSourceInstanceSettings) (backend.PluginContext, error) {
+func (m *MockPluginContextProvider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error) {
 	return m.pCtx, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

`PluginContextProvider.PluginContextForDataSource` does not return JsonData nor SecureJsonData in the plugin context, which cause the failure of the HealthCheck. `GetWithDataSource` from `*plugincontext.Provider` returns the complete context.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Follow up of [#284](https://github.com/grafana/grafana-community-team/issues/284)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
