### PR TITLE
Frontend tests: comment out flaky test

### DIFF
--- a/e2e/various-suite/solo-route.spec.ts
+++ b/e2e/various-suite/solo-route.spec.ts
@@ -22,7 +22,7 @@ describe('Solo Route', () => {
     cy.contains('uplot-main-div').should('not.exist');
   });
 
-  it('Can view solo repeated panel in scenes', () => {
+  /*it('Can view solo repeated panel in scenes', () => {
     // open Panel Tests - Graph NG
     e2e.pages.SoloPanel.visit(
       'templating-repeating-panels/templating-repeating-panels?orgId=1&from=1699934989607&to=1699956589607&panelId=panel-2-clone-0&__feature.dashboardSceneSolo=true'
@@ -30,7 +30,7 @@ describe('Solo Route', () => {
 
     e2e.components.Panels.Panel.title('server=A').should('exist');
     cy.contains('uplot-main-div').should('not.exist');
-  });
+  });*/
 
   it('Can view solo in repeated row and panel in scenes', () => {
     // open Panel Tests - Graph NG


### PR DESCRIPTION
Main builds are failing randomly due to this test failing / being flaky. Examples:
https://drone.grafana.net/grafana/grafana/224368/6/21
https://drone.grafana.net/grafana/grafana/224369/6/22
https://drone.grafana.net/grafana/grafana/224403/6/21

This PR disables the tests for now while the team looks into it: https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1739485830080159