### PR TITLE
Dashboard: SchemaV2 - arbitrary strings identifiers & panelUid

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -62,6 +62,10 @@ LibraryPanelKind: {
 LibraryPanelSpec: {
   // Panel ID for the library panel in the dashboard
   id: number
+
+  // Panel UID for the library panel
+  uid: string
+
   // Title for the library panel in the dashboard
   title: string
 
@@ -504,7 +508,7 @@ GridLayoutItemKind: {
 
 GridLayoutRowKind: {
   kind: "GridLayoutRow"
-  spec: GridLayoutRowSpec 
+  spec: GridLayoutRowSpec
 }
 
 GridLayoutRowSpec: {
@@ -526,6 +530,7 @@ GridLayoutKind: {
 
 PanelSpec: {
   id: number
+  uid: string // this will be the arbitrary uid element_identifier. Needed for transforming scene to schema v2
   title: string
   description: string
   links: [...DataLink]

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
@@ -69,6 +69,8 @@ export const defaultLibraryPanelKind = (): LibraryPanelKind => ({
 export interface LibraryPanelSpec {
 	// Panel ID for the library panel in the dashboard
 	id: number;
+	// Panel UID for the library panel
+	uid: string;
 	// Title for the library panel in the dashboard
 	title: string;
 	libraryPanel: LibraryPanelRef;
@@ -76,6 +78,7 @@ export interface LibraryPanelSpec {
 
 export const defaultLibraryPanelSpec = (): LibraryPanelSpec => ({
 	id: 0,
+	uid: "",
 	title: "",
 	libraryPanel: defaultLibraryPanelRef(),
 });
@@ -752,6 +755,7 @@ export interface GridLayoutRowSpec {
 	y: number;
 	collapsed: boolean;
 	title: string;
+	// Grid items in the row will have their Y value be relative to the rows Y value. This means a panel positioned at Y: 0 in a row with Y: 10 will be positioned at Y: 11 (row header has a heigh of 1) in the dashboard.
 	elements: GridLayoutItemKind[];
 	repeat?: RowRepeatOptions;
 }
@@ -783,6 +787,8 @@ export const defaultGridLayoutKind = (): GridLayoutKind => ({
 
 export interface PanelSpec {
 	id: number;
+	// this will be the arbitrary uid element_identifier. Needed for transforming scene to schema v2
+	uid: string;
 	title: string;
 	description: string;
 	links: DataLink[];
@@ -793,6 +799,7 @@ export interface PanelSpec {
 
 export const defaultPanelSpec = (): PanelSpec => ({
 	id: 0,
+	uid: "",
 	title: "",
 	description: "",
 	links: [],

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -370,7 +370,7 @@ function buildVizPanel(panel: PanelKind): VizPanel {
   const timeOverrideShown = (queryOptions.timeFrom || queryOptions.timeShift) && !queryOptions.hideTimeOverride;
 
   const vizPanelState: VizPanelState = {
-    key: getVizPanelKeyForPanelId(panel.spec.id),
+    key: panel.spec.uid,
     title: panel.spec.title,
     description: panel.spec.description,
     pluginId: panel.spec.vizConfig.kind,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -292,6 +292,7 @@ function getElements(state: DashboardSceneState) {
         kind: 'LibraryPanel',
         spec: {
           id: getPanelIdForVizPanel(vizPanel),
+          uid: vizPanel.state.key ?? '', // this is the element_identifier
           title: vizPanel.state.title,
           libraryPanel: {
             uid: behavior.state.uid,
@@ -340,6 +341,7 @@ function getElements(state: DashboardSceneState) {
         kind: 'Panel',
         spec: {
           id: getPanelIdForVizPanel(vizPanel),
+          uid: vizPanel.state.key ?? '', // this is the element_identifier
           title: vizPanel.state.title,
           description: vizPanel.state.description ?? '',
           links: getPanelLinks(vizPanel),
@@ -480,7 +482,7 @@ function getVizPanelQueryOptions(vizPanel: VizPanel): QueryOptionsSpec {
 
 function createElements(panels: Element[]): Record<string, Element> {
   return panels.reduce<Record<string, Element>>((elements, panel) => {
-    elements[getVizPanelKeyForPanelId(panel.spec.id)] = panel;
+    elements[panel.spec.uid] = panel;
     return elements;
   }, {});
 }

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -371,6 +371,9 @@ function yOffsetInRows(p: Panel, rowY: number): number {
 }
 
 function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
+  // Use arbitrary random string for element_identifier
+  const element_identifier = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+
   if (p.libraryPanel) {
     // LibraryPanelKind
     const panelKind: LibraryPanelKind = {
@@ -381,11 +384,11 @@ function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
           name: p.libraryPanel.name,
         },
         id: p.id!,
+        uid: element_identifier,
         title: p.title ?? '',
       },
     };
-
-    return [panelKind, p.id!.toString()];
+    return [panelKind, element_identifier];
   } else {
     // PanelKind
 
@@ -416,6 +419,7 @@ function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
             targetBlank: l.targetBlank,
           })) || [],
         id: p.id!,
+        uid: element_identifier,
         data: {
           kind: 'QueryGroup',
           spec: {
@@ -435,7 +439,7 @@ function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
       },
     };
 
-    return [panelKind, p.id!.toString()];
+    return [panelKind, element_identifier];
   }
 }
 


### PR DESCRIPTION
POC based on this [design doc](https://docs.google.com/document/d/1t3UfbTphJ1oJnvFchf6n-oV8vWwVEXIfwZSQCjhNsCg/edit?tab=t.3igmqzn72kuh#heading=h.vffpys9wixwy)

This PR implements proposal 3 - that allows dashboard creators to use arbitrary string element_identifier for element keys, and adds a `panel.uid` to keep that `element_identifier` reference. Also it will attempt to modify current dashboard runtime to start eliminating the need to support `panel.id`

Feature toggle to enable: `useV2DashboardsApi`

#### Before:
```
"elements": {
   "panel-6": { //element_identifier 
	Props related to the panel logic queries, viz config, etc
   }
},
"layout": {
   "kind": "GridLayout",
   "spec": {
     "items": [
       {
         "kind": "GridLayoutItem",
         "spec": {
           … Layout Props related to the panel (x, y, h, w)
           "element": {
             "kind": "ElementReference",
             "name": "panel-6" //element_identifier 
           }
         }
       }
     ]
   }
 }
```

#### After: Random 

```
"elements": {
   "superXyzPanel": {
	Props related to the panel logic queries, viz config, etc
   }
},
"layout": {
   "kind": "GridLayout",
   "spec": {
     "items": [
       {
         "kind": "GridLayoutItem",
         "spec": {
           … Layout Props related to the panel (x, y, h, w)
           "element": {
             "kind": "ElementReference",
             "name": "superXyzPanel"
           }
         }
       }
     ]
   }
 }

```

### Initial Issues:
* Panel edit, view, inspect and shares do not work. We will need to modify some functions in scenes.



https://github.com/user-attachments/assets/1fb5546d-f2ad-4d03-8e3c-0a3246797ab6




 