### PR TITLE
Dashboards: refactor transform scene layout to save model and transform save model to scene layout, schema v2

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -15,6 +15,7 @@ import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import { t } from 'app/core/internationalization';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 
+import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { isClonedKey, joinCloneKeys } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import {
@@ -54,6 +55,9 @@ export class DefaultGridLayoutManager
     },
     id: 'default-grid',
     createFromLayout: DefaultGridLayoutManager.createFromLayout,
+    getSerializer: () => {
+      return layoutSerializerRegistry.get('GridLayout').serializer;
+    },
   };
 
   public readonly descriptor = DefaultGridLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../utils/utils';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { DashboardGridItem } from './DashboardGridItem';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
@@ -46,7 +47,7 @@ export class DefaultGridLayoutManager
 
   public readonly isDashboardLayoutManager = true;
 
-  public static readonly descriptor = {
+  public static readonly descriptor: LayoutRegistryItem = {
     get name() {
       return t('dashboard.default-layout.name', 'Default grid');
     },
@@ -55,9 +56,7 @@ export class DefaultGridLayoutManager
     },
     id: 'default-grid',
     createFromLayout: DefaultGridLayoutManager.createFromLayout,
-    getSerializer: () => {
-      return layoutSerializerRegistry.get('GridLayout').serializer;
-    },
+    kind: 'GridLayout',
   };
 
   public readonly descriptor = DefaultGridLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -15,7 +15,6 @@ import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import { t } from 'app/core/internationalization';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 
-import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { isClonedKey, joinCloneKeys } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -8,6 +8,7 @@ import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelI
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { ResponsiveGridItem } from './ResponsiveGridItem';
 import { getEditOptions } from './ResponsiveGridLayoutManagerEditor';
@@ -24,7 +25,7 @@ export class ResponsiveGridLayoutManager
 
   public readonly isDashboardLayoutManager = true;
 
-  public static readonly descriptor = {
+  public static readonly descriptor: LayoutRegistryItem = {
     get name() {
       return t('dashboard.responsive-layout.name', 'Responsive grid');
     },
@@ -33,9 +34,8 @@ export class ResponsiveGridLayoutManager
     },
     id: 'responsive-grid',
     createFromLayout: ResponsiveGridLayoutManager.createFromLayout,
-    getSerializer: () => {
-      return layoutSerializerRegistry.get('ResponsiveGridLayout').serializer;
-    },
+
+    kind: 'ResponsiveGridLayout',
   };
 
   public readonly descriptor = ResponsiveGridLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -2,6 +2,7 @@ import { SceneComponentProps, SceneCSSGridLayout, SceneObjectBase, SceneObjectSt
 import { t } from 'app/core/internationalization';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
+import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelId } from '../../utils/utils';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -32,6 +33,9 @@ export class ResponsiveGridLayoutManager
     },
     id: 'responsive-grid',
     createFromLayout: ResponsiveGridLayoutManager.createFromLayout,
+    getSerializer: () => {
+      return layoutSerializerRegistry.get('ResponsiveGridLayout').serializer;
+    },
   };
 
   public readonly descriptor = ResponsiveGridLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -2,7 +2,6 @@ import { SceneComponentProps, SceneCSSGridLayout, SceneObjectBase, SceneObjectSt
 import { t } from 'app/core/internationalization';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
-import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelId } from '../../utils/utils';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -1,7 +1,6 @@
 import { SceneGridItemLike, SceneGridRow, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
 
-import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { isClonedKey } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -1,6 +1,7 @@
 import { SceneGridItemLike, SceneGridRow, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
 
+import { layoutSerializerRegistry } from '../../serialization/layoutSerializers/layoutSerializerRegistry';
 import { isClonedKey } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../../utils/utils';
@@ -32,6 +33,10 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
     },
     id: 'rows-layout',
     createFromLayout: RowsLayoutManager.createFromLayout,
+
+    getSerializer: () => {
+      return layoutSerializerRegistry.get('RowsLayout').serializer;
+    },
   };
 
   public readonly descriptor = RowsLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -10,6 +10,7 @@ import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutMan
 import { RowRepeaterBehavior } from '../layout-default/RowRepeaterBehavior';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { RowItem } from './RowItem';
 import { RowItemRepeaterBehavior } from './RowItemRepeaterBehavior';
@@ -24,7 +25,7 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
 
   public readonly isDashboardLayoutManager = true;
 
-  public static readonly descriptor = {
+  public static readonly descriptor: LayoutRegistryItem = {
     get name() {
       return t('dashboard.rows-layout.name', 'Rows');
     },
@@ -34,9 +35,7 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
     id: 'rows-layout',
     createFromLayout: RowsLayoutManager.createFromLayout,
 
-    getSerializer: () => {
-      return layoutSerializerRegistry.get('RowsLayout').serializer;
-    },
+    kind: 'RowsLayout',
   };
 
   public readonly descriptor = RowsLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -25,6 +25,9 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
     },
     id: 'tabs-layout',
     createFromLayout: TabsLayoutManager.createFromLayout,
+    getSerializer: () => {
+      throw new Error('Not implemented');
+    },
   };
 
   public readonly descriptor = TabsLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -25,9 +25,6 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
     },
     id: 'tabs-layout',
     createFromLayout: TabsLayoutManager.createFromLayout,
-    getSerializer: () => {
-      throw new Error('Not implemented');
-    },
   };
 
   public readonly descriptor = TabsLayoutManager.descriptor;

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -1,4 +1,5 @@
 import { SceneObject, VizPanel } from '@grafana/scenes';
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { LayoutRegistryItem } from './LayoutRegistryItem';
@@ -80,6 +81,15 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
    * @param isSource
    */
   cloneLayout?(ancestorKey: string, isSource: boolean): DashboardLayoutManager;
+}
+
+export interface LayoutManagerSerializer {
+  serialize(layout: DashboardLayoutManager, isSnapshot?: boolean): DashboardV2Spec['layout'];
+  deserialize(
+    dashboard: DashboardV2Spec['layout'],
+    elements: DashboardV2Spec['elements'],
+    preload: boolean
+  ): DashboardLayoutManager;
 }
 
 export function isDashboardLayoutManager(obj: SceneObject): obj is DashboardLayoutManager {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -86,7 +86,7 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
 export interface LayoutManagerSerializer {
   serialize(layout: DashboardLayoutManager, isSnapshot?: boolean): DashboardV2Spec['layout'];
   deserialize(
-    dashboard: DashboardV2Spec['layout'],
+    layout: DashboardV2Spec['layout'],
     elements: DashboardV2Spec['elements'],
     preload: boolean
   ): DashboardLayoutManager;

--- a/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
@@ -1,6 +1,6 @@
 import { RegistryItem } from '@grafana/data';
 
-import { DashboardLayoutManager } from './DashboardLayoutManager';
+import { DashboardLayoutManager, LayoutManagerSerializer } from './DashboardLayoutManager';
 
 /**
  * The layout descriptor used when selecting / switching layouts
@@ -17,4 +17,9 @@ export interface LayoutRegistryItem<S = {}> extends RegistryItem {
    * @param saveModel
    */
   createFromSaveModel?(saveModel: S): void;
+
+  /**
+   * Serializer for the layout
+   */
+  getSerializer(): LayoutManagerSerializer;
 }

--- a/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
@@ -1,6 +1,7 @@
 import { RegistryItem } from '@grafana/data';
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
 
-import { DashboardLayoutManager, LayoutManagerSerializer } from './DashboardLayoutManager';
+import { DashboardLayoutManager } from './DashboardLayoutManager';
 
 /**
  * The layout descriptor used when selecting / switching layouts
@@ -19,7 +20,7 @@ export interface LayoutRegistryItem<S = {}> extends RegistryItem {
   createFromSaveModel?(saveModel: S): void;
 
   /**
-   * Serializer for the layout
+   * Schema kind of layout
    */
-  getSerializer(): LayoutManagerSerializer;
+  kind?: DashboardV2Spec['layout']['kind'];
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -1,0 +1,354 @@
+import { config } from '@grafana/runtime';
+import {
+  SceneGridItemLike,
+  SceneGridLayout,
+  SceneGridRow,
+  SceneObject,
+  VizPanel,
+  VizPanelMenu,
+  VizPanelState,
+} from '@grafana/scenes';
+import {
+  DashboardV2Spec,
+  GridLayoutItemKind,
+  GridLayoutKind,
+  GridLayoutRowKind,
+  RepeatOptions,
+  Element,
+  GridLayoutItemSpec,
+  PanelKind,
+  LibraryPanelKind,
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
+import { contextSrv } from 'app/core/core';
+
+import { LibraryPanelBehavior } from '../../scene/LibraryPanelBehavior';
+import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
+import { panelLinksBehavior, panelMenuBehavior } from '../../scene/PanelMenuBehavior';
+import { PanelNotices } from '../../scene/PanelNotices';
+import { AngularDeprecation } from '../../scene/angular/AngularDeprecation';
+import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
+import { RowRepeaterBehavior } from '../../scene/layout-default/RowRepeaterBehavior';
+import { RowActions } from '../../scene/layout-default/row-actions/RowActions';
+import { setDashboardPanelContext } from '../../scene/setDashboardPanelContext';
+import { DashboardLayoutManager, LayoutManagerSerializer } from '../../scene/types/DashboardLayoutManager';
+import { isClonedKey } from '../../utils/clone';
+import { calculateGridItemDimensions, getVizPanelKeyForPanelId, isLibraryPanel } from '../../utils/utils';
+import { GRID_ROW_HEIGHT } from '../const';
+
+import { buildVizPanel } from './utils';
+
+export class DefaultGridLayoutManagerSerializer implements LayoutManagerSerializer {
+  serialize(layoutManager: DefaultGridLayoutManager, isSnapshot?: boolean): DashboardV2Spec['layout'] {
+    return {
+      kind: 'GridLayout',
+      spec: {
+        items: this.getGridLayoutItems(layoutManager, isSnapshot),
+      },
+    };
+  }
+
+  deserialize(
+    layout: DashboardV2Spec['layout'],
+    elements: DashboardV2Spec['elements'],
+    preload: boolean
+  ): DashboardLayoutManager {
+    if (layout.kind !== 'GridLayout') {
+      throw new Error('Invalid layout kind');
+    }
+    return new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        isLazy: !(preload || contextSrv.user.authenticatedBy === 'render'),
+        children: createSceneGridLayoutForItems(layout, elements),
+      }),
+    });
+  }
+
+  getGridLayoutItems(
+    body: DefaultGridLayoutManager,
+    isSnapshot?: boolean
+  ): Array<GridLayoutItemKind | GridLayoutRowKind> {
+    let items: Array<GridLayoutItemKind | GridLayoutRowKind> = [];
+    for (const child of body.state.grid.state.children) {
+      if (child instanceof DashboardGridItem) {
+        // TODO: handle panel repeater scenario
+        if (child.state.variableName) {
+          items = items.concat(this.repeaterToLayoutItems(child, isSnapshot));
+        } else {
+          items.push(this.gridItemToGridLayoutItemKind(child));
+        }
+      } else if (child instanceof SceneGridRow) {
+        if (isClonedKey(child.state.key!) && !isSnapshot) {
+          // Skip repeat rows
+          continue;
+        }
+        items.push(this.gridRowToLayoutRowKind(child, isSnapshot));
+      }
+    }
+
+    return items;
+  }
+
+  getRowRepeat(row: SceneGridRow): RepeatOptions | undefined {
+    if (row.state.$behaviors) {
+      for (const behavior of row.state.$behaviors) {
+        if (behavior instanceof RowRepeaterBehavior) {
+          return { value: behavior.state.variableName, mode: 'variable' };
+        }
+      }
+    }
+    return undefined;
+  }
+
+  gridRowToLayoutRowKind(row: SceneGridRow, isSnapshot = false): GridLayoutRowKind {
+    const children = row.state.children.map((child) => {
+      if (!(child instanceof DashboardGridItem)) {
+        throw new Error('Unsupported row child type');
+      }
+      const y = (child.state.y ?? 0) - (row.state.y ?? 0) - GRID_ROW_HEIGHT;
+      return this.gridItemToGridLayoutItemKind(child, y);
+    });
+
+    return {
+      kind: 'GridLayoutRow',
+      spec: {
+        title: row.state.title,
+        y: row.state.y ?? 0,
+        collapsed: Boolean(row.state.isCollapsed),
+        elements: children,
+        repeat: this.getRowRepeat(row),
+      },
+    };
+  }
+
+  gridItemToGridLayoutItemKind(gridItem: DashboardGridItem, yOverride?: number): GridLayoutItemKind {
+    let elementGridItem: GridLayoutItemKind | undefined;
+    let x = 0,
+      y = 0,
+      width = 0,
+      height = 0;
+
+    let gridItem_ = gridItem;
+
+    if (!(gridItem_.state.body instanceof VizPanel)) {
+      throw new Error('DashboardGridItem body expected to be VizPanel');
+    }
+
+    // Get the grid position and size
+    height = (gridItem_.state.variableName ? gridItem_.state.itemHeight : gridItem_.state.height) ?? 0;
+    x = gridItem_.state.x ?? 0;
+    y = gridItem_.state.y ?? 0;
+    width = gridItem_.state.width ?? 0;
+    const repeatVar = gridItem_.state.variableName;
+
+    // FIXME: which name should we use for the element reference, key or something else ?
+    const elementName = gridItem_.state.body.state.key ?? 'DefaultName';
+    elementGridItem = {
+      kind: 'GridLayoutItem',
+      spec: {
+        x,
+        y: yOverride ?? y,
+        width: width,
+        height: height,
+        element: {
+          kind: 'ElementReference',
+          name: elementName,
+        },
+      },
+    };
+
+    if (repeatVar) {
+      const repeat: RepeatOptions = {
+        mode: 'variable',
+        value: repeatVar,
+      };
+
+      if (gridItem_.state.maxPerRow) {
+        repeat.maxPerRow = gridItem_.getMaxPerRow();
+      }
+
+      if (gridItem_.state.repeatDirection) {
+        repeat.direction = gridItem_.getRepeatDirection();
+      }
+
+      elementGridItem.spec.repeat = repeat;
+    }
+
+    if (!elementGridItem) {
+      throw new Error('Unsupported grid item type');
+    }
+
+    return elementGridItem;
+  }
+
+  repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
+    if (!isSnapshot) {
+      return [this.gridItemToGridLayoutItemKind(repeater)];
+    } else {
+      if (repeater.state.body instanceof VizPanel && isLibraryPanel(repeater.state.body)) {
+        // TODO: implement
+        // const { x = 0, y = 0, width: w = 0, height: h = 0 } = repeater.state;
+        // return [vizPanelToPanel(repeater.state.body, { x, y, w, h }, isSnapshot)];
+        return [];
+      }
+
+      if (repeater.state.repeatedPanels) {
+        const { h, w, columnCount } = calculateGridItemDimensions(repeater);
+        const panels = repeater.state.repeatedPanels!.map((panel, index) => {
+          let x = 0,
+            y = 0;
+          if (repeater.state.repeatDirection === 'v') {
+            x = repeater.state.x!;
+            y = index * h;
+          } else {
+            x = (index % columnCount) * w;
+            y = repeater.state.y! + Math.floor(index / columnCount) * h;
+          }
+
+          const gridPos = { x, y, w, h };
+
+          const result: GridLayoutItemKind = {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: gridPos.x,
+              y: gridPos.y,
+              width: gridPos.w,
+              height: gridPos.h,
+              repeat: {
+                mode: 'variable',
+                value: repeater.state.variableName!,
+                maxPerRow: repeater.getMaxPerRow(),
+                direction: repeater.state.repeatDirection,
+              },
+              element: {
+                kind: 'ElementReference',
+                name: panel.state.key!,
+              },
+            },
+          };
+          return result;
+        });
+
+        return panels;
+      }
+      return [];
+    }
+  }
+}
+
+function createSceneGridLayoutForItems(layout: GridLayoutKind, elements: Record<string, Element>): SceneGridItemLike[] {
+  const gridElements = layout.spec.items;
+
+  return gridElements.map((element) => {
+    if (element.kind === 'GridLayoutItem') {
+      const panel = elements[element.spec.element.name];
+
+      if (!panel) {
+        throw new Error(`Panel with uid ${element.spec.element.name} not found in the dashboard elements`);
+      }
+
+      if (panel.kind === 'Panel') {
+        return buildGridItem(element.spec, panel);
+      } else if (panel.kind === 'LibraryPanel') {
+        const libraryPanel = buildLibraryPanel(panel);
+
+        return new DashboardGridItem({
+          key: `grid-item-${panel.spec.id}`,
+          x: element.spec.x,
+          y: element.spec.y,
+          width: element.spec.width,
+          height: element.spec.height,
+          itemHeight: element.spec.height,
+          body: libraryPanel,
+        });
+      } else {
+        throw new Error(`Unknown element kind: ${element.kind}`);
+      }
+    } else if (element.kind === 'GridLayoutRow') {
+      const children = element.spec.elements.map((gridElement) => {
+        const panel = elements[gridElement.spec.element.name];
+        if (panel.kind === 'Panel') {
+          return buildGridItem(gridElement.spec, panel, element.spec.y + GRID_ROW_HEIGHT + gridElement.spec.y);
+        } else {
+          throw new Error(`Unknown element kind: ${gridElement.kind}`);
+        }
+      });
+      let behaviors: SceneObject[] | undefined;
+      if (element.spec.repeat) {
+        behaviors = [new RowRepeaterBehavior({ variableName: element.spec.repeat.value })];
+      }
+      return new SceneGridRow({
+        y: element.spec.y,
+        isCollapsed: element.spec.collapsed,
+        title: element.spec.title,
+        $behaviors: behaviors,
+        actions: new RowActions({}),
+        children,
+      });
+    } else {
+      // If this has been validated by the schema we should never reach this point, which is why TS is telling us this is an error.
+      //@ts-expect-error
+      throw new Error(`Unknown layout element kind: ${element.kind}`);
+    }
+  });
+}
+
+function buildGridItem(gridItem: GridLayoutItemSpec, panel: PanelKind, yOverride?: number): DashboardGridItem {
+  const vizPanel = buildVizPanel(panel);
+  return new DashboardGridItem({
+    key: `grid-item-${panel.spec.id}`,
+    x: gridItem.x,
+    y: yOverride ?? gridItem.y,
+    width: gridItem.repeat?.direction === 'h' ? 24 : gridItem.width,
+    height: gridItem.height,
+    itemHeight: gridItem.height,
+    body: vizPanel,
+    variableName: gridItem.repeat?.value,
+    repeatDirection: gridItem.repeat?.direction,
+    maxPerRow: gridItem.repeat?.maxPerRow,
+  });
+}
+
+function buildLibraryPanel(panel: LibraryPanelKind): VizPanel {
+  const titleItems: SceneObject[] = [];
+
+  if (config.featureToggles.angularDeprecationUI) {
+    titleItems.push(new AngularDeprecation());
+  }
+
+  titleItems.push(
+    new VizPanelLinks({
+      rawLinks: [],
+      menu: new VizPanelLinksMenu({ $behaviors: [panelLinksBehavior] }),
+    })
+  );
+
+  titleItems.push(new PanelNotices());
+
+  const vizPanelState: VizPanelState = {
+    key: getVizPanelKeyForPanelId(panel.spec.id),
+    titleItems,
+    $behaviors: [
+      new LibraryPanelBehavior({
+        uid: panel.spec.libraryPanel.uid,
+        name: panel.spec.libraryPanel.name,
+      }),
+    ],
+    extendPanelContext: setDashboardPanelContext,
+    pluginId: LibraryPanelBehavior.LOADING_VIZ_PANEL_PLUGIN_ID,
+    title: panel.spec.title,
+    options: {},
+    fieldConfig: {
+      defaults: {},
+      overrides: [],
+    },
+  };
+
+  if (!config.publicDashboardAccessToken) {
+    vizPanelState.menu = new VizPanelMenu({
+      $behaviors: [panelMenuBehavior],
+    });
+  }
+
+  return new VizPanel(vizPanelState);
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -43,7 +43,7 @@ export class DefaultGridLayoutManagerSerializer implements LayoutManagerSerializ
     return {
       kind: 'GridLayout',
       spec: {
-        items: this.getGridLayoutItems(layoutManager, isSnapshot),
+        items: getGridLayoutItems(layoutManager, isSnapshot),
       },
     };
   }
@@ -63,176 +63,176 @@ export class DefaultGridLayoutManagerSerializer implements LayoutManagerSerializ
       }),
     });
   }
+}
 
-  getGridLayoutItems(
-    body: DefaultGridLayoutManager,
-    isSnapshot?: boolean
-  ): Array<GridLayoutItemKind | GridLayoutRowKind> {
-    let items: Array<GridLayoutItemKind | GridLayoutRowKind> = [];
-    for (const child of body.state.grid.state.children) {
-      if (child instanceof DashboardGridItem) {
-        // TODO: handle panel repeater scenario
-        if (child.state.variableName) {
-          items = items.concat(this.repeaterToLayoutItems(child, isSnapshot));
-        } else {
-          items.push(this.gridItemToGridLayoutItemKind(child));
-        }
-      } else if (child instanceof SceneGridRow) {
-        if (isClonedKey(child.state.key!) && !isSnapshot) {
-          // Skip repeat rows
-          continue;
-        }
-        items.push(this.gridRowToLayoutRowKind(child, isSnapshot));
+function getGridLayoutItems(
+  body: DefaultGridLayoutManager,
+  isSnapshot?: boolean
+): Array<GridLayoutItemKind | GridLayoutRowKind> {
+  let items: Array<GridLayoutItemKind | GridLayoutRowKind> = [];
+  for (const child of body.state.grid.state.children) {
+    if (child instanceof DashboardGridItem) {
+      // TODO: handle panel repeater scenario
+      if (child.state.variableName) {
+        items = items.concat(repeaterToLayoutItems(child, isSnapshot));
+      } else {
+        items.push(gridItemToGridLayoutItemKind(child));
       }
+    } else if (child instanceof SceneGridRow) {
+      if (isClonedKey(child.state.key!) && !isSnapshot) {
+        // Skip repeat rows
+        continue;
+      }
+      items.push(gridRowToLayoutRowKind(child, isSnapshot));
     }
-
-    return items;
   }
 
-  getRowRepeat(row: SceneGridRow): RepeatOptions | undefined {
-    if (row.state.$behaviors) {
-      for (const behavior of row.state.$behaviors) {
-        if (behavior instanceof RowRepeaterBehavior) {
-          return { value: behavior.state.variableName, mode: 'variable' };
-        }
+  return items;
+}
+
+function getRowRepeat(row: SceneGridRow): RepeatOptions | undefined {
+  if (row.state.$behaviors) {
+    for (const behavior of row.state.$behaviors) {
+      if (behavior instanceof RowRepeaterBehavior) {
+        return { value: behavior.state.variableName, mode: 'variable' };
       }
     }
-    return undefined;
+  }
+  return undefined;
+}
+
+function gridRowToLayoutRowKind(row: SceneGridRow, isSnapshot = false): GridLayoutRowKind {
+  const children = row.state.children.map((child) => {
+    if (!(child instanceof DashboardGridItem)) {
+      throw new Error('Unsupported row child type');
+    }
+    const y = (child.state.y ?? 0) - (row.state.y ?? 0) - GRID_ROW_HEIGHT;
+    return gridItemToGridLayoutItemKind(child, y);
+  });
+
+  return {
+    kind: 'GridLayoutRow',
+    spec: {
+      title: row.state.title,
+      y: row.state.y ?? 0,
+      collapsed: Boolean(row.state.isCollapsed),
+      elements: children,
+      repeat: getRowRepeat(row),
+    },
+  };
+}
+
+function gridItemToGridLayoutItemKind(gridItem: DashboardGridItem, yOverride?: number): GridLayoutItemKind {
+  let elementGridItem: GridLayoutItemKind | undefined;
+  let x = 0,
+    y = 0,
+    width = 0,
+    height = 0;
+
+  let gridItem_ = gridItem;
+
+  if (!(gridItem_.state.body instanceof VizPanel)) {
+    throw new Error('DashboardGridItem body expected to be VizPanel');
   }
 
-  gridRowToLayoutRowKind(row: SceneGridRow, isSnapshot = false): GridLayoutRowKind {
-    const children = row.state.children.map((child) => {
-      if (!(child instanceof DashboardGridItem)) {
-        throw new Error('Unsupported row child type');
-      }
-      const y = (child.state.y ?? 0) - (row.state.y ?? 0) - GRID_ROW_HEIGHT;
-      return this.gridItemToGridLayoutItemKind(child, y);
-    });
+  // Get the grid position and size
+  height = (gridItem_.state.variableName ? gridItem_.state.itemHeight : gridItem_.state.height) ?? 0;
+  x = gridItem_.state.x ?? 0;
+  y = gridItem_.state.y ?? 0;
+  width = gridItem_.state.width ?? 0;
+  const repeatVar = gridItem_.state.variableName;
 
-    return {
-      kind: 'GridLayoutRow',
-      spec: {
-        title: row.state.title,
-        y: row.state.y ?? 0,
-        collapsed: Boolean(row.state.isCollapsed),
-        elements: children,
-        repeat: this.getRowRepeat(row),
+  // FIXME: which name should we use for the element reference, key or something else ?
+  const elementName = gridItem_.state.body.state.key ?? 'DefaultName';
+  elementGridItem = {
+    kind: 'GridLayoutItem',
+    spec: {
+      x,
+      y: yOverride ?? y,
+      width: width,
+      height: height,
+      element: {
+        kind: 'ElementReference',
+        name: elementName,
       },
-    };
-  }
+    },
+  };
 
-  gridItemToGridLayoutItemKind(gridItem: DashboardGridItem, yOverride?: number): GridLayoutItemKind {
-    let elementGridItem: GridLayoutItemKind | undefined;
-    let x = 0,
-      y = 0,
-      width = 0,
-      height = 0;
-
-    let gridItem_ = gridItem;
-
-    if (!(gridItem_.state.body instanceof VizPanel)) {
-      throw new Error('DashboardGridItem body expected to be VizPanel');
-    }
-
-    // Get the grid position and size
-    height = (gridItem_.state.variableName ? gridItem_.state.itemHeight : gridItem_.state.height) ?? 0;
-    x = gridItem_.state.x ?? 0;
-    y = gridItem_.state.y ?? 0;
-    width = gridItem_.state.width ?? 0;
-    const repeatVar = gridItem_.state.variableName;
-
-    // FIXME: which name should we use for the element reference, key or something else ?
-    const elementName = gridItem_.state.body.state.key ?? 'DefaultName';
-    elementGridItem = {
-      kind: 'GridLayoutItem',
-      spec: {
-        x,
-        y: yOverride ?? y,
-        width: width,
-        height: height,
-        element: {
-          kind: 'ElementReference',
-          name: elementName,
-        },
-      },
+  if (repeatVar) {
+    const repeat: RepeatOptions = {
+      mode: 'variable',
+      value: repeatVar,
     };
 
-    if (repeatVar) {
-      const repeat: RepeatOptions = {
-        mode: 'variable',
-        value: repeatVar,
-      };
-
-      if (gridItem_.state.maxPerRow) {
-        repeat.maxPerRow = gridItem_.getMaxPerRow();
-      }
-
-      if (gridItem_.state.repeatDirection) {
-        repeat.direction = gridItem_.getRepeatDirection();
-      }
-
-      elementGridItem.spec.repeat = repeat;
+    if (gridItem_.state.maxPerRow) {
+      repeat.maxPerRow = gridItem_.getMaxPerRow();
     }
 
-    if (!elementGridItem) {
-      throw new Error('Unsupported grid item type');
+    if (gridItem_.state.repeatDirection) {
+      repeat.direction = gridItem_.getRepeatDirection();
     }
 
-    return elementGridItem;
+    elementGridItem.spec.repeat = repeat;
   }
 
-  repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
-    if (!isSnapshot) {
-      return [this.gridItemToGridLayoutItemKind(repeater)];
-    } else {
-      if (repeater.state.body instanceof VizPanel && isLibraryPanel(repeater.state.body)) {
-        // TODO: implement
-        // const { x = 0, y = 0, width: w = 0, height: h = 0 } = repeater.state;
-        // return [vizPanelToPanel(repeater.state.body, { x, y, w, h }, isSnapshot)];
-        return [];
-      }
+  if (!elementGridItem) {
+    throw new Error('Unsupported grid item type');
+  }
 
-      if (repeater.state.repeatedPanels) {
-        const { h, w, columnCount } = calculateGridItemDimensions(repeater);
-        const panels = repeater.state.repeatedPanels!.map((panel, index) => {
-          let x = 0,
-            y = 0;
-          if (repeater.state.repeatDirection === 'v') {
-            x = repeater.state.x!;
-            y = index * h;
-          } else {
-            x = (index % columnCount) * w;
-            y = repeater.state.y! + Math.floor(index / columnCount) * h;
-          }
+  return elementGridItem;
+}
 
-          const gridPos = { x, y, w, h };
-
-          const result: GridLayoutItemKind = {
-            kind: 'GridLayoutItem',
-            spec: {
-              x: gridPos.x,
-              y: gridPos.y,
-              width: gridPos.w,
-              height: gridPos.h,
-              repeat: {
-                mode: 'variable',
-                value: repeater.state.variableName!,
-                maxPerRow: repeater.getMaxPerRow(),
-                direction: repeater.state.repeatDirection,
-              },
-              element: {
-                kind: 'ElementReference',
-                name: panel.state.key!,
-              },
-            },
-          };
-          return result;
-        });
-
-        return panels;
-      }
+function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
+  if (!isSnapshot) {
+    return [gridItemToGridLayoutItemKind(repeater)];
+  } else {
+    if (repeater.state.body instanceof VizPanel && isLibraryPanel(repeater.state.body)) {
+      // TODO: implement
+      // const { x = 0, y = 0, width: w = 0, height: h = 0 } = repeater.state;
+      // return [vizPanelToPanel(repeater.state.body, { x, y, w, h }, isSnapshot)];
       return [];
     }
+
+    if (repeater.state.repeatedPanels) {
+      const { h, w, columnCount } = calculateGridItemDimensions(repeater);
+      const panels = repeater.state.repeatedPanels!.map((panel, index) => {
+        let x = 0,
+          y = 0;
+        if (repeater.state.repeatDirection === 'v') {
+          x = repeater.state.x!;
+          y = index * h;
+        } else {
+          x = (index % columnCount) * w;
+          y = repeater.state.y! + Math.floor(index / columnCount) * h;
+        }
+
+        const gridPos = { x, y, w, h };
+
+        const result: GridLayoutItemKind = {
+          kind: 'GridLayoutItem',
+          spec: {
+            x: gridPos.x,
+            y: gridPos.y,
+            width: gridPos.w,
+            height: gridPos.h,
+            repeat: {
+              mode: 'variable',
+              value: repeater.state.variableName!,
+              maxPerRow: repeater.getMaxPerRow(),
+              direction: repeater.state.repeatDirection,
+            },
+            element: {
+              kind: 'ElementReference',
+              name: panel.state.key!,
+            },
+          },
+        };
+        return result;
+      });
+
+      return panels;
+    }
+    return [];
   }
 }
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/ResponsiveGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/ResponsiveGridLayoutSerializer.ts
@@ -1,0 +1,65 @@
+import { SceneCSSGridLayout } from '@grafana/scenes';
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
+
+import { ResponsiveGridItem } from '../../scene/layout-responsive-grid/ResponsiveGridItem';
+import { ResponsiveGridLayoutManager } from '../../scene/layout-responsive-grid/ResponsiveGridLayoutManager';
+import { DashboardLayoutManager, LayoutManagerSerializer } from '../../scene/types/DashboardLayoutManager';
+import { getGridItemKeyForPanelId } from '../../utils/utils';
+
+import { buildVizPanel } from './utils';
+
+export class ResponsiveGridLayoutSerializer implements LayoutManagerSerializer {
+  serialize(layoutManager: ResponsiveGridLayoutManager): DashboardV2Spec['layout'] {
+    return {
+      kind: 'ResponsiveGridLayout',
+      spec: {
+        col:
+          layoutManager.state.layout.state.templateColumns?.toString() ??
+          ResponsiveGridLayoutManager.defaultCSS.templateColumns,
+        row: layoutManager.state.layout.state.autoRows?.toString() ?? ResponsiveGridLayoutManager.defaultCSS.autoRows,
+        items: layoutManager.state.layout.state.children.map((child) => {
+          if (!(child instanceof ResponsiveGridItem)) {
+            throw new Error('Expected ResponsiveGridItem');
+          }
+          return {
+            kind: 'ResponsiveGridLayoutItem',
+            spec: {
+              element: {
+                kind: 'ElementReference',
+                name: child.state?.body?.state.key ?? 'DefaultName',
+              },
+            },
+          };
+        }),
+      },
+    };
+  }
+
+  deserialize(layout: DashboardV2Spec['layout'], elements: DashboardV2Spec['elements']): DashboardLayoutManager {
+    if (layout.kind !== 'ResponsiveGridLayout') {
+      throw new Error('Invalid layout kind');
+    }
+
+    const children = layout.spec.items.map((item) => {
+      const panel = elements[item.spec.element.name];
+      if (!panel) {
+        throw new Error(`Panel with uid ${item.spec.element.name} not found in the dashboard elements`);
+      }
+      if (panel.kind !== 'Panel') {
+        throw new Error(`Unsupported element kind: ${panel.kind}`);
+      }
+      return new ResponsiveGridItem({
+        key: getGridItemKeyForPanelId(panel.spec.id),
+        body: buildVizPanel(panel),
+      });
+    });
+
+    return new ResponsiveGridLayoutManager({
+      layout: new SceneCSSGridLayout({
+        templateColumns: layout.spec.col,
+        autoRows: layout.spec.row,
+        children,
+      }),
+    });
+  }
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -5,6 +5,7 @@ import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
 import { LayoutManagerSerializer } from '../../scene/types/DashboardLayoutManager';
 
 import { layoutSerializerRegistry } from './layoutSerializerRegistry';
+import { getLayout } from './utils';
 
 export class RowsLayoutSerializer implements LayoutManagerSerializer {
   serialize(layoutManager: RowsLayoutManager): DashboardV2Spec['layout'] {
@@ -12,7 +13,7 @@ export class RowsLayoutSerializer implements LayoutManagerSerializer {
       kind: 'RowsLayout',
       spec: {
         rows: layoutManager.state.rows.map((row) => {
-          const layout = row.state.layout.descriptor.getSerializer().serialize(row.state.layout);
+          const layout = getLayout(row.state.layout);
           if (layout.kind === 'RowsLayout') {
             throw new Error('Nested RowsLayout is not supported');
           }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -1,0 +1,50 @@
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
+
+import { RowItem } from '../../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
+import { LayoutManagerSerializer } from '../../scene/types/DashboardLayoutManager';
+
+import { layoutSerializerRegistry } from './layoutSerializerRegistry';
+
+export class RowsLayoutSerializer implements LayoutManagerSerializer {
+  serialize(layoutManager: RowsLayoutManager): DashboardV2Spec['layout'] {
+    return {
+      kind: 'RowsLayout',
+      spec: {
+        rows: layoutManager.state.rows.map((row) => {
+          const layout = row.state.layout.descriptor.getSerializer().serialize(row.state.layout);
+          if (layout.kind === 'RowsLayout') {
+            throw new Error('Nested RowsLayout is not supported');
+          }
+          return {
+            kind: 'RowsLayoutRow',
+            spec: {
+              title: row.state.title,
+              collapsed: row.state.isCollapsed ?? false,
+              layout: layout,
+            },
+          };
+        }),
+      },
+    };
+  }
+
+  deserialize(
+    layout: DashboardV2Spec['layout'],
+    elements: DashboardV2Spec['elements'],
+    preload: boolean
+  ): RowsLayoutManager {
+    if (layout.kind !== 'RowsLayout') {
+      throw new Error('Invalid layout kind');
+    }
+    const rows = layout.spec.rows.map((row) => {
+      const layout = row.spec.layout;
+      return new RowItem({
+        title: row.spec.title,
+        isCollapsed: row.spec.collapsed,
+        layout: layoutSerializerRegistry.get(layout.kind).serializer.deserialize(layout, elements, preload),
+      });
+    });
+    return new RowsLayoutManager({ rows });
+  }
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -1,0 +1,20 @@
+import { Registry, RegistryItem } from '@grafana/data';
+
+import { LayoutManagerSerializer } from '../../scene/types/DashboardLayoutManager';
+
+import { DefaultGridLayoutManagerSerializer } from './DefaultGridLayoutSerializer';
+import { ResponsiveGridLayoutSerializer } from './ResponsiveGridLayoutSerializer';
+import { RowsLayoutSerializer } from './RowsLayoutSerializer';
+
+interface LayoutSerializerRegistryItem extends RegistryItem {
+  serializer: LayoutManagerSerializer;
+}
+
+export const layoutSerializerRegistry: Registry<LayoutSerializerRegistryItem> =
+  new Registry<LayoutSerializerRegistryItem>(() => {
+    return [
+      { id: 'GridLayout', name: 'Grid Layout', serializer: new DefaultGridLayoutManagerSerializer() },
+      { id: 'ResponsiveGridLayout', name: 'Responsive Grid Layout', serializer: new ResponsiveGridLayoutSerializer() },
+      { id: 'RowsLayout', name: 'Rows Layout', serializer: new RowsLayoutSerializer() },
+    ];
+  });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,0 +1,143 @@
+import { config } from '@grafana/runtime';
+import {
+  SceneDataProvider,
+  SceneDataQuery,
+  SceneDataTransformer,
+  SceneObject,
+  SceneQueryRunner,
+  VizPanel,
+  VizPanelMenu,
+  VizPanelState,
+} from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema/dist/esm/index.gen';
+import { PanelKind, PanelQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
+
+import { DashboardDatasourceBehaviour } from '../../scene/DashboardDatasourceBehaviour';
+import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
+import { panelLinksBehavior, panelMenuBehavior } from '../../scene/PanelMenuBehavior';
+import { PanelNotices } from '../../scene/PanelNotices';
+import { PanelTimeRange } from '../../scene/PanelTimeRange';
+import { AngularDeprecation } from '../../scene/angular/AngularDeprecation';
+import { setDashboardPanelContext } from '../../scene/setDashboardPanelContext';
+import { getVizPanelKeyForPanelId } from '../../utils/utils';
+import { transformMappingsToV1 } from '../transformToV1TypesUtils';
+
+export function buildVizPanel(panel: PanelKind): VizPanel {
+  const titleItems: SceneObject[] = [];
+
+  if (config.featureToggles.angularDeprecationUI) {
+    titleItems.push(new AngularDeprecation());
+  }
+
+  titleItems.push(
+    new VizPanelLinks({
+      rawLinks: panel.spec.links,
+      menu: new VizPanelLinksMenu({ $behaviors: [panelLinksBehavior] }),
+    })
+  );
+
+  titleItems.push(new PanelNotices());
+
+  const queryOptions = panel.spec.data.spec.queryOptions;
+  const timeOverrideShown = (queryOptions.timeFrom || queryOptions.timeShift) && !queryOptions.hideTimeOverride;
+
+  const vizPanelState: VizPanelState = {
+    key: getVizPanelKeyForPanelId(panel.spec.id),
+    title: panel.spec.title,
+    description: panel.spec.description,
+    pluginId: panel.spec.vizConfig.kind,
+    options: panel.spec.vizConfig.spec.options,
+    fieldConfig: transformMappingsToV1(panel.spec.vizConfig.spec.fieldConfig),
+    pluginVersion: panel.spec.vizConfig.spec.pluginVersion,
+    displayMode: panel.spec.transparent ? 'transparent' : 'default',
+    hoverHeader: !panel.spec.title && !timeOverrideShown,
+    hoverHeaderOffset: 0,
+    $data: createPanelDataProvider(panel),
+    titleItems,
+    $behaviors: [],
+    extendPanelContext: setDashboardPanelContext,
+    // _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel), //FIXME: Angular Migration
+  };
+
+  if (!config.publicDashboardAccessToken) {
+    vizPanelState.menu = new VizPanelMenu({
+      $behaviors: [panelMenuBehavior],
+    });
+  }
+
+  if (queryOptions.timeFrom || queryOptions.timeShift) {
+    vizPanelState.$timeRange = new PanelTimeRange({
+      timeFrom: queryOptions.timeFrom,
+      timeShift: queryOptions.timeShift,
+      hideTimeOverride: queryOptions.hideTimeOverride,
+    });
+  }
+
+  return new VizPanel(vizPanelState);
+}
+
+export function createPanelDataProvider(panelKind: PanelKind): SceneDataProvider | undefined {
+  const panel = panelKind.spec;
+  const targets = panel.data?.spec.queries ?? [];
+  // Skip setting query runner for panels without queries
+  if (!targets?.length) {
+    return undefined;
+  }
+
+  // Skip setting query runner for panel plugins with skipDataQuery
+  if (config.panels[panel.vizConfig.kind]?.skipDataQuery) {
+    return undefined;
+  }
+
+  let dataProvider: SceneDataProvider | undefined = undefined;
+  const datasource = getPanelDataSource(panelKind);
+
+  dataProvider = new SceneQueryRunner({
+    datasource,
+    queries: targets.map(panelQueryKindToSceneQuery),
+    maxDataPoints: panel.data.spec.queryOptions.maxDataPoints ?? undefined,
+    maxDataPointsFromWidth: true,
+    cacheTimeout: panel.data.spec.queryOptions.cacheTimeout,
+    queryCachingTTL: panel.data.spec.queryOptions.queryCachingTTL,
+    minInterval: panel.data.spec.queryOptions.interval ?? undefined,
+    dataLayerFilter: {
+      panelId: panel.id,
+    },
+    $behaviors: [new DashboardDatasourceBehaviour({})],
+  });
+
+  // Wrap inner data provider in a data transformer
+  return new SceneDataTransformer({
+    $data: dataProvider,
+    transformations: panel.data.spec.transformations.map((transformation) => transformation.spec),
+  });
+}
+
+function getPanelDataSource(panel: PanelKind): DataSourceRef | undefined {
+  if (!panel.spec.data?.spec.queries?.length) {
+    return undefined;
+  }
+
+  let datasource: DataSourceRef | undefined = undefined;
+  let isMixedDatasource = false;
+
+  panel.spec.data.spec.queries.forEach((query) => {
+    if (!datasource) {
+      datasource = query.spec.datasource;
+    } else if (datasource.uid !== query.spec.datasource?.uid || datasource.type !== query.spec.datasource?.type) {
+      isMixedDatasource = true;
+    }
+  });
+
+  return isMixedDatasource ? { type: 'mixed', uid: MIXED_DATASOURCE_NAME } : undefined;
+}
+
+function panelQueryKindToSceneQuery(query: PanelQueryKind): SceneDataQuery {
+  return {
+    refId: query.spec.refId,
+    datasource: query.spec.datasource,
+    hide: query.spec.hidden,
+    ...query.spec.query.spec,
+  };
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -10,7 +10,7 @@ import {
   VizPanelState,
 } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema/dist/esm/index.gen';
-import { PanelKind, PanelQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
+import { DashboardV2Spec, PanelKind, PanelQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { DashboardDatasourceBehaviour } from '../../scene/DashboardDatasourceBehaviour';
@@ -20,8 +20,11 @@ import { PanelNotices } from '../../scene/PanelNotices';
 import { PanelTimeRange } from '../../scene/PanelTimeRange';
 import { AngularDeprecation } from '../../scene/angular/AngularDeprecation';
 import { setDashboardPanelContext } from '../../scene/setDashboardPanelContext';
+import { DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
 import { getVizPanelKeyForPanelId } from '../../utils/utils';
 import { transformMappingsToV1 } from '../transformToV1TypesUtils';
+
+import { layoutSerializerRegistry } from './layoutSerializerRegistry';
 
 export function buildVizPanel(panel: PanelKind): VizPanel {
   const titleItems: SceneObject[] = [];
@@ -140,4 +143,12 @@ function panelQueryKindToSceneQuery(query: PanelQueryKind): SceneDataQuery {
     hide: query.spec.hidden,
     ...query.spec.query.spec,
   };
+}
+
+export function getLayout(sceneState: DashboardLayoutManager): DashboardV2Spec['layout'] {
+  const registryItem = layoutSerializerRegistry.get(sceneState.descriptor.kind ?? '');
+  if (!registryItem) {
+    throw new Error(`Layout serializer not found for kind: ${sceneState.descriptor.kind}`);
+  }
+  return registryItem.serializer.serialize(sceneState);
 }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -14,6 +14,7 @@ import {
   AdHocFiltersVariable,
   SceneDataTransformer,
   SceneGridRow,
+  SceneGridItem,
 } from '@grafana/scenes';
 import {
   AdhocVariableKind,
@@ -34,6 +35,7 @@ import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSou
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { ResponsiveGridLayoutManager } from '../scene/layout-responsive-grid/ResponsiveGridLayoutManager';
 import { DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getQueryRunnerFor } from '../utils/utils';
@@ -46,6 +48,8 @@ import {
   transformSaveModelSchemaV2ToScene,
 } from './transformSaveModelSchemaV2ToScene';
 import { transformCursorSynctoEnum } from './transformToV2TypesUtils';
+import { ResponsiveGridItem } from '../scene/layout-responsive-grid/ResponsiveGridItem';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 
 export const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
   kind: 'DashboardWithAccessInfo',
@@ -493,6 +497,113 @@ describe('transformSaveModelSchemaV2ToScene', () => {
         expect(scene.state.meta.canSave).toBe(true);
         expect(scene.state.meta.canEdit).toBe(true);
         expect(scene.state.meta.canDelete).toBe(true);
+      });
+    });
+    describe('dynamic dashboard layouts', () => {
+      it('should build a dashboard scene with a responsive grid layout', () => {
+        const dashboard = cloneDeep(defaultDashboard);
+        dashboard.spec.layout = {
+          kind: 'ResponsiveGridLayout',
+          spec: {
+            col: 'colString',
+            row: 'rowString',
+            items: [
+              {
+                kind: 'ResponsiveGridLayoutItem',
+                spec: {
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'panel-1',
+                  },
+                },
+              },
+            ],
+          },
+        };
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        const layoutManager = scene.state.body as ResponsiveGridLayoutManager;
+        expect(layoutManager.descriptor.kind).toBe('ResponsiveGridLayout');
+        expect(layoutManager.state.layout.state.templateColumns).toBe('colString');
+        expect(layoutManager.state.layout.state.autoRows).toBe('rowString');
+        expect(layoutManager.state.layout.state.children.length).toBe(1);
+        const gridItem = layoutManager.state.layout.state.children[0] as ResponsiveGridItem;
+        expect(gridItem.state.body.state.key).toBe('panel-1');
+      });
+
+      it('should build a dashboard scene with rows layout', () => {
+        const dashboard = cloneDeep(defaultDashboard);
+        dashboard.spec.layout = {
+          kind: 'RowsLayout',
+          spec: {
+            rows: [
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'row1',
+                  collapsed: false,
+                  layout: {
+                    kind: 'ResponsiveGridLayout',
+                    spec: {
+                      col: 'colString',
+                      row: 'rowString',
+                      items: [
+                        {
+                          kind: 'ResponsiveGridLayoutItem',
+                          spec: {
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'panel-1',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'row2',
+                  collapsed: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            y: 0,
+                            x: 0,
+                            height: 10,
+                            width: 10,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'panel-2',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        };
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        const layoutManager = scene.state.body as RowsLayoutManager;
+        expect(layoutManager.descriptor.kind).toBe('RowsLayout');
+        expect(layoutManager.state.rows.length).toBe(2);
+        const row1Manager = layoutManager.state.rows[0].state.layout as ResponsiveGridLayoutManager;
+        expect(row1Manager.descriptor.kind).toBe('ResponsiveGridLayout');
+        const row1GridItem = row1Manager.state.layout.state.children[0] as ResponsiveGridItem;
+        expect(row1GridItem.state.body.state.key).toBe('panel-1');
+
+        const row2Manager = layoutManager.state.rows[1].state.layout as DefaultGridLayoutManager;
+        expect(row2Manager.descriptor.kind).toBe('GridLayout');
+        const row2GridItem = row1Manager.state.layout.state.children[0] as SceneGridItem;
+        expect(row2GridItem.state.body!.state.key).toBe('panel-2');
       });
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -35,7 +35,9 @@ import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSou
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { ResponsiveGridItem } from '../scene/layout-responsive-grid/ResponsiveGridItem';
 import { ResponsiveGridLayoutManager } from '../scene/layout-responsive-grid/ResponsiveGridLayoutManager';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getQueryRunnerFor } from '../utils/utils';
@@ -48,8 +50,6 @@ import {
   transformSaveModelSchemaV2ToScene,
 } from './transformSaveModelSchemaV2ToScene';
 import { transformCursorSynctoEnum } from './transformToV2TypesUtils';
-import { ResponsiveGridItem } from '../scene/layout-responsive-grid/ResponsiveGridItem';
-import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 
 export const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
   kind: 'DashboardWithAccessInfo',
@@ -602,7 +602,7 @@ describe('transformSaveModelSchemaV2ToScene', () => {
 
         const row2Manager = layoutManager.state.rows[1].state.layout as DefaultGridLayoutManager;
         expect(row2Manager.descriptor.kind).toBe('GridLayout');
-        const row2GridItem = row1Manager.state.layout.state.children[0] as SceneGridItem;
+        const row2GridItem = row2Manager.state.grid.state.children[0] as SceneGridItem;
         expect(row2GridItem.state.body!.state.key).toBe('panel-2');
       });
     });

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -11,6 +11,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
+import { layout } from 'app/plugins/panel/nodeGraph/layeredLayout';
 
 import {
   DashboardV2Spec,
@@ -52,6 +53,7 @@ import {
   isLibraryPanel,
 } from '../utils/utils';
 
+import { getLayout } from './layoutSerializers/utils';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
 
@@ -109,7 +111,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // EOF annotations
 
     // layout
-    layout: sceneDash.body.descriptor.getSerializer().serialize(sceneDash.body),
+    layout: getLayout(sceneDash.body),
     // EOF layout
   };
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -11,7 +11,6 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
-import { layout } from 'app/plugins/panel/nodeGraph/layeredLayout';
 
 import {
   DashboardV2Spec,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -7,7 +7,6 @@ import {
   dataLayers,
   SceneDataQuery,
   SceneDataTransformer,
-  SceneGridRow,
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
@@ -24,7 +23,6 @@ import {
   DataTransformerConfig,
   PanelQuerySpec,
   DataQueryKind,
-  GridLayoutItemKind,
   QueryOptionsSpec,
   QueryVariableKind,
   TextVariableKind,
@@ -38,27 +36,13 @@ import {
   DataLink,
   LibraryPanelKind,
   Element,
-  RepeatOptions,
-  GridLayoutRowKind,
   DashboardCursorSync,
   FieldConfig,
   FieldColor,
-  GridLayoutKind,
-  RowsLayoutKind,
-  ResponsiveGridLayoutKind,
-  ResponsiveGridLayoutItemKind,
 } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha0';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
 import { PanelTimeRange } from '../scene/PanelTimeRange';
-import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
-import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
-import { RowRepeaterBehavior } from '../scene/layout-default/RowRepeaterBehavior';
-import { ResponsiveGridItem } from '../scene/layout-responsive-grid/ResponsiveGridItem';
-import { ResponsiveGridLayoutManager } from '../scene/layout-responsive-grid/ResponsiveGridLayoutManager';
-import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
-import { DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
-import { isClonedKey } from '../utils/clone';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import {
   getLibraryPanelBehavior,
@@ -66,10 +50,8 @@ import {
   getQueryRunnerFor,
   getVizPanelKeyForPanelId,
   isLibraryPanel,
-  calculateGridItemDimensions,
 } from '../utils/utils';
 
-import { GRID_ROW_HEIGHT } from './const';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
 
@@ -127,7 +109,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // EOF annotations
 
     // layout
-    layout: getLayout(sceneDash.body, isSnapshot),
+    layout: sceneDash.body.descriptor.getSerializer().serialize(sceneDash.body),
     // EOF layout
   };
 
@@ -142,75 +124,6 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
-}
-
-function getLayout(
-  layoutManager: DashboardLayoutManager,
-  isSnapshot?: boolean
-): GridLayoutKind | RowsLayoutKind | ResponsiveGridLayoutKind {
-  if (layoutManager instanceof DefaultGridLayoutManager) {
-    return getGridLayout(layoutManager, isSnapshot);
-  } else if (layoutManager instanceof RowsLayoutManager) {
-    return {
-      kind: 'RowsLayout',
-      spec: {
-        rows: layoutManager.state.rows.map((row) => {
-          if (row.state.layout instanceof RowsLayoutManager) {
-            throw new Error('Nesting row layouts is not supported');
-          }
-          let layout: GridLayoutKind | ResponsiveGridLayoutKind | undefined = undefined;
-          if (row.state.layout instanceof DefaultGridLayoutManager) {
-            layout = getGridLayout(row.state.layout, isSnapshot);
-          } else if (row.state.layout instanceof ResponsiveGridLayoutManager) {
-            layout = {
-              kind: 'ResponsiveGridLayout',
-              spec: {
-                items: getResponsiveGridLayoutItems(row.state.layout),
-                col:
-                  row.state.layout.state.layout.state.templateColumns?.toString() ??
-                  ResponsiveGridLayoutManager.defaultCSS.templateColumns,
-                row:
-                  row.state.layout.state.layout.state.autoRows?.toString() ??
-                  ResponsiveGridLayoutManager.defaultCSS.autoRows,
-              },
-            };
-          }
-          if (!layout) {
-            throw new Error('Unsupported layout type');
-          }
-          return {
-            kind: 'RowsLayoutRow',
-            spec: {
-              title: row.state.title,
-              collapsed: row.state.isCollapsed ?? false,
-              layout: layout,
-            },
-          };
-        }),
-      },
-    };
-  } else if (layoutManager instanceof ResponsiveGridLayoutManager) {
-    return {
-      kind: 'ResponsiveGridLayout',
-      spec: {
-        items: getResponsiveGridLayoutItems(layoutManager),
-        col:
-          layoutManager.state.layout.state.templateColumns?.toString() ??
-          ResponsiveGridLayoutManager.defaultCSS.templateColumns,
-        row: layoutManager.state.layout.state.autoRows?.toString() ?? ResponsiveGridLayoutManager.defaultCSS.autoRows,
-      },
-    };
-  }
-  throw new Error('Unsupported layout type');
-}
-
-function getGridLayout(layoutManager: DefaultGridLayoutManager, isSnapshot?: boolean): GridLayoutKind {
-  return {
-    kind: 'GridLayout',
-    spec: {
-      items: getGridLayoutItems(layoutManager, isSnapshot),
-    },
-  };
 }
 
 function getCursorSync(state: DashboardSceneState) {
@@ -229,146 +142,6 @@ function getLiveNow(state: DashboardSceneState) {
     return Boolean(defaultDashboardV2Spec().liveNow);
   }
   return Boolean(liveNow);
-}
-
-function getGridLayoutItems(
-  body: DefaultGridLayoutManager,
-  isSnapshot?: boolean
-): Array<GridLayoutItemKind | GridLayoutRowKind> {
-  let elements: Array<GridLayoutItemKind | GridLayoutRowKind> = [];
-  for (const child of body.state.grid.state.children) {
-    if (child instanceof DashboardGridItem) {
-      // TODO: handle panel repeater scenario
-      if (child.state.variableName) {
-        elements = elements.concat(repeaterToLayoutItems(child, isSnapshot));
-      } else {
-        elements.push(gridItemToGridLayoutItemKind(child, isSnapshot));
-      }
-    } else if (child instanceof SceneGridRow) {
-      if (isClonedKey(child.state.key!) && !isSnapshot) {
-        // Skip repeat rows
-        continue;
-      }
-      elements.push(gridRowToLayoutRowKind(child, isSnapshot));
-    }
-  }
-
-  return elements;
-}
-
-function getResponsiveGridLayoutItems(body: ResponsiveGridLayoutManager): ResponsiveGridLayoutItemKind[] {
-  const items: ResponsiveGridLayoutItemKind[] = [];
-
-  for (const child of body.state.layout.state.children) {
-    if (child instanceof ResponsiveGridItem) {
-      items.push({
-        kind: 'ResponsiveGridLayoutItem',
-        spec: {
-          element: {
-            kind: 'ElementReference',
-            name: child.state?.body?.state.key ?? 'DefaultName',
-          },
-        },
-      });
-    }
-  }
-  return items;
-}
-
-export function gridItemToGridLayoutItemKind(
-  gridItem: DashboardGridItem,
-  isSnapshot = false,
-  yOverride?: number
-): GridLayoutItemKind {
-  let elementGridItem: GridLayoutItemKind | undefined;
-  let x = 0,
-    y = 0,
-    width = 0,
-    height = 0;
-
-  let gridItem_ = gridItem;
-
-  if (!(gridItem_.state.body instanceof VizPanel)) {
-    throw new Error('DashboardGridItem body expected to be VizPanel');
-  }
-
-  // Get the grid position and size
-  height = (gridItem_.state.variableName ? gridItem_.state.itemHeight : gridItem_.state.height) ?? 0;
-  x = gridItem_.state.x ?? 0;
-  y = gridItem_.state.y ?? 0;
-  width = gridItem_.state.width ?? 0;
-  const repeatVar = gridItem_.state.variableName;
-
-  // FIXME: which name should we use for the element reference, key or something else ?
-  const elementName = gridItem_.state.body.state.key ?? 'DefaultName';
-  elementGridItem = {
-    kind: 'GridLayoutItem',
-    spec: {
-      x,
-      y: yOverride ?? y,
-      width: width,
-      height: height,
-      element: {
-        kind: 'ElementReference',
-        name: elementName,
-      },
-    },
-  };
-
-  if (repeatVar) {
-    const repeat: RepeatOptions = {
-      mode: 'variable',
-      value: repeatVar,
-    };
-
-    if (gridItem_.state.maxPerRow) {
-      repeat.maxPerRow = gridItem_.getMaxPerRow();
-    }
-
-    if (gridItem_.state.repeatDirection) {
-      repeat.direction = gridItem_.getRepeatDirection();
-    }
-
-    elementGridItem.spec.repeat = repeat;
-  }
-
-  if (!elementGridItem) {
-    throw new Error('Unsupported grid item type');
-  }
-
-  return elementGridItem;
-}
-
-function getRowRepeat(row: SceneGridRow): RepeatOptions | undefined {
-  if (row.state.$behaviors) {
-    for (const behavior of row.state.$behaviors) {
-      if (behavior instanceof RowRepeaterBehavior) {
-        return { value: behavior.state.variableName, mode: 'variable' };
-      }
-    }
-  }
-  return undefined;
-}
-
-function gridRowToLayoutRowKind(row: SceneGridRow, isSnapshot = false): GridLayoutRowKind {
-  const children = row.state.children.map((child) => {
-    if (!(child instanceof DashboardGridItem)) {
-      throw new Error('Unsupported row child type');
-    }
-    const y = (child.state.y ?? 0) - (row.state.y ?? 0) - GRID_ROW_HEIGHT;
-    return gridItemToGridLayoutItemKind(child, isSnapshot, y);
-  });
-
-  return {
-    kind: 'GridLayoutRow',
-    spec: {
-      title: row.state.title,
-      y: row.state.y ?? 0,
-      collapsed: Boolean(row.state.isCollapsed),
-      elements: children,
-      repeat: getRowRepeat(row),
-    },
-  };
 }
 
 function getElements(state: DashboardSceneState) {
@@ -575,60 +348,6 @@ function createElements(panels: Element[]): Record<string, Element> {
     elements[getVizPanelKeyForPanelId(panel.spec.id)] = panel;
     return elements;
   }, {});
-}
-
-function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
-  if (!isSnapshot) {
-    return [gridItemToGridLayoutItemKind(repeater)];
-  } else {
-    if (repeater.state.body instanceof VizPanel && isLibraryPanel(repeater.state.body)) {
-      // TODO: implement
-      // const { x = 0, y = 0, width: w = 0, height: h = 0 } = repeater.state;
-      // return [vizPanelToPanel(repeater.state.body, { x, y, w, h }, isSnapshot)];
-      return [];
-    }
-
-    if (repeater.state.repeatedPanels) {
-      const { h, w, columnCount } = calculateGridItemDimensions(repeater);
-      const panels = repeater.state.repeatedPanels!.map((panel, index) => {
-        let x = 0,
-          y = 0;
-        if (repeater.state.repeatDirection === 'v') {
-          x = repeater.state.x!;
-          y = index * h;
-        } else {
-          x = (index % columnCount) * w;
-          y = repeater.state.y! + Math.floor(index / columnCount) * h;
-        }
-
-        const gridPos = { x, y, w, h };
-
-        const result: GridLayoutItemKind = {
-          kind: 'GridLayoutItem',
-          spec: {
-            x: gridPos.x,
-            y: gridPos.y,
-            width: gridPos.w,
-            height: gridPos.h,
-            repeat: {
-              mode: 'variable',
-              value: repeater.state.variableName!,
-              maxPerRow: repeater.getMaxPerRow(),
-              direction: repeater.state.repeatDirection,
-            },
-            element: {
-              kind: 'ElementReference',
-              name: panel.state.key!,
-            },
-          },
-        };
-        return result;
-      });
-
-      return panels;
-    }
-    return [];
-  }
 }
 
 function getVariables(oldDash: DashboardSceneState) {


### PR DESCRIPTION
**What is this feature?**

This breaks apart the big chunks of code that does that transforms between save model and scene.

Most of this change is just code moving from one place to another. The most important parts to review are:



1. There is a new registry for serializers of layouts:
https://github.com/grafana/grafana/blob/d3d639c11d7334a47e5a693aa91e1806acc0199f/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts#L9-L20

2. layout managers specify their kind in the descriptor:
https://github.com/grafana/grafana/blob/d3d639c11d7334a47e5a693aa91e1806acc0199f/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts#L25

3. This is the serializer interface:  https://github.com/grafana/grafana/blob/d3d639c11d7334a47e5a693aa91e1806acc0199f/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts#L86-L93

4. This function transforms a scene layout manager to save model by getting the serializer from the registry using the layout manager kind
https://github.com/grafana/grafana/blob/d3d639c11d7334a47e5a693aa91e1806acc0199f/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts#L148-L154

5. When transforming from the save model we use the kind of the layout in the save model to get the serializer to call deserialize
https://github.com/grafana/grafana/blob/d3d639c11d7334a47e5a693aa91e1806acc0199f/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts#L152-L156
