### PR TITLE
Alerting: Metric to count imported from Prometheus rules

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -457,9 +457,9 @@ func grafanaRuleGroupToPrometheus(group string, rules []models.AlertRule) (apimo
 	}
 
 	for i, rule := range rules {
-		promDefinition := rule.PrometheusRuleDefinition()
-		if promDefinition == "" {
-			return apimodels.PrometheusRuleGroup{}, fmt.Errorf("failed to get the Prometheus definition of the rule with UID %s", rule.UID)
+		promDefinition, err := rule.PrometheusRuleDefinition()
+		if err != nil {
+			return apimodels.PrometheusRuleGroup{}, fmt.Errorf("failed to get the Prometheus definition of the rule with UID %s: %w", rule.UID, err)
 		}
 		var r apimodels.PrometheusRule
 		if err := yaml.Unmarshal([]byte(promDefinition), &r); err != nil {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -115,7 +115,10 @@ func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("[%s] %s", simpleGroup.Name, simpleGroup.Rules[0].Alert), remaining[0].Title)
 		promRuleYAML, err := yaml.Marshal(simpleGroup.Rules[0])
 		require.NoError(t, err)
-		require.Equal(t, string(promRuleYAML), remaining[0].PrometheusRuleDefinition())
+
+		promDefinition, err := remaining[0].PrometheusRuleDefinition()
+		require.NoError(t, err)
+		require.Equal(t, string(promRuleYAML), promDefinition)
 	})
 
 	t.Run("should fail to replace a provisioned rule group", func(t *testing.T) {

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -32,6 +32,7 @@ type Scheduler struct {
 	Ticker                              *ticker.Metrics
 	EvaluationMissed                    *prometheus.CounterVec
 	SimplifiedEditorRules               *prometheus.GaugeVec
+	PrometheusImportedRules             *prometheus.GaugeVec
 }
 
 func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
@@ -191,6 +192,15 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The number of alert rules using simplified editor settings.",
 			},
 			[]string{"org", "setting"},
+		),
+		PrometheusImportedRules: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "prometheus_imported_rules",
+				Help:      "The number of rules imported from a Prometheus-compatible source.",
+			},
+			[]string{"org"},
 		),
 	}
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -397,19 +397,18 @@ func WithoutInternalLabels() LabelOption {
 }
 
 func (alertRule *AlertRule) ImportedFromPrometheus() bool {
-	if alertRule.Metadata.PrometheusStyleRule == nil {
-		return false
-	}
-
-	return alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition != ""
+	_, err := alertRule.PrometheusRuleDefinition()
+	return err == nil
 }
 
-func (alertRule *AlertRule) PrometheusRuleDefinition() string {
-	if !alertRule.ImportedFromPrometheus() {
-		return ""
+func (alertRule *AlertRule) PrometheusRuleDefinition() (string, error) {
+	if alertRule.Metadata.PrometheusStyleRule != nil {
+		if alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition != "" {
+			return alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition, nil
+		}
 	}
 
-	return alertRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition
+	return "", fmt.Errorf("prometheus rule definition is missing")
 }
 
 // GetLabels returns the labels specified as part of the alert rule.

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -46,6 +46,8 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	orgsNfSettings := make(map[int64]int64)
 	// gauge for groups per org
 	groupsPerOrg := make(map[int64]map[string]struct{})
+	// gauge for rules imported from Prometheus per org
+	orgsRulesPrometheusImported := make(map[int64]int64)
 
 	simplifiedEditorSettingsPerOrg := make(map[int64]map[string]int64) // orgID -> setting -> count
 
@@ -86,6 +88,10 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 			}
 		}
 
+		if rule.ImportedFromPrometheus() {
+			orgsRulesPrometheusImported[rule.OrgID]++
+		}
+
 		// Count groups per org
 		orgGroups, ok := groupsPerOrg[rule.OrgID]
 		if !ok {
@@ -100,6 +106,7 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	sch.metrics.SimpleNotificationRules.Reset()
 	sch.metrics.Groups.Reset()
 	sch.metrics.SimplifiedEditorRules.Reset()
+	sch.metrics.PrometheusImportedRules.Reset()
 
 	// Set metrics
 	for key, count := range buckets {
@@ -110,6 +117,9 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	}
 	for orgID, groups := range groupsPerOrg {
 		sch.metrics.Groups.WithLabelValues(fmt.Sprint(orgID)).Set(float64(len(groups)))
+	}
+	for orgID, count := range orgsRulesPrometheusImported {
+		sch.metrics.PrometheusImportedRules.WithLabelValues(fmt.Sprint(orgID)).Set(float64(count))
 	}
 	for orgID, settings := range simplifiedEditorSettingsPerOrg {
 		for setting, count := range settings {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -607,10 +607,7 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 				}
 			}
 			if query.ImportedPrometheusRule != nil { // remove false-positive hits from the result
-				hasOriginalRuleDefinition := converted.Metadata.PrometheusStyleRule != nil && len(converted.Metadata.PrometheusStyleRule.OriginalRuleDefinition) > 0
-				if *query.ImportedPrometheusRule && !hasOriginalRuleDefinition {
-					continue
-				} else if !*query.ImportedPrometheusRule && hasOriginalRuleDefinition {
+				if *query.ImportedPrometheusRule != converted.ImportedFromPrometheus() {
 					continue
 				}
 			}

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -215,11 +215,7 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 			continue
 		}
 		if q.ImportedPrometheusRule != nil {
-			hasOriginalRuleDefinition := r.PrometheusRuleDefinition() != ""
-			if *q.ImportedPrometheusRule && !hasOriginalRuleDefinition {
-				continue
-			}
-			if !*q.ImportedPrometheusRule && hasOriginalRuleDefinition {
+			if *q.ImportedPrometheusRule != r.ImportedFromPrometheus() {
 				continue
 			}
 		}


### PR DESCRIPTION
**What is this feature?**

This PR adds a new metric to track the number of alert rules imported from a Prometheus-compatible datasource. The metric is a gauge (`grafana_alerting_prometheus_imported_rules`) in the scheduler metrics, similar to the existing `rule_group_rules`, `simple_routing_rules`, `simplified_editor_rules`, etc.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
