### PR TITLE
SQL Expressions: Include SQL Parser/Syntax error in the public message

### DIFF
--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -31,7 +31,7 @@ func NewSQLCommand(refID, rawSQL string) (*SQLCommand, error) {
 	if err != nil {
 		logger.Warn("invalid sql query", "sql", rawSQL, "error", err)
 		return nil, errutil.BadRequest("sql-invalid-sql",
-			errutil.WithPublicMessage("error reading SQL command"),
+			errutil.WithPublicMessage(fmt.Sprintf("invalid SQL query: %s", err)),
 		)
 	}
 	if len(tables) == 0 {


### PR DESCRIPTION
**What is this feature?**

Pass SQL Parsing errors back to the user instead of just a 500.

![image](https://github.com/user-attachments/assets/23e56bb6-44c4-4555-958b-b2a2670d7d89)


**Why do we need this feature?**

Users are understandably confused when they don't see the error message. 

Users are not tailing the server logs as they use a feature like one might in development :-)

**Which issue(s) does this PR fix?**:

#100721

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
