### PR TITLE
SQL Expressions: Add more SQLNodes and funcs to allow list

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -54,7 +54,13 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.AliasedExpr, *sqlparser.AliasedTableExpr:
 		return
 
-	case *sqlparser.BinaryExpr:
+	case *sqlparser.AndExpr, *sqlparser.OrExpr:
+		return
+
+	case *sqlparser.BinaryExpr, *sqlparser.UnaryExpr:
+		return
+
+	case sqlparser.BoolVal:
 		return
 
 	case sqlparser.ColIdent, *sqlparser.ColName, sqlparser.Columns:
@@ -87,6 +93,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.Select, sqlparser.SelectExprs:
 		return
 
+	case *sqlparser.SetOp:
+		return
+
 	case *sqlparser.StarExpr:
 		return
 
@@ -100,6 +109,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		return
 
 	case *sqlparser.Over:
+		return
+
+	case *sqlparser.ParenExpr:
 		return
 
 	case *sqlparser.Subquery:
@@ -124,6 +136,9 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 	b = true // so don't have to return true in every case but default
 
 	switch strings.ToLower(f.Name.String()) {
+	case "if":
+		return
+
 	case "sum", "avg", "count", "min", "max":
 		return
 


### PR DESCRIPTION
**What is this feature?**

Adds some more standard SQL to our allow list for SQL expressions.

**Special notes for your reviewer:**

I expect in the future we will want to make more proper tests in the targeting of specific Statement Funcs in the query, but for now examples seems a reasonable way to populate the initial list.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
