### PR TITLE
UniStore Big Objects: Fix spec rebuilding

### DIFF
--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	commonV0 "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	dashboard "github.com/grafana/grafana/pkg/apis/dashboard"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 )
@@ -51,7 +52,17 @@ func NewDashboardLargeObjectSupport(scheme *runtime.Scheme) *apistore.BasicLarge
 			if err != nil {
 				return err
 			}
-			return json.Unmarshal(blob, &dash.Spec)
+			// TODO figure out how we want to set the spec. Do we
+			// want to use the byte array? Do we want to pass in the the
+			// metaAccessor instead of (or in addition to) the runtime.Object?
+			err = json.Unmarshal(blob, &dash.Spec)
+
+			meta, err := utils.MetaAccessor(obj)
+			if err != nil {
+				return err
+			}
+
+			return meta.SetSpec(dash.Spec)
 		},
 	}
 }

--- a/pkg/registry/apis/dashboard/large_test.go
+++ b/pkg/registry/apis/dashboard/large_test.go
@@ -1,12 +1,15 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	dashboardinternal "github.com/grafana/grafana/pkg/apis/dashboard"
 	dashboardv0alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,4 +69,42 @@ func TestLargeDashboardSupport(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, panels, expectedPanelCount)
+
+	// specObj := v0alpha1.Unstructured{
+	specObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"title":       "example title",
+				"description": "example description",
+			},
+		},
+	}
+
+	dashObj := &dashboardv0alpha1.Dashboard{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: specObj,
+	}
+	err = json.Unmarshal(f, &dashObj.Spec)
+	require.NoError(t, err)
+
+	meta, err := utils.MetaAccessor(dashObj)
+	require.NoError(t, err)
+	gr := largeObject.GroupResource()
+
+	client := resource.NewBlobStoreClient(nil)
+	err = largeObject.Reconstruct(context.Background(), &resource.ResourceKey{
+		Group:     gr.Group,
+		Resource:  gr.Resource,
+		Namespace: dashObj.GetNamespace(),
+		Name:      dashObj.GetName(),
+	}, client, meta)
+
+	reconstructedSpec, err := meta.GetSpec()
+	require.NoError(t, err)
+
+	// require.Equal(t, dashObj.Spec, reconstructedSpec)
+	require.Equal(t, specObj, reconstructedSpec)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fetching a big object with `unifiedStorageBigObjectsSupport` enabled is broken. The contents of the dashboard aren't being shown. Instead the UI view for the dashboard is the same as the one displayed when creating a new dashboard. This PR fixes the implementation of `RebuildSpec` so that it captures the spec fetched from blob storage.

**Why do we need this feature?**

We need big object storage to be working for the dashboards in app platform initiative.

**Who is this feature for?**

Search and Storage / App platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/194

**Special notes for your reviewer:**

Actually, never mind about using the ephemeral instance. It’s going to be hard to create a large enough dashboard to trigger large object storage that way. Instead, I recommend testing locally and changing [this threshold](https://github.com/grafana/grafana/blob/1467d4b3e3a783cefbd53dff3b525da65eb6909c/pkg/storage/unified/apistore/large.go#L58) to 0.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
