### PR TITLE
[Provisioning] Fix sync status messages not updated

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -181,7 +181,7 @@ type SyncStatus struct {
 
 	// Summary messages (will be shown to users)
 	// +listType=atomic
-	Message []string `json:"message,omitempty"`
+	Message []string `json:"message"`
 
 	// The repository hash when the last sync ran
 	Hash string `json:"hash,omitempty"`


### PR DESCRIPTION
# Why?

the status messages were not updated.

# How?

The reason is that our merging patch strategy doesn't take the empty list of messages if it's omitted in the request.


# Before

https://github.com/user-attachments/assets/4b2f895a-3f6c-4cd2-a911-3aef83f82a9c

# After

![Screenshot 2025-02-06 at 13 10 55](https://github.com/user-attachments/assets/8158a0eb-ee23-4027-a112-84341aca7cd0)

