### PR TITLE
Alerting: Add tracking for the mode used in query and notifications step when c…

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -194,8 +194,11 @@ export const trackAlertRuleFormError = (
   reportInteraction('grafana_alerting_rule_form_error', props);
 };
 
-export const trackNewGrafanaAlertRuleFormSavedSuccess = () => {
-  reportInteraction('grafana_alerting_grafana_rule_creation_new_success');
+export const trackNewGrafanaAlertRuleFormSavedSuccess = (payload: {
+  simplifiedQueryEditor: boolean;
+  simplifiedNotificationEditor: boolean;
+}) => {
+  reportInteraction('grafana_alerting_grafana_rule_creation_new_success', payload);
 };
 
 export const trackNewGrafanaAlertRuleFormCancelled = () => {

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -156,7 +156,11 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
       // when creating a new rule, we save the manual routing setting , and editorSettings.simplifiedQueryEditor to the local storage
       storeInLocalStorageValues(values);
       await addRuleToRuleGroup.execute(ruleGroupIdentifier, ruleDefinition, evaluateEvery);
-      grafanaTypeRule && trackNewGrafanaAlertRuleFormSavedSuccess(); // new Grafana-managed rule
+      grafanaTypeRule &&
+        trackNewGrafanaAlertRuleFormSavedSuccess({
+          simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
+          simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
+        }); // new Grafana-managed rule
     } else {
       const ruleIdentifier = fromRulerRuleAndRuleGroupIdentifier(ruleGroupIdentifier, existing.rule);
       await updateRuleInRuleGroup.execute(


### PR DESCRIPTION

**What is this feature?**

This PR updates a metric in rudderstack to track if new grafana rules are created with the simple or advanced mode for the query and notifications step.

**Why do we need this feature?**

We need this metric to understand the adoption of the feature.

**Who is this feature for?**

alerting team

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
