### PR TITLE
docs: add line about custom recovery thresholds

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -191,7 +191,7 @@ You can toggle between **Default** and **Advanced** options. If the [Default vs.
 
 1. To add a recovery threshold, turn the **Custom recovery threshold** toggle on and fill in a value for when your alert rule should stop firing.
 
-   You can only add one recovery threshold in a query and it must be the alert condition.
+   You can only add one recovery threshold in a query and it must be the alert condition. Custom recovery thresholds apply to alerts which are in pending.
 
 1. Click **Set as alert condition** on the query or expression you want to set as your [alert condition](ref:alert-condition).
    {{< /collapse >}}


### PR DESCRIPTION
add documentation mention that custom recovery thresholds apply to alerts which are in pending.


**What is this feature?**

additional line of documentation [per support escalation ticket](https://github.com/grafana/support-escalations/issues/13494).

**Which issue(s) does this PR fix?**:

https://github.com/grafana/support-escalations/issues/13494

Fixes # (https://github.com/grafana/support-escalations/issues/13494)
