### PR TITLE
Dashboard Schema V2: Fix query variable bug

### DIFF
--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -533,9 +533,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
             sort: transformSortVariableToEnum(v.sort),
             query: {
               kind: v.datasource?.type || getDefaultDatasourceType(),
-              spec: {
-                ...v.query,
-              },
+              spec: query,
             },
           },
         };


### PR DESCRIPTION
I forgot to use the proper variable here, which handles string and DataQuery types🤦  This fix also fixes the `load-options-from-url` and `set-options-from-ui` tests in the V2 e2e workflow.