### PR TITLE
K8s: Add error to GetRestConfig

### DIFF
--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -34,13 +34,13 @@ func ProvideRegistryServiceSink(
 	investigationAppProvider *investigations.InvestigationsAppProvider,
 	advisorAppProvider *advisor.AdvisorAppProvider,
 ) (*Service, error) {
-	cfgWrapper := func(ctx context.Context) *rest.Config {
-		cfg := restConfigProvider.GetRestConfig(ctx)
-		if cfg == nil {
-			return nil
+	cfgWrapper := func(ctx context.Context) (*rest.Config, error) {
+		cfg, err := restConfigProvider.GetRestConfig(ctx)
+		if err != nil {
+			return nil, err
 		}
 		cfg.APIPath = "/apis"
-		return cfg
+		return cfg, nil
 	}
 
 	cfg := runner.RunnerConfig{

--- a/pkg/services/apiserver/builder/runner/runner.go
+++ b/pkg/services/apiserver/builder/runner/runner.go
@@ -12,7 +12,7 @@ import (
 )
 
 type RunnerConfig struct {
-	RestConfigGetter func(context.Context) *rest.Config
+	RestConfigGetter func(context.Context) (*rest.Config, error)
 	APIRegistrar     builder.APIRegistrar
 }
 
@@ -49,9 +49,9 @@ func (r *APIGroupRunner) Run(ctx context.Context) error {
 
 func (r *APIGroupRunner) Init(ctx context.Context) error {
 	defer close(r.initialized)
-	restConfig := r.config.RestConfigGetter(ctx)
-	if restConfig == nil {
-		return fmt.Errorf("rest config is nil")
+	restConfig, err := r.config.RestConfigGetter(ctx)
+	if err != nil {
+		return err
 	}
 	for i := range r.groups {
 		appConfig := app.Config{

--- a/pkg/services/apiserver/client/client_mock.go
+++ b/pkg/services/apiserver/client/client_mock.go
@@ -94,6 +94,6 @@ type MockTestRestConfig struct {
 	cfg *rest.Config
 }
 
-func (r MockTestRestConfig) GetRestConfig(ctx context.Context) *rest.Config {
-	return r.cfg
+func (r MockTestRestConfig) GetRestConfig(ctx context.Context) (*rest.Config, error) {
+	return r.cfg, nil
 }

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -92,7 +92,7 @@ func init() {
 // The client Config gets initialized during the first call to
 // ProvideService.
 // Any call to GetRestConfig will block until we have a restConfig available
-func GetRestConfig(ctx context.Context) *clientrest.Config {
+func GetRestConfig(ctx context.Context) (*clientrest.Config, error) {
 	<-ready
 	return restConfig.GetRestConfig(ctx)
 }
@@ -104,7 +104,7 @@ type Service interface {
 }
 
 type RestConfigProvider interface {
-	GetRestConfig(context.Context) *clientrest.Config
+	GetRestConfig(context.Context) (*clientrest.Config, error)
 }
 
 type DirectRestConfigProvider interface {
@@ -244,11 +244,11 @@ func ProvideService(
 	return s, nil
 }
 
-func (s *service) GetRestConfig(ctx context.Context) *clientrest.Config {
+func (s *service) GetRestConfig(ctx context.Context) (*clientrest.Config, error) {
 	if err := s.NamedService.AwaitRunning(ctx); err != nil {
-		return nil
+		return nil, fmt.Errorf("unable to get rest config: %w", err)
 	}
-	return s.restConfig
+	return s.restConfig, nil
 }
 
 func (s *service) IsDisabled() bool {

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -159,7 +159,7 @@ func RegisterRBACAuthZService(
 	if folderAPIURL == "" {
 		folderStore = store.NewSQLFolderStore(db, tracer)
 	} else {
-		folderStore = store.NewAPIFolderStore(tracer, func(ctx context.Context) *rest.Config {
+		folderStore = store.NewAPIFolderStore(tracer, func(ctx context.Context) (*rest.Config, error) {
 			return &rest.Config{
 				Host: folderAPIURL,
 				WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
@@ -167,7 +167,7 @@ func RegisterRBACAuthZService(
 				},
 				QPS:   50,
 				Burst: 100,
-			}
+			}, nil
 		})
 	}
 

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -48,10 +48,10 @@ type rcp struct {
 	Host string
 }
 
-func (r rcp) GetRestConfig(ctx context.Context) *clientrest.Config {
+func (r rcp) GetRestConfig(ctx context.Context) (*clientrest.Config, error) {
 	return &clientrest.Config{
 		Host: r.Host,
-	}
+	}, nil
 }
 
 func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

`GetRestConfig` now can return an error.

**Why do we need this feature?**

This error has been popping up in logs and causing confusion:
```
Error: ✗ *appregistry.Service run error: rest config is nil
```
It's always a side effect of something else failing.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
