### PR TITLE
unistore: fix dashboard conversion events

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -294,7 +294,7 @@ func (s *Storage) Watch(ctx context.Context, key string, opts storage.ListOption
 	}
 
 	reporter := apierrors.NewClientErrorReporter(500, "WATCH", "")
-	decoder := newStreamDecoder(client, s.newFunc, predicate, s.codec, cancelWatch)
+	decoder := newStreamDecoder(client, s.newFunc, predicate, s.codec, cancelWatch, s.opts.InternalConversion)
 
 	return watch.NewStreamWatcher(decoder, reporter), nil
 }

--- a/pkg/storage/unified/apistore/stream_test.go
+++ b/pkg/storage/unified/apistore/stream_test.go
@@ -1,0 +1,34 @@
+package apistore
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestStreamDecoder(t *testing.T) {
+	t.Run("toObject should handle internal conversion", func(t *testing.T) {
+		called := false
+		internalConversion := func(data []byte, obj runtime.Object) (runtime.Object, error) {
+			called = true
+			return obj, nil
+		}
+
+		decoder := &streamDecoder{
+			newFunc:            func() runtime.Object { return &unstructured.Unstructured{} },
+			internalConversion: internalConversion,
+		}
+
+		event := &resource.WatchEvent_Resource{
+			Value: []byte("test"),
+		}
+
+		obj, err := decoder.toObject(event)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		require.True(t, called, "internal conversion function should have been called")
+	})
+}


### PR DESCRIPTION
Fixes the follow error when watching a dashboard event.
```
 % kubectl get dashboards  -w
STATUS    REASON          MESSAGE
Failure   InternalError   an error on the server ("unable to decode an event from the watch stream: converting (v0alpha1.Dashboard) to (v2alpha1.Dashboard): unknown conversion") has prevented the request from succeeding`
```

Similar to https://github.com/grafana/grafana/pull/96648 but for events