### PR TITLE
Replace v0 by k8s v1 when `kubernetesDashboards` is enabled

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3670,7 +3670,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
-    "public/app/features/dashboard/api/v0.ts:5381": [
+    "public/app/features/dashboard/api/v1.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/dashboard/components/AddLibraryPanelWidget/AddLibraryPanelWidget.tsx:5381": [

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -190,13 +190,13 @@ export function ensureV2Response(
 export function ensureV1Response(
   dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | DashboardWithAccessInfo<DashboardDataDTO>
 ): DashboardDTO {
-  // if dashboard is not on v0 schema or v2 schema, return as is
+  // if dashboard is not on v1 schema or v2 schema, return as is
   if (!isDashboardResource(dashboard)) {
     return dashboard;
   }
 
   const spec = dashboard.spec;
-  // if dashboard is on v0 schema
+  // if dashboard is on v1 schema
   if (isDashboardV0Spec(spec)) {
     return {
       meta: {

--- a/public/app/features/dashboard/api/dashboard_api.test.ts
+++ b/public/app/features/dashboard/api/dashboard_api.test.ts
@@ -2,7 +2,7 @@ import { config } from '@grafana/runtime';
 
 import { getDashboardAPI, setDashboardAPI } from './dashboard_api';
 import { LegacyDashboardAPI } from './legacy';
-import { K8sDashboardAPI } from './v0';
+import { K8sDashboardAPI } from './v1';
 import { K8sDashboardV2API } from './v2';
 
 describe('DashboardApi', () => {
@@ -29,7 +29,7 @@ describe('DashboardApi', () => {
       expect(getDashboardAPI()).toBeInstanceOf(LegacyDashboardAPI);
     });
 
-    it('should use v0 api when and kubernetesDashboards toggle is enabled', () => {
+    it('should use v1 api when and kubernetesDashboards toggle is enabled', () => {
       config.featureToggles.kubernetesDashboards = true;
       expect(getDashboardAPI()).toBeInstanceOf(K8sDashboardAPI);
     });
@@ -55,12 +55,12 @@ describe('DashboardApi', () => {
       expect(getDashboardAPI()).toBeInstanceOf(LegacyDashboardAPI);
     });
 
-    it('should use v0 api when kubernetesDashboards toggle is enabled', () => {
+    it('should use v1 api when kubernetesDashboards toggle is enabled', () => {
       config.featureToggles.kubernetesDashboards = true;
       expect(getDashboardAPI()).toBeInstanceOf(K8sDashboardAPI);
     });
 
-    it('should use v0 api when kubernetesDashboards and useV2DashboardsAPI toggle is enabled', () => {
+    it('should use v1 api when kubernetesDashboards and useV2DashboardsAPI toggle is enabled', () => {
       config.featureToggles.useV2DashboardsAPI = true;
       config.featureToggles.kubernetesDashboards = true;
       expect(getDashboardAPI()).toBeInstanceOf(K8sDashboardAPI);

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -5,13 +5,12 @@ import { DashboardDTO } from 'app/types';
 import { LegacyDashboardAPI } from './legacy';
 import { DashboardAPI, DashboardWithAccessInfo } from './types';
 import { getDashboardsApiVersion } from './utils';
-import { K8sDashboardAPI } from './v0';
+import { K8sDashboardAPI } from './v1';
 import { K8sDashboardV2API } from './v2';
 
 type DashboardAPIClients = {
   legacy: DashboardAPI<DashboardDTO, Dashboard>;
-  v0: DashboardAPI<DashboardDTO, Dashboard>;
-  // v1: DashboardDTO; TODO[schema]: enable v1 when available
+  v1: DashboardAPI<DashboardDTO, Dashboard>;
   v2: DashboardAPI<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>, DashboardV2Spec>;
 };
 
@@ -40,7 +39,7 @@ export function getDashboardAPI(
   if (!clients) {
     clients = {
       legacy: new LegacyDashboardAPI(),
-      v0: new K8sDashboardAPI(),
+      v1: new K8sDashboardAPI(),
       v2: new K8sDashboardV2API(isConvertingToV1),
     };
   }

--- a/public/app/features/dashboard/api/utils.test.ts
+++ b/public/app/features/dashboard/api/utils.test.ts
@@ -7,12 +7,12 @@ describe('getDashboardsApiVersion', () => {
     jest.resetModules();
   });
 
-  it('should return v0 when dashboardScene is disabled and kubernetesDashboards is enabled', () => {
+  it('should return v1 when dashboardScene is disabled and kubernetesDashboards is enabled', () => {
     config.featureToggles = {
       dashboardScene: false,
       kubernetesDashboards: true,
     };
-    expect(getDashboardsApiVersion()).toBe('v0');
+    expect(getDashboardsApiVersion()).toBe('v1');
   });
 
   it('should return legacy when dashboardScene is disabled and kubernetesDashboards is disabled', () => {
@@ -31,13 +31,13 @@ describe('getDashboardsApiVersion', () => {
     expect(getDashboardsApiVersion()).toBe('v2');
   });
 
-  it('should return v0 when dashboardScene is enabled, useV2DashboardsAPI is disabled, and kubernetesDashboards is enabled', () => {
+  it('should return v1 when dashboardScene is enabled, useV2DashboardsAPI is disabled, and kubernetesDashboards is enabled', () => {
     config.featureToggles = {
       dashboardScene: true,
       useV2DashboardsAPI: false,
       kubernetesDashboards: true,
     };
-    expect(getDashboardsApiVersion()).toBe('v0');
+    expect(getDashboardsApiVersion()).toBe('v1');
   });
 
   it('should return legacy when dashboardScene is enabled and both useV2DashboardsAPI and kubernetesDashboards are disabled', () => {
@@ -71,7 +71,7 @@ describe('getDashboardsApiVersion', () => {
         kubernetesDashboards: true,
       };
 
-      expect(getDashboardsApiVersion()).toBe('v0');
+      expect(getDashboardsApiVersion()).toBe('v1');
     });
   });
 });

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -14,9 +14,9 @@ export function getDashboardsApiVersion() {
 
   // if dashboard scene is disabled, use legacy API response for the old architecture
   if (!config.featureToggles.dashboardScene || forcingOldDashboardArch) {
-    // for old architecture, use v0 API for k8s dashboards
+    // for old architecture, use v1 API for k8s dashboards
     if (config.featureToggles.kubernetesDashboards) {
-      return 'v0';
+      return 'v1';
     }
 
     return 'legacy';
@@ -27,20 +27,20 @@ export function getDashboardsApiVersion() {
   }
 
   if (config.featureToggles.kubernetesDashboards) {
-    return 'v0';
+    return 'v1';
   }
 
   return 'legacy';
 }
 
-// This function is used to determine if the dashboard is in v2 format or also v0 format
+// This function is used to determine if the dashboard is in v2 format or also v1 format
 export function isDashboardResource(
   obj?: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | DashboardWithAccessInfo<DashboardDataDTO> | null
 ): obj is DashboardWithAccessInfo<DashboardV2Spec> | DashboardWithAccessInfo<DashboardDataDTO> {
   if (!obj) {
     return false;
   }
-  // is v0 or v2 format?
+  // is v1 or v2 format?
   const isK8sDashboard = 'kind' in obj && obj.kind === 'DashboardWithAccessInfo';
   return isK8sDashboard;
 }
@@ -50,7 +50,7 @@ export function isDashboardV2Spec(obj: Dashboard | DashboardDataDTO | DashboardV
 }
 
 export function isDashboardV0Spec(obj: DashboardDataDTO | DashboardV2Spec): obj is DashboardDataDTO {
-  return !isDashboardV2Spec(obj); // not v2 spec means it's v0 spec
+  return !isDashboardV2Spec(obj); // not v2 spec means it's v1 spec
 }
 
 export function isDashboardV2Resource(

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -4,11 +4,11 @@ import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { DashboardDataDTO } from 'app/types';
 
 import { DashboardWithAccessInfo } from './types';
-import { K8sDashboardAPI } from './v0';
+import { K8sDashboardAPI } from './v1';
 
 const mockDashboardDto: DashboardWithAccessInfo<DashboardDataDTO> = {
   kind: 'DashboardWithAccessInfo',
-  apiVersion: 'v0alpha1',
+  apiVersion: 'v1alpha1',
 
   metadata: {
     name: 'dash-uid',
@@ -28,7 +28,7 @@ const mockDashboardDto: DashboardWithAccessInfo<DashboardDataDTO> = {
 
 const saveDashboardResponse = {
   kind: 'Dashboard',
-  apiVersion: 'dashboard.grafana.app/v0alpha1',
+  apiVersion: 'dashboard.grafana.app/v1alpha1',
   metadata: {
     name: 'adh59cn',
     namespace: 'default',
@@ -106,7 +106,7 @@ jest.mock('app/features/live/dashboard/dashboardWatcher', () => ({
   ignoreNextSave: jest.fn(),
 }));
 
-describe('v0 dashboard API', () => {
+describe('v1 dashboard API', () => {
   it('should provide folder annotations', async () => {
     jest.spyOn(backendSrv, 'getFolderByUid').mockResolvedValue({
       id: 1,

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -26,7 +26,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
   constructor() {
     this.client = new ScopedResourceClient<DashboardDataDTO>({
       group: 'dashboard.grafana.app',
-      version: 'v0alpha1',
+      version: 'v1alpha1',
       resource: 'dashboards',
     });
   }


### PR DESCRIPTION
The first step is to use k8s v1 as the default endpoint for Grafana Dashboards.

This stops using v0 since v0 just manages untyped JSONs as legacy. v1 will partially use the current Grafana Schema.

The following step will be to fall back to the v2 endpoint if the queried dashboard was stored in v2 format.

Fixes #101047