### PR TITLE
docs: document new alerting threshold operators

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -111,6 +111,12 @@ The threshold expression allows the comparison between two single values. Availa
 - **Is below**: `$B < 3`
 - **Is within range**: `$A > 0 AND $A < 10`
 - **Is outside range**: `$B < 0 OR $B > 100`
+- **Equal**: `$A == 2`
+- **Not Equal**: `$B =! 4`
+- **Greater or Equal**: `$A >= 8`
+- **Less or Equal**: `$B >= 16`
+- **Within Range Inclusive**: `$A <= 32 || $A >= 64`
+- **Outside Range Inclusive**: `$A <= 124 && $A >= 256`
 
 A threshold returns `0` when the condition is false and `1` when true.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -112,11 +112,11 @@ The threshold expression allows the comparison between two single values. Availa
 - **Is within range**: `$A > 0 AND $A < 10`
 - **Is outside range**: `$B < 0 OR $B > 100`
 - **Equal**: `$A == 2`
-- **Not Equal**: `$B =! 4`
-- **Greater or Equal**: `$A >= 8`
-- **Less or Equal**: `$B >= 16`
-- **Within Range Inclusive**: `$A <= 32 || $A >= 64`
-- **Outside Range Inclusive**: `$A <= 124 && $A >= 256`
+- **Not equal**: `$B =! 4`
+- **Greater or equal**: `$A >= 8`
+- **Less or equal**: `$B >= 16`
+- **Is within range, inclusive**: `$A <= 32 || $A >= 64`
+- **Is outside range inclusive**: `$A <= 124 && $A >= 256`
 
 A threshold returns `0` when the condition is false and `1` when true.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -115,7 +115,7 @@ The threshold expression allows the comparison between two single values. Availa
 - **Not equal**: `$B =! 4`
 - **Greater or equal**: `$A >= 8`
 - **Less or equal**: `$B >= 16`
-- **Is within range, inclusive**: `$A <= 32 || $A >= 64`
+- **Is within range, inclusive**: `$A >= 0 AND $A <= 10`
 - **Is outside range inclusive**: `$A <= 124 && $A >= 256`
 
 A threshold returns `0` when the condition is false and `1` when true.

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -109,14 +109,14 @@ The threshold expression allows the comparison between two single values. Availa
 
 - **Is above**: `$A > 5`
 - **Is below**: `$B < 3`
+- **Is equal to**: `$A == 2`
+- **Is not equal to**: `$B =! 4`
+- **Is above or equal to**: `$A >= 8`
+- **Is below or equal to**: `$B <= 16`
 - **Is within range**: `$A > 0 AND $A < 10`
 - **Is outside range**: `$B < 0 OR $B > 100`
-- **Equal**: `$A == 2`
-- **Not equal**: `$B =! 4`
-- **Greater or equal**: `$A >= 8`
-- **Less or equal**: `$B <= 16`
-- **Is within range, inclusive**: `$A >= 0 AND $A <= 10`
-- **Is outside range inclusive**: `$B <= 0 OR $B >= 100`
+- **Is within range included**: `$A >= 0 AND $A <= 10`
+- **Is outside range included**: `$B <= 0 OR $B >= 100`
 
 A threshold returns `0` when the condition is false and `1` when true.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -116,7 +116,7 @@ The threshold expression allows the comparison between two single values. Availa
 - **Greater or equal**: `$A >= 8`
 - **Less or equal**: `$B <= 16`
 - **Is within range, inclusive**: `$A >= 0 AND $A <= 10`
-- **Is outside range inclusive**: `$A <= 124 && $A >= 256`
+- **Is outside range inclusive**: `$B <= 0 OR $B >= 100`
 
 A threshold returns `0` when the condition is false and `1` when true.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -114,7 +114,7 @@ The threshold expression allows the comparison between two single values. Availa
 - **Equal**: `$A == 2`
 - **Not equal**: `$B =! 4`
 - **Greater or equal**: `$A >= 8`
-- **Less or equal**: `$B >= 16`
+- **Less or equal**: `$B <= 16`
 - **Is within range, inclusive**: `$A >= 0 AND $A <= 10`
 - **Is outside range inclusive**: `$A <= 124 && $A >= 256`
 


### PR DESCRIPTION
adding [new operators](https://github.com/grafana/grafana/pull/99516) to alerting docs:

- Equal
- Not Equal
- Greater or Equal
- Less or Equal
- Within Range Inclusive
- Outside Range Inclusive



**What is this feature?**

this is a docs update reflecting changes made in [another pr](https://github.com/grafana/grafana/pull/99516)

**Why do we need this feature?**

to appease the fabled docs gremlin that lives under the beds of engineers.

**Who is this feature for?**

users.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/pull/99516


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
