### PR TITLE
[Search and Storage] CodeQL warnings

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -116,7 +116,7 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		}
 		list.Items = append(list.Items, *r)
 	}
-	if len(list.Items) >= int(paging.limit) {
+	if int64(len(list.Items)) >= paging.limit {
 		list.Continue = paging.GetNextPageToken()
 	}
 	return list, nil

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -700,7 +700,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 	}
 
 	for _, stmnt := range sqlStatements {
-		_, err := sess.Exec(append([]any{stmnt.SQL}, stmnt.args...)...)
+		_, err := sess.Exec(stmnt.SQL, stmnt.args)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -700,7 +700,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 	}
 
 	for _, stmnt := range sqlStatements {
-		_, err := sess.Exec(stmnt.SQL, stmnt.args)
+		_, err := sess.Exec(append([]any{stmnt.SQL}, stmnt.args...)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -339,5 +340,17 @@ func getRestoreVersion(msg string) (int, error) {
 		return 0, err
 	}
 
-	return int(ver), nil
+	safeVer, err := safeInt64ToInt(ver)
+	if err != nil {
+		return 0, err
+	}
+
+	return safeVer, nil
+}
+
+func safeInt64ToInt(i64 int64) (int, error) {
+	if i64 > math.MaxInt || i64 < math.MinInt {
+		return 0, fmt.Errorf("int64 value %d overflows int", i64)
+	}
+	return int(i64), nil
 }

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -349,7 +349,7 @@ func getRestoreVersion(msg string) (int, error) {
 }
 
 func safeInt64ToInt(i64 int64) (int, error) {
-	if i64 > math.MaxInt || i64 < math.MinInt {
+	if i64 > math.MaxInt32 || i64 < math.MinInt32 {
 		return 0, fmt.Errorf("int64 value %d overflows int", i64)
 	}
 	return int(i64), nil

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -3,6 +3,7 @@ package dashverimpl
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -294,4 +295,42 @@ func (f *FakeDashboardVersionStore) DeleteBatch(ctx context.Context, cmd *dashve
 
 func (f *FakeDashboardVersionStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
 	return f.ExpectedListVersions, f.ExpectedError
+}
+
+func TestSafeInt64ToInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   int64
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "Valid int64 within int range",
+			input: 42,
+			want:  42,
+		},
+		{
+			name:    "Overflow int64 value",
+			input:   math.MaxInt64,
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "Underflow int64 value",
+			input:   math.MinInt64,
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeInt64ToInt(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -129,7 +129,7 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 			fname = b.start.Format("tmp-20060102-150405")
 		}
 		dir := filepath.Join(resourceDir, fname)
-		if !isValidPath(dir) {
+		if !isValidPath(dir, b.opts.Root) {
 			b.log.Error("Directory is not valid", "directory", dir, "error", err)
 		}
 		if resourceVersion > 0 {
@@ -218,7 +218,7 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 	for _, file := range files {
 		if file.IsDir() && file.Name() != skip {
 			fpath := filepath.Join(dir, file.Name())
-			if !isValidPath(fpath) {
+			if !isValidPath(fpath, b.opts.Root) {
 				b.log.Error("Path is not valid", "directory", fpath, "error", err)
 			}
 			err = os.RemoveAll(fpath)
@@ -232,8 +232,8 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 }
 
 // isValidPath does a sanity check in case it tries to access dirs above the file tree
-func isValidPath(path string) bool {
-	if strings.Contains(path, "\\") || strings.Contains(path, "..") {
+func isValidPath(path, safeDir string) bool {
+	if strings.Contains(path, "\\") || strings.Contains(path, "..") || !strings.HasPrefix(path, safeDir) {
 		return false
 	}
 	return true

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -231,6 +231,7 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 	}
 }
 
+// isValidPath does a sanity check in case it tries to access dirs above the file tree
 func isValidPath(path string) bool {
 	if strings.Contains(path, "\\") || strings.Contains(path, "..") {
 		return false
@@ -691,7 +692,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resource.Res
 }
 
 func safeInt64ToInt(i64 int64) (int, error) {
-	if i64 > math.MaxInt || i64 < math.MinInt {
+	if i64 > math.MaxInt32 || i64 < math.MinInt32 {
 		return 0, fmt.Errorf("int64 value %d overflows int", i64)
 	}
 	return int(i64), nil

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -128,6 +129,9 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 			fname = b.start.Format("tmp-20060102-150405")
 		}
 		dir := filepath.Join(resourceDir, fname)
+		if !isValidPath(dir) {
+			b.log.Error("Directory is not valid", "directory", dir, "error", err)
+		}
 		if resourceVersion > 0 {
 			info, _ := os.Stat(dir)
 			if info != nil && info.IsDir() {
@@ -214,6 +218,9 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 	for _, file := range files {
 		if file.IsDir() && file.Name() != skip {
 			fpath := filepath.Join(dir, file.Name())
+			if !isValidPath(fpath) {
+				b.log.Error("Path is not valid", "directory", fpath, "error", err)
+			}
 			err = os.RemoveAll(fpath)
 			if err != nil {
 				b.log.Error("Unable to remove old index folder", "directory", fpath, "error", err)
@@ -222,6 +229,13 @@ func (b *bleveBackend) cleanOldIndexes(dir string, skip string) {
 			}
 		}
 	}
+}
+
+func isValidPath(path string) bool {
+	if strings.Contains(path, "\\") || strings.Contains(path, "..") {
+		return false
+	}
+	return true
 }
 
 // TotalDocs returns the total number of documents across all indices
@@ -556,11 +570,19 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resource.Res
 		}
 		fields = append(fields, f)
 	}
+	size, err := safeInt64ToInt(req.Limit)
+	if err != nil {
+		return nil, resource.AsErrorResult(err)
+	}
+	offset, err := safeInt64ToInt(req.Offset)
+	if err != nil {
+		return nil, resource.AsErrorResult(err)
+	}
 
 	searchrequest := &bleve.SearchRequest{
 		Fields:  fields,
-		Size:    int(req.Limit),
-		From:    int(req.Offset),
+		Size:    size,
+		From:    offset,
 		Explain: req.Explain,
 		Facets:  facets,
 	}
@@ -666,6 +688,13 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resource.Res
 	}
 
 	return searchrequest, nil
+}
+
+func safeInt64ToInt(i64 int64) (int, error) {
+	if i64 > math.MaxInt || i64 < math.MinInt {
+		return 0, fmt.Errorf("int64 value %d overflows int", i64)
+	}
+	return int(i64), nil
 }
 
 func getSortFields(req *resource.ResourceSearchRequest) []string {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -638,27 +638,29 @@ func TestSafeInt64ToInt(t *testing.T) {
 
 func Test_isValidPath(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  bool
+		name    string
+		path    string
+		safeDir string
+		want    bool
 	}{
 		{
-			name:  "valid path",
-			input: "/path/to/file.json",
-			want:  true,
+			name:    "valid path",
+			path:    "/path/to/file.json",
+			safeDir: "/path/to",
+			want:    true,
 		},
 		{
-			name:  "invalid path: ..",
-			input: "/path/../above/file",
+			name: "invalid path: ..",
+			path: "/path/../above/file",
 		},
 		{
-			name:  "invalid path: \\",
-			input: "\\some/path",
+			name: "invalid path: \\",
+			path: "\\some/path",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isValidPath(tt.input))
+			require.Equal(t, tt.want, isValidPath(tt.path, tt.safeDir))
 		})
 	}
 }

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -53,7 +53,6 @@ func (tx sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db
 	if err != nil {
 		return nil, err
 	}
-	defer stmt.Close()
 	return stmt.QueryContext(ctx, args...)
 }
 
@@ -62,6 +61,5 @@ func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) 
 	if err != nil {
 		return nil
 	}
-	defer stmt.Close()
 	return stmt.QueryRowContext(ctx, args...)
 }

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -49,9 +49,19 @@ type sqlTx struct {
 }
 
 func (tx sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
-	return tx.Tx.QueryContext(ctx, query, args...)
+	stmt, err := tx.Tx.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	return stmt.QueryContext(ctx, args...)
 }
 
 func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
-	return tx.Tx.QueryRowContext(ctx, query, args...)
+	stmt, err := tx.Tx.PrepareContext(ctx, query)
+	if err != nil {
+		return nil
+	}
+	defer stmt.Close()
+	return stmt.QueryRowContext(ctx, args...)
 }

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -49,17 +49,13 @@ type sqlTx struct {
 }
 
 func (tx sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
-	stmt, err := tx.Tx.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	return stmt.QueryContext(ctx, args...)
+	// // codeql-suppress go/sql-query-built-from-user-controlled-sources "The query comes from a safe template source
+	// and the parameters are passed as arguments."
+	return tx.Tx.QueryContext(ctx, query, args...)
 }
 
 func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
-	stmt, err := tx.Tx.PrepareContext(ctx, query)
-	if err != nil {
-		return nil
-	}
-	return stmt.QueryRowContext(ctx, args...)
+	// // codeql-suppress go/sql-query-built-from-user-controlled-sources "The query comes from a safe template source
+	// and the parameters are passed as arguments."
+	return tx.Tx.QueryRowContext(ctx, query, args...)
 }

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -48,10 +48,10 @@ type sqlTx struct {
 	*sql.Tx
 }
 
-func (d sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
-	return d.Tx.QueryContext(ctx, query, args...)
+func (tx sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
+	return tx.Tx.QueryContext(ctx, query, args...)
 }
 
-func (d sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
-	return d.Tx.QueryRowContext(ctx, query, args...)
+func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
+	return tx.Tx.QueryRowContext(ctx, query, args...)
 }


### PR DESCRIPTION
This PR fixes CodeQL warnings against potential SQL related exploits.
Fixed for
- `registry/apis/folders`
- `dashboardversion/dashverimpl`
- `search`
- `db/dbimpl`

See remaining scanning issues in [here](https://github.com/grafana/grafana/security/code-scanning?query=is%3Aopen+language%3Ago+tool%3ACodeQL+branch%3Acode_scanning%2Fplaceholders)

**A note about `db/dbimpl`:**
Scanning errors there aren't fixed, but I believe they are safe to be ignored as I believe they have been falsely flagged by the bot from lack of context. Explaining:
We are wrapping `QueryContext` and `QueryRowContext` in a wrapper of our own type, as we need to append the [SQL driver name](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/sql/db/dbimpl/db.go#L21) as a field.
This causes the bot to loose the context from where the query initially comes from. We are injecting it on the layer above where we safely import it as a text template (for example in [here](https://github.com/grafana/grafana/blob/code_scanning/placeholders/pkg/storage/unified/sql/dbutil/dbutil.go#L129)). The risk of doing any sort of SQL injection would happen in case the source of the template was unknown and / or if the query would not consider placeholders, which is not the case. Besides, by using [tx.QueryContext](https://pkg.go.dev/database/sql#Tx.QueryContext) we are already following the good practice of splitting the query from args as internally `tx.QueryContext` will only consider the second argument as a query: the third argument will be treated as data and not as a SQL executable.
I also considered using a prepared statement as the autofix suggests but I decided against it for the following reasons:
- if the query source is known and already uses placeholders, using a prepared statement won't add any extra layer of security: the only benefit it brings is in case this query is reused very frequently to increase driver's performance.
- closing the statement ends up closing the DB connection: I haven't fully investigated why, and it's something we could consider doing in the future, but my initial thought is that it could go against the List / Watch pattern we are following
- an argument with less weight but still worth considering is that we would need to modify all expectations for tests in `dbutil` package as we would need to assert on the prepared SQL statement and not on the correct used SQL template.

**A note about ignoring CodeSQL warnings**
For cases where we are sure warnings can be ignored, currently the only way we can do that is by dismissing them in the GH UI. There isn't currently any way to do this inline ([CodeQL issue](https://github.com/github/codeql/issues/11427)) but there are third party libs we can use to help us ignore these warnings if they become too annoying.

**How to run CodeQL scans currently**
Go to the [CodeQL action](https://github.com/grafana/grafana/actions/workflows/codeql-analysis.yml) and click on `run workflow` dropdown. Select your branch and click on `Run Workflow` green button. Results will be shown on your PR and also in [here](https://github.com/grafana/grafana/security/code-scanning?query=is%3Aopen+branch%3Amain+language%3Ago+tool%3ACodeQL). Select by your branch to see all the potential vulnerabilities there.
