### PR TITLE
Chore: remove NameNamespace throughout codebase

### DIFF
--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -9,7 +9,7 @@ import (
 
 // DecryptStorage is the interface for wiring and dependency injection.
 type DecryptStorage interface {
-	Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error)
+	Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error)
 }
 
 // DecryptClient will have a function-call implementation and a gRPC implementation.

--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -16,10 +16,10 @@ var (
 
 // KeeperStorage is the interface for wiring and dependency injection.
 type KeeperStorage interface {
-	Create(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error)
-	Update(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Delete(ctx context.Context, nn xkube.NameNamespace) error
+	Create(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
+	Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.Keeper, error)
+	Update(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
+	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
 }
 

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -16,8 +16,8 @@ var (
 // SecureValueStorage is the interface for wiring and dependency injection.
 type SecureValueStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.SecureValue, error)
+	Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.SecureValue, error)
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Delete(ctx context.Context, nn xkube.NameNamespace) error
+	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
 }

--- a/pkg/registry/apis/secret/decrypt/client.go
+++ b/pkg/registry/apis/secret/decrypt/client.go
@@ -33,10 +33,7 @@ func (d *DecryptClientFunc) Decrypt(ctx context.Context, namespace string, names
 	decryptedValues := make(map[string]string, len(names))
 
 	for _, name := range names {
-		decryptedValue, err := d.decryptStorage.Decrypt(ctx, xkube.NameNamespace{
-			Name:      name,
-			Namespace: xkube.Namespace(namespace),
-		})
+		decryptedValue, err := d.decryptStorage.Decrypt(ctx, xkube.Namespace(namespace), name)
 		if err != nil {
 			// TODO: Return error depending on the situation...
 			// For now return an empty value and continue.

--- a/pkg/registry/apis/secret/decrypt/client_test.go
+++ b/pkg/registry/apis/secret/decrypt/client_test.go
@@ -21,14 +21,11 @@ func TestDecryptClientFunc(t *testing.T) {
 
 		decryptStorage := &MockDecryptStorage{}
 
-		ns := xkube.Namespace("default")
+		ns := "default"
 		name1, name2 := "first", "second"
 
-		nn1 := xkube.NameNamespace{Namespace: ns, Name: name1}
-		nn2 := xkube.NameNamespace{Namespace: ns, Name: name2}
-
-		decryptStorage.On("Decrypt", mock.Anything, nn1).Return(v0alpha1.ExposedSecureValue("secure-value-1"), nil).Once()
-		decryptStorage.On("Decrypt", mock.Anything, nn2).Return(v0alpha1.ExposedSecureValue(""), errors.New("mock error")).Once()
+		decryptStorage.On("Decrypt", mock.Anything, ns, name1).Return(v0alpha1.ExposedSecureValue("secure-value-1"), nil).Once()
+		decryptStorage.On("Decrypt", mock.Anything, ns, name2).Return(v0alpha1.ExposedSecureValue(""), errors.New("mock error")).Once()
 
 		client := DecryptClientFunc{decryptStorage: decryptStorage}
 
@@ -44,7 +41,7 @@ type MockDecryptStorage struct {
 	mock.Mock
 }
 
-func (m *MockDecryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (v0alpha1.ExposedSecureValue, error) {
-	args := m.Called(ctx, nn)
+func (m *MockDecryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (v0alpha1.ExposedSecureValue, error) {
+	args := m.Called(ctx, namespace, name)
 	return args.Get(0).(v0alpha1.ExposedSecureValue), args.Error(1)
 }

--- a/pkg/registry/apis/secret/reststorage/decrypt_fake.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_fake.go
@@ -18,8 +18,8 @@ type fakeDecryptStorage struct {
 	securevaluestore contracts.SecureValueStorage
 }
 
-func (s *fakeDecryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error) {
-	_, err := s.securevaluestore.Read(ctx, nn)
+func (s *fakeDecryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error) {
+	_, err := s.securevaluestore.Read(ctx, namespace, name)
 	if err != nil {
 		return "", contracts.ErrSecureValueNotFound
 	}

--- a/pkg/registry/apis/secret/reststorage/decrypt_rest.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_rest.go
@@ -67,12 +67,12 @@ func (s *DecryptRest) ProducesObject(verb string) interface{} {
 // Connect returns an http.Handler that will handle the request/response for a given API invocation.
 // See other methods implemented for supporting/optional functionality.
 func (s *DecryptRest) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing namespace")
 	}
 
-	exposedValue, err := s.storage.Decrypt(ctx, nn)
+	exposedValue, err := s.storage.Decrypt(ctx, xkube.Namespace(namespace), name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt secure value: %w", err)
 	}

--- a/pkg/registry/apis/secret/reststorage/keeper_fake.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_fake.go
@@ -42,12 +42,12 @@ func (s *fakeKeeperStorage) Create(ctx context.Context, k *secretv0alpha1.Keeper
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error) {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeKeeperStorage) Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.Keeper, error) {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
-	v, ok := ns[nn.Name]
+	v, ok := ns[name]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -73,17 +73,17 @@ func (s *fakeKeeperStorage) Update(ctx context.Context, nk *secretv0alpha1.Keepe
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeKeeperStorage) Delete(ctx context.Context, namespace xkube.Namespace, name string) error {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
-	_, ok = ns[nn.Name]
+	_, ok = ns[name]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
 	time.AfterFunc(s.latency, func() {
-		delete(ns, nn.Name)
+		delete(ns, name)
 	})
 
 	return nil

--- a/pkg/registry/apis/secret/reststorage/secure_value_fake.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_fake.go
@@ -43,12 +43,12 @@ func (s *fakeSecureValueStorage) Create(ctx context.Context, sv *secretv0alpha1.
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.SecureValue, error) {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeSecureValueStorage) Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.SecureValue, error) {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
-	v, ok := ns[nn.Name]
+	v, ok := ns[name]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -75,17 +75,17 @@ func (s *fakeSecureValueStorage) Update(ctx context.Context, nsv *secretv0alpha1
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeSecureValueStorage) Delete(ctx context.Context, namespace xkube.Namespace, name string) error {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
-	_, ok = ns[nn.Name]
+	_, ok = ns[name]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
 	time.AfterFunc(s.latency, func() {
-		delete(ns, nn.Name)
+		delete(ns, name)
 	})
 
 	return nil

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -74,9 +74,12 @@ func (s *SecureValueRest) ConvertToTable(ctx context.Context, object runtime.Obj
 
 // List calls the inner `store` (persistence) and returns a list of `securevalues` within a `namespace` filtered by the `options`.
 func (s *SecureValueRest) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	namespace := xkube.Namespace(request.NamespaceValue(ctx))
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing namespace")
+	}
 
-	secureValueList, err := s.storage.List(ctx, namespace, options)
+	secureValueList, err := s.storage.List(ctx, xkube.Namespace(namespace), options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list secure values: %w", err)
 	}
@@ -86,12 +89,12 @@ func (s *SecureValueRest) List(ctx context.Context, options *internalversion.Lis
 
 // Get calls the inner `store` (persistence) and returns a `securevalue` by `name`. It will NOT return the decrypted `value`.
 func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing namespace")
 	}
 
-	sv, err := s.storage.Read(ctx, nn)
+	sv, err := s.storage.Read(ctx, xkube.Namespace(namespace), name)
 	if err != nil {
 		if errors.Is(err, contracts.ErrSecureValueNotFound) {
 			return nil, s.resource.NewNotFound(name)
@@ -174,12 +177,12 @@ func (s *SecureValueRest) Update(
 // Delete calls the inner `store` (persistence) in order to delete the `securevalue`.
 // The second return parameter `bool` indicates whether the delete was instant or not. It always is for `securevalues`.
 func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, fmt.Errorf("missing namespace")
 	}
 
-	if err := s.storage.Delete(ctx, nn); err != nil {
+	if err := s.storage.Delete(ctx, xkube.Namespace(namespace), name); err != nil {
 		return nil, false, fmt.Errorf("delete secure value: %w", err)
 	}
 

--- a/pkg/registry/apis/secret/xkube/namespace.go
+++ b/pkg/registry/apis/secret/xkube/namespace.go
@@ -6,9 +6,3 @@ type Namespace string
 func (n Namespace) String() string {
 	return string(n)
 }
-
-// NameNamespace is a tuple of name and namespace, often used by K8s resources for uniqueness.
-type NameNamespace struct {
-	Name      string
-	Namespace Namespace
-}

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -28,14 +28,14 @@ type decryptStorage struct {
 	db db.DB
 }
 
-func (s *decryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error) {
 	// TODO: do proper checks here.
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return "", fmt.Errorf("missing auth info in context")
 	}
 
-	_, err := s.readSecureValue(ctx, nn)
+	_, err := s.readSecureValue(ctx, namespace, name)
 	if err != nil {
 		return "", fmt.Errorf("read secure value: %w", err)
 	}
@@ -45,8 +45,8 @@ func (s *decryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (s
 	return secretv0alpha1.ExposedSecureValue("super duper secure"), nil
 }
 
-func (s *decryptStorage) readSecureValue(ctx context.Context, nn xkube.NameNamespace) (*secureValueDB, error) {
-	row := &secureValueDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+func (s *decryptStorage) readSecureValue(ctx context.Context, namespace xkube.Namespace, name string) (*secureValueDB, error) {
+	row := &secureValueDB{Name: name, Namespace: namespace.String()}
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -64,13 +64,13 @@ func (s *keeperStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keepe
 	return createdKeeper, nil
 }
 
-func (s *keeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error) {
+func (s *keeperStorage) Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.Keeper, error) {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)
 		if err != nil {
@@ -146,13 +146,13 @@ func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Ke
 	return keeper, nil
 }
 
-func (s *keeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
+func (s *keeperStorage) Delete(ctx context.Context, namespace xkube.Namespace, name string) error {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Delete(row); err != nil {
 			return fmt.Errorf("failed to delete row: %w", err)

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -81,10 +81,28 @@ func (s *secureValueStorage) Create(ctx context.Context, sv *secretv0alpha1.Secu
 	return createdSecureValue, nil
 }
 
-func (s *secureValueStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.SecureValue, error) {
-	row, err := s.readInternal(ctx, nn)
+func (s *secureValueStorage) Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.SecureValue, error) {
+	_, ok := claims.AuthInfoFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing auth info in context")
+	}
+
+	row := &secureValueDB{Name: name, Namespace: namespace.String()}
+
+	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		found, err := sess.Get(row)
+		if err != nil {
+			return fmt.Errorf("could not get row: %w", err)
+		}
+
+		if !found {
+			return contracts.ErrSecureValueNotFound
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("read internal: %w", err)
+		return nil, fmt.Errorf("db failure: %w", err)
 	}
 
 	secureValue, err := row.toKubernetes()
@@ -101,14 +119,22 @@ func (s *secureValueStorage) Update(ctx context.Context, newSecureValue *secretv
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	nn := xkube.NameNamespace{
-		Name:      newSecureValue.Name,
-		Namespace: xkube.Namespace(newSecureValue.Namespace),
-	}
+	currentRow := &secureValueDB{Name: newSecureValue.Name, Namespace: newSecureValue.Namespace}
 
-	currentRow, err := s.readInternal(ctx, nn)
+	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		found, err := sess.Get(currentRow)
+		if err != nil {
+			return fmt.Errorf("could not get row: %w", err)
+		}
+
+		if !found {
+			return contracts.ErrSecureValueNotFound
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("read securevalue: %w", err)
+		return nil, fmt.Errorf("db failure: %w", err)
 	}
 
 	// This should come from the keeper.
@@ -133,7 +159,7 @@ func (s *secureValueStorage) Update(ctx context.Context, newSecureValue *secretv
 			return contracts.ErrKeeperNotFound
 		}
 
-		cond := &secureValueDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+		cond := &secureValueDB{Name: newSecureValue.Name, Namespace: newSecureValue.Namespace}
 
 		if _, err := sess.Update(newRow, cond); err != nil {
 			return fmt.Errorf("update row: %w", err)
@@ -153,7 +179,7 @@ func (s *secureValueStorage) Update(ctx context.Context, newSecureValue *secretv
 	return secureValue, nil
 }
 
-func (s *secureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
+func (s *secureValueStorage) Delete(ctx context.Context, namespace xkube.Namespace, name string) error {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
@@ -162,7 +188,7 @@ func (s *secureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace)
 	// TODO: delete from the keeper!
 
 	// TODO: do we need to delete by GUID? name+namespace is a unique index. It would avoid doing a fetch.
-	row := &secureValueDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &secureValueDB{Name: name, Namespace: namespace.String()}
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		// TODO: because this is a securevalue, do we care to inform the caller if a row was delete (existed) or not?
@@ -221,31 +247,4 @@ func (s *secureValueStorage) List(ctx context.Context, namespace xkube.Namespace
 	return &secretv0alpha1.SecureValueList{
 		Items: secureValues,
 	}, nil
-}
-
-func (s *secureValueStorage) readInternal(ctx context.Context, nn xkube.NameNamespace) (*secureValueDB, error) {
-	_, ok := claims.AuthInfoFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("missing auth info in context")
-	}
-
-	row := &secureValueDB{Name: nn.Name, Namespace: nn.Namespace.String()}
-
-	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		found, err := sess.Get(row)
-		if err != nil {
-			return fmt.Errorf("could not get row: %w", err)
-		}
-
-		if !found {
-			return contracts.ErrSecureValueNotFound
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("db failure: %w", err)
-	}
-
-	return row, nil
 }


### PR DESCRIPTION
Gets rid of `xkube.NameNamespace` which is not obvious at glance, and adds explicit parameters to the contracts for `name` and the `namespace`, while keeping the `xkube.Namespace` newtype.

It is also error-prone because the struct can be created without any of the fields required.