### PR TITLE
New Logs Panel: Log line menu

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1065,7 +1065,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           )}
           {visualisationType === 'logs' && hasData && config.featureToggles.newLogsPanel && (
             <>
-              <div data-testid="logRows" ref={logsContainerRef} className={styles.logRows}>
+              <div data-testid="logRows" ref={logsContainerRef} className={styles.logRowsWrapper}>
                 {logsContainerRef.current && (
                   <LogList
                     app={CoreApp.Explore}
@@ -1191,6 +1191,9 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
     logRows: css({
       overflowX: `${wrapLogMessage ? 'unset' : 'scroll'}`,
       overflowY: 'visible',
+      width: '100%',
+    }),
+    logRowsWrapper: css({
       width: '100%',
     }),
     visualisationType: css({

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1069,13 +1069,21 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                 {logsContainerRef.current && (
                   <LogList
                     app={CoreApp.Explore}
+                    logSupportsContext={showContextToggle}
                     containerElement={logsContainerRef.current}
                     displayedFields={displayedFields}
                     eventBus={eventBus}
                     forceEscape={forceEscape}
                     getFieldLinks={getFieldLinks}
+                    getRowContextQuery={getRowContextQuery}
                     loadMore={loadMoreLogs}
                     logs={dedupedRows}
+                    onOpenContext={onOpenContext}
+                    onPermalinkClick={onPermalinkClick}
+                    onPinLine={onPinToContentOutlineClick}
+                    onUnpinLine={onPinToContentOutlineClick}
+                    pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
+                    pinnedLogs={pinnedLogs}
                     showTime={showTime}
                     sortOrder={logsSortOrder}
                     timeRange={props.range}

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -67,6 +67,7 @@ export const LogRowMenuCell = memo(
     }, []);
     const onShowContextClick = useCallback(
       async (event: MouseEvent<HTMLElement>) => {
+        event.stopPropagation();
         handleOpenLogsContextClick(event, row, getRowContextQuery, onOpenContext);
       },
       [onOpenContext, getRowContextQuery, row]

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -10,10 +10,11 @@ import {
   MouseEvent,
 } from 'react';
 
-import { LogRowContextOptions, LogRowModel, getDefaultTimeRange, locationUtil, urlUtil } from '@grafana/data';
+import { LogRowContextOptions, LogRowModel } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 import { ClipboardButton, IconButton, PopoverContent } from '@grafana/ui';
-import { getConfig } from 'app/core/config';
+
+import { handleOpenLogsContextClick } from '../utils';
 
 import { LogRowStyles } from './getLogRowStyles';
 
@@ -35,7 +36,6 @@ interface Props {
   styles: LogRowStyles;
   mouseIsOver: boolean;
   onBlur: () => void;
-  onPinToContentOutlineClick?: (row: LogRowModel, onOpenContext: (row: LogRowModel) => void) => void;
   addonBefore?: ReactNode[];
   addonAfter?: ReactNode[];
 }
@@ -66,31 +66,10 @@ export const LogRowMenuCell = memo(
       e.stopPropagation();
     }, []);
     const onShowContextClick = useCallback(
-      async (event: MouseEvent<HTMLButtonElement>) => {
-        event.stopPropagation();
-        // if ctrl or meta key is pressed, open query in new Explore tab
-        if (
-          getRowContextQuery &&
-          (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey || event.nativeEvent.shiftKey)
-        ) {
-          const win = window.open('about:blank');
-          // for this request we don't want to use the cached filters from a context provider, but always want to refetch and clear
-          const query = await getRowContextQuery(row, undefined, false);
-          if (query && win) {
-            const url = urlUtil.renderUrl(locationUtil.assureBaseUrl(`${getConfig().appSubUrl}explore`), {
-              left: JSON.stringify({
-                datasource: query.datasource,
-                queries: [query],
-                range: getDefaultTimeRange(),
-              }),
-            });
-            win.location = url;
-
-            return;
-          }
-          win?.close();
+      async (event: MouseEvent<HTMLElement>) => {
+        if (getRowContextQuery) {
+          handleOpenLogsContextClick(event, row, getRowContextQuery, onOpenContext);
         }
-        onOpenContext(row);
       },
       [onOpenContext, getRowContextQuery, row]
     );

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -67,9 +67,7 @@ export const LogRowMenuCell = memo(
     }, []);
     const onShowContextClick = useCallback(
       async (event: MouseEvent<HTMLElement>) => {
-        if (getRowContextQuery) {
-          handleOpenLogsContextClick(event, row, getRowContextQuery, onOpenContext);
-        }
+        handleOpenLogsContextClick(event, row, getRowContextQuery, onOpenContext);
       },
       [onOpenContext, getRowContextQuery, row]
     );

--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -1,4 +1,6 @@
-import { FieldType, LogLevel, LogRowModel, toDataFrame } from '@grafana/data';
+import { FieldType, LogLevel, LogRowModel, LogsSortOrder, toDataFrame } from '@grafana/data';
+
+import { LogListModel, preProcessLogs, PreProcessOptions } from '../panel/processing';
 
 export const createLogRow = (overrides?: Partial<LogRowModel>): LogRowModel => {
   const uid = overrides?.uid || '1';
@@ -35,4 +37,17 @@ export const createLogRow = (overrides?: Partial<LogRowModel>): LogRowModel => {
     searchWords: [],
     ...overrides,
   };
+};
+
+export const createLogLine = (
+  overrides?: Partial<LogRowModel>,
+  processOptions: PreProcessOptions = {
+    escape: false,
+    order: LogsSortOrder.Descending,
+    timeZone: 'browser',
+    wrap: false,
+  }
+): LogListModel => {
+  const logs = preProcessLogs([createLogRow(overrides)], processOptions);
+  return logs[0];
 };

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -1,10 +1,10 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { usePrevious } from 'react-use';
 import { ListChildComponentProps, ListOnItemsRenderedProps } from 'react-window';
 
 import { AbsoluteTimeRange, LogsSortOrder, TimeRange } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Spinner, useTheme2 } from '@grafana/ui';
+import { Spinner, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { canScrollBottom, getVisibleRange, ScrollDirection, shouldLoadMore } from '../InfiniteScroll';
@@ -59,8 +59,7 @@ export const InfiniteScroll = ({
   const lastEvent = useRef<Event | WheelEvent | null>(null);
   const countRef = useRef(0);
   const lastLogOfPage = useRef<string[]>([]);
-  const theme = useTheme2();
-  const styles = useMemo(() => getStyles(theme), [theme]);
+  const styles = useStyles2(getStyles);
 
   useEffect(() => {
     // Logs have not changed, ignore effect

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePrevious } from 'react-use';
 import { ListChildComponentProps, ListOnItemsRenderedProps } from 'react-window';
 
@@ -60,7 +60,7 @@ export const InfiniteScroll = ({
   const countRef = useRef(0);
   const lastLogOfPage = useRef<string[]>([]);
   const theme = useTheme2();
-  const styles = getStyles(theme);
+  const styles = useMemo(() => getStyles(theme), [theme]);
 
   useEffect(() => {
     // Logs have not changed, ignore effect

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { createTheme } from '@grafana/data';
 
@@ -7,7 +8,6 @@ import { createLogLine } from '../__mocks__/logRow';
 
 import { getStyles, LogLine } from './LogLine';
 import { LogListModel } from './processing';
-import userEvent from '@testing-library/user-event';
 
 const theme = createTheme();
 const styles = getStyles(theme);
@@ -101,5 +101,5 @@ describe('LogLine', () => {
       await userEvent.click(screen.getByLabelText('Log menu'));
       expect(screen.getByText('Copy log line')).toBeInTheDocument();
     });
-  })
+  });
 });

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -2,11 +2,12 @@ import { render, screen } from '@testing-library/react';
 
 import { createTheme } from '@grafana/data';
 
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../__mocks__/logRow';
 
 import { getStyles, LogLine } from './LogLine';
 import { LogListModel } from './processing';
-import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import userEvent from '@testing-library/user-event';
 
 const theme = createTheme();
 const styles = getStyles(theme);
@@ -82,4 +83,23 @@ describe('LogLine', () => {
     expect(screen.getByText(log.body)).toBeInTheDocument();
     expect(screen.getByText('luna')).toBeInTheDocument();
   });
+
+  describe('Log line menu', () => {
+    test('Renders a log line menu', async () => {
+      render(
+        <LogLine
+          displayedFields={[]}
+          index={0}
+          log={log}
+          showTime={true}
+          style={{}}
+          styles={styles}
+          wrapLogMessage={false}
+        />
+      );
+      expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      expect(screen.getByText('Copy log line')).toBeInTheDocument();
+    });
+  })
 });

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+
+import { createLogLine } from '../__mocks__/logRow';
+
+import { getStyles, LogLine } from './LogLine';
+import { LogListModel } from './processing';
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+
+const theme = createTheme();
+const styles = getStyles(theme);
+
+describe('LogLine', () => {
+  let log: LogListModel;
+  beforeEach(() => {
+    log = createLogLine({ labels: { place: 'luna' } });
+  });
+
+  test('Renders a log line', () => {
+    render(
+      <LogLine
+        displayedFields={[]}
+        index={0}
+        log={log}
+        showTime={true}
+        style={{}}
+        styles={styles}
+        wrapLogMessage={false}
+      />
+    );
+    expect(screen.getByText(log.timestamp)).toBeInTheDocument();
+    expect(screen.getByText(log.body)).toBeInTheDocument();
+  });
+
+  test('Renders a log line with no timestamp', () => {
+    render(
+      <LogLine
+        displayedFields={[]}
+        index={0}
+        log={log}
+        showTime={false}
+        style={{}}
+        styles={styles}
+        wrapLogMessage={false}
+      />
+    );
+    expect(screen.queryByText(log.timestamp)).not.toBeInTheDocument();
+    expect(screen.getByText(log.body)).toBeInTheDocument();
+  });
+
+  test('Renders a log line with displayed fields', () => {
+    render(
+      <LogLine
+        displayedFields={['place']}
+        index={0}
+        log={log}
+        showTime={true}
+        style={{}}
+        styles={styles}
+        wrapLogMessage={false}
+      />
+    );
+    expect(screen.getByText(log.timestamp)).toBeInTheDocument();
+    expect(screen.queryByText(log.body)).not.toBeInTheDocument();
+    expect(screen.getByText('luna')).toBeInTheDocument();
+  });
+
+  test('Renders a log line with body displayed fields', () => {
+    render(
+      <LogLine
+        displayedFields={['place', LOG_LINE_BODY_FIELD_NAME]}
+        index={0}
+        log={log}
+        showTime={true}
+        style={{}}
+        styles={styles}
+        wrapLogMessage={false}
+      />
+    );
+    expect(screen.getByText(log.timestamp)).toBeInTheDocument();
+    expect(screen.getByText(log.body)).toBeInTheDocument();
+    expect(screen.getByText('luna')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -1,11 +1,14 @@
 import { css } from '@emotion/css';
 import { CSSProperties, useEffect, useRef } from 'react';
+import tinycolor from 'tinycolor2';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, LogRowModel } from '@grafana/data';
+import { PopoverContent } from '@grafana/ui';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
 import { LogLineMenu } from './LogLineMenu';
+import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
 import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, lineHeight } from './virtualization';
 
@@ -33,6 +36,7 @@ export const LogLine = ({
   wrapLogMessage,
 }: Props) => {
   const logLineRef = useRef<HTMLDivElement | null>(null);
+  const pinned = useLogIsPinned(log);
 
   useEffect(() => {
     if (!onOverflow || !logLineRef.current) {
@@ -46,7 +50,11 @@ export const LogLine = ({
   }, [index, log.uid, onOverflow, style.height]);
 
   return (
-    <div style={style} className={`${styles.logLine} ${variant ?? ''}`} ref={onOverflow ? logLineRef : undefined}>
+    <div
+      style={style}
+      className={`${styles.logLine} ${variant ?? ''} ${pinned ? styles.pinnedLogLine : ''}`}
+      ref={onOverflow ? logLineRef : undefined}
+    >
       <LogLineMenu styles={styles} log={log} />
       <div className={`${wrapLogMessage ? styles.wrappedLogLine : `${styles.unwrappedLogLine} unwrapped-log-line`}`}>
         <Log displayedFields={displayedFields} log={log} showTime={showTime} styles={styles} />
@@ -133,6 +141,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
           width: '100%',
         },
       },
+    }),
+    pinnedLogLine: css({
+      backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
     }),
     menuIcon: css({
       height: lineHeight,

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -76,7 +76,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
       {displayedFields.length > 0 ? (
         displayedFields.map((field) => (
-          <span className="field" title={field}>
+          <span className="field" title={field} key={field}>
             {getDisplayedFieldValue(field, log)}
           </span>
         ))

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -2,8 +2,7 @@ import { css } from '@emotion/css';
 import { CSSProperties, useEffect, useRef } from 'react';
 import tinycolor from 'tinycolor2';
 
-import { GrafanaTheme2, LogRowModel } from '@grafana/data';
-import { PopoverContent } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -9,7 +9,7 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
-import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, lineHeight } from './virtualization';
+import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
 
 interface Props {
   displayedFields: string[];
@@ -145,7 +145,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
     }),
     menuIcon: css({
-      height: lineHeight,
+      height: getLineHeight(),
       margin: 0,
       padding: theme.spacing(0, 0, 0, 0.5),
     }),

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -5,8 +5,9 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
+import { LogLineMenu } from './LogLineMenu';
 import { LogFieldDimension, LogListModel } from './processing';
-import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow } from './virtualization';
+import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, lineHeight } from './virtualization';
 
 interface Props {
   displayedFields: string[];
@@ -46,6 +47,7 @@ export const LogLine = ({
 
   return (
     <div style={style} className={`${styles.logLine} ${variant ?? ''}`} ref={onOverflow ? logLineRef : undefined}>
+      <LogLineMenu styles={styles} log={log} />
       <div className={`${wrapLogMessage ? styles.wrappedLogLine : `${styles.unwrappedLogLine} unwrapped-log-line`}`}>
         <Log displayedFields={displayedFields} log={log} showTime={showTime} styles={styles} />
       </div>
@@ -57,7 +59,7 @@ interface LogProps {
   displayedFields: string[];
   log: LogListModel;
   showTime: boolean;
-  styles: ReturnType<typeof getStyles>;
+  styles: LogLineStyles;
 }
 
 const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
@@ -111,6 +113,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     logLine: css({
       color: theme.colors.text.primary,
+      display: 'flex',
+      gap: theme.spacing(0.5),
+      flexDirection: 'row',
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.fontSize,
       wordBreak: 'break-all',
@@ -128,6 +133,11 @@ export const getStyles = (theme: GrafanaTheme2) => {
           width: '100%',
         },
       },
+    }),
+    menuIcon: css({
+      height: lineHeight,
+      margin: 0,
+      padding: theme.spacing(0, 0, 0, 0.5),
     }),
     logLineMessage: css({
       fontFamily: theme.typography.fontFamily,

--- a/public/app/features/logs/components/panel/LogLineMenu.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createTheme } from '@grafana/data';
+
+import { createLogLine } from '../__mocks__/logRow';
+
+import { getStyles } from './LogLine';
+import { LogLineMenu } from './LogLineMenu';
+import { LogListContext } from './LogListContext';
+import { LogListModel } from './processing';
+
+const theme = createTheme();
+const styles = getStyles(theme);
+
+describe('LogLineMenu', () => {
+  let log: LogListModel;
+  beforeEach(() => {
+    log = createLogLine({ labels: { place: 'luna' }, rowId: '1' });
+  });
+
+  test('Renders the component', async () => {
+    render(
+      <LogLineMenu log={log} styles={styles} />
+    );
+    expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('Log menu'));
+    expect(screen.getByText('Copy log line')).toBeInTheDocument();
+  });
+
+  describe('Options', () => {
+    test('Allows to copy a permalink', async () => {
+      const onPermalinkClick = jest.fn();
+      render(
+        <LogListContext.Provider value={{ onPermalinkClick }}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContext.Provider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      await userEvent.click(screen.getByText('Copy link to log line'));
+      expect(onPermalinkClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('Allows to open show context', async () => {
+      const onOpenContext = jest.fn();
+      const logSupportsContext = jest.fn().mockReturnValue(true);
+      const getRowContextQuery = jest.fn();
+      render(
+        <LogListContext.Provider value={{ getRowContextQuery, logSupportsContext, onOpenContext }}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContext.Provider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      await userEvent.click(screen.getByText('Show context'));
+      expect(onOpenContext).toHaveBeenCalledTimes(1);
+    });
+
+    test('Uses logSupportsContext to control the display of show context', async () => {
+      const onOpenContext = jest.fn();
+      const logSupportsContext = jest.fn().mockReturnValue(false);
+      const getRowContextQuery = jest.fn();
+      render(
+        <LogListContext.Provider value={{ getRowContextQuery, logSupportsContext, onOpenContext }}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContext.Provider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      expect(screen.queryByText('Show context')).not.toBeInTheDocument();
+    });
+
+    test('Allows to pin log line', async () => {
+      const onPinLine = jest.fn();
+      render(
+        <LogListContext.Provider value={{ pinnedLogs: [], onPinLine }}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContext.Provider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      await userEvent.click(screen.getByText('Pin log'));
+      expect(onPinLine).toHaveBeenCalledTimes(1);
+    });
+
+    test('Allows to unpin log line', async () => {
+      const onUnpinLine = jest.fn();
+      render(
+        <LogListContext.Provider value={{ pinnedLogs: [log.uid], onUnpinLine }}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContext.Provider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      expect(screen.queryByText('Pin log')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByText('Unpin log'));
+      expect(onUnpinLine).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/app/features/logs/components/panel/LogLineMenu.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.test.tsx
@@ -20,9 +20,7 @@ describe('LogLineMenu', () => {
   });
 
   test('Renders the component', async () => {
-    render(
-      <LogLineMenu log={log} styles={styles} />
-    );
+    render(<LogLineMenu log={log} styles={styles} />);
     expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
     await userEvent.click(screen.getByLabelText('Log menu'));
     expect(screen.getByText('Copy log line')).toBeInTheDocument();

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -72,10 +72,10 @@ export const LogLineMenu = ({ log, styles }: Props) => {
           <Menu.Item onClick={showContext} label={t('logs.log-line-menu.show-context', 'Show context')} />
         )}
         {!pinned && onPinLine && (
-          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Pin line')} />
+          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Pin log')} />
         )}
         {pinned && onUnpinLine && (
-          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Unpin line')} />
+          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Unpin log')} />
         )}
       </Menu>
     ),

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -43,11 +43,7 @@ export const LogLineMenu = ({ log, styles }: Props) => {
 
   const showContext = useCallback(
     async (event: MouseEvent<HTMLElement>) => {
-      if (getRowContextQuery) {
-        handleOpenLogsContextClick(event, log, getRowContextQuery, (log: LogRowModel) =>
-          onOpenContext?.(log, () => {})
-        );
-      }
+      handleOpenLogsContextClick(event, log, getRowContextQuery, (log: LogRowModel) => onOpenContext?.(log, () => {}));
     },
     [onOpenContext, getRowContextQuery, log]
   );

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -1,0 +1,15 @@
+import { IconButton } from "@grafana/ui";
+
+import { LogLineStyles } from "./LogLine";
+import { LogListModel } from "./processing"
+
+interface Props {
+  log: LogListModel;
+  styles: LogLineStyles;
+}
+
+export const LogLineMenu = ({ styles }: Props) => {
+  return (
+    <IconButton className={styles.menuIcon} name="ellipsis-v" aria-label="Log menu" />
+  )
+}

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -1,7 +1,8 @@
-import { IconButton } from "@grafana/ui";
+import { Dropdown, IconButton, Menu } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 
-import { LogLineStyles } from "./LogLine";
-import { LogListModel } from "./processing"
+import { LogLineStyles } from './LogLine';
+import { LogListModel } from './processing';
 
 interface Props {
   log: LogListModel;
@@ -9,7 +10,19 @@ interface Props {
 }
 
 export const LogLineMenu = ({ styles }: Props) => {
+  const menu = (
+    <Menu>
+      <Menu.Item label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
+      <Menu.Item label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
+      <Menu.Divider />
+      <Menu.Item label={t('logs.log-line-menu.show-context', 'Show context')} />
+      <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Pin to content outline')} />
+    </Menu>
+  );
+
   return (
-    <IconButton className={styles.menuIcon} name="ellipsis-v" aria-label="Log menu" />
-  )
-}
+    <Dropdown overlay={menu} placement="bottom-start">
+      <IconButton className={styles.menuIcon} name="ellipsis-v" aria-label="Log menu" />
+    </Dropdown>
+  );
+};

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -1,23 +1,91 @@
-import { Dropdown, IconButton, Menu } from '@grafana/ui';
+import { useCallback, useMemo, useRef, MouseEvent } from 'react';
+
+import { LogRowContextOptions, LogRowModel } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+import { Dropdown, IconButton, Menu, PopoverContent } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
+
+import { copyText, handleOpenLogsContextClick } from '../../utils';
 
 import { LogLineStyles } from './LogLine';
 import { LogListModel } from './processing';
 
+export type GetRowContextQueryFn = (
+  row: LogRowModel,
+  options?: LogRowContextOptions,
+  cacheFilters?: boolean
+) => Promise<DataQuery | null>;
+
 interface Props {
+  getRowContextQuery?: GetRowContextQueryFn;
   log: LogListModel;
   styles: LogLineStyles;
+  showContextToggle?: (row: LogRowModel) => boolean;
+  onOpenContext: (row: LogRowModel) => void;
+  onPermalinkClick?: (row: LogRowModel) => Promise<void>;
+  onPinLine?: (row: LogRowModel) => void;
+  onUnpinLine?: (row: LogRowModel) => void;
+  pinLineButtonTooltipTitle?: PopoverContent;
+  pinned?: boolean;
 }
 
-export const LogLineMenu = ({ styles }: Props) => {
-  const menu = (
-    <Menu>
-      <Menu.Item label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
-      <Menu.Item label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
-      <Menu.Divider />
-      <Menu.Item label={t('logs.log-line-menu.show-context', 'Show context')} />
-      <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Pin to content outline')} />
-    </Menu>
+export const LogLineMenu = ({
+  getRowContextQuery,
+  log,
+  onOpenContext,
+  onPermalinkClick,
+  onPinLine,
+  onUnpinLine,
+  pinned,
+  showContextToggle,
+  styles,
+}: Props) => {
+  const menuRef = useRef(null);
+
+  const copyLogLine = useCallback(() => {
+    copyText(log.entry, menuRef);
+  }, [log.entry]);
+
+  const shouldShowContextToggle = useMemo(
+    () => (showContextToggle ? showContextToggle(log) : false),
+    [log, showContextToggle]
+  );
+
+  const showContext = useCallback(
+    async (event: MouseEvent<HTMLElement>) => {
+      if (getRowContextQuery) {
+        handleOpenLogsContextClick(event, log, getRowContextQuery, onOpenContext);
+      }
+    },
+    [onOpenContext, getRowContextQuery, log]
+  );
+
+  const menu = useCallback(
+    () => (
+      <Menu ref={menuRef}>
+        <Menu.Item onClick={copyLogLine} label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
+        {onPermalinkClick && log.rowId !== undefined && log.uid && (
+          <Menu.Item label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
+        )}
+        {(shouldShowContextToggle || onPinLine || onUnpinLine) && <Menu.Divider />}
+        {shouldShowContextToggle && (
+          <Menu.Item onClick={showContext} label={t('logs.log-line-menu.show-context', 'Show context')} />
+        )}
+        {!pinned && onPinLine && <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Pin line')} />}
+        {pinned && onUnpinLine && <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Unpin line')} />}
+      </Menu>
+    ),
+    [
+      copyLogLine,
+      log.rowId,
+      log.uid,
+      onPermalinkClick,
+      onPinLine,
+      onUnpinLine,
+      pinned,
+      shouldShowContextToggle,
+      showContext,
+    ]
   );
 
   return (

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -2,12 +2,13 @@ import { useCallback, useMemo, useRef, MouseEvent } from 'react';
 
 import { LogRowContextOptions, LogRowModel } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
-import { Dropdown, IconButton, Menu, PopoverContent } from '@grafana/ui';
+import { Dropdown, IconButton, Menu } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { copyText, handleOpenLogsContextClick } from '../../utils';
 
 import { LogLineStyles } from './LogLine';
+import { useLogIsPinned, useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
 export type GetRowContextQueryFn = (
@@ -17,65 +18,69 @@ export type GetRowContextQueryFn = (
 ) => Promise<DataQuery | null>;
 
 interface Props {
-  getRowContextQuery?: GetRowContextQueryFn;
   log: LogListModel;
   styles: LogLineStyles;
-  showContextToggle?: (row: LogRowModel) => boolean;
-  onOpenContext: (row: LogRowModel) => void;
-  onPermalinkClick?: (row: LogRowModel) => Promise<void>;
-  onPinLine?: (row: LogRowModel) => void;
-  onUnpinLine?: (row: LogRowModel) => void;
-  pinLineButtonTooltipTitle?: PopoverContent;
-  pinned?: boolean;
 }
 
-export const LogLineMenu = ({
-  getRowContextQuery,
-  log,
-  onOpenContext,
-  onPermalinkClick,
-  onPinLine,
-  onUnpinLine,
-  pinned,
-  showContextToggle,
-  styles,
-}: Props) => {
+export const LogLineMenu = ({ log, styles }: Props) => {
+  const { getRowContextQuery, onOpenContext, onPermalinkClick, onPinLine, onUnpinLine, logSupportsContext } =
+    useLogListContext();
+  const pinned = useLogIsPinned(log);
   const menuRef = useRef(null);
 
   const copyLogLine = useCallback(() => {
     copyText(log.entry, menuRef);
   }, [log.entry]);
 
-  const shouldShowContextToggle = useMemo(
-    () => (showContextToggle ? showContextToggle(log) : false),
-    [log, showContextToggle]
+  const copyLinkToLogLine = useCallback(() => {
+    onPermalinkClick?.(log);
+  }, [log, onPermalinkClick]);
+
+  const shouldlogSupportsContext = useMemo(
+    () => (logSupportsContext ? logSupportsContext(log) : false),
+    [log, logSupportsContext]
   );
 
   const showContext = useCallback(
     async (event: MouseEvent<HTMLElement>) => {
       if (getRowContextQuery) {
-        handleOpenLogsContextClick(event, log, getRowContextQuery, onOpenContext);
+        handleOpenLogsContextClick(event, log, getRowContextQuery, (log: LogRowModel) =>
+          onOpenContext?.(log, () => {})
+        );
       }
     },
     [onOpenContext, getRowContextQuery, log]
   );
+
+  const togglePinning = useCallback(() => {
+    if (pinned) {
+      onUnpinLine?.(log);
+    } else {
+      onPinLine?.(log);
+    }
+  }, [log, onPinLine, onUnpinLine, pinned]);
 
   const menu = useCallback(
     () => (
       <Menu ref={menuRef}>
         <Menu.Item onClick={copyLogLine} label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
         {onPermalinkClick && log.rowId !== undefined && log.uid && (
-          <Menu.Item label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
+          <Menu.Item onClick={copyLinkToLogLine} label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
         )}
-        {(shouldShowContextToggle || onPinLine || onUnpinLine) && <Menu.Divider />}
-        {shouldShowContextToggle && (
+        {(shouldlogSupportsContext || onPinLine || onUnpinLine) && <Menu.Divider />}
+        {shouldlogSupportsContext && (
           <Menu.Item onClick={showContext} label={t('logs.log-line-menu.show-context', 'Show context')} />
         )}
-        {!pinned && onPinLine && <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Pin line')} />}
-        {pinned && onUnpinLine && <Menu.Item label={t('logs.log-line-menu.pin-to-outline', 'Unpin line')} />}
+        {!pinned && onPinLine && (
+          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Pin line')} />
+        )}
+        {pinned && onUnpinLine && (
+          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Unpin line')} />
+        )}
       </Menu>
     ),
     [
+      copyLinkToLogLine,
       copyLogLine,
       log.rowId,
       log.uid,
@@ -83,8 +88,9 @@ export const LogLineMenu = ({
       onPinLine,
       onUnpinLine,
       pinned,
-      shouldShowContextToggle,
+      shouldlogSupportsContext,
       showContext,
+      togglePinning,
     ]
   );
 

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -75,7 +75,7 @@ export const LogLineMenu = ({ log, styles }: Props) => {
           <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Pin log')} />
         )}
         {pinned && onUnpinLine && (
-          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.pin-to-outline', 'Unpin log')} />
+          <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.unpin-from-outline', 'Unpin log')} />
         )}
       </Menu>
     ),
@@ -96,7 +96,11 @@ export const LogLineMenu = ({ log, styles }: Props) => {
 
   return (
     <Dropdown overlay={menu} placement="bottom-start">
-      <IconButton className={styles.menuIcon} name="ellipsis-v" aria-label="Log menu" />
+      <IconButton
+        className={styles.menuIcon}
+        name="ellipsis-v"
+        aria-label={t('logs.log-line-menu.icon-label', 'Log menu')}
+      />
     </Dropdown>
   );
 };

--- a/public/app/features/logs/components/panel/LogLineMessage.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMessage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createTheme } from '@grafana/data';
+
+import { createLogLine } from '../__mocks__/logRow';
+
+import { getStyles } from './LogLine';
+import { LogLineMessage } from './LogLineMessage';
+import { LogListModel } from './processing';
+
+const theme = createTheme();
+const styles = getStyles(theme);
+
+describe('LogLineMessage', () => {
+  let log: LogListModel;
+  beforeEach(() => {
+    log = createLogLine({ labels: { place: 'luna' } });
+  });
+
+  test('Renders a log line message', () => {
+    render(
+      <LogLineMessage style={{}} styles={styles}>
+        Message
+      </LogLineMessage>
+    );
+    expect(screen.getByText('Message')).toBeInTheDocument();
+  });
+
+  test('Renders a button with the message', async () => {
+    const handleClick = jest.fn();
+    render(
+      <LogLineMessage style={{}} styles={styles} onClick={handleClick}>
+        Message
+      </LogLineMessage>
+    );
+    await userEvent.click(screen.getByText('Message'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/logs/components/panel/LogLineMessage.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMessage.test.tsx
@@ -3,21 +3,13 @@ import userEvent from '@testing-library/user-event';
 
 import { createTheme } from '@grafana/data';
 
-import { createLogLine } from '../__mocks__/logRow';
-
 import { getStyles } from './LogLine';
 import { LogLineMessage } from './LogLineMessage';
-import { LogListModel } from './processing';
 
 const theme = createTheme();
 const styles = getStyles(theme);
 
 describe('LogLineMessage', () => {
-  let log: LogListModel;
-  beforeEach(() => {
-    log = createLogLine({ labels: { place: 'luna' } });
-  });
-
   test('Renders a log line message', () => {
     render(
       <LogLineMessage style={{}} styles={styles}>

--- a/public/app/features/logs/components/panel/LogListContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
+
+import { createLogLine } from '../__mocks__/logRow';
+
+import { useLogListContextData, useLogListContext, useLogIsPinned, LogListContext } from './LogListContext';
+
+const log = createLogLine({ rowId: 'yep' });
+const value = {
+  getRowContextQuery: jest.fn(),
+  logSupportsContext: jest.fn(),
+  onPermalinkClick: jest.fn(),
+  onPinLine: jest.fn(),
+  onOpenContext: jest.fn(),
+  onUnpinLine: jest.fn(),
+  pinLineButtonTooltipTitle: 'test',
+  pinnedLogs: ['yep'],
+};
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <LogListContext.Provider value={value}>{children}</LogListContext.Provider>
+);
+
+test('Provides the Log List Context data', () => {
+  const { result } = renderHook(() => useLogListContext(), { wrapper });
+
+  expect(result.current).toEqual(value);
+});
+
+test('Allows to access context attributes', () => {
+  const { result } = renderHook(() => useLogListContextData('pinnedLogs'), { wrapper });
+
+  expect(result.current).toEqual(value.pinnedLogs);
+});
+
+test('Allows to tell if a log is pinned', () => {
+  const { result } = renderHook(() => useLogIsPinned(log), { wrapper });
+
+  expect(result.current).toBe(true);
+});
+
+test('Allows to tell if a log is pinned', () => {
+  const otherLog = createLogLine({ rowId: 'nope' });
+  const { result } = renderHook(() => useLogIsPinned(otherLog), { wrapper });
+
+  expect(result.current).toBe(false);
+});

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from "react";
+
+import { LogRowModel } from "@grafana/data";
+import { PopoverContent } from "@grafana/ui";
+
+import { GetRowContextQueryFn } from "./LogLineMenu";
+
+export interface LogListContextData {
+  getRowContextQuery?: GetRowContextQueryFn;
+  initialScrollPosition?: 'top' | 'bottom';
+  logSupportsContext?: (row: LogRowModel) => boolean;
+  onPermalinkClick?: (row: LogRowModel) => Promise<void>;
+  onPinLine?: (row: LogRowModel) => void;
+  onOpenContext?: (row: LogRowModel, onClose: () => void) => void;
+  onUnpinLine?: (row: LogRowModel) => void;
+  pinLineButtonTooltipTitle?: PopoverContent;
+  pinnedLogs?: string[];
+}
+
+export const LogListContext = createContext<LogListContextData>({});
+
+export const useLogListContextData = (key: keyof LogListContextData) => {
+  const data: LogListContextData = useContext(LogListContext);
+  return data[key];
+}
+
+export const useLogListContext = (): LogListContextData => {
+  return useContext(LogListContext);
+}
+
+export const useLogIsPinned = (log: LogRowModel) => {
+  const { pinnedLogs } = useContext(LogListContext);
+  return pinnedLogs?.some((logId) => logId === log.rowId);
+}

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -1,13 +1,12 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext } from 'react';
 
-import { LogRowModel } from "@grafana/data";
-import { PopoverContent } from "@grafana/ui";
+import { LogRowModel } from '@grafana/data';
+import { PopoverContent } from '@grafana/ui';
 
-import { GetRowContextQueryFn } from "./LogLineMenu";
+import { GetRowContextQueryFn } from './LogLineMenu';
 
 export interface LogListContextData {
   getRowContextQuery?: GetRowContextQueryFn;
-  initialScrollPosition?: 'top' | 'bottom';
   logSupportsContext?: (row: LogRowModel) => boolean;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;
@@ -22,13 +21,13 @@ export const LogListContext = createContext<LogListContextData>({});
 export const useLogListContextData = (key: keyof LogListContextData) => {
   const data: LogListContextData = useContext(LogListContext);
   return data[key];
-}
+};
 
 export const useLogListContext = (): LogListContextData => {
   return useContext(LogListContext);
-}
+};
 
 export const useLogIsPinned = (log: LogRowModel) => {
   const { pinnedLogs } = useContext(LogListContext);
   return pinnedLogs?.some((logId) => logId === log.rowId);
-}
+};

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -20,7 +20,7 @@ export interface LogFieldDimension {
   width: number;
 }
 
-interface PreProcessOptions {
+export interface PreProcessOptions {
   escape: boolean;
   getFieldLinks?: GetFieldLinksFn;
   order: LogsSortOrder;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -8,7 +8,7 @@ let gridSize = 8;
 let paddingBottom = gridSize * 0.75;
 export let lineHeight = 22;
 let measurementMode: 'canvas' | 'dom' = 'canvas';
-const iconWidth = 22;
+const iconWidth = 24;
 
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
@@ -130,7 +130,6 @@ export function measureTextHeight(text: string, maxWidth: number, beforeWidth = 
       if (beforeWidth) {
         beforeWidth = 0;
       }
-      //console.log(testLogLine)
       logLines += 1;
       start += testLogLine.length;
     }

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -194,7 +194,7 @@ export function hasUnderOrOverflow(element: HTMLDivElement, calculatedHeight?: n
   if (element.scrollHeight > height) {
     return element.scrollHeight;
   }
-  const child = element.firstChild;
+  const child = element.children[1];
   if (child instanceof HTMLDivElement && child.clientHeight < height) {
     return child.clientHeight;
   }

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -6,8 +6,9 @@ import { LogListModel } from './processing';
 let ctx: CanvasRenderingContext2D | null = null;
 let gridSize = 8;
 let paddingBottom = gridSize * 0.75;
-let lineHeight = 22;
+export let lineHeight = 22;
 let measurementMode: 'canvas' | 'dom' = 'canvas';
+const iconWidth = 22;
 
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
@@ -129,6 +130,7 @@ export function measureTextHeight(text: string, maxWidth: number, beforeWidth = 
       if (beforeWidth) {
         beforeWidth = 0;
       }
+      //console.log(testLogLine)
       logLines += 1;
       start += testLogLine.length;
     }
@@ -203,7 +205,7 @@ export function hasUnderOrOverflow(element: HTMLDivElement, calculatedHeight?: n
 const scrollBarWidth = getScrollbarWidth();
 
 export function getLogContainerWidth(container: HTMLDivElement) {
-  return container.clientWidth - scrollBarWidth;
+  return container.clientWidth - scrollBarWidth - iconWidth;
 }
 
 export function getScrollbarWidth() {

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -6,12 +6,14 @@ import { LogListModel } from './processing';
 let ctx: CanvasRenderingContext2D | null = null;
 let gridSize = 8;
 let paddingBottom = gridSize * 0.75;
-export let lineHeight = 22;
+let lineHeight = 22;
 let measurementMode: 'canvas' | 'dom' = 'canvas';
 const iconWidth = 24;
 
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
+
+export const getLineHeight = () => lineHeight;
 
 export function init(theme: GrafanaTheme2) {
   const font = `${theme.typography.fontSize}px ${theme.typography.fontFamilyMonospace}`;

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,4 +1,5 @@
 import { countBy, chain } from 'lodash';
+import { MouseEvent } from 'react';
 
 import {
   LogLevel,
@@ -15,9 +16,14 @@ import {
   LogsVolumeType,
   NumericLogLevel,
   getFieldDisplayName,
+  getDefaultTimeRange,
+  locationUtil,
+  urlUtil,
 } from '@grafana/data';
+import { getConfig } from 'app/core/config';
 
 import { getDataframeFields } from './components/logParser';
+import { GetRowContextQueryFn } from './components/panel/LogLineMenu';
 
 /**
  * Returns the log level of a log line.
@@ -302,6 +308,35 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
     textarea.remove();
   }
 };
+
+export async function handleOpenLogsContextClick(
+  event: MouseEvent<HTMLElement>,
+  row: LogRowModel,
+  getRowContextQuery: GetRowContextQueryFn,
+  onOpenContext: (row: LogRowModel) => void
+) {
+  event.stopPropagation();
+  // if ctrl or meta key is pressed, open query in new Explore tab
+  if (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey || event.nativeEvent.shiftKey) {
+    const win = window.open('about:blank');
+    // for this request we don't want to use the cached filters from a context provider, but always want to refetch and clear
+    const query = await getRowContextQuery(row, undefined, false);
+    if (query && win) {
+      const url = urlUtil.renderUrl(locationUtil.assureBaseUrl(`${getConfig().appSubUrl}explore`), {
+        left: JSON.stringify({
+          datasource: query.datasource,
+          queries: [query],
+          range: getDefaultTimeRange(),
+        }),
+      });
+      win.location = url;
+
+      return;
+    }
+    win?.close();
+  }
+  onOpenContext(row);
+}
 
 export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]) {
   const fieldCache = new FieldCache(dataFrame);

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -312,12 +312,12 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
 export async function handleOpenLogsContextClick(
   event: MouseEvent<HTMLElement>,
   row: LogRowModel,
-  getRowContextQuery: GetRowContextQueryFn,
+  getRowContextQuery: GetRowContextQueryFn | undefined,
   onOpenContext: (row: LogRowModel) => void
 ) {
   event.stopPropagation();
   // if ctrl or meta key is pressed, open query in new Explore tab
-  if (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey || event.nativeEvent.shiftKey) {
+  if (getRowContextQuery && (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey || event.nativeEvent.shiftKey)) {
     const win = window.open('about:blank');
     // for this request we don't want to use the cached filters from a context provider, but always want to refetch and clear
     const query = await getRowContextQuery(row, undefined, false);

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -315,7 +315,6 @@ export async function handleOpenLogsContextClick(
   getRowContextQuery: GetRowContextQueryFn | undefined,
   onOpenContext: (row: LogRowModel) => void
 ) {
-  event.stopPropagation();
   // if ctrl or meta key is pressed, open query in new Explore tab
   if (getRowContextQuery && (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey || event.nativeEvent.shiftKey)) {
     const win = window.open('about:blank');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2224,6 +2224,14 @@
       "log-line": "Log line",
       "no-details": "No details available"
     },
+    "log-line-menu": {
+      "copy-link": "Copy link to log line",
+      "copy-log": "Copy log line",
+      "icon-label": "Log menu",
+      "pin-to-outline": "Pin log",
+      "show-context": "Show context",
+      "unpin-from-outline": "Unpin log"
+    },
     "log-row-message": {
       "ellipsis": "… ",
       "more": "more",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -2224,6 +2224,14 @@
       "log-line": "Ŀőģ ľįŉę",
       "no-details": "Ńő đęŧäįľş äväįľäþľę"
     },
+    "log-line-menu": {
+      "copy-link": "Cőpy ľįŉĸ ŧő ľőģ ľįŉę",
+      "copy-log": "Cőpy ľőģ ľįŉę",
+      "icon-label": "Ŀőģ męŉū",
+      "pin-to-outline": "Pįŉ ľőģ",
+      "show-context": "Ŝĥőŵ čőŉŧęχŧ",
+      "unpin-from-outline": "Ůŉpįŉ ľőģ"
+    },
     "log-row-message": {
       "ellipsis": "… ",
       "more": "mőřę",


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

This PR adds a log line menu to the new Logs Panel. To provide its required callbacks and improve the current situation 
where we rely on prop drilling to pass props to leaf components within the Logs visualization, a Log List Context component has been created, to allow the menu and any other component that requires props to read them from it, without having to modify and pass it through the tree.

Additionally, this PR adds unit tests for the new components.

Demo:

https://github.com/user-attachments/assets/4a8007d9-83b6-4d56-a1b9-205eedb0e894

