### PR TITLE
Chore: Reduce stat call by using WalkDir and use filepath.Ext for file extension 

### DIFF
--- a/pkg/build/fs.go
+++ b/pkg/build/fs.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 func logAndClose(c io.Closer) {
@@ -18,12 +18,12 @@ func logAndClose(c io.Closer) {
 }
 
 func shaDir(dir string) error {
-	return filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if path == dir {
 			return nil
 		}
 
-		if strings.Contains(path, ".sha256") {
+		if filepath.Ext(path) == ".sha256" {
 			return nil
 		}
 		if err := shaFile(path); err != nil {

--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"mime"
 	"os"
@@ -288,8 +289,8 @@ func (client *Client) Delete(ctx context.Context, bucket *storage.BucketHandle, 
 // ListLocalFiles lists files in a local filesystem.
 func ListLocalFiles(dir string) ([]File, error) {
 	var files []File
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() {
 			files = append(files, File{
 				FullPath: path,
 				// Strip the dir name from the filepath

--- a/pkg/services/store/kind/dashboard/summary_test.go
+++ b/pkg/services/store/kind/dashboard/summary_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -20,13 +21,13 @@ func TestGdevReadSummaries(t *testing.T) {
 	reader := GetEntitySummaryBuilder()
 	failed := make([]string, 0, 10)
 
-	err := filepath.Walk(devdash,
-		func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(devdash,
+		func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 
-			if !info.IsDir() && strings.HasSuffix(path, ".json") {
+			if !d.IsDir() && filepath.Ext(path) == ".json" {
 				// Ignore gosec warning G304 since it's a test
 				// nolint:gosec
 				body, err := os.ReadFile(path)

--- a/pkg/tsdb/Magefile.go
+++ b/pkg/tsdb/Magefile.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,7 @@ import (
 
 func find(dir string, name string) ([]string, error) {
 	files := []string{}
-	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- filepath.Walk call os.Lstat for every file or directory that is being traversed.
- filepath.WalkDir avoids stat call by directly providing DirEntry interface.
- Use filepath.Ext for filepath extension instead of strings.HasSuffix.

