### PR TITLE
Graphite: Compare query builder query to raw query

### DIFF
--- a/public/app/plugins/datasource/graphite/components/GraphiteQueryEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteQueryEditor.tsx
@@ -53,6 +53,7 @@ function GraphiteQueryEditorContent() {
         icon="pen"
         variant="secondary"
         aria-label="Toggle editor mode"
+        tooltip={state?.queryModel?.error}
         onClick={() => {
           dispatch(actions.toggleEditorMode());
         }}

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -744,6 +744,9 @@ describe('graphiteDatasource', () => {
           params: [{ multiple: true }],
         },
         updateText: () => {},
+        render: () => {
+          return "";
+        }
       }));
     });
 

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -745,8 +745,8 @@ describe('graphiteDatasource', () => {
         },
         updateText: () => {},
         render: () => {
-          return "";
-        }
+          return '';
+        },
       }));
     });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -143,7 +143,7 @@ export class GraphiteDatasource
         target: query.target || '',
         textEditor: false,
       },
-      getTemplateSrv()
+      this.templateSrv
     );
     graphiteQuery.parseTarget();
 

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -85,11 +85,13 @@ export default class GraphiteQuery {
         // We are removing these for less false positives of query changes.
         const sanitizeQuery = (o: string): string => {
           return o.replace(/\s|'|"|,/g, '');
-        }
+        };
         const oldSanitized = sanitizeQuery(oldQuery);
-        const newSanitized = sanitizeQuery(newQuery)
+        const newSanitized = sanitizeQuery(newQuery);
         if (oldSanitized && newSanitized && oldSanitized !== newSanitized) {
-          throw new Error(`Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: ${oldQuery}\nQuery builder query: ${newQuery}`);
+          throw new Error(
+            `Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: ${oldQuery}\nQuery builder query: ${newQuery}`
+          );
         }
       }
     } catch (err) {
@@ -202,13 +204,13 @@ export default class GraphiteQuery {
         return this.templateSrv ? this.templateSrv.replace(value, this.scopedVars) : value;
       });
     };
-      const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.?select metric$/, '');
-      return reduce(this.functions, wrapFunction, metricPath);
+    const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.?select metric$/, '');
+    return reduce(this.functions, wrapFunction, metricPath);
   }
 
   updateModelTarget(targets: any) {
     if (!this.target.textEditor) {
-      this.target.target = this.generateQueryString()
+      this.target.target = this.generateQueryString();
     }
 
     this.updateRenderedTarget(this.target, targets);

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -81,6 +81,8 @@ export default class GraphiteQuery {
         const oldSanitizedQuery = this.target.target;
         const newSanitizedQuery = this.generateQueryString();
 
+        // Spaces, quotes, and commas are used when rendering the AST back into a string.
+        // We are removing these for less false positives of query changes.
         const sanitizeQuery = (o: string): string => {
           return o.replace(/\s|'|"|,/g, '');
         }

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -77,6 +77,17 @@ export default class GraphiteQuery {
 
     try {
       this.parseTargetRecursive(astNode, null);
+      if (this.target.target) {
+        const oldSanitizedQuery = this.target.target;
+        const newSanitizedQuery = this.generateQueryString();
+
+        const sanitizeQuery = (o: string): string => {
+          return o.replace(/\s|'|"|,/g, '');
+        }
+        if (sanitizeQuery(oldSanitizedQuery) !== sanitizeQuery(newSanitizedQuery)) {
+          throw new Error(`Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: ${oldSanitizedQuery}\nQuery builder query: ${newSanitizedQuery}`);
+        }
+      }
     } catch (err) {
       if (err instanceof Error) {
         console.error('error parsing target:', err.message);
@@ -181,16 +192,19 @@ export default class GraphiteQuery {
     arrayMove(this.functions, index, index + offset);
   }
 
-  updateModelTarget(targets: any) {
+  generateQueryString(): string {
     const wrapFunction = (target: string, func: FuncInstance) => {
       return func.render(target, (value: string) => {
         return this.templateSrv ? this.templateSrv.replace(value, this.scopedVars) : value;
       });
     };
-
-    if (!this.target.textEditor) {
       const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.?select metric$/, '');
-      this.target.target = reduce(this.functions, wrapFunction, metricPath);
+      return reduce(this.functions, wrapFunction, metricPath);
+  }
+
+  updateModelTarget(targets: any) {
+    if (!this.target.textEditor) {
+      this.target.target = this.generateQueryString()
     }
 
     this.updateRenderedTarget(this.target, targets);

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -83,9 +83,7 @@ export default class GraphiteQuery {
 
         // Spaces, quotes, and commas are used when rendering the AST back into a string.
         // We are removing these for less false positives of query changes.
-        const sanitizeQuery = (o: string): string => {
-          return o.replace(/\s|'|"|,/g, '');
-        };
+        const sanitizeQuery = (o: string): string => o.replace(/\s|'|"|,/g, '');
         const oldSanitized = sanitizeQuery(oldQuery);
         const newSanitized = sanitizeQuery(newQuery);
         if (oldSanitized && newSanitized && oldSanitized !== newSanitized) {

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -78,16 +78,18 @@ export default class GraphiteQuery {
     try {
       this.parseTargetRecursive(astNode, null);
       if (this.target.target) {
-        const oldSanitizedQuery = this.target.target;
-        const newSanitizedQuery = this.generateQueryString();
+        const oldQuery = this.target.target;
+        const newQuery = this.generateQueryString();
 
         // Spaces, quotes, and commas are used when rendering the AST back into a string.
         // We are removing these for less false positives of query changes.
         const sanitizeQuery = (o: string): string => {
           return o.replace(/\s|'|"|,/g, '');
         }
-        if (sanitizeQuery(oldSanitizedQuery) !== sanitizeQuery(newSanitizedQuery)) {
-          throw new Error(`Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: ${oldSanitizedQuery}\nQuery builder query: ${newSanitizedQuery}`);
+        const oldSanitized = sanitizeQuery(oldQuery);
+        const newSanitized = sanitizeQuery(newQuery)
+        if (oldSanitized && newSanitized && oldSanitized !== newSanitized) {
+          throw new Error(`Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: ${oldQuery}\nQuery builder query: ${newQuery}`);
         }
       }
     } catch (err) {

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -258,6 +258,18 @@ describe('Graphite query model', () => {
         ctx.queryModel.updateModelTarget(targets);
         expect(ctx.queryModel.target.target).toContain(nestedFunctionAsParam);
       });
+
+      //This is not preferred behavior. The query builder cannot parse `maxSeries(sum(testSeries1), sum(testSeries2))` and when it can, remove this test
+      it('should return an error when visual query builder query does not match raw query', () => {
+        jest.spyOn(console, 'error').mockImplementation();
+        ctx.target = {
+          refId: 'A',
+          target: 'maxSeries(sum(testSeries1), sum(testSeries2))',
+        };
+        ctx.targets = [ctx.target];
+        ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+        expect(ctx.queryModel.error).toBe('Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: maxSeries(sum(testSeries1), sum(testSeries2))\nQuery builder query: maxSeries(sumSeries(sumSeries(testSeries1), testSeries2))');
+      });
     });
   });
 });

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -268,7 +268,9 @@ describe('Graphite query model', () => {
         };
         ctx.targets = [ctx.target];
         ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
-        expect(ctx.queryModel.error).toBe('Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: maxSeries(sum(testSeries1), sum(testSeries2))\nQuery builder query: maxSeries(sumSeries(sumSeries(testSeries1), testSeries2))');
+        expect(ctx.queryModel.error).toBe(
+          'Failed to make a visual query builder query that is equivalent to the query.\nOriginal query: maxSeries(sum(testSeries1), sum(testSeries2))\nQuery builder query: maxSeries(sumSeries(sumSeries(testSeries1), testSeries2))'
+        );
       });
     });
   });

--- a/public/app/plugins/datasource/graphite/state/store.ts
+++ b/public/app/plugins/datasource/graphite/state/store.ts
@@ -2,7 +2,6 @@ import { AnyAction } from '@reduxjs/toolkit';
 import { Action, Dispatch } from 'redux';
 
 import { DataQuery, TimeRange } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
 
 import { TemplateSrv } from '../../../../features/templating/template_srv';
 import { GraphiteDatasource } from '../datasource';
@@ -57,7 +56,7 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
     state = {
       ...state,
       ...deps,
-      queryModel: new GraphiteQuery(deps.datasource, deps.target, getTemplateSrv()),
+      queryModel: new GraphiteQuery(deps.datasource, deps.target, state.templateSrv),
       supportsTags: deps.datasource.supportsTags,
       paused: false,
       removeTagValue: '-- remove tag --',


### PR DESCRIPTION
Compares query builder query to raw query before switching the query builder. We will not use the query builder if the queries do not match.

Errors from the query model were not being displayed to the user in the interface. We are now showing the errors in the tooltip of the toggle edit mode button. We should revisit how we show query model errors to the user. An error box would be an obvious solution, but some queries that cause errors are valid graphite queries, and we shouldn't make the user think they are invalid.

![image](https://github.com/user-attachments/assets/5c41e5dd-0110-4b2c-af33-3eee28b1b6a6)
