### PR TITLE
Metrics: Add deny list in MultiRegistry

### DIFF
--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -124,11 +124,16 @@ func (g *addPrefixWrapper) Gather() ([]*dto.MetricFamily, error) {
 var _ prometheus.Gatherer = (*multiRegistry)(nil)
 
 type multiRegistry struct {
+	denyList  map[string]struct{}
 	gatherers []prometheus.Gatherer
 }
 
 func NewMultiRegistry(gatherers ...prometheus.Gatherer) *multiRegistry {
+	denyList := map[string]struct{}{
+		"grafana_apiserver_request_slo_duration_seconds_bucket": {},
+	}
 	return &multiRegistry{
+		denyList:  denyList,
 		gatherers: gatherers,
 	}
 }
@@ -143,9 +148,12 @@ func (r *multiRegistry) Gather() (mfs []*dto.MetricFamily, err error) {
 
 		for i := 0; i < len(mf); i++ {
 			m := mf[i]
-			_, exists := names[*m.Name]
+			// skip metrics in the deny list
+			if _, denied := r.denyList[*m.Name]; denied {
+				continue
+			}
 			// prevent duplicate metric names
-			if exists {
+			if _, exists := names[*m.Name]; exists {
 				// we can skip go_ and process_ metrics without returning an error
 				// because they are known to be duplicates in both
 				// the k8s and prometheus gatherers.

--- a/pkg/infra/metrics/service_test.go
+++ b/pkg/infra/metrics/service_test.go
@@ -131,6 +131,30 @@ func TestMultiRegistry_Gather(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedMF, mf)
 	})
+
+	t.Run("denied metrics are not included", func(t *testing.T) {
+		one.GatherFunc = func() ([]*dto.MetricFamily, error) {
+			return []*dto.MetricFamily{
+				{Name: strptr("grafana_apiserver_request_slo_duration_seconds_bucket")},
+			}, nil
+		}
+
+		two.GatherFunc = func() ([]*dto.MetricFamily, error) {
+			return []*dto.MetricFamily{
+				{Name: strptr("b")},
+				{Name: strptr("a")},
+			}, nil
+		}
+
+		expectedMF := []*dto.MetricFamily{
+			{Name: strptr("a")},
+			{Name: strptr("b")},
+		}
+
+		mf, err := g.Gather()
+		require.NoError(t, err)
+		require.Equal(t, expectedMF, mf)
+	})
 }
 
 type mockGatherer struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

* adds a deny list to `MultiRegistry`.
* adds `grafana_apiserver_request_slo_duration_seconds_bucket` to the deny list

**Why do we need this feature?**

`grafana_apiserver_request_slo_duration_seconds_bucket` is not needed, but it is not easy to remove in code because it's buried in k8s code.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
