### PR TITLE
chore: add react-loading-skeleton to @grafana/runtime

### DIFF
--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -44,6 +44,7 @@
     "@grafana/ui": "11.6.0-pre",
     "history": "4.10.1",
     "lodash": "4.17.21",
+    "react-loading-skeleton": "3.5.0",
     "react-use": "17.6.0",
     "rxjs": "7.8.1",
     "tslib": "2.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3701,6 +3701,7 @@ __metadata:
     lodash: "npm:4.17.21"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
+    react-loading-skeleton: "npm:3.5.0"
     react-use: "npm:17.6.0"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"


### PR DESCRIPTION
Resolves an ESM issue where the `react-loading-skeleton` dependency is being used but was depended on via transitive dependency in `@grafana/ui`. This caused the build to render 

`import Skeleton from '../node_modules/react-loading-skeleton/dist/index.js'` 

instead of 

`import Skeleton from 'react-loading-skeleton'`

which caused tools like [Storybook](https://storybook.js.org/) or [Ladle](https://ladle.dev/) to fail to compile since the relative path was not correct. As you can see in the image below, `node_modules` is actually 3 levels above `QueryEditorWithMigration.js`

![image](https://github.com/user-attachments/assets/cd5ee05c-4ac3-483a-bd24-bfae9b59fe06)

Tested the change locally with the local npm registry and it indeed resolves the issue.
