### PR TITLE
fix(unified-storage): dont return not found error in mode 2

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -137,7 +137,7 @@ func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.
 		}
 	}()
 
-	return objLegacy, err
+	return objLegacy, nil
 }
 
 // List overrides the behavior of the generic DualWriter.

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -122,7 +122,6 @@ func TestMode2_Get(t *testing.T) {
 					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, apierrors.NewNotFound(
 						schema.GroupResource{Group: "", Resource: "pods"}, "not-found"))
 				},
-				wantErr: true,
 			},
 			{
 				name:  "should return an error when getting an object from both the LegacyStorage and Storage fails",


### PR DESCRIPTION
In mode 2, if we find an object in legacy, but not in unistore, we log an error and return both the object and a not found error.

Since go pattern is to act on the error when it's not nil, this causes us to return "not found" immediately

Ref https://github.com/grafana/search-and-storage-team/issues/208