### PR TITLE
DashboardDS: Re-run dashboard queries within MixedDS on transformation reprocessing

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -6,12 +6,23 @@ import {
   DataSourceApi,
   DataSourceJsonData,
   DataSourceRef,
+  DataTransformerID,
+  getDefaultTimeRange,
   LoadingState,
   PanelData,
+  ValueMatcherID,
 } from '@grafana/data';
+import { FilterByValueMatch, FilterByValueType } from '@grafana/data/src/transformations/transformers/filterByValue';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { SceneDataTransformer, SceneFlexLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import {
+  SceneDataTransformer,
+  SceneFlexLayout,
+  SceneQueryRunner,
+  SceneVariableSet,
+  TestVariable,
+  VizPanel,
+} from '@grafana/scenes';
 import { SHARED_DASHBOARD_QUERY, DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
@@ -21,6 +32,8 @@ import { DashboardDatasourceBehaviour } from './DashboardDatasourceBehaviour';
 import { DashboardScene } from './DashboardScene';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 const grafanaDs = {
   id: 1,
@@ -592,6 +605,68 @@ describe('DashboardDatasourceBehaviour', () => {
 
       expect(spy).toHaveBeenCalled();
     });
+  });
+
+  it('Should re-run query after transformations reprocess', async () => {
+    const sourcePanel = new VizPanel({
+      title: 'Panel A',
+      pluginId: 'table',
+      key: 'panel-1',
+      $data: new SceneDataTransformer({
+        transformations: [{ id: 'transformA', options: {} }],
+        $data: new SceneQueryRunner({
+          datasource: { uid: 'grafana' },
+          queries: [{ refId: 'A', queryType: 'randomWalk' }],
+        }),
+      }),
+    });
+
+    const dashboardDSPanel = new VizPanel({
+      title: 'Panel B',
+      pluginId: 'table',
+      key: 'panel-2',
+      $data: new SceneDataTransformer({
+        transformations: [],
+        $data: new SceneQueryRunner({
+          datasource: { uid: MIXED_DATASOURCE_NAME },
+          queries: [
+            {
+              datasource: { uid: SHARED_DASHBOARD_QUERY },
+              refId: 'B',
+              panelId: 1,
+            },
+          ],
+          $behaviors: [new DashboardDatasourceBehaviour({})],
+        }),
+      }),
+    });
+
+    const scene = new DashboardScene({
+      title: 'hello',
+      uid: 'dash-1',
+      meta: {
+        canEdit: true,
+      },
+      body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+    });
+
+    activateFullSceneTree(scene);
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // spy on runQueries that will be called by the behaviour
+    const spy = jest
+      .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+      .mockImplementation();
+
+    // transformations are reprocessed (e.g. variable change) and data is updated so
+    // we re-run the queries in the dashboardDS panel because we lose the subscription
+    // in mixed DS scenario
+    (sourcePanel.state.$data as SceneDataTransformer).setState({
+      data: { state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() },
+    });
+
+    expect(spy).toHaveBeenCalled();
   });
 });
 

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -6,23 +6,13 @@ import {
   DataSourceApi,
   DataSourceJsonData,
   DataSourceRef,
-  DataTransformerID,
   getDefaultTimeRange,
   LoadingState,
   PanelData,
-  ValueMatcherID,
 } from '@grafana/data';
-import { FilterByValueMatch, FilterByValueType } from '@grafana/data/src/transformations/transformers/filterByValue';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setPluginImportUtils } from '@grafana/runtime';
-import {
-  SceneDataTransformer,
-  SceneFlexLayout,
-  SceneQueryRunner,
-  SceneVariableSet,
-  TestVariable,
-  VizPanel,
-} from '@grafana/scenes';
+import { SceneDataTransformer, SceneFlexLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { SHARED_DASHBOARD_QUERY, DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
@@ -32,8 +22,6 @@ import { DashboardDatasourceBehaviour } from './DashboardDatasourceBehaviour';
 import { DashboardScene } from './DashboardScene';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 const grafanaDs = {
   id: 1,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There is a bug where panels using MixedDS with dashboard queries would not refresh the data on variable change where the variable would be on the source panel, specifically targeting transformations, not the query. In that case we would not re-run the query but only reprocess the transformation but in the case of MixedDS that won't work because the DS merges all the results and completes the observable, not allowing the transformation reprocessing to further emit data. 

In the case of dashboard queries that sources from a query + a transformation where a variable will trigger reprocessing the transformed data, we will just re-run the queries.

This also affects standard dashboard queries, outside MixedDS, in scenes, where if you would panel edit the results observable would complete and upon return to the dashboard, the transformations would emit but the datasource would no longer be subscribed to the results stream.

**Why do we need this feature?**

Fixes the issue

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/100261
Fixes https://github.com/grafana/grafana/issues/100259

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
