### PR TITLE
Provisioning: Export oldest items first

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/migrate.go
+++ b/pkg/registry/apis/dashboard/legacy/migrate.go
@@ -195,6 +195,7 @@ func (a *dashboardSqlAccess) migrateDashboards(ctx context.Context, orgId int64,
 		OrgID:      orgId,
 		Limit:      100000000,
 		GetHistory: opts.WithHistory, // include history
+		Order:      "ASC",            // oldest first
 	}
 
 	blobs := &BlobStoreInfo{}

--- a/pkg/registry/apis/dashboard/legacy/queries.go
+++ b/pkg/registry/apis/dashboard/legacy/queries.go
@@ -41,10 +41,16 @@ type sqlQuery struct {
 }
 
 func (r sqlQuery) Validate() error {
+	if r.Query.Order == "ASC" && r.Query.LastID > 0 {
+		return fmt.Errorf("ascending order does not support paging by last id")
+	}
 	return nil // TODO
 }
 
 func newQueryReq(sql *legacysql.LegacyDatabaseHelper, query *DashboardQuery) sqlQuery {
+	if query.Order == "" {
+		query.Order = "DESC" // use version as RV
+	}
 	return sqlQuery{
 		SQLTemplate: sqltemplate.New(sql.DialectForDriver()),
 		Query:       query,

--- a/pkg/registry/apis/dashboard/legacy/queries_test.go
+++ b/pkg/registry/apis/dashboard/legacy/queries_test.go
@@ -76,6 +76,14 @@ func TestDashboardQueries(t *testing.T) {
 						GetFolders: true,
 					}),
 				},
+				{
+					Name: "export_with_history",
+					Data: getQuery(&DashboardQuery{
+						OrgID:      1,
+						GetHistory: true,
+						Order:      "ASC",
+					}),
+				},
 			},
 			sqlQueryPanels: {
 				{

--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -33,8 +33,8 @@ WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
   AND dashboard_version.version < {{ .Arg .Query.LastID }}
   {{ end }}
   ORDER BY
-    dashboard_version.created DESC,
-    dashboard_version.version DESC,
+    dashboard_version.created {{ .Query.Order }},
+    dashboard_version.version {{ .Query.Order }},
     dashboard.uid ASC
   {{ else }}
     {{ if .Query.UID }}

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
@@ -1,0 +1,22 @@
+SELECT
+  dashboard.org_id, dashboard.id,
+  dashboard.uid, dashboard.folder_uid,
+  dashboard.deleted, plugin_id,
+  provisioning.name        as repo_name,
+  provisioning.external_id as repo_path,
+  provisioning.check_sum   as repo_hash,
+  provisioning.updated     as repo_ts,
+  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
+  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
+  dashboard_version.version, dashboard_version.message, dashboard_version.data
+FROM `grafana`.`dashboard` as dashboard
+LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
+LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
+LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
+WHERE dashboard.is_folder = FALSE
+  AND dashboard.org_id = 1
+  ORDER BY
+    dashboard_version.created ASC,
+    dashboard_version.version ASC,
+    dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
@@ -1,0 +1,22 @@
+SELECT
+  dashboard.org_id, dashboard.id,
+  dashboard.uid, dashboard.folder_uid,
+  dashboard.deleted, plugin_id,
+  provisioning.name        as repo_name,
+  provisioning.external_id as repo_path,
+  provisioning.check_sum   as repo_hash,
+  provisioning.updated     as repo_ts,
+  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
+  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
+  dashboard_version.version, dashboard_version.message, dashboard_version.data
+FROM "grafana"."dashboard" as dashboard
+LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
+LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
+LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
+WHERE dashboard.is_folder = FALSE
+  AND dashboard.org_id = 1
+  ORDER BY
+    dashboard_version.created ASC,
+    dashboard_version.version ASC,
+    dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
@@ -1,0 +1,22 @@
+SELECT
+  dashboard.org_id, dashboard.id,
+  dashboard.uid, dashboard.folder_uid,
+  dashboard.deleted, plugin_id,
+  provisioning.name        as repo_name,
+  provisioning.external_id as repo_path,
+  provisioning.check_sum   as repo_hash,
+  provisioning.updated     as repo_ts,
+  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
+  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
+  dashboard_version.version, dashboard_version.message, dashboard_version.data
+FROM "grafana"."dashboard" as dashboard
+LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
+LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
+LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
+WHERE dashboard.is_folder = FALSE
+  AND dashboard.org_id = 1
+  ORDER BY
+    dashboard_version.created ASC,
+    dashboard_version.version ASC,
+    dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/types.go
+++ b/pkg/registry/apis/dashboard/legacy/types.go
@@ -30,6 +30,9 @@ type DashboardQuery struct {
 
 	// The label requirements
 	Labels []*resource.Requirement
+
+	// DESC|ASC, how to order the IDs
+	Order string // asc required to use lastID, desc required for export with history
 }
 
 func (r *DashboardQuery) UseHistoryTable() bool {


### PR DESCRIPTION
The sort order was flipped on the "list dashboards from history" query in order to support using the version as the resourceVersion in the legacy shim.

This PR adds an additional option so that export can list history from oldest to newest