### PR TITLE
Explore: Fix screen resizing for Loki query editor

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -22,9 +22,9 @@ import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import {
   AdHocFilterItem,
+  CustomScrollbar,
   ErrorBoundaryAlert,
   PanelContainer,
-  ScrollContainer,
   Themeable2,
   withTheme2,
 } from '@grafana/ui';
@@ -582,9 +582,10 @@ export class Explore extends PureComponent<Props, ExploreState> {
             {contentOutlineVisible && (
               <ContentOutline scroller={this.scrollElement} panelId={`content-outline-container-${exploreId}`} />
             )}
-            <ScrollContainer
-              data-testid={selectors.pages.Explore.General.scrollView}
-              ref={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
+            <CustomScrollbar
+              testId={selectors.pages.Explore.General.scrollView}
+              scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
+              hideHorizontalTrack
             >
               <div className={styles.exploreContainer}>
                 {datasourceInstance ? (
@@ -652,7 +653,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
                   this.renderEmptyState(styles.exploreContainer)
                 )}
               </div>
-            </ScrollContainer>
+            </CustomScrollbar>
           </div>
         </div>
       </ContentOutlineContextProvider>


### PR DESCRIPTION
Reverting https://github.com/grafana/grafana/pull/95830 because of #98998

Fixes: #98998

Alternative solution to bring back ScrollContainer: https://github.com/grafana/grafana/pull/100178