### PR TITLE
[release-11.2.7] Chore: Update alpine docker image (minor) - 3.20.5 to 3.20.6 [security]

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -69,7 +69,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - go install github.com/bazelbuild/buildtools/buildifier@latest
@@ -112,7 +112,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -170,7 +170,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -307,7 +307,7 @@ steps:
     path: /github-app
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -414,7 +414,7 @@ steps:
     path: /github-app
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -503,7 +503,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -625,7 +625,7 @@ steps:
     path: /github-app
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -725,7 +725,7 @@ steps:
     GF_APP_MODE: development
     GF_SERVER_HTTP_PORT: "3001"
     GF_SERVER_ROUTER_LOGGING: "1"
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: grafana-server
 - commands:
   - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
@@ -946,7 +946,7 @@ steps:
   - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
     -a docker:grafana:linux/arm/v7:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER
-    --go-version=1.22.11 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.5 --tag-format='{{
+    --go-version=1.22.11 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.6 --tag-format='{{
     .version_base }}-{{ .buildID }}-{{ .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' > docker.txt
   - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
@@ -1113,7 +1113,7 @@ steps:
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1304,7 +1304,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1684,7 +1684,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1755,7 +1755,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1813,7 +1813,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1879,7 +1879,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1959,7 +1959,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2025,7 +2025,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -2099,7 +2099,7 @@ steps:
     path: /github-app
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -2198,7 +2198,7 @@ steps:
     GF_APP_MODE: development
     GF_SERVER_HTTP_PORT: "3001"
     GF_SERVER_ROUTER_LOGGING: "1"
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: grafana-server
 - commands:
   - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
@@ -2455,7 +2455,7 @@ steps:
   - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
     -a docker:grafana:linux/arm/v7:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER
-    --go-version=1.22.11 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.5 --tag-format='{{
+    --go-version=1.22.11 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.6 --tag-format='{{
     .version_base }}-{{ .buildID }}-{{ .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' > docker.txt
   - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
@@ -2667,7 +2667,7 @@ steps:
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2937,7 +2937,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -2993,7 +2993,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -3057,7 +3057,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3135,7 +3135,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3251,7 +3251,7 @@ steps:
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3479,7 +3479,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -3611,7 +3611,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -4057,7 +4057,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4132,7 +4132,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4294,7 +4294,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4396,7 +4396,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -4450,7 +4450,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4531,7 +4531,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4675,7 +4675,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4802,7 +4802,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.20.5
+    ALPINE_BASE: alpine:3.20.6
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4952,7 +4952,7 @@ steps:
   name: grabpl
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.20.5
+  image: alpine:3.20.6
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5401,7 +5401,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:20-bookworm
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.20.5
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.20.6
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM ubuntu:22.04
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
@@ -5440,7 +5440,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:20-bookworm
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
-  - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.20.5
+  - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.20.6
   - trivy --exit-code 1 --severity HIGH,CRITICAL ubuntu:22.04
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
@@ -5705,6 +5705,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: a812aa5256b686f7422b378d66f25eb0d096afbbf2ce8cc200c7984e01601876
+hmac: fab3c8e18e6f18b392684cac24c9c16a664ae13cadfabee7b244c10d48bafe52
 
 ...

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -16,7 +16,7 @@ images = {
     "node_deb": "node:{}-bookworm".format(nodejs_version[:2]),
     "cloudsdk": "google/cloud-sdk:431.0.0",
     "publish": "grafana/grafana-ci-deploy:1.3.3",
-    "alpine": "alpine:3.20.5",
+    "alpine": "alpine:3.20.6",
     "ubuntu": "ubuntu:22.04",
     "curl": "byrnedo/alpine-curl:0.1.8",
     "plugins_slack": "plugins/slack",


### PR DESCRIPTION
Backport 27837ee937217a74ac1d1cc547516fafd344fa5d from #100791

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Alpine (as base-image of the Grafana Docker-Image) released a new Minor-Version of 3.20 stream. So, it's just a small bump of the Grafana Base-Image to this release of Alpine Linux 3.20 to enhance security.

**Why do we need this feature?**

We keep the same major-version of Alpine, but we benefit from fixed security vulnerabilities in this Alpine release:
CVE | Package | OS
--- | --- | --- 
CVE-2025-26519 | musl | Alpine 3.20.5
CVE-2024-13176 | openssl | Alpine 3.20.5
CVE-2024-12797 | openssl | Alpine 3.20.5

As far as I understood openssl fixes are most of the times not relevant for Grafana (since it's using GO-libs), but I think the musl is relevant, since it's a base C standard library and related to the Linux kernel.


**Who is this feature for?**

Grafana User working with Docker-Images. They can benefit from this new base-image and are able to run Grafana with less amount of CVEs reported by Scanners.

**Special notes for your reviewer:**