### PR TITLE
Alerting: Remove id and org_id from grafana alert rule API model

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -585,8 +585,6 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 
 	gettableExtendedRuleNode := apimodels.GettableExtendedRuleNode{
 		GrafanaManagedAlert: &apimodels.GettableGrafanaRule{
-			ID:                   r.ID,
-			OrgID:                r.OrgID,
 			Title:                r.Title,
 			Condition:            r.Condition,
 			Data:                 ApiAlertQueriesFromAlertQueries(r.Data),

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1593,10 +1593,6 @@
      ],
      "type": "string"
     },
-    "id": {
-     "format": "int64",
-     "type": "integer"
-    },
     "intervalSeconds": {
      "format": "int64",
      "type": "integer"
@@ -1620,10 +1616,6 @@
     },
     "notification_settings": {
      "$ref": "#/definitions/AlertRuleNotificationSettings"
-    },
-    "orgId": {
-     "format": "int64",
-     "type": "integer"
     },
     "provenance": {
      "$ref": "#/definitions/Provenance"

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -550,8 +550,6 @@ type PostableGrafanaRule struct {
 
 // swagger:model
 type GettableGrafanaRule struct {
-	ID                   int64                          `json:"id" yaml:"id"`
-	OrgID                int64                          `json:"orgId" yaml:"orgId"`
 	Title                string                         `json:"title" yaml:"title"`
 	Condition            string                         `json:"condition" yaml:"condition"`
 	Data                 []AlertQuery                   `json:"data" yaml:"data"`

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1593,10 +1593,6 @@
      ],
      "type": "string"
     },
-    "id": {
-     "format": "int64",
-     "type": "integer"
-    },
     "intervalSeconds": {
      "format": "int64",
      "type": "integer"
@@ -1620,10 +1616,6 @@
     },
     "notification_settings": {
      "$ref": "#/definitions/AlertRuleNotificationSettings"
-    },
-    "orgId": {
-     "format": "int64",
-     "type": "integer"
     },
     "provenance": {
      "$ref": "#/definitions/Provenance"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5281,10 +5281,6 @@
             "Error"
           ]
         },
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "intervalSeconds": {
           "type": "integer",
           "format": "int64"
@@ -5308,10 +5304,6 @@
         },
         "notification_settings": {
           "$ref": "#/definitions/AlertRuleNotificationSettings"
-        },
-        "orgId": {
-          "type": "integer",
-          "format": "int64"
         },
         "provenance": {
           "$ref": "#/definitions/Provenance"

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -1143,8 +1143,6 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"__panelId__": "1"
 			},
 			"grafana_alert": {
-				"id": 1,
-				"orgId": 1,
 				"title": "AlwaysFiring",
 				"condition": "A",
 				"data": [{
@@ -1186,8 +1184,6 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 			"expr": "",
 			"for":"0s",
 			"grafana_alert": {
-				"id": 2,
-				"orgId": 1,
 				"title": "AlwaysFiringButSilenced",
 				"condition": "A",
 				"data": [{
@@ -1241,8 +1237,6 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"__panelId__": "1"
 			},
 			"grafana_alert": {
-				"id": 1,
-				"orgId": 1,
 				"title": "AlwaysFiring",
 				"condition": "A",
 				"data": [{
@@ -2525,8 +2519,6 @@ func TestIntegrationQuota(t *testing.T) {
 					       "expr":"",
 						   "for": "2m",
 					       "grafana_alert":{
-						  "id":1,
-						  "orgId":1,
 						  "title":"Updated alert rule",
 						  "condition":"A",
 						  "data":[
@@ -2640,8 +2632,6 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 									"annotation1": "val1"
 								},
 								"grafana_alert": {
-									"id": 1,
-									"orgId": 1,
 									"title": "rule under folder default",
 									"condition": "A",
 									"data": [
@@ -3123,8 +3113,6 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 							"label1": "val1"
 					   },
 					   "grafana_alert":{
-						  "id":1,
-						  "orgId":1,
 						  "title":"AlwaysFiring",
 						  "condition":"A",
 						  "data":[
@@ -3169,8 +3157,6 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					   "expr":"",
 					   "for": "0s",
 					   "grafana_alert":{
-						  "id":2,
-						  "orgId":1,
 						  "title":"AlwaysFiringButSilenced",
 						  "condition":"A",
 						  "data":[
@@ -3487,8 +3473,6 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 							"label2": "val2"
 					   },
 		               "grafana_alert":{
-		                  "id":1,
-		                  "orgId":1,
 		                  "title":"AlwaysNormal",
 		                  "condition":"A",
 		                  "data":[
@@ -3606,8 +3590,6 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 				       "expr":"",
 				       "for": "30s",
 				       "grafana_alert":{
-					  "id":1,
-					  "orgId":1,
 					  "title":"AlwaysNormal",
 					  "condition":"A",
 					  "data":[
@@ -3704,8 +3686,6 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 				       "expr":"",
                        "for": "30s",
 				       "grafana_alert":{
-					  "id":1,
-					  "orgId":1,
 					  "title":"AlwaysNormal",
 					  "condition":"A",
 					  "data":[

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -1583,7 +1583,6 @@ func TestIntegrationRuleCreate(t *testing.T) {
 						},
 					},
 					GrafanaManagedAlert: &apimodels.GettableGrafanaRule{
-						OrgID:     1,
 						Title:     "test1 rule1",
 						Condition: "A",
 						Data: []apimodels.AlertQuery{

--- a/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
@@ -12,8 +12,6 @@
         "annotation": "test-annotation"
       },
       "grafana_alert": {
-        "id": 1,
-        "orgId": 1,
         "title": "Rule1",
         "condition": "A",
         "data": [
@@ -60,8 +58,6 @@
         "annotation": "test-annotation"
       },
       "grafana_alert": {
-        "id": 2,
-        "orgId": 1,
         "title": "Rule2",
         "condition": "A",
         "data": [

--- a/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
@@ -12,8 +12,6 @@
         "annotation": "test-annotation"
       },
       "grafana_alert": {
-        "id": 3,
-        "orgId": 1,
         "title": "Rule3",
         "condition": "A",
         "data": [

--- a/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
@@ -12,8 +12,6 @@
         "annotation": "test-annotation"
       },
       "grafana_alert": {
-        "id": 1,
-        "orgId": 1,
         "title": "Rule1",
         "condition": "A",
         "data": [
@@ -60,8 +58,6 @@
         "annotation": "test-annotation"
       },
       "grafana_alert": {
-        "id": 2,
-        "orgId": 1,
         "title": "Rule2",
         "condition": "A",
         "data": [

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -16013,10 +16013,6 @@
             "Error"
           ]
         },
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "intervalSeconds": {
           "type": "integer",
           "format": "int64"
@@ -16040,10 +16036,6 @@
         },
         "notification_settings": {
           "$ref": "#/definitions/AlertRuleNotificationSettings"
-        },
-        "orgId": {
-          "type": "integer",
-          "format": "int64"
         },
         "provenance": {
           "$ref": "#/definitions/Provenance"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6087,10 +6087,6 @@
             ],
             "type": "string"
           },
-          "id": {
-            "format": "int64",
-            "type": "integer"
-          },
           "intervalSeconds": {
             "format": "int64",
             "type": "integer"
@@ -6114,10 +6110,6 @@
           },
           "notification_settings": {
             "$ref": "#/components/schemas/AlertRuleNotificationSettings"
-          },
-          "orgId": {
-            "format": "int64",
-            "type": "integer"
           },
           "provenance": {
             "$ref": "#/components/schemas/Provenance"


### PR DESCRIPTION
**What is this feature?**
This PR removes identifiers ID and OrgID from the API model of the alert rule.

**Why do we need this feature?**
1. They are just implementation details of the storage and do not serve any purpose. 
2. The new diff feature shows JSON diff and exposes those unnecessary fields. 

**Special notes for your reviewer:**
This is part of an unstable API; therefore, no deprecation time or additional notifications are necessary. 

