### PR TITLE
Provisioning: Better clone/push error support

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -78,12 +78,10 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		}
 
 		// New empty branch (same on main???)
-		if options.Branch != "" {
-			progress.SetMessage("create empty branch")
-			_, err := buffered.NewEmptyBranch(ctx, options.Branch)
-			if err != nil {
-				return fmt.Errorf("unable to create empty branch: %w", err)
-			}
+		progress.SetMessage("create empty branch")
+		_, err := buffered.CheckoutEmptyBranch(ctx, options.Branch) // or
+		if err != nil {
+			return fmt.Errorf("unable to create empty branch: %w", err)
 		}
 
 		repo = buffered     // send all writes to the buffered repo

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -141,6 +141,9 @@ func (r *jobProgressRecorder) updateSummary(result JobResourceResult) {
 			summary.Create++
 		case repository.FileActionIgnored:
 			summary.Noop++
+		case repository.FileActionRenamed:
+			summary.Delete++
+			summary.Create++
 		}
 		summary.Write = summary.Create + summary.Update
 	}

--- a/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
+++ b/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
@@ -64,7 +64,7 @@ func Clone(
 		return nil, fmt.Errorf("missing root config")
 	}
 
-	decrypted, err := secrets.Decrypt(ctx, []byte(gitcfg.EncryptedToken))
+	decrypted, err := secrets.Decrypt(ctx, gitcfg.EncryptedToken)
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting token: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/repository/go-git/wrapper_test.go
+++ b/pkg/registry/apis/provisioning/repository/go-git/wrapper_test.go
@@ -15,13 +15,29 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 )
 
+type dummySecret struct{}
+
+// Decrypt implements secrets.Service.
+func (d *dummySecret) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
+	token, ok := os.LookupEnv("gitwraptoken")
+	if !ok {
+		return nil, fmt.Errorf("missing token in environment")
+	}
+	return []byte(token), nil
+}
+
+// Encrypt implements secrets.Service.
+func (d *dummySecret) Encrypt(ctx context.Context, data []byte) ([]byte, error) {
+	panic("unimplemented")
+}
+
 // FIXME!! NOTE!!!!!
 // This is really just a sketchpad while trying to get things working
 // the test makes destructive changes to a real git repository :)
 // this should be removed before committing to main (likely sooner)
 // and replaced with integration tests that check the more specific results
 func TestGoGitWrapper(t *testing.T) {
-	token, ok := os.LookupEnv("gitwraptoken")
+	_, ok := os.LookupEnv("gitwraptoken")
 	if !ok {
 		t.Skipf("no token found in environment")
 	}
@@ -35,8 +51,7 @@ func TestGoGitWrapper(t *testing.T) {
 		Spec: v0alpha1.RepositorySpec{
 			GitHub: &v0alpha1.GitHubRepositoryConfig{
 				URL:    "https://github.com/grafana/git-ui-sync-demo",
-				Branch: "ryan-test",
-				Token:  token,
+				Branch: "ryan-test-test-test",
 			},
 		},
 	},
@@ -45,7 +60,7 @@ func TestGoGitWrapper(t *testing.T) {
 			// one commit (not 11)
 			SingleCommitBeforePush: true,
 		},
-		nil, // TODO: add a mock
+		&dummySecret{},
 		os.Stdout)
 	require.NoError(t, err)
 
@@ -57,9 +72,9 @@ func TestGoGitWrapper(t *testing.T) {
 
 	fmt.Printf("TREE:%s\n", string(jj))
 
-	branch := fmt.Sprintf("unit-test-%s", time.Now().Format("20060102-150405")) // the branch name to create
+	branch := "" //fmt.Sprintf("unit-test-%s", time.Now().Format("20060102-150405")) // the branch name to create
 
-	count, err := wrap.NewEmptyBranch(ctx, branch)
+	count, err := wrap.CheckoutEmptyBranch(ctx, branch)
 	require.NoError(t, err)
 	fmt.Printf("REMOVED: %d\n", count)
 


### PR DESCRIPTION
The current clone code will often hit errors if:
1. checking out a branch that does not exist
2. cleaning up a branch that does not exist
3. pushing with no real changes

This PR adds `force` to the checkout and push commands so that they continue regardless of state