### PR TITLE
Chore: Increase golangci-lint timeout to 15min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 10m
+  timeout: 15m
   concurrency: 10
   allow-parallel-runners: true
 linters-settings:


### PR DESCRIPTION
Short-term fix for linting timeouts in CI runners.