### PR TITLE
Combobox: Debounce async requests onOpen

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -297,7 +297,7 @@ describe('Combobox', () => {
 
       await act(async () => jest.advanceTimersByTime(200));
 
-      expect(asyncOptions).toHaveBeenCalled();
+      expect(asyncOptions).toHaveBeenCalledTimes(1);
     });
 
     it('should allow async options and select value', async () => {
@@ -312,6 +312,12 @@ describe('Combobox', () => {
 
       expect(onChangeHandler).toHaveBeenCalledWith(simpleAsyncOptions[2]);
       expect(screen.getByDisplayValue('Option 3')).toBeInTheDocument();
+
+      // Should call async once when reopening
+
+      await user.click(input);
+      await act(async () => jest.advanceTimersByTime(200));
+      expect(asyncOptions).toHaveBeenCalledTimes(1);
     });
 
     it('should ignore late responses', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -279,18 +279,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       if (isAsync && isOpen && inputValue === '') {
         setAsyncLoading(true);
         // TODO: dedupe this loading logic with debounceAsync
-        loadOptions(inputValue)
-          .then((opts) => {
-            setItems(opts, inputValue);
-            setAsyncLoading(false);
-            setAsyncError(false);
-          })
-          .catch((err) => {
-            if (!(err instanceof StaleResultError)) {
-              setAsyncError(true);
-              setAsyncLoading(false);
-            }
-          });
+        debounceAsync(inputValue);
       }
     },
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

Otherwise the component calls the async function twice; once because isOpen change and a second time because the inputValue is changing.

**Who is this feature for?**

Devs :)

**Which issue(s) does this PR fix?**:

The issue located in https://github.com/grafana/scenes/pull/1011

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
