### PR TITLE
Docs: Change link title

### DIFF
--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -32,7 +32,7 @@ Grafana relies on other open source software to operate. For a list of open sour
 Grafana supports the following operating systems:
 
 - [Debian or Ubuntu]({{< relref "./debian" >}})
-- [Red Hat, RHEL, or Fedora]({{< relref "./redhat-rhel-fedora" >}})
+- [RHEL or Fedora]({{< relref "./rhel-fedora" >}})
 - [SUSE or openSUSE]({{< relref "./suse-opensuse" >}})
 - [macOS]({{< relref "./mac" >}})
 - [Windows]({{< relref "./windows" >}})


### PR DESCRIPTION
Proposal to change the link title (also the relref behind).  At the sidebar, under: Set up > Install Grafana - there is a link with the title "RHEL or Fedora". Just to be uniform...