### PR TITLE
unistore: Add missing verb to compile

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -952,6 +952,7 @@ func (s *server) Watch(req *WatchRequest, srv ResourceStore_WatchServer) error {
 		Group:     key.Group,
 		Resource:  key.Resource,
 		Namespace: key.Namespace,
+		Verb:      utils.VerbGet,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix watch not working for Dasbhboard and Folder. 
![image](https://github.com/user-attachments/assets/658c4571-8dc6-48c1-aee3-d128ae145aa0)
