### PR TITLE
Alerting: Fix loading states

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -36,7 +36,7 @@ const RuleViewer = (): JSX.Element => {
   }, [id]);
 
   // we then fetch the rule from the correct API endpoint(s)
-  const { loading, error, result: rule } = useCombinedRule({ ruleIdentifier: identifier, limitAlerts });
+  const { loading, error, result: rule, uninitialized } = useCombinedRule({ ruleIdentifier: identifier, limitAlerts });
 
   if (error) {
     return (
@@ -46,7 +46,7 @@ const RuleViewer = (): JSX.Element => {
     );
   }
 
-  if (loading) {
+  if (loading || uninitialized) {
     return (
       <AlertingPageWrapper pageNav={defaultPageNav} navId="alert-list" isLoading={true}>
         <></>


### PR DESCRIPTION
Prior to this PR, the alert rule detail view would show a brief slash of "rule not found".

This PR solves that by checking if some requests are still uninitialized.
This PR also adds the correct check for the alert rule editor's loading state when we're still fetching the editable state (using folder check).