### PR TITLE
fix(unified-storage): dashboards not persisting folder_id with unified storage

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -400,7 +400,7 @@ func saveDashboard(sess *db.Session, cmd *dashboards.SaveDashboardCommand, emitE
 		userId = -1
 	}
 
-	if dash.FolderUID != "" && dash.FolderID == 0 { // nolint:staticcheck
+	if !dash.IsFolder && dash.FolderUID != "" && dash.FolderID == 0 { // nolint:staticcheck
 		var existing dashboards.Dashboard
 		folderIdFound, err := sess.Where("uid=? AND org_id=?", dash.FolderUID, dash.OrgID).Get(&existing)
 		if err != nil {

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -400,6 +400,18 @@ func saveDashboard(sess *db.Session, cmd *dashboards.SaveDashboardCommand, emitE
 		userId = -1
 	}
 
+	if dash.FolderUID != "" && dash.FolderID == 0 { // nolint:staticcheck
+		var existing dashboards.Dashboard
+		folderIdFound, err := sess.Where("uid=? AND org_id=?", dash.FolderUID, dash.OrgID).Get(&existing)
+		if err != nil {
+			return nil, err
+		}
+
+		if folderIdFound {
+			dash.FolderID = existing.ID // nolint:staticcheck
+		}
+	}
+
 	if dash.ID > 0 {
 		var existing dashboards.Dashboard
 		dashWithIdExists, err := sess.Where("id=? AND org_id=?", dash.ID, dash.OrgID).Get(&existing)

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -400,6 +400,8 @@ func saveDashboard(sess *db.Session, cmd *dashboards.SaveDashboardCommand, emitE
 		userId = -1
 	}
 
+	// we don't save FolderID in kubernetes object when saving through k8s
+	// this block guarantees we save dashboards with folder_id and folder_uid in those cases
 	if !dash.IsFolder && dash.FolderUID != "" && dash.FolderID == 0 { // nolint:staticcheck
 		var existing dashboards.Dashboard
 		folderIdFound, err := sess.Where("uid=? AND org_id=?", dash.FolderUID, dash.OrgID).Get(&existing)

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -389,7 +389,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		}
 		dashboard, err := dashboardStore.SaveDashboard(context.Background(), cmd)
 		require.NoError(t, err)
-		require.EqualValues(t, dashboard.FolderID, savedFolder.ID)
+		require.EqualValues(t, dashboard.FolderID, savedFolder.ID) //nolint:staticcheck
 		require.EqualValues(t, dashboard.FolderUID, savedFolder.UID)
 	})
 

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -376,6 +376,23 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		require.False(t, dashboard.Updated.IsZero())
 	})
 
+	t.Run("Should populate FolderID if FolderUID is provided when creating a dashboard", func(t *testing.T) {
+		setup()
+		cmd := dashboards.SaveDashboardCommand{
+			OrgID: 1,
+			Dashboard: simplejson.NewFromAny(map[string]interface{}{
+				"title": "folderId",
+				"tags":  []interface{}{},
+			}),
+			FolderUID: savedFolder.UID,
+			UserID:    100,
+		}
+		dashboard, err := dashboardStore.SaveDashboard(context.Background(), cmd)
+		require.NoError(t, err)
+		require.EqualValues(t, dashboard.FolderID, savedFolder.ID)
+		require.EqualValues(t, dashboard.FolderUID, savedFolder.UID)
+	})
+
 	t.Run("Should be able to update dashboard by id and remove folderId", func(t *testing.T) {
 		setup()
 		cmd := dashboards.SaveDashboardCommand{


### PR DESCRIPTION
With unified storage enabled, there's a bug with the permission check that prevents viewers/editors from viewing dashboards inside folders. This happens with every dashboard created with unified storage enabled in modes 0, 1 or 2. Dashboards created with unified storage **disabled** are not impacted. 

## screenshots of bug

View of the `public` folder using user `editor`
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/0e29b698-b052-4f52-9f6a-b0781f298d58" />

View of the `public` folder using user `admin`
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/0264378d-7bfa-4cde-b193-fd6eda267d74" />

Permissions of one of the listed dashboards to confirm nothing was changed
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/a160714b-5995-424c-8ae9-12cae30583a4" />

To reproduce, just create a dashboard inside a folder with grafana running with unified storage enabled and try to view it as a non-admin in modes 0, 1 or 2.

## root cause

With unified storage enabled, we're not sending the `FolderID` information in the kubernetes object for the dualwriter to process, only `FolderUID`. This results in missing `folder_id` in the legacy tables:

<img width="839" alt="image" src="https://github.com/user-attachments/assets/b377940e-5fe4-4000-9732-65cc9cb416e6" />

which in turn, breaks the sql permission filter that still relies on `folder_id`:
https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/permissions/dashboard.go#L240

## solution

If we try to issue a save dashboard command with a `FolderUID` but no `FolderID`, get the `FolderID` from the database and add it to the dashboard payload.

## alternatives

Two other alternatives I considered:

1. Including the `FolderID` in the save command issued by the watcher here: https://github.com/grafana/grafana/blob/main/pkg/registry/apis/dashboard/legacy/storage.go#L66

This would require us to include the `FolderID` information in the kubernetes object, like we do with `FolderUID` [here](https://github.com/grafana/grafana/blob/main/pkg/services/dashboards/service/dashboard_service.go#L2065), and persist this information in the database. 

2. Patch the permission logic to use `folder_uid` instead of `folder_id`

This is probably the "right" approach. However, I don't know what else could be broken due to the missing `folder_id` in the dashboards/folders created with unified storage, so if anything we would need to do this in addition to the proposed changes. 