### PR TITLE
Navigation: Revert new items auto-expanding

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -36,7 +36,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
   const isActive = link === activeItem || (level === MAX_DEPTH && hasActiveChild);
   const [sectionExpanded, setSectionExpanded] = useLocalStorage(
     `grafana.navigation.expanded[${link.text}]`,
-    Boolean(hasActiveChild || link.isNew)
+    Boolean(hasActiveChild)
   );
   const showExpandButton = level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage);
   const item = useRef<HTMLLIElement>(null);


### PR DESCRIPTION
Reverts an extra change from https://github.com/grafana/grafana/pull/100409 so `isNew` nav items aren't expanded by default. The menu is already a bit overcluttered with stuff and the New! badge is more than enough to draw people's attention.