### PR TITLE
Alerting: Stop running AM integration tests on CI

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -247,7 +247,8 @@
       "/pkg/services/sqlstore/migrations/ualert/**/*",
       "/pkg/services/alerting/**/*",
       "/public/app/features/alerting/**/*",
-      "/pkg/tests/api/alerting/**/*"
+      "/pkg/tests/api/alerting/**/*",
+      "/pkg/tests/alertmanager/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "area/alerting"

--- a/pkg/tests/alertmanager/alertmanager_test.go
+++ b/pkg/tests/alertmanager/alertmanager_test.go
@@ -13,7 +13,6 @@ func TestAlertmanagerIntegration_ExtraDedupStage(t *testing.T) {
 	}
 
 	t.Run("assert no flapping alerts when stopOnExtraDedup is enabled", func(t *testing.T) {
-		t.Skip("skipping flaky test")
 		s, err := NewAlertmanagerScenario()
 		require.NoError(t, err)
 		defer s.Close()

--- a/pkg/tests/alertmanager/alertmanager_test.go
+++ b/pkg/tests/alertmanager/alertmanager_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAlertmanagerIntegration_ExtraDedupStage(t *testing.T) {
+func TestAlertmanager_ExtraDedupStage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
## Context
- Flapping notification tests were added [here](https://github.com/grafana/grafana/pull/100106)
- Skip was added [here](https://github.com/grafana/grafana/pull/100640) since this was breaking the CI
- Find out what is targeting the new tests

### Summary
- Tests were breaking in grafana-enterprise ([here](https://drone.grafana.net/grafana/grafana-enterprise/82654/2/10))
- The integration tests action there has a more generic regex for selecting cases ([here](https://github.com/grafana/grafana-enterprise/blob/main/scripts/drone/steps/lib.star#L442-L442))
- Removing `Integration` from the test case name should stop it from running

- Ran the backend-enterprise tests with this to make sure we wouldn't break it again: https://drone.grafana.net/grafana/grafana-enterprise/82819/2/10