### PR TITLE
build: runs codegen on enterprise apis as well

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -86,5 +86,6 @@ grafana:codegen:lsdirs() {
 grafana::codegen:run pkg
 grafana::codegen:run pkg/apimachinery
 grafana::codegen:run pkg/aggregator
+grafana::codegen:run pkg/extensions
 
 echo "done."

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -86,6 +86,9 @@ grafana:codegen:lsdirs() {
 grafana::codegen:run pkg
 grafana::codegen:run pkg/apimachinery
 grafana::codegen:run pkg/aggregator
-grafana::codegen:run pkg/extensions
+
+if [ -d "pkg/extensions/apis" ]; then
+  grafana::codegen:run pkg/extensions
+fi
 
 echo "done."


### PR DESCRIPTION
code gen for enterprise apis can now run within this script as well since `make enterprise-dev` had landed  :) 