### PR TITLE
fix for #100274 error in DataLink when using  with spaces or underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **CodeEditor:** Fix cursor alignment [#99090](https://github.com/grafana/grafana/pull/99090), [@ashharrison90](https://github.com/ashharrison90)
 - **TransformationFilter**: Include transformation outputs in transformation filtering options: Include transformation outputs in transformation filtering options [#98323](https://github.com/grafana/grafana/pull/98323), [@Sergej-Vlasov](https://github.com/Sergej-Vlasov)
+- **DashboardScene:** Fix datalinks with `${__dashboard}` variable when dashboard title contains spaces or special characters. [#100274](https://github.com/grafana/grafana/pull/100274), [@mansoor17syed](https://github.com/mansoor17syed)
 
 <!-- 11.5.1 END -->
 <!-- 11.5.0 START -->

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -24,7 +24,8 @@ class DashboardMacro implements FormatVariable {
       case 'name':
       case 'id':
       default:
-        return dashboard.state.title;
+        // URL encode the dashboard title when it's used in URLs
+        return fieldPath === 'raw' ? dashboard.state.title : encodeURIComponent(dashboard.state.title);
     }
   }
 


### PR DESCRIPTION
**What is this feature?**
Fix for dashboard title encoding in datalinks when using scenes=true. This update ensures that dashboard titles containing spaces or special characters are properly URL-encoded when used with `${__dashboard}` variable in datalinks.

**Why do we need this feature?**
When using datalinks with `${__dashboard}` variable in Grafana v11.5.x with scenes=true, the links break if the dashboard title contains spaces or underscores. This fix ensures proper URL encoding of dashboard titles, maintaining consistent behavior with previous versions.

**Who is this feature for?**
This fix is for users who:
- Use datalinks in their dashboards
- Reference the current dashboard using `${__dashboard}` variable
- Have dashboard titles containing spaces or special characters
- Have enabled scenes=true

**Which issue(s) does this PR fix?**:
Fixes #100274

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective
  - Verify datalinks work with dashboard titles containing spaces
  - Verify datalinks work with dashboard titles containing special characters
  - Verify backward compatibility is maintained
- [x] If this is a pre-GA feature, it is behind a feature toggle
  - N/A - This is a bug fix for existing functionality
- [x] The docs are updated
  - No documentation update needed as this fixes existing functionality

**Testing performed:**
- Tested with dashboard titles containing spaces
- Tested with dashboard titles containing underscores
- Verified URL encoding is correct
- Verified existing functionality is not affected