### PR TITLE
Docs: Image renderer https configuration using environment variables

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -221,10 +221,14 @@ HTTPS protocol is supported in the image renderer v3.11.0 and later.
 
 Change the protocol of the server, it can be `http` or `https`. Default is `http`.
 
+```bash
+HTTP_PROTOCOL=https
+```
+
 ```json
 {
   "service": {
-    "protocol": "http"
+    "protocol": "https"
   }
 }
 ```
@@ -232,6 +236,11 @@ Change the protocol of the server, it can be `http` or `https`. Default is `http
 #### HTTPS certificate and key file
 
 Path to the image renderer certificate and key file used to start an HTTPS server.
+
+```bash
+HTTP_CERT_FILE=./path/to/cert
+HTTP_CERT_KEY=./path/to/key
+```
 
 ```json
 {
@@ -245,6 +254,10 @@ Path to the image renderer certificate and key file used to start an HTTPS serve
 #### HTTPS min TLS version
 
 Minimum TLS version allowed. Accepted values are: `TLSv1.2`, `TLSv1.3`. Default is `TLSv1.2`.
+
+```bash
+HTTP_MIN_TLS_VERSION=TLSv1.2
+```
 
 ```json
 {


### PR DESCRIPTION
**What is this feature?**

This PR updates the documentation after adding support for configuring HTTPS using environment variables in the image renderer.
[Image renderer related PR](https://github.com/grafana/grafana-image-renderer/pull/600)

Fixes https://github.com/grafana/grafana-image-renderer/issues/536

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
