### PR TITLE
Alerting: Delete protobuf alert rule state on alert rule deletion

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -68,6 +68,13 @@ func (st DBstore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, ruleUI
 			return err
 		}
 		logger.Debug("Deleted alert instances", "count", rows)
+
+		rows, err = sess.Table("alert_rule_state").Where("org_id = ?", orgID).In("rule_uid", ruleUID).Delete(alertRule{})
+		if err != nil {
+			return err
+		}
+		logger.Debug("Deleted alert rule state", "count", rows)
+
 		return nil
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Delete alert rule state stored as protobuf message on rule deletion.

**Why do we need this feature?**

We introduced a new storage type in https://github.com/grafana/grafana/pull/99193 under a feature flag, this PR adds state removal when the alert rule is deleted from the database.
