### PR TITLE
AccessControl: Allow plugin roles to include `plugins:write`

### DIFF
--- a/pkg/services/accesscontrol/pluginutils/utils.go
+++ b/pkg/services/accesscontrol/pluginutils/utils.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	allowedCoreActions = map[string]string{
+		"plugins:write":             "plugins:id:",
 		"plugins.app:access":        "plugins:id:",
 		"folders:create":            "folders:uid:",
 		"folders:read":              "folders:uid:",

--- a/pkg/services/accesscontrol/pluginutils/utils_test.go
+++ b/pkg/services/accesscontrol/pluginutils/utils_test.go
@@ -172,6 +172,29 @@ func TestValidatePluginRole(t *testing.T) {
 			},
 			wantErr: &ac.ErrorInvalidRole{},
 		},
+		{
+			name:     "valid core plugin permission targets plugin",
+			pluginID: "test-app",
+			role: ac.RoleDTO{
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Plugin Configurator",
+				Permissions: []ac.Permission{
+					{Action: "plugins:write", Scope: "plugins:id:test-app"},
+				},
+			},
+		},
+		{
+			name:     "invalid core plugin permission targets other plugin",
+			pluginID: "test-app",
+			role: ac.RoleDTO{
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Plugin Configurator",
+				Permissions: []ac.Permission{
+					{Action: "plugins:write", Scope: "plugins:id:other-app"},
+				},
+			},
+			wantErr: &ac.ErrorInvalidRole{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR allow plugins to define roles with the `plugins:write` action (targeting the plugin id).

This will effectively allow plugin developers to define a role that allow users to configure the plugin settings.