### PR TITLE
UniStore/Large Objects: Remove dependency on `kubernetesDashboards`

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -328,12 +328,14 @@ func (hs *HTTPServer) getDashboardHelper(ctx context.Context, orgID int64, id in
 	ctx, span := hs.tracer.Start(ctx, "api.getDashboardHelper")
 	defer span.End()
 
-	var query dashboards.GetDashboardQuery
+	query := dashboards.GetDashboardQuery{
+		ID:         id,
+		OrgID:      orgID,
+		IncludeDTO: true,
+	}
 
 	if len(uid) > 0 {
-		query = dashboards.GetDashboardQuery{UID: uid, ID: id, OrgID: orgID}
-	} else {
-		query = dashboards.GetDashboardQuery{ID: id, OrgID: orgID}
+		query.UID = uid
 	}
 
 	queryResult, err := hs.DashboardService.GetDashboard(ctx, &query)

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -265,6 +265,8 @@ type GetDashboardQuery struct {
 	FolderID  *int64
 	FolderUID *string
 	OrgID     int64
+
+	IncludeDTO bool // Add DTO subresource. Used for K8s dashboards when large object support is enabled.
 }
 
 type DashboardTagCloudItem struct {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -776,7 +776,11 @@ func (dr *DashboardServiceImpl) ValidateDashboardBeforeSave(ctx context.Context,
 	var err error
 	if dashboard.ID > 0 {
 		// if ID is set and the dashboard is not found, ErrDashboardNotFound will be returned
-		existingById, err = dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{OrgID: dashboard.OrgID, ID: dashboard.ID})
+		existingById, err = dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{
+			OrgID:      dashboard.OrgID,
+			ID:         dashboard.ID,
+			IncludeDTO: true,
+		})
 		if err != nil {
 			return false, err
 		}
@@ -789,7 +793,11 @@ func (dr *DashboardServiceImpl) ValidateDashboardBeforeSave(ctx context.Context,
 
 	var existingByUid *dashboards.Dashboard
 	if dashboard.UID != "" {
-		existingByUid, err = dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{OrgID: dashboard.OrgID, UID: dashboard.UID})
+		existingByUid, err = dr.GetDashboard(ctx, &dashboards.GetDashboardQuery{
+			OrgID:      dashboard.OrgID,
+			UID:        dashboard.UID,
+			IncludeDTO: true,
+		})
 		if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
 			return false, err
 		}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1785,7 +1785,7 @@ func (dr *DashboardServiceImpl) CleanUpDashboard(ctx context.Context, dashboardU
 func (dr *DashboardServiceImpl) getDashboardThroughK8s(ctx context.Context, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
 	var dtoSub string
 	// The DTO subresource is required in order to return a rehydrated large object.
-	if dr.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
+	if dr.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) && query.IncludeDTO {
 		dtoSub = "dto"
 	}
 

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -141,7 +141,7 @@ func (pd *PublicDashboardServiceImpl) FindDashboard(ctx context.Context, orgId i
 
 	// We don't have a signed in user for public dashboards. We are using Grafana's Identity to query the dashboard.
 	dash, err := identity.WithServiceIdentityFn(ctx, orgId, func(ctx context.Context) (*dashboards.Dashboard, error) {
-		return pd.dashboardService.GetDashboard(ctx, &dashboards.GetDashboardQuery{UID: dashboardUid, OrgID: orgId})
+		return pd.dashboardService.GetDashboard(ctx, &dashboards.GetDashboardQuery{UID: dashboardUid, OrgID: orgId, IncludeDTO: true})
 	})
 	if err != nil {
 		var dashboardErr dashboardaccess.DashboardErr

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -437,16 +437,10 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 		dashboardObject := r.Dashboard.Interface()
 		dashboardMap, ok := dashboardObject.(map[string]interface{})
 		require.True(t, ok)
-		objj, ok := dashboardMap["Object"].(map[string]interface{})
+		panels, ok := dashboardMap["panels"].([]interface{})
 		require.True(t, ok)
 
-		title, ok := objj["title"].(string)
-		require.True(t, ok)
-		require.Equal(t, "Test empty dashboard", title)
-
-		panelsMap, ok := objj["panels"].([]interface{})
-		require.True(t, ok)
-		tt, ok := panelsMap[0].(map[string]interface{})["title"]
+		tt, ok := panels[0].(map[string]interface{})["title"]
 		require.True(t, ok)
 		require.Equal(t, "Test Panel", tt)
 	})

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -444,13 +444,9 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "Test empty dashboard", title)
 
-		panels, ok := objj["panels"].(interface{})
+		panelsMap, ok := objj["panels"].([]interface{})
 		require.True(t, ok)
-		panelsMap, ok := panels.([]interface{})
-		require.True(t, ok)
-		data, ok := panelsMap[0].(interface{})
-		require.True(t, ok)
-		tt, ok := data.(map[string]interface{})["title"]
+		tt, ok := panelsMap[0].(map[string]interface{})["title"]
 		require.True(t, ok)
 		require.Equal(t, "Test Panel", tt)
 	})

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -394,6 +394,25 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 			Object: map[string]interface{}{
 				"spec": map[string]any{
 					"title": "Test empty dashboard",
+					"panels": []map[string]any{
+						{
+							"id": 1,
+							"gridPos": map[string]any{
+								"h": 8,
+								"w": 12,
+								"x": 0,
+								"y": 0,
+							},
+							"title": "Test Panel",
+							"type":  "graph",
+							"targets": []map[string]any{
+								{
+									"refId": "A",
+									"expr":  "up",
+								},
+							},
+						},
+					},
 				},
 			},
 		}
@@ -402,6 +421,19 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 		require.NoError(t, err)
 		created := obj.GetName()
 
+		// Check that the panel exists with the correct title in the created object
+		createdSpec, ok := obj.Object["spec"].(map[string]interface{})
+		require.True(t, ok, "Created spec should be a map")
+
+		createdPanels, ok := createdSpec["panels"].([]interface{})
+		require.True(t, ok, "Created panels should be an array")
+		require.Len(t, createdPanels, 1, "Created dashboard should have 1 panel")
+
+		createdPanel, ok := createdPanels[0].(map[string]interface{})
+		require.True(t, ok, "Created panel should be a map")
+		require.Equal(t, "Test Panel", createdPanel["title"], "Created panel should have the correct title")
+
+		// Retrieve and check the saved object
 		found, err := client.Resource.Get(context.Background(), created, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, created, found.GetName())
@@ -410,5 +442,17 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 		require.NoError(t, err)
 		foundTitle := meta.FindTitle("")
 		require.Equal(t, "Test empty dashboard", foundTitle)
+
+		// Check that the panel exists with the correct title in the found object
+		foundSpec, ok := found.Object["spec"].(map[string]interface{})
+		require.True(t, ok, "Found spec should be a map")
+
+		foundPanels, ok := foundSpec["panels"].([]interface{})
+		require.True(t, ok, "Found panels should be an array")
+		require.Len(t, foundPanels, 1, "Found dashboard should have 1 panel")
+
+		foundPanel, ok := foundPanels[0].(map[string]interface{})
+		require.True(t, ok, "Found panel should be a map")
+		require.Equal(t, "Test Panel", foundPanel["title"], "Found panel should have the correct title")
 	})
 }

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -377,6 +377,7 @@ func TestIntegrationDashboardsAppV1Alpha1LargeObjects(t *testing.T) {
 			EnableFeatureToggles: []string{
 				featuremgmt.FlagUnifiedStorageBigObjectsSupport,
 				featuremgmt.FlagKubernetesClientDashboardsFolders,
+				featuremgmt.FlagUnifiedStorageSearch,
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 				"dashboards.dashboard.grafana.app": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We ran into [some issues](https://raintank-corp.slack.com/archives/C06JFJ7H3GC/p1738925770961769) when big objects was enabled alongside kubernetesDashboards. For example, [editing](https://raintank-corp.slack.com/archives/C06JFJ7H3GC/p1738925836528679?thread_ts=1738925770.961769&cid=C06JFJ7H3GC) a “big” dashboard wasn’t working. Also we need to use the same feature toggle set as for the bug bash.

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/202

**Special notes for your reviewer:**
* We might want to continue with the approach of fetching the DTO whenever large objects is enabled and instead making it configurable whether we include access info or not.
* If we instead to the approach of making the inclusion of DTO (including access) configurable, we will need to revisit where exactly we want to include it.

Config for testing locally. Of note, one can verify the behavior when changing the value of `blob_threshold_bytes`.
```
[feature_toggles]
grafanaAPIServerWithExperimentalAPIs = true
grafanaAPIServerEnsureKubectlAccess = true
unifiedStorageSearch = true
unifiedStorageSearchUI = true
kubernetesClientDashboardsFolders = true

unifiedStorageBigObjectsSupport = true

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 4

[unified_storage.folders.folder.grafana.app]
dualWriterMode = 4

[grafana-apiserver]
storage_type = unified
blob_url = ./data/unified-blob-store
blob_threshold_bytes = 0
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
