### PR TITLE
Provisioning: Show progress more often

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5908,8 +5908,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"]
     ],
     "public/app/features/provisioning/Wizard/ProvisioningWizard.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -53,7 +53,7 @@ type jobProgressRecorder struct {
 func newJobProgressRecorder(progressFn progressFn) JobProgressRecorder {
 	return &jobProgressRecorder{
 		started:    time.Now(),
-		progressFn: maybeNotifyProgress(15*time.Second, progressFn),
+		progressFn: maybeNotifyProgress(5*time.Second, progressFn),
 		summaries:  make(map[string]*provisioning.JobResourceSummary),
 	}
 }

--- a/public/app/features/provisioning/OnboardingPage.tsx
+++ b/public/app/features/provisioning/OnboardingPage.tsx
@@ -15,9 +15,8 @@ export default function OnboardingPage() {
       <Page.Contents>
         <SetupWarnings />
         <Alert severity="info" title="Setting up this connection could cause a temporary outage">
-          When you connect your whole instance, depending on its size, the setup might make the dashboard unavailable to
-          users for up to 30 minutes. We recommend warning your users before starting the process. You can use the
-          announcement banner or your preferred channels.
+          When you connect your whole instance, dashboards will be unavailable while running the migration. We recommend
+          warning your users before starting the process.
         </Alert>
         <EmptyState
           variant="call-to-action"

--- a/public/app/features/provisioning/Wizard/MigrateStep.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateStep.tsx
@@ -59,7 +59,7 @@ export function MigrateStep({ onMigrationStatusChange }: MigrateStepProps) {
         </Text>
 
         <Alert severity="info" title="Note">
-          Dashboards app/Grafana will be unavailable when starting this process.
+          Dashboards will be unavailable while running this process.
         </Alert>
 
         {Boolean(stats.length) && (

--- a/public/app/features/provisioning/Wizard/MigrateStep.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateStep.tsx
@@ -42,21 +42,10 @@ export function MigrateStep({ onMigrationStatusChange }: MigrateStepProps) {
     }
   };
 
-  const onAbort = () => {
-    migrateQuery.reset();
-    setShowMigrateStatus(false);
-    onMigrationStatusChange(false);
-  };
-
   if (showMigrateStatus && migrateName) {
     return (
       <Stack direction="column" gap={2}>
         <JobStatus name={migrateName} />
-        <Stack gap={2}>
-          <Button variant="secondary" onClick={onAbort}>
-            Abort migration
-          </Button>
-        </Stack>
       </Stack>
     );
   }


### PR DESCRIPTION
This updates our progress bar every 5s with more info

Also:
* removes the "Abort migration" button (lets get it working first)
* changes the language about 30min delay