### PR TITLE
Dynamic dashboards: Implement cloneLayout for responsive grid

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
@@ -210,6 +210,22 @@ describe('DefaultGridLayoutManager', () => {
 
       expect(gridRow.state.children.length).toBe(3);
     });
+
+    it('Should clone the layout correctly', () => {
+      const { manager } = setup();
+      const clone = manager.cloneLayout('foo', true) as DefaultGridLayoutManager;
+      const panelA = findVizPanelByKey(clone, 'foo/grid-item-0/panel-0');
+      expect(panelA?.state.title).toBe('Panel A');
+
+      const panelB = findVizPanelByKey(clone, 'foo/grid-item-1/panel-1');
+      expect(panelB?.state.title).toBe('Panel B');
+
+      const panelC = findVizPanelByKey(clone, 'foo/panel-2/grid-item-3/panel-3');
+      expect(panelC?.state.title).toBe('Panel C');
+
+      const panelD = findVizPanelByKey(clone, 'foo/panel-2/grid-item-4/panel-4');
+      expect(panelD?.state.title).toBe('Panel D');
+    });
   });
 });
 

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
@@ -27,19 +27,19 @@ describe('ResponsiveGridLayoutManager', () => {
 function setup() {
   const gridItems = [
     new ResponsiveGridItem({
-      key: 'griditem-1',
+      key: 'grid-item-0',
       body: new VizPanel({
         title: 'Panel A',
-        key: 'panel-1',
+        key: 'panel-0',
         pluginId: 'table',
         $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
       }),
     }),
     new ResponsiveGridItem({
-      key: 'griditem-2',
+      key: 'grid-item-1',
       body: new VizPanel({
         title: 'Panel B',
-        key: 'panel-2',
+        key: 'panel-1',
         pluginId: 'table',
       }),
     }),

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
@@ -1,0 +1,53 @@
+import { SceneCSSGridLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { findVizPanelByKey } from '../../utils/utils';
+import { DashboardScene } from '../DashboardScene';
+
+import { ResponsiveGridItem } from './ResponsiveGridItem';
+import { ResponsiveGridLayoutManager } from './ResponsiveGridLayoutManager';
+
+describe('ResponsiveGridLayoutManager', () => {
+  it('Should clone the layout', () => {
+    const { manager } = setup();
+    const clone = manager.cloneLayout('foo', true) as ResponsiveGridLayoutManager;
+
+    expect(clone).not.toBe(manager);
+    expect(clone.state.layout).not.toBe(manager.state.layout);
+    expect(clone.state.layout.state.children).not.toBe(manager.state.layout.state.children);
+    expect(clone.state.layout.state.children.length).toBe(manager.state.layout.state.children.length);
+
+    const panelA = findVizPanelByKey(clone, 'foo/grid-item-0/panel-0');
+    expect(panelA?.state.title).toBe('Panel A');
+
+    const panelB = findVizPanelByKey(clone, 'foo/grid-item-1/panel-1');
+    expect(panelB?.state.title).toBe('Panel B');
+  });
+});
+
+function setup() {
+  const gridItems = [
+    new ResponsiveGridItem({
+      key: 'griditem-1',
+      body: new VizPanel({
+        title: 'Panel A',
+        key: 'panel-1',
+        pluginId: 'table',
+        $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
+      }),
+    }),
+    new ResponsiveGridItem({
+      key: 'griditem-2',
+      body: new VizPanel({
+        title: 'Panel B',
+        key: 'panel-2',
+        pluginId: 'table',
+      }),
+    }),
+  ];
+
+  const manager = new ResponsiveGridLayoutManager({ layout: new SceneCSSGridLayout({ children: gridItems }) });
+
+  new DashboardScene({ body: manager });
+
+  return { manager };
+}

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.test.ts
@@ -16,10 +16,10 @@ describe('ResponsiveGridLayoutManager', () => {
     expect(clone.state.layout.state.children).not.toBe(manager.state.layout.state.children);
     expect(clone.state.layout.state.children.length).toBe(manager.state.layout.state.children.length);
 
-    const panelA = findVizPanelByKey(clone, 'foo/grid-item-0/panel-0');
+    const panelA = findVizPanelByKey(clone, 'foo/grid-item-1/panel-1');
     expect(panelA?.state.title).toBe('Panel A');
 
-    const panelB = findVizPanelByKey(clone, 'foo/grid-item-1/panel-1');
+    const panelB = findVizPanelByKey(clone, 'foo/grid-item-2/panel-2');
     expect(panelB?.state.title).toBe('Panel B');
   });
 });
@@ -27,19 +27,19 @@ describe('ResponsiveGridLayoutManager', () => {
 function setup() {
   const gridItems = [
     new ResponsiveGridItem({
-      key: 'grid-item-0',
+      key: 'grid-item-1',
       body: new VizPanel({
         title: 'Panel A',
-        key: 'panel-0',
+        key: 'panel-1',
         pluginId: 'table',
         $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
       }),
     }),
     new ResponsiveGridItem({
-      key: 'grid-item-1',
+      key: 'grid-item-2',
       body: new VizPanel({
         title: 'Panel B',
-        key: 'panel-1',
+        key: 'panel-2',
         pluginId: 'table',
       }),
     }),

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -129,7 +129,7 @@ export class ResponsiveGridLayoutManager
               }),
             });
           }
-          return gridItem;
+          throw new Error('Unexpected child type');
         }),
       }),
     });

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -2,6 +2,7 @@ import { SceneComponentProps, SceneCSSGridLayout, SceneObjectBase, SceneObjectSt
 import { t } from 'app/core/internationalization';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
+import { joinCloneKeys } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelId } from '../../utils/utils';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -11,7 +12,6 @@ import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { ResponsiveGridItem } from './ResponsiveGridItem';
 import { getEditOptions } from './ResponsiveGridLayoutManagerEditor';
-import { joinCloneKeys } from '../../utils/clone';
 
 interface ResponsiveGridLayoutManagerState extends SceneObjectState {
   layout: SceneCSSGridLayout;

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -4,7 +4,12 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { joinCloneKeys } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
-import { getDashboardSceneFor, getGridItemKeyForPanelId, getVizPanelKeyForPanelId } from '../../utils/utils';
+import {
+  getDashboardSceneFor,
+  getGridItemKeyForPanelId,
+  getPanelIdForVizPanel,
+  getVizPanelKeyForPanelId,
+} from '../../utils/utils';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
@@ -119,13 +124,16 @@ export class ResponsiveGridLayoutManager
   public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
     return this.clone({
       layout: this.state.layout.clone({
-        children: this.state.layout.state.children.map((gridItem, index) => {
+        children: this.state.layout.state.children.map((gridItem) => {
           if (gridItem instanceof ResponsiveGridItem) {
-            const gridItemKey = joinCloneKeys(ancestorKey, getGridItemKeyForPanelId(index));
+            // Get the original panel ID from the gridItem's key
+            const panelId = getPanelIdForVizPanel(gridItem.state.body);
+            const gridItemKey = joinCloneKeys(ancestorKey, getGridItemKeyForPanelId(panelId));
+
             return gridItem.clone({
               key: gridItemKey,
               body: gridItem.state.body.clone({
-                key: joinCloneKeys(gridItemKey, getVizPanelKeyForPanelId(index)),
+                key: joinCloneKeys(gridItemKey, getVizPanelKeyForPanelId(panelId)),
               }),
             });
           }

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -11,6 +11,7 @@ import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
 import { ResponsiveGridItem } from './ResponsiveGridItem';
 import { getEditOptions } from './ResponsiveGridLayoutManagerEditor';
+import { joinCloneKeys } from '../../utils/clone';
 
 interface ResponsiveGridLayoutManagerState extends SceneObjectState {
   layout: SceneCSSGridLayout;
@@ -113,6 +114,25 @@ export class ResponsiveGridLayoutManager
     }
 
     return false;
+  }
+
+  public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
+    return this.clone({
+      layout: this.state.layout.clone({
+        children: this.state.layout.state.children.map((gridItem, index) => {
+          if (gridItem instanceof ResponsiveGridItem) {
+            const gridItemKey = joinCloneKeys(ancestorKey, getGridItemKeyForPanelId(index));
+            return gridItem.clone({
+              key: gridItemKey,
+              body: gridItem.state.body.clone({
+                key: joinCloneKeys(gridItemKey, getVizPanelKeyForPanelId(index)),
+              }),
+            });
+          }
+          return gridItem;
+        }),
+      }),
+    });
   }
 
   public addNewRow() {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -77,6 +77,10 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
     return false;
   }
 
+  public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
+    throw new Error('Method not implemented.');
+  }
+
   public addNewRow() {
     this.setState({ rows: [...this.state.rows, new RowItem()] });
   }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -47,6 +47,10 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
     return panels;
   }
 
+  public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
+    throw new Error('Method not implemented.');
+  }
+
   public hasVizPanels(): boolean {
     for (const tab of this.state.tabs) {
       if (tab.getLayout().hasVizPanels()) {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -80,7 +80,7 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
    * @param ancestorKey
    * @param isSource
    */
-  cloneLayout?(ancestorKey: string, isSource: boolean): DashboardLayoutManager;
+  cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager;
 }
 
 export interface LayoutManagerSerializer {


### PR DESCRIPTION
**What is this feature?**

Implements cloneLayout for responsive grid to stop repeat rows from breaking.

When repeating rows in the rows layout we call cloneLayout on the layout of the row we're going to repeat. For responsive grid this function was not implemented. That means the row layout will be undefined, which will break functionality down the line.

We're considering another approach for repeats that will mean we can remove cloneLayout, but for now this will stop repeats from breaking so that we're not blocked.