### PR TITLE
InfluxDB: Improve handling of template variables contained in regular expressions (InfluxQL)

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -363,6 +363,18 @@ describe('interpolateQueryExpr', () => {
     expect(result).toBe(expectation);
   });
 
+  it('should **not** return the escaped value if the value **is not** wrapped in regex and the query is more complex (e.g. text is contained between two / but not a regex', () => {
+    const value = 'testmatch';
+    const variableMock = queryBuilder().withId('tempVar').withName('tempVar').withMulti(false).build();
+    const result = ds.interpolateQueryExpr(
+      value,
+      variableMock,
+      `select value where ("tag"::tag =~ /value/) AND where other = $tempVar $timeFilter GROUP BY time($__interval) tz('Europe/London')`
+    );
+    const expectation = `testmatch`;
+    expect(result).toBe(expectation);
+  });
+
   it('should return floating point number as it is', () => {
     const variableMock = queryBuilder()
       .withId('tempVar')

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -359,22 +359,24 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // If matches are found this regex is evaluated to check if the variable is contained in the regex /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
-    if (query) {
-      const queryMatches = query.match(regexMatcher);
-      if (queryMatches) {
-        for (const match of queryMatches) {
-          if (match.match(regex)) {
-            if (typeof value === 'string') {
-              return escapeRegex(value);
-            }
-
-            // If the value is a string array first escape them then join them with pipe
-            // then put inside parenthesis.
-            return `(${value.map((v) => escapeRegex(v)).join('|')})`;
-          }
-        }
-      }
+    if (!query) {
+      return;
     }
+
+    const queryMatches = query.match(regexMatcher);
+    if (!queryMatches) {
+      return;
+    }
+    for (const match of queryMatches) {
+      if (!match.match(regex)) {
+        continue;
+      }
+
+      // If the value is a string array first escape them then join them with pipe
+      // then put inside parenthesis.
+      return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
+    }
+
     return value;
   }
 

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -351,19 +351,30 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // If the variable is not a multi-value variable
     // we want to see how it's been used. If it is used in a regex expression
     // we escape it. Otherwise, we return it directly.
-    // regex below checks if the variable inside /^...$/ (^ and $ is optional)
+    // The regex below searches for regexes within the query string
+    const regexMatcher = new RegExp(
+      /\/((?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+)\/((?:g(?:im?|mi?)?|i(?:gm?|mg?)?|m(?:gi?|ig?)?)?)/,
+      'gm'
+    );
+    // If matches are found this regex is evaluated to check if the variable is contained in the regex /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
-    if (query && regex.test(query)) {
-      if (typeof value === 'string') {
-        return escapeRegex(value);
+    if (query) {
+      const queryMatches = query.match(regexMatcher);
+      if (queryMatches) {
+        for (const match of queryMatches) {
+          if (match.match(regex)) {
+            if (typeof value === 'string') {
+              return escapeRegex(value);
+            }
+
+            // If the value is a string array first escape them then join them with pipe
+            // then put inside parenthesis.
+            return `(${value.map((v) => escapeRegex(v)).join('|')})`;
+          }
+        }
       }
-
-      // If the value is a string array first escape them then join them with pipe
-      // then put inside parenthesis.
-      return `(${value.map((v) => escapeRegex(v)).join('|')})`;
     }
-
     return value;
   }
 

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -360,12 +360,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
     if (!query) {
-      return;
+      return value;
     }
 
     const queryMatches = query.match(regexMatcher);
     if (!queryMatches) {
-      return;
+      return value;
     }
     for (const match of queryMatches) {
       if (!match.match(regex)) {


### PR DESCRIPTION
We support interpolating template variables that are contained within regular expressions using the InfluxQL query language.

The regular expression that carried this out had an issue where it would incorrectly capture any character between two `/` values (therefore incorrectly including and escaping template variables).

This PR fixes that issue by first identifying all regular expressions within a query, and then evaluating them individually to identify if thee variable being searched is contained therein. If the variable is found then it is escaped.

To test this, run the below InfluxQL query in a dashboard panel (the issue is not present in Explore):
```
SELECT mean("value") FROM "cpu" WHERE ("tag"::tag =~ /(anyvalue)/) AND time($__interval) fill(null) tz('Europe/London')
```

This will throw the following error:
```
InfluxDB returned error: failed to parse query: found \, expected identifier, string, number, bool at line 1, char 77
```

Running the same query using Influx built from this branch will not throw the same error.