### PR TITLE
Provisioning: Tiger team takes ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,12 @@
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /hack/ @grafana/grafana-app-platform-squad
 
+/pkg/apis/provisioning @grafana/grafana-git-ui-sync-team
+/public/app/features/provisioning @grafana/grafana-git-ui-sync-team
+/conf/provisioning/sample @grafana/grafana-git-ui-sync-team
+/pkg/registry/apis/provisioning @grafana/grafana-git-ui-sync-team
+/scripts/parse-generated-api.ts @grafana/grafana-git-ui-sync-team
+
 /apps/alerting/ @grafana/alerting-backend
 /apps/playlist/ @grafana/grafana-app-platform-squad
 /apps/investigation/ @fcjack @matryer


### PR DESCRIPTION
Until now, it's all been woned by the App Platform squad. Let's give it to us instead.