### PR TITLE
Alerting: Fix notification templates layout

### DIFF
--- a/public/app/features/alerting/unified/Templates.tsx
+++ b/public/app/features/alerting/unified/Templates.tsx
@@ -1,6 +1,5 @@
 import { Route, Routes } from 'react-router-dom-v5-compat';
 
-import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import DuplicateMessageTemplate from './components/contact-points/DuplicateMessageTemplate';
 import EditMessageTemplate from './components/contact-points/EditMessageTemplate';
 import NewMessageTemplate from './components/contact-points/NewMessageTemplate';
@@ -8,21 +7,11 @@ import { withPageErrorBoundary } from './withPageErrorBoundary';
 
 function NotificationTemplates() {
   return (
-    <AlertmanagerPageWrapper
-      navId="receivers"
-      accessType="notification"
-      pageNav={{
-        id: 'templates',
-        text: 'Notification templates',
-        subTitle: 'Create and edit a group of notification templates',
-      }}
-    >
-      <Routes>
-        <Route path=":name/edit" element={<EditMessageTemplate />} />
-        <Route path="new" element={<NewMessageTemplate />} />
-        <Route path=":name/duplicate" element={<DuplicateMessageTemplate />} />
-      </Routes>
-    </AlertmanagerPageWrapper>
+    <Routes>
+      <Route path="new" element={<NewMessageTemplate />} />
+      <Route path=":name/edit" element={<EditMessageTemplate />} />
+      <Route path=":name/duplicate" element={<DuplicateMessageTemplate />} />
+    </Routes>
   );
 }
 

--- a/public/app/features/alerting/unified/components/contact-points/DuplicateMessageTemplate.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/DuplicateMessageTemplate.tsx
@@ -2,16 +2,19 @@ import { useParams } from 'react-router-dom-v5-compat';
 
 import { Alert, LoadingPlaceholder } from '@grafana/ui';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
+import { t } from 'app/core/internationalization';
 
 import { isNotFoundError } from '../../api/util';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { generateCopiedName } from '../../utils/duplicate';
 import { stringifyErrorLike } from '../../utils/misc';
 import { updateDefinesWithUniqueValue } from '../../utils/templates';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 import { TemplateForm } from '../receivers/TemplateForm';
 
+import { ActiveTab } from './ContactPoints';
 import { useGetNotificationTemplate, useNotificationTemplates } from './useNotificationTemplates';
 
 const notFoundComponent = <EntityNotFound entity="Notification template" />;
@@ -23,15 +26,18 @@ const DuplicateMessageTemplateComponent = () => {
 
   const {
     currentData: template,
-    isLoading,
-    error,
+    isLoading: isLoadingTemplate,
+    error: templateFetchError,
   } = useGetNotificationTemplate({ alertmanager: selectedAlertmanager ?? '', uid: templateUid ?? '' });
 
   const {
     currentData: templates,
     isLoading: templatesLoading,
-    error: templatesError,
+    error: templatesFetchError,
   } = useNotificationTemplates({ alertmanager: selectedAlertmanager ?? '' });
+
+  const isLoading = isLoadingTemplate || templatesLoading;
+  const error = templateFetchError || templatesFetchError;
 
   if (!selectedAlertmanager) {
     return <EntityNotFound entity="Alertmanager" />;
@@ -41,11 +47,11 @@ const DuplicateMessageTemplateComponent = () => {
     return <EntityNotFound entity="Notification template" />;
   }
 
-  if (isLoading || templatesLoading) {
+  if (isLoading) {
     return <LoadingPlaceholder text="Loading notification template" />;
   }
 
-  if (error || templatesError || !template || !templates) {
+  if (error) {
     return isNotFoundError(error) ? (
       notFoundComponent
     ) : (
@@ -53,6 +59,10 @@ const DuplicateMessageTemplateComponent = () => {
         {stringifyErrorLike(error)}
       </Alert>
     );
+  }
+
+  if (!template) {
+    return notFoundComponent;
   }
 
   const duplicatedName = generateCopiedName(template.title, templates?.map((t) => t.title) ?? []);
@@ -67,7 +77,24 @@ const DuplicateMessageTemplateComponent = () => {
 
 function DuplicateMessageTemplate() {
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
+    <AlertmanagerPageWrapper
+      navId="receivers"
+      accessType="notification"
+      pageNav={{
+        id: 'templates',
+        text: t('alerting.notification-templates.duplicate.title', 'Duplicate notification template group'),
+        subTitle: t(
+          'alerting.notification-templates.duplicate.subTitle',
+          'Duplicate a group of notification templates'
+        ),
+        parentItem: {
+          text: t('alerting.common.titles.notification-templates', 'Notification Templates'),
+          url: createRelativeUrl('/alerting/notifications', {
+            tab: ActiveTab.NotificationTemplates,
+          }),
+        },
+      }}
+    >
       <DuplicateMessageTemplateComponent />
     </AlertmanagerPageWrapper>
   );

--- a/public/app/features/alerting/unified/components/contact-points/EditMessageTemplate.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/EditMessageTemplate.tsx
@@ -2,14 +2,17 @@ import { useParams } from 'react-router-dom-v5-compat';
 
 import { Alert, LoadingPlaceholder } from '@grafana/ui';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
+import { t } from 'app/core/internationalization';
 
 import { isNotFoundError } from '../../api/util';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { stringifyErrorLike } from '../../utils/misc';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 import { TemplateForm } from '../receivers/TemplateForm';
 
+import { ActiveTab } from './ContactPoints';
 import { useGetNotificationTemplate } from './useNotificationTemplates';
 
 const notFoundComponent = <EntityNotFound entity="Notification template" />;
@@ -19,7 +22,7 @@ const EditMessageTemplateComponent = () => {
   const templateUid = name ? decodeURIComponent(name) : undefined;
 
   const { selectedAlertmanager } = useAlertmanager();
-  const { currentData, isLoading, error } = useGetNotificationTemplate({
+  const { currentData, isLoading, error, isUninitialized } = useGetNotificationTemplate({
     alertmanager: selectedAlertmanager ?? '',
     uid: templateUid ?? '',
   });
@@ -28,7 +31,7 @@ const EditMessageTemplateComponent = () => {
     return <EntityNotFound entity="Notification template" />;
   }
 
-  if (isLoading) {
+  if (isLoading || isUninitialized) {
     return <LoadingPlaceholder text="Loading template..." />;
   }
 
@@ -51,7 +54,21 @@ const EditMessageTemplateComponent = () => {
 
 function EditMessageTemplate() {
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
+    <AlertmanagerPageWrapper
+      navId="receivers"
+      accessType="notification"
+      pageNav={{
+        id: 'templates',
+        text: t('alerting.notification-templates.edit.title', 'Edit notification template group'),
+        subTitle: t('alerting.notification-templates.edit.subTitle', 'Edit a group of notification templates'),
+        parentItem: {
+          text: t('alerting.common.titles.notification-templates', 'Notification Templates'),
+          url: createRelativeUrl('/alerting/notifications', {
+            tab: ActiveTab.NotificationTemplates,
+          }),
+        },
+      }}
+    >
       <EditMessageTemplateComponent />
     </AlertmanagerPageWrapper>
   );

--- a/public/app/features/alerting/unified/components/contact-points/NewMessageTemplate.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/NewMessageTemplate.tsx
@@ -1,16 +1,38 @@
+import { t } from 'app/core/internationalization';
+
 import { useAlertmanager } from '../../state/AlertmanagerContext';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 import { TemplateForm } from '../receivers/TemplateForm';
 
-function NewMessageTemplate() {
-  const { selectedAlertmanager } = useAlertmanager();
+import { ActiveTab } from './ContactPoints';
 
+function NewMessageTemplatePage() {
   return (
-    <AlertmanagerPageWrapper navId="receivers" accessType="notification">
-      <TemplateForm alertmanager={selectedAlertmanager ?? ''} />
+    <AlertmanagerPageWrapper
+      navId="receivers"
+      accessType="notification"
+      pageNav={{
+        id: 'templates',
+        text: t('alerting.notification-templates.new.title', 'New notification template group'),
+        subTitle: t('alerting.notification-templates.new.subTitle', 'Create a new group of notification templates'),
+        parentItem: {
+          text: t('alerting.common.titles.notification-templates', 'Notification Templates'),
+          url: createRelativeUrl('/alerting/notifications', {
+            tab: ActiveTab.NotificationTemplates,
+          }),
+        },
+      }}
+    >
+      <NewMessageTemplate />
     </AlertmanagerPageWrapper>
   );
 }
 
-export default withPageErrorBoundary(NewMessageTemplate);
+function NewMessageTemplate() {
+  const { selectedAlertmanager } = useAlertmanager();
+  return <TemplateForm alertmanager={selectedAlertmanager ?? ''} />;
+}
+
+export default withPageErrorBoundary(NewMessageTemplatePage);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -295,6 +295,9 @@
       "export-all": "Export all",
       "loading": "Loading...",
       "search-by-matchers": "Search by matchers",
+      "titles": {
+        "notification-templates": "Notification Templates"
+      },
       "view": "View"
     },
     "contact-points": {
@@ -403,6 +406,20 @@
       "preview-routing": "Preview routing",
       "title": "Alert instance routing preview",
       "uninitialized": "When you have your folder selected and your query and labels are configured, click \"Preview routing\" to see the results here."
+    },
+    "notification-templates": {
+      "duplicate": {
+        "subTitle": "Duplicate a group of notification templates",
+        "title": "Duplicate notification template group"
+      },
+      "edit": {
+        "subTitle": "Edit a group of notification templates",
+        "title": "Edit notification template group"
+      },
+      "new": {
+        "subTitle": "Create a new group of notification templates",
+        "title": "New notification template group"
+      }
     },
     "policies": {
       "default-policy": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -295,6 +295,9 @@
       "export-all": "Ēχpőřŧ äľľ",
       "loading": "Ŀőäđįŉģ...",
       "search-by-matchers": "Ŝęäřčĥ þy mäŧčĥęřş",
+      "titles": {
+        "notification-templates": "Ńőŧįƒįčäŧįőŉ Ŧęmpľäŧęş"
+      },
       "view": "Vįęŵ"
     },
     "contact-points": {
@@ -403,6 +406,20 @@
       "preview-routing": "Přęvįęŵ řőūŧįŉģ",
       "title": "Åľęřŧ įŉşŧäŉčę řőūŧįŉģ přęvįęŵ",
       "uninitialized": "Ŵĥęŉ yőū ĥävę yőūř ƒőľđęř şęľęčŧęđ äŉđ yőūř qūęřy äŉđ ľäþęľş äřę čőŉƒįģūřęđ, čľįčĸ \"Přęvįęŵ řőūŧįŉģ\" ŧő şęę ŧĥę řęşūľŧş ĥęřę."
+    },
+    "notification-templates": {
+      "duplicate": {
+        "subTitle": "Đūpľįčäŧę ä ģřőūp őƒ ŉőŧįƒįčäŧįőŉ ŧęmpľäŧęş",
+        "title": "Đūpľįčäŧę ŉőŧįƒįčäŧįőŉ ŧęmpľäŧę ģřőūp"
+      },
+      "edit": {
+        "subTitle": "Ēđįŧ ä ģřőūp őƒ ŉőŧįƒįčäŧįőŉ ŧęmpľäŧęş",
+        "title": "Ēđįŧ ŉőŧįƒįčäŧįőŉ ŧęmpľäŧę ģřőūp"
+      },
+      "new": {
+        "subTitle": "Cřęäŧę ä ŉęŵ ģřőūp őƒ ŉőŧįƒįčäŧįőŉ ŧęmpľäŧęş",
+        "title": "Ńęŵ ŉőŧįƒįčäŧįőŉ ŧęmpľäŧę ģřőūp"
+      }
     },
     "policies": {
       "default-policy": {


### PR DESCRIPTION
**What is this feature?**

This PR fixes a small regression in notification template layout and adds some translations while I'm at it.

Also removes the app chrome buttons in favor of buttons in the form.

<details><summary>Before</summary>
<img width="1745" alt="image" src="https://github.com/user-attachments/assets/80307d91-935e-4b85-92f9-e7a2f7b5bfa6" />

</details> 

After
<img width="1745" alt="Screenshot 2025-02-24 at 17 07 09" src="https://github.com/user-attachments/assets/8b36622b-4971-410f-89b7-b344f925280a" />
