### PR TITLE
k8s: unified search ui: fix url

### DIFF
--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -146,7 +146,7 @@ describe('Unified Storage Searcher', () => {
         folder: 'General',
         tags: ['monitoring', 'performance'],
         field: { errors_today: 1 },
-        url: '/dashboards/1',
+        url: '/dashboards/1/main-dashboard-title',
       },
       {
         resource: 'dashboard',
@@ -156,7 +156,7 @@ describe('Unified Storage Searcher', () => {
         folder: 'General',
         tags: ['monitoring', 'performance'],
         field: { errors_today: 2 },
-        url: '/dashboards/1',
+        url: '/dashboards/1/main-dashboard-title',
       },
     ];
 
@@ -184,7 +184,7 @@ describe('Unified Storage Searcher', () => {
         folder: 'General',
         tags: ['monitoring', 'performance'],
         field: { errors_today: 1 },
-        url: '/dashboards/1',
+        url: '/dashboards/1/main-dashboard-title',
       },
     ];
 

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash';
 import { DataFrame, DataFrameView, getDisplayProcessor, SelectableValue, toDataFrame } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
+import kbn from 'app/core/utils/kbn';
 
 import { getAPINamespace } from '../../../api/utils';
 
@@ -321,7 +322,7 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
     return {
       ...hit,
       uid: hit.name,
-      url: toURL(hit.resource, hit.name),
+      url: toURL(hit.resource, hit.name, hit.title),
       tags: hit.tags || [],
       folder: hit.folder || 'general',
       location,
@@ -369,7 +370,7 @@ async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
         locationInfo[hit.name] = {
           name: hit.title,
           kind: 'folder',
-          url: toURL('folders', hit.name),
+          url: toURL('folders', hit.name, hit.title),
         };
       }
       return locationInfo;
@@ -377,9 +378,10 @@ async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
   return rsp;
 }
 
-function toURL(resource: string, name: string): string {
+function toURL(resource: string, name: string, title: string): string {
   if (resource === 'folders') {
     return `/dashboards/f/${name}`;
   }
-  return `/d/${name}`;
+  const slug = kbn.slugifyForUrl(title);
+  return `/d/${name}/${slug}`;
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes the dashboard url when using the feature toggle `unifiedSearchUI`.

before:
https://github.com/user-attachments/assets/7aa1e58c-a5b8-4d2d-97b8-d1afcad78970

after:
https://github.com/user-attachments/assets/e9a917f3-c1e9-4ad8-8011-2296fed6f4e2

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/app-platform-wg/issues/215
