### PR TITLE
K8s: DecisionNoOpinion for claims.TypeAnonymous

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/org_id.go
+++ b/pkg/services/apiserver/auth/authorizer/org_id.go
@@ -60,6 +60,11 @@ func (auth orgIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
+	// If we have an anonymous user, let the next authorizers decide.
+	if signedInUser.GetIdentityType() == claims.TypeAnonymous {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	// Check if the user has access to the specified org
 	// nolint:staticcheck
 	userId, err := signedInUser.GetInternalID()

--- a/pkg/services/apiserver/auth/authorizer/stack_id.go
+++ b/pkg/services/apiserver/auth/authorizer/stack_id.go
@@ -37,6 +37,11 @@ func (auth stackIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 		return authorizer.DecisionDeny, fmt.Sprintf("error getting signed in user: %v", err), nil
 	}
 
+	// If we have an anonymous user, let the next authorizers decide.
+	if signedInUser.GetIdentityType() == claims.TypeAnonymous {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	info, err := claims.ParseNamespace(a.GetNamespace())
 	if err != nil {
 		return authorizer.DecisionDeny, fmt.Sprintf("error reading namespace: %v", err), nil
@@ -46,9 +51,9 @@ func (auth stackIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 	if info.Value == "" {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
-
 	if info.StackID != auth.stackID {
-		return authorizer.DecisionDeny, "wrong stack id is selected", nil
+		msg := fmt.Sprintf("wrong stack id is selected (expected: %d, found %d)", auth.stackID, info.StackID)
+		return authorizer.DecisionDeny, msg, nil
 	}
 	if info.OrgID != 1 {
 		return authorizer.DecisionDeny, "cloud instance requires org 1", nil


### PR DESCRIPTION
When a user is Anonymous, we do not need to make sure they are in the the right org/stack.

Extracted from https://github.com/grafana/grafana/pull/96329

