### PR TITLE
Fix(ShareSnapshot): fix snapshot timeout input which always append 0 …

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -25,7 +25,7 @@ interface State {
   snapshotExpires?: number;
   snapshotUrl: string;
   deleteUrl: string;
-  timeoutSeconds: number;
+  timeoutSeconds: number | string;
   externalEnabled: boolean;
   sharingButtonText: string;
 }
@@ -92,7 +92,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
 
     setTimeout(() => {
       this.saveSnapshot(this.dashboard, external);
-    }, timeoutSeconds * 1000);
+    }, Number(timeoutSeconds) * 1000);
   };
 
   saveSnapshot = async (dashboard: DashboardModel, external?: boolean) => {
@@ -119,13 +119,13 @@ export class ShareSnapshot extends PureComponent<Props, State> {
       if (external) {
         DashboardInteractions.publishSnapshotClicked({
           expires: snapshotExpires,
-          timeout: timeoutSeconds,
+          timeout: Number(timeoutSeconds),
           shareResource: getTrackingSource(this.props.panel),
         });
       } else {
         DashboardInteractions.publishSnapshotLocalClicked({
           expires: snapshotExpires,
-          timeout: timeoutSeconds,
+          timeout: Number(timeoutSeconds),
           shareResource: getTrackingSource(this.props.panel),
         });
       }
@@ -215,8 +215,15 @@ export class ShareSnapshot extends PureComponent<Props, State> {
   };
 
   onTimeoutChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ timeoutSeconds: Number(event.target.value) });
+    this.setState({ timeoutSeconds: event.target.value === '' ? '' : Number(event.target.value) });
   };
+
+  onBlurTimeout = () => {
+    this.setState((prevState) => ({
+        timeoutSeconds: Number(prevState.timeoutSeconds),
+    })
+    );
+  }
 
   onExpireChange = (option: SelectableValue<number>) => {
     this.setState({
@@ -268,7 +275,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
           />
         </Field>
         <Field label={timeoutTranslation} description={timeoutDescriptionTranslation}>
-          <Input id="timeout-input" type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
+          <Input id="timeout-input" type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} onBlur={this.onBlurTimeout} />
         </Field>
 
         <Modal.ButtonRow>


### PR DESCRIPTION
…value

	- In Snapshot Tab of Share Modal, for the Timestamp(seconds) field it is appended 0 before each new inserted value (because when the default value is deleted, the empty value is automatically converted to 0)
	- This fix will avoid this issue and will also keep 0 as a default value in case this field will remain empty

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

![image](https://github.com/user-attachments/assets/f1bbf168-37ea-4524-b75a-cd85aee183b5)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
