### PR TITLE
NodeGraphPanel: add options to select field in data frames

### DIFF
--- a/packages/grafana-schema/src/raw/composable/nodegraph/panelcfg/x/NodeGraphPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/nodegraph/panelcfg/x/NodeGraphPanelCfg_types.gen.ts
@@ -36,6 +36,42 @@ export interface Options {
      * Unit for the secondary stat to override what ever is set in the data frame.
      */
     secondaryStatUnit?: string;
+    /**
+     * Field containing the id attribute for edges
+     */
+    idField?: string;
+    /**
+     * Field containing the source attribute for edges
+     */
+    sourceField?: string;
+    /**
+     * Field containing the target attribute for edges
+     */
+    targetField?: string;
+    /**
+     * Field containing the mainstat attribute for edges
+     */
+    mainStatField?: string;
+    /**
+     * Field containing the secondarystat attribute for edges
+     */
+    secondaryStatField?: string;
+    /**
+     * Field containing the thickness attribute for edges
+     */
+    thicknessField?: string;
+    /**
+     * Field containing the color attribute for edges
+     */
+    colorField?: string;
+    /**
+     * Field containing the strokeDasharray attribute for edges
+     */
+    strokeDasharrayField?: string;
+    /**
+     * Prefix for fields to add as details
+     */
+    detailsPrefix?: string;
   };
   nodes?: {
     /**
@@ -50,6 +86,50 @@ export interface Options {
      * Define which fields are shown as part of the node arc (colored circle around the node).
      */
     arcs?: Array<ArcOption>;
+    /**
+     * Field containing the id attribute for nodes
+     */
+    idField?: string;
+    /**
+     * Field containing the title attribute for nodes
+     */
+    titleField?: string;
+    /**
+     * Field containing the subtitle attribute for nodes
+     */
+    subtitleField?: string;
+    /**
+     * Field containing the mainstat attribute for nodes
+     */
+    mainStatField?: string;
+    /**
+     * Field containing the secondarystat attribute for nodes
+     */
+    secondaryStatField?: string;
+    /**
+     * Field containing the color attribute for the node
+     */
+    colorField?: string;
+    /**
+     * Field containing the icon attribute for the node
+     */
+    iconField?: string;
+    /**
+     * Field containing the nodeRadius attribute for the node
+     */
+    nodeRadiusField?: string;
+    /**
+     * Field containing the highlighted attribute for the node
+     */
+    highlightedField?: string;
+    /**
+     * Prefix for fields to add as details for the node
+     */
+    detailsPrefix?: string;
+    /**
+     * Prefix for fields to add as arcs around the node
+     */
+    arcsPrefix?: string;
   };
   /**
    * How to handle zoom/scroll events in the node graph

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -13,7 +13,7 @@ import { Marker } from './Marker';
 import { Node } from './Node';
 import { ViewControls } from './ViewControls';
 import { Config, defaultConfig, useLayout } from './layout';
-import { EdgeDatumLayout, NodeDatum, NodesMarker, ZoomMode } from './types';
+import { EdgeDatumLayout, NodeDatum, NodeGraphOptions, NodesMarker, ZoomMode } from './types';
 import { useCategorizeFrames } from './useCategorizeFrames';
 import { useContextMenu } from './useContextMenu';
 import { useFocusPositionOnLayout } from './useFocusPositionOnLayout';
@@ -112,9 +112,9 @@ interface Props {
   getLinks: (dataFrame: DataFrame, rowIndex: number) => LinkModel[];
   nodeLimit?: number;
   panelId?: string;
-  zoomMode?: ZoomMode;
+  options?: NodeGraphOptions;
 }
-export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode }: Props) {
+export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, options }: Props) {
   const nodeCountLimit = nodeLimit || defaultNodeCountLimit;
   const { edges: edgesDataFrames, nodes: nodesDataFrames } = useCategorizeFrames(dataFrames);
 
@@ -134,8 +134,8 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode }
   // TODO we should be able to allow multiple dataframes for both edges and nodes, could be issue with node ids which in
   //  that case should be unique or figure a way to link edges and nodes dataframes together.
   const processed = useMemo(
-    () => processNodes(firstNodesDataFrame, firstEdgesDataFrame),
-    [firstEdgesDataFrame, firstNodesDataFrame]
+    () => processNodes(firstNodesDataFrame, firstEdgesDataFrame, options),
+    [firstEdgesDataFrame, firstNodesDataFrame, options]
   );
 
   // We need hover state here because for nodes we also highlight edges and for edges have labels separate to make
@@ -175,7 +175,7 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode }
   const { panRef, zoomRef, onStepUp, onStepDown, isPanning, position, scale, isMaxZoom, isMinZoom } = usePanAndZoom(
     bounds,
     focusPosition,
-    zoomMode
+    options?.zoomMode
   );
 
   const { onEdgeOpen, onNodeOpen, MenuComponent } = useContextMenu(
@@ -184,7 +184,8 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode }
     firstEdgesDataFrame,
     config,
     setConfig,
-    setFocusedNodeId
+    setFocusedNodeId,
+    options
   );
   const styles = useStyles2(getStyles);
 

--- a/public/app/plugins/panel/nodeGraph/NodeGraphPanel.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraphPanel.tsx
@@ -20,7 +20,6 @@ export const NodeGraphPanel = ({ width, height, data, options }: PanelProps<Node
       </div>
     );
   }
-
   const memoizedGetNodeGraphDataFrames = memoizeOne(getNodeGraphDataFrames);
   return (
     <div style={{ width, height }}>
@@ -28,7 +27,7 @@ export const NodeGraphPanel = ({ width, height, data, options }: PanelProps<Node
         dataFrames={memoizedGetNodeGraphDataFrames(data.series, options)}
         getLinks={getLinks}
         panelId={panelId}
-        zoomMode={options.zoomMode}
+        options={options}
       />
     </div>
   );

--- a/public/app/plugins/panel/nodeGraph/module.tsx
+++ b/public/app/plugins/panel/nodeGraph/module.tsx
@@ -1,4 +1,4 @@
-import { FieldConfigProperty, PanelPlugin } from '@grafana/data';
+import { FieldConfigProperty, FieldNamePickerBaseNameMode, PanelPlugin } from '@grafana/data';
 
 import { NodeGraphPanel } from './NodeGraphPanel';
 import { ArcOptionsEditor } from './editor/ArcOptionsEditor';
@@ -38,6 +38,83 @@ export const plugin = new PanelPlugin<NodeGraphOptions>(NodeGraphPanel)
           path: 'arcs',
           id: 'arcs',
           editor: ArcOptionsEditor,
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addTextInput({
+          category: ['Field names'],
+          name: 'Details prefix',
+          path: 'detailsPrefix',
+        });
+        builder.addTextInput({
+          category: ['Field names'],
+          name: 'Arcs prefix',
+          path: 'arcsPrefix',
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'ID field',
+          path: 'idField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Title field',
+          path: 'titleField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Subtitle field',
+          path: 'subtitleField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Secondary stat field',
+          path: 'secondaryStatField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Color field',
+          path: 'colorField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Icon field',
+          path: 'iconField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Node radius field',
+          path: 'nodeRadiusField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Highlighted field',
+          path: 'highlightedField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
         });
       },
     });
@@ -52,6 +129,77 @@ export const plugin = new PanelPlugin<NodeGraphOptions>(NodeGraphPanel)
         builder.addUnitPicker({
           name: 'Secondary stat unit',
           path: 'secondaryStatUnit',
+        });
+        builder.addTextInput({
+          category: ['Field names'],
+          name: 'Details prefix',
+          path: 'detailsPrefix',
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'ID field',
+          path: 'idField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Source field',
+          path: 'sourceField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Target field',
+          path: 'targetField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Main stat field',
+          path: 'mainStatField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Secondary stat field',
+          path: 'secondaryStatField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Thickness field',
+          path: 'thicknessField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Color field',
+          path: 'colorField',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
+        });
+        builder.addFieldNamePicker({
+          category: ['Field names'],
+          name: 'Stroke field',
+          path: 'strokeDasharrayField',
+          description:
+            'Sets the pattern of dashes and gaps used to render the edge. If unset, a solid line is used as edge. For more information and examples, refer to the stroke-dasharray MDN documentation.',
+          settings: {
+            baseNameMode: FieldNamePickerBaseNameMode.OnlyBaseNames,
+          },
         });
       },
     });

--- a/public/app/plugins/panel/nodeGraph/panelcfg.cue
+++ b/public/app/plugins/panel/nodeGraph/panelcfg.cue
@@ -34,14 +34,61 @@ composableKinds: PanelCfg: {
 					mainStatUnit?: string
 					// Unit for the secondary stat to override what ever is set in the data frame.
 					secondaryStatUnit?: string
+
 					// Define which fields are shown as part of the node arc (colored circle around the node).
 					arcs?: [...ArcOption]
+
+					// Field containing the id attribute for nodes
+					idField?: string
+					// Field containing the title attribute for nodes
+					titleField?: string
+					// Field containing the subtitle attribute for nodes
+					subtitleField?: string
+					// Field containing the mainstat attribute for nodes
+					mainStatField?: string
+					// Field containing the secondarystat attribute for nodes
+					secondaryStatField?: string
+					// Field containing the secondarystat attribute for nodes
+					secondaryStatField?: string
+					// Field containing the color attribute for the node
+					colorField?: string
+					// Field containing the icon attribute for the node
+					iconField?: string
+					// Field containing the nodeRadius attribute for the node
+					nodeRadiusField?: string
+					// Field containing the highlighted attribute for the node
+					highlightedField?: string
+
+					// Prefix for fields to add as details for the node
+					detailsPrefix?: string
+					// Prefix for fields to add as arcs around the node
+					arcsPrefix?: string
 				}
 				EdgeOptions: {
 					// Unit for the main stat to override what ever is set in the data frame.
 					mainStatUnit?: string
 					// Unit for the secondary stat to override what ever is set in the data frame.
 					secondaryStatUnit?: string
+
+          // Field containing the id attribute for edges
+					idField?: string
+					// Field containing the source attribute for edges
+					sourceField?: string
+					// Field containing the target attribute for edges
+					targetField?: string
+					// Field containing the mainstat attribute for edges
+					mainStatField?: string
+					// Field containing the secondarystat attribute for edges
+					secondaryStatField?: string
+					// Field containing the thickness attribute for edges
+					thicknessField?: string
+					// Field containing the color attribute for edges
+					colorField?: string
+					// Field containing the strokeDasharray attribute for edges
+					strokeDasharrayField?: string
+
+					// Prefix for fields to add as details
+					detailsPrefix?: string
 				}
 				ZoomMode: "cooperative" | "greedy" @cuetsy(kind="enum")
 				Options: {

--- a/public/app/plugins/panel/nodeGraph/panelcfg.gen.ts
+++ b/public/app/plugins/panel/nodeGraph/panelcfg.gen.ts
@@ -34,6 +34,42 @@ export interface Options {
      * Unit for the secondary stat to override what ever is set in the data frame.
      */
     secondaryStatUnit?: string;
+    /**
+     * Field containing the id attribute for edges
+     */
+    idField?: string;
+    /**
+     * Field containing the source attribute for edges
+     */
+    sourceField?: string;
+    /**
+     * Field containing the target attribute for edges
+     */
+    targetField?: string;
+    /**
+     * Field containing the mainstat attribute for edges
+     */
+    mainStatField?: string;
+    /**
+     * Field containing the secondarystat attribute for edges
+     */
+    secondaryStatField?: string;
+    /**
+     * Field containing the thickness attribute for edges
+     */
+    thicknessField?: string;
+    /**
+     * Field containing the color attribute for edges
+     */
+    colorField?: string;
+    /**
+     * Field containing the strokeDasharray attribute for edges
+     */
+    strokeDasharrayField?: string;
+    /**
+     * Prefix for fields to add as details
+     */
+    detailsPrefix?: string;
   };
   nodes?: {
     /**
@@ -48,6 +84,50 @@ export interface Options {
      * Define which fields are shown as part of the node arc (colored circle around the node).
      */
     arcs?: Array<ArcOption>;
+    /**
+     * Field containing the id attribute for nodes
+     */
+    idField?: string;
+    /**
+     * Field containing the title attribute for nodes
+     */
+    titleField?: string;
+    /**
+     * Field containing the subtitle attribute for nodes
+     */
+    subtitleField?: string;
+    /**
+     * Field containing the mainstat attribute for nodes
+     */
+    mainStatField?: string;
+    /**
+     * Field containing the secondarystat attribute for nodes
+     */
+    secondaryStatField?: string;
+    /**
+     * Field containing the color attribute for the node
+     */
+    colorField?: string;
+    /**
+     * Field containing the icon attribute for the node
+     */
+    iconField?: string;
+    /**
+     * Field containing the nodeRadius attribute for the node
+     */
+    nodeRadiusField?: string;
+    /**
+     * Field containing the highlighted attribute for the node
+     */
+    highlightedField?: string;
+    /**
+     * Prefix for fields to add as details for the node
+     */
+    detailsPrefix?: string;
+    /**
+     * Prefix for fields to add as arcs around the node
+     */
+    arcsPrefix?: string;
   };
   /**
    * How to handle zoom/scroll events in the node graph

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -60,24 +60,41 @@ export type NodeFields = {
   highlighted?: Field;
 };
 
-export function getNodeFields(nodes: DataFrame): NodeFields {
+export function getNodeFields(nodes: DataFrame, options?: NodeGraphOptions): NodeFields {
   const normalizedFrames = {
     ...nodes,
     fields: nodes.fields.map((field) => ({ ...field, name: field.name.toLowerCase() })),
   };
   const fieldsCache = new FieldCache(normalizedFrames);
   return {
-    id: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.id.toLowerCase()),
-    title: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.title.toLowerCase()),
-    subTitle: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.subTitle.toLowerCase()),
-    mainStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()),
-    secondaryStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()),
-    arc: findFieldsByPrefix(nodes, NodeGraphDataFrameFieldNames.arc),
-    details: findFieldsByPrefix(nodes, NodeGraphDataFrameFieldNames.detail),
-    color: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.color),
-    icon: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.icon),
-    nodeRadius: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.nodeRadius.toLowerCase()),
-    highlighted: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.highlighted.toLowerCase()),
+    id: fieldsCache.getFieldByName(
+      options?.nodes?.idField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.id.toLowerCase()
+    ),
+    title: fieldsCache.getFieldByName(
+      options?.nodes?.titleField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.title.toLowerCase()
+    ),
+    subTitle: fieldsCache.getFieldByName(
+      options?.nodes?.subtitleField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.subTitle.toLowerCase()
+    ),
+    mainStat: fieldsCache.getFieldByName(
+      options?.nodes?.mainStatField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.mainStat.toLowerCase()
+    ),
+    secondaryStat: fieldsCache.getFieldByName(
+      options?.nodes?.secondaryStatField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()
+    ),
+    arc: findFieldsByPrefix(nodes, options?.nodes?.arcsPrefix?.toLowerCase() ?? NodeGraphDataFrameFieldNames.arc),
+    details: findFieldsByPrefix(
+      nodes,
+      options?.nodes?.detailsPrefix?.toLowerCase() ?? NodeGraphDataFrameFieldNames.detail
+    ),
+    color: fieldsCache.getFieldByName(options?.nodes?.colorField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.color),
+    icon: fieldsCache.getFieldByName(options?.nodes?.iconField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.icon),
+    nodeRadius: fieldsCache.getFieldByName(
+      options?.nodes?.nodeRadiusField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.nodeRadius.toLowerCase()
+    ),
+    highlighted: fieldsCache.getFieldByName(
+      options?.nodes?.highlightedField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.highlighted.toLowerCase()
+    ),
     fixedX: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.fixedX.toLowerCase()),
     fixedY: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.fixedY.toLowerCase()),
   };
@@ -99,24 +116,43 @@ export type EdgeFields = {
   strokeDasharray?: Field;
 };
 
-export function getEdgeFields(edges: DataFrame): EdgeFields {
+export function getEdgeFields(edges: DataFrame, options?: NodeGraphOptions): EdgeFields {
   const normalizedFrames = {
     ...edges,
     fields: edges.fields.map((field) => ({ ...field, name: field.name.toLowerCase() })),
   };
   const fieldsCache = new FieldCache(normalizedFrames);
   return {
-    id: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.id.toLowerCase()),
-    source: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.source.toLowerCase()),
-    target: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.target.toLowerCase()),
-    mainStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.mainStat.toLowerCase()),
-    secondaryStat: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()),
-    details: findFieldsByPrefix(edges, NodeGraphDataFrameFieldNames.detail.toLowerCase()),
+    id: fieldsCache.getFieldByName(
+      options?.edges?.idField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.id.toLowerCase()
+    ),
+    source: fieldsCache.getFieldByName(
+      options?.edges?.sourceField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.source.toLowerCase()
+    ),
+    target: fieldsCache.getFieldByName(
+      options?.edges?.targetField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.target.toLowerCase()
+    ),
+    mainStat: fieldsCache.getFieldByName(
+      options?.edges?.mainStatField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.mainStat.toLowerCase()
+    ),
+    secondaryStat: fieldsCache.getFieldByName(
+      options?.edges?.secondaryStatField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.secondaryStat.toLowerCase()
+    ),
+    details: findFieldsByPrefix(
+      edges,
+      options?.edges?.detailsPrefix?.toLowerCase() ?? NodeGraphDataFrameFieldNames.detail.toLowerCase()
+    ),
     // @deprecated -- for edges use color instead
     highlighted: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.highlighted.toLowerCase()),
-    thickness: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.thickness.toLowerCase()),
-    color: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.color.toLowerCase()),
-    strokeDasharray: fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.strokeDasharray.toLowerCase()),
+    thickness: fieldsCache.getFieldByName(
+      options?.edges?.thicknessField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.thickness.toLowerCase()
+    ),
+    color: fieldsCache.getFieldByName(
+      options?.edges?.colorField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.color.toLowerCase()
+    ),
+    strokeDasharray: fieldsCache.getFieldByName(
+      options?.edges?.strokeDasharrayField?.toLowerCase() ?? NodeGraphDataFrameFieldNames.strokeDasharray.toLowerCase()
+    ),
   };
 }
 
@@ -129,7 +165,8 @@ function findFieldsByPrefix(frame: DataFrame, prefix: string): Field[] {
  */
 export function processNodes(
   nodes: DataFrame | undefined,
-  edges: DataFrame | undefined
+  edges: DataFrame | undefined,
+  options?: NodeGraphOptions
 ): {
   nodes: NodeDatum[];
   edges: EdgeDatum[];
@@ -144,7 +181,7 @@ export function processNodes(
   }
 
   if (nodes) {
-    const nodeFields = getNodeFields(nodes);
+    const nodeFields = getNodeFields(nodes, options);
     if (!nodeFields.id) {
       throw new Error('id field is required for nodes data frame.');
     }
@@ -175,7 +212,7 @@ export function processNodes(
     }
 
     // We may not have edges in case of single node
-    let edgeDatums: EdgeDatum[] = edges ? processEdges(edges, getEdgeFields(edges), nodesMap) : [];
+    let edgeDatums: EdgeDatum[] = edges ? processEdges(edges, getEdgeFields(edges, options), nodesMap) : [];
 
     for (const e of edgeDatums) {
       // We are adding incoming edges count, so we can later on find out which nodes are the roots
@@ -201,7 +238,7 @@ export function processNodes(
 
     const nodesMap: { [id: string]: NodeDatumFromEdge } = {};
 
-    const edgeFields = getEdgeFields(edges);
+    const edgeFields = getEdgeFields(edges, options);
 
     // Turn edges into reasonable filled in nodes
     for (let i = 0; i < edges.length; i++) {
@@ -595,7 +632,7 @@ export const applyOptionsToFrames = (frames: DataFrame[], options: NodeGraphOpti
     const fieldsCache = new FieldCache(frame);
 
     // Edges frame has source which can be used to identify nodes vs edges frames
-    if (fieldsCache.getFieldByName(NodeGraphDataFrameFieldNames.source.toLowerCase())) {
+    if (fieldsCache.getFieldByName(options.edges?.sourceField ?? NodeGraphDataFrameFieldNames.source.toLowerCase())) {
       if (options?.edges?.mainStatUnit) {
         const field = frame.fields.find((field) => field.name.toLowerCase() === NodeGraphDataFrameFieldNames.mainStat);
         if (field) {


### PR DESCRIPTION
**What is this feature?**

This PR adds panel options to select the fields used to construct the graph

**Why do we need this feature?**

Currently, the NodeGraph panel is only usable with data sources explicitly implementing queries for it, as transformations don't actually rename the underlying fields.

**Who is this feature for?**

Users building dashboards with custom node graph data.

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
