### PR TITLE
Unified Storage: Register metrics

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	onceIndex             sync.Once
+	onceSprinkles         sync.Once
 	IndexMetrics          *BleveIndexMetrics
 	SprinklesIndexMetrics *SprinklesMetrics
 )
@@ -36,7 +37,7 @@ type SprinklesMetrics struct {
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
 
 func NewSprinklesMetrics() *SprinklesMetrics {
-	onceIndex.Do(func() {
+	onceSprinkles.Do(func() {
 		SprinklesIndexMetrics = &SprinklesMetrics{
 			SprinklesLatency: prometheus.NewHistogram(prometheus.HistogramOpts{
 				Namespace:                       "index_server",


### PR DESCRIPTION
**What is this feature?**
In https://github.com/grafana/grafana/pull/100542 some new metrics was added. It by mistake uses `onceIndex` preventing us from creating this structure. This causes a panic when it tried to register them.

At least I cannot start grafana with `unifiedStorageSearch` feature toggle without this panic

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
