### PR TITLE
DynamicDashboards: Revert unnecessary empty page on new layouts

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -1,16 +1,8 @@
 import { SelectableValue } from '@grafana/data';
-import {
-  SceneComponentProps,
-  SceneCSSGridLayout,
-  SceneObjectBase,
-  SceneObjectState,
-  useSceneObjectState,
-  VizPanel,
-} from '@grafana/scenes';
+import { SceneComponentProps, SceneCSSGridLayout, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { Select } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelId } from '../../utils/utils';
@@ -148,16 +140,6 @@ export class ResponsiveGridLayoutManager
   public activateRepeaters(): void {}
 
   public static Component = ({ model }: SceneComponentProps<ResponsiveGridLayoutManager>) => {
-    const { children } = useSceneObjectState(model.state.layout, { shouldActivateOrKeepAlive: true });
-    const dashboard = getDashboardSceneFor(model);
-
-    // If we are top level layout and have no children, show empty state
-    if (model.parent === dashboard && children.length === 0) {
-      return (
-        <DashboardEmpty dashboard={dashboard} canCreate={!!dashboard.state.meta.canEdit} key="dashboard-empty-state" />
-      );
-    }
-
     return <model.state.layout.Component model={model.state.layout} />;
   };
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -12,10 +12,8 @@ import {
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
-import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 
 import { isClonedKey } from '../../utils/clone';
-import { getDashboardSceneFor } from '../../utils/utils';
 import { DashboardScene } from '../DashboardScene';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
@@ -197,14 +195,6 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
   public static Component = ({ model }: SceneComponentProps<RowsLayoutManager>) => {
     const { rows } = model.useState();
     const styles = useStyles2(getStyles);
-    const dashboard = getDashboardSceneFor(model);
-
-    // If we are top level layout and have no children, show empty state
-    if (model.parent === dashboard && rows.length === 0) {
-      return (
-        <DashboardEmpty dashboard={dashboard} canCreate={!!dashboard.state.meta.canEdit} key="dashboard-empty-state" />
-      );
-    }
 
     return (
       <div className={styles.wrapper}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Reverts code added [here](https://github.com/grafana/grafana/pull/100189) as we do not want the empty dashboard page on each layout.

**Why do we need this feature?**

Fixes the issue

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
