### PR TITLE
[release-11.1.13] IAM: fix grafana_com OAuth connector config overriding

### DIFF
--- a/pkg/login/social/connectors/grafana_com_oauth.go
+++ b/pkg/login/social/connectors/grafana_com_oauth.go
@@ -38,12 +38,12 @@ type OrgRecord struct {
 }
 
 func NewGrafanaComProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper *OrgRoleMapper, ssoSettings ssosettings.Service, features featuremgmt.FeatureToggles) *SocialGrafanaCom {
-	s := newSocialBase(social.GrafanaComProviderName, orgRoleMapper, info, features, cfg)
-
 	// Override necessary settings
 	info.AuthUrl = cfg.GrafanaComURL + "/oauth2/authorize"
 	info.TokenUrl = cfg.GrafanaComURL + "/api/oauth2/token"
 	info.AuthStyle = "inheader"
+
+	s := newSocialBase(social.GrafanaComProviderName, orgRoleMapper, info, features, cfg)
 
 	allowedOrganizations, err := util.SplitStringWithError(info.Extra[allowedOrganizationsKey])
 	if err != nil {


### PR DESCRIPTION
Backport e36c9220f9acee6d16b8cec9bb4b7408e0eaf545 from #101066

---

In https://github.com/grafana/grafana/pull/99896 I accidentally overlooked the overrides we were applying to the passed `social.OAuthInfo` struct and moved some code around, resulting in the overrides not being applied as early in the flow as they should. This PR fixes that by applying the overrides first thing in the function body, as it used to be before I modified it.
