### PR TITLE
[Provisioning] Move validation logic to repository package

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -247,7 +247,7 @@ func (b *APIBuilder) GetHealthyRepository(ctx context.Context, name string) (rep
 			ctx := identity.WithRequester(ctx, id)
 
 			// Check health again
-			s, err := b.tester.TestRepository(ctx, repo)
+			s, err := repository.TestRepository(ctx, repo)
 			if err != nil {
 				return nil, err // The status
 			}
@@ -358,7 +358,7 @@ func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o adm
 		return err
 	}
 
-	list := ValidateRepository(repo)
+	list := repository.ValidateRepository(repo)
 	cfg := repo.Config()
 
 	if a.GetOperation() == admission.Update {
@@ -456,7 +456,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.resourceLister,
 				b.parsers,
 				b.identities,
-				b.tester,
+				&repository.Tester{},
 				b.jobs,
 			)
 			if err != nil {

--- a/pkg/registry/apis/provisioning/repository/test.go
+++ b/pkg/registry/apis/provisioning/repository/test.go
@@ -1,0 +1,78 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+
+	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Tester is a struct that implements the Tester interface
+// it's temporary
+// FIXME: remove as soon as controller and jobs refactoring PRs are merged
+type Tester struct{}
+
+func (t *Tester) TestRepository(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
+	return TestRepository(ctx, repo)
+}
+
+func TestRepository(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
+	errors := ValidateRepository(repo)
+	if len(errors) > 0 {
+		rsp := &provisioning.TestResults{
+			Code:    http.StatusUnprocessableEntity, // Invalid
+			Success: false,
+			Errors:  make([]string, len(errors)),
+		}
+		for i, v := range errors {
+			rsp.Errors[i] = v.Error()
+		}
+		return rsp, nil
+	}
+
+	return repo.Test(ctx)
+}
+
+func ValidateRepository(repo Repository) field.ErrorList {
+	list := repo.Validate()
+	cfg := repo.Config()
+
+	if cfg.Spec.Title == "" {
+		list = append(list, field.Required(field.NewPath("spec", "title"), "a repository title must be given"))
+	}
+
+	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.Target == "" {
+		list = append(list, field.Required(field.NewPath("spec", "sync", "target"),
+			"The target type is required when sync is enabled"))
+	}
+
+	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.IntervalSeconds < 10 {
+		list = append(list, field.Invalid(field.NewPath("spec", "sync", "intervalSeconds"),
+			cfg.Spec.Sync.IntervalSeconds, fmt.Sprintf("Interval must be at least %d seconds", 10)))
+	}
+
+	// Reserved names (for now)
+	reserved := []string{"classic", "sql", "SQL", "plugins", "legacy", "new", "job", "github", "s3", "gcs", "file", "new", "create", "update", "delete"}
+	if slices.Contains(reserved, cfg.Name) {
+		list = append(list, field.Invalid(field.NewPath("metadata", "name"), cfg.Name, "Name is reserved, choose a different identifier"))
+	}
+
+	if cfg.Spec.Type != provisioning.LocalRepositoryType && cfg.Spec.Local != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "local"),
+			cfg.Spec.GitHub, "Local config only valid when type is local"))
+	}
+
+	if cfg.Spec.Type != provisioning.GitHubRepositoryType && cfg.Spec.GitHub != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "github"),
+			cfg.Spec.GitHub, "Github config only valid when type is github"))
+	}
+
+	if cfg.Spec.Type != provisioning.S3RepositoryType && cfg.Spec.S3 != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "s3"),
+			cfg.Spec.GitHub, "S3 config only valid when type is s3"))
+	}
+	return list
+}

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -55,7 +55,7 @@ type RepositoryController struct {
 	// Converts config to instance
 	repoGetter RepoGetter
 	identities auth.BackgroundIdentityService
-	tester     *RepositoryTester
+	tester     *repository.Tester
 
 	// To allow injection for testing.
 	processFn         func(item *queueItem) error
@@ -73,7 +73,7 @@ func NewRepositoryController(
 	resourceLister resources.ResourceLister,
 	parsers *resources.ParserFactory,
 	identities auth.BackgroundIdentityService,
-	tester *RepositoryTester,
+	tester *repository.Tester,
 	jobs jobs.JobQueue,
 ) (*RepositoryController, error) {
 	rc := &RepositoryController{

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -3,16 +3,13 @@ package provisioning
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
@@ -96,7 +93,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, opts runtime.O
 		}
 
 		// Only call test if field validation passes
-		rsp, err := s.tester.TestRepository(ctx, repo)
+		rsp, err := repository.TestRepository(ctx, repo)
 		if err != nil {
 			responder.Error(err)
 			return
@@ -111,24 +108,6 @@ type RepositoryTester struct {
 
 	// Repository+Jobs
 	client client.ProvisioningV0alpha1Interface
-}
-
-// This function will check if the repository is configured and functioning as expected
-func (t *RepositoryTester) TestRepository(ctx context.Context, repo repository.Repository) (*provisioning.TestResults, error) {
-	errors := ValidateRepository(repo)
-	if len(errors) > 0 {
-		rsp := &provisioning.TestResults{
-			Code:    http.StatusUnprocessableEntity, // Invalid
-			Success: false,
-			Errors:  make([]string, len(errors)),
-		}
-		for i, v := range errors {
-			rsp.Errors[i] = v.Error()
-		}
-		return rsp, nil
-	}
-
-	return repo.Test(ctx)
 }
 
 // This function will check if the repository is configured and functioning as expected
@@ -152,49 +131,6 @@ func (t *RepositoryTester) UpdateHealthStatus(ctx context.Context, cfg *provisio
 	_, err := t.client.Repositories(repo.GetNamespace()).
 		UpdateStatus(ctx, repo, metav1.UpdateOptions{})
 	return repo, err
-}
-
-// Validate a repository
-func ValidateRepository(repo repository.Repository) field.ErrorList {
-	list := repo.Validate()
-	cfg := repo.Config()
-
-	if cfg.Spec.Title == "" {
-		list = append(list, field.Required(field.NewPath("spec", "title"), "a repository title must be given"))
-	}
-
-	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.Target == "" {
-		list = append(list, field.Required(field.NewPath("spec", "sync", "target"),
-			"The target type is required when sync is enabled"))
-	}
-
-	resyncIntervalSeconds := int64(ResyncInterval / time.Second)
-	if cfg.Spec.Sync.Enabled && cfg.Spec.Sync.IntervalSeconds < resyncIntervalSeconds {
-		list = append(list, field.Invalid(field.NewPath("spec", "sync", "intervalSeconds"),
-			cfg.Spec.Sync.IntervalSeconds, fmt.Sprintf("Interval must be at least %d seconds", resyncIntervalSeconds)))
-	}
-
-	// Reserved names (for now)
-	reserved := []string{"classic", "sql", "SQL", "plugins", "legacy", "new", "job", "github", "s3", "gcs", "file", "new", "create", "update", "delete"}
-	if slices.Contains(reserved, cfg.Name) {
-		list = append(list, field.Invalid(field.NewPath("metadata", "name"), cfg.Name, "Name is reserved, choose a different identifier"))
-	}
-
-	if cfg.Spec.Type != provisioning.LocalRepositoryType && cfg.Spec.Local != nil {
-		list = append(list, field.Invalid(field.NewPath("spec", "local"),
-			cfg.Spec.GitHub, "Local config only valid when type is local"))
-	}
-
-	if cfg.Spec.Type != provisioning.GitHubRepositoryType && cfg.Spec.GitHub != nil {
-		list = append(list, field.Invalid(field.NewPath("spec", "github"),
-			cfg.Spec.GitHub, "Github config only valid when type is github"))
-	}
-
-	if cfg.Spec.Type != provisioning.S3RepositoryType && cfg.Spec.S3 != nil {
-		list = append(list, field.Invalid(field.NewPath("spec", "s3"),
-			cfg.Spec.GitHub, "S3 config only valid when type is s3"))
-	}
-	return list
 }
 
 var (

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -20,7 +20,6 @@ import (
 
 type testConnector struct {
 	getter RepoGetter
-	tester *RepositoryTester
 }
 
 func (*testConnector) New() runtime.Object {


### PR DESCRIPTION
Move validation logic into repository package as it's related to the spec and logic for the repository itself and we want to keep our connectors lean.

# Remarks

- In a follow up, I plan to move some status / health logic into a separate package as it's spread across connectors, controller and other spots. This is just an initial step as I run out of time for the week.
- The changes here conflict with the other open PRs, for that reason I added the `Tester` struct temporarilly.
