### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -3,7 +3,7 @@ name: publish-technical-documentation-release
 on:
   push:
     branches:
-      - v[0-9]+.[0-9]+.x
+      - release-[0-9]+.[0-9]+.[0-9]+
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
     paths:
@@ -23,7 +23,7 @@ jobs:
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
           release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
-          release_branch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.x$"
-          release_branch_with_patch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_with_patch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           website_directory: content/docs/grafana
           version_suffix: ""


### PR DESCRIPTION
This backports the changes made in https://github.com/grafana/grafana/pull/100067 (that weren't already backported) and cleanup in https://github.com/grafana/grafana/pull/100496.