### PR TITLE
K8s/Utils: Find title in unstructured content

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -699,6 +699,18 @@ func (m *grafanaMetaAccessor) FindTitle(defaultTitle string) string {
 		}
 	}
 
+	obj, ok := m.obj.(*unstructured.Unstructured)
+	if ok {
+		title, ok, _ := unstructured.NestedString(obj.Object, "spec", "title")
+		if ok && title != "" {
+			return title
+		}
+		title, ok, _ = unstructured.NestedString(obj.Object, "spec", "name")
+		if ok && title != "" {
+			return title
+		}
+	}
+
 	title := m.r.FieldByName("Title")
 	if title.IsValid() && title.Kind() == reflect.String {
 		return title.String()

--- a/pkg/apimachinery/utils/meta_test.go
+++ b/pkg/apimachinery/utils/meta_test.go
@@ -194,6 +194,7 @@ func TestMetaAccessor(t *testing.T) {
 		res.Object = map[string]any{
 			"spec": map[string]any{
 				"hello": "world",
+				"title": "Title",
 			},
 			"status": map[string]any{
 				"sloth": "🦥",
@@ -218,6 +219,7 @@ func TestMetaAccessor(t *testing.T) {
 		rv, err := meta.GetResourceVersionInt64()
 		require.NoError(t, err)
 		require.Equal(t, int64(12345), rv)
+		require.Equal(t, "Title", meta.FindTitle(""))
 
 		// Make sure access to spec works for Unstructured
 		spec, err = meta.GetSpec()


### PR DESCRIPTION
For https://github.com/grafana/grafana/pull/96329 we need to get the title from an unstructured response -- currently it does not work