### PR TITLE
[Provisioning] Fix duplicate sync jobs triggered in controller

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -124,7 +124,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		stats = &provisioning.ResourceStats{}
 	}
 
-	progress.SetMessage("update sync amd stats status at end")
+	progress.SetMessage("update status and stats")
 	data = map[string]any{
 		"status": map[string]any{
 			"sync":  syncStatus,
@@ -134,6 +134,10 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 
 	if err := r.patchStatus(ctx, cfg, data); err != nil {
 		return fmt.Errorf("update repo with job final status: %w", err)
+	}
+
+	if syncError == nil {
+		progress.SetMessage("job completed successfully")
 	}
 
 	return syncError


### PR DESCRIPTION
# What?

- Fix duplicate sync job triggered by setting the sync status to pending when sync job is triggered in controller.
- Improve logging on reasons why the controller triggered.
- Fix messaging for sync job

# Before

![image](https://github.com/user-attachments/assets/f967f2ab-8e29-4c78-9833-3bfe09df9f96)


# After
<img width="1678" alt="Screenshot 2025-02-18 at 13 09 12" src="https://github.com/user-attachments/assets/bf4d42c3-97a7-4086-ad7f-ab1dc396b6c0" />
