### PR TITLE
Dashboard: Fix for overwriting an edited dashboard in the old architecture

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { useAsyncFn } from 'react-use';
 
 import { locationUtil } from '@grafana/data';
@@ -45,6 +46,8 @@ export const useDashboardSave = (isCopy = false) => {
         const result = await saveDashboard(clone, options, dashboard, saveDashboardRtkQuery);
         dashboard.version = result.version;
 
+        // Altering the clone leads to an error due to the clone being immutable
+        clone = cloneDeep(clone);
         clone.version = result.version;
         dashboard.clearUnsavedChanges(clone, options);
 


### PR DESCRIPTION
Backport 158c5443b57742eba904eea18b6b546b6c4a0c3d from #100247

---

**What is this feature?**

Fix for overwriting an edited dashboard in the old architecture.

**Why do we need this feature?**

We have an escalation opened about it.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

https://github.com/grafana/support-escalations/issues/14570

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
