### PR TITLE
Allow barWidth values between 0 and 2 to allow overlapping bars in a bar chart

### DIFF
--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -199,7 +199,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(BarChartPanel)
         defaultValue: defaultOptions.barWidth,
         settings: {
           min: 0,
-          max: 1,
+          max: 2,
           step: 0.01,
         },
       })

--- a/public/app/plugins/panel/barchart/panelcfg.cue
+++ b/public/app/plugins/panel/barchart/panelcfg.cue
@@ -50,8 +50,8 @@ composableKinds: PanelCfg: {
 					stacking: common.StackingMode & (*"none" | _)
 					// This controls whether values are shown on top or to the left of bars.
 					showValue: common.VisibilityMode & (*"auto" | _)
-					// Controls the width of bars. 1 = Max width, 0 = Min width.
-					barWidth: float64 & >=0 & <=1 | *0.97
+					// Controls the width of bars. 2 = Max width, 0 = Min width.
+					barWidth: float64 & >=0 & <=3 | *0.97
 					// Controls the width of groups. 1 = max with, 0 = min width.
 					groupWidth: float64 & >=0 & <=1 | *0.7
 					// Enables mode which highlights the entire bar area and shows tooltip when cursor

--- a/public/app/plugins/panel/barchart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/barchart/panelcfg.gen.ts
@@ -16,7 +16,7 @@ export interface Options extends common.OptionsWithLegend, common.OptionsWithToo
    */
   barRadius?: number;
   /**
-   * Controls the width of bars. 1 = Max width, 0 = Min width.
+   * Controls the width of bars. 2 = Max width, 0 = Min width.
    */
   barWidth: number;
   /**


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This change allows a user to specify a `barWidth` value in the range 0 to 2 in the UI. Currently, the UI limits the value of `barWidth` to the range 0 to 1. 

**Why do we need this feature?**

Users may want the bars in their bar chart to overlap. This is prevented in the UI by limiting the value of `barWidth` to the range 0 to 1. Users can set this value to a value >1 by editing the dashboard json file and importing it, or provisioning it. This change allows users to set the `barWidth` value in the UI to a value between 0 and 2.

With `barWidth` set to `1.7` the bar chart appears as follows...
![Screenshot 2025-02-05 at 12 25 24 PM](https://github.com/user-attachments/assets/2b6f6843-42c8-4fae-a0cc-8e00613d3f98)

With `barWidth` set to `2` the bar chart appears as follows...
![Screenshot 2025-02-05 at 12 25 36 PM](https://github.com/user-attachments/assets/128376a3-161a-4519-8b3a-63d8ebeb0fef)


**Who is this feature for?**

This change is for users who are creating bar chart visualizations in grafana.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #91973

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
