### PR TITLE
K8s: Folder: Delete parent last

### DIFF
--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -637,10 +637,12 @@ func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFol
 		return err
 	}
 
-	folders := []string{cmd.UID}
+	folders := []string{}
 	for _, f := range descFolders {
 		folders = append(folders, f.UID)
 	}
+	// must delete children first, then the parent folder
+	folders = append(folders, cmd.UID)
 
 	if cmd.ForceDeleteRules {
 		if err := s.deleteChildrenInFolder(ctx, cmd.OrgID, folders, cmd.SignedInUser); err != nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -825,7 +825,7 @@ func TestDeleteFoldersFromApiServer(t *testing.T) {
 					{
 						Key:      resource.SEARCH_FIELD_FOLDER,
 						Operator: string(selection.In),
-						Values:   []string{"uid", "uid2"},
+						Values:   []string{"uid2", "uid"},
 					},
 				},
 			},


### PR DESCRIPTION
**What is this feature?**

This PR changes the order of folder deletion, where we instead delete the children folders first and lastly the parent folder. This prevents 404 errors if we delete the parent first (and thus the nested children), and then try to delete the children.