### PR TITLE
Image Rendering: Allow disabling ACL for GCS image uploads

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2312,6 +2312,11 @@ Optional extra path inside bucket.
 If set to true, Grafana creates a [signed URL](https://cloud.google.com/storage/docs/access-control/signed-urls) for
 the image uploaded to Google Cloud Storage.
 
+#### `uniform_bucket_level_access`
+
+Whether or not the bucket uses uniform bucket level access. If set to true, Grafana will not attempt to update ACL
+for images uploaded to Google Cloud Storage.
+
 #### `signed_url_expiration`
 
 Sets the signed URL expiration, which defaults to seven days.

--- a/pkg/components/imguploader/gcs/gcsuploader_test.go
+++ b/pkg/components/imguploader/gcs/gcsuploader_test.go
@@ -26,7 +26,7 @@ type testConfig struct {
 	signedURL string
 }
 
-func mockSDK(ctx context.Context, t *testing.T, content []byte, bucket string, signed bool) testConfig {
+func mockSDK(ctx context.Context, t *testing.T, content []byte, bucket string, signed bool, uniform bool) testConfig {
 	t.Helper()
 
 	var cfg testConfig
@@ -37,7 +37,7 @@ func mockSDK(ctx context.Context, t *testing.T, content []byte, bucket string, s
 	})
 
 	wm := mock_gcsifaces.NewMockStorageWriter(ctrl)
-	if !signed {
+	if !signed && !uniform {
 		wm.
 			EXPECT().
 			SetACL(gomock.Eq("publicRead")).
@@ -120,9 +120,9 @@ func TestUploadToGCS_DefaultCredentials(t *testing.T) {
 
 	t.Run("Without signed URL", func(t *testing.T) {
 		ctx := context.Background()
-		mockSDK(ctx, t, content, bucket, false)
+		mockSDK(ctx, t, content, bucket, false, false)
 
-		uploader, err := NewUploader("", bucket, "", false, dfltExpiration)
+		uploader, err := NewUploader("", bucket, "", false, false, dfltExpiration)
 		require.NoError(t, err)
 
 		path, err := uploader.Upload(ctx, fpath)
@@ -133,9 +133,9 @@ func TestUploadToGCS_DefaultCredentials(t *testing.T) {
 
 	t.Run("With signed URL", func(t *testing.T) {
 		ctx := context.Background()
-		cfg := mockSDK(ctx, t, content, bucket, true)
+		cfg := mockSDK(ctx, t, content, bucket, true, false)
 
-		uploader, err := NewUploader("", bucket, "", true, dfltExpiration)
+		uploader, err := NewUploader("", bucket, "", true, false, dfltExpiration)
 		require.NoError(t, err)
 
 		path, err := uploader.Upload(ctx, fpath)

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -89,6 +89,7 @@ func NewImageUploader(cfg *setting.Cfg) (ImageUploader, error) {
 		bucketName := gcssec.Key("bucket").MustString("")
 		path := gcssec.Key("path").MustString("")
 		enableSignedURLs := gcssec.Key("enable_signed_urls").MustBool(false)
+		uniformBucketLevelAccess := gcssec.Key("uniform_bucket_level_access").MustBool(false)
 		exp := gcssec.Key("signed_url_expiration").MustString("")
 		var suExp time.Duration
 		if exp != "" {
@@ -100,7 +101,7 @@ func NewImageUploader(cfg *setting.Cfg) (ImageUploader, error) {
 			suExp = defaultGCSSignedURLExpiration
 		}
 
-		return gcs.NewUploader(keyFile, bucketName, path, enableSignedURLs, suExp)
+		return gcs.NewUploader(keyFile, bucketName, path, enableSignedURLs, uniformBucketLevelAccess, suExp)
 	case "azure_blob":
 		azureBlobSec, err := cfg.Raw.GetSection("external_image_storage.azure_blob")
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes the renderer plugin compatible with Google Cloud Storage buckets with [Uniform Bucket Level Access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)

**Who is this feature for?**

Users who use GCS as their storage backend for alerting screenshots.

**Which issue(s) does this PR fix?**:

Fixes #100508 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
