### PR TITLE
[Provisioning] Consolidate job status report in JobProgressRecorder

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -123,7 +123,7 @@ type JobStatus struct {
 }
 
 // Convert a JOB to a
-func (in *JobStatus) ToSyncStatus(jobId string) SyncStatus {
+func (in JobStatus) ToSyncStatus(jobId string) SyncStatus {
 	return SyncStatus{
 		JobID:    jobId,
 		State:    in.State,

--- a/pkg/registry/apis/provisioning/jobs/export/job.go
+++ b/pkg/registry/apis/provisioning/jobs/export/job.go
@@ -21,7 +21,7 @@ type exportJob struct {
 	legacy    legacy.LegacyMigrator
 	namespace string
 
-	progress *jobs.JobProgressRecorder
+	progress jobs.JobProgressRecorder
 
 	userInfo   map[string]repository.CommitSignature
 	folderTree *resources.FolderTree
@@ -36,7 +36,7 @@ func newExportJob(ctx context.Context,
 	target repository.Repository,
 	options provisioning.ExportJobOptions,
 	client *resources.DynamicClient,
-	progress *jobs.JobProgressRecorder,
+	progress jobs.JobProgressRecorder,
 ) *exportJob {
 	prefix := options.Prefix
 	if prefix != "" {

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -48,8 +48,8 @@ func (f *resourceReader) Write(ctx context.Context, key *resource.ResourceKey, v
 
 	if result := f.job.write(ctx, item); result.Error != nil {
 		f.job.progress.Record(ctx, result)
-		if f.job.progress.TooManyErrors() {
-			return fmt.Errorf("stopping execution due to too many errors")
+		if err := f.job.progress.TooManyErrors(); err != nil {
+			return err
 		}
 	}
 
@@ -117,8 +117,8 @@ func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.
 
 		for _, item := range list.Items {
 			r.progress.Record(ctx, r.write(ctx, &item))
-			if r.progress.TooManyErrors() {
-				return fmt.Errorf("stopping execution due to too many errors")
+			if err := r.progress.TooManyErrors(); err != nil {
+				return err
 			}
 		}
 

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -48,7 +48,7 @@ func (f *resourceReader) Write(ctx context.Context, key *resource.ResourceKey, v
 
 	if result := f.job.write(ctx, item); result.Error != nil {
 		f.job.progress.Record(ctx, result)
-		if len(f.job.progress.Errors()) > 20 {
+		if f.job.progress.TooManyErrors() {
 			return fmt.Errorf("stopping execution due to too many errors")
 		}
 	}
@@ -117,7 +117,7 @@ func (r *exportJob) loadResourcesFromAPIServer(ctx context.Context, kind schema.
 
 		for _, item := range list.Items {
 			r.progress.Record(ctx, r.write(ctx, &item))
-			if len(r.progress.Errors()) > 20 {
+			if r.progress.TooManyErrors() {
 				return fmt.Errorf("stopping execution due to too many errors")
 			}
 		}

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -51,7 +51,7 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 }
 
 // Process will start a job
-func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progressFn jobs.ProgressFn) (*provisioning.JobStatus, error) {
+func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress *jobs.JobProgressRecorder) (*provisioning.JobStatus, error) {
 	if repo.Config().Spec.ReadOnly {
 		return &provisioning.JobStatus{
 			State:   provisioning.JobStateError,
@@ -67,7 +67,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		}, nil
 	}
 
-	progress := jobs.NewJobProgressRecorder(progressFn)
+	progress.SetMessage("starting export processing")
 	var (
 		err      error
 		buffered *gogit.GoGitRepo

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -51,7 +51,7 @@ func (r *ExportWorker) IsSupported(ctx context.Context, job provisioning.Job) bo
 }
 
 // Process will start a job
-func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress *jobs.JobProgressRecorder) (*provisioning.JobStatus, error) {
+func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress jobs.JobProgressRecorder) (*provisioning.JobStatus, error) {
 	if repo.Config().Spec.ReadOnly {
 		return &provisioning.JobStatus{
 			State:   provisioning.JobStateError,

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -54,12 +54,14 @@ func NewJobProgressRecorder(progressFn ProgressFn) *JobProgressRecorder {
 func (r *JobProgressRecorder) Record(ctx context.Context, result JobResourceResult) {
 	r.resultCount++
 
+	logger := logging.FromContext(ctx).With("path", result.Path, "resource", result.Resource, "group", result.Group, "action", result.Action, "name", result.Name)
 	if result.Error != nil {
-		logger := logging.FromContext(ctx)
-		logger.Error("job resource operation failed", "err", result.Error, "path", result.Path, "resource", result.Resource, "group", result.Group, "action", result.Action, "name", result.Name)
+		logger.Error("job resource operation failed", "err", result.Error)
 		if len(r.errors) < 20 {
 			r.errors = append(r.errors, result.Error.Error())
 		}
+	} else {
+		logger.Info("job resource operation succeeded")
 	}
 
 	r.updateSummary(result)

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -39,6 +39,7 @@ type JobResourceResult struct {
 }
 
 type jobProgressRecorder struct {
+	started     time.Time
 	total       int
 	ref         string
 	message     string
@@ -49,8 +50,9 @@ type jobProgressRecorder struct {
 	summaries   map[string]*provisioning.JobResourceSummary
 }
 
-func NewJobProgressRecorder(progressFn progressFn) JobProgressRecorder {
+func newJobProgressRecorder(progressFn progressFn) JobProgressRecorder {
 	return &jobProgressRecorder{
+		started:    time.Now(),
 		progressFn: maybeNotifyProgress(15*time.Second, progressFn),
 		summaries:  make(map[string]*provisioning.JobResourceSummary),
 	}
@@ -170,9 +172,9 @@ func (r *jobProgressRecorder) notify(ctx context.Context) {
 func (r *jobProgressRecorder) Complete(ctx context.Context, err error) provisioning.JobStatus {
 	// Initialize base job status
 	jobStatus := provisioning.JobStatus{
-		// TODO: do we really need to set this one here?
-		// Started:  job.Status.Started,
-		// TODO: do we really need to set this one here?
+		Started: r.started.UnixMilli(),
+		// FIXME: if we call this method twice, the state will be different
+		// This results in sync status to be different from job status
 		Finished: time.Now().UnixMilli(),
 		State:    provisioning.JobStateSuccess,
 		Message:  "completed successfully",

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -10,9 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 )
 
-// MaybeNotifyProgress will only notify if a certain amount of time has passed
+// maybeNotifyProgress will only notify if a certain amount of time has passed
 // or if the job completed
-func MaybeNotifyProgress(threshold time.Duration, fn ProgressFn) ProgressFn {
+func maybeNotifyProgress(threshold time.Duration, fn ProgressFn) ProgressFn {
 	var last time.Time
 
 	return func(ctx context.Context, status provisioning.JobStatus) error {
@@ -48,7 +48,7 @@ type JobProgressRecorder struct {
 
 func NewJobProgressRecorder(progressFn ProgressFn) *JobProgressRecorder {
 	return &JobProgressRecorder{
-		progressFn: MaybeNotifyProgress(15*time.Second, progressFn),
+		progressFn: maybeNotifyProgress(15*time.Second, progressFn),
 		summaries:  make(map[string]*provisioning.JobResourceSummary),
 	}
 }

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -167,7 +167,7 @@ func (r *jobProgressRecorder) notify(ctx context.Context) {
 	}
 }
 
-func (r *jobProgressRecorder) Complete(ctx context.Context, err error) *provisioning.JobStatus {
+func (r *jobProgressRecorder) Complete(ctx context.Context, err error) provisioning.JobStatus {
 	// Initialize base job status
 	jobStatus := provisioning.JobStatus{
 		// TODO: do we really need to set this one here?
@@ -197,5 +197,5 @@ func (r *jobProgressRecorder) Complete(ctx context.Context, err error) *provisio
 		jobStatus.Message = r.message
 	}
 
-	return &jobStatus
+	return jobStatus
 }

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -90,8 +91,12 @@ func (r *JobProgressRecorder) SetTotal(total int) {
 	r.total = total
 }
 
-func (r *JobProgressRecorder) TooManyErrors() bool {
-	return r.errorCount > 20
+func (r *JobProgressRecorder) TooManyErrors() error {
+	if r.errorCount > 20 {
+		return fmt.Errorf("too many errors: %d", r.errorCount)
+	}
+
+	return nil
 }
 
 func (r *JobProgressRecorder) summary() []*provisioning.JobResourceSummary {

--- a/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
@@ -108,7 +108,7 @@ func (c *PullRequestWorker) IsSupported(ctx context.Context, job provisioning.Jo
 func (c *PullRequestWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
-	progress jobs.ProgressFn,
+	progress *jobs.JobProgressRecorder,
 ) (*provisioning.JobStatus, error) {
 	cfg := repo.Config().Spec
 

--- a/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
@@ -108,7 +108,7 @@ func (c *PullRequestWorker) IsSupported(ctx context.Context, job provisioning.Jo
 func (c *PullRequestWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
-	progress *jobs.JobProgressRecorder,
+	progress jobs.JobProgressRecorder,
 ) (*provisioning.JobStatus, error) {
 	cfg := repo.Config().Spec
 

--- a/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
@@ -109,27 +109,27 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
 	progress jobs.JobProgressRecorder,
-) (*provisioning.JobStatus, error) {
+) error {
 	cfg := repo.Config().Spec
 
 	options := job.Spec.PullRequest
 	if options == nil {
-		return nil, apierrors.NewBadRequest("missing spec.pr")
+		return apierrors.NewBadRequest("missing spec.pr")
 	}
 
 	prRepo, ok := repo.(PullRequestRepo)
 	if !ok {
-		return nil, fmt.Errorf("repository is not a github repository")
+		return fmt.Errorf("repository is not a github repository")
 	}
 
 	baseURL, err := url.Parse(c.urlProvider(job.Namespace))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing base url: %w", err)
+		return fmt.Errorf("error parsing base url: %w", err)
 	}
 
 	parser, err := c.parsers.GetParser(ctx, repo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get parser for %s: %w", repo.Config().Name, err)
+		return fmt.Errorf("failed to get parser for %s: %w", repo.Config().Name, err)
 	}
 
 	// TODO: Figure out how we want to determine this in practice.
@@ -139,10 +139,8 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	// TODO: clean specification to have better options
 	if !linting &&
 		!cfg.GitHub.GenerateDashboardPreviews {
-		return &provisioning.JobStatus{
-			State:   provisioning.JobStateSuccess,
-			Message: "linting and previews are not required",
-		}, nil
+		progress.SetMessage("linting and previews are not required")
+		return nil
 	}
 
 	logger := logging.FromContext(ctx).With("pr", options.PR)
@@ -155,25 +153,17 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	// list pull requests changes files
 	files, err := prRepo.CompareFiles(ctx, base, ref)
 	if err != nil {
-		return &provisioning.JobStatus{
-			State:   provisioning.JobStateError,
-			Message: fmt.Sprintf("failed to list pull request files: %s", err.Error()),
-		}, nil
+		return fmt.Errorf("failed to list pull request files: %s", err.Error())
 	}
 
 	// clear all previous comments
 	if err := prRepo.ClearAllPullRequestFileComments(ctx, options.PR); err != nil {
-		return &provisioning.JobStatus{
-			State:   provisioning.JobStateError,
-			Message: fmt.Sprintf("failed to clear pull request comments: %+v", err),
-		}, nil
+		return fmt.Errorf("failed to clear pull request comments: %+v", err)
 	}
 
 	if len(files) == 0 {
-		return &provisioning.JobStatus{
-			State:   provisioning.JobStateSuccess,
-			Message: "no files to process",
-		}, nil
+		progress.SetMessage("no files to process")
+		return nil
 	}
 
 	previews := make([]resourcePreview, 0, len(files))
@@ -186,10 +176,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		logger := logger.With("file", f.Path)
 		fileInfo, err := prRepo.Read(ctx, f.Path, ref)
 		if err != nil {
-			return &provisioning.JobStatus{
-				State:   provisioning.JobStateError,
-				Message: fmt.Sprintf("failed to read file %s: %+v", f.Path, err),
-			}, nil
+			return fmt.Errorf("failed to read file %s: %+v", f.Path, err)
 		}
 
 		parsed, err := parser.Parse(ctx, fileInfo, true)
@@ -205,11 +192,11 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		if linting && len(parsed.Lint) > 0 && f.Action != repository.FileActionDeleted {
 			var buf bytes.Buffer
 			if err := c.lintTemplate.Execute(&buf, parsed.Lint); err != nil {
-				return nil, fmt.Errorf("execute lint comment template: %w", err)
+				return fmt.Errorf("execute lint comment template: %w", err)
 			}
 
 			if err := prRepo.CommentPullRequestFile(ctx, options.PR, f.Path, ref, buf.String()); err != nil {
-				return nil, fmt.Errorf("comment pull request file %s: %w", f.Path, err)
+				return fmt.Errorf("comment pull request file %s: %w", f.Path, err)
 			}
 
 			logger.Info("lint comment added")
@@ -234,16 +221,15 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		case repository.FileActionDeleted:
 			preview.OriginalURL = c.previewURL(baseURL, repo.Config().GetName(), base, f.Path, options.URL)
 		default:
-			return nil, fmt.Errorf("unknown file action: %s", f.Action)
+			return fmt.Errorf("unknown file action: %s", f.Action)
 		}
 
 		if cfg.GitHub.GenerateDashboardPreviews && f.Action != repository.FileActionDeleted {
 			screenshotURL, err := c.renderer.RenderDashboardPreview(ctx, repo.Config().GetNamespace(), repo.Config().GetName(), f.Path, ref)
 			if err != nil {
-				return nil, fmt.Errorf("render dashboard preview: %w", err)
+				return fmt.Errorf("render dashboard preview: %w", err)
 			}
 			preview.PreviewScreenshotURL = screenshotURL
-
 			logger.Info("dashboard preview added", "screenshotURL", screenshotURL)
 		}
 
@@ -253,20 +239,17 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	if len(previews) > 0 && cfg.GitHub.GenerateDashboardPreviews {
 		var buf bytes.Buffer
 		if err := c.prevTemplate.Execute(&buf, previews); err != nil {
-			return nil, fmt.Errorf("execute previews comment template: %w", err)
+			return fmt.Errorf("execute previews comment template: %w", err)
 		}
 
 		if err := prRepo.CommentPullRequest(ctx, options.PR, buf.String()); err != nil {
-			return nil, fmt.Errorf("comment pull request: %w", err)
+			return fmt.Errorf("comment pull request: %w", err)
 		}
 
 		logger.Info("previews comment added", "number", len(previews))
 	}
 
-	return &provisioning.JobStatus{
-		State:   provisioning.JobStateSuccess,
-		Message: "finished", // can update with useful feedback
-	}, nil
+	return nil
 }
 
 // previewURL returns the URL to preview the file in Grafana

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -220,9 +220,10 @@ func (s *jobStore) processByWorker(ctx context.Context, worker Worker, job provi
 		return nil, errors.New("unknown repository")
 	}
 
-	return worker.Process(ctx, repo, job, func(ctx context.Context, j provisioning.JobStatus) error {
+	progressRecorder := NewJobProgressRecorder(func(ctx context.Context, j provisioning.JobStatus) error {
 		return s.Update(ctx, job.Namespace, job.Name, j)
 	})
+	return worker.Process(ctx, repo, job, progressRecorder)
 }
 
 // Checkout the next "pending" job

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -74,7 +74,7 @@ func (r *SyncWorker) IsSupported(ctx context.Context, job provisioning.Job) bool
 func (r *SyncWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
-	progress *jobs.JobProgressRecorder,
+	progress jobs.JobProgressRecorder,
 ) (*provisioning.JobStatus, error) {
 	progress.SetMessage("starting sync processing")
 	cfg := repo.Config()
@@ -147,7 +147,7 @@ func (r *SyncWorker) Process(ctx context.Context,
 }
 
 // start a job and run it
-func (r *SyncWorker) createJob(ctx context.Context, repo repository.Repository, progress *jobs.JobProgressRecorder) (*syncJob, error) {
+func (r *SyncWorker) createJob(ctx context.Context, repo repository.Repository, progress jobs.JobProgressRecorder) (*syncJob, error) {
 	cfg := repo.Config()
 	if !cfg.Spec.Sync.Enabled {
 		return nil, errors.New("sync is not enabled")
@@ -201,7 +201,7 @@ func (r *SyncWorker) patchStatus(ctx context.Context, repo *provisioning.Reposit
 // created once for each sync execution
 type syncJob struct {
 	repository   repository.Repository
-	progress     *jobs.JobProgressRecorder
+	progress     jobs.JobProgressRecorder
 	parser       *resources.Parser
 	lister       resources.ResourceLister
 	folders      dynamic.ResourceInterface

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -74,12 +74,13 @@ func (r *SyncWorker) IsSupported(ctx context.Context, job provisioning.Job) bool
 func (r *SyncWorker) Process(ctx context.Context,
 	repo repository.Repository,
 	job provisioning.Job,
-	progressFn jobs.ProgressFn,
+	progress *jobs.JobProgressRecorder,
 ) (*provisioning.JobStatus, error) {
+	progress.SetMessage("starting sync processing")
 	cfg := repo.Config()
 	logger := logging.FromContext(ctx).With("job", job.GetName(), "namespace", job.GetNamespace())
 
-	// Update sync status at the start
+	progress.SetMessage("starting sync processing")
 	data := map[string]any{
 		"status": map[string]any{
 			"sync": job.Status.ToSyncStatus(job.Name),
@@ -91,7 +92,7 @@ func (r *SyncWorker) Process(ctx context.Context,
 	}
 
 	// Create job
-	progress := jobs.NewJobProgressRecorder(progressFn)
+	progress.SetMessage("starting sync processing")
 	syncJob, err := r.createJob(ctx, repo, progress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sync job: %w", err)

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -285,7 +285,7 @@ func (r *syncJob) applyChanges(ctx context.Context, changes []ResourceFileChange
 
 	// Create folder structure first
 	for _, change := range changes {
-		if len(r.progress.Errors()) > 20 {
+		if r.progress.TooManyErrors() {
 			r.progress.Record(ctx, jobs.JobResourceResult{
 				Name:     change.Existing.Name,
 				Resource: change.Existing.Resource,
@@ -348,7 +348,7 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 	r.progress.SetMessage("replicating versioned changes")
 
 	for _, change := range diff {
-		if len(r.progress.Errors()) > 20 {
+		if r.progress.TooManyErrors() {
 			r.progress.Record(ctx, jobs.JobResourceResult{
 				Path: change.Path,
 				// FIXME: should we use a skipped action instead? or a different action type?

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -31,7 +31,7 @@ type JobQueue interface {
 
 type Worker interface {
 	IsSupported(ctx context.Context, job provisioning.Job) bool
-	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress ProgressFn) (*provisioning.JobStatus, error)
+	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress *JobProgressRecorder) (*provisioning.JobStatus, error)
 }
 
 // ProgressFn is a function that can be called to update the progress of a job

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -42,7 +42,7 @@ type JobProgressRecorder interface {
 
 type Worker interface {
 	IsSupported(ctx context.Context, job provisioning.Job) bool
-	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress JobProgressRecorder) (*provisioning.JobStatus, error)
+	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress JobProgressRecorder) error
 }
 
 // ProgressFn is a function that can be called to update the progress of a job

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -37,7 +37,7 @@ type JobProgressRecorder interface {
 	GetRef() string
 	SetTotal(total int)
 	TooManyErrors() error
-	Complete(ctx context.Context, err error) *provisioning.JobStatus
+	Complete(ctx context.Context, err error) provisioning.JobStatus
 }
 
 type Worker interface {

--- a/pkg/registry/apis/provisioning/jobs/types.go
+++ b/pkg/registry/apis/provisioning/jobs/types.go
@@ -29,9 +29,20 @@ type JobQueue interface {
 	Register(worker Worker)
 }
 
+type JobProgressRecorder interface {
+	Record(ctx context.Context, result JobResourceResult)
+	SetMessage(msg string)
+	GetMessage() string
+	SetRef(ref string)
+	GetRef() string
+	SetTotal(total int)
+	TooManyErrors() error
+	Complete(ctx context.Context, err error) *provisioning.JobStatus
+}
+
 type Worker interface {
 	IsSupported(ctx context.Context, job provisioning.Job) bool
-	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress *JobProgressRecorder) (*provisioning.JobStatus, error)
+	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress JobProgressRecorder) (*provisioning.JobStatus, error)
 }
 
 // ProgressFn is a function that can be called to update the progress of a job


### PR DESCRIPTION
# Why?

We don't want to create or handle job status or logging for job execution all over the place. We want to have a single place and not creating artificial situations.

# What

- Log also successful operation
- Consolidate stop logic under TooManyErrors.
- Use error for TooManyErrors.
- Pass the progress recorder.
- Define JobProgressRecorder interface.
- Do not expect workers to return status.
- Remove scenarios due to pointers.
- Use recorder to manage the entire state.
