### PR TITLE
[release-11.1.12] CI: release comms should trigger on merges to release- branches

### DIFF
--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -19,7 +19,7 @@ on:
     - closed
     branches:
     - 'main'
-    - 'v*.*.*'
+    - 'release-*.*.*'
 
 jobs:
   setup:


### PR DESCRIPTION
Backport 14477a7fe9c11cbbd63dc6532d08f621ce27aefa from #100901

---


