### PR TITLE
fix(unified-storage): error on failed primary deletes in mode2

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -213,7 +213,7 @@ func (d *DualWriterMode2) Delete(ctx context.Context, name string, deleteValidat
 	d.recordStorageDuration(err != nil, mode2Str, d.resource, method, startStorage)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.WithValues("objectList", deletedS).Error(err, "could not delete from duplicate storage")
+			log.WithValues("objectList", deletedS).Error(err, "could not delete from unified storage")
 			return nil, false, err
 		}
 	}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -207,28 +207,25 @@ func (d *DualWriterMode2) Delete(ctx context.Context, name string, deleteValidat
 	log := d.Log.WithValues("name", name, "method", method)
 	ctx = klog.NewContext(ctx, log)
 
-	startLegacy := time.Now()
-	deletedLS, async, err := d.Legacy.Delete(ctx, name, deleteValidation, options)
-
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.WithValues("objectList", deletedLS).Error(err, "could not delete from legacy store")
-			d.recordLegacyDuration(true, mode2Str, d.resource, method, startLegacy)
-			return deletedLS, async, err
-		}
-	}
-	d.recordLegacyDuration(false, mode2Str, d.resource, method, startLegacy)
-
+	// We should delete from Unified storage first so we can retry if legacy fails.
 	startStorage := time.Now()
 	deletedS, async, err := d.Storage.Delete(ctx, name, deleteValidation, options)
+	d.recordStorageDuration(err != nil, mode2Str, d.resource, method, startStorage)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.WithValues("objectList", deletedS).Error(err, "could not delete from duplicate storage")
-			d.recordStorageDuration(true, mode2Str, d.resource, method, startStorage)
+			return nil, false, err
 		}
-		return deletedS, async, err
 	}
-	d.recordStorageDuration(false, mode2Str, d.resource, method, startStorage)
+
+	startLegacy := time.Now()
+	deletedLS, async, err := d.Legacy.Delete(ctx, name, deleteValidation, options)
+	d.recordLegacyDuration(err != nil, mode2Str, d.resource, method, startLegacy)
+	// Deleting from legacy should always work in mode two, as legacy is still the primary database and
+	// needs to have all the data.
+	if err != nil {
+		return nil, false, err
+	}
 
 	go func() {
 		areEqual := Compare(deletedS, deletedLS)

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -209,7 +209,7 @@ func (d *DualWriterMode2) Delete(ctx context.Context, name string, deleteValidat
 
 	// We should delete from Unified storage first so we can retry if legacy fails.
 	startStorage := time.Now()
-	deletedS, async, err := d.Storage.Delete(ctx, name, deleteValidation, options)
+	deletedS, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
 	d.recordStorageDuration(err != nil, mode2Str, d.resource, method, startStorage)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
In mode2 the legacy database is still our primary database. Deletes that fail to this database should always return an error to the caller, checking for existence doesn't make sense here. I also reversed the call chain, so one can retry.