### PR TITLE
Alerting: Fix useAlertingQueryRunner re-rendering loop

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query.tsx
@@ -1,25 +1,21 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { useObservable } from 'react-use';
 
-import { LoadingState, PanelData } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Alert, Stack } from '@grafana/ui';
 import { CombinedRule } from 'app/types/unified-alerting';
 
 import { GrafanaRuleQueryViewer, QueryPreview } from '../../../GrafanaRuleQueryViewer';
 import { useAlertQueriesStatus } from '../../../hooks/useAlertQueriesStatus';
-import { AlertingQueryRunner } from '../../../state/AlertingQueryRunner';
 import { alertRuleToQueries } from '../../../utils/query';
 import { isFederatedRuleGroup, isGrafanaRulerRule } from '../../../utils/rules';
+import { useAlertQueryRunner } from '../../rule-editor/query-and-alert-condition/useAlertQueryRunner';
 
 interface Props {
   rule: CombinedRule;
 }
 
 const QueryResults = ({ rule }: Props) => {
-  const runner = useMemo(() => new AlertingQueryRunner(), []);
-  const data = useObservable(runner.get());
-  const loadingData = isLoading(data);
+  const { queryPreviewData, runQueries, isPreviewLoading } = useAlertQueryRunner();
 
   const queries = useMemo(() => alertRuleToQueries(rule), [rule]);
 
@@ -31,9 +27,9 @@ const QueryResults = ({ rule }: Props) => {
       if (rule && isGrafanaRulerRule(rule.rulerRule)) {
         condition = rule.rulerRule.grafana_alert.condition;
       }
-      runner.run(queries, condition ?? 'A');
+      runQueries(queries, condition ?? 'A');
     }
-  }, [queries, allDataSourcesAvailable, rule, runner]);
+  }, [queries, allDataSourcesAvailable, rule, runQueries]);
 
   useEffect(() => {
     if (allDataSourcesAvailable) {
@@ -41,15 +37,11 @@ const QueryResults = ({ rule }: Props) => {
     }
   }, [allDataSourcesAvailable, onRunQueries]);
 
-  useEffect(() => {
-    return () => runner.destroy();
-  }, [runner]);
-
   const isFederatedRule = isFederatedRuleGroup(rule.group);
 
   return (
     <>
-      {loadingData ? (
+      {isPreviewLoading ? (
         'Loading...'
       ) : (
         <>
@@ -58,27 +50,30 @@ const QueryResults = ({ rule }: Props) => {
               rule={rule}
               condition={rule.rulerRule.grafana_alert.condition}
               queries={queries}
-              evalDataByQuery={data}
+              evalDataByQuery={queryPreviewData}
             />
           )}
 
-          {!isGrafanaRulerRule(rule.rulerRule) && !isFederatedRule && data && Object.keys(data).length > 0 && (
-            <Stack direction="column" gap={1}>
-              {queries.map((query) => {
-                return (
-                  <QueryPreview
-                    key={query.refId}
-                    rule={rule}
-                    refId={query.refId}
-                    model={query.model}
-                    dataSource={Object.values(config.datasources).find((ds) => ds.uid === query.datasourceUid)}
-                    queryData={data[query.refId]}
-                    relativeTimeRange={query.relativeTimeRange}
-                  />
-                );
-              })}
-            </Stack>
-          )}
+          {!isGrafanaRulerRule(rule.rulerRule) &&
+            !isFederatedRule &&
+            queryPreviewData &&
+            Object.keys(queryPreviewData).length > 0 && (
+              <Stack direction="column" gap={1}>
+                {queries.map((query) => {
+                  return (
+                    <QueryPreview
+                      key={query.refId}
+                      rule={rule}
+                      refId={query.refId}
+                      model={query.model}
+                      dataSource={Object.values(config.datasources).find((ds) => ds.uid === query.datasourceUid)}
+                      queryData={queryPreviewData[query.refId]}
+                      relativeTimeRange={query.relativeTimeRange}
+                    />
+                  );
+                })}
+              </Stack>
+            )}
           {!isFederatedRule && !allDataSourcesAvailable && (
             <Alert title="Query not available" severity="warning">
               Cannot display the query preview. Some of the data sources used in the queries are not available.
@@ -89,13 +84,5 @@ const QueryResults = ({ rule }: Props) => {
     </>
   );
 };
-
-function isLoading(data?: Record<string, PanelData>): boolean {
-  if (!data) {
-    return true;
-  }
-
-  return !!Object.values(data).find((d) => d.state === LoadingState.Loading);
-}
 
 export { QueryResults };

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -51,11 +51,10 @@ export class AlertingQueryRunner {
   }
 
   async run(queries: AlertQuery[], condition: string) {
-    const empty = initialState(queries, LoadingState.Done);
     const queriesToRun = await this.prepareQueries(queries);
 
     if (queriesToRun.length === 0) {
-      return this.subject.next(empty);
+      return;
     }
 
     this.subscription = runRequest(this.backendSrv, queriesToRun, condition).subscribe({


### PR DESCRIPTION
Fixes infinite re-rendering loop of `useAlertingQueryRunner` for Loki data sources

For empty queries `AlertingQueryRunner` used to provide a new PanelData with a new timeRange interval on every `run` request. This triggers re-rendering of any components using `useAlertingQueryRunner` due to preview data change, leading to infinite loops in some scenarios (query builder updating the query and running the runner on query changes)

To break the loop, for empty `queries` the runner will be no longer pushing new values to subscribers. It will do nothing instead. This should prevent unintentional re-renders


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
