### PR TITLE
Provisioning: Fix local Write so it generates parent folders

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/job.go
+++ b/pkg/registry/apis/provisioning/jobs/export/job.go
@@ -3,9 +3,11 @@ package export
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -95,6 +97,7 @@ func (r *exportJob) getSummary(gr schema.GroupResource) *provisioning.JobResourc
 }
 
 func (r *exportJob) loadFolders(ctx context.Context) error {
+	logger := r.logger
 	targetRepoName := r.target.Config().Name
 	status := r.jobStatus
 	status.Message = "reading folder tree"
@@ -104,9 +107,45 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 		Resource: folders.RESOURCE,
 	}), targetRepoName)
 
+	summary := r.getSummary(schema.GroupResource{
+		Group:    folders.GROUP,
+		Resource: folders.RESOURCE,
+	})
+
+	// first create folders
+	// TODO! this should not be necessary if writing to a path also makes the parents
+	status.Message = "writing folders"
+	err = foldersTree.Walk(ctx, func(ctx context.Context, folder resources.Folder) error {
+		p := folder.Path + "/"
+		if r.prefix != "" {
+			p = r.prefix + "/" + p
+		}
+		logger := logger.With("path", p)
+
+		_, err = r.target.Read(ctx, p, r.ref)
+		if err != nil && !(errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err)) {
+			logger.Error("failed to check if folder exists before writing", "error", err)
+			return fmt.Errorf("failed to check if folder exists before writing: %w", err)
+		} else if err == nil {
+			logger.Info("folder already exists")
+			summary.Noop++
+			return nil
+		}
+
+		// Create with an empty body will make a folder (or .keep file if unsupported)
+		if err := r.target.Create(ctx, p, r.ref, nil, "export folder `"+p+"`"); err != nil {
+			logger.Error("failed to write a folder in repository", "error", err)
+			return fmt.Errorf("failed to write folder in repo: %w", err)
+		}
+		summary.Create++
+		logger.Debug("successfully exported folder")
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write folders: %w", err)
+	}
 	r.foldersTree = foldersTree
-	r.logger.Info("Loaded folders.  They will be exported implicilty with resources")
-	return err
+	return nil
 }
 
 func (r *exportJob) export(ctx context.Context, kind schema.GroupVersionResource) error {

--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -350,21 +350,25 @@ func (r *localRepository) Update(ctx context.Context, path string, ref string, d
 	return os.WriteFile(path, data, 0600)
 }
 
-func (r *localRepository) Write(ctx context.Context, path, ref string, data []byte, comment string) error {
+func (r *localRepository) Write(ctx context.Context, fpath, ref string, data []byte, comment string) error {
 	if err := r.validateRequest(ref); err != nil {
 		return err
 	}
 
-	path, err := safepath.Join(r.path, path)
+	fpath, err := safepath.Join(r.path, fpath)
 	if err != nil {
 		return fmt.Errorf("join path: %w", err)
 	}
 
-	if strings.HasSuffix(path, "/") {
-		return os.MkdirAll(path, 0600)
+	if strings.HasSuffix(fpath, "/") {
+		return os.MkdirAll(fpath, 0700)
 	}
 
-	return os.WriteFile(path, data, 0600)
+	if err := os.MkdirAll(path.Dir(fpath), 0700); err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("failed to create path: %w", err))
+	}
+
+	return os.WriteFile(fpath, data, 0600)
 }
 
 func (r *localRepository) Delete(ctx context.Context, path string, ref string, comment string) error {


### PR DESCRIPTION
When exporting a file we currently explicitly create each folder -- this is not necessary because it will be created when we write a resource anyway.

When/if we do want to support *explicit* folder metadata, we will need to export a file for each folder