### PR TITLE
feat: expose Live message size limit to frontend

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -199,6 +199,7 @@ export interface GrafanaConfig {
   trustedTypesDefaultPolicyEnabled: boolean;
   cspReportOnlyEnabled: boolean;
   liveEnabled: boolean;
+  liveMessageSizeLimit: number;
   /** @deprecated Use `theme2` instead. */
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -107,6 +107,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   trustedTypesDefaultPolicyEnabled = false;
   cspReportOnlyEnabled = false;
   liveEnabled = true;
+  liveMessageSizeLimit = 65536;
   /** @deprecated Use `theme2` instead. */
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -154,20 +154,21 @@ type FrontendSettingsSqlConnectionLimitsDTO struct {
 }
 
 type FrontendSettingsDTO struct {
-	DefaultDatasource  string                           `json:"defaultDatasource"`
-	Datasources        map[string]plugins.DataSourceDTO `json:"datasources"`
-	MinRefreshInterval string                           `json:"minRefreshInterval"`
-	Panels             map[string]plugins.PanelDTO      `json:"panels"`
-	Apps               map[string]*plugins.AppDTO       `json:"apps"`
-	AppUrl             string                           `json:"appUrl"`
-	AppSubUrl          string                           `json:"appSubUrl"`
-	AllowOrgCreate     bool                             `json:"allowOrgCreate"`
-	AuthProxyEnabled   bool                             `json:"authProxyEnabled"`
-	LdapEnabled        bool                             `json:"ldapEnabled"`
-	JwtHeaderName      string                           `json:"jwtHeaderName"`
-	JwtUrlLogin        bool                             `json:"jwtUrlLogin"`
-	LiveEnabled        bool                             `json:"liveEnabled"`
-	AutoAssignOrg      bool                             `json:"autoAssignOrg"`
+	DefaultDatasource    string                           `json:"defaultDatasource"`
+	Datasources          map[string]plugins.DataSourceDTO `json:"datasources"`
+	MinRefreshInterval   string                           `json:"minRefreshInterval"`
+	Panels               map[string]plugins.PanelDTO      `json:"panels"`
+	Apps                 map[string]*plugins.AppDTO       `json:"apps"`
+	AppUrl               string                           `json:"appUrl"`
+	AppSubUrl            string                           `json:"appSubUrl"`
+	AllowOrgCreate       bool                             `json:"allowOrgCreate"`
+	AuthProxyEnabled     bool                             `json:"authProxyEnabled"`
+	LdapEnabled          bool                             `json:"ldapEnabled"`
+	JwtHeaderName        string                           `json:"jwtHeaderName"`
+	JwtUrlLogin          bool                             `json:"jwtUrlLogin"`
+	LiveEnabled          bool                             `json:"liveEnabled"`
+	LiveMessageSizeLimit int                              `json:"liveMessageSizeLimit"`
+	AutoAssignOrg        bool                             `json:"autoAssignOrg"`
 
 	VerifyEmailEnabled  bool `json:"verifyEmailEnabled"`
 	SigV4AuthEnabled    bool `json:"sigV4AuthEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -194,6 +194,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		JwtHeaderName:                       hs.Cfg.JWTAuth.HeaderName,
 		JwtUrlLogin:                         hs.Cfg.JWTAuth.URLLogin,
 		LiveEnabled:                         hs.Cfg.LiveMaxConnections != 0,
+		LiveMessageSizeLimit:                hs.Cfg.LiveMessageSizeLimit,
 		AutoAssignOrg:                       hs.Cfg.AutoAssignOrg,
 		VerifyEmailEnabled:                  hs.Cfg.VerifyEmailEnabled,
 		SigV4AuthEnabled:                    hs.Cfg.SigV4AuthEnabled,


### PR DESCRIPTION
Developers using Grafana Live need to know whether a message is too
big to be sent over the Grafana Live websocket. Since this limit
is configurable, it is useful to expose it to the frontend.

This commit adds a new field to the frontend settings,
`liveMessageSizeLimit`, which the frontend can use to access the
limit configured in the backend.

Relates to #99770.
