### PR TITLE
Ks8/Folders: Fix status codes returned on GET

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -142,7 +142,8 @@ func (s *legacyStorage) Get(ctx context.Context, name string, options *metav1.Ge
 		if errors.Is(err, dashboards.ErrFolderNotFound) || err == nil {
 			err = resourceInfo.NewNotFound(name)
 		}
-		return nil, err
+		statusErr := apierrors.ToFolderStatusError(err)
+		return nil, &statusErr
 	}
 
 	r, err := convertToK8sResource(dto, s.namespacer)


### PR DESCRIPTION
**What is this feature?**

Similar to https://github.com/grafana/grafana/pull/95055 but for folder fetching - return the correct status code if we fail to fetch a folder.

Eg, if access to a folder is denied, we now return 403 instead of 500, so the error is correctly dealt with [here](https://github.com/grafana/grafana/blob/3e6f40c87386984be60e391b26a7559e3469dac3/pkg/api/dashboard.go#L204) .

**Why do we need this feature?**

To allow a user to view nested dashboard if a user has access to this dashboard but not some of its parent folders.

**Who is this feature for?**

Internal

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1182

**Special notes for your reviewer:**

To repro the issue and check that it's been fixed:
* set the following config:
```
[feature_toggles]
kubernetesCliDashboards = true
kubernetesClientDashboardsFolders = true
kubernetesFoldersServiceV2 = true
unifiedStorageSearchUI = true

[unified_storage.folders.folder.grafana.app]
dualWriterMode = 1
dualWriterPeriodicDataSyncJobEnabled = true

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 1
dualWriterPeriodicDataSyncJobEnabled = true
```
* run Grafana and create a user with None role and some nested folders;
* grant the user access to one of the nested folders (but not the root folder);
* create a dashboard in this nested folder;
* try to access this dashboard as the user with None role.