### PR TITLE
New Logs Panel: Displayed fields support

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1070,8 +1070,10 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                   <LogList
                     app={CoreApp.Explore}
                     containerElement={logsContainerRef.current}
+                    displayedFields={displayedFields}
                     eventBus={eventBus}
                     forceEscape={forceEscape}
+                    getFieldLinks={getFieldLinks}
                     loadMore={loadMoreLogs}
                     logs={dedupedRows}
                     showTime={showTime}

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -235,7 +235,7 @@ const getStyles = (theme: GrafanaTheme2, oldestLogsFirst: boolean) => {
   return {
     navContainer: css({
       maxHeight: navContainerHeight,
-      width: oldestLogsFirst ? '58px' : 'auto',
+      width: oldestLogsFirst && !config.featureToggles.newLogsPanel ? '58px' : 'auto',
       display: 'flex',
       flexDirection: 'column',
       justifyContent: config.featureToggles.logsInfiniteScrolling

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -22,6 +22,7 @@ interface ChildrenProps {
 
 interface Props {
   children: (props: ChildrenProps) => ReactNode;
+  displayedFields: string[];
   handleOverflow: (index: number, id: string, height: number) => void;
   loadMore?: (range: AbsoluteTimeRange) => void;
   logs: LogListModel[];
@@ -38,6 +39,7 @@ type InfiniteLoaderState = 'idle' | 'out-of-bounds' | 'pre-scroll' | 'loading';
 
 export const InfiniteScroll = ({
   children,
+  displayedFields,
   handleOverflow,
   loadMore,
   logs,
@@ -139,6 +141,7 @@ export const InfiniteScroll = ({
       }
       return (
         <LogLine
+          displayedFields={displayedFields}
           index={index}
           log={logs[index]}
           showTime={showTime}
@@ -149,7 +152,7 @@ export const InfiniteScroll = ({
         />
       );
     },
-    [handleOverflow, infiniteLoaderState, logs, onLoadMore, showTime, sortOrder, wrapLogMessage]
+    [displayedFields, handleOverflow, infiniteLoaderState, logs, onLoadMore, showTime, sortOrder, wrapLogMessage]
   );
 
   const onItemsRendered = useCallback(

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -4,12 +4,12 @@ import { ListChildComponentProps, ListOnItemsRenderedProps } from 'react-window'
 
 import { AbsoluteTimeRange, LogsSortOrder, TimeRange } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Spinner } from '@grafana/ui';
+import { Spinner, useTheme2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { canScrollBottom, getVisibleRange, ScrollDirection, shouldLoadMore } from '../InfiniteScroll';
 
-import { LogLine } from './LogLine';
+import { getStyles, LogLine } from './LogLine';
 import { LogLineMessage } from './LogLineMessage';
 import { LogListModel } from './processing';
 
@@ -59,6 +59,8 @@ export const InfiniteScroll = ({
   const lastEvent = useRef<Event | WheelEvent | null>(null);
   const countRef = useRef(0);
   const lastLogOfPage = useRef<string[]>([]);
+  const theme = useTheme2();
+  const styles = getStyles(theme);
 
   useEffect(() => {
     // Logs have not changed, ignore effect
@@ -146,13 +148,14 @@ export const InfiniteScroll = ({
           log={logs[index]}
           showTime={showTime}
           style={style}
+          styles={styles}
           variant={getLogLineVariant(logs, index, lastLogOfPage.current)}
           wrapLogMessage={wrapLogMessage}
           onOverflow={handleOverflow}
         />
       );
     },
-    [displayedFields, handleOverflow, infiniteLoaderState, logs, onLoadMore, showTime, sortOrder, wrapLogMessage]
+    [displayedFields, handleOverflow, infiniteLoaderState, logs, onLoadMore, showTime, sortOrder, styles, wrapLogMessage]
   );
 
   const onItemsRendered = useCallback(

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -136,7 +136,11 @@ export const InfiniteScroll = ({
     ({ index, style }: ListChildComponentProps) => {
       if (!logs[index] && infiniteLoaderState !== 'idle') {
         return (
-          <LogLineMessage style={style} onClick={infiniteLoaderState === 'pre-scroll' ? onLoadMore : undefined}>
+          <LogLineMessage
+            style={style}
+            styles={styles}
+            onClick={infiniteLoaderState === 'pre-scroll' ? onLoadMore : undefined}
+          >
             {getMessageFromInfiniteLoaderState(infiniteLoaderState, sortOrder)}
           </LogLineMessage>
         );
@@ -155,7 +159,17 @@ export const InfiniteScroll = ({
         />
       );
     },
-    [displayedFields, handleOverflow, infiniteLoaderState, logs, onLoadMore, showTime, sortOrder, styles, wrapLogMessage]
+    [
+      displayedFields,
+      handleOverflow,
+      infiniteLoaderState,
+      logs,
+      onLoadMore,
+      showTime,
+      sortOrder,
+      styles,
+      wrapLogMessage,
+    ]
   );
 
   const onItemsRendered = useCallback(

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -64,7 +64,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
   return (
     <>
       {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
-      {log.logLevel && <span className={`${styles.level} level-${log.logLevel} field`}>{log.logLevel}</span>}
+      <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
       {displayedFields.length > 0 ? (
         displayedFields.map((field) => (
           <span className="field" title={field}>
@@ -185,9 +185,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       gridColumnGap: theme.spacing(FIELD_GAP_MULTIPLIER),
       whiteSpace: 'pre',
       paddingBottom: theme.spacing(0.75),
-      '& .field': {
-        textAlign: 'center',
-      },
     }),
     wrappedLogLine: css({
       whiteSpace: 'pre-wrap',

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -47,7 +47,10 @@ export const LogLine = ({
 
   return (
     <div style={style} className={`${styles.logLine} ${variant}`} ref={onOverflow ? logLineRef : undefined}>
-      <div className={wrapLogMessage ? styles.wrappedLogLine : styles.unwrappedLogLine}>
+      <div
+        style={wrapLogMessage ? undefined : getFieldStyles(log)}
+        className={`${wrapLogMessage ? styles.wrappedLogLine : styles.unwrappedLogLine}`}
+      >
         <Log displayedFields={displayedFields} log={log} showTime={showTime} styles={styles} />
       </div>
     </div>
@@ -64,11 +67,13 @@ interface LogProps {
 const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
   return (
     <>
-      {showTime && <span className={`${styles.timestamp} level-${log.logLevel}`}>{log.timestamp}</span>}
-      {log.logLevel && <span className={`${styles.level} level-${log.logLevel}`}>{log.logLevel}</span>}
-      {displayedFields.length > 0
-        ? displayedFields.map((field) => <span>{getDisplayedFieldValue(field, log)}</span>)
-        : log.body}
+      {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
+      {log.logLevel && <span className={`${styles.level} level-${log.logLevel} field`}>{log.logLevel}</span>}
+      {displayedFields.length > 0 ? (
+        displayedFields.map((field) => <span className="field">{getDisplayedFieldValue(field, log)}</span>)
+      ) : (
+        <span className="field">{log.body}</span>
+      )}
     </>
   );
 };
@@ -85,6 +90,12 @@ export function getDisplayedFieldValue(fieldName: string, log: LogListModel): st
   });
 
   return field ? field.values.toString() : '';
+}
+
+function getFieldStyles(log: LogListModel) {
+  return {
+    gridTemplateColumns: `${log.dimensions[0].width}px ${log.dimensions[1].width}px 1fr`,
+  };
 }
 
 export const getStyles = (theme: GrafanaTheme2) => {
@@ -125,7 +136,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
     timestamp: css({
       color: theme.colors.text.secondary,
       display: 'inline-block',
-      marginRight: theme.spacing(1),
       '&.level-critical': {
         color: colors.critical,
       },
@@ -146,7 +156,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.secondary,
       fontWeight: theme.typography.fontWeightBold,
       display: 'inline-block',
-      marginRight: theme.spacing(1),
       '&.level-critical': {
         color: colors.critical,
       },
@@ -172,12 +181,17 @@ export const getStyles = (theme: GrafanaTheme2) => {
       outline: 'solid 1px red',
     }),
     unwrappedLogLine: css({
+      display: 'grid',
+      gridColumnGap: theme.spacing(1.5),
       whiteSpace: 'pre',
       paddingBottom: theme.spacing(0.75),
     }),
     wrappedLogLine: css({
       whiteSpace: 'pre-wrap',
       paddingBottom: theme.spacing(0.75),
+      '& .field:not(:last-child)': {
+        marginRight: theme.spacing(1.5),
+      },
     }),
   };
 };

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -15,6 +15,7 @@ interface Props {
   log: LogListModel;
   showTime: boolean;
   style: CSSProperties;
+  styles: LogLineStyles;
   onOverflow?: (index: number, id: string, height: number) => void;
   variant?: 'infinite-scroll';
   wrapLogMessage: boolean;
@@ -25,13 +26,12 @@ export const LogLine = ({
   index,
   log,
   style,
+  styles,
   onOverflow,
   showTime,
   variant,
   wrapLogMessage,
 }: Props) => {
-  const theme = useTheme2();
-  const styles = getStyles(theme);
   const logLineRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -98,6 +98,7 @@ function getFieldStyles(log: LogListModel) {
   };
 }
 
+export type LogLineStyles = ReturnType<typeof getStyles>;
 export const getStyles = (theme: GrafanaTheme2) => {
   const colors = {
     critical: '#B877D9',

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -181,6 +181,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
       gridColumnGap: theme.spacing(1.5),
       whiteSpace: 'pre',
       paddingBottom: theme.spacing(0.75),
+      '& .field': {
+        textAlign: 'center',
+      },
     }),
     wrappedLogLine: css({
       whiteSpace: 'pre-wrap',

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -189,8 +189,11 @@ export const getStyles = (theme: GrafanaTheme2) => {
     wrappedLogLine: css({
       whiteSpace: 'pre-wrap',
       paddingBottom: theme.spacing(0.75),
-      '& .field:not(:last-child)': {
+      '& .field': {
         marginRight: theme.spacing(FIELD_GAP_MULTIPLIER),
+      },
+      '& .field:last-child': {
+        marginRight: 0,
       },
     }),
   };

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -8,6 +8,7 @@ import { LogListModel } from './processing';
 import { hasUnderOrOverflow } from './virtualization';
 
 interface Props {
+  displayedFields: string[];
   index: number;
   log: LogListModel;
   showTime: boolean;
@@ -17,7 +18,16 @@ interface Props {
   wrapLogMessage: boolean;
 }
 
-export const LogLine = ({ index, log, style, onOverflow, showTime, variant, wrapLogMessage }: Props) => {
+export const LogLine = ({
+  displayedFields,
+  index,
+  log,
+  style,
+  onOverflow,
+  showTime,
+  variant,
+  wrapLogMessage,
+}: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
   const logLineRef = useRef<HTMLDivElement | null>(null);

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -66,12 +66,14 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
     <>
       {showTime && <span className={`${styles.timestamp} level-${log.logLevel}`}>{log.timestamp}</span>}
       {log.logLevel && <span className={`${styles.level} level-${log.logLevel}`}>{log.logLevel}</span>}
-      {displayedFields.length > 0 ? displayedFields.map((field) => <span>{getFieldValue(field, log)}</span>) : log.body}
+      {displayedFields.length > 0
+        ? displayedFields.map((field) => <span>{getDisplayedFieldValue(field, log)}</span>)
+        : log.body}
     </>
   );
 };
 
-function getFieldValue(fieldName: string, log: LogListModel) {
+export function getDisplayedFieldValue(fieldName: string, log: LogListModel): string {
   if (fieldName === LOG_LINE_BODY_FIELD_NAME) {
     return log.body;
   }
@@ -82,7 +84,7 @@ function getFieldValue(fieldName: string, log: LogListModel) {
     return field.keys[0] === fieldName;
   });
 
-  return field ? field.values : '';
+  return field ? field.values.toString() : '';
 }
 
 export const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
 import { LogFieldDimension, LogListModel } from './processing';
-import { hasUnderOrOverflow } from './virtualization';
+import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow } from './virtualization';
 
 interface Props {
   displayedFields: string[];
@@ -66,7 +66,11 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
       {log.logLevel && <span className={`${styles.level} level-${log.logLevel} field`}>{log.logLevel}</span>}
       {displayedFields.length > 0 ? (
-        displayedFields.map((field) => <span className="field">{getDisplayedFieldValue(field, log)}</span>)
+        displayedFields.map((field) => (
+          <span className="field" title={field}>
+            {getDisplayedFieldValue(field, log)}
+          </span>
+        ))
       ) : (
         <span className="field">{log.body}</span>
       )}
@@ -178,7 +182,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     unwrappedLogLine: css({
       display: 'grid',
-      gridColumnGap: theme.spacing(1.5),
+      gridColumnGap: theme.spacing(FIELD_GAP_MULTIPLIER),
       whiteSpace: 'pre',
       paddingBottom: theme.spacing(0.75),
       '& .field': {
@@ -189,7 +193,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       whiteSpace: 'pre-wrap',
       paddingBottom: theme.spacing(0.75),
       '& .field:not(:last-child)': {
-        marginRight: theme.spacing(1.5),
+        marginRight: theme.spacing(FIELD_GAP_MULTIPLIER),
       },
     }),
   };

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -2,11 +2,10 @@ import { css } from '@emotion/css';
 import { CSSProperties, useEffect, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useTheme2 } from '@grafana/ui';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
-import { LogListModel } from './processing';
+import { LogFieldDimension, LogListModel } from './processing';
 import { hasUnderOrOverflow } from './virtualization';
 
 interface Props {
@@ -46,11 +45,8 @@ export const LogLine = ({
   }, [index, log.uid, onOverflow, style.height]);
 
   return (
-    <div style={style} className={`${styles.logLine} ${variant}`} ref={onOverflow ? logLineRef : undefined}>
-      <div
-        style={wrapLogMessage ? undefined : getFieldStyles(log)}
-        className={`${wrapLogMessage ? styles.wrappedLogLine : styles.unwrappedLogLine}`}
-      >
+    <div style={style} className={`${styles.logLine} ${variant ?? ''}`} ref={onOverflow ? logLineRef : undefined}>
+      <div className={`${wrapLogMessage ? styles.wrappedLogLine : `${styles.unwrappedLogLine} unwrapped-log-line`}`}>
         <Log displayedFields={displayedFields} log={log} showTime={showTime} styles={styles} />
       </div>
     </div>
@@ -92,10 +88,9 @@ export function getDisplayedFieldValue(fieldName: string, log: LogListModel): st
   return field ? field.values.toString() : '';
 }
 
-function getFieldStyles(log: LogListModel) {
-  return {
-    gridTemplateColumns: `${log.dimensions[0].width}px ${log.dimensions[1].width}px 1fr`,
-  };
+export function getGridTemplateColumns(dimensions: LogFieldDimension[]) {
+  const columns = dimensions.map((dimension) => dimension.width).join('px ');
+  return `${columns}px 1fr`;
 }
 
 export type LogLineStyles = ReturnType<typeof getStyles>;

--- a/public/app/features/logs/components/panel/LogLineMessage.tsx
+++ b/public/app/features/logs/components/panel/LogLineMessage.tsx
@@ -1,18 +1,15 @@
 import { CSSProperties, ReactNode } from 'react';
 
-import { useTheme2 } from '@grafana/ui';
-
-import { getStyles } from './LogLine';
+import { LogLineStyles } from './LogLine';
 
 interface Props {
   children: ReactNode;
   onClick?: () => void;
   style: CSSProperties;
+  styles: LogLineStyles;
 }
 
-export const LogLineMessage = ({ children, onClick, style }: Props) => {
-  const theme = useTheme2();
-  const styles = getStyles(theme);
+export const LogLineMessage = ({ children, onClick, style, styles }: Props) => {
   return (
     <div style={style} className={`${styles.logLine} ${styles.logLineMessage}`}>
       {onClick ? (

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -71,8 +71,8 @@ export const LogList = ({
   const widthRef = useRef(containerElement.clientWidth);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const dimensions = useMemo(
-    () => calculateFieldDimensions(processedLogs, displayedFields),
-    [displayedFields, processedLogs]
+    () => wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields),
+    [displayedFields, processedLogs, wrapLogMessage]
   );
   const styles = getStyles(dimensions);
 

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -150,7 +150,7 @@ export const LogList = ({
     >
       {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
         <VariableSizeList
-          className={styles.unwrappedLogLine}
+          className={styles.logList}
           height={listHeight}
           itemCount={itemCount}
           itemSize={getLogLineSize.bind(null, processedLogs, containerElement, dimensions, {
@@ -174,7 +174,7 @@ export const LogList = ({
 
 function getStyles(dimensions: LogFieldDimension[]) {
   return {
-    unwrappedLogLine: css({
+    logList: css({
       '& .unwrapped-log-line': {
         display: 'grid',
         gridTemplateColumns: getGridTemplateColumns(dimensions),

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -116,7 +116,6 @@ export const LogList = ({
 
   const handleOverflow = useCallback(
     (index: number, id: string, height: number) => {
-      console.log('overflow');
       if (containerElement) {
         storeLogLineSize(id, containerElement, height);
         listRef.current?.resetAfterIndex(index);
@@ -153,7 +152,7 @@ export const LogList = ({
           className={styles.logList}
           height={listHeight}
           itemCount={itemCount}
-          itemSize={getLogLineSize.bind(null, processedLogs, containerElement, dimensions, {
+          itemSize={getLogLineSize.bind(null, processedLogs, containerElement, displayedFields, {
             wrap: wrapLogMessage,
             showTime,
           })}

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -71,7 +71,7 @@ export const LogList = ({
   const widthRef = useRef(containerElement.clientWidth);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const dimensions = useMemo(
-    () => wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields),
+    () => (wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields)),
     [displayedFields, processedLogs, wrapLogMessage]
   );
   const styles = getStyles(dimensions);

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -74,7 +74,7 @@ export const LogList = ({
     () => (wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields)),
     [displayedFields, processedLogs, wrapLogMessage]
   );
-  const styles = getStyles(dimensions);
+  const styles = getStyles(dimensions, { showTime });
 
   useEffect(() => {
     initVirtualization(theme);
@@ -171,12 +171,13 @@ export const LogList = ({
   );
 };
 
-function getStyles(dimensions: LogFieldDimension[]) {
+function getStyles(dimensions: LogFieldDimension[], { showTime }: { showTime: boolean }) {
+  const columns = showTime ? dimensions : dimensions.filter((_, index) => index > 0);
   return {
     logList: css({
       '& .unwrapped-log-line': {
         display: 'grid',
-        gridTemplateColumns: getGridTemplateColumns(dimensions),
+        gridTemplateColumns: getGridTemplateColumns(columns),
       },
     }),
   };

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -1,4 +1,4 @@
-import { dateTimeFormat, LogRowModel, LogsSortOrder } from '@grafana/data';
+import { dateTimeFormat, LogLevel, LogRowModel, LogsSortOrder } from '@grafana/data';
 
 import { escapeUnescapedString, sortLogRows } from '../../utils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
@@ -10,6 +10,7 @@ import { measureTextWidth } from './virtualization';
 
 export interface LogListModel extends LogRowModel {
   body: string;
+  displayLevel: string;
   fields: FieldDef[];
   timestamp: string;
 }
@@ -63,10 +64,24 @@ const preProcessLog = (
   return {
     ...log,
     body,
+    displayLevel: logLevelToDisplayLevel(log.logLevel),
     fields: getAllFields(log, getFieldLinks),
     timestamp,
   };
 };
+
+function logLevelToDisplayLevel(level = '') {
+  switch (level) {
+    case LogLevel.critical:
+      return 'crit';
+    case LogLevel.warning:
+      return 'warn';
+    case LogLevel.unknown:
+      return '';
+    default:
+      return level;
+  }
+}
 
 export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
   if (!logs.length) {
@@ -80,7 +95,7 @@ export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: 
     if (width > timestampWidth) {
       timestampWidth = Math.round(width);
     }
-    width = measureTextWidth(logs[i].logLevel);
+    width = measureTextWidth(logs[i].displayLevel);
     if (width > levelWidth) {
       levelWidth = Math.round(width);
     }

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -10,12 +10,12 @@ export interface LogListModel extends LogRowModel {
   body: string;
   fields: FieldDef[];
   timestamp: string;
-  dimensions: LogDimensions;
+  dimensions: LogDimension[];
 }
 
-export interface LogDimensions {
-  timestampWidth: number;
-  levelWidth: number;
+export interface LogDimension {
+  field: string;
+  width: number;
 }
 
 interface PreProcessOptions {
@@ -31,7 +31,12 @@ export const preProcessLogs = (
   { escape, getFieldLinks, order, timeZone, wrap }: PreProcessOptions
 ): LogListModel[] => {
   const orderedLogs = sortLogRows(logs, order);
-  return orderedLogs.map((log) => preProcessLog(log, { escape, expanded: false, getFieldLinks, timeZone, wrap }));
+  const processedLogs = orderedLogs.map((log) =>
+    preProcessLog(log, { escape, expanded: false, getFieldLinks, timeZone, wrap })
+  );
+  const dimensions = calculateFieldDimensions(processedLogs);
+  processedLogs.forEach((log) => (log.dimensions = dimensions));
+  return processedLogs;
 };
 
 interface PreProcessLogOptions {
@@ -64,9 +69,35 @@ const preProcessLog = (
     body,
     fields: getAllFields(log, getFieldLinks),
     timestamp,
-    dimensions: {
-      timestampWidth: measureTextWidth(timestamp),
-      levelWidth: measureTextWidth(log.logLevel),
-    },
+    dimensions: [],
   };
+};
+
+export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
+  if (!logs.length) {
+    return [];
+  }
+  let timestampWidth = 0;
+  let levelWidth = 0;
+  for (let i = 0; i < logs.length; i++) {
+    let width = measureTextWidth(logs[i].timestamp);
+    if (width > timestampWidth) {
+      timestampWidth = Math.round(width);
+    }
+    width = measureTextWidth(logs[i].logLevel);
+    if (width > levelWidth) {
+      levelWidth = Math.round(width);
+    }
+  }
+  const dimensions: LogDimension[] = [
+    {
+      field: 'timestamp',
+      width: timestampWidth,
+    },
+    {
+      field: 'level',
+      width: levelWidth,
+    },
+  ];
+  return dimensions;
 };

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,6 +1,6 @@
 import { BusEventWithPayload, GrafanaTheme2 } from '@grafana/data';
 
-import { LogListModel } from './processing';
+import { LogFieldDimension, LogListModel } from './processing';
 
 let ctx: CanvasRenderingContext2D | null = null;
 let gridSize = 8;
@@ -146,6 +146,7 @@ interface DisplayOptions {
 export function getLogLineSize(
   logs: LogListModel[],
   container: HTMLDivElement | null,
+  fieldDimensions: LogFieldDimension[],
   { wrap, showTime }: DisplayOptions,
   index: number
 ) {
@@ -163,10 +164,10 @@ export function getLogLineSize(
   const gap = gridSize * 1.5;
   let optionsWidth = 0;
   if (showTime) {
-    optionsWidth += logs[index].dimensions[0].width + gap;
+    optionsWidth += fieldDimensions[0].width + gap;
   }
   if (logs[index].logLevel) {
-    optionsWidth += logs[index].dimensions[1].width + gap;
+    optionsWidth += fieldDimensions[1].width + gap;
   }
   const { height } = measureTextHeight(logs[index].body, getLogContainerWidth(container), optionsWidth);
   return height;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -160,13 +160,13 @@ export function getLogLineSize(
   if (storedSize) {
     return storedSize;
   }
-  const gap = gridSize;
+  const gap = gridSize * 1.5;
   let optionsWidth = 0;
   if (showTime) {
-    optionsWidth += logs[index].dimensions.timestampWidth + gap;
+    optionsWidth += logs[index].dimensions[0].width + gap;
   }
   if (logs[index].logLevel) {
-    optionsWidth += logs[index].dimensions.levelWidth + gap;
+    optionsWidth += logs[index].dimensions[1].width + gap;
   }
   const { height } = measureTextHeight(logs[index].body, getLogContainerWidth(container), optionsWidth);
   return height;

--- a/public/app/plugins/panel/logs-new/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs-new/LogsPanel.tsx
@@ -102,6 +102,7 @@ export const LogsPanel = ({
         <LogList
           app={CoreApp.Dashboard}
           containerElement={logsContainer}
+          displayedFields={[]}
           eventBus={eventBus}
           initialScrollPosition={initialScrollPosition}
           logs={logs}


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

This PR adds panel support to display certain selected fields (displayed fields), and updates the styles and behavior of the log lines depending on the state of "wrap lines":

- When wrap lines is off, the timestamp, level, and any displayed field, will be displayed in a tabular way, to help comparing values between lines.  
  ![imagen](https://github.com/user-attachments/assets/33975c04-7676-4242-81d1-3eeb3dd3b284)
- When wrap lines is off, timestamp, level, and displayed fields, will use all the available space in the panel.
  ![imagen](https://github.com/user-attachments/assets/313eede9-ad95-491a-ab91-c890a36813b0)

To test, use the current panel to select displayed fields, copy the URL, and load it using the new panel, as there are no other ways at the moment to set displayed fields from the new visualization.

https://github.com/user-attachments/assets/3e3298cf-ce97-4a85-8aa9-caee1e88c3c3

