### PR TITLE
Dashboards: Remove `schemaVersion < min_version` validation

### DIFF
--- a/pkg/apis/dashboard/migration/migrate.go
+++ b/pkg/apis/dashboard/migration/migrate.go
@@ -9,10 +9,6 @@ func Migrate(dash map[string]interface{}, targetVersion int) error {
 	inputVersion := schemaversion.GetSchemaVersion(dash)
 	dash["schemaVersion"] = inputVersion
 
-	if inputVersion < schemaversion.MINIUM_VERSION {
-		return schemaversion.NewMinimumVersionError(inputVersion)
-	}
-
 	for nextVersion := inputVersion + 1; nextVersion <= targetVersion; nextVersion++ {
 		if migration, ok := schemaversion.Migrations[nextVersion]; ok {
 			if err := migration(dash); err != nil {

--- a/pkg/apis/dashboard/migration/migrate_test.go
+++ b/pkg/apis/dashboard/migration/migrate_test.go
@@ -22,15 +22,6 @@ func TestMigrate(t *testing.T) {
 	files, err := os.ReadDir(INPUT_DIR)
 	require.NoError(t, err)
 
-	t.Run("minimum version check", func(t *testing.T) {
-		err := migration.Migrate(map[string]interface{}{
-			"schemaVersion": schemaversion.MINIUM_VERSION - 1,
-		}, schemaversion.MINIUM_VERSION)
-
-		var minVersionErr = schemaversion.NewMinimumVersionError(schemaversion.MINIUM_VERSION - 1)
-		require.ErrorAs(t, err, &minVersionErr)
-	})
-
 	for _, f := range files {
 		if f.IsDir() {
 			continue

--- a/pkg/apis/dashboard/migration/schemaversion/errors.go
+++ b/pkg/apis/dashboard/migration/schemaversion/errors.go
@@ -2,22 +2,7 @@ package schemaversion
 
 import "fmt"
 
-var _ error = &MinimumVersionError{}
 var _ error = &MigrationError{}
-
-// MinimumVersionError is an error that is returned when the schema version is below the minimum version.
-func NewMinimumVersionError(inputVersion int) *MinimumVersionError {
-	return &MinimumVersionError{inputVersion: inputVersion}
-}
-
-// MinimumVersionError is an error type for minimum version errors.
-type MinimumVersionError struct {
-	inputVersion int
-}
-
-func (e *MinimumVersionError) Error() string {
-	return fmt.Errorf("input schema version is below minimum version. input: %d minimum: %d", e.inputVersion, MINIUM_VERSION).Error()
-}
 
 // ErrMigrationFailed is an error that is returned when a migration fails.
 func NewMigrationError(msg string, currentVersion, targetVersion int) *MigrationError {

--- a/pkg/apis/dashboard/migration/schemaversion/migrations.go
+++ b/pkg/apis/dashboard/migration/schemaversion/migrations.go
@@ -4,10 +4,7 @@ import "strconv"
 
 type SchemaVersionMigrationFunc func(map[string]interface{}) error
 
-const (
-	MINIUM_VERSION = 36
-	LATEST_VERSION = 40
-)
+const LATEST_VERSION = 40
 
 var Migrations = map[int]SchemaVersionMigrationFunc{
 	37: V37,

--- a/pkg/apis/dashboard/v1alpha1/conversion.go
+++ b/pkg/apis/dashboard/v1alpha1/conversion.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"errors"
-
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	klog "k8s.io/klog/v2"
 
@@ -15,12 +13,7 @@ func Convert_v0alpha1_Unstructured_To_v1alpha1_DashboardSpec(in *common.Unstruct
 	out.Unstructured = *in
 	err := migration.Migrate(out.Unstructured.Object, schemaversion.LATEST_VERSION)
 	if err != nil {
-		minErr := &schemaversion.MinimumVersionError{}
-		if errors.As(err, &minErr) {
-			out.Unstructured.Object["__migrationError"] = err.Error()
-		} else {
-			return err
-		}
+		return err
 	}
 
 	t, ok := out.Unstructured.Object["title"].(string)

--- a/pkg/apis/dashboard/v2alpha1/conversion.go
+++ b/pkg/apis/dashboard/v2alpha1/conversion.go
@@ -1,8 +1,6 @@
 package v2alpha1
 
 import (
-	"errors"
-
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	klog "k8s.io/klog/v2"
 
@@ -15,12 +13,7 @@ func Convert_v0alpha1_Unstructured_To_v2alpha1_DashboardSpec(in *common.Unstruct
 	out.Unstructured = *in
 	err := migration.Migrate(out.Unstructured.Object, schemaversion.LATEST_VERSION)
 	if err != nil {
-		minErr := &schemaversion.MinimumVersionError{}
-		if errors.As(err, &minErr) {
-			out.Unstructured.Object["__migrationError"] = err.Error()
-		} else {
-			return err
-		}
+		return err
 	}
 
 	t, ok := out.Unstructured.Object["title"].(string)


### PR DESCRIPTION
The current logic was checking if the stored dashboard was lower than a min_version. That min version reflected the oldest version we were able to migrate.

Because we saw that many dashboards are older than 37, and some don't even have the property, we decided to remove that check to run all the migrations possible. We will make our best effort to make everything as close as possible to a valid Schema v1 dashboard.

This is just the first step towards supporting most front-end migrations except the ones with limitations: instantiating plugins.