### PR TITLE
Provisioning: Refactor webhook to another interface

### DIFF
--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -392,14 +392,3 @@ func (r *localRepository) History(ctx context.Context, path string, ref string) 
 		},
 	}
 }
-
-// Webhook implements Repository.
-func (r *localRepository) Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error) {
-	return &provisioning.WebhookResponse{
-		Code: http.StatusAccepted,
-		Job: &provisioning.JobSpec{
-			Repository: r.Config().GetName(),
-			Action:     provisioning.JobActionSync, // sync the latest changes
-		},
-	}, nil
-}

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -88,13 +88,12 @@ type Repository interface {
 
 	// History of changes for a path
 	History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error)
-
-	// For repositories that support webhooks
-	Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error)
 }
 
 // Hooks called after the repository has been created, updated or deleted
 type RepositoryHooks interface {
+	// For repositories that support webhooks
+	Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error)
 	OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnDelete(ctx context.Context) error


### PR DESCRIPTION
Not all repositories support webhooks. Let's not require it as part of a repository, rather as an addon feature.