### PR TITLE
Frontend sandbox: Improve signature elegibility check to avoid extra requests

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
@@ -21,8 +21,6 @@ export function setSandboxEnabledCheck(checker: SandboxEnabledCheck) {
   sandboxEnabledCheck = checker;
 }
 
-const pluginElegibilityCache = new Map<string, Promise<boolean>>();
-
 export async function shouldLoadPluginInFrontendSandbox({
   isAngular,
   pluginId,
@@ -64,17 +62,8 @@ export async function isPluginFrontendSandboxEligible({
     return false;
   }
 
-  // skip cache for jest tests
-  if (!process.env.JEST_WORKER_ID && pluginElegibilityCache.has(pluginId)) {
-    return pluginElegibilityCache.get(pluginId)!;
-  }
-
   // grafana signature and internal plugins are not allowed in the sandbox
-  const result = isPluginSignatureEligibleForSandbox({ pluginId });
-  // promise meomization to prevent redundant requests
-  pluginElegibilityCache.set(pluginId, result);
-
-  return result;
+  return isPluginSignatureEligibleForSandbox({ pluginId });
 
 }
 

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
@@ -64,7 +64,6 @@ export async function isPluginFrontendSandboxEligible({
 
   // grafana signature and internal plugins are not allowed in the sandbox
   return isPluginSignatureEligibleForSandbox({ pluginId });
-
 }
 
 async function isPluginSignatureEligibleForSandbox({ pluginId }: SandboxEligibilityCheckParams): Promise<boolean> {


### PR DESCRIPTION
**What is this feature?**

* It changes the logic so we first check the local installed plugin settings and fallback to gcom

**Why do we need this feature?**

* to prevent unnecessary request to the backend and the gcom api

**Who is this feature for?**

All users of the frontend sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
