### PR TITLE
SecureValues: make decrypters an optional field

### DIFF
--- a/pkg/apis/secret/v0alpha1/secure_value.go
+++ b/pkg/apis/secret/v0alpha1/secure_value.go
@@ -32,7 +32,8 @@ type SecureValueSpec struct {
 	// Name of the keeper, being the actual storage of the secure value.
 	Keeper string `json:"keeper,omitempty"`
 
-	// The Decrypters that are allowed to decrypt this secret
+	// The Decrypters that are allowed to decrypt this secret.
+	// An empty list means no service can decrypt it.
 	// Support and behavior is still TBD, but could likely look like:
 	// * testdata.grafana.app/{name1}
 	// * testdata.grafana.app/{name2}
@@ -41,6 +42,7 @@ type SecureValueSpec struct {
 	// [{ group:"testdata.grafana.app", name="name1"},
 	//  { group:"runner.k6.grafana.app"}]
 	// +listType=atomic
+	// +optional
 	Decrypters []string `json:"decrypters"`
 }
 

--- a/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
@@ -681,7 +681,7 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "The Decrypters that are allowed to decrypt this secret Support and behavior is still TBD, but could likely look like: * testdata.grafana.app/{name1} * testdata.grafana.app/{name2} * runner.k6.grafana.app/*  -- allow any k6 test runner Rather than a string pattern, we may want a more explicit object: [{ group:\"testdata.grafana.app\", name=\"name1\"},\n { group:\"runner.k6.grafana.app\"}]",
+							Description: "The Decrypters that are allowed to decrypt this secret. An empty list means no service can decrypt it. Support and behavior is still TBD, but could likely look like: * testdata.grafana.app/{name1} * testdata.grafana.app/{name2} * runner.k6.grafana.app/*  -- allow any k6 test runner Rather than a string pattern, we may want a more explicit object: [{ group:\"testdata.grafana.app\", name=\"name1\"},\n { group:\"runner.k6.grafana.app\"}]",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -695,7 +695,7 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"title", "decrypters"},
+				Required: []string{"title"},
 			},
 		},
 	}

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -207,10 +207,9 @@ func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admiss
 	}
 
 	// General validations.
-
 	decrypterGroups := make(map[string]map[string]int, 0)
 
-	// Decrypters must match "{group}/{name OR *}" and must be unique.
+	// If populated, `Decrypters` must match "{group}/{name OR *}" and must be unique.
 	for i, decrypter := range sv.Spec.Decrypters {
 		group, name, found := strings.Cut(decrypter, "/")
 		if !found {
@@ -303,10 +302,6 @@ func validateSecureValueCreate(sv *secretv0alpha1.SecureValue) field.ErrorList {
 
 	if sv.Spec.Value != "" && sv.Spec.Ref != "" {
 		errs = append(errs, field.Required(field.NewPath("spec"), "only one of `value` or `ref` can be set"))
-	}
-
-	if len(sv.Spec.Decrypters) == 0 {
-		errs = append(errs, field.Required(field.NewPath("spec", "decrypters"), "`decrypters` is required"))
 	}
 
 	return errs

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -54,15 +54,6 @@ func TestValidateSecureValue(t *testing.T) {
 			require.Len(t, errs, 1)
 			require.Equal(t, "spec", errs[0].Field)
 		})
-
-		t.Run("`decrypters` must be present", func(t *testing.T) {
-			sv := validSecureValue.DeepCopy()
-			sv.Spec.Decrypters = make([]string, 0)
-
-			errs := ValidateSecureValue(sv, nil, admission.Create)
-			require.Len(t, errs, 1)
-			require.Equal(t, "spec.decrypters", errs[0].Field)
-		})
 	})
 
 	t.Run("when updating a securevalue", func(t *testing.T) {

--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -49,7 +49,7 @@ func initSecretStore(mg *migrator.Migrator) string {
 			// Spec
 			{Name: "title", Type: migrator.DB_Text, Nullable: false},
 			{Name: "keeper", Type: migrator.DB_Text, Nullable: false},
-			{Name: "decrypters", Type: migrator.DB_Text, Nullable: false},
+			{Name: "decrypters", Type: migrator.DB_Text, Nullable: true},
 			{Name: "ref", Type: migrator.DB_Text, Nullable: true}, // Reference to third-party storage secret path.
 			{Name: "external_id", Type: migrator.DB_Text, Nullable: false},
 		},


### PR DESCRIPTION
If the `decrypters` field is empty, it means a `SecureValue` is not decryptable(?) by any service.

This is a valid use-case where a user might want to create a `SecureValue` but not yet grant decrypt access to any service/machine.

Yes, this breaks the dev DB, when we deploy a new version there I will manually fix the table, should just be a query or two :)