### PR TITLE
TableNG: Add support for `ActionsCell`

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -4,6 +4,6 @@ import { GeneralTableProps } from './types';
 
 export function Table(props: GeneralTableProps) {
   let table = props.useTableNg ? <TableNG {...props} /> : <TableRT {...props} />;
-  table = <TableRT {...props} />;
+  // table = <TableRT {...props} />;
   return table;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ActionsCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ActionsCell.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../../../themes';
+import { ActionButton } from '../../../Actions/ActionButton';
+import { CellNGProps } from '../types';
+
+export const ActionsCell = (props: CellNGProps) => {
+  const { actions } = props;
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.buttonsGap}>
+      {actions && actions.map((action, i) => <ActionButton key={i} action={action} variant="secondary" />)}
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  buttonsGap: css({
+    display: 'flex',
+    gap: 6,
+  }),
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ActionsCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ActionsCell.tsx
@@ -4,10 +4,9 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../../../themes';
 import { ActionButton } from '../../../Actions/ActionButton';
-import { CellNGProps } from '../types';
+import { ActionCellProps } from '../types';
 
-export const ActionsCell = (props: CellNGProps) => {
-  const { actions } = props;
+export const ActionsCell = ({ actions }: ActionCellProps) => {
   const styles = useStyles2(getStyles);
 
   return (

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -11,6 +11,7 @@ import { getTextAlign } from '../../utils';
 import { CellColors } from '../types';
 import { getCellColors } from '../utils';
 
+import { ActionsCell } from './ActionsCell';
 import AutoCell from './AutoCell';
 import { BarGaugeCell } from './BarGaugeCell';
 import { DataLinksCell } from './DataLinksCell';
@@ -27,6 +28,7 @@ import { SparklineCell } from './SparklineCell';
 export function TableCellNG(props: any) {
   const {
     field,
+    frame,
     value,
     theme,
     timeRange,
@@ -37,6 +39,7 @@ export function TableCellNG(props: any) {
     setIsInspecting,
     setContextMenuProps,
     cellInspect,
+    getActions,
   } = props;
   const { config: fieldConfig } = field;
   const defaultCellOptions: TableAutoCellOptions = { type: TableCellDisplayMode.Auto };
@@ -55,6 +58,8 @@ export function TableCellNG(props: any) {
   const divWidthRef = useRef<HTMLDivElement>(null);
   const [divWidth, setDivWidth] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
+
+  const actions = getActions ? getActions(frame, field) : [];
 
   useLayoutEffect(() => {
     if (divWidthRef.current && divWidthRef.current.clientWidth !== 0) {
@@ -93,6 +98,7 @@ export function TableCellNG(props: any) {
           timeRange={timeRange}
           height={height}
           width={divWidth}
+          rowIdx={rowIdx}
         />
       );
       break;
@@ -104,19 +110,41 @@ export function TableCellNG(props: any) {
           height={height}
           justifyContent={justifyContent}
           value={value}
+          rowIdx={rowIdx}
         />
       );
       break;
     case TableCellDisplayMode.JSONView:
-      cell = <JSONCell value={value} justifyContent={justifyContent} />;
+      cell = <JSONCell value={value} justifyContent={justifyContent} rowIdx={rowIdx} />;
       break;
     case TableCellDisplayMode.DataLinks:
-      cell = <DataLinksCell value={value} field={field} theme={theme} justifyContent={justifyContent} />;
+      cell = (
+        <DataLinksCell value={value} field={field} theme={theme} justifyContent={justifyContent} rowIdx={rowIdx} />
+      );
+      break;
+    case TableCellDisplayMode.Actions:
+      cell = (
+        <ActionsCell
+          value={value}
+          field={field}
+          theme={theme}
+          justifyContent={justifyContent}
+          rowIdx={rowIdx}
+          actions={actions}
+        />
+      );
       break;
     case TableCellDisplayMode.Auto:
     default:
       cell = (
-        <AutoCell value={value} field={field} theme={theme} justifyContent={justifyContent} cellOptions={cellOptions} />
+        <AutoCell
+          value={value}
+          field={field}
+          theme={theme}
+          justifyContent={justifyContent}
+          cellOptions={cellOptions}
+          rowIdx={rowIdx}
+        />
       );
   }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -69,6 +69,7 @@ export function TableNG(props: TableNGProps) {
     footerOptions,
     onColumnResize,
     enablePagination,
+    getActions,
   } = props;
 
   const textWrap = fieldConfig?.defaults?.custom?.cellOptions.wrapText ?? false;
@@ -353,6 +354,7 @@ export function TableNG(props: TableNGProps) {
               setIsInspecting={setIsInspecting}
               setContextMenuProps={setContextMenuProps}
               cellInspect={cellInspect}
+              getActions={getActions}
             />
           );
         },

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -10,7 +10,6 @@ export interface CellNGProps {
   height?: number;
   justifyContent: Property.JustifyContent;
   rowIdx?: number;
-  actions?: ActionModel[];
 }
 
 export interface RowExpanderNGProps {
@@ -29,6 +28,10 @@ export interface BarGaugeCellProps extends CellNGProps {
 export interface ImageCellProps extends CellNGProps {
   cellOptions: TableCellOptions;
   height: number;
+}
+
+export interface ActionCellProps {
+  actions?: ActionModel[];
 }
 
 export interface SparklineCellProps extends BarGaugeCellProps {}

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -1,6 +1,6 @@
 import { Property } from 'csstype';
 
-import { Field, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { ActionModel, Field, GrafanaTheme2, TimeRange } from '@grafana/data';
 import { TableCellOptions } from '@grafana/schema';
 
 export interface CellNGProps {
@@ -10,6 +10,7 @@ export interface CellNGProps {
   height?: number;
   justifyContent: Property.JustifyContent;
   rowIdx?: number;
+  actions?: ActionModel[];
 }
 
 export interface RowExpanderNGProps {

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -6,6 +6,7 @@ import {
   ReducerID,
   standardEditorsRegistry,
   identityOverrideProcessor,
+  FieldConfigProperty,
 } from '@grafana/data';
 import { TableCellOptions, TableCellDisplayMode, defaultTableFieldOptions, TableCellHeight } from '@grafana/schema';
 
@@ -23,6 +24,11 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelChangeHandler(tablePanelChangedHandler)
   .setMigrationHandler(tableMigrationHandler)
   .useFieldConfig({
+    standardOptions: {
+      [FieldConfigProperty.Actions]: {
+        hideFromDefaults: false,
+      },
+    },
     useCustomConfig: (builder) => {
       builder
         .addNumberInput({


### PR DESCRIPTION
This PR adds support for `ActionsCell`.


![Screenshot 2025-02-19 at 6 53 32 PM](https://github.com/user-attachments/assets/bce090c8-cb95-40fd-98c6-7277a0b78db9)

Fixes https://github.com/grafana/grafana/issues/95106


[debug-actions-cell.json.txt](https://github.com/user-attachments/files/18877791/debug-actions-cell.json.txt)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
