### PR TITLE
Alerting: Fix default max_attempts value in the docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1821,7 +1821,7 @@ The timeout string is a possibly signed sequence of decimal numbers, followed by
 
 #### `max_attempts`
 
-Sets a maximum number of times Grafana attempts to evaluate an alert rule before giving up on that evaluation. The default value is `1`.
+Sets a maximum number of times Grafana attempts to evaluate an alert rule before giving up on that evaluation. The default value is `3`.
 
 #### `min_interval`
 


### PR DESCRIPTION
The [doc](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#max_attempts) says:

> Sets a maximum number of times we’ll attempt to evaluate an alert rule before giving up on that evaluation. The default value is 1.

The default value has been changed to 3 recently: https://github.com/grafana/grafana/pull/97461