### PR TITLE
TableNG: Fix bottom summary cell styles

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
@@ -7,6 +7,7 @@ import { BarGauge } from '../../../BarGauge/BarGauge';
 import { DataLinksContextMenu, DataLinksContextMenuApi } from '../../../DataLinks/DataLinksContextMenu';
 import { getAlignmentFactor, getCellOptions } from '../../utils';
 import { BarGaugeCellProps } from '../types';
+import { extractPixelValue } from '../utils';
 
 const defaultScale: ThresholdsConfig = {
   mode: ThresholdsMode.Absolute,
@@ -20,11 +21,6 @@ const defaultScale: ThresholdsConfig = {
       value: 20,
     },
   ],
-};
-
-/** Extracts numeric pixel value from theme spacing */
-const extractPixelValue = (spacing: string | number): number => {
-  return typeof spacing === 'number' ? spacing : parseFloat(spacing) || 0;
 };
 
 export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: BarGaugeCellProps) => {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/BarGaugeCell.tsx
@@ -22,9 +22,15 @@ const defaultScale: ThresholdsConfig = {
   ],
 };
 
+/** Extracts numeric pixel value from theme spacing */
+const extractPixelValue = (spacing: string | number): number => {
+  return typeof spacing === 'number' ? spacing : parseFloat(spacing) || 0;
+};
+
 export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: BarGaugeCellProps) => {
   const displayValue = field.display!(value);
   const cellOptions = getCellOptions(field);
+  const heightOffset = extractPixelValue(theme.spacing(1));
 
   let config = getFieldConfigWithMinMax(field, false);
   if (!config.thresholds) {
@@ -63,7 +69,7 @@ export const BarGaugeCell = ({ value, field, theme, height, width, rowIdx }: Bar
     return (
       <BarGauge
         width={width}
-        height={height}
+        height={height - heightOffset}
         field={config}
         display={field.display}
         text={{ valueSize: 14 }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -706,7 +706,6 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     '--rdg-background-color': theme.colors.background.primary,
     '--rdg-header-background-color': theme.colors.background.primary,
     '--rdg-border-color': 'transparent',
-    '--rdg-summary-border-color': theme.colors.border.medium,
     '--rdg-color': theme.colors.text.primary,
     // TODO replace with ScrollContainer
     overflow: 'hidden',
@@ -715,6 +714,11 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
     '&:hover': {
       '--rdg-row-hover-background-color': theme.colors.action.hover,
       overflow: 'scroll',
+    },
+
+    '.rdg-summary-row': {
+      backgroundColor: theme.colors.background.primary,
+      '--rdg-summary-border-color': theme.colors.border.medium,
     },
   }),
   menuItem: css({

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -20,8 +20,9 @@ export interface RowExpanderNGProps {
 
 export interface BarGaugeCellProps extends CellNGProps {
   height: number;
-  width: number;
+  theme: GrafanaTheme2;
   timeRange: TimeRange;
+  width: number;
 }
 
 export interface ImageCellProps extends CellNGProps {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -250,3 +250,8 @@ export const getCellLinks = (field: Field, rowIdx: number) => {
 
   return links;
 };
+
+/** Extracts numeric pixel value from theme spacing */
+export const extractPixelValue = (spacing: string | number): number => {
+  return typeof spacing === 'number' ? spacing : parseFloat(spacing) || 0;
+};


### PR DESCRIPTION
## What does this PR do? 📓 

This PR fixes the style clash between the footer summary row and normal grid row.

**Before**

https://github.com/user-attachments/assets/8fbf87e6-982b-41e2-a964-313e61b9fdc0

**After**

https://github.com/user-attachments/assets/5a6f8733-a646-4687-81ba-6c4c21adb610

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
