### PR TITLE
App platform bug bash: Call with requester to GetParent in unifiedStoreImpl

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -353,7 +353,10 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
 		if q.WithFullpath || q.WithFullpathUIDs {
-			parents, err := ss.GetParents(ctx, folder.GetParentsQuery{UID: f.UID, OrgID: q.OrgID})
+			nextCtx, _ := identity.WithServiceIdentity(ctx, q.OrgID)
+			// TODO: probably need to add a new context with the service identity to get all parents for all
+			// calls to GetParents
+			parents, err := ss.GetParents(nextCtx, folder.GetParentsQuery{UID: f.UID, OrgID: q.OrgID})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get parents for folder %s: %w", f.UID, err)
 			}


### PR DESCRIPTION
Adds `identity.WithServiceIdentity()` to call the `GetParents()` inside of `unifiedstore.go`

**why:**
we need to have access to the parent for a given uid, otherwise we would error out internally and not be able to search/recall the access to a direct access for someone who does not have access to a parent.

NOTE:
If this is a solution, we would need to figure out where we would want to call ctx with ServiceIdentity instead of the user for internal calls, i.e. the `GetParents` calls happening through the code.

previous solution:

https://github.com/user-attachments/assets/e19eace6-77b9-4c75-82b5-93ab9e94ffac



new solution:

https://github.com/user-attachments/assets/2f88dd85-2c53-4963-9d6b-26c7812dd6f1


