### PR TITLE
Alerting docs: clarify that `silences` and `mute timings` do not interrupt alert evaluation

### DIFF
--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -61,7 +61,7 @@ refs:
 
 # Configure silences
 
-Silences stop notifications from getting created and last for only a specified window of time. Use them to temporarily prevent alert notifications, such as during incident response or a maintenance window.
+Silences stop notifications from being created for a specified time window but do not interrupt alert evaluation. Use them to temporarily prevent alert notifications, such as during incident response or a maintenance window.
 
 {{< admonition type="note" >}}
 Silences are assigned to a [specific Alertmanager](ref:alertmanager-architecture) and only suppress notifications for alerts managed by that Alertmanager.

--- a/docs/sources/alerting/configure-notifications/mute-timings.md
+++ b/docs/sources/alerting/configure-notifications/mute-timings.md
@@ -39,7 +39,9 @@ refs:
 
 # Configure mute timings
 
-A mute timing is a recurring interval of time when no new notifications for a policy are generated or sent. Use them to prevent alerts from firing a specific and reoccurring period, for example, a regular maintenance period or weekends.
+A mute timing is a recurring interval that stops notifications for one or multiple notification policies during a specified period. It suppresses notifications but does not interrupt alert evaluation.
+
+Use mute timings to temporarily pause notifications for a specific recurring period, such as a regular maintenance window or weekends.
 
 {{< admonition type="note" >}}
 Mute timings are assigned to a [specific Alertmanager](ref:alertmanager-architecture) and only suppress notifications for alerts managed by that Alertmanager.

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -132,7 +132,7 @@ Each notification policy decides where to send the alert (contact point) and whe
 
 ### Silences and mute timings
 
-[Silences](ref:silences) and [mute timings](ref:mute-timings) allow you to pause notifications without interrupting alert rule evaluation. Use a silence to pause notifications on an ad-hoc basis, such as during a maintenance window; and use mute timings to pause notifications at regular intervals, such as evenings and weekends.
+[Silences](ref:silences) and [mute timings](ref:mute-timings) allow you to pause notifications without interrupting alert rule evaluation. Use a silence to pause notifications on a one-time basis, such as during a maintenance window; and use mute timings to pause notifications at regular intervals, such as evenings and weekends.
 
 ### Architecture
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -132,7 +132,7 @@ Each notification policy decides where to send the alert (contact point) and whe
 
 ### Silences and mute timings
 
-[Silences](ref:silences) and [mute timings](ref:mute-timings) allow you to pause notifications for specific alerts or even entire notification policies. Use a silence to pause notifications on an ad-hoc basis, such as during a maintenance window; and use mute timings to pause notifications at regular intervals, such as evenings and weekends.
+[Silences](ref:silences) and [mute timings](ref:mute-timings) allow you to pause notifications without interrupting alert rule evaluation. Use a silence to pause notifications on an ad-hoc basis, such as during a maintenance window; and use mute timings to pause notifications at regular intervals, such as evenings and weekends.
 
 ### Architecture
 

--- a/docs/sources/alerting/fundamentals/notifications/_index.md
+++ b/docs/sources/alerting/fundamentals/notifications/_index.md
@@ -126,7 +126,7 @@ Grafana Alerting provides advanced notification capabilities that you’ll find 
 
 For instance, you can customize notifications with shared [templates](ref:templates) that provide actionable alert information and can be reused for multiple notifications.
 
-Additionally, you can use [silences](ref:silences) and [mute timings](ref:mute-timings) to pause notifications for a given time window or at regular intervals, respectively.
+Additionally, you can use [silences](ref:silences) and [mute timings](ref:mute-timings) to pause or suppress notifications without interrupting alert evaluation.
 
 ## Architecture
 


### PR DESCRIPTION
Clarify that `silences` and `mute timings` do not interrupt alert evaluation, which is a common question.


