### PR TITLE
Storage: Filter List requests using accessclient item checker

### DIFF
--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 var gvrKeepers = schema.GroupVersionResource{
-	Group:    "secret.grafana.app",
-	Version:  "v0alpha1",
-	Resource: "keepers",
+	Group:    secretv0alpha1.GROUP,
+	Version:  secretv0alpha1.VERSION,
+	Resource: secretv0alpha1.KeeperResourceInfo.GetName(),
 }
 
 func TestIntegrationKeeper(t *testing.T) {
@@ -567,11 +567,12 @@ func TestIntegrationKeeper(t *testing.T) {
 		})
 
 		t.Run("LIST", func(t *testing.T) {
-			// List Keepers from the limited client should return only 1, but it doesn't.
+			// List Keepers from the limited client should return only 1.
 			rawList, err := clientScopedLimited.Resource.List(ctx, metav1.ListOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, rawList)
-			require.Len(t, rawList.Items, 1) // TODO: Can view both Keepers. How can we limit that?
+			require.Len(t, rawList.Items, 1)
+			require.Equal(t, keeperName, rawList.Items[0].GetName())
 
 			// List Keepers from the scope-all client should return all of them.
 			rawList, err = clientScopedAll.Resource.List(ctx, metav1.ListOptions{})

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 var gvrSecureValues = schema.GroupVersionResource{
-	Group:    "secret.grafana.app",
-	Version:  "v0alpha1",
-	Resource: "securevalues",
+	Group:    secretv0alpha1.GROUP,
+	Version:  secretv0alpha1.VERSION,
+	Resource: secretv0alpha1.SecureValuesResourceInfo.GetName(),
 }
 
 func TestIntegrationSecureValue(t *testing.T) {
@@ -491,11 +491,12 @@ func TestIntegrationSecureValue(t *testing.T) {
 		})
 
 		t.Run("LIST", func(t *testing.T) {
-			// List SecureValues from the limited client should return only 1, but it doesn't.
+			// List SecureValues from the limited client should return only 1.
 			rawList, err := clientScopedLimited.Resource.List(ctx, metav1.ListOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, rawList)
-			require.Len(t, rawList.Items, 1) // TODO: Can view both SecureValues. How can we limit that?
+			require.Len(t, rawList.Items, 1)
+			require.Equal(t, secureValueName, rawList.Items[0].GetName())
 
 			// List SecureValues from the scope-all client should return all of them.
 			rawList, err = clientScopedAll.Resource.List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
This implements filtering on the `List` action, so that users which have scoped permissions on a certain SecureValue or Keeper cannot list resources they don't have access to.

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1217