### PR TITLE
Provisioning: avoid migration wizard if things are already in unified storage

### DIFF
--- a/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
@@ -1,10 +1,27 @@
+import { useNavigate } from 'react-router-dom-v5-compat';
+
 import { Page } from 'app/core/components/Page/Page';
 
 import { SetupWarnings } from '../SetupWarnings';
+import { useGetFrontendSettingsQuery } from '../api';
+import { PROVISIONING_URL } from '../constants';
 
 import { ProvisioningWizard } from './ProvisioningWizard';
 
 export default function MigrateToProvisioningPage() {
+  const settings = useGetFrontendSettingsQuery();
+  const navigate = useNavigate();
+  if (settings.data) {
+    // Do run the migration wizard if you are already using unified storage
+    if (!Boolean(settings.data.legacyStorage)) {
+      navigate(PROVISIONING_URL);
+    }
+    // Do run the migration wizard if something is already targeting the instance
+    if (settings.data.items.find((v) => v.target === 'instance')) {
+      navigate(PROVISIONING_URL);
+    }
+  }
+
   return (
     <Page
       navId="provisioning"

--- a/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { Page } from 'app/core/components/Page/Page';

--- a/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
@@ -14,11 +14,11 @@ export default function MigrateToProvisioningPage() {
   const navigate = useNavigate();
   useEffect(() => {
     if (settings.data) {
-      // Do run the migration wizard if you are already using unified storage
+      // Do not run the migration wizard if you are already using unified storage
       if (!Boolean(settings.data.legacyStorage)) {
         navigate(PROVISIONING_URL);
       }
-      // Do run the migration wizard if something is already targeting the instance
+      // Do not run the migration wizard if something is already targeting the instance
       if (settings.data.items.find((v) => v.target === 'instance')) {
         navigate(PROVISIONING_URL);
       }

--- a/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
+++ b/public/app/features/provisioning/Wizard/MigrateToProvisioningPage.tsx
@@ -11,16 +11,18 @@ import { ProvisioningWizard } from './ProvisioningWizard';
 export default function MigrateToProvisioningPage() {
   const settings = useGetFrontendSettingsQuery();
   const navigate = useNavigate();
-  if (settings.data) {
-    // Do run the migration wizard if you are already using unified storage
-    if (!Boolean(settings.data.legacyStorage)) {
-      navigate(PROVISIONING_URL);
+  useEffect(() => {
+    if (settings.data) {
+      // Do run the migration wizard if you are already using unified storage
+      if (!Boolean(settings.data.legacyStorage)) {
+        navigate(PROVISIONING_URL);
+      }
+      // Do run the migration wizard if something is already targeting the instance
+      if (settings.data.items.find((v) => v.target === 'instance')) {
+        navigate(PROVISIONING_URL);
+      }
     }
-    // Do run the migration wizard if something is already targeting the instance
-    if (settings.data.items.find((v) => v.target === 'instance')) {
-      navigate(PROVISIONING_URL);
-    }
-  }
+  }, [settings.data, navigate]);
 
   return (
     <Page


### PR DESCRIPTION
Do not let people run the migration wizard if it is already migrated