### PR TITLE
[release-11.4.2] Auth: Fix redirect with JWT auth URL login

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -390,6 +390,11 @@ function handleRedirectTo(): void {
   const queryParams = locationService.getSearch();
   const redirectToParamKey = 'redirectTo';
 
+  if (queryParams.has('auth_token')) {
+    // URL Login should not be redirected
+    window.sessionStorage.removeItem(RedirectToUrlKey);
+  }
+
   if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {
     const rawRedirectTo = queryParams.get(redirectToParamKey)!;
     window.sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent(rawRedirectTo));


### PR DESCRIPTION
Backport acc15219296206fb1a971b3742110e6a9d972cef from #100295

---

**What is this feature?**
Fixes a bug with redirect handling when Grafana is embedded into an iframe and the `auth_login` parameter is used to pass the JWT token to Grafana.

**Why do we need this feature?**
After JWT expiration the `auth_token` query parameter was added to the `redirectTo` URL blocking the update of the `auth_token` query param.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
