### PR TITLE
IDToken: cache invalidation

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -207,7 +207,6 @@ type HTTPServer struct {
 	tempUserService      tempUser.Service
 	loginAttemptService  loginAttempt.Service
 	orgService           org.Service
-	idService            auth.IDService
 	orgDeletionService   org.DeletionService
 	TeamService          team.Service
 	accesscontrolService accesscontrol.Service
@@ -273,7 +272,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	annotationRepo annotations.Repository, tagService tag.Service, searchv2HTTPService searchV2.SearchHTTPService, oauthTokenService oauthtoken.OAuthTokenService,
 	statsService stats.Service, authnService authn.Service, pluginsCDNService *pluginscdn.Service, promGatherer prometheus.Gatherer,
 	starApi *starApi.API, promRegister prometheus.Registerer, clientConfigProvider grafanaapiserver.DirectRestConfigProvider, anonService anonymous.Service,
-	userVerifier user.Verifier, pluginPreinstall plugininstaller.Preinstall, idService auth.IDService,
+	userVerifier user.Verifier, pluginPreinstall plugininstaller.Preinstall,
 ) (*HTTPServer, error) {
 	web.Env = cfg.Env
 	m := web.New()
@@ -361,7 +360,6 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		tempUserService:              tempUserService,
 		loginAttemptService:          loginAttemptService,
 		orgService:                   orgService,
-		idService:                    idService,
 		orgDeletionService:           orgDeletionService,
 		TeamService:                  teamService,
 		navTreeService:               navTreeService,

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -7,11 +7,9 @@ import (
 	"net/http"
 	"strconv"
 
-	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/authn"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -432,10 +430,6 @@ func (hs *HTTPServer) updateOrgUserHelper(c *contextmodel.ReqContext, cmd org.Up
 		if hs.isExternallySynced(hs.Cfg, authInfo.AuthModule) {
 			return response.Err(org.ErrCannotChangeRoleForExternallySyncedUser.Errorf("Cannot change role for externally synced user"))
 		}
-	}
-
-	if err := hs.idService.RemoveIDToken(c.Req.Context(), &authn.Identity{ID: strconv.FormatInt(cmd.UserID, 10), Type: claims.TypeUser, OrgID: cmd.OrgID}); err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to invalidate the ID token cache", err)
 	}
 
 	if err := hs.orgService.UpdateOrgUser(c.Req.Context(), &cmd); err != nil {

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -9,12 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/services/auth/idtest"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -205,12 +202,11 @@ func TestOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 
 func TestOrgUsersAPIEndpoint_updateOrgRole(t *testing.T) {
 	type testCase struct {
-		desc                    string
-		SkipOrgRoleSync         bool
-		AuthEnabled             bool
-		AuthModule              string
-		shouldInvalidateIDToken bool
-		expectedCode            int
+		desc            string
+		SkipOrgRoleSync bool
+		AuthEnabled     bool
+		AuthModule      string
+		expectedCode    int
 	}
 	permissions := []accesscontrol.Permission{
 		{Action: accesscontrol.ActionOrgUsersRead, Scope: "users:*"},
@@ -220,12 +216,11 @@ func TestOrgUsersAPIEndpoint_updateOrgRole(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			desc:                    "should be able to change basicRole when skip_org_role_sync true",
-			SkipOrgRoleSync:         true,
-			AuthEnabled:             true,
-			AuthModule:              login.LDAPAuthModule,
-			shouldInvalidateIDToken: true,
-			expectedCode:            http.StatusOK,
+			desc:            "should be able to change basicRole when skip_org_role_sync true",
+			SkipOrgRoleSync: true,
+			AuthEnabled:     true,
+			AuthModule:      login.LDAPAuthModule,
+			expectedCode:    http.StatusOK,
 		},
 		{
 			desc:            "should not be able to change basicRole when skip_org_role_sync false",
@@ -242,20 +237,18 @@ func TestOrgUsersAPIEndpoint_updateOrgRole(t *testing.T) {
 			expectedCode:    http.StatusForbidden,
 		},
 		{
-			desc:                    "should be able to change basicRole with a basic Auth",
-			SkipOrgRoleSync:         false,
-			AuthEnabled:             false,
-			AuthModule:              "",
-			shouldInvalidateIDToken: true,
-			expectedCode:            http.StatusOK,
+			desc:            "should be able to change basicRole with a basic Auth",
+			SkipOrgRoleSync: false,
+			AuthEnabled:     false,
+			AuthModule:      "",
+			expectedCode:    http.StatusOK,
 		},
 		{
-			desc:                    "should be able to change basicRole with a basic Auth",
-			SkipOrgRoleSync:         true,
-			AuthEnabled:             true,
-			AuthModule:              "",
-			shouldInvalidateIDToken: true,
-			expectedCode:            http.StatusOK,
+			desc:            "should be able to change basicRole with a basic Auth",
+			SkipOrgRoleSync: true,
+			AuthEnabled:     true,
+			AuthModule:      "",
+			expectedCode:    http.StatusOK,
 		},
 	}
 
@@ -286,11 +279,6 @@ func TestOrgUsersAPIEndpoint_updateOrgRole(t *testing.T) {
 				}
 				hs.userService = &usertest.FakeUserService{ExpectedSignedInUser: userWithPermissions}
 				hs.orgService = &orgtest.FakeOrgService{}
-				idService := &idtest.MockService{}
-				if tt.shouldInvalidateIDToken {
-					idService.On("RemoveIDToken", mock.Anything, mock.Anything).Return(nil)
-				}
-				hs.idService = idService
 				hs.SocialService = &socialtest.FakeSocialService{
 					ExpectedAuthInfoProvider: &social.OAuthInfo{Enabled: tt.AuthEnabled, SkipOrgRoleSync: tt.SkipOrgRoleSync},
 				}
@@ -627,7 +615,6 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 					ExpectedUser:         &user.User{},
 					ExpectedSignedInUser: userWithPermissions(1, tt.permissions),
 				}
-				hs.idService = &idtest.FakeService{}
 				hs.accesscontrolService = &actest.FakeService{}
 			})
 
@@ -650,24 +637,16 @@ func TestPatchOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 		name         string
 		role         org.RoleType
 		permissions  []accesscontrol.Permission
-		setup        func(*testing.T, *idtest.MockService)
 		input        string
 		expectedCode int
 	}
 
 	tests := []testCase{
 		{
-			name:        "user with permissions can update org role",
-			permissions: []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: "users:*"}},
-			role:        org.RoleAdmin,
-			input:       `{"role": "Viewer"}`,
-			setup: func(t *testing.T, idService *idtest.MockService) {
-				idService.On("RemoveIDToken", mock.Anything, mock.MatchedBy(func(id *authn.Identity) bool {
-					return id.GetIdentityType() == types.TypeUser &&
-						id.GetID() == "user:1" &&
-						id.GetOrgID() == int64(1)
-				})).Return(nil)
-			},
+			name:         "user with permissions can update org role",
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: "users:*"}},
+			role:         org.RoleAdmin,
+			input:        `{"role": "Viewer"}`,
 			expectedCode: http.StatusOK,
 		},
 		{
@@ -694,11 +673,6 @@ func TestPatchOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 						AuthModule: "",
 					},
 				}
-				idService := &idtest.MockService{}
-				if tt.setup != nil {
-					tt.setup(t, idService)
-				}
-				hs.idService = idService
 				hs.accesscontrolService = &actest.FakeService{}
 				hs.userService = &usertest.FakeUserService{
 					ExpectedUser:         &user.User{},

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -63,7 +63,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		s.metrics.tokenSigningDurationHistogram.Observe(time.Since(t).Seconds())
 	}(time.Now())
 
-	cacheKey := prefixCacheKey(id.GetCacheKey())
+	cacheKey := getCacheKey(id)
 
 	type resultType struct {
 		token    string
@@ -140,7 +140,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 }
 
 func (s *Service) RemoveIDToken(ctx context.Context, id identity.Requester) error {
-	return s.cache.Delete(ctx, prefixCacheKey(id.GetCacheKey()))
+	return s.cache.Delete(ctx, getCacheKey(id))
 }
 
 func (s *Service) hook(ctx context.Context, identity *authn.Identity, _ *authn.Request) error {
@@ -181,8 +181,8 @@ func getAudience(orgID int64) jwt.Audience {
 	return jwt.Audience{fmt.Sprintf("org:%d", orgID)}
 }
 
-func prefixCacheKey(key string) string {
-	return fmt.Sprintf("%s-%s", cachePrefix, key)
+func getCacheKey(ident identity.Requester) string {
+	return cachePrefix + ident.GetCacheKey() + string(ident.GetOrgRole())
 }
 
 func shouldLogErr(err error) bool {

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -101,4 +102,34 @@ func TestService_SignIdentity(t *testing.T) {
 		assert.Equal(t, claims.TypeUser, gotClaims.Rest.Type)
 		assert.Equal(t, "edpu3nnt61se8e", gotClaims.Rest.Identifier)
 	})
+
+	t.Run("should sign new token if org role has changed", func(t *testing.T) {
+		s := ProvideService(
+			setting.NewCfg(), signer, remotecache.NewFakeCacheStorage(),
+			&authntest.FakeService{}, nil,
+		)
+
+		ident := &authn.Identity{
+			ID:              "1",
+			Type:            claims.TypeUser,
+			AuthenticatedBy: login.AzureADAuthModule,
+			Login:           "U1",
+			UID:             "edpu3nnt61se8e",
+			OrgID:           1,
+			OrgRoles:        map[int64]org.RoleType{1: org.RoleAdmin},
+		}
+
+		first, _, err := s.SignIdentity(context.Background(), ident)
+		require.NoError(t, err)
+
+		second, _, err := s.SignIdentity(context.Background(), ident)
+		require.NoError(t, err)
+
+		assert.Equal(t, first, second)
+
+		ident.OrgRoles[1] = org.RoleEditor
+		third, _, err := s.SignIdentity(context.Background(), ident)
+		assert.NotEqual(t, first, third)
+	})
+
 }

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -129,6 +129,7 @@ func TestService_SignIdentity(t *testing.T) {
 
 		ident.OrgRoles[1] = org.RoleEditor
 		third, _, err := s.SignIdentity(context.Background(), ident)
+		require.NoError(t, err)
 		assert.NotEqual(t, first, third)
 	})
 

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -132,5 +132,4 @@ func TestService_SignIdentity(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, first, third)
 	})
-
 }


### PR DESCRIPTION
**What is this feature?**
Instead if doing explicit calls to remove cached id tokens when org role changes we can use the role as part of the cache key. Then if the org role changes we will sign a new one because its no found in the cache.

Follow up to https://github.com/grafana/grafana/pull/100383

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
