### PR TITLE
[release-11.4.2] AuthN: Refetch user on "ErrUserAlreadyExists"

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/authlib/claims"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -445,6 +446,35 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 			require.EqualValues(t, tt.wantID, tt.args.id)
 		})
 	}
+}
+
+func TestUserSync_SyncUserRetryFetch(t *testing.T) {
+	userSrv := usertest.NewMockService(t)
+	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
+	userSrv.On("Create", mock.Anything, mock.Anything).Return(nil, user.ErrUserAlreadyExists).Once()
+	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(&user.User{ID: 1}, nil).Once()
+
+	s := ProvideUserSync(
+		userSrv,
+		authinfoimpl.ProvideOSSUserProtectionService(),
+		&authinfotest.FakeService{},
+		&quotatest.FakeQuotaService{},
+		tracing.NewNoopTracerService(),
+		featuremgmt.WithFeatures(),
+	)
+
+	email := "test@test.com"
+
+	err := s.SyncUserHook(context.Background(), &authn.Identity{
+		ClientParams: authn.ClientParams{
+			SyncUser:    true,
+			AllowSignUp: true,
+			LookUpParams: login.UserLookupParams{
+				Email: &email,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
 }
 
 func TestUserSync_FetchSyncedUserHook(t *testing.T) {

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -460,7 +460,6 @@ func TestUserSync_SyncUserRetryFetch(t *testing.T) {
 		&authinfotest.FakeService{},
 		&quotatest.FakeQuotaService{},
 		tracing.NewNoopTracerService(),
-		featuremgmt.WithFeatures(),
 	)
 
 	email := "test@test.com"


### PR DESCRIPTION
Backport 0b4c622df8e3796d02b714f7d261215e23178eb6 from #100346 

 ---
 
 **What is this feature?**
 We have a potential race condition during `SyncUserHook`. For most clients this is a none issue but for something like auth proxy it happens regularly.
 
 To solve the issue we try to fetch the user again if we get `user.ErrUserAlreadyExists`. This should be safe because we fetch with the same params we do in the first call. 
 
 **Which issue(s) does this PR fix?**:
 Fixes #
 
 **Special notes for your reviewer:**
 
 Please check that:
 - [ ] It works as expected from a user's perspective.
 - [ ] If this is a pre-GA feature, it is behind a feature toggle.
 - [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
