### PR TITLE
PluginExtensions: Making it possible to set secureJsonData on datasource config page.

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -193,7 +193,10 @@ export type PluginExtensionPanelContext = {
   data?: PanelData;
 };
 
-export type PluginExtensionDataSourceConfigContext<JsonData extends DataSourceJsonData = DataSourceJsonData> = {
+export type PluginExtensionDataSourceConfigContext<
+  JsonData extends DataSourceJsonData = DataSourceJsonData,
+  SecureJsonData = {},
+> = {
   // The current datasource settings
   dataSource: DataSourceSettings<JsonData>;
 
@@ -209,6 +212,7 @@ export type PluginExtensionDataSourceConfigContext<JsonData extends DataSourceJs
   // Can be used to update the `jsonData` field on the datasource
   // (Only updates the form, it still needs to be saved by the user)
   setJsonData: (jsonData: JsonData) => void;
+  setSecureJsonData: (secureJsonData: SecureJsonData) => void;
 };
 
 export type PluginExtensionCommandPaletteContext = {};

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -358,6 +358,7 @@ describe('<EditDataSource>', () => {
       expect(props.context.dataSource).toBeDefined();
       expect(props.context.dataSourceMeta).toBeDefined();
       expect(props.context.setJsonData).toBeDefined();
+      expect(props.context.setSecureJsonData).toBeDefined();
       expect(props.context.testingStatus).toBeDefined();
     });
   });

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -211,7 +211,7 @@ export function EditDataSourceView({
           <div key={extension.id}>
             <Component
               context={{
-                dataSource: omit(dataSource, ['secureJsonData']),
+                dataSource: dataSource,
                 dataSourceMeta: dataSourceMeta,
                 testingStatus,
                 setJsonData: (jsonData) =>

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -219,6 +219,11 @@ export function EditDataSourceView({
                     ...dataSource,
                     jsonData: { ...dataSource.jsonData, ...jsonData },
                   }),
+                setSecureJsonData: (secureJsonData) =>
+                  onOptionsChange({
+                    ...dataSource,
+                    secureJsonData: { ...dataSource.secureJsonData, ...secureJsonData },
+                  }),
               }}
             />
           </div>

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -1,5 +1,4 @@
 import { AnyAction } from '@reduxjs/toolkit';
-import { omit } from 'lodash';
 import { useMemo } from 'react';
 import * as React from 'react';
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes it possible for `grafana-auth-app` and `grafana-pdc-app` to also interact with the secure json data. Prior to this PR they could only interact with json data.

**Why do we need this feature?**

To be able to setup tokens via the `grafana-pdc-app` extension.

**Who is this feature for?**

Users using the PDC functionality

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
