### PR TITLE
feat(unified-storage): keep tags on reduce of dashboards

### DIFF
--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -31,7 +31,7 @@ func NewDashboardLargeObjectSupport(scheme *runtime.Scheme) *apistore.BasicLarge
 			dash.Spec = spec
 			dash.SetManagedFields(nil) // this could be bigger than the object!
 
-			keep := []string{"title", "description", "schemaVersion"}
+			keep := []string{"title", "description", "tags", "schemaVersion"}
 			for _, k := range keep {
 				v, ok := old[k]
 				if ok {

--- a/pkg/registry/apis/dashboard/large_test.go
+++ b/pkg/registry/apis/dashboard/large_test.go
@@ -54,7 +54,8 @@ func TestLargeDashboardSupport(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"schemaVersion": 33,
-		"title": "Panel tests - All panels"
+		"title": "Panel tests - All panels",
+		"tags": ["gdev","panel-tests","all-panels"]
 	}`, string(small))
 
 	// Now make it big again


### PR DESCRIPTION
This PRs ensures that we keep the tags when reducing large objects. Tags can be used by the indexer to filter queries down:

https://github.com/grafana/grafana/blob/f4426e22bfc419b21d7c45dba9911d835c7999ce/pkg/storage/unified/search/dashboard.go#L280