### PR TITLE
NodeGraph: Fix for dangling edge lines

### DIFF
--- a/public/app/plugins/panel/nodeGraph/Edge.tsx
+++ b/public/app/plugins/panel/nodeGraph/Edge.tsx
@@ -10,15 +10,17 @@ export const defaultEdgeColor = '#999';
 
 interface Props {
   edge: EdgeDatumLayout;
+  index: number;
   hovering: boolean;
   svgIdNamespace: string;
   onClick: (event: MouseEvent<SVGElement>, link: EdgeDatumLayout) => void;
   onMouseEnter: (id: string) => void;
   onMouseLeave: (id: string) => void;
+  processedNodesLength: number;
 }
 
 export const Edge = memo(function Edge(props: Props) {
-  const { edge, onClick, onMouseEnter, onMouseLeave, hovering, svgIdNamespace } = props;
+  const { edge, index, onClick, onMouseEnter, onMouseLeave, hovering, svgIdNamespace, processedNodesLength } = props;
 
   // Not great typing but after we do layout these properties are full objects not just references
   const { source, target, sourceNodeRadius, targetNodeRadius } = edge as {
@@ -56,6 +58,7 @@ export const Edge = memo(function Edge(props: Props) {
       <EdgeArrowMarker id={markerId} fill={edgeColor} headHeight={arrowHeadHeight} />
       <EdgeArrowMarker id={coloredMarkerId} fill={highlightedEdgeColor} headHeight={arrowHeadHeight} />
       <g
+        key={`${edge.id}-${index}-${processedNodesLength}-g`}
         onClick={(event) => onClick(event, edge)}
         style={{ cursor: 'pointer' }}
         aria-label={`Edge from: ${source.id} to: ${target.id}`}

--- a/public/app/plugins/panel/nodeGraph/Edge.tsx
+++ b/public/app/plugins/panel/nodeGraph/Edge.tsx
@@ -10,7 +10,6 @@ export const defaultEdgeColor = '#999';
 
 interface Props {
   edge: EdgeDatumLayout;
-  index: number;
   hovering: boolean;
   svgIdNamespace: string;
   onClick: (event: MouseEvent<SVGElement>, link: EdgeDatumLayout) => void;
@@ -20,7 +19,7 @@ interface Props {
 }
 
 export const Edge = memo(function Edge(props: Props) {
-  const { edge, index, onClick, onMouseEnter, onMouseLeave, hovering, svgIdNamespace, processedNodesLength } = props;
+  const { edge, onClick, onMouseEnter, onMouseLeave, hovering, svgIdNamespace, processedNodesLength } = props;
 
   // Not great typing but after we do layout these properties are full objects not just references
   const { source, target, sourceNodeRadius, targetNodeRadius } = edge as {
@@ -58,7 +57,7 @@ export const Edge = memo(function Edge(props: Props) {
       <EdgeArrowMarker id={markerId} fill={edgeColor} headHeight={arrowHeadHeight} />
       <EdgeArrowMarker id={coloredMarkerId} fill={highlightedEdgeColor} headHeight={arrowHeadHeight} />
       <g
-        key={`${edge.id}-${index}-${processedNodesLength}-g`}
+        key={`${edge.id}-${edge.source.y ?? ''}-${processedNodesLength}-g`}
         onClick={(event) => onClick(event, edge)}
         style={{ cursor: 'pointer' }}
         aria-label={`Edge from: ${source.id} to: ${target.id}`}

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -354,10 +354,9 @@ interface EdgesProps {
 const Edges = memo(function Edges(props: EdgesProps) {
   return (
     <>
-      {props.edges.map((e, index) => (
+      {props.edges.map((e) => (
         <Edge
-          key={`${e.id}-${index}-${props.processedNodesLength}`}
-          index={index}
+          key={`${e.id}-${e.source.y ?? ''}-${props.processedNodesLength}`}
           edge={e}
           hovering={
             (e.source as NodeDatum).id === props.nodeHoveringId ||

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -227,6 +227,7 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode }
                 onMouseEnter={setEdgeHover}
                 onMouseLeave={clearEdgeHover}
                 svgIdNamespace={svgIdNamespace}
+                processedNodesLength={processed.nodes.length}
               />
             )}
             <Nodes
@@ -348,13 +349,15 @@ interface EdgesProps {
   onClick: (event: MouseEvent<SVGElement>, link: EdgeDatumLayout) => void;
   onMouseEnter: (id: string) => void;
   onMouseLeave: (id: string) => void;
+  processedNodesLength: number;
 }
 const Edges = memo(function Edges(props: EdgesProps) {
   return (
     <>
-      {props.edges.map((e) => (
+      {props.edges.map((e, index) => (
         <Edge
-          key={e.id}
+          key={`${e.id}-${index}-${props.processedNodesLength}`}
+          index={index}
           edge={e}
           hovering={
             (e.source as NodeDatum).id === props.nodeHoveringId ||
@@ -365,6 +368,7 @@ const Edges = memo(function Edges(props: EdgesProps) {
           onMouseEnter={props.onMouseEnter}
           onMouseLeave={props.onMouseLeave}
           svgIdNamespace={props.svgIdNamespace}
+          processedNodesLength={props.processedNodesLength}
         />
       ))}
     </>


### PR DESCRIPTION
**What is this feature?**

Adds more unique key to node graph edges.

**Why do we need this feature?**

An edge's id is built like the following `source-target` where `source` is the source node id and `target` is the target node id. If a node graph is already rendered and receives new data where there is also a connected source and target node with the same id, then React thinks it is the same element (same key) in the DOM and won't actually remove it from the DOM, it just updates the edge component. In our case, this means the old edge is left where it is and the new edge in rendered with new co-ordinates.

**Who is this feature for?**

Node Graph users.
