### PR TITLE
AuthN: No longer authenticate api keys that are not attached to a service account

### DIFF
--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -23,8 +23,6 @@ var (
 	errAPIKeyExpired     = errutil.Unauthorized("api-key.expired", errutil.WithPublicMessage("Expired API key"))
 	errAPIKeyRevoked     = errutil.Unauthorized("api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
 	errAPIKeyOrgMismatch = errutil.Unauthorized("api-key.organization-mismatch", errutil.WithPublicMessage("API key does not belong to the requested organization"))
-
-	errAPIKeyInvalidType = errutil.BadRequest("api-key.invalid-type-id")
 )
 
 var (


### PR DESCRIPTION
**What is this feature?**
We should no longer authenticate api keys that are not attached to service account. It would be great to get rid of this identity type now that we no longer support them so there is a bunch of stuff we can clean up


**Which issue(s) does this PR fix?**:
Part of https://github.com/grafana/grafana/issues/53567

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
