### PR TITLE
Explore metrics: Add option to use regex

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -653,6 +653,8 @@ function getVariableSet(
         layout: 'vertical',
         defaultKeys: [],
         applyMode: 'manual',
+        supportsMultiValueOperators: true,
+        allowCustomValue: true,
       }),
       new AdHocFiltersVariable({
         name: VAR_FILTERS,
@@ -666,6 +668,7 @@ function getVariableSet(
         applyMode: 'manual',
         // since we only support prometheus datasources, this is always true
         supportsMultiValueOperators: true,
+        allowCustomValue: true,
       }),
       ...getVariablesWithOtelJoinQueryConstant(otelJoinQuery ?? ''),
       new ConstantVariable({
@@ -689,6 +692,7 @@ function getVariableSet(
         applyMode: 'manual',
         // since we only support prometheus datasources, this is always true
         supportsMultiValueOperators: true,
+        allowCustomValue: true,
         // skipUrlSync: true
       }),
       // Legacy variable needed for bookmarking which is necessary because


### PR DESCRIPTION
There was a change in Scenes recently that removed regex operators in the adhoc filters variable if the config option "allowCustomValue" was not defined.

https://github.com/grafana/scenes/pull/1031

This change fixes that and ensures similar operators across all adhoc variable filters in the app.

**Special notes for your reviewer:**
1. Open explore metrics app and start and exploration.
2. Click on a variable filter at the top of the app.
3. See the `=~` operator available as a selection for operators.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
