### PR TITLE
Don't remove DWARF info from Go binaries in dev

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -243,7 +243,16 @@ func ldflags(opts BuildOpts) (string, error) {
 		buildBranch = v
 	}
 	var b bytes.Buffer
-	b.WriteString("-w")
+	if !opts.isDev {
+		// Only ask the linker to strip DWARF information if we're not in
+		// dev, to avoid seeing stuff like this when using delve:
+		//
+		//   ~ $ dlv attach $(pgrep grafana)
+		//   (dlv) l main.main
+		//   Command failed: location "main.main" not found
+		//
+		b.WriteString("-w")
+	}
 	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", commitSha))
 	if enterpriseCommitSha != "" {


### PR DESCRIPTION
Only ask the linker to strip DWARF information if we're not in dev, to avoid seeing stuff like this when using delve:

```
    ~ $ dlv attach $(pgrep grafana)
    (dlv) l main.main
    Command failed: location "main.main" not found
```

After this change:

```
    ~ $ dlv attach $(pgrep grafana)
    Type 'help' for list of commands.
    (dlv) l main.main
    Showing /home/justin/code/grafana/pkg/cmd/grafana/main.go:23 (PC: 0xac93533)
        18: var commit = gcli.DefaultCommitValue
        19: var enterpriseCommit = gcli.DefaultCommitValue
        20: var buildBranch = "main"
        21: var buildstamp string
        22:
        23: func main() {
        24:         app := MainApp()
        25:
        26:         if err := app.Run(os.Args); err != nil {

```
