### PR TITLE
OpenTSDB: Support v2.4

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -136,6 +136,14 @@ datasources:
       tsdbResolution: 1
       tsdbVersion: 3
 
+  - name: gdev-opentsdb-v2.4
+    type: opentsdb
+    access: proxy
+    url: http://localhost:4242
+    jsonData:
+      tsdbResolution: 1
+      tsdbVersion: 4
+
   - name: gdev-elasticsearch
     type: elasticsearch
     uid: gdev-elasticsearch

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -99,7 +99,7 @@ While using OpenTSDB 2.2 data source, make sure you use either Filters or Tags a
 {{% /admonition %}}
 
 {{% admonition type="note" %}}
-When using OpenTSDB 2.4 with alerting the query will be executed with the parameter `arrays=true`. This will return the data points from OpenTSDB as an array of arrays rather than a map of key-value pairs. Grafana will then convert this data into the appropriate data frame format.
+When using OpenTSDB 2.4 with alerting, queries are executed with the parameter `arrays=true`. This causes OpenTSDB to return data points as an array of arrays instead of a map of key-value pairs. Grafana then converts this data into the appropriate data frame format.
 {{% /admonition %}}
 
 ### Auto complete suggestions

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -104,7 +104,7 @@ When using OpenTSDB 2.4 with alerting, queries are executed with the parameter `
 
 ### Auto complete suggestions
 
-As soon as you start typing metric names, tag names and tag values , you should see highlighted auto complete suggestions for them.
+As you begin typing metric names, tag names, or tag values, highlighted autocomplete suggestions will appear.
 The autocomplete only works if the OpenTSDB suggest API is enabled.
 
 ## Templating queries

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -62,7 +62,7 @@ To configure basic settings for the data source, complete the following steps:
 | **Default**         | Default data source that will be be pre-selected for new panels.                         |
 | **URL**             | The HTTP protocol, IP, and port of your OpenTSDB server (default port is usually 4242).  |
 | **Allowed cookies** | Listing of cookies to forward to the data source.                                        |
-| **Version**         | The OpenTSDB version.                                                                    |
+| **Version**         | The OpenTSDB version (supported versions are: 2.4, 2.3, 2.2 and versions less than 2.1). |
 | **Resolution**      | Metrics from OpenTSDB may have data points with either second or millisecond resolution. |
 | **Lookup limit**    | Default is 1000.                                                                         |
 
@@ -96,6 +96,10 @@ can be used to query OpenTSDB. Fill Policy is also introduced in OpenTSDB 2.2.
 
 {{% admonition type="note" %}}
 While using OpenTSDB 2.2 data source, make sure you use either Filters or Tags as they are mutually exclusive. If used together, might give you weird results.
+{{% /admonition %}}
+
+{{% admonition type="note" %}}
+When using OpenTSDB 2.4 with alerting the query will be executed with the parameter `arrays=true`. This will return the data points from OpenTSDB as an array of arrays rather than a map of key-value pairs. Grafana will then convert this data into the appropriate dataframe format.
 {{% /admonition %}}
 
 ### Auto complete suggestions

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -99,7 +99,7 @@ While using OpenTSDB 2.2 data source, make sure you use either Filters or Tags a
 {{% /admonition %}}
 
 {{% admonition type="note" %}}
-When using OpenTSDB 2.4 with alerting the query will be executed with the parameter `arrays=true`. This will return the data points from OpenTSDB as an array of arrays rather than a map of key-value pairs. Grafana will then convert this data into the appropriate dataframe format.
+When using OpenTSDB 2.4 with alerting the query will be executed with the parameter `arrays=true`. This will return the data points from OpenTSDB as an array of arrays rather than a map of key-value pairs. Grafana will then convert this data into the appropriate data frame format.
 {{% /admonition %}}
 
 ### Auto complete suggestions

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -185,8 +185,7 @@ func parseResponse24(responseData []OpenTsdbResponse24, refID string, frames dat
 	for _, val := range responseData {
 		frame := createInitialFrame(val.OpenTsdbCommon, len(val.DataPoints), refID)
 
-		points := val.DataPoints
-		for i, point := range points {
+		for i, point := range val.DataPoints {
 			frame.SetRow(i, time.Unix(int64(point[0]), 0).UTC(), point[1])
 		}
 

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,7 +89,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 	q := req.Queries[0]
 
-	myRefID := q.RefID
+	refID := q.RefID
 
 	tsdbQuery.Start = q.TimeRange.From.UnixNano() / int64(time.Millisecond)
 	tsdbQuery.End = q.TimeRange.To.UnixNano() / int64(time.Millisecond)
@@ -124,7 +126,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 	}()
 
-	result, err := s.parseResponse(logger, res, myRefID)
+	result, err := s.parseResponse(logger, res, refID, dsInfo.TSDBVersion)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
@@ -138,9 +140,11 @@ func (s *Service) createRequest(ctx context.Context, logger log.Logger, dsInfo *
 		return nil, err
 	}
 	u.Path = path.Join(u.Path, "api/query")
-	queryParams := u.Query()
-	queryParams.Set("arrays", "true")
-	u.RawQuery = queryParams.Encode()
+	if dsInfo.TSDBVersion == 4 {
+		queryParams := u.Query()
+		queryParams.Set("arrays", "true")
+		u.RawQuery = queryParams.Encode()
+	}
 
 	postData, err := json.Marshal(data)
 	if err != nil {
@@ -158,7 +162,68 @@ func (s *Service) createRequest(ctx context.Context, logger log.Logger, dsInfo *
 	return req, nil
 }
 
-func (s *Service) parseResponse(logger log.Logger, res *http.Response, myRefID string) (*backend.QueryDataResponse, error) {
+func createInitialFrame(val OpenTsdbCommon, length int, refID string) *data.Frame {
+	labels := data.Labels{}
+	for label, value := range val.Tags {
+		labels[label] = value
+	}
+
+	frame := data.NewFrameOfFieldTypes(val.Metric, length, data.FieldTypeTime, data.FieldTypeFloat64)
+	frame.Meta = &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti, TypeVersion: data.FrameTypeVersion{0, 1}}
+	frame.RefID = refID
+	timeField := frame.Fields[0]
+	timeField.Name = data.TimeSeriesTimeFieldName
+	dataField := frame.Fields[1]
+	dataField.Name = val.Metric
+	dataField.Labels = labels
+
+	return frame
+}
+
+// Parse response function for OpenTSDB version 2.4
+func parseResponse24(responseData []OpenTsdbResponse24, refID string, frames data.Frames) data.Frames {
+	for _, val := range responseData {
+		frame := createInitialFrame(val.OpenTsdbCommon, len(val.DataPoints), refID)
+
+		points := val.DataPoints
+		for i, point := range points {
+			frame.SetRow(i, time.Unix(int64(point[0]), 0).UTC(), point[1])
+		}
+
+		frames = append(frames, frame)
+	}
+
+	return frames
+}
+
+// Parse response function for OpenTSDB versions < 2.4
+func parseResponseLT24(responseData []OpenTsdbResponse, refID string, frames data.Frames) (data.Frames, error) {
+	for _, val := range responseData {
+		frame := createInitialFrame(val.OpenTsdbCommon, len(val.DataPoints), refID)
+
+		// Order the timestamps in ascending order to avoid issues like https://github.com/grafana/grafana/issues/38729
+		timestamps := make([]string, 0, len(val.DataPoints))
+		for timestamp := range val.DataPoints {
+			timestamps = append(timestamps, timestamp)
+		}
+		sort.Strings(timestamps)
+
+		for i, timeString := range timestamps {
+			timestamp, err := strconv.ParseInt(timeString, 10, 64)
+			if err != nil {
+				logger.Info("Failed to unmarshal opentsdb timestamp", "timestamp", timeString)
+				return frames, err
+			}
+			frame.SetRow(i, time.Unix(timestamp, 0).UTC(), val.DataPoints[timeString])
+		}
+
+		frames = append(frames, frame)
+	}
+
+	return frames, nil
+}
+
+func (s *Service) parseResponse(logger log.Logger, res *http.Response, refID string, tsdbVersion float32) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	body, err := io.ReadAll(res.Body)
@@ -176,38 +241,34 @@ func (s *Service) parseResponse(logger log.Logger, res *http.Response, myRefID s
 		return nil, fmt.Errorf("request failed, status: %s", res.Status)
 	}
 
-	var responseData []OpenTsdbResponse
-	err = json.Unmarshal(body, &responseData)
-	if err != nil {
-		logger.Info("Failed to unmarshal opentsdb response", "error", err, "status", res.Status, "body", string(body))
-		return nil, err
-	}
-
 	frames := data.Frames{}
-	for _, val := range responseData {
-		labels := data.Labels{}
-		for label, value := range val.Tags {
-			labels[label] = value
+
+	var responseData []OpenTsdbResponse
+	var responseData24 []OpenTsdbResponse24
+	if tsdbVersion == 4 {
+		err = json.Unmarshal(body, &responseData24)
+		if err != nil {
+			logger.Info("Failed to unmarshal opentsdb response", "error", err, "status", res.Status, "body", string(body))
+			return nil, err
 		}
 
-		frame := data.NewFrameOfFieldTypes(val.Metric, len(val.DataPoints), data.FieldTypeTime, data.FieldTypeFloat64)
-		frame.Meta = &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti, TypeVersion: data.FrameTypeVersion{0, 1}}
-		frame.RefID = myRefID
-		timeField := frame.Fields[0]
-		timeField.Name = data.TimeSeriesTimeFieldName
-		dataField := frame.Fields[1]
-		dataField.Name = "value"
-		dataField.Labels = labels
-
-		points := val.DataPoints
-		for i, point := range points {
-			frame.SetRow(i, time.Unix(int64(point[0]), 0).UTC(), point[1])
+		frames = parseResponse24(responseData24, refID, frames)
+	} else {
+		err = json.Unmarshal(body, &responseData)
+		if err != nil {
+			logger.Info("Failed to unmarshal opentsdb response", "error", err, "status", res.Status, "body", string(body))
+			return nil, err
 		}
-		frames = append(frames, frame)
+
+		frames, err = parseResponseLT24(responseData, refID, frames)
+		if err != nil {
+			return nil, err
+		}
 	}
-	result := resp.Responses[myRefID]
+
+	result := resp.Responses[refID]
 	result.Frames = frames
-	resp.Responses[myRefID] = result
+	resp.Responses[refID] = result
 	return resp, nil
 }
 

--- a/pkg/tsdb/opentsdb/types.go
+++ b/pkg/tsdb/opentsdb/types.go
@@ -6,8 +6,17 @@ type OpenTsdbQuery struct {
 	Queries []map[string]any `json:"queries"`
 }
 
+type OpenTsdbCommon struct {
+	Metric string            `json:"metric"`
+	Tags   map[string]string `json:"tags"`
+}
+
 type OpenTsdbResponse struct {
-	Metric     string            `json:"metric"`
-	Tags       map[string]string `json:"tags"`
-	DataPoints [][]float64       `json:"dps"`
+	OpenTsdbCommon
+	DataPoints map[string]float64 `json:"dps"`
+}
+
+type OpenTsdbResponse24 struct {
+	OpenTsdbCommon
+	DataPoints [][]float64 `json:"dps"`
 }

--- a/public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx
@@ -9,6 +9,7 @@ const tsdbVersions = [
   { label: '<=2.1', value: 1 },
   { label: '==2.2', value: 2 },
   { label: '==2.3', value: 3 },
+  { label: '==2.4', value: 4 },
 ];
 
 const tsdbResolutions = [


### PR DESCRIPTION
This PR marks OpenTSDB v2.4 as being supported. This is done to fix a bug introduced in #90991. That PR modified how the API response was processed but didn't take into account that APIs older than v2.4 did not support returning data as an array of arrays.

To fix this v2.4 is now supported and, when v2.4 is the version selected, any alerting query will be executed with the query parameter `arrays=true` which will return the data as an array of arrays. Conversely, for older APIs, the original key-value data format will be used. 

However, to avoid any bugs like those introduced by #77841 the data will now be ordered on the backend.

This should ensure that both #82027 and #38729 remain fixed whilst also fixing #94150 and #100359.