### PR TITLE
[Provisioning] Use ProgressRecorder in Export Job

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -24,7 +24,6 @@ var _ resource.BatchResourceWriter = (*folderReader)(nil)
 type folderReader struct {
 	tree           *resources.FolderTree
 	targetRepoName string
-	progress       *jobs.JobProgressRecorder
 }
 
 // Close implements resource.BatchResourceWriter.
@@ -48,6 +47,7 @@ func (f *folderReader) Write(ctx context.Context, key *resource.ResourceKey, val
 	return f.tree.AddUnstructured(item, f.targetRepoName)
 }
 
+// FIXME: revise logging in this method
 func (r *exportJob) loadFolders(ctx context.Context) error {
 	logger := r.logger
 	r.progress.SetMessage("reading folder tree")
@@ -55,6 +55,7 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 	repoName := r.target.Config().Name
 
 	if r.legacy != nil {
+		r.progress.SetMessage("migrate folder tree from legacy")
 		reader := &folderReader{
 			tree:           r.folderTree,
 			targetRepoName: repoName,
@@ -71,6 +72,8 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 			return fmt.Errorf("unable to read folders from legacy storage %w", err)
 		}
 	} else {
+		// TODO: should this be logging or message or both?
+		r.progress.SetMessage("read folder tree from unified storage")
 		client := r.client.Resource(schema.GroupVersionResource{
 			Group:    folders.GROUP,
 			Version:  folders.VERSION,
@@ -84,10 +87,16 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 		if rawList.GetContinue() != "" {
 			return fmt.Errorf("unable to list all folders in one request: %s", rawList.GetContinue())
 		}
+
 		for _, item := range rawList.Items {
 			err = r.folderTree.AddUnstructured(&item, repoName)
 			if err != nil {
-				// summary.Errors = append(summary.Errors, err.Error())
+				r.progress.Record(ctx, jobs.JobResourceResult{
+					Name:     item.GetName(),
+					Resource: folders.RESOURCE,
+					Group:    folders.GROUP,
+					Error:    err,
+				})
 			}
 		}
 	}
@@ -96,29 +105,43 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 	// NOTE: this is required so that empty folders exist when finished
 	r.progress.SetMessage("writing folders")
 
-	err := tree.Walk(ctx, func(ctx context.Context, folder resources.Folder) error {
+	err := r.folderTree.Walk(ctx, func(ctx context.Context, folder resources.Folder) error {
 		p := folder.Path + "/"
 		if r.prefix != "" {
 			p = r.prefix + "/" + p
 		}
 		logger := logger.With("path", p)
 
+		result := jobs.JobResourceResult{
+			Name:     folder.ID,
+			Resource: folders.RESOURCE,
+			Group:    folders.GROUP,
+			Path:     p,
+		}
+
 		_, err := r.target.Read(ctx, p, r.ref)
 		if err != nil && !(errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err)) {
-			logger.Error("failed to check if folder exists before writing", "error", err)
-			return fmt.Errorf("failed to check if folder exists before writing: %w", err)
+			result.Error = fmt.Errorf("failed to check if folder exists before writing: %w", err)
+			// TODO: what should we do here? Should we stop execution?
+			return result.Error
 		} else if err == nil {
 			logger.Info("folder already exists")
-			// summary.Noop++
+			result.Action = repository.FileActionIgnored
+			r.progress.Record(ctx, result)
 			return nil
 		}
 
+		result.Action = repository.FileActionCreated
+		msg := fmt.Sprintf("export folder %s", p)
 		// Create with an empty body will make a folder (or .keep file if unsupported)
-		if err := r.target.Create(ctx, p, r.ref, nil, "export folder `"+p+"`"); err != nil {
-			logger.Error("failed to write a folder in repository", "error", err)
-			return fmt.Errorf("failed to write folder in repo: %w", err)
+		if err := r.target.Create(ctx, p, r.ref, nil, msg); err != nil {
+			result.Error = fmt.Errorf("failed to write folder in repo: %w", err)
+			r.progress.Record(ctx, result)
+			// TODO: should we stop execution here?
+			return result.Error
 		}
-		// summary.Create++
+
+		r.progress.Record(ctx, result)
 		logger.Debug("successfully exported folder")
 		return nil
 	})

--- a/pkg/registry/apis/provisioning/jobs/export/job.go
+++ b/pkg/registry/apis/provisioning/jobs/export/job.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -28,82 +26,45 @@ type exportJob struct {
 	legacy    legacy.LegacyMigrator
 	namespace string
 
-	progress         jobs.ProgressFn
-	progressInterval time.Duration
-	progressLast     time.Time
-	foldersTree      *resources.FolderTree
-	userInfo         map[string]repository.CommitSignature
+	progress *jobs.JobProgressRecorder
+
+	userInfo   map[string]repository.CommitSignature
+	folderTree *resources.FolderTree
 
 	prefix         string // from options (now clean+safe)
 	ref            string // from options (only git)
 	keepIdentifier bool
 	withHistory    bool
-
-	jobStatus *provisioning.JobStatus
-	summary   map[string]*provisioning.JobResourceSummary
 }
 
 func newExportJob(ctx context.Context,
 	target repository.Repository,
 	options provisioning.ExportJobOptions,
 	client *resources.DynamicClient,
-	progress jobs.ProgressFn,
+	progress *jobs.JobProgressRecorder,
 ) *exportJob {
 	prefix := options.Prefix
 	if prefix != "" {
 		prefix = safepath.Clean(prefix)
 	}
 	return &exportJob{
-		namespace:        target.Config().Namespace,
-		target:           target,
-		client:           client,
-		logger:           logging.FromContext(ctx),
-		progress:         progress,
-		progressLast:     time.Now(),
-		progressInterval: time.Second * 5,
-
+		namespace:      target.Config().Namespace,
+		target:         target,
+		client:         client,
+		logger:         logging.FromContext(ctx),
+		progress:       progress,
 		prefix:         prefix,
 		ref:            options.Branch,
 		keepIdentifier: options.Identifier,
 		withHistory:    options.History,
-
-		jobStatus: &provisioning.JobStatus{
-			State: provisioning.JobStateWorking,
-		},
-		summary: make(map[string]*provisioning.JobResourceSummary),
+		folderTree:     resources.NewEmptyFolderTree(),
 	}
 }
 
-// Send progress messages to any listeners
-func (r *exportJob) maybeNotify(ctx context.Context) {
-	if time.Since(r.progressLast) > r.progressInterval {
-		r.progressLast = time.Now()
-		err := r.progress(ctx, *r.jobStatus)
-		if err != nil {
-			r.logger.Warn("unable to send progress", "err", err)
-		}
-	}
-}
-
-// Register summary information for a group/resource
-func (r *exportJob) getSummary(gr schema.GroupResource) *provisioning.JobResourceSummary {
-	summary, ok := r.summary[gr.String()]
-	if !ok {
-		summary = &provisioning.JobResourceSummary{
-			Group:    gr.Group,
-			Resource: gr.Resource,
-		}
-		r.summary[gr.String()] = summary
-		r.jobStatus.Summary = append(r.jobStatus.Summary, summary)
-	}
-	return summary
-}
-
-func (r *exportJob) add(ctx context.Context, summary *provisioning.JobResourceSummary, obj *unstructured.Unstructured) error {
+func (r *exportJob) add(ctx context.Context, obj *unstructured.Unstructured) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	r.maybeNotify(ctx)
 
 	item, err := utils.MetaAccessor(obj)
 	if err != nil {
@@ -138,7 +99,7 @@ func (r *exportJob) add(ctx context.Context, summary *provisioning.JobResourceSu
 	ctx = r.withAuthorSignature(ctx, item)
 
 	// Get the absolute path of the folder
-	fid, ok := r.foldersTree.DirPath(folder, "")
+	fid, ok := r.folderTree.DirPath(folder, "")
 	if !ok {
 		fid = resources.Folder{
 			Path: "__folder_not_found/" + slugify.Slugify(folder),
@@ -175,13 +136,13 @@ func (r *exportJob) add(ctx context.Context, summary *provisioning.JobResourceSu
 	// Write the file
 	err = r.target.Write(ctx, fileName, r.ref, body, commitMessage)
 	if err != nil {
-		summary.Error++
+		// summary.Error++
 		r.logger.Error("failed to write a file in repository", "error", err)
-		if len(summary.Errors) < 20 {
-			summary.Errors = append(summary.Errors, fmt.Sprintf("error writing: %s", fileName))
-		}
+		// if len(summary.Errors) < 20 {
+		// 	summary.Errors = append(summary.Errors, fmt.Sprintf("error writing: %s", fileName))
+		// }
 	} else {
-		summary.Write++
+		// summary.Write++
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -220,7 +220,9 @@ func (r *exportJob) write(ctx context.Context, obj *unstructured.Unstructured) j
 	}
 
 	err = r.target.Write(ctx, fileName, r.ref, body, commitMessage)
-	result.Error = fmt.Errorf("failed to write file: %w", err)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to write file: %w", err)
+	}
 
 	return result
 }

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -2,15 +2,19 @@ package export
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	dashboards "github.com/grafana/grafana/pkg/apis/dashboard"
+	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/safepath"
 	"github.com/grafana/grafana/pkg/storage/unified/parquet"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -18,8 +22,7 @@ import (
 var _ resource.BatchResourceWriter = (*resourceReader)(nil)
 
 type resourceReader struct {
-	job    *exportJob
-	logger logging.Logger
+	job *exportJob
 }
 
 // Close implements resource.BatchResourceWriter.
@@ -40,14 +43,10 @@ func (f *resourceReader) Write(ctx context.Context, key *resource.ResourceKey, v
 		return fmt.Errorf("failed to unmarshal unstructured: %w", err)
 	}
 
-	err = f.job.add(ctx, item)
-	if err != nil {
-		f.logger.Warn("error adding from legacy", "name", key.Name, "err", err)
-		// f.summary.Errors = append(f.summary.Errors, fmt.Sprintf("%s: %s", key.Name, err.Error()))
-		// if len(f.summary.Errors) > 50 {
-		// 	return err
-		// }
+	if err := f.job.write(ctx, item); err != nil {
+		return fmt.Errorf("write legacy item: %w", err)
 	}
+
 	return nil
 }
 
@@ -63,30 +62,27 @@ func (r *exportJob) loadResources(ctx context.Context) error {
 		if r.legacy != nil {
 			r.progress.SetMessage(fmt.Sprintf("migrate %s resource", kind.Resource))
 			gr := kind.GroupResource()
-			reader := &resourceReader{
-				job:    r,
-				logger: r.logger,
-			}
 			opts := legacy.MigrateOptions{
 				Namespace:   r.namespace,
 				WithHistory: r.withHistory,
 				Resources:   []schema.GroupResource{gr},
-				Store:       parquet.NewBatchResourceWriterClient(reader),
+				Store:       parquet.NewBatchResourceWriterClient(&resourceReader{job: r}),
 				OnlyCount:   true, // first get the count
 			}
-			_, err := r.legacy.Migrate(ctx, opts)
+			stats, err := r.legacy.Migrate(ctx, opts)
 			if err != nil {
 				return fmt.Errorf("unable to count legacy items %w", err)
 			}
 
-			// if len(stats.Summary) > 0 {
-			// 	count := stats.Summary[0].Count
-			// 	history := stats.Summary[0].History
-			// 	if history > count {
-			// 		count = history // the number of items we will process
-			// 	}
-			// 	reader.summary.Total = count
-			// }
+			// FIXME: explain why we calculate it in this way
+			if len(stats.Summary) > 0 {
+				count := stats.Summary[0].Count
+				history := stats.Summary[0].History
+				if history > count {
+					count = history // the number of items we will process
+				}
+				r.progress.SetTotal(int(count))
+			}
 
 			opts.OnlyCount = false // this time actually write
 			_, err = r.legacy.Migrate(ctx, opts)
@@ -106,7 +102,7 @@ func (r *exportJob) loadResources(ctx context.Context) error {
 func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.GroupVersionResource) error {
 	client := r.client.Resource(kind)
 
-	continueToken := ""
+	var continueToken string
 	for {
 		list, err := client.List(ctx, metav1.ListOptions{Limit: 100, Continue: continueToken})
 		if err != nil {
@@ -114,7 +110,8 @@ func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.
 		}
 
 		for _, item := range list.Items {
-			if err = r.add(ctx, &item); err != nil {
+			// TODO: when to stop execution?
+			if err = r.write(ctx, &item); err != nil {
 				return fmt.Errorf("error adding value: %w", err)
 			}
 		}
@@ -123,6 +120,95 @@ func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.
 		if continueToken == "" {
 			break
 		}
+	}
+
+	return nil
+}
+
+func (r *exportJob) write(ctx context.Context, obj *unstructured.Unstructured) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context error: %w", err)
+	}
+
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return fmt.Errorf("extract meta accessor: %w", err)
+	}
+
+	// Message from annotations
+	commitMessage := meta.GetMessage()
+	if commitMessage == "" {
+		g := meta.GetGeneration()
+		if g > 0 {
+			commitMessage = fmt.Sprintf("Generation: %d", g)
+		} else {
+			commitMessage = "exported from grafana"
+		}
+	}
+
+	name := meta.GetName()
+	repoName := meta.GetRepositoryName()
+	if repoName == r.target.Config().GetName() {
+		r.logger.Info("skip dashboard since it is already in repository", "dashboard", name)
+		// TODO: add ignore
+		return nil
+	}
+
+	title := meta.FindTitle("")
+	if title == "" {
+		title = name
+	}
+	folder := meta.GetFolder()
+
+	// Add the author in context (if available)
+	ctx = r.withAuthorSignature(ctx, meta)
+
+	// Get the absolute path of the folder
+	fid, ok := r.folderTree.DirPath(folder, "")
+	if !ok {
+		// FIXME: Shouldn't this fail instead?
+		fid = resources.Folder{
+			Path: "__folder_not_found/" + slugify.Slugify(folder),
+		}
+		r.logger.Error("folder of item was not in tree of repository")
+	}
+
+	// Clear the metadata
+	delete(obj.Object, "metadata")
+
+	if r.keepIdentifier {
+		meta.SetName(name) // keep the identifier in the metadata
+	}
+
+	body, err := json.MarshalIndent(obj.Object, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal dashboard %s: %w", name, err)
+	}
+
+	fileName := slugify.Slugify(title) + ".json"
+	if fid.Path != "" {
+		fileName, err = safepath.Join(fid.Path, fileName)
+		if err != nil {
+			return fmt.Errorf("error adding file path %s: %w", title, err)
+		}
+	}
+	if r.prefix != "" {
+		fileName, err = safepath.Join(r.prefix, fileName)
+		if err != nil {
+			return fmt.Errorf("error adding path prefix %s: %w", r.prefix, err)
+		}
+	}
+
+	// Write the file
+	err = r.target.Write(ctx, fileName, r.ref, body, commitMessage)
+	if err != nil {
+		// summary.Error++
+		r.logger.Error("failed to write a file in repository", "error", err)
+		// if len(summary.Errors) < 20 {
+		// 	summary.Errors = append(summary.Errors, fmt.Sprintf("error writing: %s", fileName))
+		// }
+	} else {
+		// summary.Write++
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -42,7 +42,7 @@ func (f *resourceReader) Write(ctx context.Context, key *resource.ResourceKey, v
 	item := &unstructured.Unstructured{}
 	err := item.UnmarshalJSON(value)
 	if err != nil {
-		// TODO: should we fail here?
+		// TODO: should we fail the entire execution?
 		return fmt.Errorf("failed to unmarshal unstructured: %w", err)
 	}
 
@@ -132,11 +132,11 @@ func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.
 }
 
 func (r *exportJob) write(ctx context.Context, obj *unstructured.Unstructured) jobs.JobResourceResult {
+	gvk := obj.GroupVersionKind()
 	result := jobs.JobResourceResult{
 		Name:     obj.GetName(),
-		Resource: obj.GetKind(),
-		Group:    "", // TODO
-		Path:     "",
+		Resource: gvk.Kind,
+		Group:    gvk.Group,
 		Action:   repository.FileActionCreated,
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -37,8 +37,9 @@ func (f *resourceReader) Write(ctx context.Context, key *resource.ResourceKey, v
 	item := &unstructured.Unstructured{}
 	err := item.UnmarshalJSON(value)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal unstructured: %w", err)
 	}
+
 	err = f.job.add(ctx, item)
 	if err != nil {
 		f.logger.Warn("error adding from legacy", "name", key.Name, "err", err)

--- a/pkg/registry/apis/provisioning/jobs/export/users.go
+++ b/pkg/registry/apis/provisioning/jobs/export/users.go
@@ -14,10 +14,6 @@ import (
 )
 
 func (r *exportJob) loadUsers(ctx context.Context) error {
-	status := r.jobStatus
-	status.Message = "reading user info"
-	r.maybeNotify(ctx)
-
 	client := r.client.Resource(schema.GroupVersionResource{
 		Group:    iam.GROUP,
 		Version:  iam.VERSION,
@@ -32,6 +28,7 @@ func (r *exportJob) loadUsers(ctx context.Context) error {
 		return fmt.Errorf("unable to list all users in one request: %s", rawList.GetContinue())
 	}
 
+	// FIXME: should we improve logging here?
 	var ok bool
 	r.userInfo = make(map[string]repository.CommitSignature)
 	for _, item := range rawList.Items {

--- a/pkg/registry/apis/provisioning/jobs/export/users.go
+++ b/pkg/registry/apis/provisioning/jobs/export/users.go
@@ -28,11 +28,11 @@ func (r *exportJob) loadUsers(ctx context.Context) error {
 		return fmt.Errorf("unable to list all users in one request: %s", rawList.GetContinue())
 	}
 
-	// FIXME: should we improve logging here?
 	var ok bool
 	r.userInfo = make(map[string]repository.CommitSignature)
 	for _, item := range rawList.Items {
 		sig := repository.CommitSignature{}
+		// FIXME: should we improve logging here?
 		sig.Name, ok, err = unstructured.NestedString(item.Object, "spec", "login")
 		if !ok || err != nil {
 			continue

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -51,58 +51,69 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 }
 
 // Process will start a job
-func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.ProgressFn) (*provisioning.JobStatus, error) {
+func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progressFn jobs.ProgressFn) (*provisioning.JobStatus, error) {
 	if repo.Config().Spec.ReadOnly {
 		return &provisioning.JobStatus{
-			State:  provisioning.JobStateError,
-			Errors: []string{"Exporting to a read only repository is not supported"},
+			State:   provisioning.JobStateError,
+			Message: "Exporting to a read only repository is not supported",
 		}, nil
 	}
 
 	options := job.Spec.Export
 	if options == nil {
 		return &provisioning.JobStatus{
-			State:  provisioning.JobStateError,
-			Errors: []string{"Export job missing export settings"},
+			State:   provisioning.JobStateError,
+			Message: "Export job missing export settings",
 		}, nil
 	}
 
-	var err error
-	var buffered *gogit.GoGitRepo
+	progress := jobs.NewJobProgressRecorder(progressFn)
+	var (
+		err      error
+		buffered *gogit.GoGitRepo
+	)
+
 	if repo.Config().Spec.GitHub != nil {
+		progress.SetMessage("clone target")
 		buffered, err = gogit.Clone(ctx, repo.Config(), gogit.GoGitCloneOptions{
 			Root:                   r.clonedir,
 			SingleCommitBeforePush: !options.History,
 		}, r.secrets, os.Stdout)
 		if err != nil {
 			return &provisioning.JobStatus{
-				State:  provisioning.JobStateError,
-				Errors: []string{"Unable to clone target", err.Error()},
+				State:   provisioning.JobStateError,
+				Message: "Unable to clone target",
+				Errors:  []string{err.Error()},
 			}, nil
 		}
 
 		// New empty branch (same on main???)
 		if options.Branch != "" {
+			progress.SetMessage("create empty branch")
 			_, err := buffered.NewEmptyBranch(ctx, options.Branch)
 			if err != nil {
 				return &provisioning.JobStatus{
-					State:  provisioning.JobStateError,
-					Errors: []string{"Unable to create empty branch", err.Error()},
+					State:   provisioning.JobStateError,
+					Message: "Unable to create empty branch",
+					Errors:  []string{err.Error()},
 				}, nil
 			}
 		}
+
 		repo = buffered     // send all writes to the buffered repo
 		options.Branch = "" // :( the branch is now baked into the repo
 	}
 
 	dynamicClient, _, err := r.clients.New(repo.Config().Namespace)
 	if err != nil {
+		// TODO: how do we really want to return errors?
 		return nil, fmt.Errorf("error getting client %w", err)
 	}
 
 	worker := newExportJob(ctx, repo, *options, dynamicClient, progress)
 
 	if options.History {
+		progress.SetMessage("load users")
 		err = worker.loadUsers(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error loading users %w", err)
@@ -115,28 +126,27 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	}
 
 	// Load and write all folders
+	progress.SetMessage("start folder export")
 	err = worker.loadFolders(ctx)
 	if err != nil {
-		return worker.jobStatus, err
+		// TODO: handle better
+		return progress.Complete(ctx, err), err
 	}
 
+	progress.SetMessage("start resource export")
 	err = worker.loadResources(ctx)
 	if err != nil {
-		return worker.jobStatus, err
+		// TODO: handle better
+		return progress.Complete(ctx, err), err
 	}
 
-	status := worker.jobStatus
-	if buffered != nil && status.State != provisioning.JobStateError {
-		status.Message = "pushing changes..."
-		worker.maybeNotify(ctx) // force notify?
-		err = buffered.Push(ctx, os.Stdout)
-		status.Message = ""
+	// TODO: handle the errors properly
+	if buffered != nil {
+		progress.SetMessage("push changes")
+		if err := buffered.Push(ctx, os.Stdout); err != nil {
+			return progress.Complete(ctx, err), err
+		}
 	}
 
-	// Add summary info to response
-	if !status.State.Finished() && err == nil {
-		status.State = provisioning.JobStateSuccess
-		status.Message = ""
-	}
-	return status, err
+	return progress.Complete(ctx, nil), err
 }

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -35,13 +35,13 @@ type JobResourceResult struct {
 }
 
 type JobProgressRecorder struct {
-	total      int
-	ref        string
-	message    string
-	results    []JobResourceResult
-	errors     []string
-	progressFn ProgressFn
-	summaries  map[string]*provisioning.JobResourceSummary
+	total       int
+	ref         string
+	message     string
+	resultCount int
+	errors      []string
+	progressFn  ProgressFn
+	summaries   map[string]*provisioning.JobResourceSummary
 }
 
 func NewJobProgressRecorder(progressFn ProgressFn) *JobProgressRecorder {
@@ -52,10 +52,7 @@ func NewJobProgressRecorder(progressFn ProgressFn) *JobProgressRecorder {
 }
 
 func (r *JobProgressRecorder) Record(ctx context.Context, result JobResourceResult) {
-	if r.results == nil {
-		r.results = make([]JobResourceResult, 0)
-	}
-	r.results = append(r.results, result)
+	r.resultCount++
 
 	if result.Error != nil {
 		logger := logging.FromContext(ctx)
@@ -140,7 +137,7 @@ func (r *JobProgressRecorder) progress() float64 {
 		return 0
 	}
 
-	return float64(r.total - len(r.results)/r.total*100)
+	return float64(r.resultCount) / float64(r.total) * 100
 }
 
 func (r *JobProgressRecorder) notify(ctx context.Context) {

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -24,8 +24,7 @@ func MaybeNotifyProgress(threshold time.Duration, fn ProgressFn) ProgressFn {
 	}
 }
 
-// FIXME: ProgressRecorder should be moved to jobs package and initialized in the queue
-
+// FIXME: ProgressRecorder should be initialized in the queue
 type JobResourceResult struct {
 	Name     string
 	Resource string
@@ -42,11 +41,13 @@ type JobProgressRecorder struct {
 	results    []JobResourceResult
 	errors     []string
 	progressFn ProgressFn
+	summaries  map[string]*provisioning.JobResourceSummary
 }
 
 func NewJobProgressRecorder(progressFn ProgressFn) *JobProgressRecorder {
 	return &JobProgressRecorder{
 		progressFn: MaybeNotifyProgress(15*time.Second, progressFn),
+		summaries:  make(map[string]*provisioning.JobResourceSummary),
 	}
 }
 
@@ -59,9 +60,12 @@ func (r *JobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	if result.Error != nil {
 		logger := logging.FromContext(ctx)
 		logger.Error("job resource operation failed", "err", result.Error, "path", result.Path, "resource", result.Resource, "group", result.Group, "action", result.Action, "name", result.Name)
-		r.errors = append(r.errors, result.Error.Error())
+		if len(r.errors) < 20 {
+			r.errors = append(r.errors, result.Error.Error())
+		}
 	}
 
+	r.updateSummary(result)
 	r.notify(ctx)
 }
 
@@ -90,63 +94,45 @@ func (r *JobProgressRecorder) Errors() []string {
 }
 
 func (r *JobProgressRecorder) summary() []*provisioning.JobResourceSummary {
-	if len(r.results) == 0 {
+	if len(r.summaries) == 0 {
 		return nil
 	}
 
-	// Group results by resource+group
-	groupedResults := make(map[string][]JobResourceResult)
-	for _, result := range r.results {
-		key := result.Resource + ":" + result.Group
-		groupedResults[key] = append(groupedResults[key], result)
-	}
-
-	summaries := make([]*provisioning.JobResourceSummary, 0)
-	for _, results := range groupedResults {
-		if len(results) == 0 {
-			continue
-		}
-
-		// Count actions
-		actions := make(map[repository.FileAction]int64)
-		var errors []string
-		for _, result := range results {
-			if result.Error != nil {
-				errors = append(errors, result.Error.Error())
-			} else {
-				actions[result.Action]++
-			}
-		}
-
-		// Create summary for this group
-
-		// Default to unknown if resource or group is empty
-		resource := results[0].Resource
-		if resource == "" {
-			resource = "unknown"
-		}
-
-		group := results[0].Group
-		if group == "" {
-			group = "unknown"
-		}
-
-		summary := &provisioning.JobResourceSummary{
-			Resource: resource,
-			Group:    group,
-			Delete:   actions[repository.FileActionDeleted],
-			Update:   actions[repository.FileActionUpdated],
-			Create:   actions[repository.FileActionCreated],
-			Write:    actions[repository.FileActionCreated] + actions[repository.FileActionUpdated],
-			Error:    int64(len(errors)),
-			Noop:     actions[repository.FileActionIgnored],
-			Errors:   errors,
-		}
-
+	summaries := make([]*provisioning.JobResourceSummary, 0, len(r.summaries))
+	for _, summary := range r.summaries {
 		summaries = append(summaries, summary)
 	}
 
 	return summaries
+}
+
+func (r *JobProgressRecorder) updateSummary(result JobResourceResult) {
+	key := result.Resource + ":" + result.Group
+	summary, exists := r.summaries[key]
+	if !exists {
+		summary = &provisioning.JobResourceSummary{
+			Resource: result.Resource,
+			Group:    result.Group,
+		}
+		r.summaries[key] = summary
+	}
+
+	if result.Error != nil {
+		summary.Errors = append(summary.Errors, result.Error.Error())
+		summary.Error++
+	} else {
+		switch result.Action {
+		case repository.FileActionDeleted:
+			summary.Delete++
+		case repository.FileActionUpdated:
+			summary.Update++
+		case repository.FileActionCreated:
+			summary.Create++
+		case repository.FileActionIgnored:
+			summary.Noop++
+		}
+		summary.Write = summary.Create + summary.Update
+	}
 }
 
 func (r *JobProgressRecorder) progress() float64 {

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -101,7 +102,7 @@ func NewEmptyFolderTree() *FolderTree {
 func (t *FolderTree) AddUnstructured(item *unstructured.Unstructured, skipRepo string) error {
 	meta, err := utils.MetaAccessor(item)
 	if err != nil {
-		return err
+		return fmt.Errorf("extract meta accessor: %w", err)
 	}
 	if meta.GetRepositoryName() == skipRepo {
 		return nil // skip it... already in tree?


### PR DESCRIPTION
# Why

Reporting progress is something that will be common across jobs and should be done in the same way.

In this way the specific job logic will remain cleaner and more focused on the job itself.

# What

- Use progress recorder instead
- Move things to resources
- Refactor progress to precalculate summary
- Do not store results

# Remarks

More to come but I want to chunk things a bit.

#  Screenshots
![Screenshot 2025-02-14 at 09 57 27](https://github.com/user-attachments/assets/d0de7236-06d1-4a95-9f89-d0acdfe5557e)
![Screenshot 2025-02-14 at 09 57 30](https://github.com/user-attachments/assets/d0be38c9-1c47-4f27-944f-9f8b9b5ea25d)
![Screenshot 2025-02-14 at 09 57 47](https://github.com/user-attachments/assets/869d6898-64b2-4702-8a5c-5e5da0452997)
![Screenshot 2025-02-14 at 09 57 57](https://github.com/user-attachments/assets/cc1d4092-9183-43df-8731-7b3b96d66f4e)
![Screenshot 2025-02-14 at 09 58 12](https://github.com/user-attachments/assets/b3fb236d-ec3b-4f04-ab35-828ce44b4427)

