### PR TITLE
Advisor: Enable frontend code generation for the `checktype` kind

### DIFF
--- a/apps/advisor/kinds/checktype.cue
+++ b/apps/advisor/kinds/checktype.cue
@@ -7,7 +7,7 @@ checktype: {
 	versions: {
 		"v0alpha1": {
 			codegen: {
-				frontend: false
+				frontend: true
 				backend:  true
 			}
 			schema: {


### PR DESCRIPTION
### What changed?

Enabled the frontend `codegen` for the `CheckType`. (The generated frontend types will be used by the grafana-advisor-app).