### PR TITLE
unistore: add small buffer of watched events

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -218,7 +218,7 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 			if err != nil {
 				b.log.Error("Unable to remove old index folder", "directory", fpath, "error", err)
 			} else {
-				b.log.Error("Removed old index folder", "directory", fpath)
+				b.log.Info("Removed old index folder", "directory", fpath)
 			}
 		}
 	}


### PR DESCRIPTION
Add a small buffer to the stream channel.

Currently, the channel has no buffer meaning writing into the stream will block until the previous event is pulled.
Under contention in search, the events might take time being indexed and events might accumulate in the background.

Currently, the poller will artificially sleep 100ms ([here](https://github.com/grafana/grafana/blob/880abe135629cd0cd29cd77f11bfad511711c53f/pkg/storage/unified/sql/backend.go#L760-L761)) between to batch, contributing (a little) to increasing the processing lag. By adding a small buffer, we allow faster recovery.