### PR TITLE
Remove embedded WriteEvent from WrittenEvent struct, to avoid having unnecessary fields.

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	claims "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	dashboard "github.com/grafana/grafana/pkg/apis/dashboard"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -86,7 +87,10 @@ func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.Writ
 	if a.subscribers != nil {
 		go func() {
 			write := &resource.WrittenEvent{
-				WriteEvent: event,
+				Type:       event.Type,
+				Key:        event.Key,
+				PreviousRV: event.PreviousRV,
+				Value:      event.Value,
 
 				Timestamp:       time.Now().UnixMilli(),
 				ResourceVersion: rv,

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -131,7 +131,10 @@ func (s *cdkBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64
 	if s.stream != nil {
 		go func() {
 			write := &WrittenEvent{
-				WriteEvent:      event,
+				Type:            event.Type,
+				Key:             event.Key,
+				PreviousRV:      event.PreviousRV,
+				Value:           event.Value,
 				Timestamp:       time.Now().UnixMilli(),
 				ResourceVersion: rv,
 			}

--- a/pkg/storage/unified/resource/event.go
+++ b/pkg/storage/unified/resource/event.go
@@ -21,18 +21,24 @@ type WriteEvent struct {
 	ObjectOld utils.GrafanaMetaAccessor
 }
 
-// WriteEvents after they include a resource version
+// WrittenEvent is a WriteEvent reported with a resource version.
 type WrittenEvent struct {
-	WriteEvent
+	Type       WatchEvent_Type
+	Key        *ResourceKey
+	PreviousRV int64
+
+	// The json payload (without resourceVersion)
+	Value []byte
+
 	// Metadata
 	Folder string
 
-	// The resource version
+	// The resource version.
 	ResourceVersion int64
 
 	// Timestamp when the event is created
 	Timestamp int64
 }
 
-// A function to write events
+// EventAppender is a function to write events.
 type EventAppender = func(context.Context, *WriteEvent) (int64, error)

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -851,17 +851,15 @@ func (b *backend) poll(ctx context.Context, grp string, res string, since int64,
 			prevRV = new(int64)
 		}
 		stream <- &resource.WrittenEvent{
-			WriteEvent: resource.WriteEvent{
-				Value: rec.Value,
-				Key: &resource.ResourceKey{
-					Namespace: rec.Key.Namespace,
-					Group:     rec.Key.Group,
-					Resource:  rec.Key.Resource,
-					Name:      rec.Key.Name,
-				},
-				Type:       resource.WatchEvent_Type(rec.Action),
-				PreviousRV: *prevRV,
+			Value: rec.Value,
+			Key: &resource.ResourceKey{
+				Namespace: rec.Key.Namespace,
+				Group:     rec.Key.Group,
+				Resource:  rec.Key.Resource,
+				Name:      rec.Key.Name,
 			},
+			Type:            resource.WatchEvent_Type(rec.Action),
+			PreviousRV:      *prevRV,
 			Folder:          rec.Folder,
 			ResourceVersion: rec.ResourceVersion,
 			// Timestamp:  , // TODO: add timestamp


### PR DESCRIPTION
This PR removes embedded `resource.WriteEvent` from `resource.WrittenEvent` struct. Main motivation is to remove some unnecessary fields from `WrittenEvent`, specifically `Object` and `ObjectOld`, because it's confusing, and reported events are not expected to set those fields.