### PR TITLE
Dashboard history: Track version created timestamp in restore

### DIFF
--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
@@ -52,6 +52,7 @@ describe('VersionHistoryTable', () => {
       version: mockVersions[1].version,
       index: 1,
       confirm: false,
+      timestamp: mockVersions[1].created,
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
@@ -70,6 +70,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck, onRestore }
                             version: version.version,
                             index: idx,
                             confirm: false,
+                            timestamp: version.created,
                           });
                         }}
                       >

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -118,7 +118,7 @@ export const DashboardInteractions = {
   },
 
   // Dashboards versions interactions
-  versionRestoreClicked: (properties: { version: number; index?: number; confirm: boolean }) => {
+  versionRestoreClicked: (properties: { version: number; index?: number; confirm: boolean; timestamp?: Date }) => {
     reportDashboardInteraction('version_restore_clicked', properties);
   },
   showMoreVersionsClicked: () => {


### PR DESCRIPTION
**What is this feature?**

This PR adds the created at timestamp to the restore event, so we can understand how far back people are typically restoring their dashboards.

Follow-up to https://github.com/grafana/grafana/pull/98855