### PR TITLE
Auth: Use authinfo instead

### DIFF
--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 	"k8s.io/apimachinery/pkg/api/apitesting"
@@ -32,12 +32,13 @@ func TestPrepareObjectForStorage(t *testing.T) {
 			LargeObjectSupport: nil,
 		},
 	}
-	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, UserUID: "user-uid"})
 
-	t.Run("Error getting requester from context", func(t *testing.T) {
+	ctx := authtypes.WithAuthInfo(context.Background(), &identity.StaticRequester{UserID: 1, UserUID: "user-uid", Type: authtypes.TypeUser})
+
+	t.Run("Error getting auth info from context", func(t *testing.T) {
 		_, err := s.prepareObjectForStorage(context.Background(), nil)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "a Requester was not found in the context")
+		require.Contains(t, err.Error(), "missing auth info")
 	})
 
 	t.Run("Error on missing name", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**
Update to use `types.AuthInfoFrom` instead so we work with the interface we should use.

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
