### PR TITLE
Chore: Bump undici

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31112,9 +31112,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.19.5":
-  version: 6.19.8
-  resolution: "undici@npm:6.19.8"
-  checksum: 10/19ae4ba38b029a664d99fd330935ef59136cf99edb04ed821042f27b5a9e84777265fb744c8a7abc83f2059afb019446c69a4ebef07bbc0ed6b2de8d67ef4090
+  version: 6.21.1
+  resolution: "undici@npm:6.21.1"
+  checksum: 10/eeccc07e9073ae8e755fdc0dc8cdfaa426c01ec6f815425c3ecedba2e5394cea4993962c040dd168951714a82f0d001a13018c3ae3ad4534f0fa97afe425c08d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps transitive dependency


```
❯ yarn why undici --recursive
└─ grafana@workspace:.
   └─ i18next-parser@npm:9.1.0 (via npm:9.1.0)
      └─ cheerio@npm:1.0.0 (via npm:^1.0.0)
         └─ undici@npm:6.19.8 (via npm:^6.19.5)
```