### PR TITLE
refactor(unified-storage): proper log errors in mode1 and don't fetch in background

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -66,8 +66,11 @@ func (d *DualWriterMode1) Create(ctx context.Context, in runtime.Object, createV
 
 	createdCopy := created.DeepCopyObject()
 
-	//nolint:errcheck
-	go d.createOnUnifiedStorage(ctx, createValidation, createdCopy, options)
+	go func() {
+		if err := d.createOnUnifiedStorage(ctx, createValidation, createdCopy, options); err != nil {
+			log.Error(err, "unable to create object in unified storage")
+		}
+	}()
 
 	return created, err
 }
@@ -116,9 +119,6 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 	}
 	d.recordLegacyDuration(errLegacy != nil, mode1Str, d.resource, method, startLegacy)
 
-	//nolint:errcheck
-	go d.getFromUnifiedStorage(ctx, res, name, options)
-
 	return res, errLegacy
 }
 
@@ -158,9 +158,6 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 	if err != nil {
 		log.Error(err, "unable to list object in legacy storage")
 	}
-
-	//nolint:errcheck
-	go d.listFromUnifiedStorage(ctx, options, res)
 
 	return res, err
 }
@@ -202,8 +199,11 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 		return res, async, err
 	}
 
-	//nolint:errcheck
-	go d.deleteFromUnifiedStorage(ctx, res, name, deleteValidation, options)
+	go func() {
+		if err := d.deleteFromUnifiedStorage(ctx, res, name, deleteValidation, options); err != nil {
+			log.Error(err, "unable to delete object in unified storage")
+		}
+	}()
 
 	return res, async, err
 }
@@ -245,8 +245,11 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 		return res, err
 	}
 
-	//nolint:errcheck
-	go d.deleteCollectionFromUnifiedStorage(ctx, res, deleteValidation, options, listOptions)
+	go func() {
+		if err := d.deleteCollectionFromUnifiedStorage(ctx, res, deleteValidation, options, listOptions); err != nil {
+			log.Error(err, "unable to delete collection in unified storage")
+		}
+	}()
 
 	return res, err
 }
@@ -287,8 +290,11 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 		return objLegacy, async, err
 	}
 
-	//nolint:errcheck
-	go d.updateOnUnifiedStorageMode1(ctx, objLegacy, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	go func() {
+		if err := d.updateOnUnifiedStorageMode1(ctx, objLegacy, name, objInfo, createValidation, updateValidation, forceAllowCreate, options); err != nil {
+			log.Error(err, "unable to update object in unified storage")
+		}
+	}()
 
 	return objLegacy, async, err
 }


### PR DESCRIPTION
… in background

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
