### PR TITLE
[release-11.5.3] [DOC] Add shared note for Explore app rename to Drilldown

### DIFF
--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -12,11 +12,7 @@ hero:
   level: 1
   width: 100
   height: 100
-<<<<<<< HEAD
-  description: Use Explore Profiles to investigate and identify issues using profiling data.
-=======
   description: Use the Grafana Drilldown apps to investigate and identify issues using telemetry data.
->>>>>>> 95b88e592dc ([DOC] Add shared note for Explore app rename to Drilldown (#101166))
 cards:
   title_class: pt-0 lh-1
   items:

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -12,7 +12,11 @@ hero:
   level: 1
   width: 100
   height: 100
+<<<<<<< HEAD
   description: Use Explore Profiles to investigate and identify issues using profiling data.
+=======
+  description: Use the Grafana Drilldown apps to investigate and identify issues using telemetry data.
+>>>>>>> 95b88e592dc ([DOC] Add shared note for Explore app rename to Drilldown (#101166))
 cards:
   title_class: pt-0 lh-1
   items:
@@ -39,6 +43,8 @@ cards:
 The Grafana Explore apps are designed for effortless data exploration through intuitive, queryless interactions.
 
 Easily explore telemetry signals with these specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
+
+{{< docs/shared source="grafana" lookup="plugins/rename-note.md" version="<GRAFANA_VERSION>" >}}
 
 To learn more, read:
 

--- a/docs/sources/explore/simplified-exploration/metrics/index.md
+++ b/docs/sources/explore/simplified-exploration/metrics/index.md
@@ -16,7 +16,9 @@ weight: 200
 
 Grafana Explore Metrics is a query-less experience for browsing **Prometheus-compatible** metrics. Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
 
-With Explore Metrics, you can:
+{{< docs/shared source="grafana" lookup="plugins/rename-note.md" version="<GRAFANA_VERSION>" >}}
+
+With Metrics Drilldown, you can:
 
 - Easily segment metrics based on their labels, so you can immediately spot anomalies and identify issues.
 - Automatically display the optimal visualization for each metric type (gauge vs. counter, for example) without manual setup.
@@ -25,13 +27,13 @@ With Explore Metrics, you can:
 - View a history of user steps when navigating through metrics and their filters.
 - Seamlessly pivot to related telemetry, including log data.
 
-{{< docs/play title="Explore Metrics" url="https://play.grafana.org/explore/metrics/trail?from=now-1h&to=now&var-ds=grafanacloud-demoinfra-prom&var-filters=&refresh=&metricPrefix=all" >}}
+{{< docs/play title="Metrics Drilldown" url="https://play.grafana.org/explore/metrics/trail?from=now-1h&to=now&var-ds=grafanacloud-demoinfra-prom&var-filters=&refresh=&metricPrefix=all" >}}
 
-You can access Explore Metrics either as a standalone experience or as part of Grafana dashboards.
+You can access Metrics Drilldown either as a standalone experience or as part of Grafana dashboards.
 
 ## Standalone experience
 
-To access Explore Metrics as a standalone experience:
+To access Metrics Drilldown as a standalone experience:
 
 1. Click the arrow next to **Explore** in the Grafana left-side menu and click **Metrics**. You are taken to an overview page that shows recent metrics, bookmarks, and the option to select a new metric exploration.
 1. To get started with a new exploration, click **+ New metric exploration**.
@@ -64,7 +66,7 @@ Once you have gathered your metrics exploration data you can:
 
 ## Dashboard experience
 
-To access Explore Metrics via a dashboard:
+To access Metrics Drilldown via a dashboard:
 
 1. Navigate to your dashboard.
 1. Select a time series panel.

--- a/docs/sources/shared/plugins/rename-note.md
+++ b/docs/sources/shared/plugins/rename-note.md
@@ -1,0 +1,19 @@
+---
+headless: true
+labels:
+  products:
+    - enterprise
+    - oss
+---
+
+[//]: # 'This file contains a rename note for Explore to Drilldown apps.'
+[//]: # 'This shared file is included in a lot of files. Check the app docs in'
+[//]: # 'drilldown-traces, drilldown-logs, drilldown-profiles, grafana, and website/grafana-cloud.'
+[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
+[//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
+
+{{< admonition type="note" >}}
+The Grafana Explore apps have changed to Grafana Drilldown apps.
+For example, Explore Logs is now Logs Drilldown.
+To learn more, read [Grafana Drilldown apps: the improved queryless experience known as the Explore apps](https://grafana.com/blog/2025/02/20/grafana-drilldown-apps-the-improved-queryless-experience-formerly-known-as-the-explore-apps/).
+{{< /admonition >}}


### PR DESCRIPTION
Backport 95b88e592dcaa04557c05e1a61d70964d8012dc7 from #101166

---

Adds a shared note to notify readers that the Explore apps have been renamed to Drilldown apps. 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
