### PR TITLE
tests(unified-storage): use unified storage grpc client

### DIFF
--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -115,7 +115,7 @@ func newClient(opts options.StorageOptions,
 		}
 
 		// Create a connection to the gRPC server.
-		conn, err := grpcConn(opts.Address, reg)
+		conn, err := GrpcConn(opts.Address, reg)
 		if err != nil {
 			return nil, err
 		}
@@ -161,8 +161,8 @@ func newResourceClient(conn *grpc.ClientConn, cfg *setting.Cfg, features feature
 	return resource.NewRemoteResourceClient(tracer, conn, clientCfgMapping(grpcutils.ReadGrpcClientConfig(cfg)), cfg.Env == setting.Dev)
 }
 
-// grpcConn creates a new gRPC connection to the provided address.
-func grpcConn(address string, reg prometheus.Registerer) (*grpc.ClientConn, error) {
+// GrpcConn creates a new gRPC connection to the provided address.
+func GrpcConn(address string, reg prometheus.Registerer) (*grpc.ClientConn, error) {
 	// This works for now as the Provide function is only called once during startup.
 	// We might eventually want to tight this factory to a struct for more runtime control.
 	metrics := clientMetrics{

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/authlib/authn"
@@ -20,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
@@ -510,7 +509,7 @@ func TestClientServer(t *testing.T) {
 	})
 
 	t.Run("Create a client", func(t *testing.T) {
-		conn, err := grpc.NewClient(svc.GetAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := unified.GrpcConn(svc.GetAddress(), prometheus.NewPedanticRegistry())
 		require.NoError(t, err)
 		client, err = resource.NewRemoteResourceClient(tracing.NewNoopTracerService(), conn, authn.GrpcClientConfig{}, true)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR uses the unified storage grpc client, to make sure it's tested during the integration tests.