### PR TITLE
Chore: remove xkube throughout codebase

### DIFF
--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
 // DecryptStorage is the interface for wiring and dependency injection.
 type DecryptStorage interface {
-	Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error)
+	Decrypt(ctx context.Context, name string, namespace string) (secretv0alpha1.ExposedSecureValue, error)
 }

--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -9,5 +9,5 @@ import (
 
 // DecryptStorage is the interface for wiring and dependency injection.
 type DecryptStorage interface {
-	Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error)
+	Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error)
 }

--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -17,9 +17,9 @@ var (
 // KeeperStorage is the interface for wiring and dependency injection.
 type KeeperStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error)
+	Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error)
 	Update(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Delete(ctx context.Context, nn xkube.NameNamespace) error
+	Delete(ctx context.Context, name string, namespace xkube.Namespace) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
 }
 

--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -17,10 +17,10 @@ var (
 // KeeperStorage is the interface for wiring and dependency injection.
 type KeeperStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error)
+	Read(ctx context.Context, name string, namespace string) (*secretv0alpha1.Keeper, error)
 	Update(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
-	Delete(ctx context.Context, name string, namespace xkube.Namespace) error
-	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
+	Delete(ctx context.Context, name string, namespace string) error
+	List(ctx context.Context, namespace string, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
 }
 
 // ErrKeeperInvalidSecureValues is returned when a Keeper references SecureValues that do not exist.

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 )
 
@@ -16,8 +15,8 @@ var (
 // SecureValueStorage is the interface for wiring and dependency injection.
 type SecureValueStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.SecureValue, error)
+	Read(ctx context.Context, name string, namespace string) (*secretv0alpha1.SecureValue, error)
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Delete(ctx context.Context, name string, namespace xkube.Namespace) error
-	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
+	Delete(ctx context.Context, name string, namespace string) error
+	List(ctx context.Context, namespace string, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
 }

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -16,8 +16,8 @@ var (
 // SecureValueStorage is the interface for wiring and dependency injection.
 type SecureValueStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.SecureValue, error)
+	Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.SecureValue, error)
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Delete(ctx context.Context, nn xkube.NameNamespace) error
+	Delete(ctx context.Context, name string, namespace xkube.Namespace) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
 }

--- a/pkg/registry/apis/secret/reststorage/decrypt_fake.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_fake.go
@@ -5,7 +5,6 @@ import (
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
 func NewFakeDecryptStore(securevaluestore contracts.SecureValueStorage) contracts.DecryptStorage {
@@ -18,7 +17,7 @@ type fakeDecryptStorage struct {
 	securevaluestore contracts.SecureValueStorage
 }
 
-func (s *fakeDecryptStorage) Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *fakeDecryptStorage) Decrypt(ctx context.Context, name string, namespace string) (secretv0alpha1.ExposedSecureValue, error) {
 	_, err := s.securevaluestore.Read(ctx, name, namespace)
 	if err != nil {
 		return "", contracts.ErrSecureValueNotFound

--- a/pkg/registry/apis/secret/reststorage/decrypt_fake.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_fake.go
@@ -18,8 +18,8 @@ type fakeDecryptStorage struct {
 	securevaluestore contracts.SecureValueStorage
 }
 
-func (s *fakeDecryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error) {
-	_, err := s.securevaluestore.Read(ctx, nn)
+func (s *fakeDecryptStorage) Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error) {
+	_, err := s.securevaluestore.Read(ctx, name, namespace)
 	if err != nil {
 		return "", contracts.ErrSecureValueNotFound
 	}

--- a/pkg/registry/apis/secret/reststorage/decrypt_rest.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_rest.go
@@ -67,12 +67,12 @@ func (s *DecryptRest) ProducesObject(verb string) interface{} {
 // Connect returns an http.Handler that will handle the request/response for a given API invocation.
 // See other methods implemented for supporting/optional functionality.
 func (s *DecryptRest) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing namespace")
 	}
 
-	exposedValue, err := s.storage.Decrypt(ctx, nn)
+	exposedValue, err := s.storage.Decrypt(ctx, name, xkube.Namespace(namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt secure value: %w", err)
 	}

--- a/pkg/registry/apis/secret/reststorage/decrypt_rest.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_rest.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
 var (
@@ -72,7 +71,7 @@ func (s *DecryptRest) Connect(ctx context.Context, name string, opts runtime.Obj
 		return nil, fmt.Errorf("missing namespace")
 	}
 
-	exposedValue, err := s.storage.Decrypt(ctx, name, xkube.Namespace(namespace))
+	exposedValue, err := s.storage.Decrypt(ctx, name, string(namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt secure value: %w", err)
 	}

--- a/pkg/registry/apis/secret/reststorage/keeper_fake.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_fake.go
@@ -42,12 +42,12 @@ func (s *fakeKeeperStorage) Create(ctx context.Context, k *secretv0alpha1.Keeper
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error) {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeKeeperStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error) {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
-	v, ok := ns[nn.Name]
+	v, ok := ns[name]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -73,17 +73,17 @@ func (s *fakeKeeperStorage) Update(ctx context.Context, nk *secretv0alpha1.Keepe
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeKeeperStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
-	_, ok = ns[nn.Name]
+	_, ok = ns[name]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
 	time.AfterFunc(s.latency, func() {
-		delete(ns, nn.Name)
+		delete(ns, name)
 	})
 
 	return nil

--- a/pkg/registry/apis/secret/reststorage/keeper_fake.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_fake.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,8 +41,8 @@ func (s *fakeKeeperStorage) Create(ctx context.Context, k *secretv0alpha1.Keeper
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error) {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeKeeperStorage) Read(ctx context.Context, name string, namespace string) (*secretv0alpha1.Keeper, error) {
+	ns, ok := s.values[namespace]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -73,8 +72,8 @@ func (s *fakeKeeperStorage) Update(ctx context.Context, nk *secretv0alpha1.Keepe
 	return &v, nil
 }
 
-func (s *fakeKeeperStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeKeeperStorage) Delete(ctx context.Context, name string, namespace string) error {
+	ns, ok := s.values[namespace]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
@@ -89,10 +88,10 @@ func (s *fakeKeeperStorage) Delete(ctx context.Context, name string, namespace x
 	return nil
 }
 
-func (s *fakeKeeperStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeKeeperStorage) List(ctx context.Context, namespace string, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
+	ns, ok := s.values[namespace]
 	if !ok {
-		s.values[namespace.String()] = ns
+		s.values[namespace] = ns
 	}
 	l := make([]secretv0alpha1.Keeper, len(ns))
 	for _, v := range ns {

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -74,7 +74,7 @@ func (s *KeeperRest) ConvertToTable(ctx context.Context, object runtime.Object, 
 
 // List calls the inner `store` (persistence) and returns a list of `Keepers` within a `namespace` filtered by the `options`.
 func (s *KeeperRest) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	namespace := xkube.Namespace(request.NamespaceValue(ctx))
+	namespace := string(request.NamespaceValue(ctx))
 
 	keepersList, err := s.storage.List(ctx, namespace, options)
 	if err != nil {
@@ -91,7 +91,7 @@ func (s *KeeperRest) Get(ctx context.Context, name string, options *metav1.GetOp
 		return nil, fmt.Errorf("missing namespace")
 	}
 
-	kp, err := s.storage.Read(ctx, name, xkube.Namespace(namespace))
+	kp, err := s.storage.Read(ctx, name, string(namespace))
 	if err != nil {
 		if errors.Is(err, contracts.ErrKeeperNotFound) {
 			return nil, s.resource.NewNotFound(name)
@@ -190,7 +190,7 @@ func (s *KeeperRest) Delete(ctx context.Context, name string, deleteValidation r
 		return nil, false, fmt.Errorf("missing namespace")
 	}
 
-	if err := s.storage.Delete(ctx, name, xkube.Namespace(namespace)); err != nil {
+	if err := s.storage.Delete(ctx, name, string(namespace)); err != nil {
 		return nil, false, fmt.Errorf("failed to delete keeper: %w", err)
 	}
 

--- a/pkg/registry/apis/secret/reststorage/secure_value_fake.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_fake.go
@@ -43,12 +43,12 @@ func (s *fakeSecureValueStorage) Create(ctx context.Context, sv *secretv0alpha1.
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.SecureValue, error) {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeSecureValueStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.SecureValue, error) {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
-	v, ok := ns[nn.Name]
+	v, ok := ns[name]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -75,17 +75,17 @@ func (s *fakeSecureValueStorage) Update(ctx context.Context, nsv *secretv0alpha1
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
-	ns, ok := s.values[nn.Namespace.String()]
+func (s *fakeSecureValueStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
+	ns, ok := s.values[namespace.String()]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
-	_, ok = ns[nn.Name]
+	_, ok = ns[name]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
 	time.AfterFunc(s.latency, func() {
-		delete(ns, nn.Name)
+		delete(ns, name)
 	})
 
 	return nil

--- a/pkg/registry/apis/secret/reststorage/secure_value_fake.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_fake.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,8 +42,8 @@ func (s *fakeSecureValueStorage) Create(ctx context.Context, sv *secretv0alpha1.
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.SecureValue, error) {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeSecureValueStorage) Read(ctx context.Context, name string, namespace string) (*secretv0alpha1.SecureValue, error) {
+	ns, ok := s.values[namespace]
 	if !ok {
 		return nil, contracts.ErrSecureValueNotFound
 	}
@@ -75,8 +74,8 @@ func (s *fakeSecureValueStorage) Update(ctx context.Context, nsv *secretv0alpha1
 	return &v, nil
 }
 
-func (s *fakeSecureValueStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeSecureValueStorage) Delete(ctx context.Context, name string, namespace string) error {
+	ns, ok := s.values[namespace]
 	if !ok {
 		return contracts.ErrSecureValueNotFound
 	}
@@ -91,11 +90,11 @@ func (s *fakeSecureValueStorage) Delete(ctx context.Context, name string, namesp
 	return nil
 }
 
-func (s *fakeSecureValueStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error) {
-	ns, ok := s.values[namespace.String()]
+func (s *fakeSecureValueStorage) List(ctx context.Context, namespace string, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error) {
+	ns, ok := s.values[namespace]
 	if !ok {
 		ns = make(map[string]secretv0alpha1.SecureValue)
-		s.values[namespace.String()] = ns
+		s.values[namespace] = ns
 	}
 	l := make([]secretv0alpha1.SecureValue, len(ns))
 	for _, v := range ns {

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -74,7 +74,7 @@ func (s *SecureValueRest) ConvertToTable(ctx context.Context, object runtime.Obj
 
 // List calls the inner `store` (persistence) and returns a list of `securevalues` within a `namespace` filtered by the `options`.
 func (s *SecureValueRest) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	namespace := xkube.Namespace(request.NamespaceValue(ctx))
+	namespace := request.NamespaceValue(ctx)
 
 	secureValueList, err := s.storage.List(ctx, namespace, options)
 	if err != nil {
@@ -91,7 +91,7 @@ func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.
 		return nil, fmt.Errorf("missing namespace")
 	}
 
-	sv, err := s.storage.Read(ctx, name, xkube.Namespace(namespace))
+	sv, err := s.storage.Read(ctx, name, namespace)
 	if err != nil {
 		if errors.Is(err, contracts.ErrSecureValueNotFound) {
 			return nil, s.resource.NewNotFound(name)
@@ -179,7 +179,7 @@ func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidat
 		return nil, false, fmt.Errorf("missing namespace")
 	}
 
-	if err := s.storage.Delete(ctx, name, xkube.Namespace(namespace)); err != nil {
+	if err := s.storage.Delete(ctx, name, string(namespace)); err != nil {
 		return nil, false, fmt.Errorf("delete secure value: %w", err)
 	}
 

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -86,12 +86,12 @@ func (s *SecureValueRest) List(ctx context.Context, options *internalversion.Lis
 
 // Get calls the inner `store` (persistence) and returns a `securevalue` by `name`. It will NOT return the decrypted `value`.
 func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing namespace")
 	}
 
-	sv, err := s.storage.Read(ctx, nn)
+	sv, err := s.storage.Read(ctx, name, xkube.Namespace(namespace))
 	if err != nil {
 		if errors.Is(err, contracts.ErrSecureValueNotFound) {
 			return nil, s.resource.NewNotFound(name)
@@ -174,12 +174,12 @@ func (s *SecureValueRest) Update(
 // Delete calls the inner `store` (persistence) in order to delete the `securevalue`.
 // The second return parameter `bool` indicates whether the delete was instant or not. It always is for `securevalues`.
 func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	nn := xkube.NameNamespace{
-		Name:      name,
-		Namespace: xkube.Namespace(request.NamespaceValue(ctx)),
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, fmt.Errorf("missing namespace")
 	}
 
-	if err := s.storage.Delete(ctx, nn); err != nil {
+	if err := s.storage.Delete(ctx, name, xkube.Namespace(namespace)); err != nil {
 		return nil, false, fmt.Errorf("delete secure value: %w", err)
 	}
 

--- a/pkg/registry/apis/secret/xkube/namespace.go
+++ b/pkg/registry/apis/secret/xkube/namespace.go
@@ -1,8 +1,0 @@
-package xkube
-
-// Namespace is a newtype of string that improves type safety.
-type Namespace string
-
-func (n Namespace) String() string {
-	return string(n)
-}

--- a/pkg/registry/apis/secret/xkube/namespace.go
+++ b/pkg/registry/apis/secret/xkube/namespace.go
@@ -6,9 +6,3 @@ type Namespace string
 func (n Namespace) String() string {
 	return string(n)
 }
-
-// NameNamespace is a tuple of name and namespace, often used by K8s resources for uniqueness.
-type NameNamespace struct {
-	Name      string
-	Namespace Namespace
-}

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -8,7 +8,6 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -28,7 +27,7 @@ type decryptStorage struct {
 	db db.DB
 }
 
-func (s *decryptStorage) Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *decryptStorage) Decrypt(ctx context.Context, name string, namespace string) (secretv0alpha1.ExposedSecureValue, error) {
 	// TODO: do proper checks here.
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
@@ -45,8 +44,8 @@ func (s *decryptStorage) Decrypt(ctx context.Context, name string, namespace xku
 	return secretv0alpha1.ExposedSecureValue("super duper secure"), nil
 }
 
-func (s *decryptStorage) readSecureValue(ctx context.Context, name string, namespace xkube.Namespace) (*secureValueDB, error) {
-	row := &secureValueDB{Name: name, Namespace: namespace.String()}
+func (s *decryptStorage) readSecureValue(ctx context.Context, name string, namespace string) (*secureValueDB, error) {
+	row := &secureValueDB{Name: name, Namespace: namespace}
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -28,14 +28,14 @@ type decryptStorage struct {
 	db db.DB
 }
 
-func (s *decryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *decryptStorage) Decrypt(ctx context.Context, name string, namespace xkube.Namespace) (secretv0alpha1.ExposedSecureValue, error) {
 	// TODO: do proper checks here.
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return "", fmt.Errorf("missing auth info in context")
 	}
 
-	_, err := s.readSecureValue(ctx, nn)
+	_, err := s.readSecureValue(ctx, name, namespace)
 	if err != nil {
 		return "", fmt.Errorf("read secure value: %w", err)
 	}
@@ -45,8 +45,8 @@ func (s *decryptStorage) Decrypt(ctx context.Context, nn xkube.NameNamespace) (s
 	return secretv0alpha1.ExposedSecureValue("super duper secure"), nil
 }
 
-func (s *decryptStorage) readSecureValue(ctx context.Context, nn xkube.NameNamespace) (*secureValueDB, error) {
-	row := &secureValueDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+func (s *decryptStorage) readSecureValue(ctx context.Context, name string, namespace xkube.Namespace) (*secureValueDB, error) {
+	row := &secureValueDB{Name: name, Namespace: namespace.String()}
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -64,13 +64,13 @@ func (s *keeperStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keepe
 	return createdKeeper, nil
 }
 
-func (s *keeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secretv0alpha1.Keeper, error) {
+func (s *keeperStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error) {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)
 		if err != nil {
@@ -146,13 +146,13 @@ func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Ke
 	return keeper, nil
 }
 
-func (s *keeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) error {
+func (s *keeperStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Delete(row); err != nil {
 			return fmt.Errorf("failed to delete row: %w", err)

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -8,7 +8,6 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -64,13 +63,13 @@ func (s *keeperStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keepe
 	return createdKeeper, nil
 }
 
-func (s *keeperStorage) Read(ctx context.Context, name string, namespace xkube.Namespace) (*secretv0alpha1.Keeper, error) {
+func (s *keeperStorage) Read(ctx context.Context, name string, namespace string) (*secretv0alpha1.Keeper, error) {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: name, Namespace: namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)
 		if err != nil {
@@ -146,13 +145,13 @@ func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Ke
 	return keeper, nil
 }
 
-func (s *keeperStorage) Delete(ctx context.Context, name string, namespace xkube.Namespace) error {
+func (s *keeperStorage) Delete(ctx context.Context, name string, namespace string) error {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
 	}
 
-	row := &keeperDB{Name: name, Namespace: namespace.String()}
+	row := &keeperDB{Name: name, Namespace: namespace}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Delete(row); err != nil {
 			return fmt.Errorf("failed to delete row: %w", err)
@@ -167,7 +166,7 @@ func (s *keeperStorage) Delete(ctx context.Context, name string, namespace xkube
 	return nil
 }
 
-func (s *keeperStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
+func (s *keeperStorage) List(ctx context.Context, namespace string, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
 	_, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")
@@ -181,7 +180,7 @@ func (s *keeperStorage) List(ctx context.Context, namespace xkube.Namespace, opt
 	keeperRows := make([]*keeperDB, 0)
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		cond := &keeperDB{Namespace: namespace.String()}
+		cond := &keeperDB{Namespace: namespace}
 
 		if err := sess.Find(&keeperRows, cond); err != nil {
 			return fmt.Errorf("failed to find rows: %w", err)


### PR DESCRIPTION
Same as https://github.com/grafana/grafana/pull/100400 but also removes the `xkube.Namespace` type and just uses plain `string`.