### PR TITLE
Docs: Passwordless auth is not available in cloud

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/passwordless/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/passwordless/index.md
@@ -15,7 +15,9 @@ Passwordless authentication lets Grafana users authenticate with a magic link or
 
 ## Enable passwordless authentication
 
-{{< docs/experimental product="passwordless authentication" featureFlag="passwordlessMagicLinkAuthentication" >}}
+{{% admonition type="note" %}}
+Passwordless authentication is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the passwordlessMagicLinkAuthentication feature toggle in Grafana to use this feature.
+{{% /admonition %}}
 
 To enable passwordless authentication, use the following configuration:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/passwordless/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/passwordless/index.md
@@ -16,7 +16,7 @@ Passwordless authentication lets Grafana users authenticate with a magic link or
 ## Enable passwordless authentication
 
 {{% admonition type="note" %}}
-Passwordless authentication is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the passwordlessMagicLinkAuthentication feature toggle in Grafana to use this feature.
+Passwordless authentication is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `passwordlessMagicLinkAuthentication` feature toggle in Grafana to use this feature.
 {{% /admonition %}}
 
 To enable passwordless authentication, use the following configuration:


### PR DESCRIPTION
Passwordless authentication is currently not available in Cloud. We need to change this as soon as possible so I thought to override by manually adding the note, instead of using the generic component. 
![image (1)](https://github.com/user-attachments/assets/053e36ce-6c48-4f31-b169-061d11825ef2)
