### PR TITLE
Explore metrics: Remove operators =| and !=| from adhoc filters

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -653,7 +653,6 @@ function getVariableSet(
         layout: 'vertical',
         defaultKeys: [],
         applyMode: 'manual',
-        supportsMultiValueOperators: true,
         allowCustomValue: true,
       }),
       new AdHocFiltersVariable({
@@ -666,8 +665,6 @@ function getVariableSet(
         filters: initialFilters ?? [],
         baseFilters: getBaseFiltersForMetric(metric),
         applyMode: 'manual',
-        // since we only support prometheus datasources, this is always true
-        supportsMultiValueOperators: true,
         allowCustomValue: true,
       }),
       ...getVariablesWithOtelJoinQueryConstant(otelJoinQuery ?? ''),
@@ -690,8 +687,6 @@ function getVariableSet(
         filters: initialFilters ?? [],
         baseFilters: getBaseFiltersForMetric(metric),
         applyMode: 'manual',
-        // since we only support prometheus datasources, this is always true
-        supportsMultiValueOperators: true,
         allowCustomValue: true,
         // skipUrlSync: true
       }),


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/98223

Prometheus does not support =| and !=| so this removes those operators from the adhoc filters.

![Screenshot 2025-02-07 at 11 26 09 AM](https://github.com/user-attachments/assets/efb43984-a36b-4392-a0c2-7c43741fd020)

**Special notes for your reviewer:**
1. Open Explore metrics app
2. Click the labels to the right of the data source picker
3. Select and operator
4. See that =| and !=| are no longer present as selections in the filters


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
