### PR TITLE
SecretsService: Keeper Update fix and add encryption config

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2071,6 +2071,21 @@ dev_mode = false
 # How much artificial delay to add to store operations. Simulates async k8s behavior. 
 dev_stub_latency = 0
 
+# Used for signing
+secret_key = SW2YcwTIb9zpOOhoPsMm
+# Current key provider used for envelope encryption, default to static value specified by secret_key
+encryption_provider = secretKey.v1
+# List of configured key providers, space separated (Enterprise only): e.g., awskms.v1 azurekv.v1
+available_encryption_providers =
+
+[secrets_manager.encryption]
+# Defines the time-to-live (TTL) for decrypted data encryption keys stored in memory (cache).
+# Please note that small values may cause performance issues due to a high frequency decryption operations.
+data_keys_cache_ttl = 15m
+# Defines the frequency of data encryption keys cache cleanup interval.
+# On every interval, decrypted data encryption keys that reached the TTL are removed from the cache.
+data_keys_cache_cleanup_interval = 1m
+
 ################################## Frontend development configuration ###################################
 # Warning! Any settings placed in this section will be available on `process.env.frontend_dev_{foo}` within frontend code
 # Any values placed here may be accessible to the UI. Do not place sensitive information here.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1983,6 +1983,21 @@ timeout = 30s
 # How much artificial delay to add to store operations. Simulates async k8s behavior. 
 ; dev_stub_latency = 0
 
+# Used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+# Current key provider used for envelope encryption, default to static value specified by secret_key
+;encryption_provider = secretKey.v1
+# List of configured key providers, space separated (Enterprise only): e.g., awskms.v1 azurekv.v1
+;available_encryption_providers =
+
+[secrets_manager.encryption]
+# Defines the time-to-live (TTL) for decrypted data encryption keys stored in memory (cache).
+# Please note that small values may cause performance issues due to a high frequency decryption operations.
+;data_keys_cache_ttl = 15m
+# Defines the frequency of data encryption keys cache cleanup interval.
+# On every interval, decrypted data encryption keys that reached the TTL are removed from the cache.
+;data_keys_cache_cleanup_interval = 1m
+
 ################################## Frontend development configuration ###################################
 # Warning! Any settings placed in this section will be available on `process.env.frontend_dev_{foo}` within frontend code
 # Any values placed here may be accessible to the UI. Do not place sensitive information here.

--- a/pkg/registry/apis/secret/encryption/manager/helpers.go
+++ b/pkg/registry/apis/secret/encryption/manager/helpers.go
@@ -25,10 +25,10 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	defaultKey := "SdlklWklckeLS"
 	raw, err := ini.Load([]byte(`
-			[security]
+			[secrets_manager]
 			secret_key = ` + defaultKey + `
 	
-			[security.encryption]
+			[secrets_manager.encryption]
 			data_keys_cache_ttl = 5m
 			data_keys_cache_cleanup_interval = 1ns`))
 	require.NoError(tb, err)

--- a/pkg/registry/apis/secret/encryption/manager/manager.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager.go
@@ -63,11 +63,11 @@ func NewEncryptionManager(
 	cfg *setting.Cfg,
 	usageStats usagestats.Service,
 ) (*EncryptionManager, error) {
-	ttl := cfg.SectionWithEnvOverrides("security.encryption").Key("data_keys_cache_ttl").MustDuration(15 * time.Minute)
+	ttl := cfg.SectionWithEnvOverrides("secrets_manager.encryption").Key("data_keys_cache_ttl").MustDuration(15 * time.Minute)
 
 	currentProviderID := encryption.ProviderID(
 		kmsproviders.NormalizeProviderID(secrets.ProviderID(
-			cfg.SectionWithEnvOverrides("security").Key("encryption_provider").MustString(kmsproviders.Default),
+			cfg.SectionWithEnvOverrides("secrets_manager").Key("encryption_provider").MustString(kmsproviders.Default),
 		)))
 
 	s := &EncryptionManager{
@@ -424,7 +424,7 @@ func (s *EncryptionManager) ReEncryptDataKeys(ctx context.Context, namespace str
 
 func (s *EncryptionManager) Run(ctx context.Context) error {
 	gc := time.NewTicker(
-		s.cfg.SectionWithEnvOverrides("security.encryption").Key("data_keys_cache_cleanup_interval").
+		s.cfg.SectionWithEnvOverrides("secrets_manager.encryption").Key("data_keys_cache_cleanup_interval").
 			MustDuration(time.Minute),
 	)
 

--- a/pkg/registry/apis/secret/encryption/manager/manager_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager_test.go
@@ -95,10 +95,10 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	defaultKey := "SdlklWklckeLS"
 	raw, err := ini.Load([]byte(`
-		[security]
+		[secrets_manager]
 		secret_key = ` + defaultKey + `
 
-		[security.encryption]
+		[secrets_manager.encryption]
 		data_keys_cache_ttl = 5m
 		data_keys_cache_cleanup_interval = 1ns`))
 	require.NoError(t, err)
@@ -192,12 +192,12 @@ func TestEncryptionService_UseCurrentProvider(t *testing.T) {
 
 	t.Run("Should use encrypt/decrypt methods of the current encryption provider", func(t *testing.T) {
 		rawCfg := `
-		[security]
+		[secrets_manager]
 		secret_key = sdDkslslld
 		encryption_provider = fakeProvider.v1
 		available_encryption_providers = fakeProvider.v1
 
-		[security.encryption.fakeProvider.v1]
+		[secrets_manager.encryption.fakeProvider.v1]
 		`
 
 		raw, err := ini.Load([]byte(rawCfg))
@@ -509,10 +509,10 @@ func TestIntegration_SecretsService(t *testing.T) {
 			features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 			defaultKey := "SdlklWklckeLS"
 			raw, err := ini.Load([]byte(`
-				[security]
+				[secrets_manager]
 				secret_key = ` + defaultKey + `
 		
-				[security.encryption]
+				[secrets_manager.encryption]
 				data_keys_cache_ttl = 5m
 				data_keys_cache_cleanup_interval = 1ns`))
 			require.NoError(t, err)

--- a/pkg/registry/apis/secret/encryption/migrator/migrator.go
+++ b/pkg/registry/apis/secret/encryption/migrator/migrator.go
@@ -72,7 +72,7 @@ func (m *SecretsMigrator) RollBackSecrets(ctx context.Context) (bool, error) {
 	// 		m.secretsSrv,
 	// 		m.encryptionSrv,
 	// 		m.sqlStore,
-	// 		m.settings.KeyValue("security", "secret_key").Value(),
+	// 		m.settings.KeyValue("secrets_manager", "secret_key").Value(),
 	// 	); failed {
 	// 		anyFailure = true
 	// 	}

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 
 func Test_OSSKeeperService_GetKeepers(t *testing.T) {
 	cfg := `
-	[security]
+	[secrets_manager]
 	secret_key = sdDkslslld
 	encryption_provider = secretKey.v1
 	available_encryption_providers = secretKey.v1

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
@@ -82,7 +82,12 @@ func (s *SQLKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Update")
 	defer span.End()
 
-	err := s.store.Update(ctx, externalID.String(), []byte(exposedValueOrRef))
+	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef), encryption.WithoutScope())
+	if err != nil {
+		return fmt.Errorf("unable to encrypt value: %w", err)
+	}
+
+	err = s.store.Update(ctx, externalID.String(), encryptedData)
 	if err != nil {
 		return fmt.Errorf("failed to update encrypted value: %w", err)
 	}

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 
 func Test_SQLKeeperSetup(t *testing.T) {
 	cfg := `
-	[security]
+	[secrets_manager]
 	secret_key = sdDkslslld
 	encryption_provider = secretKey.v1
 	available_encryption_providers = secretKey.v1
@@ -134,10 +134,9 @@ func Test_SQLKeeperSetup(t *testing.T) {
 		require.NoError(t, err)
 
 		exposedVal, err := sqlKeeper.Expose(ctx, nil, namespace1, externalId1)
-		require.Error(t, err)
-		assert.Empty(t, exposedVal)
-
-		assert.NotEqual(t, plaintext1, exposedVal)
+		require.NoError(t, err)
+		assert.NotNil(t, exposedVal)
+		assert.Equal(t, plaintext2, exposedVal.DangerouslyExposeAndConsumeValue())
 	})
 
 	t.Run("updating a non existent encrypted value returns error", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Fix the keeper Update method to encrypt then update 🙈.
Add encryption config under `secrets_manager` config section and have encryption manager read from it.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1158
Trying to break down the work for using default sql keeper and connecting the flow.
