### PR TITLE
Provisioning: Avoid starting sync jobs when using legacy storage

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -416,7 +416,8 @@ func (rc *RepositoryController) process(item *queueItem) error {
 	}
 
 	// Trigger sync job after we have applied all patch operations
-	if obj.Spec.Sync.Enabled && obj.Status.Health.Healthy &&
+	if obj.Spec.Sync.Enabled &&
+		obj.Status.Health.Healthy &&
 		!dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, rc.dualwrite) {
 		job, err := rc.jobs.Add(ctx, &provisioning.Job{
 			ObjectMeta: v1.ObjectMeta{

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -521,6 +521,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				&repository.Tester{},
 				b.jobs,
 				b.secrets,
+				b.storageStatus,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently we need to make sure to avoid setting `spec.sync.enabled` until *after* we migrate -- since any job we stat will fail.

This PR checks that legacy status before adding jobs -- this will allow us to save repos with sync enabled