### PR TITLE
SQL Expressions: Add str_to_date function and unskip test

### DIFF
--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -148,27 +148,21 @@ func TestQueryFramesNumericSelect(t *testing.T) {
 }
 
 func TestQueryFramesDateTimeSelect(t *testing.T) {
-	t.Skip("need a fix in go-mysql-server, and then handle the datetime strings (or figure out why strings and not time.Time)")
 	expectedFrame := &data.Frame{
 		RefID: "a",
 		Name:  "a",
 		Fields: []*data.Field{
-			data.NewField("ts", nil, []time.Time{}),
+			data.NewField("ts", nil, []*time.Time{
+				p(time.Date(2025, 2, 3, 3, 0, 0, 0, time.UTC)),
+			}),
 		},
 	}
 
 	db := DB{}
 
-	// It doesn't like the T in the time string
 	qry := `SELECT str_to_date('2025-02-03T03:00:00','%Y-%m-%dT%H:%i:%s') as ts`
 
-	// This comes back as a string, which needs to be dealt with?
-	//qry := `SELECT str_to_date('2025-02-03-03:00:00','%Y-%m-%d-%H:%i:%s') as ts`
-
-	// This is a datetime(6), need to deal with that as well
-	//qry := `SELECT current_timestamp() as ts`
-
-	f, err := db.QueryFrames(context.Background(), "b", qry, []*data.Frame{})
+	f, err := db.QueryFrames(context.Background(), "a", qry, nil)
 	require.NoError(t, err)
 
 	if diff := cmp.Diff(expectedFrame, f, data.FrameTestCompareOptions()...); diff != "" {

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -130,6 +130,9 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 	case "coalesce":
 		return
 
+	case "str_to_date":
+		return
+
 	default:
 		return false
 	}


### PR DESCRIPTION
**What is this feature?**

A bug in go-mysql-server prevented datetime from returning as the correct type, and the str_to_date function. That has been fixed, https://github.com/dolthub/dolt/issues/8807 , and we have updated the dependency https://github.com/grafana/grafana/pull/100222 

So we have allowed the function, and un-skipped the test.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
