### PR TITLE
TableNG: Add actions support

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
@@ -14,18 +14,19 @@ interface AutoCellProps extends CellNGProps {
   cellOptions: TableCellOptions;
 }
 
-export default function AutoCell({ value, field, justifyContent, cellOptions, rowIdx }: AutoCellProps) {
+export default function AutoCell({ value, field, justifyContent, cellOptions, rowIdx, actions }: AutoCellProps) {
   const styles = useStyles2(getStyles, justifyContent);
 
   const displayValue = field.display!(value);
   const formattedValue = formattedValueToString(displayValue);
   const hasLinks = Boolean(getCellLinks(field, rowIdx)?.length);
+  const hasActions = Boolean(actions?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
   return (
     <div className={styles.cell}>
-      {hasLinks ? (
-        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []}>
+      {hasLinks || hasActions ? (
+        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []} actions={actions}>
           {(api) => {
             if (api.openMenu) {
               return (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
@@ -72,7 +72,6 @@ export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx, actio
     );
   };
 
-  // @TODO: Actions
   return (
     <>
       {hasLinks || hasActions ? (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
@@ -21,7 +21,7 @@ const defaultScale: ThresholdsConfig = {
   ],
 };
 
-export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: BarGaugeCellProps) => {
+export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx, actions }: BarGaugeCellProps) => {
   const displayValue = field.display!(value);
   const cellOptions = getCellOptions(field);
 
@@ -45,6 +45,7 @@ export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: Bar
   }
 
   const hasLinks = Boolean(getCellLinks(field, rowIdx)?.length);
+  const hasActions = Boolean(actions?.length);
 
   const alignmentFactors = getAlignmentFactor(field, displayValue, rowIdx!);
 
@@ -74,9 +75,10 @@ export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: Bar
   // @TODO: Actions
   return (
     <>
-      {hasLinks ? (
+      {hasLinks || hasActions ? (
         <DataLinksContextMenu
           links={() => getCellLinks(field, rowIdx) || []}
+          actions={actions}
           style={{ display: 'flex', width: '100%' }}
         >
           {(api) => renderComponent(api)}

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -12,10 +12,11 @@ import { getCellLinks } from '../utils';
 
 const DATALINKS_HEIGHT_OFFSET = 10;
 
-export const ImageCell = ({ cellOptions, field, height, justifyContent, value, rowIdx }: ImageCellProps) => {
+export const ImageCell = ({ cellOptions, field, height, justifyContent, value, rowIdx, actions }: ImageCellProps) => {
   const calculatedHeight = height - DATALINKS_HEIGHT_OFFSET;
   const styles = useStyles2(getStyles, calculatedHeight, justifyContent);
   const hasLinks = Boolean(getCellLinks(field, rowIdx)?.length);
+  const hasActions = Boolean(actions?.length);
 
   const { text } = field.display!(value);
   const { alt, title } =
@@ -26,8 +27,8 @@ export const ImageCell = ({ cellOptions, field, height, justifyContent, value, r
   // TODO: Implement actions
   return (
     <div className={styles.imageContainer}>
-      {hasLinks ? (
-        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []}>
+      {hasLinks || hasActions ? (
+        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []} actions={actions}>
           {(api) => {
             if (api.openMenu) {
               return (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -24,7 +24,6 @@ export const ImageCell = ({ cellOptions, field, height, justifyContent, value, r
 
   const img = <img alt={alt} src={text} className={styles.image} title={title} />;
 
-  // TODO: Implement actions
   return (
     <div className={styles.imageContainer}>
       {hasLinks || hasActions ? (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
@@ -28,7 +28,6 @@ export const JSONCell = ({ value, justifyContent, field, rowIdx, actions }: Omit
   const hasLinks = Boolean(getCellLinks(field, rowIdx)?.length);
   const hasActions = Boolean(actions?.length);
 
-  // TODO: Implement actions
   return (
     <div className={styles.jsonText}>
       {hasLinks || hasActions ? (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/JSONCell.tsx
@@ -10,7 +10,7 @@ import { DataLinksContextMenu } from '../../../DataLinks/DataLinksContextMenu';
 import { CellNGProps } from '../types';
 import { getCellLinks } from '../utils';
 
-export const JSONCell = ({ value, justifyContent, field, rowIdx }: Omit<CellNGProps, 'theme'>) => {
+export const JSONCell = ({ value, justifyContent, field, rowIdx, actions }: Omit<CellNGProps, 'theme'>) => {
   const styles = useStyles2(getStyles, justifyContent);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
@@ -26,12 +26,13 @@ export const JSONCell = ({ value, justifyContent, field, rowIdx }: Omit<CellNGPr
   }
 
   const hasLinks = Boolean(getCellLinks(field, rowIdx)?.length);
+  const hasActions = Boolean(actions?.length);
 
   // TODO: Implement actions
   return (
     <div className={styles.jsonText}>
-      {hasLinks ? (
-        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []}>
+      {hasLinks || hasActions ? (
+        <DataLinksContextMenu links={() => getCellLinks(field, rowIdx) || []} actions={actions}>
           {(api) => {
             if (api.openMenu) {
               return (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -25,6 +25,7 @@ import { SparklineCell } from './SparklineCell';
 export function TableCellNG(props: any) {
   const {
     field,
+    frame,
     value,
     theme,
     timeRange,
@@ -35,6 +36,7 @@ export function TableCellNG(props: any) {
     setIsInspecting,
     setContextMenuProps,
     cellInspect,
+    getActions,
   } = props;
   const { config: fieldConfig } = field;
   const { type: cellType } = fieldConfig.custom.cellOptions;
@@ -54,6 +56,8 @@ export function TableCellNG(props: any) {
   const divWidthRef = useRef<HTMLDivElement>(null);
   const [divWidth, setDivWidth] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
+
+  const actions = getActions ? getActions(frame, field) : [];
 
   useLayoutEffect(() => {
     if (divWidthRef.current && divWidthRef.current.clientWidth !== 0) {
@@ -93,6 +97,7 @@ export function TableCellNG(props: any) {
           height={height}
           width={divWidth}
           rowIdx={rowIdx}
+          actions={actions}
         />
       );
       break;
@@ -105,11 +110,12 @@ export function TableCellNG(props: any) {
           justifyContent={justifyContent}
           value={value}
           rowIdx={rowIdx}
+          actions={actions}
         />
       );
       break;
     case TableCellDisplayMode.JSONView:
-      cell = <JSONCell value={value} justifyContent={justifyContent} field={field} rowIdx={rowIdx} />;
+      cell = <JSONCell value={value} justifyContent={justifyContent} field={field} rowIdx={rowIdx} actions={actions} />;
       break;
     case TableCellDisplayMode.Auto:
     default:
@@ -121,6 +127,7 @@ export function TableCellNG(props: any) {
           justifyContent={justifyContent}
           cellOptions={fieldConfig.custom.cellOptions}
           rowIdx={rowIdx}
+          actions={actions}
         />
       );
   }

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -62,6 +62,7 @@ export function TableNG(props: TableNGProps) {
     footerOptions,
     onColumnResize,
     enablePagination,
+    getActions,
   } = props;
 
   const textWrap = fieldConfig?.defaults?.custom?.cellOptions.wrapText ?? false;
@@ -326,6 +327,7 @@ export function TableNG(props: TableNGProps) {
                 <TableCellNG
                   key={key}
                   value={value}
+                  frame={main}
                   field={field}
                   theme={theme}
                   timeRange={timeRange}
@@ -349,6 +351,7 @@ export function TableNG(props: TableNGProps) {
                   setIsInspecting={setIsInspecting}
                   setContextMenuProps={setContextMenuProps}
                   cellInspect={cellInspect}
+                  getActions={getActions}
                 />
               );
             },

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -1,6 +1,6 @@
 import { Property } from 'csstype';
 
-import { Field, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { ActionModel, Field, GrafanaTheme2, TimeRange } from '@grafana/data';
 import { TableCellOptions } from '@grafana/schema';
 
 export interface CellNGProps {
@@ -10,6 +10,7 @@ export interface CellNGProps {
   height?: number;
   justifyContent: Property.JustifyContent;
   rowIdx: number;
+  actions?: ActionModel[];
 }
 
 export interface RowExpanderNGProps {


### PR DESCRIPTION
This PR adds actions support to `AutoCell`, `BarGaugeCell`, `ImageCell`, `JsonCell`

TODO:
- Actions confirmation in the context menu (in old table)


Fixes https://github.com/grafana/grafana/issues/95180


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
