### PR TITLE
[release-11.4.3] Alerting: Fix token-based Slack image upload to work with channel names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.13.0 // @grafana/grafana-backend-group
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20250123200557-d08d1a8c6d83 // @grafana/alerting-backend
+	github.com/grafana/alerting v0.0.0-20250220140551-171d63dc0433 // @grafana/alerting-backend
 	github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 // @grafana/identity-access-team
 	github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd // @grafana/identity-access-team
 	github.com/grafana/codejen v0.0.3 // @grafana/dataviz-squad

--- a/go.sum
+++ b/go.sum
@@ -2256,6 +2256,8 @@ github.com/grafana/alerting v0.0.0-20241216200650-863916c31666 h1:yT+hJkmegtRnpH
 github.com/grafana/alerting v0.0.0-20241216200650-863916c31666/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
 github.com/grafana/alerting v0.0.0-20250123200557-d08d1a8c6d83 h1:My4siUgC1Fsxw4xIUlUVLOk70W2oHMkV1TyHNzIvXh8=
 github.com/grafana/alerting v0.0.0-20250123200557-d08d1a8c6d83/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
+github.com/grafana/alerting v0.0.0-20250220140551-171d63dc0433 h1:JfmmfBC36MmVQG4aMAPsSyaeN0qKcR52zQkgXOOu168=
+github.com/grafana/alerting v0.0.0-20250220140551-171d63dc0433/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 h1:zYF/RBulpvMqPYR3gbzJZ8t/j/Eymn5FNidSYkueNCA=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564/go.mod h1:PFzXbCrn0GIpN4KwT6NP1l5Z1CPLfmKHnYx8rZzQcyY=
 github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd h1:sIlR7n38/MnZvX2qxDEszywXdI5soCwQ78aTDSARvus=


### PR DESCRIPTION
Backport from #100988, uses `grafana/alerting` release branch: https://github.com/grafana/alerting/commit/171d63dc043393d68c9ef9972470e4e1604e794b

---

**What is this feature?**

Upgrades grafana/alerting to https://github.com/grafana/alerting/commit/00d67037a5f1de218f2412bae8fdb67bd2fe31ac which includes the fix:

https://github.com/grafana/alerting/pull/284

> Fixes `channel_not_found` error when finalizing an image upload for a Slack integration that uses both `Token` and channel `Name` (`#example`) as the recipient instead of channel `ID` (`C123ABC456`).
> 
> The cause was a previous [change](https://github.com/grafana/alerting/pull/256) to support `files_upload_v2` that required the use of the [files.completUploadExternal](https://api.slack.com/methods/files.completeUploadExternal) endpoint which does not support referencing channels by name, only ID.
> 
> Now we obtain the channel ID from the `chat.postMessage` response specifically for these bot token image uploads.

**Who is this feature for?**

Users with Slack contact points using Bot Tokens combined with Recipients defined as the Channel Name instead of Channel ID.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/100283

Will need backport to 11.5.x and 11.4.x as the cause was backported that far.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.

