### PR TITLE
PluginExtensions: Fixed so we expose the proper types for usePluginComponents

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5602,8 +5602,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/plugins/extensions/usePluginComponents.tsx:5381": [
-      [0, 0, 0, "\'@grafana/runtime/src/services/pluginExtensions/getPluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/plugins/extensions/usePluginFunctions.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -5607,9 +5607,6 @@ exports[`better eslint`] = {
     "public/app/features/plugins/extensions/usePluginFunctions.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/plugins/extensions/usePluginLinks.tsx:5381": [
-      [0, 0, 0, "\'@grafana/runtime/src/services/pluginExtensions/getPluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/plugins/extensions/validators.ts:5381": [
       [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -21,9 +21,6 @@ export {
   type GetPluginExtensionsResult,
   type UsePluginExtensions,
   type UsePluginExtensionsResult,
-  type UsePluginComponentResult,
-  type UsePluginFunctionsOptions,
-  type UsePluginFunctionsResult,
 } from './pluginExtensions/getPluginExtensions';
 export {
   setPluginExtensionsHook,
@@ -32,10 +29,29 @@ export {
   usePluginComponentExtensions,
 } from './pluginExtensions/usePluginExtensions';
 
-export { setPluginComponentHook, usePluginComponent } from './pluginExtensions/usePluginComponent';
-export { setPluginComponentsHook, usePluginComponents } from './pluginExtensions/usePluginComponents';
-export { setPluginLinksHook, usePluginLinks } from './pluginExtensions/usePluginLinks';
-export { setPluginFunctionsHook, usePluginFunctions } from './pluginExtensions/usePluginFunctions';
+export {
+  setPluginComponentHook,
+  usePluginComponent,
+  type UsePluginComponentResult,
+} from './pluginExtensions/usePluginComponent';
+export {
+  setPluginComponentsHook,
+  usePluginComponents,
+  type UsePluginComponentsResult,
+  type UsePluginComponentsOptions,
+} from './pluginExtensions/usePluginComponents';
+export {
+  setPluginLinksHook,
+  usePluginLinks,
+  type UsePluginLinksOptions,
+  type UsePluginLinksResult,
+} from './pluginExtensions/usePluginLinks';
+export {
+  setPluginFunctionsHook,
+  usePluginFunctions,
+  type UsePluginFunctionsOptions,
+  type UsePluginFunctionsResult,
+} from './pluginExtensions/usePluginFunctions';
 
 export { isPluginExtensionLink, isPluginExtensionComponent } from './pluginExtensions/utils';
 export { setCurrentUser } from './user';

--- a/packages/grafana-runtime/src/services/pluginExtensions/getPluginExtensions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getPluginExtensions.ts
@@ -1,10 +1,4 @@
-import type {
-  PluginExtension,
-  PluginExtensionLink,
-  PluginExtensionComponent,
-  PluginExtensionFunction,
-  PluginExtensionComponentMeta,
-} from '@grafana/data';
+import type { PluginExtension, PluginExtensionLink, PluginExtensionComponent } from '@grafana/data';
 
 import { isPluginExtensionComponent, isPluginExtensionLink } from './utils';
 
@@ -23,11 +17,6 @@ export type GetPluginExtensionsOptions = {
   limitPerPlugin?: number;
 };
 
-export type UsePluginComponentOptions = {
-  extensionPointId: string;
-  limitPerPlugin?: number;
-};
-
 export type GetPluginExtensionsResult<T = PluginExtension> = {
   extensions: T[];
 };
@@ -35,37 +24,6 @@ export type GetPluginExtensionsResult<T = PluginExtension> = {
 export type UsePluginExtensionsResult<T = PluginExtension> = {
   extensions: T[];
   isLoading: boolean;
-};
-
-export type UsePluginComponentResult<Props = {}> = {
-  component: React.ComponentType<Props> | undefined | null;
-  isLoading: boolean;
-};
-
-export type UsePluginComponentsResult<Props = {}> = {
-  components: Array<React.ComponentType<Props> & { meta: PluginExtensionComponentMeta }>;
-  isLoading: boolean;
-};
-
-export type UsePluginLinksOptions = {
-  extensionPointId: string;
-  context?: object | Record<string | symbol, unknown>;
-  limitPerPlugin?: number;
-};
-
-export type UsePluginLinksResult = {
-  isLoading: boolean;
-  links: PluginExtensionLink[];
-};
-
-export type UsePluginFunctionsOptions = {
-  extensionPointId: string;
-  limitPerPlugin?: number;
-};
-
-export type UsePluginFunctionsResult<Signature> = {
-  isLoading: boolean;
-  functions: Array<PluginExtensionFunction<Signature>>;
 };
 
 let singleton: GetPluginExtensions | undefined;

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponent.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponent.ts
@@ -1,6 +1,9 @@
-import { UsePluginComponentResult } from './getPluginExtensions';
+export type UsePluginComponent<Props extends object = {}> = (componentId: string) => UsePluginComponentResult<Props>;
 
-export type UsePluginComponent<Props extends object = {}> = (id: string) => UsePluginComponentResult<Props>;
+export type UsePluginComponentResult<Props = {}> = {
+  component: React.ComponentType<Props> | undefined | null;
+  isLoading: boolean;
+};
 
 let singleton: UsePluginComponent | undefined;
 
@@ -12,9 +15,9 @@ export function setPluginComponentHook(hook: UsePluginComponent): void {
   singleton = hook;
 }
 
-export function usePluginComponent<Props extends object = {}>(id: string): UsePluginComponentResult<Props> {
+export function usePluginComponent<Props extends object = {}>(componentId: string): UsePluginComponentResult<Props> {
   if (!singleton) {
     throw new Error('setPluginComponentHook(options) can only be used after the Grafana instance has started.');
   }
-  return singleton(id) as UsePluginComponentResult<Props>;
+  return singleton(componentId) as UsePluginComponentResult<Props>;
 }

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
@@ -1,13 +1,23 @@
-import { GetPluginExtensionsOptions, UsePluginComponentsResult } from './getPluginExtensions';
+import { PluginExtensionComponentMeta } from '@grafana/data';
+
+export type UsePluginComponentsOptions = {
+  extensionPointId: string;
+  limitPerPlugin?: number;
+};
+
+export type UsePluginComponentsResult<Props = {}> = {
+  components: Array<React.ComponentType<Props> & { meta: PluginExtensionComponentMeta }>;
+  isLoading: boolean;
+};
 
 export type UsePluginComponents<Props extends object = {}> = (
-  options: GetPluginExtensionsOptions
+  options: UsePluginComponentsOptions
 ) => UsePluginComponentsResult<Props>;
 
 let singleton: UsePluginComponents | undefined;
 
 export function setPluginComponentsHook(hook: UsePluginComponents): void {
-  // We allow overriding the registry in tests
+  // We allow overriding the hook in tests
   if (singleton && process.env.NODE_ENV !== 'test') {
     throw new Error('setPluginComponentsHook() function should only be called once, when Grafana is starting.');
   }
@@ -15,7 +25,7 @@ export function setPluginComponentsHook(hook: UsePluginComponents): void {
 }
 
 export function usePluginComponents<Props extends object = {}>(
-  options: GetPluginExtensionsOptions
+  options: UsePluginComponentsOptions
 ): UsePluginComponentsResult<Props> {
   if (!singleton) {
     throw new Error('setPluginComponentsHook(options) can only be used after the Grafana instance has started.');

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginFunctions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginFunctions.ts
@@ -1,4 +1,14 @@
-import { UsePluginFunctionsOptions, UsePluginFunctionsResult } from './getPluginExtensions';
+import { PluginExtensionFunction } from '@grafana/data';
+
+export type UsePluginFunctionsOptions = {
+  extensionPointId: string;
+  limitPerPlugin?: number;
+};
+
+export type UsePluginFunctionsResult<Signature> = {
+  isLoading: boolean;
+  functions: Array<PluginExtensionFunction<Signature>>;
+};
 
 export type UsePluginFunctions<T> = (options: UsePluginFunctionsOptions) => UsePluginFunctionsResult<T>;
 

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginLinks.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginLinks.ts
@@ -1,4 +1,15 @@
-import { UsePluginLinksOptions, UsePluginLinksResult } from './getPluginExtensions';
+import { PluginExtensionLink } from '@grafana/data';
+
+export type UsePluginLinksOptions = {
+  extensionPointId: string;
+  context?: object | Record<string | symbol, unknown>;
+  limitPerPlugin?: number;
+};
+
+export type UsePluginLinksResult = {
+  isLoading: boolean;
+  links: PluginExtensionLink[];
+};
 
 export type UsePluginLinks = (options: UsePluginLinksOptions) => UsePluginLinksResult;
 

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -2,10 +2,7 @@ import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 
 import { PluginExtensionComponentMeta, PluginExtensionTypes, usePluginContext } from '@grafana/data';
-import {
-  UsePluginComponentOptions,
-  UsePluginComponentsResult,
-} from '@grafana/runtime/src/services/pluginExtensions/getPluginExtensions';
+import { UsePluginComponentsOptions, UsePluginComponentsResult } from '@grafana/runtime';
 
 import { useAddedComponentsRegistry } from './ExtensionRegistriesContext';
 import * as errors from './errors';
@@ -19,7 +16,7 @@ import { isExtensionPointIdValid, isExtensionPointMetaInfoMissing } from './vali
 export function usePluginComponents<Props extends object = {}>({
   limitPerPlugin,
   extensionPointId,
-}: UsePluginComponentOptions): UsePluginComponentsResult<Props> {
+}: UsePluginComponentsOptions): UsePluginComponentsResult<Props> {
   const registry = useAddedComponentsRegistry();
   const registryState = useObservable(registry.asObservable());
   const pluginContext = usePluginContext();

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -3,10 +3,7 @@ import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 
 import { PluginExtensionLink, PluginExtensionTypes, usePluginContext } from '@grafana/data';
-import {
-  UsePluginLinksOptions,
-  UsePluginLinksResult,
-} from '@grafana/runtime/src/services/pluginExtensions/getPluginExtensions';
+import { UsePluginLinksOptions, UsePluginLinksResult } from '@grafana/runtime';
 
 import { useAddedLinksRegistry } from './ExtensionRegistriesContext';
 import * as errors from './errors';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When we introduced the `usePluginComponents` hook we accidentally used the "old" options type instead of the new one. This is a breaking change when it comes to build time but during runtime this will not have any effect other than the context is passed when calling the `usePluginComponents`.  It has always been ignored so no behavioural change in that regards.

**Why do we need this feature?**

We should expose the proper typings to guide developers how to use these APIs.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I also moved the `*Options` and `*Result` types to where they are using. Still exposed the same way externally from `@grafana/runtime`. Also I exposed the `UsePluginComponentsOption` and `UsePluginComponentsResult` that wasn't exposed before.

PR for migration guide can be found [here](https://github.com/grafana/plugin-tools/pull/1553).

I have tried to check all consumers of this by searching on github and the only plugins I can find using these APIs doesn't pass the context in the options. So this change should be OK to do.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
