### PR TITLE
Skip flaky test that's breaking the CI pipelines

### DIFF
--- a/pkg/tests/alertmanager/alertmanager_test.go
+++ b/pkg/tests/alertmanager/alertmanager_test.go
@@ -13,6 +13,7 @@ func TestAlertmanagerIntegration_ExtraDedupStage(t *testing.T) {
 	}
 
 	t.Run("assert no flapping alerts when stopOnExtraDedup is enabled", func(t *testing.T) {
+		t.Skip("skipping flaky test")
 		s, err := NewAlertmanagerScenario()
 		require.NoError(t, err)
 		defer s.Close()


### PR DESCRIPTION
**What is this feature?**

The skipped test is consistently broken and it is breaking CI pipelines.

**Why do we need this feature?**

To unblock other PRs.