### PR TITLE
Combobox: fix check for existing options when creating a custom value

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -244,7 +244,7 @@ describe('Combobox', () => {
       expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
     });
 
-    it('should not allow creating a custom value when the value already exists', async () => {
+    it('should allow creating a custom value just when the value does not exist previously', async () => {
       const onChangeHandler = jest.fn();
       render(<Combobox options={options} value={null} onChange={onChangeHandler} createCustomValue />);
       const input = screen.getByRole('combobox');
@@ -252,7 +252,9 @@ describe('Combobox', () => {
       await userEvent.keyboard('{Enter}');
       expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
       expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ value: '4' }));
-      expect(onChangeHandler).not.toHaveBeenCalledWith(expect.objectContaining({ description: undefined }));
+      await userEvent.type(input, '4s');
+      await userEvent.keyboard('{Enter}');
+      expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
     });
 
     it('should provide custom string when all options are numbers', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -244,7 +244,7 @@ describe('Combobox', () => {
       expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
     });
 
-    it('should allow creating a custom value just when the value does not exist previously', async () => {
+    it('should not allow creating a custom value when it is an existing value', async () => {
       const onChangeHandler = jest.fn();
       render(<Combobox options={options} value={null} onChange={onChangeHandler} createCustomValue />);
       const input = screen.getByRole('combobox');
@@ -252,9 +252,7 @@ describe('Combobox', () => {
       await userEvent.keyboard('{Enter}');
       expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
       expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ value: '4' }));
-      await userEvent.type(input, '4s');
-      await userEvent.keyboard('{Enter}');
-      expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
+      expect(onChangeHandler).not.toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
     });
 
     it('should provide custom string when all options are numbers', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -241,7 +241,18 @@ describe('Combobox', () => {
       await userEvent.keyboard('{Enter}');
 
       expect(screen.getByDisplayValue('Use custom value')).toBeInTheDocument();
-      expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ value: 'Use custom value' }));
+      expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));
+    });
+
+    it('should not allow creating a custom value when the value already exists', async () => {
+      const onChangeHandler = jest.fn();
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} createCustomValue />);
+      const input = screen.getByRole('combobox');
+      await userEvent.type(input, '4');
+      await userEvent.keyboard('{Enter}');
+      expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
+      expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ value: '4' }));
+      expect(onChangeHandler).not.toHaveBeenCalledWith(expect.objectContaining({ description: undefined }));
     });
 
     it('should provide custom string when all options are numbers', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -250,6 +250,7 @@ describe('Combobox', () => {
       const input = screen.getByRole('combobox');
       await userEvent.type(input, '4');
       await userEvent.keyboard('{Enter}');
+      expect(screen.queryByDisplayValue('Use custom value')).not.toBeInTheDocument();
       expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
       expect(onChangeHandler).toHaveBeenCalledWith(expect.objectContaining({ value: '4' }));
       expect(onChangeHandler).not.toHaveBeenCalledWith(expect.objectContaining({ description: 'Use custom value' }));

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -129,9 +129,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       let itemsToSet = items;
       logOptions(itemsToSet.length, RECOMMENDED_ITEMS_AMOUNT, id, ariaLabelledBy);
       if (inputValue && createCustomValue) {
-        const optionMatchingInput = items.find(
-          (opt) => opt.label === 'Custom value: ' + inputValue || opt.value === inputValue
-        );
+        const optionMatchingInput = items.find((opt) => opt.value === inputValue);
 
         if (!optionMatchingInput) {
           const customValueOption = {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -129,7 +129,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       let itemsToSet = items;
       logOptions(itemsToSet.length, RECOMMENDED_ITEMS_AMOUNT, id, ariaLabelledBy);
       if (inputValue && createCustomValue) {
-        const optionMatchingInput = items.find((opt) => opt.value === inputValue);
+        const optionMatchingInput = items.find((opt) => opt.value === inputValue || opt.label === inputValue);
 
         if (!optionMatchingInput) {
           const customValueOption = {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -129,7 +129,9 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       let itemsToSet = items;
       logOptions(itemsToSet.length, RECOMMENDED_ITEMS_AMOUNT, id, ariaLabelledBy);
       if (inputValue && createCustomValue) {
-        const optionMatchingInput = items.find((opt) => opt.value === inputValue || opt.label === inputValue);
+        //Since the label of a normal option does not have to match its value and a custom option has the same value and label,
+        //we just focus on the value to check if the option already exists
+        const optionMatchingInput = items.find((opt) => opt.value === inputValue);
 
         if (!optionMatchingInput) {
           const customValueOption = {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -62,7 +62,9 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
     (opts: Array<ComboboxOption<T>>) => {
       let currentOptions: Array<ComboboxOption<T>> = opts;
       if (createCustomValue && userTypedSearch) {
-        const customValueExists = opts.some((opt) => opt.value === userTypedSearch || opt.label === userTypedSearch);
+        //Since the label of a normal option does not have to match its value and a custom option has the same value and label,
+        //we just focus on the value to check if the option already exists
+        const customValueExists = opts.some((opt) => opt.value === userTypedSearch);
         if (!customValueExists) {
           currentOptions = [
             {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -62,7 +62,7 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
     (opts: Array<ComboboxOption<T>>) => {
       let currentOptions: Array<ComboboxOption<T>> = opts;
       if (createCustomValue && userTypedSearch) {
-        const customValueExists = opts.some((opt) => opt.value === userTypedSearch);
+        const customValueExists = opts.some((opt) => opt.value === userTypedSearch || opt.label === userTypedSearch);
         if (!customValueExists) {
           currentOptions = [
             {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix the checking for existing options that match the custom value.

**Why do we need this feature?**
To avoid adding a custom value when it already exists.

**Who is this feature for?**
Everyone using `Combobox` and `MultiCombobox`

**Which issue(s) does this PR fix?**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
