### PR TITLE
Authz: Check for parent uid instead of id

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
+
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -732,6 +733,8 @@ func (dr *DashboardServiceImpl) SaveDashboard(ctx context.Context, dto *dashboar
 		return nil, err
 	}
 
+	fmt.Println("Save dashboard")
+
 	// new dashboard created
 	if dto.Dashboard.ID == 0 {
 		dr.setDefaultPermissions(ctx, dto, dash, false)
@@ -989,10 +992,8 @@ func (dr *DashboardServiceImpl) setDefaultPermissions(ctx context.Context, dto *
 	}
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
-	// nolint:staticcheck
-	inFolder := dash.FolderID > 0
-	var permissions []accesscontrol.SetResourcePermissionCommand
 
+	var permissions []accesscontrol.SetResourcePermissionCommand
 	if !provisioned && dto.User.IsIdentityType(claims.TypeUser, claims.TypeServiceAccount) {
 		userID, err := dto.User.GetInternalID()
 		if err != nil {
@@ -1004,7 +1005,7 @@ func (dr *DashboardServiceImpl) setDefaultPermissions(ctx context.Context, dto *
 		}
 	}
 
-	if !inFolder {
+	if dash.FolderUID == "" {
 		permissions = append(permissions, []accesscontrol.SetResourcePermissionCommand{
 			{BuiltinRole: string(org.RoleEditor), Permission: dashboardaccess.PERMISSION_EDIT.String()},
 			{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_VIEW.String()},
@@ -1025,9 +1026,7 @@ func (dr *DashboardServiceImpl) setDefaultFolderPermissions(ctx context.Context,
 		return
 	}
 
-	inFolder := f.ParentUID != ""
 	var permissions []accesscontrol.SetResourcePermissionCommand
-
 	if !provisioned && cmd.SignedInUser.IsIdentityType(claims.TypeUser) {
 		userID, err := cmd.SignedInUser.GetInternalID()
 		if err != nil {
@@ -1039,7 +1038,7 @@ func (dr *DashboardServiceImpl) setDefaultFolderPermissions(ctx context.Context,
 		}
 	}
 
-	if !inFolder {
+	if f.ParentUID == "" {
 		permissions = append(permissions, []accesscontrol.SetResourcePermissionCommand{
 			{BuiltinRole: string(org.RoleEditor), Permission: dashboardaccess.PERMISSION_EDIT.String()},
 			{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_VIEW.String()},

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -733,8 +733,6 @@ func (dr *DashboardServiceImpl) SaveDashboard(ctx context.Context, dto *dashboar
 		return nil, err
 	}
 
-	fmt.Println("Save dashboard")
-
 	// new dashboard created
 	if dto.Dashboard.ID == 0 {
 		dr.setDefaultPermissions(ctx, dto, dash, false)


### PR DESCRIPTION
**What is this feature?**
We should check FolderUID of dashboards when determine if they have a parent or not.

Otherwise we always apply default permissions, even for dashboards that have a folder.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
