### PR TITLE
Explore: Add ScrollContainer

### DIFF
--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -68,6 +68,8 @@ export interface BoxProps extends FlexProps, SizeProps, Omit<React.HTMLAttribute
   /** Sets the HTML element that will be rendered as a Box. Defaults to 'div' */
   element?: ElementType;
   position?: ResponsiveProp<Property.Position>;
+
+  overflow?: ResponsiveProp<Property.Overflow>;
 }
 
 export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, ref) => {
@@ -109,6 +111,7 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     minHeight,
     maxHeight,
     position,
+    overflow,
     ...rest
   } = props;
   const styles = useStyles2(
@@ -141,7 +144,8 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     alignItems,
     boxShadow,
     gap,
-    position
+    position,
+    overflow
   );
   const sizeStyles = useStyles2(getSizeStyles, width, minWidth, maxWidth, height, minHeight, maxHeight);
   const Element = element ?? 'div';
@@ -209,7 +213,8 @@ const getStyles = (
   alignItems: BoxProps['alignItems'],
   boxShadow: BoxProps['boxShadow'],
   gap: BoxProps['gap'],
-  position: BoxProps['position']
+  position: BoxProps['position'],
+  overflow: BoxProps['overflow']
 ) => {
   return {
     root: css([
@@ -306,6 +311,9 @@ const getStyles = (
       })),
       getResponsiveStyle(theme, position, (val) => ({
         position: val,
+      })),
+      getResponsiveStyle(theme, overflow, (val) => ({
+        overflow: val,
       })),
     ]),
   };

--- a/packages/grafana-ui/src/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/grafana-ui/src/components/ScrollContainer/ScrollContainer.tsx
@@ -34,6 +34,7 @@ export const ScrollContainer = forwardRef<HTMLDivElement, PropsWithChildren<Prop
     const defaults: Partial<BoxProps> = {
       maxHeight: '100%',
       minHeight: 0,
+      overflow: 'auto',
     };
     const boxProps = { ...defaults, ...rest };
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -22,9 +22,9 @@ import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import {
   AdHocFilterItem,
-  CustomScrollbar,
   ErrorBoundaryAlert,
   PanelContainer,
+  ScrollContainer,
   Themeable2,
   withTheme2,
 } from '@grafana/ui';
@@ -582,10 +582,9 @@ export class Explore extends PureComponent<Props, ExploreState> {
             {contentOutlineVisible && (
               <ContentOutline scroller={this.scrollElement} panelId={`content-outline-container-${exploreId}`} />
             )}
-            <CustomScrollbar
-              testId={selectors.pages.Explore.General.scrollView}
-              scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
-              hideHorizontalTrack
+            <ScrollContainer
+              data-testid={selectors.pages.Explore.General.scrollView}
+              ref={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
             >
               <div className={styles.exploreContainer}>
                 {datasourceInstance ? (
@@ -653,7 +652,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
                   this.renderEmptyState(styles.exploreContainer)
                 )}
               </div>
-            </CustomScrollbar>
+            </ScrollContainer>
           </div>
         </div>
       </ContentOutlineContextProvider>


### PR DESCRIPTION
Sprinking some magic dust to fix #98998 + have ScrollContainer back in Explore after [this bad boy](https://github.com/grafana/grafana/pull/100176) is merged (which reverted [original PR to add ScrollContainer in Explore](https://github.com/grafana/grafana/pull/95830))

> [!NOTE]
> The PR targets https://github.com/grafana/grafana/pull/100176 to show how ScrollContainer can be put back after  https://github.com/grafana/grafana/pull/100176 is merged

Not exactly sure what's going on in here. Without setting the overflow to something else than `visible` ResizeObserver in from Monaco does not receive size updates when the container shrinks (only when it expands) 🤯 

<img width="501" alt="Screenshot 2025-02-06 at 12 10 33" src="https://github.com/user-attachments/assets/56c23776-79ca-4124-bcbc-a83a6a987c17" />

Adding overflow fixes the issue described in #98998, though I'm not sure if it's okay to have overflow property in Box 🤔  