### PR TITLE
Provisioning: Refactor history to its own interface

### DIFF
--- a/pkg/registry/apis/provisioning/history.go
+++ b/pkg/registry/apis/provisioning/history.go
@@ -6,11 +6,13 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 )
 
 type historySubresource struct {
@@ -58,6 +60,12 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hist, ok := repo.(repository.Historical)
+		if !ok {
+			responder.Error(errors.NewBadRequest("this repository does not support history"))
+			return
+		}
+
 		query := r.URL.Query()
 		ref := query.Get("ref")
 
@@ -71,7 +79,7 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 		logger := logger.With("ref", ref, "path", filePath)
 		ctx := logging.Context(r.Context(), logger)
 
-		commits, err := repo.History(ctx, filePath, ref)
+		commits, err := hist.History(ctx, filePath, ref)
 		if err != nil {
 			logger.Debug("failed to get history", "error", err)
 			responder.Error(err)

--- a/pkg/registry/apis/provisioning/history.go
+++ b/pkg/registry/apis/provisioning/history.go
@@ -60,7 +60,7 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hist, ok := repo.(repository.Historical)
+		versioned, ok := repo.(repository.VersionedRepository)
 		if !ok {
 			responder.Error(errors.NewBadRequest("this repository does not support history"))
 			return
@@ -79,7 +79,7 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 		logger := logger.With("ref", ref, "path", filePath)
 		ctx := logging.Context(r.Context(), logger)
 
-		commits, err := hist.History(ctx, filePath, ref)
+		commits, err := versioned.History(ctx, filePath, ref)
 		if err != nil {
 			logger.Debug("failed to get history", "error", err)
 			responder.Error(err)

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -38,9 +38,9 @@ type githubRepository struct {
 }
 
 var (
-	_ Repository      = (*githubRepository)(nil)
-	_ RepositoryHooks = (*githubRepository)(nil)
-	_ Historical      = (*githubRepository)(nil)
+	_ Repository          = (*githubRepository)(nil)
+	_ RepositoryHooks     = (*githubRepository)(nil)
+	_ VersionedRepository = (*githubRepository)(nil)
 )
 
 func NewGitHub(

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -37,7 +37,11 @@ type githubRepository struct {
 	repo  string
 }
 
-var _ Repository = (*githubRepository)(nil)
+var (
+	_ Repository      = (*githubRepository)(nil)
+	_ RepositoryHooks = (*githubRepository)(nil)
+	_ Historical      = (*githubRepository)(nil)
+)
 
 func NewGitHub(
 	ctx context.Context,

--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -383,12 +383,3 @@ func (r *localRepository) Delete(ctx context.Context, path string, ref string, c
 
 	return os.Remove(path)
 }
-
-func (r *localRepository) History(ctx context.Context, path string, ref string) ([]provisioning.HistoryItem, error) {
-	return nil, &apierrors.StatusError{
-		ErrStatus: metav1.Status{
-			Message: "history is not yet implemented",
-			Code:    http.StatusNotImplemented,
-		},
-	}
-}

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -85,9 +85,6 @@ type Repository interface {
 
 	// Delete a file in the remote repository
 	Delete(ctx context.Context, path, ref, message string) error
-
-	// History of changes for a path
-	History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error)
 }
 
 // Hooks called after the repository has been created, updated or deleted
@@ -97,6 +94,11 @@ type RepositoryHooks interface {
 	OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error)
 	OnDelete(ctx context.Context) error
+}
+
+type Historical interface {
+	// History of changes for a path
+	History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error)
 }
 
 type FileAction string

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -96,11 +96,6 @@ type RepositoryHooks interface {
 	OnDelete(ctx context.Context) error
 }
 
-type Historical interface {
-	// History of changes for a path
-	History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error)
-}
-
 type FileAction string
 
 const (
@@ -126,6 +121,8 @@ type VersionedFileChange struct {
 // this inferface may be extended to make the the original Repository interface
 // more agnostic to the underlying storage system
 type VersionedRepository interface {
+	// History of changes for a path
+	History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error)
 	LatestRef(ctx context.Context) (string, error)
 	CompareFiles(ctx context.Context, base, ref string) ([]VersionedFileChange, error)
 }


### PR DESCRIPTION
Same thing as #100733: not all repositories support history, so don't require it for them all.