### PR TITLE
Provisioning: Start in "mode5" when nothing exists in legacy

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apis/dashboard"
 	folders "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
@@ -851,6 +852,7 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 		}
 	}
 
+	logger := logging.DefaultLogger.With("logger", "provisioning startup")
 	mode5 := func(gr schema.GroupResource) error {
 		status, _ := b.storageStatus.Status(ctx, gr)
 		if !status.ReadUnified {
@@ -860,6 +862,7 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 			status.Runtime = false
 			status.Migrated = time.Now().UnixMilli()
 			_, err = b.storageStatus.Update(ctx, status)
+			logger.Info("set unified storage access", "group", gr.Group, "resource", gr.Resource)
 			return err
 		}
 		return nil // already reading unified

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -830,7 +830,14 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 		return nil
 	}
 
+	// Count how many things exist
 	rsp, err := b.legacyMigrator.Migrate(ctx, legacy.MigrateOptions{
+		Namespace: "default", // FIXME!!
+		Resources: []schema.GroupResource{{
+			Group: dashboard.GROUP, Resource: dashboard.DASHBOARD_RESOURCE,
+		}, {
+			Group: folders.GROUP, Resource: folders.RESOURCE,
+		}},
 		OnlyCount: true,
 	})
 	if err != nil {
@@ -845,8 +852,9 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 	status, _ := b.storageStatus.Status(ctx, dashboard.DashboardResourceInfo.GroupResource())
 	if !status.ReadUnified {
 		status.ReadUnified = true
-		status.WriteLegacy = false //
+		status.WriteLegacy = false
 		status.WriteUnified = true
+		status.Runtime = false
 		status.Migrated = time.Now().UnixMilli()
 		_, err = b.storageStatus.Update(ctx, status)
 		if err != nil {
@@ -859,6 +867,7 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 		status.ReadUnified = true
 		status.WriteLegacy = false //
 		status.WriteUnified = true
+		status.Runtime = false
 		status.Migrated = time.Now().UnixMilli()
 		b.storageStatus.Update(ctx, status)
 		_, err = b.storageStatus.Update(ctx, status)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -823,7 +823,9 @@ func (b *APIBuilder) encryptSecrets(ctx context.Context, repo *provisioning.Repo
 	return nil
 }
 
-// When starting an empty instance -- switch to mode 5
+// FIXME: This logic does not belong in provisioning! (but required for now)
+// When starting an empty instance, we shift so that we never reference legacy storage
+// This should run somewhere else at startup by default (dual writer? dashboards?)
 func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 	ctx := context.Background()
 	if !dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, b.storageStatus) {
@@ -832,7 +834,7 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 
 	// Count how many things exist
 	rsp, err := b.legacyMigrator.Migrate(ctx, legacy.MigrateOptions{
-		Namespace: "default", // FIXME!!
+		Namespace: "default", // FIXME! this works for single org, but need to check multi-org
 		Resources: []schema.GroupResource{{
 			Group: dashboard.GROUP, Resource: dashboard.DASHBOARD_RESOURCE,
 		}, {

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -88,7 +88,7 @@ func (m *service) StartMigration(ctx context.Context, gr schema.GroupResource, k
 			return v, fmt.Errorf("already migrated")
 		}
 		if key != v.UpdateKey {
-			return v, fmt.Errorf("key mismatch")
+			return v, fmt.Errorf("migration key mismatch")
 		}
 		if v.Migrating > 0 {
 			return v, fmt.Errorf("migration in progress")
@@ -120,7 +120,7 @@ func (m *service) Update(ctx context.Context, status StorageStatus) (StorageStat
 		return v, fmt.Errorf("no running status")
 	}
 	if status.UpdateKey != v.UpdateKey {
-		return v, fmt.Errorf("key mismatch")
+		return v, fmt.Errorf("key mismatch (resource: %s, expected:%d, received: %d)", v.Resource, v.UpdateKey, status.UpdateKey)
 	}
 	if status.Migrating > 0 {
 		return v, fmt.Errorf("update can not change migrating status")


### PR DESCRIPTION
Now when starting on a new/clean system -- we do not get asked to migrate 🎉 

<img width="714" alt="image" src="https://github.com/user-attachments/assets/fb0b2875-f38a-4018-a2aa-4137d571cfc5" />
