### PR TITLE
Explore metrics: Always check that custom var is present for otel dep env migration

### DIFF
--- a/public/app/features/trails/migrations/otelDeploymentEnvironment.ts
+++ b/public/app/features/trails/migrations/otelDeploymentEnvironment.ts
@@ -32,8 +32,15 @@ export function migrateOtelDeploymentEnvironment(trail: DataTrail, urlParams: Ur
   ) {
     return;
   }
-  // if there is no dep env, does not need to be migrated
-  if (!deploymentEnv) {
+
+  // check that there is a deployment environment variable value to migrate
+  // in some cases the deployment environment may not present
+  // but due to this change it is now always present and the value is undefined
+  // https://github.com/grafana/scenes/pull/1033
+  if (
+    !deploymentEnv ||
+    (Array.isArray(deploymentEnv) && deploymentEnv.length > 0 && deploymentEnv[0] === 'undefined')
+  ) {
     return;
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/14566

**What is this?**

This is a bug fix for when the OTel experience was being enabled on loading Explore metrics with a URL. 

![Screenshot 2025-02-06 at 2 29 46 PM](https://github.com/user-attachments/assets/b4336ae0-8b5d-4938-833f-062d44e1f4ea)

**What happened?**

We recently consolidated the filters for the OTel experience going from three variables to one. These variable were present in the URL and the otel variable `var-deployment_environment` was present only if the OTel experience had been enabled. 

There needed to be a migration to check that URLs that had OTel specific variables behaved the same. Part of this check was that the previous variable `var-deployment_environment` was present in the URL. If it was present, then the OTel experience had been enabled and we would migrate this value to the new consolidated filters. If it was not present, we would skip the migration.

In Scenes, [this change](https://github.com/grafana/scenes/pull/1033) was introduced that caused the custom variable `var-deployment_environment` to always be present, to always have a value `undefined`, which then always migrated all URLs to show the OTel experience had been turned on, thus causing the bug.

**Special notes for your reviewer:**
How to test:
1. Load Explore metrics with a URL that has a `var-filter` in it like the following:
2. `http://localhost:3000/explore/metrics/trail?nativeHistogramMetric=&from=now-1h&to=now&timezone=browser&var-ds=<DS-VAR>&var-otel_resources=&var-filters=cluster%7C%3D%7CC2&var-otel_and_metric_filters=&var-deployment_environment=undefined&metricPrefix=all`
3. See that it loads and does not turn on the OTel experience.
4. Next, to see the bug, go into the code and change the following, commenting out the second line check for the deployment environment var existing but the value is the string 'undefined'
```
  if (
    !deploymentEnv // ||
    // (Array.isArray(deploymentEnv) && deploymentEnv.length > 0 && deploymentEnv[0] === 'undefined')
  ) {
    return;
  }
```
5. Load the same url you used previously, where var-filter has a value.
6. See that OTel is turned on and it will look something like the following where the deployment environment is selected
![Screenshot 2025-02-06 at 2 29 46 PM](https://github.com/user-attachments/assets/7015cb71-9dee-42fd-93d8-9afbe11ebad0)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
