### PR TITLE
Alerting: API to read rule groups using mimirtool

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -1,15 +1,21 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -17,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/prom"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -39,6 +46,18 @@ func errInvalidHeaderValue(header string) error {
 	return errInvalidHeaderValueBase.Build(errutil.TemplateData{Public: map[string]any{"Header": header}})
 }
 
+// ConvertPrometheusSrv converts Prometheus rules to Grafana rules
+// and retrieves them in a Prometheus-compatible format.
+//
+// It is designed to support mimirtool integration, so that rules that work with Mimir
+// can be imported into Grafana. It works similarly to the provisioning API,
+// where once a rule group is created, it is marked as "provisioned" (via provenance mechanism)
+// and is not editable in the UI.
+//
+// This service returns only rule groups that were initially imported from Prometheus-compatible sources.
+// Rule groups not imported from Prometheus are excluded because their original rule definitions are unavailable.
+// When a rule group is converted from Prometheus to Grafana, the original definition is preserved alongside
+// the Grafana rule and used for reading requests here.
 type ConvertPrometheusSrv struct {
 	cfg              *setting.UnifiedAlertingSettings
 	logger           log.Logger
@@ -57,27 +76,117 @@ func NewConvertPrometheusSrv(cfg *setting.UnifiedAlertingSettings, logger log.Lo
 	}
 }
 
+// RouteConvertPrometheusGetRules returns all Grafana-managed alert rules in all namespaces (folders)
+// that were imported from a Prometheus-compatible source.
+// It responds with a YAML containing a mapping of folders to arrays of Prometheus rule groups.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetRules(c *contextmodel.ReqContext) response.Response {
-	return response.Error(501, "Not implemented", nil)
+	logger := srv.logger.FromContext(c.Req.Context())
+
+	filterOpts := &provisioning.FilterOptions{
+		ImportedPrometheusRule: util.Pointer(true),
+	}
+	groups, err := srv.alertRuleService.GetAlertGroupsWithFolderFullpath(c.Req.Context(), c.SignedInUser, filterOpts)
+	if err != nil {
+		logger.Error("Failed to get alert groups", "error", err)
+		return errorToResponse(err)
+	}
+
+	namespaces, err := grafanaNamespacesToPrometheus(groups)
+	if err != nil {
+		logger.Error("Failed to convert Grafana rules to Prometheus format", "error", err)
+		return errorToResponse(err)
+	}
+
+	return response.YAML(http.StatusOK, namespaces)
 }
 
+// RouteConvertPrometheusDeleteNamespace deletes all rule groups that were imported from a Prometheus-compatible source
+// within a specified namespace.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteNamespace(c *contextmodel.ReqContext, namespaceTitle string) response.Response {
 	return response.Error(501, "Not implemented", nil)
 }
 
+// RouteConvertPrometheusDeleteRuleGroup deletes a specific rule group if it was imported from a Prometheus-compatible source.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteRuleGroup(c *contextmodel.ReqContext, namespaceTitle string, group string) response.Response {
 	return response.Error(501, "Not implemented", nil)
 }
 
+// RouteConvertPrometheusGetNamespace returns the Grafana-managed alert rules for a specified namespace (folder).
+// It responds with a YAML containing a mapping of a single folder to an array of Prometheus rule groups.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetNamespace(c *contextmodel.ReqContext, namespaceTitle string) response.Response {
-	return response.Error(501, "Not implemented", nil)
+	logger := srv.logger.FromContext(c.Req.Context())
+
+	logger.Debug("Looking up folder in the root by title", "folder_title", namespaceTitle)
+	namespace, err := srv.ruleStore.GetNamespaceInRootByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser)
+	if err != nil {
+		logger.Error("Failed to get folder", "error", err)
+		return namespaceErrorResponse(err)
+	}
+
+	filterOpts := &provisioning.FilterOptions{
+		ImportedPrometheusRule: util.Pointer(true),
+		NamespaceUIDs:          []string{namespace.UID},
+	}
+	groups, err := srv.alertRuleService.GetAlertGroupsWithFolderFullpath(c.Req.Context(), c.SignedInUser, filterOpts)
+	if err != nil {
+		logger.Error("Failed to get alert groups", "error", err)
+		return errorToResponse(err)
+	}
+
+	ns, err := grafanaNamespacesToPrometheus(groups)
+	if err != nil {
+		logger.Error("Failed to convert Grafana rules to Prometheus format", "error", err)
+		return errorToResponse(err)
+	}
+
+	return response.YAML(http.StatusOK, ns)
 }
 
+// RouteConvertPrometheusGetRuleGroup retrieves a single rule group for a given namespace (folder)
+// in Prometheus-compatible YAML format if it was imported from a Prometheus-compatible source.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetRuleGroup(c *contextmodel.ReqContext, namespaceTitle string, group string) response.Response {
-	// Just to make the mimirtool rules load work. It first checks if the group exists, and if the endpoint returns 501 it fails.
-	return response.YAML(http.StatusOK, apimodels.PrometheusRuleGroup{})
+	logger := srv.logger.FromContext(c.Req.Context())
+
+	logger.Debug("Looking up folder in the root by title", "folder_title", namespaceTitle)
+	namespace, err := srv.ruleStore.GetNamespaceInRootByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser)
+	if err != nil {
+		logger.Error("Failed to get folder", "error", err)
+		return namespaceErrorResponse(err)
+	}
+
+	filterOpts := &provisioning.FilterOptions{
+		ImportedPrometheusRule: util.Pointer(true),
+		NamespaceUIDs:          []string{namespace.UID},
+		RuleGroups:             []string{group},
+	}
+	groupsWithFolders, err := srv.alertRuleService.GetAlertGroupsWithFolderFullpath(c.Req.Context(), c.SignedInUser, filterOpts)
+	if err != nil {
+		logger.Error("Failed to get alert group", "error", err)
+		return errorToResponse(err)
+	}
+	if len(groupsWithFolders) == 0 {
+		return response.Error(http.StatusNotFound, "Rule group not found", nil)
+	}
+	if len(groupsWithFolders) > 1 {
+		logger.Error("Multiple rule groups found when only one was expected", "folder_title", namespaceTitle, "group", group)
+		// It shouldn't happen, but if we get more than 1 group, we return an error.
+		return response.Error(http.StatusInternalServerError, "Multiple rule groups found", nil)
+	}
+
+	promGroup, err := grafanaRuleGroupToPrometheus(groupsWithFolders[0].Title, groupsWithFolders[0].Rules)
+	if err != nil {
+		logger.Error("Failed to convert Grafana rule to Prometheus format", "error", err)
+		return errorToResponse(err)
+	}
+
+	return response.YAML(http.StatusOK, promGroup)
 }
 
+// RouteConvertPrometheusPostRuleGroup converts a Prometheus rule group into a Grafana rule group
+// and creates or updates it within the specified namespace (folder).
+//
+// If the group already exists and was not imported from a Prometheus-compatible source initially,
+// it will not be replaced and an error will be returned.
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroup(c *contextmodel.ReqContext, namespaceTitle string, promGroup apimodels.PrometheusRuleGroup) response.Response {
 	logger := srv.logger.FromContext(c.Req.Context())
 	logger = logger.New("folder_title", namespaceTitle, "group", promGroup.Name)
@@ -101,6 +210,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroup(c *contextm
 
 	group, err := srv.convertToGrafanaRuleGroup(c, ds, ns.UID, promGroup, logger)
 	if err != nil {
+		logger.Error("Failed to convert Prometheus rules to Grafana rules", "error", err)
 		return errorToResponse(err)
 	}
 
@@ -201,4 +311,55 @@ func parseBooleanHeader(header string, headerName string) (bool, error) {
 		return false, errInvalidHeaderValue(headerName)
 	}
 	return val, nil
+}
+
+func grafanaNamespacesToPrometheus(groups []models.AlertRuleGroupWithFolderFullpath) (map[string][]apimodels.PrometheusRuleGroup, error) {
+	result := map[string][]apimodels.PrometheusRuleGroup{}
+
+	for _, group := range groups {
+		promGroup, err := grafanaRuleGroupToPrometheus(group.Title, group.Rules)
+		if err != nil {
+			return nil, err
+		}
+		result[group.FolderFullpath] = append(result[group.FolderFullpath], promGroup)
+	}
+
+	return result, nil
+}
+
+func grafanaRuleGroupToPrometheus(group string, rules []models.AlertRule) (apimodels.PrometheusRuleGroup, error) {
+	if len(rules) == 0 {
+		return apimodels.PrometheusRuleGroup{}, nil
+	}
+
+	interval := time.Duration(rules[0].IntervalSeconds) * time.Second
+	promGroup := apimodels.PrometheusRuleGroup{
+		Name:     group,
+		Interval: prommodel.Duration(interval),
+		Rules:    make([]apimodels.PrometheusRule, len(rules)),
+	}
+
+	for i, rule := range rules {
+		promDefinition := rule.PrometheusRuleDefinition()
+		if promDefinition == "" {
+			return apimodels.PrometheusRuleGroup{}, fmt.Errorf("failed to get the Prometheus definition of the rule with UID %s", rule.UID)
+		}
+		var r apimodels.PrometheusRule
+		if err := yaml.Unmarshal([]byte(promDefinition), &r); err != nil {
+			return apimodels.PrometheusRuleGroup{}, fmt.Errorf("failed to unmarshal Prometheus rule definition of the rule with UID %s: %w", rule.UID, err)
+		}
+		promGroup.Rules[i] = r
+	}
+
+	return promGroup, nil
+}
+
+func namespaceErrorResponse(err error) response.Response {
+	if errors.Is(err, dashboards.ErrFolderAccessDenied) {
+		// If there is no such folder, the error is ErrFolderAccessDenied.
+		// We should return 404 in this case, otherwise mimirtool does not work correctly.
+		return response.Empty(http.StatusNotFound)
+	}
+
+	return toNamespaceErrorResponse(err)
 }

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -77,7 +77,7 @@ type AlertRuleService interface {
 	DeleteRuleGroup(ctx context.Context, user identity.Requester, folder, group string, provenance alerting_models.Provenance) error
 	GetAlertRuleWithFolderFullpath(ctx context.Context, u identity.Requester, ruleUID string) (provisioning.AlertRuleWithFolderFullpath, error)
 	GetAlertRuleGroupWithFolderFullpath(ctx context.Context, u identity.Requester, folder, group string) (alerting_models.AlertRuleGroupWithFolderFullpath, error)
-	GetAlertGroupsWithFolderFullpath(ctx context.Context, u identity.Requester, folderUIDs []string) ([]alerting_models.AlertRuleGroupWithFolderFullpath, error)
+	GetAlertGroupsWithFolderFullpath(ctx context.Context, u identity.Requester, opts *provisioning.FilterOptions) ([]alerting_models.AlertRuleGroupWithFolderFullpath, error)
 }
 
 func (srv *ProvisioningSrv) RouteGetPolicyTree(c *contextmodel.ReqContext) response.Response {
@@ -452,7 +452,7 @@ func (srv *ProvisioningSrv) RouteGetAlertRulesExport(c *contextmodel.ReqContext)
 		return srv.RouteGetAlertRuleGroupExport(c, folderUIDs[0], group)
 	}
 
-	groupsWithFullpath, err := srv.alertRules.GetAlertGroupsWithFolderFullpath(c.Req.Context(), c.SignedInUser, folderUIDs)
+	groupsWithFullpath, err := srv.alertRules.GetAlertGroupsWithFolderFullpath(c.Req.Context(), c.SignedInUser, &provisioning.FilterOptions{NamespaceUIDs: folderUIDs})
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get alert rules", err)
 	}

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -4932,6 +4932,7 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert",
     "type": "object"

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -6,10 +6,10 @@ import (
 
 // swagger:route GET /convert/prometheus/config/v1/rules convert_prometheus RouteConvertPrometheusGetRules
 //
-// Gets all namespaces with their rule groups in Prometheus format.
+// Gets all Grafana-managed alert rules that were imported from Prometheus-compatible sources, grouped by namespace.
 //
 //     Produces:
-//     - application/json
+//     - application/yaml
 //
 //     Responses:
 //       200: PrometheusNamespace
@@ -18,10 +18,10 @@ import (
 
 // swagger:route GET /convert/prometheus/config/v1/rules/{NamespaceTitle} convert_prometheus RouteConvertPrometheusGetNamespace
 //
-// Gets rules in prometheus format for a given namespace.
+// Gets Grafana-managed alert rules that were imported from Prometheus-compatible sources for a specified namespace (folder).
 //
 //     Produces:
-//     - application/json
+//     - application/yaml
 //
 //     Responses:
 //       200: PrometheusNamespace
@@ -30,10 +30,10 @@ import (
 
 // swagger:route GET /convert/prometheus/config/v1/rules/{NamespaceTitle}/{Group} convert_prometheus RouteConvertPrometheusGetRuleGroup
 //
-// Gets a rule group in Prometheus format.
+// Gets a single rule group in Prometheus-compatible format if it was imported from a Prometheus-compatible source.
 //
 //     Produces:
-//     - application/json
+//     - application/yaml
 //
 //     Responses:
 //       200: PrometheusRuleGroup
@@ -42,7 +42,9 @@ import (
 
 // swagger:route POST /convert/prometheus/config/v1/rules/{NamespaceTitle} convert_prometheus RouteConvertPrometheusPostRuleGroup
 //
-// Creates or updates a rule group in Prometheus format.
+// Converts a Prometheus rule group into a Grafana rule group and creates or updates it within the specified namespace.
+// If the group already exists and was not imported from a Prometheus-compatible source initially,
+// it will not be replaced and an error will be returned.
 //
 //     Consumes:
 //     - application/yaml
@@ -59,7 +61,7 @@ import (
 
 // swagger:route DELETE /convert/prometheus/config/v1/rules/{NamespaceTitle} convert_prometheus RouteConvertPrometheusDeleteNamespace
 //
-// Deletes all rule groups in the given namespace.
+// Deletes all rule groups that were imported from Prometheus-compatible sources within the specified namespace.
 //
 //     Produces:
 //     - application/json
@@ -70,7 +72,7 @@ import (
 
 // swagger:route DELETE /convert/prometheus/config/v1/rules/{NamespaceTitle}/{Group} convert_prometheus RouteConvertPrometheusDeleteRuleGroup
 //
-// Deletes a rule group in Prometheus format.
+// Deletes a specific rule group if it was imported from a Prometheus-compatible source.
 //
 //     Produces:
 //     - application/json

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -4770,7 +4770,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup",
     "type": "object"
@@ -6403,7 +6402,7 @@
    "get": {
     "operationId": "RouteConvertPrometheusGetRules",
     "produces": [
-     "application/json"
+     "application/yaml"
     ],
     "responses": {
      "200": {
@@ -6425,7 +6424,7 @@
       }
      }
     },
-    "summary": "Gets all namespaces with their rule groups in Prometheus format.",
+    "summary": "Gets all Grafana-managed alert rules that were imported from Prometheus-compatible sources, grouped by namespace.",
     "tags": [
      "convert_prometheus"
     ]
@@ -6459,7 +6458,7 @@
       }
      }
     },
-    "summary": "Deletes all rule groups in the given namespace.",
+    "summary": "Deletes all rule groups that were imported from Prometheus-compatible sources within the specified namespace.",
     "tags": [
      "convert_prometheus"
     ]
@@ -6475,7 +6474,7 @@
      }
     ],
     "produces": [
-     "application/json"
+     "application/yaml"
     ],
     "responses": {
      "200": {
@@ -6497,7 +6496,7 @@
       }
      }
     },
-    "summary": "Gets rules in prometheus format for a given namespace.",
+    "summary": "Gets Grafana-managed alert rules that were imported from Prometheus-compatible sources for a specified namespace (folder).",
     "tags": [
      "convert_prometheus"
     ]
@@ -6506,6 +6505,7 @@
     "consumes": [
      "application/yaml"
     ],
+    "description": "If the group already exists and was not imported from a Prometheus-compatible source initially,\nit will not be replaced and an error will be returned.",
     "operationId": "RouteConvertPrometheusPostRuleGroup",
     "parameters": [
      {
@@ -6554,7 +6554,7 @@
       }
      }
     },
-    "summary": "Creates or updates a rule group in Prometheus format.",
+    "summary": "Converts a Prometheus rule group into a Grafana rule group and creates or updates it within the specified namespace.",
     "tags": [
      "convert_prometheus"
     ],
@@ -6595,7 +6595,7 @@
       }
      }
     },
-    "summary": "Deletes a rule group in Prometheus format.",
+    "summary": "Deletes a specific rule group if it was imported from a Prometheus-compatible source.",
     "tags": [
      "convert_prometheus"
     ]
@@ -6617,7 +6617,7 @@
      }
     ],
     "produces": [
-     "application/json"
+     "application/yaml"
     ],
     "responses": {
      "200": {
@@ -6639,7 +6639,7 @@
       }
      }
     },
-    "summary": "Gets a rule group in Prometheus format.",
+    "summary": "Gets a single rule group in Prometheus-compatible format if it was imported from a Prometheus-compatible source.",
     "tags": [
      "convert_prometheus"
     ]

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1105,12 +1105,12 @@
     "/convert/prometheus/config/v1/rules": {
       "get": {
         "produces": [
-          "application/json"
+          "application/yaml"
         ],
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Gets all namespaces with their rule groups in Prometheus format.",
+        "summary": "Gets all Grafana-managed alert rules that were imported from Prometheus-compatible sources, grouped by namespace.",
         "operationId": "RouteConvertPrometheusGetRules",
         "responses": {
           "200": {
@@ -1137,12 +1137,12 @@
     "/convert/prometheus/config/v1/rules/{NamespaceTitle}": {
       "get": {
         "produces": [
-          "application/json"
+          "application/yaml"
         ],
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Gets rules in prometheus format for a given namespace.",
+        "summary": "Gets Grafana-managed alert rules that were imported from Prometheus-compatible sources for a specified namespace (folder).",
         "operationId": "RouteConvertPrometheusGetNamespace",
         "parameters": [
           {
@@ -1174,6 +1174,7 @@
         }
       },
       "post": {
+        "description": "If the group already exists and was not imported from a Prometheus-compatible source initially,\nit will not be replaced and an error will be returned.",
         "consumes": [
           "application/yaml"
         ],
@@ -1183,7 +1184,7 @@
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Creates or updates a rule group in Prometheus format.",
+        "summary": "Converts a Prometheus rule group into a Grafana rule group and creates or updates it within the specified namespace.",
         "operationId": "RouteConvertPrometheusPostRuleGroup",
         "parameters": [
           {
@@ -1238,7 +1239,7 @@
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Deletes all rule groups in the given namespace.",
+        "summary": "Deletes all rule groups that were imported from Prometheus-compatible sources within the specified namespace.",
         "operationId": "RouteConvertPrometheusDeleteNamespace",
         "parameters": [
           {
@@ -1267,12 +1268,12 @@
     "/convert/prometheus/config/v1/rules/{NamespaceTitle}/{Group}": {
       "get": {
         "produces": [
-          "application/json"
+          "application/yaml"
         ],
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Gets a rule group in Prometheus format.",
+        "summary": "Gets a single rule group in Prometheus-compatible format if it was imported from a Prometheus-compatible source.",
         "operationId": "RouteConvertPrometheusGetRuleGroup",
         "parameters": [
           {
@@ -1316,7 +1317,7 @@
         "tags": [
           "convert_prometheus"
         ],
-        "summary": "Deletes a rule group in Prometheus format.",
+        "summary": "Deletes a specific rule group if it was imported from a Prometheus-compatible source.",
         "operationId": "RouteConvertPrometheusDeleteRuleGroup",
         "parameters": [
           {
@@ -8710,7 +8711,6 @@
       }
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "type": "object",

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -394,6 +394,22 @@ func WithoutInternalLabels() LabelOption {
 	}
 }
 
+func (alertRule *AlertRule) ImportedFromPrometheus() bool {
+	if alertRule.Metadata.PrometheusStyleRule == nil {
+		return false
+	}
+
+	return alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition != ""
+}
+
+func (alertRule *AlertRule) PrometheusRuleDefinition() string {
+	if !alertRule.ImportedFromPrometheus() {
+		return ""
+	}
+
+	return alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition
+}
+
 // GetLabels returns the labels specified as part of the alert rule.
 func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 	labels := alertRule.Labels
@@ -806,6 +822,8 @@ type ListAlertRulesQuery struct {
 
 	ReceiverName     string
 	TimeIntervalName string
+
+	ImportedPrometheusRule *bool
 }
 
 // CountAlertRulesQuery is the query for counting alert rules

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -216,6 +216,14 @@ func (a *AlertRuleMutators) WithEditorSettingsSimplifiedNotificationsSection(ena
 	}
 }
 
+func (a *AlertRuleMutators) WithPrometheusOriginalRuleDefinition(definition string) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.Metadata.PrometheusStyleRule = &PrometheusStyleRule{
+			OriginalRuleDefinition: definition,
+		}
+	}
+}
+
 func (a *AlertRuleMutators) WithGroupIndex(groupIndex int) AlertRuleMutator {
 	return func(rule *AlertRule) {
 		rule.RuleGroupIndex = groupIndex

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1644,7 +1644,7 @@ func TestProvisiongWithFullpath(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, namespaceTitle, res2.FolderFullpath)
 
-		res3, err := ruleService.GetAlertGroupsWithFolderFullpath(context.Background(), &signedInUser, []string{namespaceUID})
+		res3, err := ruleService.GetAlertGroupsWithFolderFullpath(context.Background(), &signedInUser, &FilterOptions{NamespaceUIDs: []string{namespaceUID}})
 		require.NoError(t, err)
 		assert.Equal(t, namespaceTitle, res3[0].FolderFullpath)
 	})
@@ -1675,7 +1675,7 @@ func TestProvisiongWithFullpath(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "my-namespace/my-other-namespace containing multiple \\/\\/", res2.FolderFullpath)
 
-		res3, err := ruleService.GetAlertGroupsWithFolderFullpath(context.Background(), &signedInUser, []string{otherNamespaceUID})
+		res3, err := ruleService.GetAlertGroupsWithFolderFullpath(context.Background(), &signedInUser, &FilterOptions{NamespaceUIDs: []string{otherNamespaceUID}})
 		require.NoError(t, err)
 		assert.Equal(t, "my-namespace/my-other-namespace containing multiple \\/\\/", res3[0].FolderFullpath)
 	})

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -554,6 +554,13 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 			}
 		}
 
+		if query.ImportedPrometheusRule != nil {
+			q, err = st.filterImportedPrometheusRules(*query.ImportedPrometheusRule, q)
+			if err != nil {
+				return err
+			}
+		}
+
 		q = q.Asc("namespace_uid", "rule_group", "rule_group_idx", "id")
 
 		alertRules := make([]*ngmodels.AlertRule, 0)
@@ -590,6 +597,14 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 				if !slices.ContainsFunc(converted.NotificationSettings, func(settings ngmodels.NotificationSettings) bool {
 					return slices.Contains(settings.MuteTimeIntervals, query.TimeIntervalName)
 				}) {
+					continue
+				}
+			}
+			if query.ImportedPrometheusRule != nil { // remove false-positive hits from the result
+				hasOriginalRuleDefinition := converted.Metadata.PrometheusStyleRule != nil && len(converted.Metadata.PrometheusStyleRule.OriginalRuleDefinition) > 0
+				if *query.ImportedPrometheusRule && !hasOriginalRuleDefinition {
+					continue
+				} else if !*query.ImportedPrometheusRule && hasOriginalRuleDefinition {
 					continue
 				}
 			}
@@ -926,6 +941,23 @@ func (st DBstore) filterByContentInNotificationSettings(value string, sess *xorm
 		search = strings.ReplaceAll(strings.ReplaceAll(search, `\`, `\\`), `"`, `\"`)
 	}
 	return sess.And(fmt.Sprintf("notification_settings %s ?", st.SQLStore.GetDialect().LikeStr()), "%"+search+"%"), nil
+}
+
+func (st DBstore) filterImportedPrometheusRules(value bool, sess *xorm.Session) (*xorm.Session, error) {
+	if value {
+		// Filter for rules that have both prometheus_style_rule and original_rule_definition in metadata
+		return sess.And(
+			"metadata LIKE ? AND metadata LIKE ?",
+			"%prometheus_style_rule%",
+			"%original_rule_definition%",
+		), nil
+	}
+	// Filter for rules that don't have prometheus_style_rule and original_rule_definition in metadata
+	return sess.And(
+		"metadata NOT LIKE ? AND metadata NOT LIKE ?",
+		"%prometheus_style_rule%",
+		"%original_rule_definition%",
+	), nil
 }
 
 func (st DBstore) RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string, validateProvenance func(ngmodels.Provenance) bool, dryRun bool) ([]ngmodels.AlertRuleKey, []ngmodels.AlertRuleKey, error) {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
@@ -289,7 +290,7 @@ func (f *RuleStore) GetNamespaceInRootByTitle(ctx context.Context, title string,
 		}
 	}
 
-	return nil, fmt.Errorf("namespace with title '%s' not found", title)
+	return nil, dashboards.ErrFolderNotFound
 }
 
 func (f *RuleStore) UpdateAlertRules(_ context.Context, _ *models.UserUID, q []models.UpdateRule) error {

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -546,14 +546,14 @@ func (a apiClient) PostSilence(t *testing.T, s apimodels.PostableSilence) (apimo
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/alertmanager/grafana/api/v2/silences", a.url), bytes.NewReader(b))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	return sendRequest[apimodels.PostSilencesOKBody](t, req, http.StatusAccepted)
+	return sendRequestJSON[apimodels.PostSilencesOKBody](t, req, http.StatusAccepted)
 }
 
 func (a apiClient) GetSilence(t *testing.T, id string) (apimodels.GettableSilence, int, string) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/alertmanager/grafana/api/v2/silence/%s", a.url, id), nil)
 	require.NoError(t, err)
-	return sendRequest[apimodels.GettableSilence](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.GettableSilence](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetSilences(t *testing.T, filters ...string) (apimodels.GettableSilences, int, string) {
@@ -568,7 +568,7 @@ func (a apiClient) GetSilences(t *testing.T, filters ...string) (apimodels.Getta
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.GettableSilences](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.GettableSilences](t, req, http.StatusOK)
 }
 
 func (a apiClient) DeleteSilence(t *testing.T, id string) (any, int, string) {
@@ -580,7 +580,7 @@ func (a apiClient) DeleteSilence(t *testing.T, id string) (any, int, string) {
 		Message string `json:"message"`
 	}
 
-	return sendRequest[dynamic](t, req, http.StatusOK)
+	return sendRequestJSON[dynamic](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetRulesGroup(t *testing.T, folder string, group string) (apimodels.RuleGroupConfigResponse, int) {
@@ -694,7 +694,7 @@ func (a apiClient) GetRuleGroupProvisioning(t *testing.T, folderUID string, grou
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/provisioning/folder/%s/rule-groups/%s", a.url, folderUID, groupName), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.AlertRuleGroup](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.AlertRuleGroup](t, req, http.StatusOK)
 }
 
 func (a apiClient) CreateOrUpdateRuleGroupProvisioning(t *testing.T, group apimodels.AlertRuleGroup) (apimodels.AlertRuleGroup, int, string) {
@@ -709,7 +709,7 @@ func (a apiClient) CreateOrUpdateRuleGroupProvisioning(t *testing.T, group apimo
 	require.NoError(t, err)
 	req.Header.Add("Content-Type", "application/json")
 
-	return sendRequest[apimodels.AlertRuleGroup](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.AlertRuleGroup](t, req, http.StatusOK)
 }
 
 func (a apiClient) SubmitRuleForBacktesting(t *testing.T, config apimodels.BacktestConfig) (int, string) {
@@ -808,7 +808,7 @@ func (a apiClient) GetAllMuteTimingsWithStatus(t *testing.T) (apimodels.MuteTimi
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/provisioning/mute-timings", a.url), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.MuteTimings](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.MuteTimings](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetMuteTimingByNameWithStatus(t *testing.T, name string) (apimodels.MuteTimeInterval, int, string) {
@@ -817,7 +817,7 @@ func (a apiClient) GetMuteTimingByNameWithStatus(t *testing.T, name string) (api
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/provisioning/mute-timings/%s", a.url, name), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.MuteTimeInterval](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.MuteTimeInterval](t, req, http.StatusOK)
 }
 
 func (a apiClient) CreateMuteTimingWithStatus(t *testing.T, interval apimodels.MuteTimeInterval) (apimodels.MuteTimeInterval, int, string) {
@@ -832,7 +832,7 @@ func (a apiClient) CreateMuteTimingWithStatus(t *testing.T, interval apimodels.M
 	req.Header.Add("Content-Type", "application/json")
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.MuteTimeInterval](t, req, http.StatusCreated)
+	return sendRequestJSON[apimodels.MuteTimeInterval](t, req, http.StatusCreated)
 }
 
 func (a apiClient) EnsureMuteTiming(t *testing.T, interval apimodels.MuteTimeInterval) {
@@ -854,7 +854,7 @@ func (a apiClient) UpdateMuteTimingWithStatus(t *testing.T, interval apimodels.M
 	req.Header.Add("Content-Type", "application/json")
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.MuteTimeInterval](t, req, http.StatusAccepted)
+	return sendRequestJSON[apimodels.MuteTimeInterval](t, req, http.StatusAccepted)
 }
 
 func (a apiClient) DeleteMuteTimingWithStatus(t *testing.T, name string) (int, string) {
@@ -908,7 +908,7 @@ func (a apiClient) GetRouteWithStatus(t *testing.T) (apimodels.Route, int, strin
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/provisioning/policies", a.url), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.Route](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.Route](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetRoute(t *testing.T) apimodels.Route {
@@ -989,7 +989,7 @@ func (a apiClient) GetRuleHistoryWithStatus(t *testing.T, ruleUID string) (data.
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	require.NoError(t, err)
 
-	return sendRequest[data.Frame](t, req, http.StatusOK)
+	return sendRequestJSON[data.Frame](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetAllTimeIntervalsWithStatus(t *testing.T) ([]apimodels.GettableTimeIntervals, int, string) {
@@ -998,7 +998,7 @@ func (a apiClient) GetAllTimeIntervalsWithStatus(t *testing.T) ([]apimodels.Gett
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/notifications/time-intervals", a.url), nil)
 	require.NoError(t, err)
 
-	return sendRequest[[]apimodels.GettableTimeIntervals](t, req, http.StatusOK)
+	return sendRequestJSON[[]apimodels.GettableTimeIntervals](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetTimeIntervalByNameWithStatus(t *testing.T, name string) (apimodels.GettableTimeIntervals, int, string) {
@@ -1007,7 +1007,7 @@ func (a apiClient) GetTimeIntervalByNameWithStatus(t *testing.T, name string) (a
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/notifications/time-intervals/%s", a.url, name), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.GettableTimeIntervals](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.GettableTimeIntervals](t, req, http.StatusOK)
 }
 
 func (a apiClient) CreateReceiverWithStatus(t *testing.T, receiver apimodels.EmbeddedContactPoint) (apimodels.EmbeddedContactPoint, int, string) {
@@ -1022,7 +1022,7 @@ func (a apiClient) CreateReceiverWithStatus(t *testing.T, receiver apimodels.Emb
 	req.Header.Add("Content-Type", "application/json")
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.EmbeddedContactPoint](t, req, http.StatusAccepted)
+	return sendRequestJSON[apimodels.EmbeddedContactPoint](t, req, http.StatusAccepted)
 }
 
 func (a apiClient) EnsureReceiver(t *testing.T, receiver apimodels.EmbeddedContactPoint) {
@@ -1075,33 +1075,33 @@ func (a apiClient) GetAlertmanagerConfigWithStatus(t *testing.T) (apimodels.Gett
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/alertmanager/grafana/config/api/v1/alerts", a.url), nil)
 	require.NoError(t, err)
 
-	return sendRequest[apimodels.GettableUserConfig](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.GettableUserConfig](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetActiveAlertsWithStatus(t *testing.T) (apimodels.AlertGroups, int, string) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/alertmanager/grafana/api/v2/alerts/groups", a.url), nil)
 	require.NoError(t, err)
-	return sendRequest[apimodels.AlertGroups](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.AlertGroups](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetRuleVersionsWithStatus(t *testing.T, ruleUID string) (apimodels.GettableRuleVersions, int, string) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/ruler/grafana/api/v1/rule/%s/versions", a.url, ruleUID), nil)
 	require.NoError(t, err)
-	return sendRequest[apimodels.GettableRuleVersions](t, req, http.StatusOK)
+	return sendRequestJSON[apimodels.GettableRuleVersions](t, req, http.StatusOK)
 }
 
 func (a apiClient) GetRuleByUID(t *testing.T, ruleUID string) apimodels.GettableExtendedRuleNode {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/ruler/grafana/api/v1/rule/%s", a.url, ruleUID), nil)
 	require.NoError(t, err)
-	rule, status, raw := sendRequest[apimodels.GettableExtendedRuleNode](t, req, http.StatusOK)
+	rule, status, raw := sendRequestJSON[apimodels.GettableExtendedRuleNode](t, req, http.StatusOK)
 	requireStatusCode(t, http.StatusOK, status, raw)
 	return rule
 }
 
-func (a apiClient) ConvertPrometheusPostRuleGroup(t *testing.T, namespaceTitle, datasourceUID string, promGroup apimodels.PrometheusRuleGroup, headers map[string]string) {
+func (a apiClient) ConvertPrometheusPostRuleGroup(t *testing.T, namespaceTitle, datasourceUID string, promGroup apimodels.PrometheusRuleGroup, headers map[string]string) (apimodels.ConvertPrometheusResponse, int, string) {
 	t.Helper()
 
 	data, err := yaml.Marshal(promGroup)
@@ -1116,30 +1116,85 @@ func (a apiClient) ConvertPrometheusPostRuleGroup(t *testing.T, namespaceTitle, 
 		req.Header.Add(key, value)
 	}
 
-	_, status, raw := sendRequest[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
-	requireStatusCode(t, http.StatusAccepted, status, raw)
+	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
 }
 
-func sendRequest[T any](t *testing.T, req *http.Request, successStatusCode int) (T, int, string) {
+func (a apiClient) ConvertPrometheusGetRuleGroupRules(t *testing.T, namespaceTitle, groupName string) apimodels.PrometheusRuleGroup {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/convert/prometheus/config/v1/rules/%s/%s", a.url, namespaceTitle, groupName), nil)
+	require.NoError(t, err)
+	rule, status, raw := sendRequestYAML[apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
+	requireStatusCode(t, http.StatusOK, status, raw)
+	return rule
+}
+
+func (a apiClient) ConvertPrometheusGetNamespaceRules(t *testing.T, namespaceTitle string) map[string][]apimodels.PrometheusRuleGroup {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/convert/prometheus/config/v1/rules/%s", a.url, namespaceTitle), nil)
+	require.NoError(t, err)
+	ns, status, raw := sendRequestYAML[map[string][]apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
+	requireStatusCode(t, http.StatusOK, status, raw)
+	return ns
+}
+
+func (a apiClient) ConvertPrometheusGetAllRules(t *testing.T) map[string][]apimodels.PrometheusRuleGroup {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/convert/prometheus/config/v1/rules", a.url), nil)
+	require.NoError(t, err)
+	result, status, raw := sendRequestYAML[map[string][]apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
+	requireStatusCode(t, http.StatusOK, status, raw)
+	return result
+}
+
+func sendRequestRaw(t *testing.T, req *http.Request) ([]byte, int, error) {
 	t.Helper()
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, 0, err
+	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return body, resp.StatusCode, nil
+}
+
+func sendRequestJSON[T any](t *testing.T, req *http.Request, successStatusCode int) (T, int, string) {
+	t.Helper()
 	var result T
 
-	if resp.StatusCode != successStatusCode {
-		return result, resp.StatusCode, string(body)
+	body, statusCode, err := sendRequestRaw(t, req)
+	require.NoError(t, err)
+
+	if statusCode != successStatusCode {
+		return result, statusCode, string(body)
 	}
 
 	err = json.Unmarshal(body, &result)
 	require.NoError(t, err)
-	return result, resp.StatusCode, string(body)
+	return result, statusCode, string(body)
+}
+
+func sendRequestYAML[T any](t *testing.T, req *http.Request, successStatusCode int) (T, int, string) {
+	t.Helper()
+	var result T
+
+	body, statusCode, err := sendRequestRaw(t, req)
+	require.NoError(t, err)
+
+	if statusCode != successStatusCode {
+		return result, statusCode, string(body)
+	}
+
+	err = yaml.Unmarshal(body, &result)
+	require.NoError(t, err)
+	return result, statusCode, string(body)
 }
 
 func requireStatusCode(t *testing.T, expected, actual int, response string) {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22771,6 +22771,7 @@
       }
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -12838,6 +12838,7 @@
         "type": "object"
       },
       "gettableAlerts": {
+        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },


### PR DESCRIPTION
**What is this feature?**

Follow-up for https://github.com/grafana/grafana/pull/100558.

This feature adds API endpoints to read alert rules using mimirtool. There are three new endpoints:
* `GET /convert/prometheus/config/v1/rules` - get all rule groups in all namespaces (folders)
* `GET /convert/prometheus/config/v1/rules/{NamespaceTitle}` - get rule groups in a specific namespace
* `GET /convert/prometheus/config/v1/rules/{NamespaceTitle}/{Group}` - get a single rule group

These endpoints only return rules that were originally imported using the `/convert/prometheus/` API. Other alert rules, for example created directly in Grafana, are not accessible, and their namespaces and groups will not be shown.

For example, if there is the following folder structure with rules:

```
├── folder-1
│   └── group-1 [rule-1 rule-2] # Grafana rules
└── folder-2
    └── group-2 [rule-3] # imported from a Prometheus definition
```

In this case, the new API will return only `group-2` from `folder-2`, and `group-1` from `folder-1` will not be visible.

**How to test locally**

1. Start Grafana locally with the `alertingConversionAPI` feature flag enabled.
2. Upload some simple rules using the [CLI tool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/). They should appear in the UI as provisioned rules. See the https://github.com/grafana/grafana/pull/100558 for more details.
3. List namespaces and rule groups:

```
MIMIR_ADDRESS=http://127.0.0.1:3000/api/convert/ \
MIMIR_API_KEY=admin \
MIMIR_TENANT_ID=admin \
mimirtool rules list
```

Print all rules in YAML: `... mimirtool rules print`.
Get a specific rule group: `... mimirtool rules get <namespace> <rule_group_name>`.

You can find more info about mimirtool [here](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#list-rules).

Part of https://github.com/grafana/alerting-squad/issues/1032