### PR TITLE
PanelPlugin: Allow inverting `hideFromDefaults`

### DIFF
--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -55,7 +55,7 @@ export function createFieldConfigRegistry<TFieldConfigOptions>(
       const customDefault = config.standardOptions[id]?.defaultValue;
       const customSettings = config.standardOptions[id]?.settings;
 
-      if (customHideFromDefaults) {
+      if (customHideFromDefaults !== undefined) {
         fieldConfigProp = {
           ...fieldConfigProp,
           hideFromDefaults: customHideFromDefaults,

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -308,25 +308,4 @@ describe('OptionsPaneOptions', () => {
     scenario.render();
     expect(screen.getByLabelText(overrideRuleTooltipDescription)).toBeInTheDocument();
   });
-
-  it('should not render categories with hidden fields only', () => {
-    const scenario = new OptionsPaneOptionsTestScenario();
-
-    scenario.plugin = getPanelPlugin({
-      id: 'TestPanel',
-    }).useFieldConfig({
-      standardOptions: {},
-      useCustomConfig: (b) => {
-        b.addBooleanSwitch({
-          name: 'CustomBool',
-          path: 'CustomBool',
-          hideFromDefaults: true,
-          category: ['Axis'],
-        });
-      },
-    });
-
-    scenario.render();
-    expect(screen.queryByRole('heading', { name: /Axis/ })).not.toBeInTheDocument();
-  });
 });

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -143,6 +143,29 @@ describe('OptionsPaneOptions', () => {
     expect(screen.queryByLabelText(OptionsPaneSelector.fieldLabel('TestPanel HiddenFromDef'))).not.toBeInTheDocument();
   });
 
+  it('should render options that are specifically not marked as hidden from defaults', () => {
+    const scenario = new OptionsPaneOptionsTestScenario();
+
+    scenario.plugin = getPanelPlugin({
+      id: 'TestPanel',
+    }).useFieldConfig({
+      standardOptions: {},
+      useCustomConfig: (b) => {
+        b.addBooleanSwitch({
+          name: 'CustomBool',
+          path: 'CustomBool',
+        }).addBooleanSwitch({
+          name: 'HiddenFromDef',
+          path: 'HiddenFromDef',
+          hideFromDefaults: false,
+        });
+      },
+    });
+
+    scenario.render();
+    expect(screen.queryByLabelText(OptionsPaneSelector.fieldLabel('TestPanel HiddenFromDef'))).toBeInTheDocument();
+  });
+
   it('should create categories for field options with category', () => {
     const scenario = new OptionsPaneOptionsTestScenario();
     scenario.render();
@@ -284,5 +307,26 @@ describe('OptionsPaneOptions', () => {
 
     scenario.render();
     expect(screen.getByLabelText(overrideRuleTooltipDescription)).toBeInTheDocument();
+  });
+
+  it('should not render categories with hidden fields only', () => {
+    const scenario = new OptionsPaneOptionsTestScenario();
+
+    scenario.plugin = getPanelPlugin({
+      id: 'TestPanel',
+    }).useFieldConfig({
+      standardOptions: {},
+      useCustomConfig: (b) => {
+        b.addBooleanSwitch({
+          name: 'CustomBool',
+          path: 'CustomBool',
+          hideFromDefaults: true,
+          category: ['Axis'],
+        });
+      },
+    });
+
+    scenario.render();
+    expect(screen.queryByRole('heading', { name: /Axis/ })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR allows hiding an option from defaults and show it in a specific panel.
Needed to hide an option by default but enable it in just a few panels.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
