### PR TITLE
Chore: emit mega menu docked state on every event

### DIFF
--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -9,7 +9,7 @@ export class Store {
     window.localStorage[key] = value;
   }
 
-  getBool(key: string, def: boolean): boolean {
+  getBool<DefaultValue = boolean>(key: string, def: DefaultValue): DefaultValue | boolean {
     if (def !== void 0 && !this.exists(key)) {
       return def;
     }

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -13,6 +13,7 @@ import { RouteDescriptor } from '../../navigation/types';
 import { buildBreadcrumbs } from '../Breadcrumbs/utils';
 
 import { ReturnToPreviousProps } from './ReturnToPrevious/ReturnToPrevious';
+import { getMegaMenuDockedState, MenuDockState } from './menuPreference';
 import { HistoryEntry, TOP_BAR_LEVEL_HEIGHT } from './types';
 
 export interface AppChromeState {
@@ -39,10 +40,7 @@ export class AppChromeService {
   private currentRoute?: RouteDescriptor;
   private routeChangeHandled = true;
 
-  private megaMenuDocked = Boolean(
-    window.innerWidth >= config.theme2.breakpoints.values.xl &&
-      store.getBool(DOCKED_LOCAL_STORAGE_KEY, Boolean(window.innerWidth >= config.theme2.breakpoints.values.xxl))
-  );
+  private megaMenuDocked = getMegaMenuDockedState() !== MenuDockState.Undocked;
 
   private sessionStorageData = window.sessionStorage.getItem('returnToPrevious');
   private returnToPreviousData = this.sessionStorageData ? JSON.parse(this.sessionStorageData) : undefined;

--- a/public/app/core/components/AppChrome/menuPreference.ts
+++ b/public/app/core/components/AppChrome/menuPreference.ts
@@ -1,0 +1,24 @@
+import { store } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+export const DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.docked';
+
+export enum MenuDockState {
+  Undocked,
+  Docked,
+  AutoDocked,
+}
+
+export function getMegaMenuDockedState() {
+  if (window.innerWidth < config.theme2.breakpoints.values.xl) {
+    return MenuDockState.Undocked;
+  }
+
+  const preference = store.getBool(DOCKED_LOCAL_STORAGE_KEY, null);
+
+  if (preference === null && window.innerWidth >= config.theme2.breakpoints.values.xxl) {
+    return MenuDockState.AutoDocked;
+  }
+
+  return preference ? MenuDockState.Docked : MenuDockState.Undocked;
+}

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,4 +1,5 @@
 import { EchoBackend, EchoMeta, EchoEvent, EchoSrv } from '@grafana/runtime';
+import { getMegaMenuDockedState, MenuDockState } from 'app/core/components/AppChrome/menuPreference';
 
 import { contextSrv } from '../context_srv';
 
@@ -67,6 +68,14 @@ export class Echo implements EchoSrv {
   };
 
   getMeta = (): EchoMeta => {
+    const menuState = getMegaMenuDockedState();
+    const menuStateString =
+      menuState === MenuDockState.Undocked
+        ? 'undocked'
+        : menuState === MenuDockState.AutoDocked
+          ? 'autoDocked'
+          : 'docked';
+
     return {
       sessionId: '',
       userId: contextSrv.user.id,
@@ -87,6 +96,7 @@ export class Echo implements EchoSrv {
       timeSinceNavigationStart: performance.now(),
       path: window.location.pathname,
       url: window.location.href,
+      dockedMegaMenu: menuStateString, // todo: add to type
     };
   };
 }


### PR DESCRIPTION
Draft stab at emitting a property on events to know the state of the mega menu. I want to be able to distinguish between users who've fiddled with the menu and docked it explicitly, or who've left it auto-docked at a wider breakpoint.

I'm having trouble abstracting this code out in a nice way so the breakpoint logic doesn't have to be copied into Echo as well 🤔 

Looking at this now, i realise this current approach is not reactive to the menu docking/undocking when the user changes the size of their browser. Instead would have to get this from AppChromeService state?