### PR TITLE
Alerting: Do not record rule version if no difference

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -329,7 +329,13 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, 
 			v := alertRuleToAlertRuleVersion(converted)
 			v.Version++
 			v.ParentVersion = r.Existing.Version
-			ruleVersions = append(ruleVersions, v)
+
+			// check if there is diff between existing and new, and if no, skip saving version.
+			existingConverted, err := alertRuleFromModelsAlertRule(*r.Existing)
+			if err != nil || !alertRuleToAlertRuleVersion(existingConverted).EqualSpec(v) {
+				ruleVersions = append(ruleVersions, v)
+			}
+
 			keys = append(keys, ngmodels.AlertRuleKey{OrgID: r.New.OrgID, UID: r.New.UID})
 		}
 		if len(ruleVersions) > 0 {


### PR DESCRIPTION
**What is this feature?**
This PR updates rule storage to not save a version during update operation if there is no difference between old and new version. 

**Why do we need this feature?**
This is a follow-up for https://github.com/grafana/grafana/pull/100093 and addresses behavior introduced https://github.com/grafana/grafana/pull/50274: when a rule is updated all rules that belong to the same group gets a noop update with version increase for optimistic concurrency. This PR keeps the same behavior but skips saving a rule into version table
