### PR TITLE
added plugin version to grafana_ds_test_datasource_clicked rudderstack analytics events

### DIFF
--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -5,6 +5,7 @@ import {
   TestDataSourceResponse,
   DataSourceTestSucceeded,
   DataSourceTestFailed,
+  DataSourceApi,
 } from '@grafana/data';
 import {
   config,
@@ -125,6 +126,11 @@ export const initDataSourceSettings = (
   };
 };
 
+const getPluginVersion = (dsApi: DataSourceApi) => {
+  const isCorePlugin = (dsApi?.meta?.module || '').startsWith('core');
+  return isCorePlugin ? config?.buildInfo?.version : dsApi?.meta?.info?.version;
+};
+
 export const testDataSource = (
   dataSourceName: string,
   editRoute = DATASOURCES_ROUTES.Edit,
@@ -153,6 +159,7 @@ export const testDataSource = (
         trackDataSourceTested({
           grafana_version: config.buildInfo.version,
           plugin_id: dsApi.type,
+          plugin_version: getPluginVersion(dsApi),
           datasource_uid: dsApi.uid,
           success: true,
           path: editLink,
@@ -165,6 +172,7 @@ export const testDataSource = (
         trackDataSourceTested({
           grafana_version: config.buildInfo.version,
           plugin_id: dsApi.type,
+          plugin_version: getPluginVersion(dsApi),
           datasource_uid: dsApi.uid,
           success: false,
           path: editLink,


### PR DESCRIPTION
Analytics (rudderstack) event for `grafana_ds_test_datasource_clicked` doesn't capture the plugin version. This PR adds plugin version for the same.

## for core datasource

For core datasources it uses the grafana version.

<img width="1528" alt="image" src="https://github.com/user-attachments/assets/01670cc6-a865-4e3a-afa8-cf9ba57cbd7a" />

## for external datasource

<img width="1563" alt="image" src="https://github.com/user-attachments/assets/8acfc716-d8a9-4d42-bb63-bc16f2166e87" />
 