### PR TITLE
Added width style to the action button

### DIFF
--- a/packages/grafana-ui/src/components/Actions/ActionButton.tsx
+++ b/packages/grafana-ui/src/components/Actions/ActionButton.tsx
@@ -18,7 +18,13 @@ export function ActionButton({ action, ...buttonProps }: ActionButtonProps) {
 
   return (
     <>
-      <Button variant="primary" size="sm" onClick={() => setShowConfirm(true)} {...buttonProps}>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => setShowConfirm(true)}
+        {...buttonProps}
+        style={{ width: 'fit-content' }}
+      >
         {action.title}
       </Button>
       {showConfirm && (

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -126,7 +126,7 @@ export const OptionsPaneCategory = React.memo(
           <Button
             data-testid={selectors.components.OptionsGroup.toggle(id)}
             type="button"
-            fill="texs"
+            fill="text"
             size="md"
             variant="secondary"
             aria-expanded={isExpanded}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -126,7 +126,7 @@ export const OptionsPaneCategory = React.memo(
           <Button
             data-testid={selectors.components.OptionsGroup.toggle(id)}
             type="button"
-            fill="text"
+            fill="texs"
             size="md"
             variant="secondary"
             aria-expanded={isExpanded}


### PR DESCRIPTION
Fixes #100764

This allows the actions button to fit to content instead of filling to the width of the tooltip
**Special notes for your reviewer:**

**Before**
![image](https://github.com/user-attachments/assets/921eec52-b29f-443a-b4c1-dcfe0ea5bf7f)

**After**
![image](https://github.com/user-attachments/assets/f3c28207-90d3-4ed2-a56d-541eb46f58f0)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
