### PR TITLE
Authz: client cache

### DIFF
--- a/pkg/services/authz/client.go
+++ b/pkg/services/authz/client.go
@@ -124,6 +124,10 @@ func newInProcLegacyClient(server *rbac.Service, tracer tracing.Tracer) (authlib
 		authzlib.WithGrpcConnectionClientOption(channel),
 		authzlib.WithDisableAccessTokenClientOption(),
 		authzlib.WithTracerClientOption(tracer),
+		authzlib.WithCacheClientOption(cache.NewLocalCache(cache.Config{
+			Expiry:          30 * time.Second,
+			CleanupInterval: 2 * time.Minute,
+		})),
 	)
 }
 
@@ -147,6 +151,10 @@ func newGrpcLegacyClient(authCfg *Cfg, tracer tracing.Tracer) (authlib.AccessCli
 			grpc.WithStreamInterceptor(clientInterceptor.StreamClientInterceptor),
 		),
 		authzlib.WithTracerClientOption(tracer),
+		authzlib.WithCacheClientOption(cache.NewLocalCache(cache.Config{
+			Expiry:          30 * time.Second,
+			CleanupInterval: 2 * time.Minute,
+		})),
 		// TODO: remove this once access tokens are supported on-prem
 		authzlib.WithDisableAccessTokenClientOption(),
 	)
@@ -181,6 +189,10 @@ func newCloudLegacyClient(authCfg *Cfg, tracer tracing.Tracer) (authlib.AccessCl
 			grpc.WithUnaryInterceptor(clientInterceptor.UnaryClientInterceptor),
 			grpc.WithStreamInterceptor(clientInterceptor.StreamClientInterceptor),
 		),
+		authzlib.WithCacheClientOption(cache.NewLocalCache(cache.Config{
+			Expiry:          30 * time.Second,
+			CleanupInterval: 2 * time.Minute,
+		})),
 		authzlib.WithTracerClientOption(tracer),
 	)
 	if err != nil {

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	shortCacheTTL        = 1 * time.Minute
-	shortCleanupInterval = 5 * time.Minute
-	longCacheTTL         = 5 * time.Minute
-	longCleanupInterval  = 10 * time.Minute
+	shortCacheTTL        = 30 * time.Second
+	shortCleanupInterval = 2 * time.Minute
+	longCacheTTL         = 2 * time.Minute
+	longCleanupInterval  = 4 * time.Minute
 )
 
 type Service struct {
@@ -82,7 +82,7 @@ func NewService(
 		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, longCacheTTL),
 		permCache:       newCacheWrap[map[string]bool](cache, logger, shortCacheTTL),
 		teamCache:       newCacheWrap[[]int64](cache, logger, shortCacheTTL),
-		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, longCacheTTL),
+		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, shortCacheTTL),
 		folderCache:     newCacheWrap[map[string]FolderNode](cache, logger, shortCacheTTL),
 		sf:              new(singleflight.Group),
 	}


### PR DESCRIPTION
**What is this feature?**
We are using really long ttl for caches within authz service and client.

I created this pr and we can talk a bit about the adjustments. It is not optimal to have long ttls (especially in the client) because right now we don't have any way to invalidate the cache.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1143

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
