### PR TITLE
[release-11.4.2] Chore: pin tonistiigi/binfmt version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -689,7 +689,9 @@ steps:
     token:
       from_secret: drone_token
 - commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --version
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --uninstall 'qemu-*'
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --install all
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
@@ -2154,7 +2156,9 @@ steps:
   image: node:20.9.0-alpine
   name: build-frontend-packages
 - commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --version
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --uninstall 'qemu-*'
+  - docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --install all
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
@@ -5729,6 +5733,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 2af2d120c04a6d58fe77bc237398143ec84e10c1825e761dfbfdfbbf90a89519
+hmac: 2b06b33f549498dcf3784702c29a6abddd3719b73b941e88caacf89efe11712c
 
 ...

--- a/scripts/drone/steps/rgm.star
+++ b/scripts/drone/steps/rgm.star
@@ -47,7 +47,9 @@ def rgm_artifacts_step(
             "_EXPERIMENTAL_DAGGER_CLOUD_TOKEN": from_secret(rgm_dagger_token),
         },
         "commands": [
-            "docker run --privileged --rm tonistiigi/binfmt --install all",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --version",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --uninstall 'qemu-*'",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --install all",
             cmd +
             "--go-version={} ".format(golang_version) +
             "--yarn-cache=$$YARN_CACHE_FOLDER " +
@@ -78,7 +80,9 @@ def rgm_build_docker_step(ubuntu, alpine, depends_on = ["yarn-install"], file = 
             "_EXPERIMENTAL_DAGGER_CLOUD_TOKEN": from_secret(rgm_dagger_token),
         },
         "commands": [
-            "docker run --privileged --rm tonistiigi/binfmt --install all",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --version",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --uninstall 'qemu-*'",
+            "docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --install all",
             "/src/grafana-build artifacts " +
             "-a docker:grafana:linux/amd64 " +
             "-a docker:grafana:linux/amd64:ubuntu " +


### PR DESCRIPTION
Backport a9b4b1e5be23e4bd30dce11fc738f4ff4a6111b5 from #100510

---

Pins tonistiigi/binfmt docker image in Drone build to `tonistiigi/binfmt:qemu-v7.0.0-28`
