### PR TITLE
Alerting: Add webhook timeout option for upstream alertmanagers

### DIFF
--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -400,6 +400,14 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
           },
         }
       ),
+      option(
+        'timeout',
+        'Timeout',
+        'The maximum time to wait for a webhook request to complete, before failing the request and allowing it to be retried. The default value of 0s indicates that no timeout should be applied. NOTE: This will have no effect if set higher than the group_interval.',
+        {
+          placeholder: 'Use duration format, for example: 1.2s, 100ms',
+        }
+      ),
       httpConfigOption,
     ],
   },


### PR DESCRIPTION
**What is this feature?**
Adds timeout option for webhook config in upstream alertmanagers (Prom/Mimir)

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/101122
