### PR TITLE
Add documentation for global `$__url_time_range` variable

### DIFF
--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -399,6 +399,10 @@ The syntax above also works with `${__to}`.
 
 You can use this variable in URLs, as well. For example, you can send a user to a dashboard that shows a time range from six hours ago until now: https://play.grafana.org/d/000000012/grafana-play-home?viewPanel=2&orgId=1?from=now-6h&to=now
 
+### `$__url_time_range`
+
+It is also possible to utilise the complete time range by employing the variable `$__url_time_range`. This will result in the expression `from=XXXX&to=XXXX` in which Unix timestamps are used. 
+
 ### `$__interval`
 
 You can use the `$__interval` variable as a parameter to group by time (for InfluxDB, MySQL, Postgres, MSSQL), Date histogram interval (for Elasticsearch), or as a _summarize_ function parameter (for Graphite).

--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -401,7 +401,7 @@ You can use this variable in URLs, as well. For example, you can send a user to 
 
 ### `$__url_time_range`
 
-It is also possible to utilise the complete time range by employing the variable `$__url_time_range`. This will result in the expression `from=XXXX&to=XXXX` in which Unix timestamps are used. 
+It is also possible to utilise the complete time range by employing the variable `$__url_time_range`. This will result in the expression `from=XXXX&to=XXXX&timezone=XXX`. 
 
 ### `$__interval`
 


### PR DESCRIPTION
**What is this feature?**

Adds documentation for the `$__url_time_range` variable

**Why do we need this feature?**

No mention yet in the docs.
