### PR TITLE
Log Context: Unify pinnedLogs and pinnedRowId props

### DIFF
--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -61,7 +61,6 @@ export interface Props {
   permalinkedRowId?: string;
   scrollIntoView?: (element: HTMLElement) => void;
   isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
-  pinnedRowId?: string;
   pinnedLogs?: string[];
   /**
    * If false or undefined, the `contain:strict` css property will be added to the wrapping `<table>` for performance reasons.
@@ -305,7 +304,7 @@ export const LogRows = memo(
                   onPinLine={props.onPinLine}
                   onUnpinLine={props.onUnpinLine}
                   pinLineButtonTooltipTitle={props.pinLineButtonTooltipTitle}
-                  pinned={props.pinnedRowId === row.uid || pinnedLogs?.some((logId) => logId === row.rowId)}
+                  pinned={pinnedLogs?.some((logId) => logId === row.rowId || logId === row.uid)}
                   isFilterLabelActive={props.isFilterLabelActive}
                   handleTextSelection={handleSelection}
                   enableLogDetails={enableLogDetails}

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -561,7 +561,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                   onClickHideField={hideField}
                   onUnpinLine={() => setSticky(false)}
                   onPinLine={() => setSticky(true)}
-                  pinnedRowId={sticky ? row.uid : undefined}
+                  pinnedLogs={sticky ? [row.uid] : undefined}
                   overflowingContent={true}
                   scrollElement={null}
                 />


### PR DESCRIPTION
Found while working on https://github.com/grafana/grafana/pull/101060 . Both props had the same effect but used in different contexts.

Not only unifies the behavior, but it's also one less prop that a new panel would need to support.