### PR TITLE
Docs: move missing ref URI to correct page

### DIFF
--- a/docs/sources/dashboards/create-reports/_index.md
+++ b/docs/sources/dashboards/create-reports/_index.md
@@ -19,11 +19,6 @@ title: Create and manage reports
 description: Generate and share PDF reports from your Grafana dashboards
 weight: 600
 refs:
-  change-ui-theme:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/organization-preferences/#change-grafana-ui-theme
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/organization-preferences/#change-grafana-ui-theme
   grafana-enterprise:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/

--- a/docs/sources/dashboards/create-reports/report-settings/index.md
+++ b/docs/sources/dashboards/create-reports/report-settings/index.md
@@ -11,6 +11,12 @@ menuTitle: Settings
 title: Reporting settings
 description: Manage organizational Reporting settings
 weight: 700
+refs:
+  change-ui-theme:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/organization-preferences/#change-grafana-ui-theme
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/organization-preferences/#change-grafana-ui-theme
 ---
 
 # Reporting settings


### PR DESCRIPTION
Moved `change-ui-theme` ref URI from **Create reports** page to **Report settings** page 
