### PR TITLE
App platform: Shared with me parent folder not reachable errors out.

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -618,11 +618,11 @@ func (s *Service) getAvailableNonRootFolders(ctx context.Context, q *folder.GetC
 		})
 	} else {
 		dashFolders, err = s.GetFolders(ctx, folder.GetFoldersQuery{
-			UIDs:             folderUids,
-			OrgID:            q.OrgID,
-			SignedInUser:     q.SignedInUser,
-			OrderByTitle:     true,
-			WithFullpathUIDs: true,
+			UIDs:         folderUids,
+			OrgID:        q.OrgID,
+			SignedInUser: q.SignedInUser,
+			OrderByTitle: true,
+			// WithFullpathUIDs: true,
 		})
 	}
 	if err != nil {


### PR DESCRIPTION
**Problem:**
For app platform, It is not possible to get a child folder in `sharedwithme` when user does not have access to parent. We get an access denied request for a folder shared with user whom do not have access to the parent folder.

in the legacy folder service, we were giving the fullpath in the URL, falsely showing folder title in the breadcrumb.

**Solution:**
- This PR solves this by not querying for `WithFullpathUIDs` making the `GetParents()` lookup to not execute
- 

```go
	if forceLegacy {
		dashFolders, err = s.GetFoldersLegacy(ctx, folder.GetFoldersQuery{
			UIDs:             folderUids,
			OrgID:            q.OrgID,
			SignedInUser:     q.SignedInUser,
			OrderByTitle:     true,
			WithFullpathUIDs: true,
		})
	} else {
		dashFolders, err = s.GetFolders(ctx, folder.GetFoldersQuery{
			UIDs:         folderUids,
			OrgID:        q.OrgID,
			SignedInUser: q.SignedInUser,
			OrderByTitle: true,
			// Removed the WithFullPathUIDs: true,
		})
	}
```

using
```ini
# app platform
mysqlParseTime = true
grafanaAPIServerEnsureKubectlAccess = true
grafanaAPIServerWithExperimentalAPIs = true
kubernetesFoldersServiceV2 = true
unifiedStorage = true
unifiedStorageSearch = true
unifiedStorageSearchUI = true
kubernetesCliDashboards = true

[unified_storage.folders.folder.grafana.app]
dualWriterMode = 4
# when in modes 1 and 2, can enable the background syncer
# dualWriterPeriodicDataSyncJobEnabled = false

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 4
# when in modes 1 and 2, can enable the background syncer
# dualWriterPeriodicDataSyncJobEnabled = true

[grafana-apiserver]
storage_type = unified
```

Read the full issue here: https://github.com/grafana/identity-access-team/issues/1145