### PR TITLE
QuickAdd: move to mega menu

### DIFF
--- a/pkg/build/cmd/artifactspage.go
+++ b/pkg/build/cmd/artifactspage.go
@@ -1,0 +1,1 @@
+/Users/torkelodegaard/dev/grafana-enterprise/src/pkg/build/cmd/artifactspage.go

--- a/pkg/build/cmd/artifactspage.tmpl.html
+++ b/pkg/build/cmd/artifactspage.tmpl.html
@@ -1,0 +1,1 @@
+/Users/torkelodegaard/dev/grafana-enterprise/src/pkg/build/cmd/artifactspage.tmpl.html

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -159,7 +159,8 @@ const getStyles = (theme: GrafanaTheme2, hasActions: boolean) => {
       zIndex: 2,
 
       [theme.breakpoints.up('xl')]: {
-        display: 'block',
+        display: 'flex',
+        flexDirection: 'column',
       },
     }),
     scopesDashboardsContainer: css({

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -13,6 +13,7 @@ import { setBookmark } from 'app/core/reducers/navBarTree';
 import { usePatchUserPreferencesMutation } from 'app/features/preferences/api/index';
 import { useDispatch, useSelector } from 'app/types';
 
+import { QuickAdd } from '../QuickAdd/QuickAdd';
 import { TOP_BAR_LEVEL_HEIGHT } from '../types';
 
 import { MegaMenuHeader } from './MegaMenuHeader';
@@ -112,6 +113,7 @@ export const MegaMenu = memo(
     return (
       <div data-testid={selectors.components.NavMenu.Menu} ref={ref} {...restProps}>
         <MegaMenuHeader handleDockedMenu={handleDockedMenu} handleMegaMenu={handleMegaMenu} onClose={onClose} />
+        <QuickAdd />
         <nav className={styles.content}>
           <ScrollContainer height="100%" overflowX="hidden" showScrollIndicators>
             <ul className={styles.itemList} aria-label={t('navigation.megamenu.list-label', 'Navigation')}>

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -1,35 +1,18 @@
-import { css } from '@emotion/css';
 import { useMemo, useState } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Menu, Dropdown, useStyles2, useTheme2, ToolbarButton } from '@grafana/ui';
-import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
+import { Menu, Dropdown, Button, Icon, Box } from '@grafana/ui';
 import { useSelector } from 'app/types';
-
-import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
 import { findCreateActions } from './utils';
 
 export interface Props {}
 
 export const QuickAdd = ({}: Props) => {
-  const styles = useStyles2(getStyles);
-  const theme = useTheme2();
   const navBarTree = useSelector((state) => state.navBarTree);
-  const breakpoint = theme.breakpoints.values.sm;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
   const createActions = useMemo(() => findCreateActions(navBarTree), [navBarTree]);
-  const showQuickAdd = createActions.length > 0 && !isSmallScreen;
-
-  useMediaQueryChange({
-    breakpoint,
-    onChange: (e) => {
-      setIsSmallScreen(!e.matches);
-    },
-  });
 
   const MenuActions = () => {
     return (
@@ -46,34 +29,13 @@ export const QuickAdd = ({}: Props) => {
     );
   };
 
-  return showQuickAdd ? (
-    <>
+  return (
+    <Box paddingX={2} paddingTop={2} paddingBottom={0.5} display={'flex'} alignItems={'center'}>
       <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={setIsOpen}>
-        <ToolbarButton
-          iconOnly
-          icon={isSmallScreen ? 'plus-circle' : 'plus'}
-          isOpen={isSmallScreen ? undefined : isOpen}
-          aria-label="New"
-        />
+        <Button variant="secondary" icon={'plus'} aria-label="New" fullWidth>
+          New <Icon name={isOpen ? 'angle-up' : 'angle-down'} />
+        </Button>
       </Dropdown>
-      <NavToolbarSeparator className={styles.separator} />
-    </>
-  ) : null;
+    </Box>
+  );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  buttonContent: css({
-    alignItems: 'center',
-    display: 'flex',
-  }),
-  buttonText: css({
-    [theme.breakpoints.down('md')]: {
-      display: 'none',
-    },
-  }),
-  separator: css({
-    [theme.breakpoints.down('sm')]: {
-      display: 'none',
-    },
-  }),
-});

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -16,7 +16,6 @@ import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { HistoryContainer } from '../History/HistoryContainer';
 import { enrichHelpItem } from '../MegaMenu/utils';
-import { QuickAdd } from '../QuickAdd/QuickAdd';
 import { TOP_BAR_LEVEL_HEIGHT } from '../types';
 
 import { ProfileButton } from './ProfileButton';
@@ -74,7 +73,6 @@ export const SingleTopBar = memo(function SingleTopBar({
       <Stack gap={0.5} alignItems="center">
         <TopSearchBarCommandPaletteTrigger />
         {unifiedHistoryEnabled && <HistoryContainer />}
-        <QuickAdd />
         {enrichedHelpNode && (
           <Dropdown overlay={() => <TopNavBarMenu node={enrichedHelpNode} />} placement="bottom-end">
             <ToolbarButton iconOnly icon="question-circle" aria-label="Help" />


### PR DESCRIPTION
Problem

* We want to move to a simplified and more vertically space efficient "single top nav" design that can accommodate 1-3 page actions as well as the current search. This way we can get rid of the "double row" nav we have today (with breadcrumb bar level and toolbar level). The toolbar level is very poorly utilized and takes up very precious vertical space. 

To make room for page level actions and to avoid confusion with those page level actions I think the global New / create action (dropdown) should be moved to the mega menu

I think we have basically 2 options on placement
* A) Top 
* B) bottom

workflow / design (When you click it)
* A) open dropdown like today
* B) expand a section like the other nav categories
* c) Go to a new full page with big cards (that you can click) with explanations for each create actions (maybe too few create actions for that today, but an option for the future) 

![Screenshot 2025-02-17 at 14 48 58](https://github.com/user-attachments/assets/08c6a06d-61b4-4ad9-8d8c-66ebae7388d7)
![Screenshot 2025-02-17 at 14 48 45](https://github.com/user-attachments/assets/dcaf5952-0caa-4c26-9473-d15d60d0f0be)

Simplified single level navbar draft / WIP design: 
![image](https://github.com/user-attachments/assets/825a2829-9126-45dc-8807-09298675e0f5)



