### PR TITLE
TabsLayout: Implements url sync and removes double scene object reference

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -70,10 +70,6 @@ export class TabItem
     return new TabItems(items.filter((item) => item instanceof TabItem));
   }
 
-  public onChangeTab() {
-    this.getParentLayout().changeTab(this);
-  }
-
   public onChangeTitle(title: string) {
     this.setState({ title });
   }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -1,4 +1,10 @@
-import { SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
+import {
+  SceneObjectBase,
+  SceneObjectState,
+  SceneObjectUrlSyncConfig,
+  SceneObjectUrlValues,
+  VizPanel,
+} from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
 
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
@@ -9,7 +15,7 @@ import { TabsLayoutManagerRenderer } from './TabsLayoutManagerRenderer';
 
 interface TabsLayoutManagerState extends SceneObjectState {
   tabs: TabItem[];
-  currentTab: TabItem;
+  currentTabIndex: number;
 }
 
 export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> implements DashboardLayoutManager {
@@ -26,14 +32,42 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
     },
     id: 'tabs-layout',
     createFromLayout: TabsLayoutManager.createFromLayout,
-
     kind: 'TabsLayout',
   };
 
   public readonly descriptor = TabsLayoutManager.descriptor;
 
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['tab'] });
+
+  public constructor(state: Partial<TabsLayoutManagerState>) {
+    super({
+      ...state,
+      tabs: state.tabs ?? [new TabItem()],
+      currentTabIndex: state.currentTabIndex ?? 0,
+    });
+  }
+
+  public getUrlState() {
+    return { tab: this.state.currentTabIndex.toString() };
+  }
+
+  public updateFromUrl(values: SceneObjectUrlValues) {
+    if (!values.tab) {
+      return;
+    }
+    if (typeof values.tab === 'string') {
+      this.setState({ currentTabIndex: parseInt(values.tab, 10) });
+    }
+  }
+
+  public getCurrentTab(): TabItem {
+    return this.state.tabs.length > this.state.currentTabIndex
+      ? this.state.tabs[this.state.currentTabIndex]
+      : this.state.tabs[0];
+  }
+
   public addPanel(vizPanel: VizPanel) {
-    this.state.currentTab.getLayout().addPanel(vizPanel);
+    this.getCurrentTab().getLayout().addPanel(vizPanel);
   }
 
   public getVizPanels(): VizPanel[] {
@@ -62,12 +96,12 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
   }
 
   public addNewRow() {
-    this.state.currentTab.getLayout().addNewRow();
+    this.getCurrentTab().getLayout().addNewRow();
   }
 
   public addNewTab() {
     const currentTab = new TabItem();
-    this.setState({ tabs: [...this.state.tabs, currentTab], currentTab });
+    this.setState({ tabs: [...this.state.tabs, currentTab], currentTabIndex: this.state.tabs.length });
   }
 
   public editModeChanged(isEditing: boolean) {
@@ -78,32 +112,28 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
     this.state.tabs.forEach((tab) => tab.getLayout().activateRepeaters?.());
   }
 
-  public removeTab(tab: TabItem) {
-    if (this.state.currentTab === tab) {
-      const currentTabIndex = this.state.tabs.indexOf(tab);
-      const nextTabIndex = currentTabIndex === 0 ? 1 : currentTabIndex - 1;
-      const nextTab = this.state.tabs[nextTabIndex];
-      this.setState({ tabs: this.state.tabs.filter((t) => t !== tab), currentTab: nextTab });
+  public removeTab(tabToRemove: TabItem) {
+    const currentTab = this.getCurrentTab();
+
+    if (currentTab === tabToRemove) {
+      const nextTabIndex = this.state.currentTabIndex > 0 ? this.state.currentTabIndex - 1 : 0;
+      this.setState({ tabs: this.state.tabs.filter((t) => t !== tabToRemove), currentTabIndex: nextTabIndex });
       return;
     }
 
-    const filteredTab = this.state.tabs.filter((tab) => tab !== this.state.currentTab);
+    const filteredTab = this.state.tabs.filter((tab) => tab !== tabToRemove);
     const tabs = filteredTab.length === 0 ? [new TabItem()] : filteredTab;
 
-    this.setState({ tabs, currentTab: tabs[tabs.length - 1] });
-  }
-
-  public changeTab(tab: TabItem) {
-    this.setState({ currentTab: tab });
+    this.setState({ tabs, currentTabIndex: 0 });
   }
 
   public static createEmpty(): TabsLayoutManager {
     const tab = new TabItem();
-    return new TabsLayoutManager({ tabs: [tab], currentTab: tab });
+    return new TabsLayoutManager({ tabs: [tab], currentTabIndex: 0 });
   }
 
   public static createFromLayout(layout: DashboardLayoutManager): TabsLayoutManager {
     const tab = new TabItem({ layout: layout.clone() });
-    return new TabsLayoutManager({ tabs: [tab], currentTab: tab });
+    return new TabsLayoutManager({ tabs: [tab], currentTabIndex: 0 });
   }
 }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -7,7 +7,6 @@ import {
 } from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
 
-import { getLayoutManagerFor } from '../../utils/utils';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -7,6 +7,7 @@ import {
 } from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
 
+import { getLayoutManagerFor } from '../../utils/utils';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
@@ -113,6 +114,11 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
   }
 
   public removeTab(tabToRemove: TabItem) {
+    // Do not allow removing last tab (for now)
+    if (this.state.tabs.length === 1) {
+      return;
+    }
+
     const currentTab = this.getCurrentTab();
 
     if (currentTab === tabToRemove) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -140,6 +140,6 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
 
   public static createFromLayout(layout: DashboardLayoutManager): TabsLayoutManager {
     const tab = new TabItem({ layout: layout.clone() });
-    return new TabsLayoutManager({ tabs: [tab], currentTabIndex: 0 });
+    return new TabsLayoutManager({ tabs: [tab] });
   }
 }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -135,7 +135,7 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
 
   public static createEmpty(): TabsLayoutManager {
     const tab = new TabItem();
-    return new TabsLayoutManager({ tabs: [tab], currentTabIndex: 0 });
+    return new TabsLayoutManager({ tabs: [tab] });
   }
 
   public static createFromLayout(layout: DashboardLayoutManager): TabsLayoutManager {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -8,7 +8,8 @@ import { TabsLayoutManager } from './TabsLayoutManager';
 
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
   const styles = useStyles2(getStyles);
-  const { tabs, currentTab } = model.useState();
+  const { tabs, currentTabIndex } = model.useState();
+  const currentTab = tabs[currentTabIndex];
   const { layout } = currentTab.useState();
 
   return (
@@ -18,7 +19,9 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
           <tab.Component model={tab} key={tab.state.key!} />
         ))}
       </TabsBar>
-      <TabContent className={styles.tabContentContainer}>{layout && <layout.Component model={layout} />}</TabContent>
+      <TabContent className={styles.tabContentContainer}>
+        {currentTab && <layout.Component model={layout} />}
+      </TabContent>
     </>
   );
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -44,6 +44,6 @@ export class TabsLayoutSerializer implements LayoutManagerSerializer {
         layout: layoutSerializerRegistry.get(layout.kind).serializer.deserialize(layout, elements, preload),
       });
     });
-    return new TabsLayoutManager({ tabs, currentTab: tabs[0] });
+    return new TabsLayoutManager({ tabs });
   }
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -549,14 +549,7 @@ describe('dynamic layouts', () => {
       }),
     ];
 
-    const scene = setupDashboardScene(
-      getMinimalSceneState(
-        new TabsLayoutManager({
-          currentTab: tabs[0],
-          tabs,
-        })
-      )
-    );
+    const scene = setupDashboardScene(getMinimalSceneState(new TabsLayoutManager({ tabs })));
     const result = transformSceneToSaveModelSchemaV2(scene);
     expect(result.layout.kind).toBe('TabsLayout');
     const tabsLayout = result.layout.spec as TabsLayoutSpec;


### PR DESCRIPTION
**Problems**
* Current tabs layout has double reference to the "currentTab" (due to not using SceneObjectRef for the currentTab)
* No url sync or href link for tabs 

**Changes**
* Switch currentTab to currentTabIndex 
* Add URL sync for currentTabIndex
* Make tabs use href links (so you can cmd+click them)

Bugs fixed
* Tabs layout crashes when you remove the last tab, I prevent the last tab from being removed for now. Maybe we should remove the layout when removing the last tab but leaving this logic until we decide how to handle handle this. 
