### PR TITLE
Unified Storage: Fix legacy dashboard query when using continue token

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -32,7 +32,7 @@ WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
   {{ else if .Query.LastID }}
   AND dashboard_version.version <= {{ .Arg .Query.LastID }}
   {{ end }}
-  ORDER BY 
+  ORDER BY
     dashboard_version.created DESC,
     dashboard_version.version DESC,
     dashboard.uid ASC
@@ -40,7 +40,7 @@ WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
     {{ if .Query.UID }}
     AND dashboard.uid = {{ .Arg .Query.UID }}
     {{ else if .Query.LastID }}
-    AND dashboard.id > {{ .Arg .Query.LastID }}
+    AND dashboard.id < {{ .Arg .Query.LastID }}
     {{ end }}
     {{ if .Query.GetTrash }}
     AND dashboard.deleted IS NOT NULL

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard_next_page.sql
@@ -15,6 +15,6 @@ LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id > 22
+    AND dashboard.id < 22
     AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
@@ -18,7 +18,7 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
-  ORDER BY 
+  ORDER BY
     dashboard_version.created DESC,
     dashboard_version.version DESC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard_next_page.sql
@@ -15,6 +15,6 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id > 22
+    AND dashboard.id < 22
     AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
@@ -18,7 +18,7 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
-  ORDER BY 
+  ORDER BY
     dashboard_version.created DESC,
     dashboard_version.version DESC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard_next_page.sql
@@ -15,6 +15,6 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id > 22
+    AND dashboard.id < 22
     AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
@@ -18,7 +18,7 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
-  ORDER BY 
+  ORDER BY
     dashboard_version.created DESC,
     dashboard_version.version DESC,
     dashboard.uid ASC


### PR DESCRIPTION
We were running into paging issues when Listing legacy dashboards. It would only return two pages.

The problem is that the query is ordered by dashboard id in DESC order, but we are filtering with a AND dashboard.id > LastID.

Fixes it to respect the desc id order.