### PR TITLE
fix(unified-storage): use dedicated mocks per storage type

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -170,7 +169,7 @@ func TestMode1_Get(t *testing.T) {
 			},
 			{
 				name:  "error when getting an object in the legacy store fails",
-				input: objectFailName("get"),
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},
@@ -402,7 +401,7 @@ func TestMode1_Delete(t *testing.T) {
 			},
 			{
 				name:  "error when deleting an object in the legacy store",
-				input: objectFailName("delete"),
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -644,7 +643,7 @@ func TestMode1_Update(t *testing.T) {
 			},
 			{
 				name:  "error updating an object in legacy",
-				input: objectFailName("update"),
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -753,8 +752,4 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-}
-
-func objectFailName(prefix string) string {
-	return fmt.Sprintf("%s/%s", prefix, failingObject)
 }

--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -152,14 +152,12 @@ func TestMode1_Get(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, name string)
 		setupStorageFn func(m *mock.Mock, name string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "get an object only in the legacy store",
-				input: "foo",
+				name: "get an object only in the legacy store",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
@@ -168,8 +166,7 @@ func TestMode1_Get(t *testing.T) {
 				},
 			},
 			{
-				name:  "error when getting an object in the legacy store fails",
-				input: "foo",
+				name: "error when getting an object in the legacy store fails",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},
@@ -180,6 +177,8 @@ func TestMode1_Get(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -189,15 +188,15 @@ func TestMode1_Get(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
 
-			obj, err := dw.Get(context.Background(), tt.input, &metav1.GetOptions{})
+			obj, err := dw.Get(context.Background(), name, &metav1.GetOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -221,26 +220,25 @@ func TestMode1_GetFromUnifiedStorage(t *testing.T) {
 		setupStorageFn func(m *mock.Mock, name string)
 		ctx            *context.Context
 		name           string
-		input          string
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "Get from unified storage",
-				input: "foo",
+				name: "Get from unified storage",
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 			{
-				name:  "Get from unified storage works even if parent context is canceled",
-				input: "foo",
-				ctx:   &ctxCanceled,
+				name: "Get from unified storage works even if parent context is canceled",
+				ctx:  &ctxCanceled,
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -251,10 +249,10 @@ func TestMode1_GetFromUnifiedStorage(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			ctx := context.TODO()
@@ -263,7 +261,7 @@ func TestMode1_GetFromUnifiedStorage(t *testing.T) {
 			}
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
-			err := dw.(*DualWriterMode1).getFromUnifiedStorage(ctx, exampleObj, tt.input, &metav1.GetOptions{})
+			err := dw.(*DualWriterMode1).getFromUnifiedStorage(ctx, exampleObj, name, &metav1.GetOptions{})
 			require.NoError(t, err)
 		})
 	}
@@ -384,14 +382,12 @@ func TestMode1_Delete(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, name string)
 		setupStorageFn func(m *mock.Mock, name string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "deleting an object in the legacy store",
-				input: "foo",
+				name: "deleting an object in the legacy store",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -400,8 +396,7 @@ func TestMode1_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "error when deleting an object in the legacy store",
-				input: "foo",
+				name: "error when deleting an object in the legacy store",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -412,6 +407,8 @@ func TestMode1_Delete(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -421,22 +418,22 @@ func TestMode1_Delete(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
 
-			obj, _, err := dw.Delete(context.Background(), tt.input, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			obj, _, err := dw.Delete(context.Background(), name, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
-			us.AssertNotCalled(t, "Delete", context.Background(), tt.input, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			us.AssertNotCalled(t, "Delete", context.Background(), name, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 			require.Equal(t, obj, exampleObj)
 			require.NotEqual(t, obj, anotherObj)
 		})
@@ -452,7 +449,6 @@ func TestMode1_DeleteFromUnifiedStorage(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, name string)
 		setupStorageFn func(m *mock.Mock, name string)
 		name           string
-		input          string
 	}
 	tests :=
 		[]testCase{
@@ -471,6 +467,8 @@ func TestMode1_DeleteFromUnifiedStorage(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -480,10 +478,10 @@ func TestMode1_DeleteFromUnifiedStorage(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			ctx := context.TODO()
@@ -493,7 +491,7 @@ func TestMode1_DeleteFromUnifiedStorage(t *testing.T) {
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
 
-			err := dw.(*DualWriterMode1).deleteFromUnifiedStorage(ctx, exampleObj, tt.input, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			err := dw.(*DualWriterMode1).deleteFromUnifiedStorage(ctx, exampleObj, name, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 			require.NoError(t, err)
 		})
 	}
@@ -626,14 +624,12 @@ func TestMode1_Update(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, input string)
 		setupStorageFn func(m *mock.Mock, input string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "update an object in legacy",
-				input: "foo",
+				name: "update an object in legacy",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -642,8 +638,7 @@ func TestMode1_Update(t *testing.T) {
 				},
 			},
 			{
-				name:  "error updating an object in legacy",
-				input: "foo",
+				name: "error updating an object in legacy",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -654,6 +649,8 @@ func TestMode1_Update(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -663,15 +660,15 @@ func TestMode1_Update(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
 
-			obj, _, err := dw.Update(context.Background(), tt.input, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
+			obj, _, err := dw.Update(context.Background(), name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -694,13 +691,11 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 		setupStorageFn func(m *mock.Mock, input string)
 		setupGetFn     func(m *mock.Mock, input string)
 		name           string
-		input          string
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "Update on unified storage",
-				input: "foo",
+				name: "Update on unified storage",
 				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(anotherObj, false, nil)
 				},
@@ -709,9 +704,8 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 				},
 			},
 			{
-				name:  "Update on unified storage works even if parent context is canceled",
-				ctx:   &ctxCanceled,
-				input: "foo",
+				name: "Update on unified storage works even if parent context is canceled",
+				ctx:  &ctxCanceled,
 				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(anotherObj, false, nil)
 				},
@@ -720,6 +714,8 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 				},
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -730,15 +726,15 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			if tt.setupGetFn != nil {
-				tt.setupGetFn(ls.Mock, tt.input)
-				tt.setupGetFn(us.Mock, tt.input)
+				tt.setupGetFn(ls.Mock, name)
+				tt.setupGetFn(us.Mock, name)
 			}
 
 			ctx := context.TODO()
@@ -748,7 +744,7 @@ func TestMode1_UpdateOnUnifiedStorage(t *testing.T) {
 
 			dw := NewDualWriter(Mode1, ls, us, p, kind)
 
-			err := dw.(*DualWriterMode1).updateOnUnifiedStorageMode1(ctx, exampleObj, tt.input, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
+			err := dw.(*DualWriterMode1).updateOnUnifiedStorageMode1(ctx, exampleObj, name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -244,14 +244,12 @@ func TestMode2_Delete(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, input string)
 		setupStorageFn func(m *mock.Mock, input string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should delete an object from both the LegacyStorage and Storage",
-				input: "foo",
+				name: "should delete an object from both the LegacyStorage and Storage",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -260,8 +258,7 @@ func TestMode2_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when deleting an object from the LegacyStorage fails",
-				input: "foo",
+				name: "should return an error when deleting an object from the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -271,8 +268,7 @@ func TestMode2_Delete(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when deleting an object from the Storage fails",
-				input: "foo",
+				name: "should return an error when deleting an object from the Storage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -282,8 +278,7 @@ func TestMode2_Delete(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when the object is not found in LegacyStorage",
-				input: "foo",
+				name: "should return an error when the object is not found in LegacyStorage",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false,
 						apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
@@ -294,8 +289,7 @@ func TestMode2_Delete(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should not return an error when the object is not found in Storage",
-				input: "foo",
+				name: "should not return an error when the object is not found in Storage",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -305,8 +299,7 @@ func TestMode2_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when deleting an object from both the LegacyStorage and Storage fails",
-				input: "foo",
+				name: "should return an error when deleting an object from both the LegacyStorage and Storage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -317,6 +310,8 @@ func TestMode2_Delete(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -326,15 +321,15 @@ func TestMode2_Delete(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
 
-			obj, _, err := dw.Delete(context.Background(), tt.input, func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			obj, _, err := dw.Delete(context.Background(), name, func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -352,14 +347,12 @@ func TestMode2_DeleteCollection(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock)
 		setupStorageFn func(m *mock.Mock)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should delete a collection from both the LegacyStorage and Storage",
-				input: "foo",
+				name: "should delete a collection from both the LegacyStorage and Storage",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
 				},
@@ -368,8 +361,7 @@ func TestMode2_DeleteCollection(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when deleting a collection from the Storage fails",
-				input: "fail",
+				name: "should return an error when deleting a collection from the Storage fails",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
 				},
@@ -379,14 +371,15 @@ func TestMode2_DeleteCollection(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when deleting a collection from the LegacyStorage fails",
-				input: "fail",
+				name: "should return an error when deleting a collection from the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -405,7 +398,7 @@ func TestMode2_DeleteCollection(t *testing.T) {
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
 
-			obj, err := dw.DeleteCollection(context.Background(), func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: tt.input}}, &metainternalversion.ListOptions{})
+			obj, err := dw.DeleteCollection(context.Background(), func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: name}}, &metainternalversion.ListOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -422,14 +415,12 @@ func TestMode2_Update(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, input string)
 		setupStorageFn func(m *mock.Mock, input string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when updating an object in both the LegacyStorage and Storage is successful",
-				input: "foo",
+				name: "should succeed when updating an object in both the LegacyStorage and Storage is successful",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -439,16 +430,14 @@ func TestMode2_Update(t *testing.T) {
 				expectedObj: exampleObj,
 			},
 			{
-				name:  "should return an error when updating the LegacyStorage fails",
-				input: "foo",
+				name: "should return an error when updating the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when updating the Storage fails",
-				input: "foo",
+				name: "should return an error when updating the Storage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -459,6 +448,8 @@ func TestMode2_Update(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -468,15 +459,15 @@ func TestMode2_Update(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
 
-			obj, _, err := dw.Update(context.Background(), tt.input, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
+			obj, _, err := dw.Update(context.Background(), name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -29,20 +29,24 @@ func TestMode2_Create(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "creating an object in both the LegacyStorage and Storage",
+				name:  "should create an object in both the LegacyStorage and Storage",
 				input: exampleObj,
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil)
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
 				},
-				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, exampleObj, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
+					// We don't use the input here, as the input is transformed before being passed to unified storage.
+					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 			{
-				name:  "error when creating object in the legacy store fails",
+				name:  "should return an error when creating an object in the LegacyStorage fails",
 				input: failingObj,
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
 					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				},
+				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
 				},
 				wantErr: true,
 			},
@@ -52,16 +56,15 @@ func TestMode2_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
@@ -89,7 +92,7 @@ func TestMode2_Get(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "getting an object from storage",
+				name:  "should get an object from both the LegacyStorage and Storage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
@@ -99,7 +102,7 @@ func TestMode2_Get(t *testing.T) {
 				},
 			},
 			{
-				name:  "object not present in storage but present in legacy store",
+				name:  "should return an error when getting an object from the Storage fails",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
@@ -107,9 +110,22 @@ func TestMode2_Get(t *testing.T) {
 				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
 				},
+				wantErr: true,
 			},
 			{
-				name:  "error when getting object in both stores fails",
+				name:  "should not error when object is not found in the Storage but found in the LegacyStorage",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, apierrors.NewNotFound(
+						schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
+				},
+				wantErr: true,
+			},
+			{
+				name:  "should return an error when getting an object from both the LegacyStorage and Storage fails",
 				input: "object-fail",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
@@ -125,16 +141,15 @@ func TestMode2_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
@@ -163,7 +178,7 @@ func TestMode2_List(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:        "object present in both Storage and LegacyStorage",
+				name:        "should return a list of objects from both the LegacyStorage and Storage",
 				inputLegacy: exampleOption,
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
@@ -172,22 +187,43 @@ func TestMode2_List(t *testing.T) {
 					m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
 				},
 			},
+			{
+				name:        "should return an error when listing objects from the LegacyStorage fails",
+				inputLegacy: exampleOption,
+				setupLegacyFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				},
+				setupStorageFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+				},
+				wantErr: true,
+			},
+			{
+				name:        "should return an error when listing objects from the Storage fails",
+				inputLegacy: exampleOption,
+				setupLegacyFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+				},
+				setupStorageFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				},
+				wantErr: true,
+			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m)
+				tt.setupLegacyFn(ls.Mock)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m)
+				tt.setupStorageFn(us.Mock)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
@@ -214,7 +250,7 @@ func TestMode2_Delete(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "delete in legacy and storage",
+				name:  "should delete an object from both the LegacyStorage and Storage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
@@ -224,39 +260,53 @@ func TestMode2_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "object delete in legacy not found, but found in storage",
+				name:  "should return an error when deleting an object from the LegacyStorage fails",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, "not-found-legacy", mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
 				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
-				},
-			},
-			{
-				name:  " object delete in storage not found, but found in legacy",
-				input: "foo",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
-				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, "not-found-storage", mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
-				},
-			},
-			{
-				name:  " object not found in both",
-				input: "object-fail",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
-				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
 				},
 				wantErr: true,
 			},
 			{
-				name:  " object delete error",
-				input: "object-fail",
+				name:  "should return an error when deleting an object from the Storage fails",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				},
+				wantErr: true,
+			},
+			{
+				name:  "should return an error when the object is not found in LegacyStorage",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false,
+						apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, nil)
+				},
+				wantErr: true,
+			},
+			{
+				name:  "should not return an error when the object is not found in Storage",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false,
+						apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
+				},
+			},
+			{
+				name:  "should return an error when deleting an object from both the LegacyStorage and Storage fails",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -271,16 +321,15 @@ func TestMode2_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)
@@ -309,7 +358,7 @@ func TestMode2_DeleteCollection(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "deleting a collection in both stores",
+				name:  "should delete a collection from both the LegacyStorage and Storage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
@@ -319,10 +368,10 @@ func TestMode2_DeleteCollection(t *testing.T) {
 				},
 			},
 			{
-				name:  "error deleting a collection in the storage when legacy store is successful",
+				name:  "should return an error when deleting a collection from the Storage fails",
 				input: "fail",
 				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
+					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
 				},
 				setupStorageFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
@@ -330,7 +379,7 @@ func TestMode2_DeleteCollection(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "deleting a collection when error in legacy store",
+				name:  "should return an error when deleting a collection from the LegacyStorage fails",
 				input: "fail",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
@@ -379,7 +428,7 @@ func TestMode2_Update(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "update an object in both stores",
+				name:  "should succeed when updating an object in both the LegacyStorage and Storage is successful",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
@@ -390,9 +439,20 @@ func TestMode2_Update(t *testing.T) {
 				expectedObj: exampleObj,
 			},
 			{
-				name:  "error updating legacy store",
-				input: "object-fail",
+				name:  "should return an error when updating the LegacyStorage fails",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				},
+				wantErr: true,
+			},
+			{
+				name:  "should return an error when updating the Storage fails",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
 				wantErr: true,
@@ -403,16 +463,15 @@ func TestMode2_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode2, ls, us, p, kind)

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -289,7 +289,7 @@ func TestMode2_Delete(t *testing.T) {
 						apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
 				},
 				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, nil)
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
 				wantErr: true,
 			},

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -26,17 +26,18 @@ func TestMode3_Create(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "creating an object in both the LegacyStorage and Storage",
+				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
 				},
-				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, exampleObj, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
+					// We don't use the input here, as the input is transformed before being passed to unified storage.
+					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
 				},
 			},
 			{
-				name:  "error when creating object in the legacy store fails",
+				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
 					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
@@ -44,14 +45,15 @@ func TestMode3_Create(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "error when creating object in the unistore fails - legacy delete should be called",
+				name:  "should return an error when creating an object in the unified store fails and delete from LegacyStorage",
 				input: exampleObj,
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
 					m.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, true, nil).Once()
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
 				},
-				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, exampleObj, mock.Anything, mock.Anything).Return(exampleObj, errors.New("error")).Once()
+				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
+					// We don't use the input here, as the input is transformed before being passed to unified storage.
+					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
 				},
 				wantErr: true,
 			},
@@ -61,16 +63,15 @@ func TestMode3_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
@@ -89,6 +90,7 @@ func TestMode3_Create(t *testing.T) {
 
 func TestMode3_Get(t *testing.T) {
 	type testCase struct {
+		setupLegacyFn  func(m *mock.Mock, name string)
 		setupStorageFn func(m *mock.Mock, name string)
 		name           string
 		input          string
@@ -97,19 +99,35 @@ func TestMode3_Get(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "get an object only in unified store",
+				name:  "should succeed when getting an object from both stores",
 				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, name string) {
+					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				},
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 			{
-				name:  "error when getting an object in the unified store fails",
-				input: "object-fail",
+				name:  "should return an error when getting an object in the unified store fails",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, name string) {
+					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				},
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
+			},
+			{
+				name:  "should succeed when getting an object in the LegacyStorage fails",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, name string) {
+					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				},
+				setupStorageFn: func(m *mock.Mock, name string) {
+					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				},
 			},
 		}
 
@@ -117,13 +135,15 @@ func TestMode3_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
+			if tt.setupLegacyFn != nil {
+				tt.setupLegacyFn(ls.Mock, tt.input)
+			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			p := prometheus.NewRegistry()
@@ -155,14 +175,14 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "Get from legacy storage",
+				name:  "should succeed when getting an object from the LegacyStorage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 			{
-				name:  "Get from legacy storage works even if parent context is canceled",
+				name:  "should succeed when getting an object from the LegacyStorage even if parent context is canceled",
 				input: "foo",
 				ctx:   &ctxCanceled,
 				setupLegacyFn: func(m *mock.Mock, name string) {
@@ -175,13 +195,12 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 
 			ctx := context.TODO()
@@ -200,22 +219,19 @@ func TestMode3_List(t *testing.T) {
 	type testCase struct {
 		setupStorageFn func(m *mock.Mock, options *metainternalversion.ListOptions)
 		name           string
-		options        *metainternalversion.ListOptions
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:    "error when listing an object in the unified store is not implemented",
-				options: &metainternalversion.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "fail"}},
+				name: "should return an error when listing an object in the UnifiedStorage is failing",
 				setupStorageFn: func(m *mock.Mock, options *metainternalversion.ListOptions) {
 					m.On("List", mock.Anything, options).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
-				name:    "list objects in the unified store",
-				options: &metainternalversion.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}},
+				name: "should succeed when listing objects in the UnifiedStorage is successful",
 				setupStorageFn: func(m *mock.Mock, options *metainternalversion.ListOptions) {
 					m.On("List", mock.Anything, options).Return(exampleList, nil)
 				},
@@ -226,18 +242,17 @@ func TestMode3_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.options)
+				tt.setupStorageFn(us.Mock, &metainternalversion.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}})
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 
-			res, err := dw.List(context.Background(), tt.options)
+			res, err := dw.List(context.Background(), &metainternalversion.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}})
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -261,7 +276,7 @@ func TestMode3_Delete(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "delete in legacy and storage",
+				name:  "should succeed when deleting an object in both stores",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
@@ -271,39 +286,38 @@ func TestMode3_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "object delete in legacy not found, but found in storage",
+				name:  "should succeed when deleting an object in the LegacyStorage is not found, but found in the UnifiedStorage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, "not-found-legacy", mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
 				},
 				setupStorageFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
 			},
 			{
-				name:  " object delete in storage not found, but found in legacy",
+				name:  "should succeed when deleting an object in the UnifiedStorage is not found in the LegacyStorage",
+				input: "foo",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				},
+			},
+			{
+				name:  "should not return an error when deleting an object in the LegacyStorage is not found in UnifiedStorage",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
 				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, "not-found-storage", mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
 				},
 			},
 			{
-				name:  " object not found in both",
-				input: "object-fail",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
-				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
-				},
-				wantErr: true,
-			},
-			{
-				name:  " object delete error",
-				input: "object-fail",
+				name:  "should return an error when deleting an object in the LegacyStorage and UnifiedStorage is failing",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -318,16 +332,15 @@ func TestMode3_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
@@ -356,7 +369,7 @@ func TestMode3_DeleteCollection(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "deleting a collection in both stores",
+				name:  "should succeed when deleting a collection in both stores",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
@@ -366,7 +379,7 @@ func TestMode3_DeleteCollection(t *testing.T) {
 				},
 			},
 			{
-				name:  "error deleting a collection in the storage when legacy store is successful",
+				name:  "should return an error when deleting a collection in the storage fails and LegacyStorage is successful",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
@@ -377,10 +390,10 @@ func TestMode3_DeleteCollection(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "error deleting a collection legacy store",
-				input: "fail",
+				name:  "should return an error when deleting a collection in the LegacyStorage fails",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "fail"}}, mock.Anything).Return(nil, errors.New("error"))
+					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -390,16 +403,15 @@ func TestMode3_DeleteCollection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m)
+				tt.setupLegacyFn(ls.Mock)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m)
+				tt.setupStorageFn(us.Mock)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
@@ -427,7 +439,7 @@ func TestMode3_Update(t *testing.T) {
 	tests :=
 		[]testCase{
 			{
-				name:  "update an object in both stores",
+				name:  "should succeed when updating an object in both stores",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
@@ -438,16 +450,16 @@ func TestMode3_Update(t *testing.T) {
 				expectedObj: exampleObj,
 			},
 			{
-				name:  "error updating legacy store",
-				input: "object-fail",
+				name:  "should return an error when updating an object in the LegacyStorage fails",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error")).Once()
 				},
 				wantErr: true,
 			},
 			{
-				name:  "error updating unistore",
-				input: "object-fail",
+				name:  "should return an error when updating an object in the UnifiedStorage fails",
+				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
 				},
@@ -462,16 +474,15 @@ func TestMode3_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
 			s := (Storage)(nil)
-			m := &mock.Mock{}
 
-			ls := legacyStoreMock{m, l}
-			us := storageMock{m, s}
+			ls := legacyStoreMock{&mock.Mock{}, l}
+			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(m, tt.input)
+				tt.setupLegacyFn(ls.Mock, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(m, tt.input)
+				tt.setupStorageFn(us.Mock, tt.input)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,11 +79,11 @@ func TestMode3_Create(t *testing.T) {
 			obj, err := dw.Create(context.Background(), tt.input, createFn, &metav1.CreateOptions{})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.Equal(t, exampleObj, obj)
+			require.Equal(t, exampleObj, obj)
 		})
 	}
 }
@@ -150,12 +150,12 @@ func TestMode3_Get(t *testing.T) {
 			obj, err := dw.Get(context.Background(), name, &metav1.GetOptions{})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.Equal(t, obj, exampleObj)
-			assert.NotEqual(t, obj, anotherObj)
+			require.Equal(t, obj, exampleObj)
+			require.NotEqual(t, obj, anotherObj)
 		})
 	}
 }
@@ -207,7 +207,7 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 			err := dw.(*DualWriterMode3).getFromLegacyStorage(ctx, exampleObj, name, &metav1.GetOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -252,12 +252,12 @@ func TestMode3_List(t *testing.T) {
 			res, err := dw.List(context.Background(), &metainternalversion.ListOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.Equal(t, exampleList, res)
-			assert.NotEqual(t, anotherList, res)
+			require.Equal(t, exampleList, res)
+			require.NotEqual(t, anotherList, res)
 		})
 	}
 }
@@ -332,12 +332,12 @@ func TestMode3_Delete(t *testing.T) {
 			obj, _, err := dw.Delete(context.Background(), name, func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.Equal(t, obj, exampleObj)
-			assert.NotEqual(t, obj, anotherObj)
+			require.Equal(t, obj, exampleObj)
+			require.NotEqual(t, obj, anotherObj)
 		})
 	}
 }
@@ -401,10 +401,10 @@ func TestMode3_DeleteCollection(t *testing.T) {
 			obj, err := dw.DeleteCollection(context.Background(), func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: name}}, &metainternalversion.ListOptions{})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.Equal(t, exampleList, obj)
+			require.Equal(t, exampleList, obj)
 		})
 	}
 }
@@ -470,12 +470,12 @@ func TestMode3_Update(t *testing.T) {
 			obj, _, err := dw.Update(context.Background(), name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.Equal(t, tt.expectedObj, obj)
-			assert.NotEqual(t, anotherObj, obj)
+			require.Equal(t, tt.expectedObj, obj)
+			require.NotEqual(t, anotherObj, obj)
 		})
 	}
 }

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -306,16 +306,6 @@ func TestMode3_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should not return an error when deleting an object in the LegacyStorage is not found in UnifiedStorage",
-				input: "foo",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
-				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
-				},
-			},
-			{
 				name:  "should return an error when deleting an object in the LegacyStorage and UnifiedStorage is failing",
 				input: "foo",
 				setupLegacyFn: func(m *mock.Mock, input string) {

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -93,14 +93,12 @@ func TestMode3_Get(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, name string)
 		setupStorageFn func(m *mock.Mock, name string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when getting an object from both stores",
-				input: "foo",
+				name: "should succeed when getting an object from both stores",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
@@ -109,8 +107,7 @@ func TestMode3_Get(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when getting an object in the unified store fails",
-				input: "foo",
+				name: "should return an error when getting an object in the unified store fails",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
@@ -120,8 +117,7 @@ func TestMode3_Get(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should succeed when getting an object in the LegacyStorage fails",
-				input: "foo",
+				name: "should succeed when getting an object in the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},
@@ -130,6 +126,8 @@ func TestMode3_Get(t *testing.T) {
 				},
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -140,16 +138,16 @@ func TestMode3_Get(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			p := prometheus.NewRegistry()
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 
-			obj, err := dw.Get(context.Background(), tt.input, &metav1.GetOptions{})
+			obj, err := dw.Get(context.Background(), name, &metav1.GetOptions{})
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -170,26 +168,25 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 		setupLegacyFn func(m *mock.Mock, name string)
 		ctx           *context.Context
 		name          string
-		input         string
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when getting an object from the LegacyStorage",
-				input: "foo",
+				name: "should succeed when getting an object from the LegacyStorage",
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 			{
-				name:  "should succeed when getting an object from the LegacyStorage even if parent context is canceled",
-				input: "foo",
-				ctx:   &ctxCanceled,
+				name: "should succeed when getting an object from the LegacyStorage even if parent context is canceled",
+				ctx:  &ctxCanceled,
 				setupLegacyFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
 				},
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -200,7 +197,7 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 
 			ctx := context.TODO()
@@ -209,7 +206,7 @@ func TestMode1_GetFromLegacyStorage(t *testing.T) {
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
-			err := dw.(*DualWriterMode3).getFromLegacyStorage(ctx, exampleObj, tt.input, &metav1.GetOptions{})
+			err := dw.(*DualWriterMode3).getFromLegacyStorage(ctx, exampleObj, name, &metav1.GetOptions{})
 			assert.NoError(t, err)
 		})
 	}
@@ -270,14 +267,12 @@ func TestMode3_Delete(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, input string)
 		setupStorageFn func(m *mock.Mock, input string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when deleting an object in both stores",
-				input: "foo",
+				name: "should succeed when deleting an object in both stores",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -286,8 +281,7 @@ func TestMode3_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should succeed when deleting an object in the LegacyStorage is not found, but found in the UnifiedStorage",
-				input: "foo",
+				name: "should succeed when deleting an object in the LegacyStorage is not found, but found in the UnifiedStorage",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
 				},
@@ -296,8 +290,7 @@ func TestMode3_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should succeed when deleting an object in the UnifiedStorage is not found in the LegacyStorage",
-				input: "foo",
+				name: "should succeed when deleting an object in the UnifiedStorage is not found in the LegacyStorage",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, input))
 				},
@@ -306,8 +299,7 @@ func TestMode3_Delete(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when deleting an object in the LegacyStorage and UnifiedStorage is failing",
-				input: "foo",
+				name: "should return an error when deleting an object in the LegacyStorage and UnifiedStorage is failing",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
@@ -318,6 +310,8 @@ func TestMode3_Delete(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -327,15 +321,15 @@ func TestMode3_Delete(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 
-			obj, _, err := dw.Delete(context.Background(), tt.input, func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			obj, _, err := dw.Delete(context.Background(), name, func(context.Context, runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -353,14 +347,12 @@ func TestMode3_DeleteCollection(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock)
 		setupStorageFn func(m *mock.Mock)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when deleting a collection in both stores",
-				input: "foo",
+				name: "should succeed when deleting a collection in both stores",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
 				},
@@ -369,8 +361,7 @@ func TestMode3_DeleteCollection(t *testing.T) {
 				},
 			},
 			{
-				name:  "should return an error when deleting a collection in the storage fails and LegacyStorage is successful",
-				input: "foo",
+				name: "should return an error when deleting a collection in the storage fails and LegacyStorage is successful",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
 				},
@@ -380,14 +371,15 @@ func TestMode3_DeleteCollection(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when deleting a collection in the LegacyStorage fails",
-				input: "foo",
+				name: "should return an error when deleting a collection in the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 		}
+
+	name := "foo"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -406,7 +398,7 @@ func TestMode3_DeleteCollection(t *testing.T) {
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 
-			obj, err := dw.DeleteCollection(context.Background(), func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: tt.input}}, &metainternalversion.ListOptions{})
+			obj, err := dw.DeleteCollection(context.Background(), func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: name}}, &metainternalversion.ListOptions{})
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -423,14 +415,12 @@ func TestMode3_Update(t *testing.T) {
 		setupLegacyFn  func(m *mock.Mock, input string)
 		setupStorageFn func(m *mock.Mock, input string)
 		name           string
-		input          string
 		wantErr        bool
 	}
 	tests :=
 		[]testCase{
 			{
-				name:  "should succeed when updating an object in both stores",
-				input: "foo",
+				name: "should succeed when updating an object in both stores",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
 				},
@@ -440,16 +430,14 @@ func TestMode3_Update(t *testing.T) {
 				expectedObj: exampleObj,
 			},
 			{
-				name:  "should return an error when updating an object in the LegacyStorage fails",
-				input: "foo",
+				name: "should return an error when updating an object in the LegacyStorage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error")).Once()
 				},
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when updating an object in the UnifiedStorage fails",
-				input: "foo",
+				name: "should return an error when updating an object in the UnifiedStorage fails",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
 				},
@@ -460,6 +448,8 @@ func TestMode3_Update(t *testing.T) {
 			},
 		}
 
+	name := "foo"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := (LegacyStorage)(nil)
@@ -469,15 +459,15 @@ func TestMode3_Update(t *testing.T) {
 			us := storageMock{&mock.Mock{}, s}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls.Mock, name)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us.Mock, name)
 			}
 
 			dw := NewDualWriter(Mode3, ls, us, p, kind)
 
-			obj, _, err := dw.Update(context.Background(), tt.input, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
+			obj, _, err := dw.Update(context.Background(), name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
@@ -80,8 +80,8 @@ func TestSetDualWritingMode(t *testing.T) {
 			DataSyncerRecordsLimit: 1000,
 			DataSyncerInterval:     time.Hour,
 		})
-		assert.NoError(t, err)
-		assert.Equal(t, tt.expectedMode, dwMode)
+		require.NoError(t, err)
+		require.Equal(t, tt.expectedMode, dwMode)
 	}
 }
 
@@ -124,7 +124,7 @@ func TestCompare(t *testing.T) {
 	}
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, Compare(tt.input1, tt.input2))
+			require.Equal(t, tt.expected, Compare(tt.input1, tt.input2))
 		})
 	}
 }

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -57,13 +57,16 @@ func TestSetDualWritingMode(t *testing.T) {
 	for _, tt := range tests {
 		l := (LegacyStorage)(nil)
 		s := (Storage)(nil)
-		m := &mock.Mock{}
 
-		m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
-		m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+		sm := &mock.Mock{}
+		sm.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+		sm.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+		sm.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+		us := storageMock{sm, s}
 
-		ls := legacyStoreMock{m, l}
-		us := storageMock{m, s}
+		lm := &mock.Mock{}
+		lm.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+		ls := legacyStoreMock{lm, l}
 
 		dwMode, err := SetDualWritingMode(context.Background(), tt.kvStore, &SyncerConfig{
 			LegacyStorage:     ls,

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -11,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
+
+const failingObject = "object-fail"
 
 type legacyStoreMock struct {
 	*mock.Mock
@@ -30,7 +33,7 @@ func (m legacyStoreMock) Get(ctx context.Context, name string, options *metav1.G
 	}
 
 	args := m.Called(ctx, name, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
@@ -49,7 +52,7 @@ func (m legacyStoreMock) Create(ctx context.Context, obj runtime.Object, createV
 		return nil, args.Error(1)
 	}
 	name := acc.GetName()
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
@@ -80,7 +83,7 @@ func (m legacyStoreMock) Update(ctx context.Context, name string, objInfo rest.U
 	default:
 	}
 	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
@@ -94,7 +97,7 @@ func (m legacyStoreMock) Delete(ctx context.Context, name string, deleteValidati
 	}
 
 	args := m.Called(ctx, name, deleteValidation, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
 	if name == "not-found-legacy" {
@@ -125,7 +128,7 @@ func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOp
 	}
 
 	args := m.Called(ctx, name, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
 	}
 	if name == "not-found" {
@@ -147,7 +150,7 @@ func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValid
 		return nil, args.Error(1)
 	}
 	name := acc.GetName()
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
@@ -179,7 +182,7 @@ func (m storageMock) Update(ctx context.Context, name string, objInfo rest.Updat
 	}
 
 	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
@@ -193,7 +196,7 @@ func (m storageMock) Delete(ctx context.Context, name string, deleteValidation r
 	}
 
 	args := m.Called(ctx, name, deleteValidation, options)
-	if name == "object-fail" {
+	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -3,17 +3,13 @@ package rest
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/stretchr/testify/mock"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
-
-const failingObject = "object-fail"
 
 type legacyStoreMock struct {
 	*mock.Mock
@@ -33,9 +29,6 @@ func (m legacyStoreMock) Get(ctx context.Context, name string, options *metav1.G
 	}
 
 	args := m.Called(ctx, name, options)
-	if strings.Contains(name, failingObject) {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -50,13 +43,8 @@ func (m legacyStoreMock) Create(ctx context.Context, obj runtime.Object, createV
 	}
 
 	args := m.Called(ctx, obj, createValidation, options)
-	acc, err := meta.Accessor(obj)
-	if err != nil {
-		return nil, args.Error(1)
-	}
-	name := acc.GetName()
-	if strings.Contains(name, failingObject) {
-		return nil, args.Error(1)
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
@@ -69,9 +57,6 @@ func (m legacyStoreMock) List(ctx context.Context, options *metainternalversion.
 	}
 
 	args := m.Called(ctx, options)
-	if options.Kind == "fail" {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -89,9 +74,6 @@ func (m legacyStoreMock) Update(ctx context.Context, name string, objInfo rest.U
 	default:
 	}
 	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if strings.Contains(name, failingObject) {
-		return nil, false, args.Error(2)
-	}
 	if err := args.Get(2); err != nil {
 		return nil, false, err.(error)
 	}
@@ -106,12 +88,6 @@ func (m legacyStoreMock) Delete(ctx context.Context, name string, deleteValidati
 	}
 
 	args := m.Called(ctx, name, deleteValidation, options)
-	if strings.Contains(name, failingObject) {
-		return nil, false, args.Error(2)
-	}
-	if name == "not-found-legacy" {
-		return nil, false, args.Error(2)
-	}
 	if err := args.Get(2); err != nil {
 		return nil, false, err.(error)
 	}
@@ -125,9 +101,6 @@ func (m legacyStoreMock) DeleteCollection(ctx context.Context, deleteValidation 
 	default:
 	}
 	args := m.Called(ctx, deleteValidation, options, listOptions)
-	if options.Kind == "fail" {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -143,12 +116,6 @@ func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOp
 	}
 
 	args := m.Called(ctx, name, options)
-	if strings.Contains(name, failingObject) {
-		return nil, args.Error(1)
-	}
-	if name == "not-found" {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -163,14 +130,6 @@ func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValid
 	}
 
 	args := m.Called(ctx, obj, createValidation, options)
-	acc, err := meta.Accessor(obj)
-	if err != nil {
-		return nil, args.Error(1)
-	}
-	name := acc.GetName()
-	if strings.Contains(name, failingObject) {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -185,9 +144,6 @@ func (m storageMock) List(ctx context.Context, options *metainternalversion.List
 	}
 
 	args := m.Called(ctx, options)
-	if options.Kind == "fail" {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}
@@ -206,9 +162,6 @@ func (m storageMock) Update(ctx context.Context, name string, objInfo rest.Updat
 	}
 
 	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if strings.Contains(name, failingObject) {
-		return nil, false, args.Error(2)
-	}
 	if err := args.Get(2); err != nil {
 		return nil, false, err.(error)
 	}
@@ -223,9 +176,6 @@ func (m storageMock) Delete(ctx context.Context, name string, deleteValidation r
 	}
 
 	args := m.Called(ctx, name, deleteValidation, options)
-	if strings.Contains(name, failingObject) {
-		return nil, false, args.Error(2)
-	}
 	if err := args.Get(2); err != nil {
 		return nil, false, err.(error)
 	}
@@ -240,9 +190,6 @@ func (m storageMock) DeleteCollection(ctx context.Context, deleteValidation rest
 	}
 
 	args := m.Called(ctx, deleteValidation, options, listOptions)
-	if options.Kind == "fail" {
-		return nil, args.Error(1)
-	}
 	if err := args.Get(1); err != nil {
 		return nil, err.(error)
 	}

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -69,6 +69,9 @@ func (m legacyStoreMock) List(ctx context.Context, options *metainternalversion.
 	if options.Kind == "fail" {
 		return nil, args.Error(1)
 	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
 
@@ -86,6 +89,9 @@ func (m legacyStoreMock) Update(ctx context.Context, name string, objInfo rest.U
 	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
+	if err := args.Get(2); err != nil {
+		return nil, false, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
 }
 
@@ -102,6 +108,9 @@ func (m legacyStoreMock) Delete(ctx context.Context, name string, deleteValidati
 	}
 	if name == "not-found-legacy" {
 		return nil, false, args.Error(2)
+	}
+	if err := args.Get(2); err != nil {
+		return nil, false, err.(error)
 	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
 }
@@ -133,6 +142,9 @@ func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOp
 	}
 	if name == "not-found" {
 		return nil, args.Error(1)
+	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
@@ -167,6 +179,9 @@ func (m storageMock) List(ctx context.Context, options *metainternalversion.List
 	if options.Kind == "fail" {
 		return nil, args.Error(1)
 	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
 
@@ -185,6 +200,9 @@ func (m storageMock) Update(ctx context.Context, name string, objInfo rest.Updat
 	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
+	if err := args.Get(2); err != nil {
+		return nil, false, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
 }
 
@@ -199,6 +217,9 @@ func (m storageMock) Delete(ctx context.Context, name string, deleteValidation r
 	if strings.Contains(name, failingObject) {
 		return nil, false, args.Error(2)
 	}
+	if err := args.Get(2); err != nil {
+		return nil, false, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
 }
 
@@ -212,6 +233,9 @@ func (m storageMock) DeleteCollection(ctx context.Context, deleteValidation rest
 	args := m.Called(ctx, deleteValidation, options, listOptions)
 	if options.Kind == "fail" {
 		return nil, args.Error(1)
+	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -125,6 +125,9 @@ func (m legacyStoreMock) DeleteCollection(ctx context.Context, deleteValidation 
 	if options.Kind == "fail" {
 		return nil, args.Error(1)
 	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
 
@@ -164,6 +167,9 @@ func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValid
 	name := acc.GetName()
 	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
+	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
 	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -36,6 +36,9 @@ func (m legacyStoreMock) Get(ctx context.Context, name string, options *metav1.G
 	if strings.Contains(name, failingObject) {
 		return nil, args.Error(1)
 	}
+	if err := args.Get(1); err != nil {
+		return nil, err.(error)
+	}
 	return args.Get(0).(runtime.Object), args.Error(1)
 }
 


### PR DESCRIPTION
This PR is fixing all the dualwriter tests. All of the tests where sharing one mock instance for the different storage backend. This caused some tests to not run as we would have expected it. Here a small example (pkg/apiserver/rest/dualwriter_test.go).

Before:
```golang
l := (LegacyStorage)(nil)
s := (Storage)(nil)

m := &mock.Mock{}
// DANGEROUS: We use only one mock instance for two different structs but register two 
//            different calls with different outputs. The mocking library will always return the first
//            call that matches the given arguments. So the second "List" will never be used,
//            as it has the same arguments as the first one (Anything, Anything).
m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)

ls := legacyStoreMock{m, l}
us := storageMock{m, s}
```

After:
```golang
// We use one dedicated mock per backend, now we also need to mock other functions, as the 
// whole test changed behavior, as we don't return the same list twice.
sm := &mock.Mock{}
sm.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
sm.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
sm.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
us := storageMock{sm, s}

lm := &mock.Mock{}
lm.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
ls := legacyStoreMock{lm, l}
```

I fixed this for all out tests, I didn't fix is for the syncer because we will probably drop it. I also reworded nearly every testcase and made the way we mock errors more reliable -- not dependent on input fields.

This only touches test files and no code, so a passing CI is a strong signal.