### PR TITLE
Auth: Add early return if `auth_token` is in the URL for JWT auth

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -406,6 +406,7 @@ function handleRedirectTo(): void {
   if (queryParams.has('auth_token')) {
     // URL Login should not be redirected
     window.sessionStorage.removeItem(RedirectToUrlKey);
+    return
   }
 
   if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -406,7 +406,7 @@ function handleRedirectTo(): void {
   if (queryParams.has('auth_token')) {
     // URL Login should not be redirected
     window.sessionStorage.removeItem(RedirectToUrlKey);
-    return
+    return;
   }
 
   if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {


### PR DESCRIPTION
**What is this feature?**
Add early return to the `handleRedirectTo` in case the `auth_token` is present in the URL.

**Why do we need this feature?**

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
