### PR TITLE
Graphite: Handle graphite series' with spaces

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -123,6 +123,46 @@ describe('graphiteDatasource', () => {
       expect(result.data[1].meta.notices).toBeUndefined();
       expect(result.data[1].refId).toBe('B');
     });
+    it('handles series with spaces in the name', () => {
+      const refIDMap = {
+        refIDA: 'A',
+        refIDB: 'B',
+      };
+      const result = ctx.ds.convertResponseToDataFrames(
+        createFetchResponse({
+          meta: {
+            stats: {
+              'executeplan.cache-hit-partial.count': 5,
+              'executeplan.cache-hit.count': 10,
+            },
+          },
+          series: [
+            {
+              target: 'series A with spaces refIDA',
+              datapoints: [
+                [100, 200],
+                [101, 201],
+              ],
+            },
+            {
+              target: 'series B with spaces refIDB',
+              datapoints: [
+                [200, 300],
+                [201, 301],
+              ],
+            },
+          ],
+        }),
+        refIDMap
+      );
+
+      expect(result.data.length).toBe(2);
+      expect(getFrameDisplayName(result.data[0])).toBe('series A with spaces');
+      expect(getFrameDisplayName(result.data[1])).toBe('series B with spaces');
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].refId).toBe('A');
+      expect(result.data[1].refId).toBe('B');
+    });
   });
 
   describe('When querying graphite with one target using query editor target spec', () => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -300,14 +300,11 @@ export class GraphiteDatasource
 
     for (let i = 0; i < series.length; i++) {
       const s = series[i];
-      // Retrieve the original refID of the query
-      const splitTarget = s.target.split(' ');
 
       let refId = '';
-      if (splitTarget.length === 1) {
-        // If there is only one element, it means that there is no refID
-        s.target = splitTarget[0];
-      } else {
+      // Retrieve the original refID of the query
+      const splitTarget = s.target.split(' ');
+      if (splitTarget.length > 1) {
         // refID should always be the last element
         refId = splitTarget.pop() || '';
         s.target = splitTarget.join(' ');

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -42,6 +42,7 @@ import {
   GraphiteQueryType,
   GraphiteType,
   MetricTankRequestMeta,
+  MetricTankSeriesMeta,
 } from './types';
 import { reduceError } from './utils';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
@@ -285,7 +286,13 @@ export class GraphiteDatasource
     }
 
     // Series are either at the root or under a node called 'series'
-    const series = result.data.series || result.data;
+    const series: Array<{
+      target: string;
+      title: string;
+      tags: Record<string, string | number>;
+      datapoints: Array<[number, number]>;
+      meta: MetricTankSeriesMeta[];
+    }> = result.data.series || result.data;
 
     if (!isArray(series)) {
       throw { message: 'Missing series in result', data: result };
@@ -294,9 +301,18 @@ export class GraphiteDatasource
     for (let i = 0; i < series.length; i++) {
       const s = series[i];
       // Retrieve the original refID of the query
-      const [target, refId] = s.target.split(' ');
-      s.target = target;
+      const splitTarget = s.target.split(' ');
 
+      let refId = '';
+      let target = '';
+      if (splitTarget.length === 1) {
+        // If there is only one element, it means that there is no refID
+        target = splitTarget[0];
+      } else {
+        // refID should always be the last element
+        refId = splitTarget.pop() || '';
+        s.target = splitTarget.join(' ');
+      }
       // Disables Grafana own series naming
       s.title = s.target;
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -304,10 +304,9 @@ export class GraphiteDatasource
       const splitTarget = s.target.split(' ');
 
       let refId = '';
-      let target = '';
       if (splitTarget.length === 1) {
         // If there is only one element, it means that there is no refID
-        target = splitTarget[0];
+        s.target = splitTarget[0];
       } else {
         // refID should always be the last element
         refId = splitTarget.pop() || '';


### PR DESCRIPTION
Graphite series names can have spaces. The logic introduced to add `refID` values to frames led to series names with spaces being incorrectly truncated.

Fixes a bug introduced in #99911.