### PR TITLE
[Provisioning] Fix webhook and finalizer issues

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github/impl.go
+++ b/pkg/registry/apis/provisioning/repository/github/impl.go
@@ -439,6 +439,9 @@ func (r *githubClient) CreateWebhook(ctx context.Context, owner, repository stri
 	if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusServiceUnavailable {
 		return WebhookConfig{}, ErrServiceUnavailable
 	}
+	if err != nil {
+		return WebhookConfig{}, err
+	}
 
 	return WebhookConfig{
 		ID: createdHook.GetID(),


### PR DESCRIPTION
# Why?

I had noticed that the webhook information was not present anymore and that the finalizer wasn't working to clean up resources on repository removal.

The reason was that we have been leaving behind many webhooks in our demo repository as we have been testing things out and abruptly deleting the `data` folder without deleting the k8s resource.

Apparently, the maximum number of webhooks per repository is 20 and when we would reach that the repository creation would fail silently and the finalizer would not be able to clean up the resources afterwards as webhook removal would fail.

# How?

We were not returning an error in the Github Client.

# Screenshots

![Screenshot 2025-02-20 at 13 11 00](https://github.com/user-attachments/assets/be992849-c181-429f-8a52-3034a4140857)

Notice the last repositories without the webhook link. 

![image](https://github.com/user-attachments/assets/0cdf23a9-62a2-4779-ad1c-538cbc551451)



# After the change

The repo creation will fail explicitly:

```
INFO [02-20|13:11:56] RepositoryController processing key      caller=logger.go:215 time=2025-02-20T13:11:56.931821+01:00 logger=provisioning-repository-controller work_key=default/github-demo-5
INFO [02-20|13:11:56] spec changed                             caller=logger.go:215 time=2025-02-20T13:11:56.931841+01:00 logger=provisioning-repository-controller key=default/github-demo-5 Generation=2 ObservedGeneration=1
INFO [02-20|13:11:56] running health check                     caller=logger.go:215 time=2025-02-20T13:11:56.932927+01:00 logger=provisioning-repository-controller key=default/github-demo-5
INFO [02-20|13:11:57] health check completed                   caller=logger.go:215 time=2025-02-20T13:11:57.761487+01:00 logger=provisioning-repository-controller key=default/github-demo-5 healthy=true checked=1740053517761 errors=0
INFO [02-20|13:11:57] handle repository spec update            caller=logger.go:215 time=2025-02-20T13:11:57.761682+01:00 logger=provisioning-repository-controller key=default/github-demo-5 Generation=2 ObservedGeneration=1
ERROR[02-20|13:11:58] RepositoryController failed to process key caller=logger.go:235 time=2025-02-20T13:11:58.116768+01:00 logger=provisioning-repository-controller work_key=default/github-demo-5 error="error running OnCreate: POST https://api.github.com/repos/grafana/git-ui-sync-demo/hooks: 422 Validation Failed [{Resource:Hook Field: Code:custom Message:The \"push\" event cannot have more than 20 hooks} {Resource:Hook Field: Code:custom Message:The \"pull_request\" event cannot have more than 20 hooks}]" attempts=1
```

```

```
