### PR TITLE
ExploreMetrics: Update name of queryless metrics experience

### DIFF
--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -86,7 +86,7 @@ export {
 } from './types';
 export { PrometheusVariableSupport } from './variables';
 
-// For explore metrics
+// For Grafana Metrics Drilldown
 export { default as PromQlLanguageProvider } from './language_provider';
 export { getPrometheusTime } from './language_utils';
 export { isValidLegacyName, utf8Support, wrapUtf8Filters } from './utf8_support';

--- a/public/app/features/trails/Integrations/dashboardIntegration.ts
+++ b/public/app/features/trails/Integrations/dashboardIntegration.ts
@@ -61,7 +61,7 @@ export async function addDataTrailPanelAction(dashboard: DashboardScene, panel: 
 
   if (subMenu.length > 0) {
     items.push({
-      text: 'Explore metrics',
+      text: 'Metrics drilldown',
       iconClassName: 'code-branch',
       subMenu: getUnique(subMenu),
     });
@@ -109,7 +109,7 @@ function createCommonEmbeddedTrailStateProps(item: QueryMetric, dashboard: Dashb
 
   const commonProps = {
     scene: embeddedTrail,
-    title: 'Explore metrics',
+    title: 'Metrics drilldown',
   };
 
   return commonProps;

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
@@ -80,7 +80,7 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
       return;
     }
     const ctx = {
-      origin: 'Explore Metrics',
+      origin: 'Metrics Drilldown',
       type: 'timeseries',
       queries,
       timeRange: { ...timeRange.state.value },

--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -154,7 +154,7 @@ export class MetricDatasourceHelper {
   }
 
   /**
-   * Used for additional filtering for adhoc vars labels in Explore metrics.
+   * Used for additional filtering for adhoc vars labels in Grafana Metrics Drilldown.
    * @param options
    * @returns
    */
@@ -170,7 +170,7 @@ export class MetricDatasourceHelper {
   }
 
   /**
-   * Used for additional filtering for adhoc vars label values in Explore metrics.
+   * Used for additional filtering for adhoc vars label values in Grafana Metrics Drilldown.
    * @param options
    * @returns
    */

--- a/public/app/features/trails/otel/util.ts
+++ b/public/app/features/trails/otel/util.ts
@@ -548,7 +548,7 @@ function checkLabelPromotion(filters: AdHocVariableFilter[], nonPromotedOtelReso
  * Once we know this, we can add the selected filter to either the
  * VAR_OTEL_RESOURCES or VAR_FILTERS variable.
  *
- * When the correct variable is updated, the rest of the explore metrics behavior will remain the same.
+ * When the correct variable is updated, the rest of the Grafana Metrics Drilldown behavior will remain the same.
  *
  * @param newStateFilters
  * @param prevStateFilters


### PR DESCRIPTION
## What does this PR do?

Explore Metrics is being renamed to Grafana Metrics Drilldown. This name change reflects a broader naming of the Drilldown app suite. This PR updates code comments and superficial labels to reflect this change.

## Related issue

This PR closes #100296.