### PR TITLE
Prometheus: Fix cursor jump in prometheus code editor

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -133,6 +133,8 @@ const MonacoQueryField = (props: Props) => {
       ref={containerRef}
     >
       <ReactMonacoEditor
+        // see https://github.com/suren-atoyan/monaco-react/issues/365
+        saveViewState
         overrideServices={overrideServicesRef.current}
         options={options}
         language="promql"

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -1,7 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
 import { css } from '@emotion/css';
 import { parser } from '@prometheus-io/lezer-promql';
-import { debounce } from 'lodash';
 import { promLanguageDefinition } from 'monaco-promql';
 import { useEffect, useRef } from 'react';
 import { useLatest } from 'react-use';
@@ -105,13 +104,12 @@ const MonacoQueryField = (props: Props) => {
   // we need only one instance of `overrideServices` during the lifetime of the react component
   const overrideServicesRef = useRef(getOverrideServices());
   const containerRef = useRef<HTMLDivElement>(null);
-  const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder, onChange, datasource } = props;
+  const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder, datasource } = props;
 
   const lpRef = useLatest(languageProvider);
   const historyRef = useLatest(history);
   const onRunQueryRef = useLatest(onRunQuery);
   const onBlurRef = useLatest(onBlur);
-  const onChangeRef = useLatest(onChange);
 
   const autocompleteDisposeFun = useRef<(() => void) | null>(null);
 
@@ -202,23 +200,6 @@ const MonacoQueryField = (props: Props) => {
           editor.onDidContentSizeChange(updateElementHeight);
           updateElementHeight();
 
-          // Whenever the editor changes, lets save the last value so the next query for this editor will be up-to-date.
-          // This change is being introduced to fix a bug where you can submit a query via shift+enter:
-          // If you clicked into another field and haven't un-blurred the active field,
-          // then the query that is run will be stale, as the reference is only updated
-          // with the value of the last blurred input.
-          // This can run quite slowly, so we're debouncing this which should accomplish two things
-          // 1. Should prevent this function from blocking the current call stack by pushing into the web API callback queue
-          // 2. Should prevent a bunch of duplicates of this function being called as the user is typing
-          const updateCurrentEditorValue = debounce(() => {
-            const editorValue = editor.getValue();
-            onChangeRef.current(editorValue);
-          }, lpRef.current.datasource.getDebounceTimeInMilliseconds());
-
-          editor.getModel()?.onDidChangeContent(() => {
-            updateCurrentEditorValue();
-          });
-
           // handle: shift + enter
           // FIXME: maybe move this functionality into CodeEditor?
           editor.addCommand(
@@ -236,9 +217,8 @@ const MonacoQueryField = (props: Props) => {
             command: null,
           });
 
-          /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the
-                    command palette uses. Pass the event out of monaco manually
-                    */
+          // Something in this configuration of monaco doesn't bubble up [mod]+K,
+          // which the command palette uses. Pass the event out of monaco manually
           editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK, function () {
             global.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
           });

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldLazy.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldLazy.tsx
@@ -4,8 +4,6 @@ import { Suspense } from 'react';
 import MonacoQueryField from './MonacoQueryField';
 import { Props } from './MonacoQueryFieldProps';
 
-// const Field = React.lazy(() => import('./MonacoQueryField'));
-
 export const MonacoQueryFieldLazy = (props: Props) => {
   return (
     <Suspense fallback={null}>

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldProps.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldProps.ts
@@ -16,7 +16,5 @@ export type Props = {
   placeholder: string;
   onRunQuery: (value: string) => void;
   onBlur: (value: string) => void;
-  // onChange will never initiate a query, it just denotes that a query value has been changed
-  onChange: (value: string) => void;
   datasource: PrometheusDatasource;
 };

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -23,13 +23,5 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
     onChange(value);
   };
 
-  /**
-   * Handles changes without running any queries
-   * @param value
-   */
-  const handleChange = (value: string) => {
-    onChange(value);
-  };
-
-  return <MonacoQueryFieldLazy onChange={handleChange} onRunQuery={handleRunQuery} onBlur={handleBlur} {...rest} />;
+  return <MonacoQueryFieldLazy onRunQuery={handleRunQuery} onBlur={handleBlur} {...rest} />;
 };


### PR DESCRIPTION
**What is this feature?**

There is no reliable way to reproduce this issue but please check the video below for a reproduction steps:

reproduced at:
00:40
01:03
01:45

https://github.com/user-attachments/assets/c35787f5-745b-4bcd-a0df-9218696511db

Another reproduction:

https://github.com/user-attachments/assets/a63b40b4-fffd-47cc-a156-ec973df43e17

I believe setting a custom `onChange` method causes a race condition where onChange happens after some time (debounce) and the value at the time it runs, is being set to the field. and it's happening when user's typing and it causes the cursor jump. So I revert the custom `onChange` function implementation that was introduced here: https://github.com/grafana/grafana/pull/60191 and https://github.com/grafana/grafana/pull/55513

**Why do we need this feature?**

To prevent annoying cursor jumps while writing a query.

**Who is this feature for?**

All prometheus users who use code mode to write query
