### PR TITLE
Prometheus: Fix operator handling when making label expressions utf-8 friendly

### DIFF
--- a/packages/grafana-prometheus/src/utf8_support.test.ts
+++ b/packages/grafana-prometheus/src/utf8_support.test.ts
@@ -124,4 +124,31 @@ describe('wrapUtf8Filters', () => {
     const expected = 'key1="nested \\"escaped\\" quotes",key2="value with \\"escaped\\" quotes"';
     expect(result).toEqual(expected);
   });
+
+  it('should handle different Prometheus operators correctly', () => {
+    const inputs = [
+      'label="value"', // equals
+      'label!="different value"', // not equals
+      'label=~"regex.*value"', // regex match
+      'label!~"not.regex.*value"', // regex not match
+      'utf8.label.spaß!="no match"', // utf8 with not equals
+      'utf8.label.spaß=~"match.*"', // utf8 with regex match
+      'complex case=~".*",simple="value"', // multiple operators
+    ];
+
+    const expected = [
+      'label="value"',
+      'label!="different value"',
+      'label=~"regex.*value"',
+      'label!~"not.regex.*value"',
+      '"utf8.label.spaß"!="no match"',
+      '"utf8.label.spaß"=~"match.*"',
+      '"complex case"=~".*",simple="value"',
+    ];
+
+    inputs.forEach((input, index) => {
+      const result = wrapUtf8Filters(input);
+      expect(result).toEqual(expected[index]);
+    });
+  });
 });

--- a/packages/grafana-prometheus/src/utf8_support.ts
+++ b/packages/grafana-prometheus/src/utf8_support.ts
@@ -87,6 +87,14 @@ export const wrapUtf8Filters = (filterStr: string): string => {
   let currentValue = '';
   let inQuotes = false;
   let temp = '';
+  const addResult = () => {
+    const operatorMatch = temp.match(operatorRegex);
+    if (operatorMatch) {
+      const operator = operatorMatch[0];
+      [currentKey, currentValue] = temp.split(operator);
+      resultArray.push(`${utf8Support(currentKey.trim())}${operator}"${currentValue.slice(1, -1)}"`);
+    }
+  };
 
   for (const char of filterStr) {
     if (char === '"' && temp[temp.length - 1] !== '\\') {
@@ -95,12 +103,7 @@ export const wrapUtf8Filters = (filterStr: string): string => {
       temp += char;
     } else if (char === ',' && !inQuotes) {
       // When outside quotes and encountering ',', finalize the current pair
-      const operatorMatch = temp.match(operatorRegex);
-      if (operatorMatch) {
-        const operator = operatorMatch[0];
-        [currentKey, currentValue] = temp.split(operator);
-        resultArray.push(`${utf8Support(currentKey.trim())}${operator}"${currentValue.slice(1, -1)}"`);
-      }
+      addResult();
       temp = ''; // Reset for the next pair
     } else {
       // Collect characters
@@ -110,12 +113,7 @@ export const wrapUtf8Filters = (filterStr: string): string => {
 
   // Handle the last key-value pair
   if (temp) {
-    const operatorMatch = temp.match(operatorRegex);
-    if (operatorMatch) {
-      const operator = operatorMatch[0];
-      [currentKey, currentValue] = temp.split(operator);
-      resultArray.push(`${utf8Support(currentKey.trim())}${operator}"${currentValue.slice(1, -1)}"`);
-    }
+    addResult();
   }
   return resultArray.join(',');
 };

--- a/packages/grafana-prometheus/src/utf8_support.ts
+++ b/packages/grafana-prometheus/src/utf8_support.ts
@@ -82,6 +82,7 @@ const isValidCodePoint = (codePoint: number): boolean => {
 
 export const wrapUtf8Filters = (filterStr: string): string => {
   const resultArray: string[] = [];
+  const operatorRegex = /(=~|!=|!~|=)/; // NOTE: the order of the operators is important here
   let currentKey = '';
   let currentValue = '';
   let inQuotes = false;
@@ -94,8 +95,12 @@ export const wrapUtf8Filters = (filterStr: string): string => {
       temp += char;
     } else if (char === ',' && !inQuotes) {
       // When outside quotes and encountering ',', finalize the current pair
-      [currentKey, currentValue] = temp.split('=');
-      resultArray.push(`${utf8Support(currentKey.trim())}="${currentValue.slice(1, -1)}"`);
+      const operatorMatch = temp.match(operatorRegex);
+      if (operatorMatch) {
+        const operator = operatorMatch[0];
+        [currentKey, currentValue] = temp.split(operator);
+        resultArray.push(`${utf8Support(currentKey.trim())}${operator}"${currentValue.slice(1, -1)}"`);
+      }
       temp = ''; // Reset for the next pair
     } else {
       // Collect characters
@@ -105,9 +110,12 @@ export const wrapUtf8Filters = (filterStr: string): string => {
 
   // Handle the last key-value pair
   if (temp) {
-    [currentKey, currentValue] = temp.split('=');
-    resultArray.push(`${utf8Support(currentKey.trim())}="${currentValue.slice(1, -1)}"`);
+    const operatorMatch = temp.match(operatorRegex);
+    if (operatorMatch) {
+      const operator = operatorMatch[0];
+      [currentKey, currentValue] = temp.split(operator);
+      resultArray.push(`${utf8Support(currentKey.trim())}${operator}"${currentValue.slice(1, -1)}"`);
+    }
   }
-
   return resultArray.join(',');
 };


### PR DESCRIPTION
## Related issues

This PR fixes #100474 and unblocks a fix for #98564.

## What is this change?

As described in #100474, `@grafana/prometheus`' `wrapUtf8Filters` wasn't correctly handling filter expressions with operators other than `=`. This PR adds support for [other operators used in Prometheus label expressions](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors).