### PR TITLE
[search] fix offset param in finddashboards

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -221,11 +221,14 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 	// get limit and offset from query params
 	limit := 50
 	offset := 0
+	page := 1
 	if queryParams.Has("limit") {
 		limit, _ = strconv.Atoi(queryParams.Get("limit"))
 	}
 	if queryParams.Has("offset") {
 		offset, _ = strconv.Atoi(queryParams.Get("offset"))
+	} else if queryParams.Has("page") {
+		page, _ = strconv.Atoi(queryParams.Get("page"))
 	}
 
 	searchRequest := &resource.ResourceSearchRequest{
@@ -233,7 +236,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		Query:   queryParams.Get("query"),
 		Limit:   int64(limit),
 		Offset:  int64(offset),
-		Page:    int64(offset), // on modes 0-2 (legacy) we use "Page" instead of "Offset"
+		Page:    int64(page), // for modes 0-2 (legacy)
 		Explain: queryParams.Has("explain") && queryParams.Get("explain") != "false",
 	}
 	fields := []string{"title", "folder", "tags"}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1755,7 +1755,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 
 	request.Limit = query.Limit
 	request.Page = query.Page
-	request.Offset = query.Page - 1 // bleve's offset is 0 indexed
+	request.Offset = (query.Page - 1) * query.Limit // only relevant when running in modes 3+
 
 	namespace := dr.k8sclient.GetNamespace(query.OrgId)
 	var err error


### PR DESCRIPTION
introduced in https://github.com/grafana/grafana/pull/99765

Due to the way I tested the API endpoints I had a feeling that `Offset` was behaving like the `Page` param, but it turns out it's behaving like it should. 

This PR converts the page to offset when hitting `/api/search` so it behaves like "page" when hitting Unified storage, and separates the "page" query param from "offset" in the k8s endpoint