### PR TITLE
CI: test if test-plugins folder exists before adding

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -143,7 +143,8 @@ jobs:
 
       - name: Add package.json changes
         run: |
-          git add package.json lerna.json yarn.lock packages public e2e/test-plugins
+          git add package.json lerna.json yarn.lock packages public
+          test -e e2e/test-plugins && git add e2e/test-plugins
           git commit -m "Update version to ${{ inputs.version }}"
 
       - name: Git push


### PR DESCRIPTION
The current action to [create a release PR](https://github.com/grafana/grafana/actions/runs/13389548070/job/37399149142) fails on branches before 11.3.0 because of https://github.com/grafana/grafana/pull/97506. e2e/test-plugins was added in https://github.com/grafana/grafana/pull/91873 but it's not in the release branch for older versions hence it fails to run:

`git add package.json lerna.json yarn.lock packages public e2e/test-plugins`

This PR adds an extra check before adding test-plugins