### PR TITLE
ImportDashboardForm: Add more meaningful error message for Editor user

### DIFF
--- a/public/app/features/manage-dashboards/utils/validation.ts
+++ b/public/app/features/manage-dashboards/utils/validation.ts
@@ -53,6 +53,12 @@ export const validateUid = (value: string) => {
     })
     .catch((error) => {
       error.isHandled = true;
+
+      // when Editor user tries to import admin only dashboard (with same uid) he gets an unhelpful 403 error
+      //  therefore handling this use case to return some indication of whats wrong
+      if (error.status === 403) {
+        return 'Dashboard with the same UID already exists';
+      }
       return true;
     });
 };


### PR DESCRIPTION
Part fix for https://github.com/grafana/support-escalations/issues/14247

Issue:
When Editor user tries to import a dashboard that is already saved and has only Admin permission we get an unhelpful 403 error on UID validation. Adding a special condition to display some indication of what is wrong.

more of a quick fix while we have our hands full with other work