### PR TITLE
[release-11.4.2] Dashboards: Fix repeats not being added on refresh when using searchLayout

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import classNames from 'classnames';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneGridRow, VizPanel, sceneGraph } from '@grafana/scenes';
@@ -12,6 +12,7 @@ import { forceActivateFullSceneObjectTree } from '../utils/utils';
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { DashboardRepeatsProcessedEvent } from './types/DashboardRepeatsProcessedEvent';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -25,6 +26,7 @@ export function PanelSearchLayout({ dashboard, panelSearch = '', panelsPerRow }:
   const { body } = dashboard.state;
   const filteredPanels: VizPanel[] = [];
   const styles = useStyles2(getStyles);
+  const [_, setRepeatsUpdated] = useState('');
 
   const bodyGrid = body instanceof DefaultGridLayoutManager ? body.state.grid : null;
 
@@ -34,11 +36,11 @@ export function PanelSearchLayout({ dashboard, panelSearch = '', panelsPerRow }:
 
   for (const gridItem of bodyGrid.state.children) {
     if (gridItem instanceof DashboardGridItem) {
-      filterPanels(gridItem, dashboard, panelSearch, filteredPanels);
+      filterPanels(gridItem, dashboard, panelSearch, filteredPanels, setRepeatsUpdated);
     } else if (gridItem instanceof SceneGridRow) {
       for (const rowItem of gridItem.state.children) {
         if (rowItem instanceof DashboardGridItem) {
-          filterPanels(rowItem, dashboard, panelSearch, filteredPanels);
+          filterPanels(rowItem, dashboard, panelSearch, filteredPanels, setRepeatsUpdated);
         }
       }
     }
@@ -98,7 +100,8 @@ function filterPanels(
   gridItem: DashboardGridItem,
   dashboard: DashboardScene,
   searchString: string,
-  filteredPanels: VizPanel[]
+  filteredPanels: VizPanel[],
+  setRepeatsUpdated: (updated: string) => void
 ) {
   const interpolatedSearchString = sceneGraph.interpolate(dashboard, searchString).toLowerCase();
 
@@ -107,6 +110,12 @@ function filterPanels(
     const panel = gridItem.state.body;
     const interpolatedTitle = panel.interpolate(panel.state.title, undefined, 'text').toLowerCase();
     if (interpolatedTitle.includes(interpolatedSearchString)) {
+      gridItem.subscribeToEvent(DashboardRepeatsProcessedEvent, (event) => {
+        const source = event.payload.source;
+        if (source instanceof DashboardGridItem) {
+          setRepeatsUpdated(event.payload.source.state.key ?? '');
+        }
+      });
       gridItem.activate();
     }
   }

--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -12,7 +12,7 @@ import { forceActivateFullSceneObjectTree } from '../utils/utils';
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-import { DashboardRepeatsProcessedEvent } from './types/DashboardRepeatsProcessedEvent';
+import { DashboardRepeatsProcessedEvent } from './types';
 
 export interface Props {
   dashboard: DashboardScene;


### PR DESCRIPTION
Backport 1018aec6bcd0be36f9de4efda325fe189f28ccd3 from #100621

---

When using the searchLayout repeated panels are not added on refresh if they are repeated on a variable that takes a while to load.

When we first load the searchLayout we add all the panels that match the search criteria to the grid. We also add repeated panels. If a panel is repeated on a variable that has not yet loaded, the function that creates the repeats will return early and be triggered again when the variable has loaded. The problem is that by then it's to late, the panels have all been added already.

This fix makes sure we update the searchLayout again after repeats have been processed.

A dashboard json to replicate the issue, it uses postgres devenv (start with make devenv sources=postgres)

```
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 1,
  "id": 635,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "description": "",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [
            "mean",
            "min",
            "max",
            "lastNotNull"
          ],
          "displayMode": "table",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "11.6.0-pre",
      "repeat": "splitByFabric",
      "repeatDirection": "h",
      "targets": [
        {
          "refId": "A"
        }
      ],
      "title": "[${splitByFabric}] Node count - voyager-api-feed",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "description": "",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "maxPerRow": 4,
      "options": {
        "legend": {
          "calcs": [
            "mean",
            "min",
            "max",
            "lastNotNull"
          ],
          "displayMode": "table",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "11.6.0-pre",
      "repeat": "copy_of_splitByFabric",
      "repeatDirection": "h",
      "targets": [
        {
          "refId": "A"
        }
      ],
      "title": "[${copy_of_splitByFabric}] Node count - voyager-api-feed",
      "type": "timeseries"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "text": [
            "Jan",
            "Feb"
          ],
          "value": [
            "Jan",
            "Feb"
          ]
        },
        "datasource": {
          "type": "grafana-postgresql-datasource",
          "uid": "PBBCEC2D313BC06C3"
        },
        "definition": "SELECT 'Jan' AS Qtr1, 'Apr' AS Qtr2\nUNION ALL SELECT 'Feb' AS Qtr1, 'May' AS Qtr2\nUNION ALL SELECT 'Mar' AS Qtr1, 'Jun' AS Qtr2",
        "label": "query 1",
        "multi": true,
        "name": "splitByFabric",
        "options": [],
        "query": "SELECT 'Jan' AS Qtr1, 'Apr' AS Qtr2\nUNION ALL SELECT 'Feb' AS Qtr1, 'May' AS Qtr2\nUNION ALL SELECT 'Mar' AS Qtr1, 'Jun' AS Qtr2",
        "refresh": 1,
        "regex": "",
        "type": "query"
      },
      {
        "current": {
          "text": [
            "Mar",
            "Feb",
            "Apr"
          ],
          "value": [
            "Mar",
            "Feb",
            "Apr"
          ]
        },
        "datasource": {
          "type": "grafana-postgresql-datasource",
          "uid": "PBBCEC2D313BC06C3"
        },
        "definition": "SELECT 'Jan' AS Qtr1, 'Apr' AS Qtr2\nUNION ALL SELECT 'Feb' AS Qtr1, 'May' AS Qtr2\nUNION ALL SELECT 'Mar' AS Qtr1, 'Jun' AS Qtr2",
        "label": "Query 2",
        "multi": true,
        "name": "copy_of_splitByFabric",
        "options": [],
        "query": "SELECT 'Jan' AS Qtr1, 'Apr' AS Qtr2\nUNION ALL SELECT 'Feb' AS Qtr1, 'May' AS Qtr2\nUNION ALL SELECT 'Mar' AS Qtr1, 'Jun' AS Qtr2",
        "refresh": 1,
        "regex": "",
        "type": "query"
      },
      {
        "current": {
          "text": "3",
          "value": "3"
        },
        "description": "Select how many columns per row to resize the panels to",
        "includeAll": false,
        "label": "Resize",
        "name": "systemDynamicRowSizeVar",
        "options": [
          {
            "selected": false,
            "text": "1",
            "value": "1"
          },
          {
            "selected": false,
            "text": "2",
            "value": "2"
          },
          {
            "selected": true,
            "text": "3",
            "value": "3"
          },
          {
            "selected": false,
            "text": "4",
            "value": "4"
          }
        ],
        "query": "1,2,3,4",
        "type": "custom"
      },
      {
        "current": {
          "text": "api",
          "value": "api"
        },
        "description": "asd",
        "label": "seee",
        "name": "systemPanelFilterVar",
        "options": [
          {
            "selected": true,
            "text": "api",
            "value": "api"
          }
        ],
        "query": "api",
        "type": "textbox"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {
    "refresh_intervals": [
      "1m",
      "5m",
      "15m",
      "30m",
      "1h",
      "2h",
      "1d"
    ]
  },
  "timezone": "",
  "title": "test search layout",
  "uid": "af890d95f6a25b86450b1906d4acd2a2eddef89",
  "version": 36,
  "weekStart": ""
}
```