### PR TITLE
iam: Fix debouncing in user, team and service account pickers

### DIFF
--- a/public/app/core/components/Select/ServiceAccountPicker.tsx
+++ b/public/app/core/components/Select/ServiceAccountPicker.tsx
@@ -1,4 +1,5 @@
-import { debounce, DebouncedFuncLeading, isNil } from 'lodash';
+import debounce from 'debounce-promise';
+import { isNil } from 'lodash';
 import { Component } from 'react';
 
 import { SelectableValue } from '@grafana/data';
@@ -17,42 +18,38 @@ export interface State {
 }
 
 export class ServiceAccountPicker extends Component<Props, State> {
-  debouncedSearch: DebouncedFuncLeading<typeof this.search>;
-
   constructor(props: Props) {
     super(props);
     this.state = { isLoading: false };
-    this.search = this.search.bind(this);
-
-    this.debouncedSearch = debounce(this.search, 300, {
-      leading: true,
-      trailing: true,
-    });
   }
 
-  search(query?: string) {
-    this.setState({ isLoading: true });
+  search = debounce(
+    async (query?: string) => {
+      this.setState({ isLoading: true });
 
-    if (isNil(query)) {
-      query = '';
-    }
+      if (isNil(query)) {
+        query = '';
+      }
 
-    return getBackendSrv()
-      .get(`/api/serviceaccounts/search?query=${query}&perpage=100`)
-      .then((result: ServiceAccountsState) => {
-        return result.serviceAccounts.map((sa) => ({
-          id: sa.id,
-          uid: sa.uid,
-          value: sa,
-          label: sa.login,
-          imgUrl: sa.avatarUrl,
-          login: sa.login,
-        }));
-      })
-      .finally(() => {
-        this.setState({ isLoading: false });
-      });
-  }
+      return getBackendSrv()
+        .get(`/api/serviceaccounts/search?query=${query}&perpage=100`)
+        .then((result: ServiceAccountsState) => {
+          return result.serviceAccounts.map((sa) => ({
+            id: sa.id,
+            uid: sa.uid,
+            value: sa,
+            label: sa.login,
+            imgUrl: sa.avatarUrl,
+            login: sa.login,
+          }));
+        })
+        .finally(() => {
+          this.setState({ isLoading: false });
+        });
+    },
+    300,
+    { leading: true }
+  );
 
   render() {
     const { className, onSelected, inputId } = this.props;
@@ -66,7 +63,7 @@ export class ServiceAccountPicker extends Component<Props, State> {
           inputId={inputId}
           isLoading={isLoading}
           defaultOptions={true}
-          loadOptions={this.debouncedSearch}
+          loadOptions={this.search}
           onChange={onSelected}
           placeholder="Start typing to search for service accounts"
           noOptionsMessage="No service accounts found"

--- a/public/app/core/components/Select/UserPicker.tsx
+++ b/public/app/core/components/Select/UserPicker.tsx
@@ -1,4 +1,5 @@
-import { debounce, DebouncedFuncLeading, isNil } from 'lodash';
+import debounce from 'debounce-promise';
+import { isNil } from 'lodash';
 import { Component } from 'react';
 
 import { SelectableValue } from '@grafana/data';
@@ -17,42 +18,38 @@ export interface State {
 }
 
 export class UserPicker extends Component<Props, State> {
-  debouncedSearch: DebouncedFuncLeading<typeof this.search>;
-
   constructor(props: Props) {
     super(props);
     this.state = { isLoading: false };
-    this.search = this.search.bind(this);
-
-    this.debouncedSearch = debounce(this.search, 300, {
-      leading: true,
-      trailing: true,
-    });
   }
 
-  search(query?: string) {
-    this.setState({ isLoading: true });
+  search = debounce(
+    async (query?: string) => {
+      this.setState({ isLoading: true });
 
-    if (isNil(query)) {
-      query = '';
-    }
+      if (isNil(query)) {
+        query = '';
+      }
 
-    return getBackendSrv()
-      .get(`/api/org/users/lookup?query=${query}&limit=100`)
-      .then((result: OrgUser[]) => {
-        return result.map((user) => ({
-          id: user.userId,
-          uid: user.uid,
-          value: user,
-          label: user.login,
-          imgUrl: user.avatarUrl,
-          login: user.login,
-        }));
-      })
-      .finally(() => {
-        this.setState({ isLoading: false });
-      });
-  }
+      return getBackendSrv()
+        .get(`/api/org/users/lookup?query=${query}&limit=100`)
+        .then((result: OrgUser[]) => {
+          return result.map((user) => ({
+            id: user.userId,
+            uid: user.uid,
+            value: user,
+            label: user.login,
+            imgUrl: user.avatarUrl,
+            login: user.login,
+          }));
+        })
+        .finally(() => {
+          this.setState({ isLoading: false });
+        });
+    },
+    300,
+    { leading: true }
+  );
 
   render() {
     const { className, onSelected, inputId } = this.props;
@@ -66,7 +63,7 @@ export class UserPicker extends Component<Props, State> {
           inputId={inputId}
           isLoading={isLoading}
           defaultOptions={true}
-          loadOptions={this.debouncedSearch}
+          loadOptions={this.search}
           onChange={onSelected}
           placeholder="Start typing to search for user"
           noOptionsMessage="No users found"


### PR DESCRIPTION
**What is this feature?**

The User, Team and Service Account pickers behave incorrectly when typing fast due to an issue with debouncing (as outlined in https://github.com/grafana/grafana/pull/50303). Inspired by the findings of the aforementioned PR, as well as https://github.com/grafana/grafana/pull/59434, this PR leverages `debounced-promise` to fix the issue for the pickers owned by the IAM team.

**Why do we need this feature?**

For an improved user experience, but more specifically, to solve a customer escalation.