### PR TITLE
Azure Monitor: Set error source in http and user errors accordingly

### DIFF
--- a/pkg/tsdb/azuremonitor/azmoncredentials/builder.go
+++ b/pkg/tsdb/azuremonitor/azmoncredentials/builder.go
@@ -1,10 +1,12 @@
 package azmoncredentials
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
 )
 
@@ -95,7 +97,7 @@ func getFromLegacy(data map[string]interface{}, secureData map[string]string) (a
 		clientSecret := secureData["clientSecret"]
 
 		if secureData["clientSecret"] == "" {
-			return nil, fmt.Errorf("unable to instantiate credentials, clientSecret must be set")
+			return nil, backend.DownstreamError(errors.New("unable to instantiate credentials, clientSecret must be set"))
 		}
 
 		credentials := &azcredentials.AzureClientSecretCredentials{

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -269,7 +269,11 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 
 	res, err := cli.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to request subscription details: %s", err)
+		err = fmt.Errorf("failed to request subscription details: %s", err)
+		if backend.IsDownstreamHTTPError(err) {
+			err = backend.DownstreamError(err)
+		}
+		return "", err
 	}
 
 	defer func() {


### PR DESCRIPTION
Noticed that following errors are frequent and they have incorrect error source in Azure Monitor https://ops.grafana-ops.net/goto/1MvKdTcNg?orgId=1:
- `error getting credentials: unable to instantiate credentials, clientSecret must be set` 
- `failed to request subscription details: Get "..." net/http: request canceled (Client.Timeout exceeded while awaiting headers)`

This PR fixes it by adding correct error source to `unable to instantiate credentials` error and by using  `backend.IsDownstreamHTTPError(err)` to get error source from failed request. 

