### PR TITLE
TableNG: Fix cell hover issue

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -108,7 +108,7 @@ export function TableCellNG(props: any) {
   };
 
   return (
-    <div ref={divWidthRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <div ref={divWidthRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className={styles.cell}>
       {cell}
       {cellInspect && isHovered && (
         <div className={styles.cellActions}>
@@ -127,6 +127,11 @@ export function TableCellNG(props: any) {
 }
 
 const getStyles = (theme: GrafanaTheme2, isRightAligned: boolean) => ({
+  cell: css({
+    height: '100%',
+    alignContent: 'center',
+    paddingInline: '8px',
+  }),
   cellActions: css({
     display: 'flex',
     position: 'absolute',

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -637,7 +637,7 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
 
-    // reset default cell styles to handle cell styles inside custom cell component
+    // Reset default cell styles for custom cell component styling
     paddingInline: '0',
 
     '&:hover': {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -636,6 +636,9 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
 
+    // reset default cell styles to handle cell styles inside custom cell component
+    paddingInline: '0',
+
     '&:hover': {
       // TODO: border was replaced with boxShadow, because it was causing cell shift on hover
       boxShadow: 'rgb(61, 113, 217) 0px 0px 2px',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an issue where the table cell hover effect was triggered only when hovering over the cell’s context instead of the entire cell.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #100125 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
