### PR TITLE
Provisioning: Reintroduce unauthenticated webhooks

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -50,7 +50,14 @@ import (
 
 const repoControllerWorkers = 1
 
-var _ builder.APIGroupBuilder = (*APIBuilder)(nil)
+var (
+	_ builder.APIGroupBuilder               = (*APIBuilder)(nil)
+	_ builder.APIGroupMutation              = (*APIBuilder)(nil)
+	_ builder.APIGroupValidation            = (*APIBuilder)(nil)
+	_ builder.APIGroupRouteProvider         = (*APIBuilder)(nil)
+	_ builder.APIGroupPostStartHookProvider = (*APIBuilder)(nil)
+	_ builder.OpenAPIPostProcessor          = (*APIBuilder)(nil)
+)
 
 type APIBuilder struct {
 	urlProvider      func(namespace string) string

--- a/pkg/services/apiserver/auth/authorizer/org_id.go
+++ b/pkg/services/apiserver/auth/authorizer/org_id.go
@@ -60,6 +60,11 @@ func (auth orgIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
+	// If we have an access policy, let the API decide.
+	if signedInUser.GetIdentityType() == claims.TypeAccessPolicy {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	// Check if the user has access to the specified org
 	// nolint:staticcheck
 	userId, err := signedInUser.GetInternalID()

--- a/pkg/services/apiserver/auth/authorizer/org_id.go
+++ b/pkg/services/apiserver/auth/authorizer/org_id.go
@@ -60,8 +60,8 @@ func (auth orgIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	// If we have an access policy, let the API decide.
-	if signedInUser.GetIdentityType() == claims.TypeAccessPolicy {
+	// If we have an anonymous user, let the next authorizers decide.
+	if signedInUser.GetIdentityType() == claims.TypeAnonymous {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 

--- a/pkg/services/apiserver/auth/authorizer/provider.go
+++ b/pkg/services/apiserver/auth/authorizer/provider.go
@@ -20,11 +20,7 @@ type GrafanaAuthorizer struct {
 }
 
 func NewGrafanaAuthorizer(cfg *setting.Cfg, orgService orgsvc.Service) *GrafanaAuthorizer {
-	// Individual services may have explicit implementations
-	apis := make(map[string]authorizer.Authorizer)
-
 	authorizers := []authorizer.Authorizer{
-		&authorizerForAPI{apis},
 		&impersonationAuthorizer{},
 		authorizerfactory.NewPrivilegedGroups(k8suser.SystemPrivilegedGroup),
 	}
@@ -35,6 +31,10 @@ func NewGrafanaAuthorizer(cfg *setting.Cfg, orgService orgsvc.Service) *GrafanaA
 	} else {
 		authorizers = append(authorizers, newOrgIDAuthorizer(orgService))
 	}
+
+	// Individual services may have explicit implementations
+	apis := make(map[string]authorizer.Authorizer)
+	authorizers = append(authorizers, &authorizerForAPI{apis})
 
 	// org role is last -- and will return allow for verbs that match expectations
 	// The apiVersion flavors will run first and can return early when FGAC has appropriate rules

--- a/pkg/services/apiserver/auth/authorizer/provider.go
+++ b/pkg/services/apiserver/auth/authorizer/provider.go
@@ -20,7 +20,11 @@ type GrafanaAuthorizer struct {
 }
 
 func NewGrafanaAuthorizer(cfg *setting.Cfg, orgService orgsvc.Service) *GrafanaAuthorizer {
+	// Individual services may have explicit implementations
+	apis := make(map[string]authorizer.Authorizer)
+
 	authorizers := []authorizer.Authorizer{
+		&authorizerForAPI{apis},
 		&impersonationAuthorizer{},
 		authorizerfactory.NewPrivilegedGroups(k8suser.SystemPrivilegedGroup),
 	}
@@ -31,10 +35,6 @@ func NewGrafanaAuthorizer(cfg *setting.Cfg, orgService orgsvc.Service) *GrafanaA
 	} else {
 		authorizers = append(authorizers, newOrgIDAuthorizer(orgService))
 	}
-
-	// Individual services may have explicit implementations
-	apis := make(map[string]authorizer.Authorizer)
-	authorizers = append(authorizers, &authorizerForAPI{apis})
 
 	// org role is last -- and will return allow for verbs that match expectations
 	// The apiVersion flavors will run first and can return early when FGAC has appropriate rules

--- a/pkg/services/apiserver/auth/authorizer/stack_id.go
+++ b/pkg/services/apiserver/auth/authorizer/stack_id.go
@@ -50,6 +50,12 @@ func (auth stackIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 		msg := fmt.Sprintf("wrong stack id is selected (expected: %d, found %d)", auth.stackID, info.StackID)
 		return authorizer.DecisionDeny, msg, nil
 	}
+
+	// If we have an anonymous user, let the next authorizers decide.
+	if signedInUser.GetIdentityType() == claims.TypeAnonymous {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	if info.OrgID != 1 {
 		return authorizer.DecisionDeny, "cloud instance requires org 1", nil
 	}

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -31,6 +31,7 @@ const (
 	ClientSAML         = "auth.client.saml"
 	ClientPasswordless = "auth.client.passwordless"
 	ClientLDAP         = "ldap"
+	ClientProvisioning = "auth.client.apiserver.provisioning"
 )
 
 const (

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -124,6 +124,10 @@ func ProvideRegistration(
 		authnSvc.RegisterClient(clients.ProvideOAuth(clientName, cfg, oauthTokenService, socialService, settingsProviderService, features))
 	}
 
+	if features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
+		authnSvc.RegisterClient(clients.ProvideProvisioning())
+	}
+
 	// FIXME (jguer): move to User package
 	userSync := sync.ProvideUserSync(userService, userProtectionService, authInfoService, quotaService, tracer, features)
 	orgSync := sync.ProvideOrgSync(userService, orgService, accessControlService, cfg, tracer)

--- a/pkg/services/authn/clients/provisioning.go
+++ b/pkg/services/authn/clients/provisioning.go
@@ -1,0 +1,62 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	claims "github.com/grafana/authlib/types"
+	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+var (
+	_ authn.ContextAwareClient = (*Provisioning)(nil)
+	_ fmt.Stringer             = (*Provisioning)(nil) // for debugging
+)
+
+type Provisioning struct {
+	webhookRegexp *regexp.Regexp
+}
+
+func ProvideProvisioning() *Provisioning {
+	// It's fine to compile a regexp here. The function is only called once per instance of APIBuilder, of which there should only ever be 1.
+	// Assumption: APIVERSION has no leading or trailing slashes.
+	webhookRegexp := regexp.MustCompile("^/apis/" + regexp.QuoteMeta(provisioning.APIVERSION) + "/namespaces/[^/]+/repositories/[^/]+/webhook$")
+	return &Provisioning{webhookRegexp}
+}
+
+func (p *Provisioning) String() string {
+	return p.Name()
+}
+
+func (*Provisioning) Name() string {
+	return authn.ClientProvisioning
+}
+
+func (p *Provisioning) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	return &authn.Identity{
+		Type:            claims.TypeAccessPolicy,
+		Name:            p.Name(),
+		UID:             p.Name(),
+		Login:           p.Name(),
+		AuthID:          p.Name(),
+		OrgID:           r.OrgID,
+		AuthenticatedBy: authn.ClientProvisioning,
+		LastSeenAt:      time.Now(),
+	}, nil
+}
+
+func (*Provisioning) IsEnabled() bool {
+	return true
+}
+
+func (p *Provisioning) Test(ctx context.Context, r *authn.Request) bool {
+	path := r.HTTPRequest.URL.Path
+	return p.webhookRegexp.MatchString(path)
+}
+
+func (*Provisioning) Priority() uint {
+	return 50
+}

--- a/pkg/services/authn/clients/provisioning.go
+++ b/pkg/services/authn/clients/provisioning.go
@@ -37,7 +37,7 @@ func (*Provisioning) Name() string {
 
 func (p *Provisioning) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	return &authn.Identity{
-		Type:            claims.TypeAccessPolicy,
+		Type:            claims.TypeAnonymous,
 		Name:            p.Name(),
 		UID:             p.Name(),
 		Login:           p.Name(),

--- a/pkg/services/authn/clients/provisioning.go
+++ b/pkg/services/authn/clients/provisioning.go
@@ -58,5 +58,5 @@ func (p *Provisioning) Test(ctx context.Context, r *authn.Request) bool {
 }
 
 func (*Provisioning) Priority() uint {
-	return 50
+	return 5 // let most other clients go first
 }

--- a/pkg/services/authn/clients/provisioning_test.go
+++ b/pkg/services/authn/clients/provisioning_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/authlib/types"
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/stretchr/testify/assert"
@@ -56,10 +57,9 @@ func TestProvisioning_Authenticate(t *testing.T) {
 	identity, err := svc.Authenticate(ctx, req)
 	require.NoError(t, err, "Authenticate shouldn't err")
 
+	assert.Equal(t, types.TypeAnonymous, identity.GetIdentityType(), "IdentityType")
 	assert.Equal(t, "auth.client.apiserver.provisioning", identity.UID, "UID")
 	assert.Equal(t, "auth.client.apiserver.provisioning", identity.Login, "Login")
-	assert.Equal(t, "auth.client.apiserver.provisioning", identity.Email, "Email")
-	assert.Equal(t, "555", identity.ID, "ID")
 	assert.Equal(t, "auth.client.apiserver.provisioning", identity.AuthenticatedBy, "AuthenticatedBy")
 	assert.Equal(t, false, identity.GetIsGrafanaAdmin(), "IsAdmin")
 }

--- a/pkg/services/authn/clients/provisioning_test.go
+++ b/pkg/services/authn/clients/provisioning_test.go
@@ -1,0 +1,72 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvisioning_Test(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		Name, URL string
+		Valid     bool
+	}{
+		{"Root path is invalid", "https://grafana.localhost/", false},
+		{"Non-provisioning path", "https://grafana.localhost/hello/world", false},
+		{"Provisioning path that isn't webhook", "https://grafana.localhost/apis/provisioning.grafana.app/v0alpha1/namespaces/x/repositories/y/unittest", false},
+		{"Webhook path", "https://grafana.localhost/apis/provisioning.grafana.app/v0alpha1/namespaces/x/repositories/y/webhook", true},
+		{"Webhook path with subpath", "https://grafana.localhost/apis/provisioning.grafana.app/v0alpha1/namespaces/x/repositories/y/webhook/unittest", false}, // this'll have to change if we ever want subpaths
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			svc := ProvideProvisioning()
+
+			url, err := url.Parse(tt.URL)
+			require.NoError(t, err, "couldn't parse input URL")
+			req := &authn.Request{HTTPRequest: &http.Request{
+				URL: url,
+			}}
+
+			assert.Equal(t, tt.Valid, svc.Test(ctx, req))
+		})
+	}
+}
+
+func TestProvisioning_Authenticate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	url, err := url.Parse("https://grafana.localhost/apis/provisioning.grafana.app/v0alpha1/namespaces/x/repositories/y/webhook")
+	require.NoError(t, err, "couldn't parse URL known to be good?")
+	req := &authn.Request{HTTPRequest: &http.Request{
+		URL: url,
+	}}
+
+	svc := ProvideProvisioning()
+	identity, err := svc.Authenticate(ctx, req)
+	require.NoError(t, err, "Authenticate shouldn't err")
+
+	assert.Equal(t, "auth.client.apiserver.provisioning", identity.UID, "UID")
+	assert.Equal(t, "auth.client.apiserver.provisioning", identity.Login, "Login")
+	assert.Equal(t, "auth.client.apiserver.provisioning", identity.Email, "Email")
+	assert.Equal(t, "555", identity.ID, "ID")
+	assert.Equal(t, "auth.client.apiserver.provisioning", identity.AuthenticatedBy, "AuthenticatedBy")
+	assert.Equal(t, false, identity.GetIsGrafanaAdmin(), "IsAdmin")
+}
+
+func TestProvisioning_Assumptions(t *testing.T) {
+	t.Run("APIVERSION constant has no leading or trailing slashes", func(t *testing.T) {
+		assert.False(t, strings.HasPrefix(provisioning.APIVERSION, "/"), "found leading / in APIVERSION: %s", provisioning.APIVERSION)
+		assert.False(t, strings.HasSuffix(provisioning.APIVERSION, "/"), "found trailing / in APIVERSION: %s", provisioning.APIVERSION)
+	})
+}

--- a/public/app/features/provisioning/SetupWarnings.tsx
+++ b/public/app/features/provisioning/SetupWarnings.tsx
@@ -33,10 +33,7 @@ dualWriterMode = 5
 
 # For Github webhook support, you will need something like:
 [server]
-root_url = https://supreme-exact-beetle.ngrok-free.app
-
-[auth.anonymous]
-enabled = true`;
+root_url = https://supreme-exact-beetle.ngrok-free.app`;
 
 const ngrok_example = `ngrok http 3000
 
@@ -61,10 +58,7 @@ HTTP Requests
 const webhook_ini = `...
 
 [server]
-root_url = https://d60d-83-33-235-27.ngrok-free.app
-
-[auth.anonymous]
-enabled = true`;
+root_url = https://d60d-83-33-235-27.ngrok-free.app`;
 
 export function SetupWarnings() {
   const [isCustomIniOpen, setCustomIniOpen] = useLocalStorage('collapse_custom_ini', true);
@@ -112,9 +106,7 @@ export function SetupWarnings() {
 
       <Collapse isOpen={isWebhookOpen} label="Webhook Support" onToggle={handleWebhookToggle} collapsible>
         <Alert severity="info" title="">
-          <Text element="h5">
-            Webhook support requires the server to run on a public URL — and (for now) anonymous access
-          </Text>
+          <Text element="h5">Webhook support requires the server to run on a public URL.</Text>
           <pre>
             <code>{webhook_ini}</code>
           </pre>


### PR DESCRIPTION
This is a second attempt at #99964. I've tested for the same issues of repeating requests, which is not occurring.

Closes: https://github.com/grafana/git-ui-sync-project/issues/22