### PR TITLE
PluginExtensions: Exposing registry meta for components returned via `usePluginComponents`

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -548,6 +548,7 @@ export {
   type PluginExtension,
   type PluginExtensionLink,
   type PluginExtensionComponent,
+  type PluginExtensionComponentMeta,
   type PluginExtensionConfig,
   type PluginExtensionFunction,
   type PluginExtensionLinkConfig,

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -32,6 +32,8 @@ export type PluginExtensionLink = PluginExtensionBase & {
   category?: string;
 };
 
+export type PluginExtensionComponentMeta = Omit<PluginExtensionComponent, 'component'>;
+
 export type PluginExtensionComponent<Props = {}> = PluginExtensionBase & {
   type: PluginExtensionTypes.component;
   component: React.ComponentType<Props>;

--- a/packages/grafana-runtime/src/services/pluginExtensions/getPluginExtensions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getPluginExtensions.ts
@@ -3,6 +3,7 @@ import type {
   PluginExtensionLink,
   PluginExtensionComponent,
   PluginExtensionFunction,
+  PluginExtensionComponentMeta,
 } from '@grafana/data';
 
 import { isPluginExtensionComponent, isPluginExtensionLink } from './utils';
@@ -42,7 +43,7 @@ export type UsePluginComponentResult<Props = {}> = {
 };
 
 export type UsePluginComponentsResult<Props = {}> = {
-  components: Array<React.ComponentType<Props>>;
+  components: Array<React.ComponentType<Props> & { meta: PluginExtensionComponentMeta }>;
   isLoading: boolean;
 };
 

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -159,6 +159,50 @@ describe('usePluginComponents()', () => {
     expect(screen.queryByText('Hello World3')).toBeNull();
   });
 
+  it('should return component with meta information attached to it', async () => {
+    registries.addedComponentsRegistry.register({
+      pluginId,
+      configs: [
+        {
+          targets: extensionPointId,
+          title: '1',
+          description: '1',
+          component: () => <div>Hello World1</div>,
+        },
+        {
+          targets: extensionPointId,
+          title: '2',
+          description: '2',
+          component: () => <div>Hello World2</div>,
+        },
+        {
+          targets: 'plugins/another-extension/v1',
+          title: '3',
+          description: '3',
+          component: () => <div>Hello World3</div>,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => usePluginComponents({ extensionPointId }), { wrapper });
+
+    expect(result.current.components.length).toBe(2);
+    expect(result.current.components[0].meta).toEqual({
+      pluginId,
+      title: '1',
+      description: '1',
+      id: '-1921123020',
+      type: 'component',
+    });
+    expect(result.current.components[1].meta).toEqual({
+      pluginId,
+      title: '2',
+      description: '2',
+      id: '-1921123019',
+      type: 'component',
+    });
+  });
+
   it('should dynamically update the extensions registered for a certain extension point', () => {
     let { result, rerender } = renderHook(() => usePluginComponents({ extensionPointId }), { wrapper });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When we created the new reactive APIs we missed providing the registry `configuration` information for components that used to be exposed when fetching components via `getPluginComponents`.

**Why do we need this feature?**

Most scenarios you never need that meta information but there are a couple of valid use cases where you want to group components based on plugin id or some other meta information.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #94132

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
