### PR TITLE
PieChart: allow custom sorting of pie chart data

### DIFF
--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -106,6 +106,7 @@ export const PieChart = ({
           <Pie
             data={filteredFieldDisplayValues}
             pieValue={getValue}
+            pieSortValues={() => -1}
             outerRadius={layout.outerRadius}
             innerRadius={layout.innerRadius}
             cornerRadius={3}


### PR DESCRIPTION
**What is this feature?**

Allow custom sorting of pie chart data

**Why do we need this feature?**

Overriding sorting of user data seems to counteract the amount of user options that grafana offers. Sorting is builtin in almost all data sources and can be optionally added through a transformation.  Disabling sorting allows for more advanced use cases that were not possible beforehand.

**Who is this feature for?**

Everyone who wants to control the order of their data in pie charts

**Which issue(s) does this PR fix?**:

Fixes #82972

**Special notes for your reviewer:**

I'm a python script kiddy and this is my first typescript change ever 😬 I would love to make this configurable, but had so much trouble to set up everything. Maybe you can give me a hint on how to add user options. Changing the default behaviour is not my intent.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~~If this is a pre-GA feature, it is behind a feature toggle.~~
- [ ] ~~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~~ Sorting is not described in the [docs](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/pie-chart/)
