### PR TITLE
Dashboard history: rename rudderstack variable

### DIFF
--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
@@ -52,7 +52,7 @@ describe('VersionHistoryTable', () => {
       version: mockVersions[1].version,
       index: 1,
       confirm: false,
-      timestamp: mockVersions[1].created,
+      version_date: mockVersions[1].created,
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
@@ -70,7 +70,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck, onRestore }
                             version: version.version,
                             index: idx,
                             confirm: false,
-                            timestamp: version.created,
+                            version_date: version.created,
                           });
                         }}
                       >

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -118,7 +118,7 @@ export const DashboardInteractions = {
   },
 
   // Dashboards versions interactions
-  versionRestoreClicked: (properties: { version: number; index?: number; confirm: boolean; timestamp?: Date }) => {
+  versionRestoreClicked: (properties: { version: number; index?: number; confirm: boolean; version_date?: Date }) => {
     reportDashboardInteraction('version_restore_clicked', properties);
   },
   showMoreVersionsClicked: () => {


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/100451/files

timestamp is a default field in rudderstack, so we need to rename it