### PR TITLE
MultiCombobox: Add basic docs and make story public

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.mdx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.mdx
@@ -1,0 +1,21 @@
+import { Meta, Preview, ArgTypes } from '@storybook/blocks';
+
+import { MultiCombobox } from './MultiCombobox';
+
+<Meta title="MDX|MultiCombobox" component={MultiCombobox} />
+
+# MultiCombobox
+
+The behavior of MultiCombobox is the same as Combobox, but it allows you to select multiple options. For all non-multi behavior, see the Combobox docs.
+
+## "All" functionality
+
+Use the prop `enableAllOption` to show the "All" option.
+
+If no filtering is done, it will select all options, returning the same array as the `options` prop.
+
+With filtering, it will select the filtered subset of options.
+
+## Props
+
+<ArgTypes of={MultiCombobox} />

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.mdx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.mdx
@@ -6,15 +6,14 @@ import { MultiCombobox } from './MultiCombobox';
 
 # MultiCombobox
 
-The behavior of MultiCombobox is the same as Combobox, but it allows you to select multiple options. For all non-multi behavior, see the Combobox docs.
+The behavior of the MultiCombobox is similar to that of the Combobox, but it allows you to select multiple options. For all non-multi behaviors, see the Combobox documentation.
 
 ## "All" functionality
 
 Use the prop `enableAllOption` to show the "All" option.
 
-If no filtering is done, it will select all options, returning the same array as the `options` prop.
-
-With filtering, it will select the filtered subset of options.
+- If no filtering is applied, selecting "All" will select all options, returning the same array as the `options` prop.
+- With filtering, selecting "All" will choose the filtered subset of options.
 
 ## Props
 

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.story.tsx
@@ -6,12 +6,18 @@ import { ComponentProps } from 'react';
 import { Field } from '../Forms/Field';
 
 import { MultiCombobox } from './MultiCombobox';
+import mdx from './MultiCombobox.mdx';
 import { generateOptions, fakeSearchAPI, generateGroupingOptions } from './storyUtils';
 import { ComboboxOption } from './types';
 
 const meta: Meta<typeof MultiCombobox> = {
   title: 'Forms/MultiCombobox',
   component: MultiCombobox,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
 const loadOptionsAction = action('options called');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes the MultiCombobox story public. Followup to  #100368

**Why do we need this feature?**

We are already exporting the component, so it would be good to see some public docs for it.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
