### PR TITLE
Alerting docs: remove admonition about auto-generated policies

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -257,16 +257,11 @@ Complete the following steps to set up notifications.
 
    1. You can also optionally select a mute timing as well as groupings and timings to define when not to send notifications.
 
-      {{< admonition type="note" >}}
-      An auto-generated notification policy is generated. Only admins can view these auto-generated policies from the **Notification policies** list view. Any changes have to be made in the alert rules form. {{< /admonition >}}
-
    **Use notification policy**
 
-   1. Choose this option to use the [notification policy tree](ref:notification-policies) to direct your notifications.
+   1. Choose this option to use the [notification policy tree](ref:notification-policies) to handle alert notifications.
 
-      {{< admonition type="note" >}}
-      All alert rules and instances, irrespective of their labels, match the default notification policy. If there are no nested policies, or no nested policies match the labels in the alert rule or alert instance, then the default notification policy is the matching policy.
-      {{< /admonition >}}
+      All notifications for this alert rule are managed by the notification policy tree, which routes alerts based on their labels. If an alert does not match a specific policy, the default notification policy applies, ensuring all alerts are handled.
 
    1. Preview your alert instance routing set up.
 


### PR DESCRIPTION
Auto-generated notification policies are not currently visible in the UI.

This PR removes an outdated admonition following a recent release and includes a minor text update to align related instructions with the latest changes.


- [Current version](http://localhost:3002/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-notifications)
- [Preview](https://deploy-preview-grafana-100501-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-notifications)

