### PR TITLE
TableNG: Fix bottom summary cell styles

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -716,6 +716,11 @@ const getStyles = (theme: GrafanaTheme2, textWrap: boolean) => ({
       '--rdg-row-hover-background-color': theme.colors.action.hover,
       overflow: 'scroll',
     },
+
+    '.rdg-summary-row': {
+      backgroundColor: theme.colors.background.primary,
+      '--rdg-summary-border-color': theme.colors.border.medium,
+    },
   }),
   menuItem: css({
     maxWidth: '200px',


### PR DESCRIPTION
## What does this PR do? 📓 

This PR fixes the style clash between the footer summary row and normal grid row.

**Before**

https://github.com/user-attachments/assets/8fbf87e6-982b-41e2-a964-313e61b9fdc0

**After**

https://github.com/user-attachments/assets/5a6f8733-a646-4687-81ba-6c4c21adb610

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
