### PR TITLE
Alerting: Remove rule group edit from single rule editor

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Field,
   Icon,
-  IconButton,
   Input,
   Label,
   Modal,
@@ -28,7 +27,6 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 import { GRAFANA_RULER_CONFIG } from '../../api/featureDiscoveryApi';
 import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../rule-editor/formDefaults';
 import { RuleFormValues } from '../../types/rule-form';
-import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import {
   isGrafanaAlertingRuleByType,
   isGrafanaManagedRuleByType,
@@ -38,7 +36,7 @@ import {
 import { parsePrometheusDuration } from '../../utils/time';
 import { CollapseToggle } from '../CollapseToggle';
 import { ProvisioningBadge } from '../Provisioning';
-import { EditRuleGroupModal, evaluateEveryValidationOptions } from '../rules/EditRuleGroupModal';
+import { evaluateEveryValidationOptions } from '../rules/EditRuleGroupModal';
 
 import { EvaluationGroupQuickPick } from './EvaluationGroupQuickPick';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
@@ -160,7 +158,6 @@ export function GrafanaEvaluationBehaviorStep({
   const isGrafanaAlertingRule = isGrafanaAlertingRuleByType(type);
   const isGrafanaRecordingRule = isGrafanaRecordingRuleByType(type);
   const { currentData: rulerNamespace, isLoading: loadingGroups } = useFetchGroupsForFolder(folder?.uid ?? '');
-  const [isEditingGroup, setIsEditingGroup] = useState(false);
 
   const groupOptions = useMemo(() => {
     return rulerNamespace ? namespaceToGroupOptions(rulerNamespace, enableProvisionedGroups) : [];
@@ -169,7 +166,6 @@ export function GrafanaEvaluationBehaviorStep({
   const existingGroup = Object.values(rulerNamespace ?? {})
     .flat()
     .find((ruleGroup) => ruleGroup.name === group);
-  const isNewGroup = !existingGroup && !loadingGroups;
 
   // synchronize the evaluation interval with the group name when it's an existing group
   useEffect(() => {
@@ -177,11 +173,6 @@ export function GrafanaEvaluationBehaviorStep({
       setValue('evaluateEvery', existingGroup.interval ?? DEFAULT_GROUP_EVALUATION_INTERVAL);
     }
   }, [existingGroup, setValue]);
-
-  const closeEditGroupModal = () => setIsEditingGroup(false);
-  const onOpenEditGroupModal = () => setIsEditingGroup(true);
-
-  const editGroupDisabled = loadingGroups || isNewGroup || !folder?.uid || !group;
 
   const [isCreatingEvaluationGroup, setIsCreatingEvaluationGroup] = useState(false);
 
@@ -287,38 +278,15 @@ export function GrafanaEvaluationBehaviorStep({
           )}
         </Stack>
 
-        {folder?.uid && isEditingGroup && (
-          <EditRuleGroupModal
-            ruleGroupIdentifier={{
-              dataSourceName: GRAFANA_RULES_SOURCE_NAME,
-              groupName: existingGroup?.name ?? '',
-              namespaceName: folder?.uid ?? '',
-            }}
-            rulerConfig={GRAFANA_RULER_CONFIG}
-            onClose={() => closeEditGroupModal()}
-            intervalEditOnly
-            hideFolder={true}
-          />
-        )}
         {folder?.title && group && (
           <div className={styles.evaluationContainer}>
             <Stack direction="column" gap={0}>
               <div className={styles.marginTop}>
                 <Stack direction="column" gap={1}>
                   {getValues('group') && getValues('evaluateEvery') && (
-                    <Stack direction="row" gap={1} alignItems="center">
-                      <Trans i18nKey="alerting.rule-form.evaluation.group-text" values={{ evaluateEvery }}>
-                        All rules in the selected group are evaluated every {{ evaluateEvery }}.
-                      </Trans>
-                      {!isNewGroup && (
-                        <IconButton
-                          name="pen"
-                          aria-label="Edit"
-                          disabled={editGroupDisabled}
-                          onClick={onOpenEditGroupModal}
-                        />
-                      )}
-                    </Stack>
+                    <Trans i18nKey="alerting.rule-form.evaluation.group-text" values={{ evaluateEvery }}>
+                      All rules in the selected group are evaluated every {{ evaluateEvery }}.
+                    </Trans>
                   )}
                 </Stack>
               </div>


### PR DESCRIPTION
**What is this feature?**

As discussed with the team, the ability to edit the evaluation interval on the edit page of a single rule is destructive to other rules within that group and adds very little benefits over editing the rule group from the list view.

This PR thus removes the rule group edit feature from the alert rule detail page.

**Special notes for your reviewer:**

None