### PR TITLE
Update `ErrRequestErrorBase` from `[plugin.downstreamError]` to `[plugin.requestFailureError]`

### DIFF
--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -249,7 +249,7 @@ func TestDataSourceQueryError(t *testing.T) {
 			expectedStatus: errutil.StatusInternal.HTTPStatus(),
 			expectedBody: body{
 				Message:    "An error occurred within the plugin",
-				MessageId:  "plugin.requestError",
+				MessageId:  "plugin.requestFailureError",
 				StatusCode: 500,
 			},
 		},

--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -249,7 +249,7 @@ func TestDataSourceQueryError(t *testing.T) {
 			expectedStatus: errutil.StatusInternal.HTTPStatus(),
 			expectedBody: body{
 				Message:    "An error occurred within the plugin",
-				MessageId:  "plugin.downstreamError",
+				MessageId:  "plugin.requestError",
 				StatusCode: 500,
 			},
 		},

--- a/pkg/apimachinery/errutil/errors.go
+++ b/pkg/apimachinery/errutil/errors.go
@@ -114,7 +114,7 @@ func ValidationFailed(msgID string, opts ...BaseOpt) Base {
 // msgID should be structured as component.errorBrief, for example
 //
 //	sqleng.connectionError
-//	plugin.downstreamError
+//	plugin.requestError
 func Internal(msgID string, opts ...BaseOpt) Base {
 	return NewBase(StatusInternal, msgID, opts...)
 }

--- a/pkg/apimachinery/errutil/errors.go
+++ b/pkg/apimachinery/errutil/errors.go
@@ -114,7 +114,7 @@ func ValidationFailed(msgID string, opts ...BaseOpt) Base {
 // msgID should be structured as component.errorBrief, for example
 //
 //	sqleng.connectionError
-//	plugin.requestError
+//	plugin.requestFailureError
 func Internal(msgID string, opts ...BaseOpt) Base {
 	return NewBase(StatusInternal, msgID, opts...)
 }

--- a/pkg/plugins/backendplugin/grpcplugin/client_v2.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_v2.go
@@ -356,14 +356,14 @@ func handleGrpcStatusError(ctx context.Context, errorSource errstatus.Source, er
 		if innerErr != nil {
 			logger.Error("Could not set downstream error source", "error", innerErr)
 		}
-		return plugins.ErrPluginRequestErrorBase.Errorf("%v", err)
+		return plugins.ErrPluginRequestFailureErrorBase.Errorf("%v", err)
 	case backend.ErrorSourcePlugin:
 		errorSourceErr := backend.WithErrorSource(ctx, backend.ErrorSourcePlugin)
 		if errorSourceErr != nil {
 			logger.Error("Could not set plugin error source", "error", errorSourceErr)
 		}
 		// plugin request errors are coming from plugin and not Grafana server
-		return plugins.ErrPluginRequestErrorBase.Errorf("%v", err)
+		return plugins.ErrPluginRequestFailureErrorBase.Errorf("%v", err)
 	}
 	return fmt.Errorf("%v: %w", "Failed to query data", err)
 }

--- a/pkg/plugins/backendplugin/grpcplugin/client_v2.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_v2.go
@@ -356,15 +356,14 @@ func handleGrpcStatusError(ctx context.Context, errorSource errstatus.Source, er
 		if innerErr != nil {
 			logger.Error("Could not set downstream error source", "error", innerErr)
 		}
-		return plugins.ErrPluginDownstreamErrorBase.Errorf("%v", err)
+		return plugins.ErrPluginRequestErrorBase.Errorf("%v", err)
 	case backend.ErrorSourcePlugin:
 		errorSourceErr := backend.WithErrorSource(ctx, backend.ErrorSourcePlugin)
 		if errorSourceErr != nil {
 			logger.Error("Could not set plugin error source", "error", errorSourceErr)
 		}
-		// a downstream error is returned here as plugin errors are considered as downstream errors in the
-		// context of the Grafana server.
-		return plugins.ErrPluginDownstreamErrorBase.Errorf("%v", err)
+		// plugin request errors are coming from plugin and not Grafana server
+		return plugins.ErrPluginRequestErrorBase.Errorf("%v", err)
 	}
 	return fmt.Errorf("%v: %w", "Failed to query data", err)
 }

--- a/pkg/plugins/backendplugin/grpcplugin/client_v2.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_v2.go
@@ -362,7 +362,7 @@ func handleGrpcStatusError(ctx context.Context, errorSource errstatus.Source, er
 		if errorSourceErr != nil {
 			logger.Error("Could not set plugin error source", "error", errorSourceErr)
 		}
-		// plugin request errors are coming from plugin and not Grafana server
+		// plugin request has failed after being sent from the Grafana server
 		return plugins.ErrPluginRequestFailureErrorBase.Errorf("%v", err)
 	}
 	return fmt.Errorf("%v: %w", "Failed to query data", err)

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -24,9 +24,9 @@ var (
 		errutil.WithPublicMessage("Plugin health check failed"),
 		errutil.WithDownstream())
 
-	// ErrPluginRequestErrorBase error returned when a plugin request fails.
+	// ErrPluginRequestFailureErrorBase error returned when a plugin request fails.
 	// Exposed as a base error to wrap it with plugin request errors.
-	ErrPluginRequestErrorBase = errutil.Internal("plugin.requestError",
+	ErrPluginRequestFailureErrorBase = errutil.Internal("plugin.requestFailureError",
 		errutil.WithPublicMessage("An error occurred within the plugin"),
 		errutil.WithDownstream())
 

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -24,9 +24,9 @@ var (
 		errutil.WithPublicMessage("Plugin health check failed"),
 		errutil.WithDownstream())
 
-	// ErrPluginDownstreamErrorBase error returned when a plugin request fails.
-	// Exposed as a base error to wrap it with plugin downstream errors.
-	ErrPluginDownstreamErrorBase = errutil.Internal("plugin.downstreamError",
+	// ErrPluginRequestErrorBase error returned when a plugin request fails.
+	// Exposed as a base error to wrap it with plugin request errors.
+	ErrPluginRequestErrorBase = errutil.Internal("plugin.requestError",
 		errutil.WithPublicMessage("An error occurred within the plugin"),
 		errutil.WithDownstream())
 

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -68,7 +68,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: query data request canceled: %w", err)
 		}
 
-		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to query data: %w", err)
+		return nil, plugins.ErrPluginRequestErrorBase.Errorf("client: failed to query data: %w", err)
 	}
 
 	for refID, res := range resp.Responses {
@@ -127,7 +127,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request canceled: %w", err)
 		}
 
-		return plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to call resources: %w", err)
+		return plugins.ErrPluginRequestErrorBase.Errorf("client: failed to call resources: %w", err)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: collect metrics request canceled: %w", err)
 		}
 
-		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to collect metrics: %w", err)
+		return nil, plugins.ErrPluginRequestErrorBase.Errorf("client: failed to collect metrics: %w", err)
 	}
 
 	return resp, nil

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -68,7 +68,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: query data request canceled: %w", err)
 		}
 
-		return nil, plugins.ErrPluginRequestErrorBase.Errorf("client: failed to query data: %w", err)
+		return nil, plugins.ErrPluginRequestFailureErrorBase.Errorf("client: failed to query data: %w", err)
 	}
 
 	for refID, res := range resp.Responses {
@@ -127,7 +127,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request canceled: %w", err)
 		}
 
-		return plugins.ErrPluginRequestErrorBase.Errorf("client: failed to call resources: %w", err)
+		return plugins.ErrPluginRequestFailureErrorBase.Errorf("client: failed to call resources: %w", err)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: collect metrics request canceled: %w", err)
 		}
 
-		return nil, plugins.ErrPluginRequestErrorBase.Errorf("client: failed to collect metrics: %w", err)
+		return nil, plugins.ErrPluginRequestFailureErrorBase.Errorf("client: failed to collect metrics: %w", err)
 	}
 
 	return resp, nil

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -38,7 +38,7 @@ func TestQueryData(t *testing.T) {
 			},
 			{
 				err:           errors.New("surprise surprise"),
-				expectedError: plugins.ErrPluginRequestErrorBase,
+				expectedError: plugins.ErrPluginRequestFailureErrorBase,
 			},
 			{
 				err:           context.Canceled,

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -38,7 +38,7 @@ func TestQueryData(t *testing.T) {
 			},
 			{
 				err:           errors.New("surprise surprise"),
-				expectedError: plugins.ErrPluginDownstreamErrorBase,
+				expectedError: plugins.ErrPluginRequestErrorBase,
 			},
 			{
 				err:           context.Canceled,


### PR DESCRIPTION
We currently have a few error bases that enrich errors. The one used for wrapping errors from plugin requests is `ErrPluginDownstreamErrorBase`. This means any error returned by a plugin will have `[plugin.downstreamError]` prepended in the logs. While technically correct, this can be confusing for us - plugin developers who rely on these logs - as it might be mistaken for a `plugin/downstream` error source.  (see [this as example)](https://raintank-corp.slack.com/archives/C068FL57F0V/p1739546044263619?thread_ts=1739463434.354989&cid=C068FL57F0V)

The confusion arises because we use `error source = plugin/downstream` to indicate that the error originates from the plugin or outside. However, the log message `[plugin.downstreamError] ...` can create ambiguity about what "downstream" actually refers to.  

To improve clarity, I suggest changing it to `[plugin.requestError]`. This explicitly indicates that the error comes from the plugin request, avoiding any misinterpretation of "downstream." Also the word "downstream" is not adding any additional value for us.

Moreover, other error bases do not include "downstream" or other information where the error originated:
- ErrPluginRequestCanceledErrorBase
- errMethodNotImplementedBase
- errPluginUnavailableBase
- errPluginNotRegisteredBase

I am also totally open to other suggestions. 