### PR TITLE
TableNG: Get collapsed icon state correct + update `rowHeight`

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -137,6 +137,7 @@ export function TableNG(props: TableNGProps) {
   // setSortColumns is still used to trigger re-render
   const sortColumnsRef = useRef(sortColumns);
   const [expandedRows, setExpandedRows] = useState<number[]>([]);
+  const [isNestedTable, setIsNestedTable] = useState(false);
 
   function getDefaultRowHeight(): number {
     const bodyFontSize = theme.typography.fontSize;
@@ -486,8 +487,16 @@ export function TableNG(props: TableNGProps) {
 
   const columns = useMemo(
     () => mapFrameToDataGrid(props.data, calcsRef),
-    [props.data, calcsRef, filter, expandedRows, footerOptions] // eslint-disable-line react-hooks/exhaustive-deps
+    [props.data, calcsRef, filter, expandedRows, expandedRows.length, footerOptions] // eslint-disable-line react-hooks/exhaustive-deps
   );
+
+  useEffect(() => {
+    const nestedDataField = props.data.fields.find(({ type }) => type === FieldType.nestedFrames);
+    const hasNestedData = nestedDataField !== undefined;
+    if (hasNestedData) {
+      setIsNestedTable(true);
+    }
+  }, [props.data.fields]);
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {
@@ -543,7 +552,7 @@ export function TableNG(props: TableNGProps) {
           sortable: true,
           resizable: true,
         }}
-        rowHeight={textWrap ? calculateRowHeight : defaultRowHeight}
+        rowHeight={textWrap || isNestedTable ? calculateRowHeight : defaultRowHeight}
         // TODO: This doesn't follow current table behavior
         style={{ width, height }}
         renderers={{ renderRow: myRowRenderer }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -45,6 +45,13 @@ export type FilterType = {
   };
 };
 
+/**
+ * getIsNestedTable is a helper function that takes a DataFrame and returns a
+ * boolean value based on the presence of nested frames
+ */
+const getIsNestedTable = (dataFrame: DataFrame): boolean =>
+  dataFrame.fields.some(({ type }) => type === FieldType.nestedFrames);
+
 export function TableNG(props: TableNGProps) {
   const { height, width, timeRange, cellHeight, noHeader, fieldConfig, footerOptions, onColumnResize } = props;
 
@@ -210,12 +217,10 @@ export function TableNG(props: TableNGProps) {
   const mapFrameToDataGrid = (main: DataFrame, calcsRef: React.MutableRefObject<string[]>, subTable?: boolean) => {
     const columns: TableColumn[] = [];
 
-    // Check for nestedFrames
-    const nestedDataField = main.fields.find((f) => f.type === FieldType.nestedFrames);
-    const hasNestedData = nestedDataField !== undefined;
+    const isNestedTable = getIsNestedTable(main);
 
     // If nested frames, add expansion control column
-    if (hasNestedData) {
+    if (isNestedTable) {
       const expanderField: Field = {
         name: '',
         type: FieldType.other,
@@ -491,12 +496,9 @@ export function TableNG(props: TableNGProps) {
   );
 
   useEffect(() => {
-    const nestedDataField = props.data.fields.find(({ type }) => type === FieldType.nestedFrames);
-    const hasNestedData = nestedDataField !== undefined;
-    if (hasNestedData) {
-      setIsNestedTable(true);
-    }
-  }, [props.data.fields]);
+    const isNestedTable = getIsNestedTable(props.data);
+    setIsNestedTable(isNestedTable);
+  }, [props.data]);
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -217,10 +217,10 @@ export function TableNG(props: TableNGProps) {
   const mapFrameToDataGrid = (main: DataFrame, calcsRef: React.MutableRefObject<string[]>, subTable?: boolean) => {
     const columns: TableColumn[] = [];
 
-    const isNestedTable = getIsNestedTable(main);
+    const hasNestedFrames = getIsNestedTable(main);
 
     // If nested frames, add expansion control column
-    if (isNestedTable) {
+    if (hasNestedFrames) {
       const expanderField: Field = {
         name: '',
         type: FieldType.other,
@@ -496,8 +496,8 @@ export function TableNG(props: TableNGProps) {
   );
 
   useEffect(() => {
-    const isNestedTable = getIsNestedTable(props.data);
-    setIsNestedTable(isNestedTable);
+    const hasNestedFrames = getIsNestedTable(props.data);
+    setIsNestedTable(hasNestedFrames);
   }, [props.data]);
 
   // This effect needed to set header cells refs before row height calculation


### PR DESCRIPTION
### What does this PR do? 📓 

My last PR (https://github.com/grafana/grafana/pull/100544) introduced a regression for nested tables. We _also_ need to calculate the cell height for nested tables, not just when `textWrap` is toggled on. The fix is this (plus also a new local state variable for `isNestedTable` which could be useful) ➡️ 

``` typescript
rowHeight={textWrap || isNestedTable ? calculateRowHeight : defaultRowHeight}
```

However, the primary goal of this PR is to fix the nested table caret icon indicating collapsed/expanded state. The fix for this (it's a hack) is to add `expandedRows.length` to the `useMemo` dependency array when calculating columns. I still think the best approach to this is this other PR I have open here https://github.com/grafana/grafana/pull/100088.

#### Demo 🎥 

https://github.com/user-attachments/assets/e8654c01-c0f6-4d86-965a-61ac7aab8f66

Fixes #99808

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
