### PR TITLE
TableNG: Image cell implementation

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -1,0 +1,36 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { TableCellDisplayMode } from '@grafana/schema';
+
+import { useStyles2 } from '../../../../themes';
+import { getCellOptions } from '../../utils';
+import { ImageCellProps } from '../types';
+
+const DATALINKS_HEIGHT_OFFSET = 10;
+
+export const ImageCell = ({ field, height, value }: ImageCellProps) => {
+  const calculatedHeight = height - DATALINKS_HEIGHT_OFFSET;
+  const styles = useStyles2(getStyles, calculatedHeight);
+
+  const cellOptions = getCellOptions(field);
+  const { text } = field.display!(value);
+  const { alt, title } =
+    cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { alt: undefined, title: undefined };
+
+  const img = <img alt={alt} src={text} className={styles.image} title={title} />;
+
+  // TODO: Implement DataLinksContextMenu + actions
+  return <div className={styles.imageContainer}>{img}</div>;
+};
+
+const getStyles = (theme: GrafanaTheme2, height: number) => ({
+  image: css({
+    height,
+    width: 'auto',
+  }),
+  imageContainer: css({
+    display: 'flex',
+    justifyContent: 'center',
+  }),
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { Property } from 'csstype';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { TableCellDisplayMode } from '@grafana/schema';
@@ -9,9 +10,9 @@ import { ImageCellProps } from '../types';
 
 const DATALINKS_HEIGHT_OFFSET = 10;
 
-export const ImageCell = ({ field, height, value }: ImageCellProps) => {
+export const ImageCell = ({ field, height, justifyContent, value }: ImageCellProps) => {
   const calculatedHeight = height - DATALINKS_HEIGHT_OFFSET;
-  const styles = useStyles2(getStyles, calculatedHeight);
+  const styles = useStyles2(getStyles, calculatedHeight, justifyContent);
 
   const cellOptions = getCellOptions(field);
   const { text } = field.display!(value);
@@ -24,13 +25,13 @@ export const ImageCell = ({ field, height, value }: ImageCellProps) => {
   return <div className={styles.imageContainer}>{img}</div>;
 };
 
-const getStyles = (theme: GrafanaTheme2, height: number) => ({
+const getStyles = (theme: GrafanaTheme2, height: number, justifyContent: Property.JustifyContent | undefined) => ({
   image: css({
     height,
     width: 'auto',
   }),
   imageContainer: css({
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent,
   }),
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -5,16 +5,14 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { TableCellDisplayMode } from '@grafana/schema';
 
 import { useStyles2 } from '../../../../themes';
-import { getCellOptions } from '../../utils';
 import { ImageCellProps } from '../types';
 
 const DATALINKS_HEIGHT_OFFSET = 10;
 
-export const ImageCell = ({ field, height, justifyContent, value }: ImageCellProps) => {
+export const ImageCell = ({ cellOptions, field, height, justifyContent, value }: ImageCellProps) => {
   const calculatedHeight = height - DATALINKS_HEIGHT_OFFSET;
   const styles = useStyles2(getStyles, calculatedHeight, justifyContent);
 
-  const cellOptions = getCellOptions(field);
   const { text } = field.display!(value);
   const { alt, title } =
     cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { alt: undefined, title: undefined };
@@ -25,7 +23,7 @@ export const ImageCell = ({ field, height, justifyContent, value }: ImageCellPro
   return <div className={styles.imageContainer}>{img}</div>;
 };
 
-const getStyles = (theme: GrafanaTheme2, height: number, justifyContent: Property.JustifyContent | undefined) => ({
+const getStyles = (theme: GrafanaTheme2, height: number, justifyContent: Property.JustifyContent) => ({
   image: css({
     height,
     width: 'auto',

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -4,6 +4,7 @@ import { TableCellDisplayMode } from '@grafana/schema';
 
 import AutoCell from './AutoCell';
 import { BarGaugeCell } from './BarGaugeCell';
+import { ImageCell } from './ImageCell';
 import { SparklineCell } from './SparklineCell';
 
 // interface TableCellNGProps {
@@ -61,6 +62,9 @@ export function TableCellNG(props: any) {
           width={divWidth}
         />
       );
+      break;
+    case TableCellDisplayMode.Image:
+      cell = <ImageCell value={value} field={field} height={height} />;
       break;
     case TableCellDisplayMode.Auto:
     default:

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -64,7 +64,7 @@ export function TableCellNG(props: any) {
       );
       break;
     case TableCellDisplayMode.Image:
-      cell = <ImageCell value={value} field={field} height={height} />;
+      cell = <ImageCell field={field} height={height} justifyContent={justifyContent} value={value} />;
       break;
     case TableCellDisplayMode.Auto:
     default:

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -96,7 +96,15 @@ export function TableCellNG(props: any) {
       );
       break;
     case TableCellDisplayMode.Image:
-      cell = <ImageCell field={field} height={height} justifyContent={justifyContent} value={value} />;
+      cell = (
+        <ImageCell
+          cellOptions={fieldConfig.custom.cellOptions}
+          field={field}
+          height={height}
+          justifyContent={justifyContent}
+          value={value}
+        />
+      );
       break;
     case TableCellDisplayMode.JSONView:
       cell = <JSONCell value={value} justifyContent={justifyContent} />;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -1,6 +1,7 @@
 import { Property } from 'csstype';
 
 import { Field, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { TableCellOptions } from '@grafana/schema';
 
 export interface CellNGProps {
   value: any;
@@ -24,6 +25,7 @@ export interface BarGaugeCellProps extends CellNGProps {
 }
 
 export interface ImageCellProps extends CellNGProps {
+  cellOptions: TableCellOptions;
   height: number;
 }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -5,7 +5,7 @@ import { Field, GrafanaTheme2, TimeRange } from '@grafana/data';
 export interface CellNGProps {
   value: any;
   field: Field;
-  theme: GrafanaTheme2;
+  theme?: GrafanaTheme2;
   height?: number;
   justifyContent?: Property.JustifyContent;
   rowIdx?: number;
@@ -22,6 +22,10 @@ export interface BarGaugeCellProps extends CellNGProps {
   height: number;
   width: number;
   timeRange: TimeRange;
+}
+
+export interface ImageCellProps extends CellNGProps {
+  height: number;
 }
 
 export interface SparklineCellProps extends BarGaugeCellProps {}


### PR DESCRIPTION
### What does this PR do? 📓 

Implements feature parity for `ImageCell` as a part of TableNG.

Note: Still have to implement actions + datalinks.

Fixes #94771 

#### Current Table 📷 

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/8f694718-63ae-4eb7-8bea-162ea3c63058" />

#### TableNG 📷 

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/0cab08c8-bb43-428e-89bd-2dc2e15b7d96" />