### PR TITLE
TableNG: Cell height performance improvement

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -678,8 +678,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "React Hook useCallback has an unnecessary dependency: \'DEFAULT_CELL_PADDING\'. Either exclude it or remove the dependency array. Outer scope values like \'DEFAULT_CELL_PADDING\' aren\'t valid dependencies because mutating them doesn\'t re-render the component.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "packages/grafana-ui/src/components/Table/TableNG/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -678,9 +678,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "React Hook useCallback has an unnecessary dependency: \'DEFAULT_CELL_PADDING\'. Either exclude it or remove the dependency array. Outer scope values like \'DEFAULT_CELL_PADDING\' aren\'t valid dependencies because mutating them doesn\'t re-render the component.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "packages/grafana-ui/src/components/Table/TableNG/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -527,7 +527,7 @@ export function TableNG(props: TableNGProps) {
         DEFAULT_CELL_PADDING
       );
     },
-    [expandedRows, defaultRowHeight, columnTypes, headerCellRefs, osContext, defaultLineHeight, DEFAULT_CELL_PADDING]
+    [expandedRows, defaultRowHeight, columnTypes, headerCellRefs, osContext, defaultLineHeight]
   );
 
   // Return the data grid

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -543,7 +543,7 @@ export function TableNG(props: TableNGProps) {
           sortable: true,
           resizable: true,
         }}
-        rowHeight={!textWrap ? defaultRowHeight : (row) => calculateRowHeight(row)}
+        rowHeight={textWrap ? calculateRowHeight : defaultRowHeight}
         // TODO: This doesn't follow current table behavior
         style={{ width, height }}
         renderers={{ renderRow: myRowRenderer }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -508,6 +508,28 @@ export function TableNG(props: TableNGProps) {
     );
   };
 
+  const calculateRowHeight = useCallback(
+    (row: TableRow) => {
+      // Logic for sub-tables
+      if (Number(row.__depth) === 1 && !expandedRows.includes(Number(row.__index))) {
+        return 0;
+      } else if (Number(row.__depth) === 1 && expandedRows.includes(Number(row.__index))) {
+        const headerCount = row.data.meta?.custom?.noHeader ? 0 : 1;
+        return defaultRowHeight * (row.data.length + headerCount); // TODO this probably isn't very robust
+      }
+      return getRowHeight(
+        row,
+        columnTypes,
+        headerCellRefs,
+        osContext,
+        defaultLineHeight,
+        defaultRowHeight,
+        DEFAULT_CELL_PADDING
+      );
+    },
+    [expandedRows, defaultRowHeight, columnTypes, headerCellRefs, osContext, defaultLineHeight, DEFAULT_CELL_PADDING]
+  );
+
   // Return the data grid
   return (
     <>
@@ -521,24 +543,7 @@ export function TableNG(props: TableNGProps) {
           sortable: true,
           resizable: true,
         }}
-        rowHeight={(row) => {
-          if (Number(row.__depth) === 1 && !expandedRows.includes(Number(row.__index))) {
-            return 0;
-          } else if (Number(row.__depth) === 1 && expandedRows.includes(Number(row.__index))) {
-            const headerCount = row.data.meta?.custom?.noHeader ? 0 : 1;
-            return defaultRowHeight * (row.data.length + headerCount); // TODO this probably isn't very robust
-          }
-          return getRowHeight(
-            row,
-            columnTypes,
-            headerCellRefs,
-            osContext,
-            defaultLineHeight,
-            defaultRowHeight,
-            DEFAULT_CELL_PADDING,
-            textWrap
-          );
-        }}
+        rowHeight={(row) => (textWrap ? calculateRowHeight(row) : defaultRowHeight)}
         // TODO: This doesn't follow current table behavior
         style={{ width, height }}
         renderers={{ renderRow: myRowRenderer }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -543,7 +543,7 @@ export function TableNG(props: TableNGProps) {
           sortable: true,
           resizable: true,
         }}
-        rowHeight={(row) => (textWrap ? calculateRowHeight(row) : defaultRowHeight)}
+        rowHeight={!textWrap ? defaultRowHeight : (row) => calculateRowHeight(row)}
         // TODO: This doesn't follow current table behavior
         style={{ width, height }}
         renderers={{ renderRow: myRowRenderer }}

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -63,6 +63,10 @@ export function getCellHeight(
   return defaultRowHeight;
 }
 
+/**
+ * getRowHeight determines cell height based on cell width + text length. Used
+ * for when textWrap is enabled.
+ */
 export function getRowHeight(
   row: Record<string, string>,
   columnTypes: Record<string, string>,
@@ -70,12 +74,8 @@ export function getRowHeight(
   osContext: OffscreenCanvasRenderingContext2D | null,
   lineHeight: number,
   defaultRowHeight: number,
-  padding: number,
-  textWrap: boolean
+  padding: number
 ): number {
-  if (!textWrap) {
-    return defaultRowHeight;
-  }
   /**
    * 0. loop through all cells in row
    * 1. find text cell in row


### PR DESCRIPTION
### What does this PR do? 📓 

Conditionally calls `calculateRowHeight`, which is now a `useCallback`. Putting the config logic upfront to check for `textWrap` before entering the callback _should_ help with performance. Since we're doing the logic check upfront, we can remove the `textWrap` IF statement in the function.

Fixes #99624

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
