### PR TITLE
influxdb - fix nil pointer usage - fixes #100723

### DIFF
--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -176,8 +176,7 @@ func execute(ctx context.Context, tracer trace.Tracer, dsInfo *models.Datasource
 	res, err := dsInfo.HTTPClient.Do(request)
 	if err != nil {
 		return backend.DataResponse{
-			Error:       err,
-			ErrorSource: backend.ErrorSourceFromHTTPStatus(res.StatusCode),
+			Error: err,
 		}, err
 	}
 	defer func() {


### PR DESCRIPTION
When introducing errorsource over in:

https://github.com/grafana/grafana/pull/99900

I introduced a bug - trying to use a http response with a non-nil error. In that case, the response is nil, so code panics.

This PR removes that check.

