### PR TITLE
TableNG: JSON cell implementation + hover fixes

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
@@ -1,63 +1,21 @@
 import { css } from '@emotion/css';
 import { Property } from 'csstype';
-import { useRef } from 'react';
 
 import { GrafanaTheme2, formattedValueToString } from '@grafana/data';
 
 import { useStyles2 } from '../../../../themes';
 import { CellNGProps } from '../types';
 
-interface AutoCellProps extends CellNGProps {
-  shouldTextOverflow: () => boolean;
-  setIsHovered: (isHovered: boolean) => void;
-}
-
-// z-index value to be able to show the full text on hover
-const CELL_Z_INDEX = '1';
-
-export default function AutoCell({ value, field, justifyContent, shouldTextOverflow }: AutoCellProps) {
+export default function AutoCell({ value, field, justifyContent }: CellNGProps) {
   const displayValue = field.display!(value);
   const formattedValue = formattedValueToString(displayValue);
 
   const styles = useStyles2(getStyles, justifyContent);
-  const divRef = useRef<HTMLDivElement>(null);
 
-  const handleMouseEnter = () => {
-    if (!shouldTextOverflow()) {
-      return;
-    }
-
-    // TODO: The table cell styles in TableNG do not update dynamically even if we change the state
-    const div = divRef.current;
-    const tableCellDiv = div?.parentElement?.parentElement;
-    tableCellDiv?.style.setProperty('position', 'absolute');
-    tableCellDiv?.style.setProperty('top', '0');
-    tableCellDiv?.style.setProperty('z-index', CELL_Z_INDEX);
-    tableCellDiv?.style.setProperty('white-space', 'normal');
-  };
-
-  const handleMouseLeave = () => {
-    if (!shouldTextOverflow()) {
-      return;
-    }
-
-    // TODO: The table cell styles in TableNG do not update dynamically even if we change the state
-    const div = divRef.current;
-    const tableCellDiv = div?.parentElement?.parentElement;
-    tableCellDiv?.style.setProperty('position', 'relative');
-    tableCellDiv?.style.removeProperty('top');
-    tableCellDiv?.style.removeProperty('z-index');
-    tableCellDiv?.style.setProperty('white-space', 'nowrap');
-  };
-
-  return (
-    <div ref={divRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className={styles.cell}>
-      {formattedValue}
-    </div>
-  );
+  return <div className={styles.cell}>{formattedValue}</div>;
 }
 
-const getStyles = (theme: GrafanaTheme2, justifyContent: Property.JustifyContent) => ({
+const getStyles = (theme: GrafanaTheme2, justifyContent: Property.JustifyContent | undefined) => ({
   cell: css({
     display: 'flex',
     justifyContent: justifyContent,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
@@ -20,6 +20,7 @@ export const JSONCell = ({ value }: Omit<CellNGProps, 'theme' | 'field'>) => {
     displayValue = JSON.stringify(localValue, null, ' ');
   }
 
+  // TODO: Implement DataLinksContextMenu + actions
   return <div className={styles.jsonText}>{displayValue}</div>;
 };
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/css';
+import { isString } from 'lodash';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../../../themes';
+import { CellNGProps } from '../types';
+
+export const JSONCell = ({ value }: Omit<CellNGProps, 'theme' | 'field'>) => {
+  const styles = useStyles2(getStyles);
+
+  let localValue = value;
+  let displayValue = localValue;
+
+  if (isString(localValue)) {
+    try {
+      localValue = JSON.parse(localValue);
+    } catch {} // ignore errors
+  } else {
+    displayValue = JSON.stringify(localValue, null, ' ');
+  }
+
+  return <div className={styles.jsonText}>{displayValue}</div>;
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  jsonText: css({
+    cursor: 'pointer',
+    fontFamily: 'monospace',
+  }),
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { Property } from 'csstype';
 import { isString } from 'lodash';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -6,8 +7,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '../../../../themes';
 import { CellNGProps } from '../types';
 
-export const JSONCell = ({ value }: Omit<CellNGProps, 'theme' | 'field'>) => {
-  const styles = useStyles2(getStyles);
+export const JSONCell = ({ value, justifyContent }: Omit<CellNGProps, 'theme' | 'field'>) => {
+  const styles = useStyles2(getStyles, justifyContent);
 
   let localValue = value;
   let displayValue = localValue;
@@ -24,9 +25,11 @@ export const JSONCell = ({ value }: Omit<CellNGProps, 'theme' | 'field'>) => {
   return <div className={styles.jsonText}>{displayValue}</div>;
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, justifyContent: Property.JustifyContent) => ({
   jsonText: css({
+    display: 'flex',
     cursor: 'pointer',
     fontFamily: 'monospace',
+    justifyContent: justifyContent,
   }),
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -88,7 +88,7 @@ export function TableCellNG(props: any) {
       );
       break;
     case TableCellDisplayMode.JSONView:
-      cell = <JSONCell value={value} />;
+      cell = <JSONCell value={value} justifyContent={justifyContent} />;
       break;
     case TableCellDisplayMode.Auto:
     default:

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -82,6 +82,7 @@ export function TableNG(props: TableNGProps) {
   const [contextMenuProps, setContextMenuProps] = useState<{
     rowIdx?: number;
     value: string;
+    mode?: TableCellInspectorMode.code | TableCellInspectorMode.text;
     top?: number;
     left?: number;
   } | null>(null);
@@ -580,7 +581,7 @@ export function TableNG(props: TableNGProps) {
 
       {isInspecting && (
         <TableCellInspector
-          mode={TableCellInspectorMode.text}
+          mode={contextMenuProps?.mode ?? TableCellInspectorMode.text}
           value={contextMenuProps?.value}
           onDismiss={() => {
             setIsInspecting(false);

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -7,7 +7,7 @@ export interface CellNGProps {
   field: Field;
   theme: GrafanaTheme2;
   height?: number;
-  justifyContent: Property.JustifyContent;
+  justifyContent?: Property.JustifyContent;
   rowIdx?: number;
 }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -7,7 +7,7 @@ export interface CellNGProps {
   field: Field;
   theme: GrafanaTheme2;
   height?: number;
-  justifyContent?: Property.JustifyContent;
+  justifyContent: Property.JustifyContent;
   rowIdx?: number;
 }
 


### PR DESCRIPTION
### What does this PR do? 📓 

This PR adds support for JSON cell type. It also makes a few adjustments to hover behavior (please let me know your thoughts on this).

**JSON Cell Notes:** 

- Still need to implement data links and actions. 
- The inspect behavior for JSON cell type previously was handled within the JSON cell. Since that logic has been hoisted into TableCellNG, it leads to a nice and clean JSON cell implementation. Thanks, Ihor!
- I made some changes to our `ContextMenu` state to support a dynamic mode for the Table Inspector. When a user opens the inspector for JSON, it needs to be in code mode, not text mode. 

**Auto Cell Notes:** 

- I think it makes sense to hoist the hover logic outside of `<AutoCell />`, because it's not just auto cell types that support overflow hover, right?

**Other notes:** 

- I added a `height` property to the hover div so it matches at a minimum the cell height. I think this looks more tidy.

#### JSON in TableNG w/hover

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/920cb73f-9fa6-419a-b6b8-841d8c4fa8d5" />

#### Quick snap of how the new hover behavior works + height, etc.

https://github.com/user-attachments/assets/5f4c3dc4-aba0-49fe-ad86-62644eeee88e