### PR TITLE
Authz: folder api tls settings

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -169,7 +169,6 @@ func RegisterRBACAuthZService(
 				TLSClientConfig: rest.TLSClientConfig{
 					Insecure: cfg.Folder.Insecure,
 					CAFile:   cfg.Folder.CAFile,
-					CAData:   []byte{},
 				},
 				QPS:   50,
 				Burst: 100,

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -174,14 +173,6 @@ func RegisterRBACAuthZService(
 				Burst: 100,
 			}, nil
 		})
-	}
-
-	_ = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: false,
-			},
-		},
 	}
 
 	server := rbac.NewService(

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -165,6 +165,11 @@ func RegisterRBACAuthZService(
 				WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
 					return &tokenExhangeRoundTripper{te: exchangeClient, rt: rt}
 				},
+				TLSClientConfig: rest.TLSClientConfig{
+					// FIXME: We should provide ca cert so we can verify ceritificates
+					// https://github.com/grafana/identity-access-team/issues/1096
+					Insecure: true,
+				},
 				QPS:   50,
 				Burst: 100,
 			}, nil

--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -63,7 +63,10 @@ type RBACServerSettings struct {
 }
 
 type FolderAPISettings struct {
-	Host     string
+	// Host is hostname for folder api
+	Host string
+	// Insecure will skip verfication of ceritificates. Should only be used for testing
 	Insecure bool
-	CAFile   string
+	// CAFile is a filepath to trusted root certificates for server
+	CAFile string
 }

--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -65,7 +65,7 @@ type RBACServerSettings struct {
 type FolderAPISettings struct {
 	// Host is hostname for folder api
 	Host string
-	// Insecure will skip verfication of ceritificates. Should only be used for testing
+	// Insecure will skip verification of ceritificates. Should only be used for testing
 	Insecure bool
 	// CAFile is a filepath to trusted root certificates for server
 	CAFile string

--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -57,3 +57,13 @@ func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
 
 	return s, nil
 }
+
+type RBACServerSettings struct {
+	Folder FolderAPISettings
+}
+
+type FolderAPISettings struct {
+	Host     string
+	Insecure bool
+	CAFile   string
+}


### PR DESCRIPTION
**What is this feature?**
When using folder api we need to be able to control some tls settings.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/1115

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
