### PR TITLE
TableNG: Column width refactor + 36px min width

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -80,11 +80,15 @@ export function TableNG(props: TableNGProps) {
   const prevProps = useRef(props);
   useEffect(() => {
     // TODO: there is a usecase when adding a new column to the table doesn't update the table
-    if (prevProps.current.data.fields.length !== props.data.fields.length) {
+    if (
+      prevProps.current.data.fields.length !== props.data.fields.length ||
+      prevProps.current.fieldConfig?.overrides !== fieldConfig?.overrides ||
+      prevProps.current.fieldConfig?.defaults !== fieldConfig?.defaults
+    ) {
       setRevId(revId + 1);
     }
     prevProps.current = props;
-  }, [props.data]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [props, revId, fieldConfig?.overrides, fieldConfig?.defaults]);
 
   const [contextMenuProps, setContextMenuProps] = useState<{
     rowIdx?: number;

--- a/packages/grafana-ui/src/components/Table/TableNG/constants.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/constants.ts
@@ -1,0 +1,16 @@
+import { getScrollbarWidth } from '@grafana/ui';
+
+/** Column width and sizing configuration */
+export const COLUMN = {
+  DEFAULT_WIDTH: 150,
+  EXPANDER_WIDTH: 50,
+  MIN_WIDTH: 36,
+};
+
+/** Table layout and display constants */
+export const TABLE = {
+  CELL_PADDING: 6,
+  MAX_CELL_HEIGHT: 48,
+  PAGINATION_LIMIT: 750,
+  SCROLL_BAR_WIDTH: getScrollbarWidth(),
+};

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -10,6 +10,7 @@ import {
   DisplayValue,
   LinkModel,
   DisplayValueAlignmentFactors,
+  DataFrame,
 } from '@grafana/data';
 import {
   TableCellBackgroundDisplayMode,
@@ -21,7 +22,8 @@ import {
 
 import { getTextColorForAlphaBackground } from '../../../utils';
 
-import { CellColors, TableRow, TableFieldOptionsType } from './types';
+import { CellColors, TableRow, TableFieldOptionsType, TableNGProps } from './types';
+import { COLUMN } from './constants';
 
 export function getCellHeight(
   text: string,
@@ -410,3 +412,16 @@ function convertRGBAToHex(backgroundColor: string, rgbaColor: string): string {
   const rgba = tinycolor(rgbaColor);
   return tinycolor.mix(bg, rgba, rgba.getAlpha() * 100).toHexString();
 }
+
+/** Returns true if the DataFrame contains nested frames */
+export const getIsNestedTable = (dataFrame: DataFrame): boolean =>
+  dataFrame.fields.some(({ type }) => type === FieldType.nestedFrames);
+
+/** Returns the width of a column based on overrides, field config, and defaults */
+export const getColumnWidth = (field: Field, fieldConfig: TableNGProps['fieldConfig'], key: string): number => {
+  const overrideWidth = fieldConfig?.overrides
+    ?.find(({ matcher: { id, options } }) => id === 'byName' && options === key)
+    ?.properties?.find(({ id }) => id === 'width')?.value;
+
+  return overrideWidth ?? field.config?.custom?.width ?? fieldConfig?.defaults?.custom?.width ?? COLUMN.DEFAULT_WIDTH;
+};


### PR DESCRIPTION
## What does this PR do? 📓 

- Updates min-width to 36px for all columns
- Refactors the column width code to clean it up 🧹 
- Adds a `constants.ts` file to clean up `TableNG.ts` file and separate presentation from constants/logic

Fixes #99085

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
