### PR TITLE
Authz: Setup access claims for service identity 

### DIFF
--- a/pkg/apimachinery/identity/static.go
+++ b/pkg/apimachinery/identity/static.go
@@ -30,10 +30,11 @@ type StaticRequester struct {
 	Namespace       string
 	IsGrafanaAdmin  bool
 	// Permissions grouped by orgID and actions
-	Permissions   map[int64]map[string][]string
-	IDToken       string
-	IDTokenClaims *authnlib.Claims[authnlib.IDTokenClaims]
-	CacheKey      string
+	Permissions       map[int64]map[string][]string
+	IDToken           string
+	IDTokenClaims     *authnlib.Claims[authnlib.IDTokenClaims]
+	AccessTokenClaims *authnlib.Claims[authnlib.AccessTokenClaims]
+	CacheKey          string
 }
 
 // GetID returns typed id for the entity
@@ -62,10 +63,16 @@ func (u *StaticRequester) GetAudience() []string {
 }
 
 func (u *StaticRequester) GetTokenPermissions() []string {
+	if u.AccessTokenClaims != nil {
+		return u.AccessTokenClaims.Rest.Permissions
+	}
 	return []string{}
 }
 
 func (u *StaticRequester) GetTokenDelegatedPermissions() []string {
+	if u.AccessTokenClaims != nil {
+		return u.AccessTokenClaims.Rest.DelegatedPermissions
+	}
 	return []string{}
 }
 

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -145,5 +145,7 @@ func ProvideRegistration(
 
 	nsSync := sync.ProvideNamespaceSync(cfg)
 	authnSvc.RegisterPostAuthHook(nsSync.SyncNamespace, 150)
+	authnSvc.RegisterPostAuthHook(sync.AccessClaimsHook, 160)
+
 	return Registration{}
 }

--- a/pkg/services/authn/authnimpl/sync/access_claims.go
+++ b/pkg/services/authn/authnimpl/sync/access_claims.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"context"
+
+	authnlib "github.com/grafana/authlib/authn"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+func NewAccessClaimsSync() AccessClaimsSync {
+	return AccessClaimsSync{}
+}
+
+type AccessClaimsSync struct{}
+
+func AccessClaimsHook(ctx context.Context, id *authn.Identity, _ *authn.Request) error {
+	if id.AccessTokenClaims == nil {
+		// When normal authencation flows are used withint grafana we don't have any access token e.g. using user
+		// session. This makes it impossible to authorize using AccessClient because we don't have any access claims
+		// with deletegated permissions. To get around this we use the hardcoded delegated
+		// permissions.
+		id.AccessTokenClaims = &authnlib.Claims[authnlib.AccessTokenClaims]{
+			Rest: authnlib.AccessTokenClaims{
+				DelegatedPermissions: identity.ServiceIdentityClaims.Rest.DelegatedPermissions,
+			},
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/authn/grpcutils/inproc_exchanger.go
+++ b/pkg/services/authn/grpcutils/inproc_exchanger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 type inProcExchanger struct {
@@ -37,8 +38,8 @@ func createInProcToken() (*authn.TokenExchangeResponse, error) {
 		},
 		Rest: authn.AccessTokenClaims{
 			Namespace:            "*",
-			Permissions:          []string{"folder.grafana.app:*", "dashboard.grafana.app:*"},
-			DelegatedPermissions: []string{"folder.grafana.app:*", "dashboard.grafana.app:*"},
+			Permissions:          identity.ServiceIdentityClaims.Rest.Permissions,
+			DelegatedPermissions: identity.ServiceIdentityClaims.Rest.DelegatedPermissions,
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**
With https://github.com/grafana/grafana/pull/100803 we removed the setting disabling checking the access token.

This is fine in every case except when we use `AccessClient` within grafana and the identity is authenticated with any method that does not include a access token.

When the client is called we check if we have delegated permissions to do the action. I added `ServiceIdentityClaims` that we use for:

* Inproc token permissions when communicating with resource store.
* Add it to identities that was not authenticated with access token.

