### PR TITLE
K8s: Dualwriter mode3: Return error from unistore

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -118,6 +118,7 @@ func (d *DualWriterMode3) Get(ctx context.Context, name string, options *metav1.
 	d.recordStorageDuration(err != nil, mode3Str, d.resource, method, startStorage)
 	if err != nil {
 		log.Error(err, "unable to get object in storage")
+		return storageObj, err
 	}
 
 	//nolint:errcheck

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -118,7 +118,7 @@ func (d *DualWriterMode3) Get(ctx context.Context, name string, options *metav1.
 	d.recordStorageDuration(err != nil, mode3Str, d.resource, method, startStorage)
 	if err != nil {
 		log.Error(err, "unable to get object in storage")
-		return storageObj, err
+		return nil, err
 	}
 
 	//nolint:errcheck

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -107,10 +107,7 @@ func TestMode3_Get(t *testing.T) {
 				},
 			},
 			{
-				name: "should return an error when getting an object in the unified store fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
-				},
+				name: "should return an error when getting an object in the unified store fails, and should not go to legacy",
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},


### PR DESCRIPTION
**What is this feature?**

This PR changes the logic in mode3 to return errors from unistore right away (rather than also going to legacy store), as this was a part of what caused the infinite loop: https://github.com/grafana/identity-access-team/issues/1144#issuecomment-2665303815
