### PR TITLE
SecretsService: keeper Update with sql keeper implementation

### DIFF
--- a/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
@@ -52,3 +52,17 @@ func (s *FakeKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig
 func (s *FakeKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID keepertypes.ExternalID) error {
 	return nil
 }
+
+func (s *FakeKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID keepertypes.ExternalID, exposedValueOrRef string) error {
+	ns, ok := s.values[namespace]
+	if !ok {
+		return keepertypes.ErrSecretNotFound
+	}
+	_, ok = ns[externalID.String()]
+	if !ok {
+		return keepertypes.ErrSecretNotFound
+	}
+
+	ns[externalID.String()] = exposedValueOrRef
+	return nil
+}

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
@@ -20,8 +20,9 @@ type OSSKeeperService struct {
 	store             encryptionstorage.EncryptedValueStorage
 }
 
-func ProvideService(encryptionManager *manager.EncryptionManager, store encryptionstorage.EncryptedValueStorage) (OSSKeeperService, error) {
+func ProvideService(tracer tracing.Tracer, encryptionManager *manager.EncryptionManager, store encryptionstorage.EncryptedValueStorage) (OSSKeeperService, error) {
 	return OSSKeeperService{
+		tracer:            tracer,
 		encryptionManager: encryptionManager,
 		store:             store,
 	}, nil

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
@@ -78,7 +78,7 @@ func setupTestService(t *testing.T, config string) (OSSKeeperService, error) {
 	require.NoError(t, err)
 
 	// Initialize the keeper service
-	keeperService, err := ProvideService(encMgr, encValueStore)
+	keeperService, err := ProvideService(tracing.InitializeTracerForTest(), encMgr, encValueStore)
 
 	return keeperService, err
 }

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
@@ -77,3 +77,14 @@ func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 	}
 	return nil
 }
+
+func (s *SQLKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID keepertypes.ExternalID, exposedValueOrRef string) error {
+	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Update")
+	defer span.End()
+
+	err := s.store.Update(ctx, externalID.String(), []byte(exposedValueOrRef))
+	if err != nil {
+		return fmt.Errorf("failed to update encrypted value: %w", err)
+	}
+	return nil
+}

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
@@ -106,7 +106,7 @@ func Test_SQLKeeperSetup(t *testing.T) {
 		assert.Empty(t, exposedVal)
 	})
 
-	t.Run("deleting an existing secure value does not return error", func(t *testing.T) {
+	t.Run("deleting an existing encrypted value does not return error", func(t *testing.T) {
 		externalID, err := sqlKeeper.Store(ctx, nil, namespace1, plaintext1)
 		require.NoError(t, err)
 		require.NotEmpty(t, externalID)
@@ -120,9 +120,33 @@ func Test_SQLKeeperSetup(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("deleting an non existing secure value does not return error", func(t *testing.T) {
+	t.Run("deleting an non existing encrypted value does not return error", func(t *testing.T) {
 		err = sqlKeeper.Delete(ctx, nil, namespace1, nonExistentID)
 		require.NoError(t, err)
+	})
+
+	t.Run("updating an existent encrypted value returns no error", func(t *testing.T) {
+		externalId1, err := sqlKeeper.Store(ctx, nil, namespace1, plaintext1)
+		require.NoError(t, err)
+		require.NotEmpty(t, externalId1)
+
+		err = sqlKeeper.Update(ctx, nil, namespace1, externalId1, plaintext2)
+		require.NoError(t, err)
+
+		exposedVal, err := sqlKeeper.Expose(ctx, nil, namespace1, externalId1)
+		require.Error(t, err)
+		assert.Empty(t, exposedVal)
+
+		assert.NotEqual(t, plaintext1, exposedVal)
+	})
+
+	t.Run("updating a non existent encrypted value returns error", func(t *testing.T) {
+		externalId1, err := sqlKeeper.Store(ctx, nil, namespace1, plaintext1)
+		require.NoError(t, err)
+		require.NotEmpty(t, externalId1)
+
+		err = sqlKeeper.Update(ctx, nil, namespace1, nonExistentID, plaintext2)
+		require.Error(t, err)
 	})
 }
 

--- a/pkg/registry/apis/secret/secretkeeper/types/types.go
+++ b/pkg/registry/apis/secret/secretkeeper/types/types.go
@@ -23,6 +23,7 @@ const (
 
 type Keeper interface {
 	Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (ExternalID, error)
+	Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID, exposedValueOrRef string) error
 	Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID) (secretv0alpha1.ExposedSecureValue, error)
 	Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID) error
 }


### PR DESCRIPTION
**What is this feature?**
Adding keeper Update method to the interface and sql implementation.

(I was relying on Store but realised we should do it separately as we are updating the existing value by externalID)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1207
