### PR TITLE
Themes: Adds 1 more GrafanaCon theme (wip)

### DIFF
--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -6,7 +6,7 @@ import { NewThemeOptions } from '../createTheme';
  */
 
 const whiteBase = `210, 210, 220`;
-const secondaryBase = `250, 225, 195`;
+const secondaryBase = `210, 210, 220`;
 const brandMain = '#ff934d';
 const brandText = '#f99a5c';
 

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -1,6 +1,10 @@
 import { NewThemeOptions } from '../createTheme';
 
-const gildedGroveTheme: NewThemeOptions = {
+/**
+ * Torkel's GrafanaCon theme
+ * very WIP state
+ */
+const gloomTheme: NewThemeOptions = {
   name: 'Gloom',
   colors: {
     mode: 'dark',
@@ -10,7 +14,7 @@ const gildedGroveTheme: NewThemeOptions = {
       strong: 'rgba(200, 200, 180, 0.30)',
     },
     text: {
-      primary: 'rgb(250, 250, 239)',
+      primary: 'rgb(210, 210, 220)',
       secondary: 'rgba(200, 200, 180, 0.85)',
       disabled: 'rgba(200, 200, 180, 0.6)',
       link: '#ff934d',
@@ -64,4 +68,4 @@ const gildedGroveTheme: NewThemeOptions = {
   },
 };
 
-export default gildedGroveTheme;
+export default gloomTheme;

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -54,10 +54,10 @@ const gloomTheme: NewThemeOptions = {
     },
 
     action: {
-      hover: `rgba(${whiteBase}, 0.10)`,
-      selected: `rgba(${whiteBase}, 0.12)`,
+      hover: `rgba(${secondaryBase}, 0.10)`,
+      selected: `rgba(${secondaryBase}, 0.12)`,
       selectedBorder: brandMain,
-      focus: `rgba(${whiteBase}, 0.10)`,
+      focus: `rgba(${secondaryBase}, 0.10)`,
       hoverOpacity: 0.05,
       disabledText: disabledText,
       disabledBackground: `rgba(${whiteBase}, 0.04)`,

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -47,16 +47,16 @@ const gloomTheme: NewThemeOptions = {
 
     background: {
       canvas: '#000',
-      primary: '#111',
-      secondary: '#222',
+      primary: '#170c0c',
+      secondary: '#231919',
     },
 
     action: {
-      hover: `rgba(${whiteBase}, 0.16)`,
+      hover: `rgba(${whiteBase}, 0.10)`,
       selected: `rgba(${whiteBase}, 0.12)`,
       selectedBorder: brandMain,
-      focus: `rgba(${whiteBase}, 0.16)`,
-      hoverOpacity: 0.08,
+      focus: `rgba(${whiteBase}, 0.10)`,
+      hoverOpacity: 0.05,
       disabledText: disabledText,
       disabledBackground: `rgba(${whiteBase}, 0.04)`,
       disabledOpacity: 0.38,

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -6,7 +6,7 @@ import { NewThemeOptions } from '../createTheme';
  */
 
 const whiteBase = `210, 210, 220`;
-const secondaryBase = `250, 220, 189`;
+const secondaryBase = `250, 225, 195`;
 const brandMain = '#ff934d';
 const brandText = '#f99a5c';
 
@@ -48,9 +48,8 @@ const gloomTheme: NewThemeOptions = {
 
     background: {
       canvas: '#000',
-      primary: '#170c0c',
-      //secondary: '#231919',
-      secondary: '#281c1c',
+      primary: '#140b0b',
+      secondary: '#231919',
     },
 
     action: {

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -7,8 +7,8 @@ import { NewThemeOptions } from '../createTheme';
 
 const whiteBase = `210, 210, 220`;
 const secondaryBase = `210, 210, 220`;
-const brandMain = '#ff934d';
-const brandText = '#f99a5c';
+const brandMain = '#3d71d9';
+const brandText = '#6e9fff';
 
 const disabledText = `rgba(${whiteBase}, 0.6)`;
 
@@ -18,7 +18,7 @@ const gloomTheme: NewThemeOptions = {
     mode: 'dark',
     border: {
       weak: `rgba(${whiteBase}, 0.08)`,
-      medium: `rgba(${whiteBase}, 0.12)`,
+      medium: `rgba(${whiteBase}, 0.15)`,
       strong: `rgba(${whiteBase}, 0.30)`,
     },
 
@@ -63,10 +63,10 @@ const gloomTheme: NewThemeOptions = {
       disabledOpacity: 0.38,
     },
 
-    gradients: {
-      brandHorizontal: 'linear-gradient(270deg, #ff934d 0%, #FEAC34 100%)',
-      brandVertical: 'linear-gradient(0.01deg, #ff934d 0.01%, #FEAC34 99.99%)',
-    },
+    // gradients: {
+    //   brandHorizontal: 'linear-gradient(270deg, #ff934d 0%, #FEAC34 100%)',
+    //   brandVertical: 'linear-gradient(0.01deg, #ff934d 0.01%, #FEAC34 99.99%)',
+    // },
 
     contrastThreshold: 3,
     hoverFactor: 0.03,

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -7,8 +7,10 @@ import { NewThemeOptions } from '../createTheme';
 
 const whiteBase = `210, 210, 220`;
 const secondaryBase = `210, 210, 220`;
-const brandMain = '#3d71d9';
-const brandText = '#6e9fff';
+//const brandMain = '#3d71d9';
+//const brandText = '#6e9fff';
+const brandMain = '#ff934d';
+const brandText = '#f99a5c';
 
 const disabledText = `rgba(${whiteBase}, 0.6)`;
 

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -4,61 +4,69 @@ import { NewThemeOptions } from '../createTheme';
  * Torkel's GrafanaCon theme
  * very WIP state
  */
+
+const whiteBase = `210, 210, 220`;
+const brandMain = '#ff934d';
+const brandText = '#f99a5c';
+
+const disabledText = `rgba(${whiteBase}, 0.6)`;
+
 const gloomTheme: NewThemeOptions = {
   name: 'Gloom',
   colors: {
     mode: 'dark',
     border: {
-      weak: 'rgba(200, 200, 180, 0.12)',
-      medium: 'rgba(200, 200, 180, 0.20)',
-      strong: 'rgba(200, 200, 180, 0.30)',
+      weak: `rgba(${whiteBase}, 0.08)`,
+      medium: `rgba(${whiteBase}, 0.12)`,
+      strong: `rgba(${whiteBase}, 0.30)`,
     },
+
     text: {
-      primary: 'rgb(210, 210, 220)',
-      secondary: 'rgba(200, 200, 180, 0.85)',
-      disabled: 'rgba(200, 200, 180, 0.6)',
-      link: '#ff934d',
-      maxContrast: '#FFFFFF',
+      primary: `rgb(${whiteBase})`,
+      secondary: `rgba(${whiteBase}, 0.65)`,
+      disabled: disabledText,
+      link: brandText,
+      maxContrast: '#FFF',
     },
+
     primary: {
-      main: '#ff934d',
-      text: '#ff934d',
-      border: '#ff934d',
+      main: brandMain,
+      text: brandText,
+      border: brandMain,
       name: 'primary',
-      // shade: 'rgb(255, 173, 80)',
-      // transparent: '#FEAC3426',
-      //  contrastText: '#111614',
-      //  borderTransparent: '#FFD78340',
     },
+
     secondary: {
-      main: 'rgba(200, 200, 180, 0.10)',
-      shade: 'rgba(200, 200, 180, 0.14)',
-      transparent: 'rgba(200, 200, 180, 0.08)',
-      text: 'rgb(200, 200, 180)',
-      contrastText: 'rgb(200, 200, 180)',
-      border: 'rgba(200, 200, 180, 0.08)',
-      name: 'secondary',
-      borderTransparent: 'rgba(200, 200, 180, 0.25)',
+      main: `rgba(${whiteBase}, 0.10)`,
+      shade: `rgba(${whiteBase}, 0.14)`,
+      transparent: `rgba(${whiteBase}, 0.08)`,
+      text: `rgba(${whiteBase})`,
+      contrastText: `rgb(${whiteBase})`,
+      border: `rgba(${whiteBase}, 0.08)`,
     },
+
     background: {
       canvas: '#000',
       primary: '#111',
       secondary: '#222',
     },
+
     action: {
-      hover: 'rgba(200, 200, 180, 0.10)',
-      selected: 'rgba(200, 200, 180, 0.12)',
-      selectedBorder: '#ff934d',
-      focus: 'rgba(200, 200, 180, 0.10)',
+      hover: `rgba(${whiteBase}, 0.16)`,
+      selected: `rgba(${whiteBase}, 0.12)`,
+      selectedBorder: brandMain,
+      focus: `rgba(${whiteBase}, 0.16)`,
       hoverOpacity: 0.08,
-      disabledText: 'rgba(200, 200, 180, 0.6)',
-      disabledBackground: 'rgba(200, 200, 180, 0.04)',
+      disabledText: disabledText,
+      disabledBackground: `rgba(${whiteBase}, 0.04)`,
       disabledOpacity: 0.38,
     },
+
     gradients: {
       brandHorizontal: 'linear-gradient(270deg, #ff934d 0%, #FEAC34 100%)',
       brandVertical: 'linear-gradient(0.01deg, #ff934d 0.01%, #FEAC34 99.99%)',
     },
+
     contrastThreshold: 3,
     hoverFactor: 0.03,
     tonalOffset: 0.15,

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -1,0 +1,67 @@
+import { NewThemeOptions } from '../createTheme';
+
+const gildedGroveTheme: NewThemeOptions = {
+  name: 'Gloom',
+  colors: {
+    mode: 'dark',
+    border: {
+      weak: 'rgba(200, 200, 180, 0.12)',
+      medium: 'rgba(200, 200, 180, 0.20)',
+      strong: 'rgba(200, 200, 180, 0.30)',
+    },
+    text: {
+      primary: 'rgb(250, 250, 239)',
+      secondary: 'rgba(200, 200, 180, 0.85)',
+      disabled: 'rgba(200, 200, 180, 0.6)',
+      link: '#ff934d',
+      maxContrast: '#FFFFFF',
+    },
+    primary: {
+      main: '#ff934d',
+      text: '#ff934d',
+      border: '#ff934d',
+      name: 'primary',
+      // shade: 'rgb(255, 173, 80)',
+      // transparent: '#FEAC3426',
+      //  contrastText: '#111614',
+      //  borderTransparent: '#FFD78340',
+    },
+    secondary: {
+      main: 'rgba(200, 200, 180, 0.10)',
+      shade: 'rgba(200, 200, 180, 0.14)',
+      transparent: 'rgba(200, 200, 180, 0.08)',
+      text: 'rgb(200, 200, 180)',
+      contrastText: 'rgb(200, 200, 180)',
+      border: 'rgba(200, 200, 180, 0.08)',
+      name: 'secondary',
+      borderTransparent: 'rgba(200, 200, 180, 0.25)',
+    },
+    background: {
+      canvas: '#000',
+      primary: '#111',
+      secondary: '#222',
+    },
+    action: {
+      hover: 'rgba(200, 200, 180, 0.10)',
+      selected: 'rgba(200, 200, 180, 0.12)',
+      selectedBorder: '#ff934d',
+      focus: 'rgba(200, 200, 180, 0.10)',
+      hoverOpacity: 0.08,
+      disabledText: 'rgba(200, 200, 180, 0.6)',
+      disabledBackground: 'rgba(200, 200, 180, 0.04)',
+      disabledOpacity: 0.38,
+    },
+    gradients: {
+      brandHorizontal: 'linear-gradient(270deg, #ff934d 0%, #FEAC34 100%)',
+      brandVertical: 'linear-gradient(0.01deg, #ff934d 0.01%, #FEAC34 99.99%)',
+    },
+    contrastThreshold: 3,
+    hoverFactor: 0.03,
+    tonalOffset: 0.15,
+  },
+  shape: {
+    borderRadius: 5,
+  },
+};
+
+export default gildedGroveTheme;

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -48,8 +48,8 @@ const gloomTheme: NewThemeOptions = {
 
     background: {
       canvas: '#000',
-      primary: '#140b0b',
-      secondary: '#231919',
+      primary: '#0d0b14',
+      secondary: '#19171f',
     },
 
     action: {

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -6,6 +6,7 @@ import { NewThemeOptions } from '../createTheme';
  */
 
 const whiteBase = `210, 210, 220`;
+const secondaryBase = `250, 220, 189`;
 const brandMain = '#ff934d';
 const brandText = '#f99a5c';
 
@@ -37,18 +38,19 @@ const gloomTheme: NewThemeOptions = {
     },
 
     secondary: {
-      main: `rgba(${whiteBase}, 0.10)`,
-      shade: `rgba(${whiteBase}, 0.14)`,
-      transparent: `rgba(${whiteBase}, 0.08)`,
-      text: `rgba(${whiteBase})`,
-      contrastText: `rgb(${whiteBase})`,
-      border: `rgba(${whiteBase}, 0.08)`,
+      main: `rgba(${secondaryBase}, 0.10)`,
+      shade: `rgba(${secondaryBase}, 0.14)`,
+      transparent: `rgba(${secondaryBase}, 0.08)`,
+      text: `rgba(${secondaryBase})`,
+      contrastText: `rgb(${secondaryBase})`,
+      border: `rgba(${secondaryBase}, 0.08)`,
     },
 
     background: {
       canvas: '#000',
       primary: '#170c0c',
-      secondary: '#231919',
+      //secondary: '#231919',
+      secondary: '#281c1c',
     },
 
     action: {

--- a/packages/grafana-data/src/themes/themeDefinitions/index.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/index.ts
@@ -9,3 +9,4 @@ export { default as synthwave } from './synthwave';
 export { default as tron } from './tron';
 export { default as victorian } from './victorian';
 export { default as zen } from './zen';
+export { default as gloom } from './gloom';

--- a/pkg/services/preference/themes.go
+++ b/pkg/services/preference/themes.go
@@ -21,6 +21,7 @@ var themes = []ThemeDTO{
 	{ID: "tron", Type: "dark", IsExtra: true},
 	{ID: "victorian", Type: "dark", IsExtra: true},
 	{ID: "zen", Type: "light", IsExtra: true},
+	{ID: "gloom", Type: "dark", IsExtra: true},
 }
 
 func GetThemeByID(id string) *ThemeDTO {

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -92,6 +92,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
       allowedExtraThemes.push('gildedgrove');
       allowedExtraThemes.push('sapphiredusk');
       allowedExtraThemes.push('tron');
+      allowedExtraThemes.push('gloom');
     }
 
     this.themeOptions = getBuiltInThemes(allowedExtraThemes).map((theme) => ({


### PR DESCRIPTION
named it Gloom because it it pretty dark but happy with name suggestions

This is pretty close to current dark theme but trying to be a bit more dark and sharp (and with a bit more saturation). 

* Absolute black as canvas 
* Text so a bit more mellow similar to github dark and our default dark theme (compared to gilded grove which has super bright text) 
* hover action is a bit more subdued 
* Primary color and link color is unchanged (might tweak later)
* Secondary button pretty same as dark theme 

This is all very much WIP, but want to have 1 of these GrafanaCon themes that I can play around with over the coming months :) 

![Screenshot 2025-02-06 at 21 09 54](https://github.com/user-attachments/assets/2ea8fb66-e8c6-49cb-86aa-1bc934e0280a)
![Screenshot 2025-02-06 at 21 09 36](https://github.com/user-attachments/assets/8cad983c-2c3b-4e53-bc15-80ee7ece4c98)
![Screenshot 2025-02-06 at 21 09 22](https://github.com/user-attachments/assets/193b273b-a9ea-4a88-b71a-5a79917c427b)

