### PR TITLE
Elasticsearch: Replace level in adhoc filters with level field name

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -812,6 +812,13 @@ describe('ElasticDatasource', () => {
           const query = ds.addAdHocFilters('', filters);
           expect(query).toBe('field\\:name:/field value\\//');
         });
+
+        it('should replace level with the log level field', () => {
+          const ds = createElasticDatasource({ jsonData: { logLevelField: 'level_field' } });
+          const filters = [{ key: 'level', operator: '=', value: 'foo', condition: '' }];
+          const query = ds.addAdHocFilters('', filters);
+          expect(query).toBe('level_field:"foo"');
+        });
       });
     });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1139,7 +1139,7 @@ export class ElasticDatasource
     }
     let finalQuery = query;
     adhocFilters.forEach((filter) => {
-      finalQuery = addAddHocFilter(finalQuery, filter);
+      finalQuery = addAddHocFilter(finalQuery, filter, this.logLevelField);
     });
 
     return finalQuery;

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -83,7 +83,7 @@ function concatenate(query: string, filter: string, condition = 'AND'): string {
 /**
  * Adds a label:"value" expression to the query.
  */
-export function addAddHocFilter(query: string, filter: AdHocVariableFilter): string {
+export function addAddHocFilter(query: string, filter: AdHocVariableFilter, logLevelField?: string): string {
   if (!filter.key || !filter.value) {
     return query;
   }
@@ -94,15 +94,20 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
     value: filter.value.toString(),
   };
 
+  let key = filter.key;
+  if (logLevelField && key === 'level') {
+    key = logLevelField;
+  }
+
   const equalityFilters = ['=', '!='];
   if (equalityFilters.includes(filter.operator)) {
-    return addFilterToQuery(query, filter.key, filter.value, filter.operator === '=' ? '' : '-');
+    return addFilterToQuery(query, key, filter.value, filter.operator === '=' ? '' : '-');
   }
   /**
    * Keys and values in ad hoc filters may contain characters such as
    * colons, which needs to be escaped.
    */
-  const key = escapeFilter(filter.key);
+  key = escapeFilter(key);
   const value = escapeFilterValue(filter.value);
   const regexValue = escapeFilterValue(filter.value, false);
   let addHocFilter = '';


### PR DESCRIPTION
The problem in the original issue is that when we make a logs query, we rename the `logLevelField` field to `level`, and when users try to make an adhoc query with that `level` field it fails because the datasource doesn't have that field.
Outside of significantly changing the logs data representation (which we could ask about? But seems like a compatibility nightmare) the primary 2 choices for fixes are
1) This, which is replacing 'level' in adhoc filter keys with the level field name. The one thing is that this could cause an issue if they have a different field named 'level' (which seems unlikely?)
2) Adding the level field under both 'level' and its original name, which seems like it could be confusing for users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #94130

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
