### PR TITLE
Alerting notification preview: Remove private annotations and labels from alert instance payload

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/AlertInstanceModalSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/AlertInstanceModalSelector.tsx
@@ -60,6 +60,13 @@ export function AlertInstanceModalSelector({
         if (!rules[instance.labels.alertname]) {
           rules[instance.labels.alertname] = [];
         }
+        const filteredAnnotations = Object.fromEntries(
+          Object.entries(instance.annotations).filter(([key]) => !key.startsWith('__'))
+        );
+        const filteredLabels = Object.fromEntries(
+          Object.entries(instance.labels).filter(([key]) => !key.startsWith('__'))
+        );
+        instance = { ...instance, annotations: filteredAnnotations, labels: filteredLabels };
         rules[instance.labels.alertname].push(instance);
       });
     }


### PR DESCRIPTION
Private annotations and private labels are not available in notification templates. Displaying internal properties could be misleading, as users might expect them to be accessible in notification template variables.


Closes https://github.com/grafana/alerting-squad/issues/1000.
> Front-end should strip private annotations from the payload when selecting an existing alert instance – we don't inject those private annotations in the templating pipeline.

This PR ensures private annotations and private labels are removed from the alert instance payload.

**Before**


![Screenshot 2025-02-11 at 11 43 35](https://github.com/user-attachments/assets/fc2d0f80-75d3-42d2-aa5f-919fa0a0c432)

**After**



![Screenshot 2025-02-11 at 11 44 48](https://github.com/user-attachments/assets/8c68294f-24d9-4a75-bb84-4a45f4e736a2)



