### PR TITLE
K8s: add a bool setting to select request header auth versus enterprise behavior

### DIFF
--- a/pkg/services/apiserver/aggregator/aggregator.go
+++ b/pkg/services/apiserver/aggregator/aggregator.go
@@ -129,13 +129,18 @@ func CreateAggregatorConfig(commandOptions *options.Options, sharedConfig generi
 		},
 		ExtraConfig: aggregatorapiserver.ExtraConfig{
 			DisableRemoteAvailableConditionController: true,
-			ProxyClientCertFile:                       commandOptions.KubeAggregatorOptions.ProxyClientCertFile,
-			ProxyClientKeyFile:                        commandOptions.KubeAggregatorOptions.ProxyClientKeyFile,
 			// NOTE: while ProxyTransport can be skipped in the configuration, it allows honoring
 			// DISABLE_HTTP2, HTTPS_PROXY and NO_PROXY env vars as needed
 			ProxyTransport:  createProxyTransport(),
 			ServiceResolver: serviceResolver,
 		},
+	}
+
+	if commandOptions.KubeAggregatorOptions.LegacyClientCertAuth {
+		// NOTE: the availability controller below is a bit different and uses the cert/key pair regardless
+		// of the legacy bool, this is because we are still using that for discovery requests
+		aggregatorConfig.ExtraConfig.ProxyClientCertFile = commandOptions.KubeAggregatorOptions.ProxyClientCertFile
+		aggregatorConfig.ExtraConfig.ProxyClientKeyFile = commandOptions.KubeAggregatorOptions.ProxyClientKeyFile
 	}
 
 	if err := commandOptions.KubeAggregatorOptions.ApplyTo(aggregatorConfig, commandOptions.RecommendedOptions.Etcd); err != nil {

--- a/pkg/services/apiserver/aggregator/aggregator.go
+++ b/pkg/services/apiserver/aggregator/aggregator.go
@@ -57,7 +57,8 @@ import (
 // making sure we only register metrics once into legacy registry
 var registerIntoLegacyRegistryOnce sync.Once
 
-func readCABundlePEM(path string, devMode bool) ([]byte, error) {
+//nolint:unused
+func _readCABundlePEM(path string, devMode bool) ([]byte, error) {
 	if devMode {
 		return nil, nil
 	}
@@ -152,10 +153,6 @@ func CreateAggregatorConfig(commandOptions *options.Options, sharedConfig generi
 		return NewConfig(aggregatorConfig, sharedInformerFactory, []builder.APIGroupBuilder{serviceAPIBuilder}, nil), nil
 	}
 
-	_, err = readCABundlePEM(commandOptions.KubeAggregatorOptions.APIServiceCABundleFile, commandOptions.ExtraOptions.DevMode)
-	if err != nil {
-		return nil, err
-	}
 	remoteServices, err := ReadRemoteServices(commandOptions.KubeAggregatorOptions.RemoteServicesFile)
 	if err != nil {
 		return nil, err

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -48,7 +48,7 @@ func (o *KubeAggregatorOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ProxyClientKeyFile, "proxy-client-key-file", o.ProxyClientKeyFile,
 		"path to proxy client key file")
 
-	fs.BoolVar(&o.LegacyClientCertAuth, "legacy-client-cert-auth", true,
+	fs.BoolVar(&o.LegacyClientCertAuth, "legacy_client_cert_auth", true,
 		"whether to use legacy client cert auth")
 }
 

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -23,6 +23,7 @@ type KubeAggregatorOptions struct {
 	AlternateDNS           []string
 	ProxyClientCertFile    string
 	ProxyClientKeyFile     string
+	LegacyClientCertAuth   bool
 	RemoteServicesFile     string
 	APIServiceCABundleFile string
 }
@@ -45,6 +46,9 @@ func (o *KubeAggregatorOptions) AddFlags(fs *pflag.FlagSet) {
 		"path to proxy client cert file")
 
 	fs.StringVar(&o.ProxyClientKeyFile, "proxy-client-key-file", o.ProxyClientKeyFile,
+		"path to proxy client key file")
+
+	fs.BoolVar(&o.LegacyClientCertAuth, "legacy-client-cert-auth", true,
 		"path to proxy client key file")
 }
 

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -49,7 +49,7 @@ func (o *KubeAggregatorOptions) AddFlags(fs *pflag.FlagSet) {
 		"path to proxy client key file")
 
 	fs.BoolVar(&o.LegacyClientCertAuth, "legacy-client-cert-auth", true,
-		"path to proxy client key file")
+		"whether to use legacy client cert auth")
 }
 
 func (o *KubeAggregatorOptions) Validate() []error {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Earlier today, I first titled this PR a a phase out of FlagKubernetesAggregator. But later made a 360 U-turn on this.

We realized that the cloud implementation won't be ready just yet to allow the use of bespoke token auth for discovery and its much easier to preserve the cert pair settings for that use-case. We want to move towards using the said bespoke token auth for the reverse proxy part of aggregator.

This PR has thus been reworked to include a bool `LegacyClientCertAuth` under `KubeAggregatorOptions` which can be used to opt into new enterprise behavior as we roll the feature forward - which would be hybrid during the interim/testing phase as we improve it: completely switch to token auth for all of the use-case (discovery and reverse proxying).

**Why do we need this feature?**

To roll out the new aggregation auth feature in cloud.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
