### PR TITLE
Upgrade codeql version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -67,4 +67,4 @@ jobs:
         make build-go
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
**What is this feature?**

We are using a deprecated version of CodeQL, as  mentioned here: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

Now that we are minimising SQL related risks, we should run this check against the most recent version, so that we don't see these kind of errors when running the tool.
Run with new version triggered manually [here](https://github.com/grafana/grafana/actions/runs/13408542334/job/37453197775)

<img width="1152" alt="Screenshot 2025-02-18 at 17 20 40" src="https://github.com/user-attachments/assets/240a5be3-c374-408f-9a34-c9ca005b1169" />


