### PR TITLE
K8s: don't publish metrics for local services that are always available

### DIFF
--- a/pkg/services/apiserver/aggregator/availableController.go
+++ b/pkg/services/apiserver/aggregator/availableController.go
@@ -127,7 +127,10 @@ func NewAvailableConditionController(
 func (c *AvailableConditionController) sync(key string) error {
 	originalAPIService, err := c.apiServiceLister.Get(key)
 	if apierrors.IsNotFound(err) {
-		c.metrics.ForgetAPIService(key)
+		if originalAPIService.Spec.Service != nil {
+			// Only reset state, if the service was a remote service
+			c.metrics.ForgetAPIService(key)
+		}
 		return nil
 	}
 	if err != nil {
@@ -292,7 +295,10 @@ func (c *AvailableConditionController) sync(key string) error {
 // apiservices. Doing that means we don't want to quickly issue no-op updates.
 func (c *AvailableConditionController) updateAPIServiceStatus(originalAPIService, newAPIService *apiregistrationv1.APIService) (*apiregistrationv1.APIService, error) {
 	// update this metric on every sync operation to reflect the actual state
-	c.metrics.SetUnavailableGauge(newAPIService)
+	if newAPIService.Spec.Service != nil {
+		// Only expose the metric for remote services, trusts the type on the new object
+		c.metrics.SetUnavailableGauge(newAPIService)
+	}
 
 	if equality.Semantic.DeepEqual(originalAPIService.Status, newAPIService.Status) {
 		return newAPIService, nil
@@ -319,7 +325,10 @@ func (c *AvailableConditionController) updateAPIServiceStatus(originalAPIService
 		return nil, err
 	}
 
-	c.metrics.SetUnavailableCounter(originalAPIService, newAPIService)
+	if newAPIService.Spec.Service != nil {
+		// Only expose the metric for remote services, trusts the type on the new object
+		c.metrics.SetUnavailableCounter(originalAPIService, newAPIService)
+	}
 	return newAPIService, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A minor optimization since these metrics are useless for local services.

**Why do we need this feature?**

Availability metrics only count for remote services. This should reduce unnecessary metric noise and storage.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
