### PR TITLE
Alerting: Remove leftover legacy alerting types

### DIFF
--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -6,11 +6,6 @@ export enum SortOrder {
   TimeDesc,
 }
 
-export enum ShowOption {
-  Current = 'current',
-  RecentChanges = 'changes',
-}
-
 export enum GroupMode {
   Default = 'default',
   Custom = 'custom',

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -21,26 +21,6 @@ export enum ViewMode {
   Stat = 'stat',
 }
 
-export interface AlertListOptions {
-  showOptions: ShowOption;
-  maxItems: number;
-  sortOrder: SortOrder;
-  dashboardAlerts: boolean;
-  alertName: string;
-  dashboardTitle: string;
-  tags: string[];
-  stateFilter: {
-    ok: boolean;
-    paused: boolean;
-    no_data: boolean;
-    execution_error: boolean;
-    alerting: boolean;
-    pending: boolean;
-  };
-  folderId: number;
-  showInactiveAlerts: boolean;
-}
-
 export interface StateFilter {
   firing: boolean;
   pending: boolean;


### PR DESCRIPTION


**What is this feature?**

I found some  legacy alerting types that are no longer referenced in the codebase that appear to have been missed in #83671.

**Why do we need this feature?**

Removing legacy code helps keep things clean and less confusing.

