### PR TITLE
Alerting: Remove ID and OrgID from hash calculation

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -314,8 +314,6 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 
 	// fields that do not affect the state.
 	// TODO consider removing fields below from the fingerprint
-	writeInt(rule.ID)
-	writeInt(rule.OrgID)
 	writeInt(int64(rule.For))
 	if rule.DashboardUID != nil {
 		writeString(*rule.DashboardUID)

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -262,6 +262,8 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			"UpdatedBy":       {},
 			"IntervalSeconds": {},
 			"Annotations":     {},
+			"ID":              {},
+			"OrgID":           {},
 		}
 
 		tp := reflect.TypeOf(rule).Elem()


### PR DESCRIPTION
**What is this feature?**
This PR removes fields ID and OrgID from the calculation of the hash that is used to determine changes in the rule to reset a state.

**Why do we need this feature?**
The fields are just implementation details of the storage and are not used anywhere in state manager. However, sometimes (for example, provisioning API) the request ends up in re-creating a rule under a new ID, which resets the state even though the rule specification does not change. 

Related to: https://github.com/grafana/grafana/issues/83250

