### PR TITLE
fix(unified-storage): return legacy data in mode 2

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -94,7 +94,7 @@ const (
 	Mode1
 	// Mode2 is the dual writing mode that represents writing to LegacyStorage and Storage and reading from LegacyStorage.
 	// The objects written to storage will include any labels and annotations.
-	// When reading values, the results will be from Storage when they exist, otherwise from legacy storage
+	// When reading values, the results will be form LegacyStorage.
 	Mode2
 	// Mode3 represents writing to LegacyStorage and Storage and reading from Storage.
 	// NOTE: Requesting mode3 will only happen when after a background sync job succeeds

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -94,7 +94,7 @@ const (
 	Mode1
 	// Mode2 is the dual writing mode that represents writing to LegacyStorage and Storage and reading from LegacyStorage.
 	// The objects written to storage will include any labels and annotations.
-	// When reading values, the results will be form LegacyStorage.
+	// When reading values, the results will be from LegacyStorage.
 	Mode2
 	// Mode3 represents writing to LegacyStorage and Storage and reading from Storage.
 	// NOTE: Requesting mode3 will only happen when after a background sync job succeeds

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -54,7 +54,7 @@ func (d *DualWriterMode2) Mode() DualWriterMode {
 // Create overrides the behavior of the generic DualWriter and writes to LegacyStorage and Storage.
 func (d *DualWriterMode2) Create(ctx context.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	var method = "create"
-	log := d.Log.WithValues("method", method, "resource", d.resource)
+	log := d.Log.WithValues("method", method)
 	ctx = klog.NewContext(ctx, log)
 
 	accIn, err := meta.Accessor(in)

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -127,7 +127,7 @@ func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.
 			log.Error(err, "unable to fetch object from storage")
 			return nil, err
 		}
-		log.Info("object not found in storage, fetching from legacy")
+		log.Info("object not found in storage, dual write or migration didn't happen yet")
 	}
 
 	go func() {

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -32,10 +32,9 @@ type DualWriterMode2 struct {
 
 const mode2Str = "2"
 
-// NewDualWriterMode2 returns a new DualWriter in mode 2.
-// Mode 2 represents writing to LegacyStorage first, then to Storage
-// When reading, values from storage will be returned if they exist
-// otherwise the value from legacy will be used
+// newDualWriterMode2 returns a new DualWriter in mode 2.
+// Mode 2 represents writing to LegacyStorage first, then to Storage.
+// When reading, values from LegacyStorage will be returned.
 func newDualWriterMode2(legacy LegacyStorage, storage Storage, dwm *dualWriterMetrics, resource string) *DualWriterMode2 {
 	return &DualWriterMode2{
 		Legacy:            legacy,

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -155,6 +155,16 @@ func (d *DualWriterMode2) List(ctx context.Context, options *metainternalversion
 		return ll, err
 	}
 	d.recordLegacyDuration(false, mode2Str, d.resource, method, startLegacy)
+
+	// Even if we don't compare, we want to fetch from unified storage and check that it doesn't error.
+	startStorage := time.Now()
+	if _, err := d.Storage.List(ctx, options); err != nil {
+		log.Error(err, "unable to list objects from storage")
+		d.recordStorageDuration(true, mode2Str, d.resource, method, startStorage)
+		return nil, err
+	}
+	d.recordStorageDuration(false, mode2Str, d.resource, method, startStorage)
+
 	return ll, nil
 }
 


### PR DESCRIPTION
This PR changes a few things with mode 2 to make it semantically correct.

- **Main change:** We always return the legacy object and never the unified one.
- The order of operation is always legacy and then unified.
- On error we never return an object, always nil and the error.
- Comparing wasn't removed but is done in the background.
- Using one distinct mock per storage type to fix overwrites happening.
- Replace `asserts` with `require` to fail early.