### PR TITLE
Dashboard Scene: Fix unnecessary diffing

### DIFF
--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -90,7 +90,7 @@ type GrafanaClientAnnotations = {
 
 // Labels
 type GrafanaLabels = {
-  [DeprecatedInternalId]?: number;
+  [DeprecatedInternalId]?: string;
 };
 
 export interface Resource<T = object, S = object, K = string> extends TypeMeta<K> {

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -64,7 +64,7 @@ export class V1DashboardSerializer implements DashboardSceneSerializerLike<Dashb
       id: null,
       uid: '',
       title: options.title || '',
-      description: options.description || '',
+      description: options.description || undefined,
       tags: options.isNew || options.copyTags ? saveModel.tags : [],
     };
   }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -131,7 +131,11 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
 
   const isDashboardEditable = Boolean(dashboard.editable);
   const canSave = dto.access.canSave !== false;
-  const dashboardId = metadata.labels?.[DeprecatedInternalId];
+  let dashboardId: number | undefined = undefined;
+
+  if (metadata.labels?.[DeprecatedInternalId]) {
+    dashboardId = parseInt(metadata.labels[DeprecatedInternalId], 10);
+  }
 
   const meta: DashboardMeta = {
     canShare: dto.access.canShare !== false,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -114,7 +114,7 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
   const dashboard: Dashboard = {
     ...defaultDashboard,
     title: state.title,
-    description: state.description ?? undefined,
+    description: state.description || undefined,
     uid: state.uid,
     id: state.id,
     editable: state.editable,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -114,7 +114,7 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
   const dashboard: Dashboard = {
     ...defaultDashboard,
     title: state.title,
-    description: state.description || undefined,
+    description: state.description ?? undefined,
     uid: state.uid,
     id: state.id,
     editable: state.editable,

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -426,7 +426,7 @@ describe('ResponseTransformers', () => {
             [AnnoKeySlug]: 'dashboard-slug',
           },
           labels: {
-            [DeprecatedInternalId]: 123,
+            [DeprecatedInternalId]: '123',
           },
         },
       };

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -442,7 +442,7 @@ describe('ResponseTransformers', () => {
       expect(transformed.metadata.annotations?.[AnnoKeyFolder]).toEqual('folder1');
       expect(transformed.metadata.annotations?.[AnnoKeySlug]).toEqual('dashboard-slug');
       expect(transformed.metadata.annotations?.[AnnoKeyDashboardGnetId]).toBe('something-like-a-uid');
-      expect(transformed.metadata.labels?.[DeprecatedInternalId]).toBe(123);
+      expect(transformed.metadata.labels?.[DeprecatedInternalId]).toBe('123');
 
       // Spec
       const spec = transformed.spec;

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -133,7 +133,7 @@ export function ensureV2Response(
     };
     creationTimestamp = dto.meta.created;
     labelsMeta = {
-      [DeprecatedInternalId]: dashboard.id ?? undefined,
+      [DeprecatedInternalId]: dashboard.id?.toString() ?? undefined,
     };
   }
 

--- a/public/app/features/dashboard/api/v0.ts
+++ b/public/app/features/dashboard/api/v0.ts
@@ -10,6 +10,7 @@ import {
   AnnoKeyMessage,
   AnnoKeyFolder,
   Resource,
+  DeprecatedInternalId,
 } from 'app/features/apiserver/types';
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
@@ -32,8 +33,6 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
 
   saveDashboard(options: SaveDashboardCommand<Dashboard>): Promise<SaveDashboardResponseDTO> {
     const dashboard = options.dashboard as DashboardDataDTO; // type for the uid property
-    // k8s apis server doesn't use dashboard.id
-    delete dashboard.id;
     const obj: ResourceForCreate<DashboardDataDTO> = {
       metadata: {
         ...options?.k8s,
@@ -108,6 +107,10 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
         },
         dashboard: dash.spec,
       };
+
+      if (dash.metadata.labels?.[DeprecatedInternalId]) {
+        result.dashboard.id = parseInt(dash.metadata.labels[DeprecatedInternalId], 10);
+      }
 
       if (dash.metadata.annotations?.[AnnoKeyFolder]) {
         try {

--- a/public/app/features/dashboard/api/v0.ts
+++ b/public/app/features/dashboard/api/v0.ts
@@ -32,6 +32,8 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
 
   saveDashboard(options: SaveDashboardCommand<Dashboard>): Promise<SaveDashboardResponseDTO> {
     const dashboard = options.dashboard as DashboardDataDTO; // type for the uid property
+    // k8s apis server doesn't use dashboard.id
+    delete dashboard.id;
     const obj: ResourceForCreate<DashboardDataDTO> = {
       metadata: {
         ...options?.k8s,

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -113,7 +113,7 @@ describe('v2 dashboard API - Save', () => {
     k8s: {
       name: 'test-dash',
       labels: {
-        [DeprecatedInternalId]: 123,
+        [DeprecatedInternalId]: '123',
       },
 
       annotations: {

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -143,10 +143,15 @@ export class K8sDashboardV2API
       })
     );
 
+    let dashId = 0;
+    if (v.metadata.labels?.[DeprecatedInternalId]) {
+      dashId = parseInt(v.metadata.labels[DeprecatedInternalId], 10);
+    }
+
     return {
       uid: v.metadata.name,
       version: parseInt(v.metadata.resourceVersion, 10) ?? 0,
-      id: v.metadata.labels?.[DeprecatedInternalId] ?? 0,
+      id: dashId,
       status: 'success',
       url,
       slug: '',


### PR DESCRIPTION
During the last bug bash for k8s dashboards, we found that after saving a new dashboard user gets notified that there are additional changes, which is confusing for the users. This PR fixes those issues:
-  **legacy API and k8s v0**: dashboard `description` is being removed from the JSON, which produces a positive diff
- **k8s v0:**  `id: null` was sent in the request when creating a dashboard, and this property is then removed from JSON when `transformSceneToSaveModel` runs, which produces a positive diff. k8s dashboards don't use id property so it will always be null if sent when initially saving a new dashboard. I've left a [comment](url) in the part that implements the fix for some additional findings and my confusion at why this property even appears in the save request 

For more details about this bug check the issue below:
Fixes #100104

For reviewers, please test with:

- [ ] Legacy API 
- [ ] k8s API - this is the config you'll need to run it with k8s API:

```
app_mode = development

[feature_toggles]
provisioning = true
kubernetesFoldersServiceV2 = true
kubernetesDashboards = true
grafanaAPIServerWithExperimentalAPIs = true
unifiedStorageSearch = true
unifiedStorageSearchUI = true
kubernetesCliDashboards = true
dashboardRestore = true ; SOFT delete in SQL api

# If you want easy kubectl setup development mode
grafanaAPIServerEnsureKubectlAccess = true

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 2

[unified_storage.folders.folder.grafana.app]
dualWriterMode = 2
```
