### PR TITLE
[Provisioning] Fix issue with last ref

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -176,8 +176,8 @@ type SyncStatus struct {
 	// +listType=atomic
 	Message []string `json:"message"`
 
-	// The repository hash when the last sync ran
-	Hash string `json:"hash,omitempty"`
+	// The repository ref when the last successful sync ran
+	LastRef string `json:"last_ref,omitempty"`
 
 	// Incremental synchronization for versioned repositories
 	Incremental bool `json:"incremental,omitempty"`

--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -177,7 +177,7 @@ type SyncStatus struct {
 	Message []string `json:"message"`
 
 	// The repository ref when the last successful sync ran
-	LastRef string `json:"last_ref,omitempty"`
+	LastRef string `json:"lastRef,omitempty"`
 
 	// Incremental synchronization for versioned repositories
 	Incremental bool `json:"incremental,omitempty"`

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -992,7 +992,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositorySpec(ref common.ReferenceCa
 					},
 					"workflows": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UI driven Workflow taht allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly)",
+							Description: "UI driven Workflow that allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly)",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -1745,9 +1745,9 @@ func schema_pkg_apis_provisioning_v0alpha1_SyncStatus(ref common.ReferenceCallba
 							},
 						},
 					},
-					"hash": {
+					"last_ref": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The repository hash when the last sync ran",
+							Description: "The repository ref when the last successful sync ran",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1745,7 +1745,7 @@ func schema_pkg_apis_provisioning_v0alpha1_SyncStatus(ref common.ReferenceCallba
 							},
 						},
 					},
-					"last_ref": {
+					"lastRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The repository ref when the last successful sync ran",
 							Type:        []string{"string"},

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -13,5 +13,4 @@ API rule violation: list_type_missing,github.com/grafana/grafana/pkg/apis/provis
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,JobSpec,PullRequest
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,GitHub
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,SyncStatus,JobID
-API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,SyncStatus,LastRef
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,WebhookResponse,Message

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -13,4 +13,5 @@ API rule violation: list_type_missing,github.com/grafana/grafana/pkg/apis/provis
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,JobSpec,PullRequest
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,GitHub
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,SyncStatus,JobID
+API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,SyncStatus,LastRef
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,WebhookResponse,Message

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/syncstatus.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/syncstatus.go
@@ -17,7 +17,7 @@ type SyncStatusApplyConfiguration struct {
 	Finished    *int64                         `json:"finished,omitempty"`
 	Scheduled   *int64                         `json:"scheduled,omitempty"`
 	Message     []string                       `json:"message,omitempty"`
-	LastRef     *string                        `json:"last_ref,omitempty"`
+	LastRef     *string                        `json:"lastRef,omitempty"`
 	Incremental *bool                          `json:"incremental,omitempty"`
 }
 

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/syncstatus.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/syncstatus.go
@@ -17,7 +17,7 @@ type SyncStatusApplyConfiguration struct {
 	Finished    *int64                         `json:"finished,omitempty"`
 	Scheduled   *int64                         `json:"scheduled,omitempty"`
 	Message     []string                       `json:"message,omitempty"`
-	Hash        *string                        `json:"hash,omitempty"`
+	LastRef     *string                        `json:"last_ref,omitempty"`
 	Incremental *bool                          `json:"incremental,omitempty"`
 }
 
@@ -77,11 +77,11 @@ func (b *SyncStatusApplyConfiguration) WithMessage(values ...string) *SyncStatus
 	return b
 }
 
-// WithHash sets the Hash field in the declarative configuration to the given value
+// WithLastRef sets the LastRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Hash field is set to the value of the last call.
-func (b *SyncStatusApplyConfiguration) WithHash(value string) *SyncStatusApplyConfiguration {
-	b.Hash = &value
+// If called multiple times, the LastRef field is set to the value of the last call.
+func (b *SyncStatusApplyConfiguration) WithLastRef(value string) *SyncStatusApplyConfiguration {
+	b.LastRef = &value
 	return b
 }
 

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -3438,7 +3438,7 @@
             ]
           },
           "workflows": {
-            "description": "UI driven Workflow taht allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly)",
+            "description": "UI driven Workflow that allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly)",
             "type": "array",
             "items": {
               "type": "string",
@@ -3938,16 +3938,16 @@
             "type": "integer",
             "format": "int64"
           },
-          "hash": {
-            "description": "The repository hash when the last sync ran",
-            "type": "string"
-          },
           "incremental": {
             "description": "Incremental synchronization for versioned repositories",
             "type": "boolean"
           },
           "job": {
             "description": "The ID for the job that ran this sync",
+            "type": "string"
+          },
+          "lastRef": {
+            "description": "The repository ref when the last successful sync ran",
             "type": "string"
           },
           "message": {

--- a/pkg/tests/apis/provisioning/testdata/local-tmp.json
+++ b/pkg/tests/apis/provisioning/testdata/local-tmp.json
@@ -15,6 +15,7 @@
             "intervalSeconds": 60
         },
         "title": "Load tmp dashboards",
-        "type": "local"
+        "type": "local",
+        "workflows": []
     }
 }

--- a/public/app/features/provisioning/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/RepositoryOverview.tsx
@@ -140,7 +140,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                     <Text color="secondary">Last Ref:</Text>
                   </div>
                   <div className={styles.valueColumn}>
-                    <Text variant="body">{status?.sync.last_ref ? status.sync.last_ref.substring(0, 7) : 'N/A'}</Text>
+                    <Text variant="body">{status?.sync.lastRef ? status.sync.lastRef.substring(0, 7) : 'N/A'}</Text>
                   </div>
 
                   <div className={styles.labelColumn}>

--- a/public/app/features/provisioning/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/RepositoryOverview.tsx
@@ -140,7 +140,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                     <Text color="secondary">Last Ref:</Text>
                   </div>
                   <div className={styles.valueColumn}>
-                    <Text variant="body">{status?.sync.hash ? status.sync.hash.substring(0, 7) : 'N/A'}</Text>
+                    <Text variant="body">{status?.sync.last_ref ? status.sync.last_ref.substring(0, 7) : 'N/A'}</Text>
                   </div>
 
                   <div className={styles.labelColumn}>

--- a/public/app/features/provisioning/api/endpoints.gen.ts
+++ b/public/app/features/provisioning/api/endpoints.gen.ts
@@ -802,7 +802,7 @@ export type RepositorySpec = {
      - `"github"`
      - `"local"` */
   type: 'github' | 'local';
-  /** UI driven Workflow taht allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly) */
+  /** UI driven Workflow that allow changes to the contends of the repository. The order is relevant for defining the precedence of the workflows. When empty, the repository does not support any edits (eg, readonly) */
   workflows: ('branch' | 'write')[];
 };
 export type HealthStatus = {
@@ -822,12 +822,12 @@ export type ResourceCount = {
 export type SyncStatus = {
   /** When the sync job finished */
   finished?: number;
-  /** The repository hash when the last sync ran */
-  hash?: string;
   /** Incremental synchronization for versioned repositories */
   incremental?: boolean;
   /** The ID for the job that ran this sync */
   job?: string;
+  /** The repository ref when the last successful sync ran */
+  lastRef?: string;
   /** Summary messages (will be shown to users) */
   message: string[];
   /** When the next sync check is scheduled */


### PR DESCRIPTION
Fix issue with the last reference in sync.

There was a silly bug there. I have also used the occasion to rename `hash` to `last_ref` as we use ref everywhere and `hash` we use it for file hashes.

# Before
![Screenshot 2025-02-20 at 13 32 39](https://github.com/user-attachments/assets/b4fc2f1b-33b3-47cc-91fb-f3d77102216e)

# After

<img width="587" alt="Screenshot 2025-02-20 at 15 58 29" src="https://github.com/user-attachments/assets/578cd76d-d0d1-41b2-ae6a-f5a31f5e1cd0" />

