### PR TITLE
[Provisioning] Use smaller methods to process repository events

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -51,11 +51,6 @@ type queueItem struct {
 	attempts int
 }
 
-type syncDecision struct {
-	shouldSkip  bool
-	incremental bool
-}
-
 // RepositoryController controls how and when CRD is established.
 type RepositoryController struct {
 	client         client.ProvisioningV0alpha1Interface

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -51,6 +51,11 @@ type queueItem struct {
 	attempts int
 }
 
+type syncDecision struct {
+	shouldSkip  bool
+	incremental bool
+}
+
 // RepositoryController controls how and when CRD is established.
 type RepositoryController struct {
 	client         client.ProvisioningV0alpha1Interface
@@ -246,6 +251,183 @@ func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provision
 	return nil
 }
 
+func (rc *RepositoryController) shouldCheckHealth(obj *provisioning.Repository) bool {
+	if obj.Status.Health.Checked == 0 || obj.Generation != obj.Status.ObservedGeneration {
+		return true
+	}
+
+	healthAge := time.Since(time.UnixMilli(obj.Status.Health.Checked))
+	if obj.Status.Health.Healthy {
+		return healthAge > time.Minute*5 // when healthy, check every 5 mins
+	}
+
+	return healthAge > time.Minute // otherwise within a minute
+}
+
+func (rc *RepositoryController) runHealthCheck(ctx context.Context, repo repository.Repository) provisioning.HealthStatus {
+	logger := logging.FromContext(ctx)
+	logger.Info("running health check")
+	res, err := rc.tester.TestRepository(ctx, repo)
+	if err != nil {
+		res = &provisioning.TestResults{
+			Success: false,
+			Errors: []string{
+				"error running test repository",
+				err.Error(),
+			},
+		}
+	}
+
+	healthStatus := provisioning.HealthStatus{
+		Healthy: res.Success,
+		Checked: time.Now().UnixMilli(),
+		Message: res.Errors,
+	}
+	logger.Info("health check completed", "status", healthStatus)
+
+	return healthStatus
+}
+
+func (rc *RepositoryController) shouldResync(obj *provisioning.Repository) bool {
+	// don't trigger resync if a sync was never started
+	if obj.Status.Sync.Finished == 0 && obj.Status.Sync.State == "" {
+		return false
+	}
+
+	syncAge := time.Since(time.UnixMilli(obj.Status.Sync.Finished))
+	syncInterval := time.Duration(obj.Spec.Sync.IntervalSeconds) * time.Second
+	tolerance := time.Second
+
+	// HACK: how would this work in a multi-tenant world or under heavy load?
+	// It will start queueing up jobs and we will have to deal with that
+	pendingForTooLong := syncAge >= syncInterval/2 && obj.Status.Sync.State == provisioning.JobStatePending
+	isRunning := obj.Status.Sync.State == provisioning.JobStateWorking
+
+	return obj.Spec.Sync.Enabled && syncAge >= (syncInterval-tolerance) && !pendingForTooLong && !isRunning
+}
+
+func (rc *RepositoryController) runHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) (*provisioning.WebhookStatus, error) {
+	logger := logging.FromContext(ctx)
+	hooks, _ := repo.(repository.Hooks)
+	if hooks == nil || obj.Generation == obj.Status.ObservedGeneration {
+		return nil, nil
+	}
+
+	if obj.Status.ObservedGeneration < 1 {
+		logger.Info("handle repository create")
+		webhookStatus, err := hooks.OnCreate(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error running OnCreate: %w", err)
+		}
+		return webhookStatus, nil
+	}
+
+	logger.Info("handle repository spec update", "Generation", obj.Generation, "ObservedGeneration", obj.Status.ObservedGeneration)
+	webhookStatus, err := hooks.OnUpdate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error running OnUpdate: %w", err)
+	}
+
+	return webhookStatus, nil
+}
+
+func (rc *RepositoryController) determineSyncStrategy(ctx context.Context, obj *provisioning.Repository, shouldResync bool, healthStatus provisioning.HealthStatus) *provisioning.SyncJobOptions {
+	logger := logging.FromContext(ctx)
+
+	switch {
+	case !obj.Spec.Sync.Enabled:
+		logger.Info("skip sync as it's disabled")
+		return nil
+	case !healthStatus.Healthy:
+		logger.Info("skip sync for unhealthy repository")
+		return nil
+	case dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, rc.dualwrite):
+		logger.Info("skip sync as we are reading from legacy storage")
+		return nil
+	case healthStatus.Healthy != obj.Status.Health.Healthy:
+		logger.Info("repository became healthy, full resync")
+		return &provisioning.SyncJobOptions{}
+	case obj.Status.ObservedGeneration < 1:
+		logger.Info("full sync for new repository")
+		return &provisioning.SyncJobOptions{}
+	case obj.Generation != obj.Status.ObservedGeneration:
+		logger.Info("full sync for spec change")
+		return &provisioning.SyncJobOptions{}
+	case shouldResync:
+		logger.Info("incremental sync for sync interval")
+		return &provisioning.SyncJobOptions{Incremental: true}
+	default:
+		return nil
+	}
+}
+
+func (rc *RepositoryController) addSyncJob(ctx context.Context, obj *provisioning.Repository, syncOptions *provisioning.SyncJobOptions) error {
+	job, err := rc.jobs.Add(ctx, &provisioning.Job{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: obj.Namespace,
+		},
+		Spec: provisioning.JobSpec{
+			Repository: obj.GetName(),
+			Action:     provisioning.JobActionSync,
+			Sync:       syncOptions,
+		},
+	})
+	if err != nil {
+		// FIXME: should we update the status of the repository if we fail to add the job?
+		return fmt.Errorf("error adding sync job: %w", err)
+	}
+
+	logging.FromContext(ctx).Info("sync job triggered", "job", job.Name)
+	return nil
+}
+
+func (rc *RepositoryController) patchStatus(ctx context.Context, obj *provisioning.Repository, patchOperations []map[string]interface{}) error {
+	if len(patchOperations) == 0 {
+		return nil
+	}
+
+	patch, err := json.Marshal(patchOperations)
+	if err != nil {
+		return fmt.Errorf("error encoding status patch: %w", err)
+	}
+
+	_, err = rc.client.Repositories(obj.GetNamespace()).
+		Patch(ctx, obj.Name, types.JSONPatchType, patch, v1.PatchOptions{}, "status")
+	if err != nil {
+		return fmt.Errorf("error applying status patch: %w", err)
+	}
+
+	return nil
+}
+
+func (rc *RepositoryController) determineSyncStatus(obj *provisioning.Repository, syncOptions *provisioning.SyncJobOptions) *provisioning.SyncStatus {
+	const unhealthyMessage = "Repository is unhealthy"
+
+	hasUnhealthyMessage := len(obj.Status.Sync.Message) > 0 && obj.Status.Sync.Message[0] == unhealthyMessage
+	switch {
+	case syncOptions != nil:
+		return &provisioning.SyncStatus{
+			State:   provisioning.JobStatePending,
+			LastRef: obj.Status.Sync.LastRef,
+			Started: time.Now().UnixMilli(),
+		}
+	case obj.Status.Health.Healthy && hasUnhealthyMessage: // if the repository is healthy and the message is set, clear it
+		// FIXME: is this the clearest way to do this? Should we introduce another status or way of way of handling more
+		// specific errors?
+		return &provisioning.SyncStatus{
+			LastRef: obj.Status.Sync.LastRef,
+		}
+	case !obj.Status.Health.Healthy && !hasUnhealthyMessage: // if the repository is unhealthy and the message is not already set, set it
+		return &provisioning.SyncStatus{
+			State:   provisioning.JobStateError,
+			Message: []string{unhealthyMessage},
+			LastRef: obj.Status.Sync.LastRef,
+		}
+	default:
+		return nil
+	}
+}
+
 //nolint:gocyclo
 func (rc *RepositoryController) process(item *queueItem) error {
 	logger := rc.logger.With("key", item.key)
@@ -274,34 +456,12 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		return rc.handleDelete(ctx, obj)
 	}
 
-	healthAge := time.Since(time.UnixMilli(obj.Status.Health.Checked))
-	syncAge := time.Since(time.UnixMilli(obj.Status.Sync.Finished))
-	if obj.Status.Sync.Finished == 0 && obj.Status.Sync.State == "" {
-		syncAge = 0 // don't trigger resync unless there was previously a sync
-	}
-
-	syncInterval := time.Duration(obj.Spec.Sync.IntervalSeconds) * time.Second
-	tolerance := time.Second
-	// HACK: how would this work in a multi-tenant world or under heavy load?
-	// It will start queueing up jobs and we will have to deal with that
-	pendingForTooLong := syncAge >= syncInterval/2 && obj.Status.Sync.State == provisioning.JobStatePending
-	isRunning := obj.Status.Sync.State == provisioning.JobStateWorking
-	shouldResync := obj.Spec.Sync.Enabled && syncAge >= (syncInterval-tolerance) && !pendingForTooLong && !isRunning
+	shouldResync := rc.shouldResync(obj)
+	shouldCheckHealth := rc.shouldCheckHealth(obj)
 	hasSpecChanged := obj.Generation != obj.Status.ObservedGeneration
 	patchOperations := []map[string]interface{}{}
 
-	var shouldHealthcheck bool
-	switch {
-	case hasSpecChanged:
-		shouldHealthcheck = true
-	case obj.Status.Health.Checked == 0:
-		shouldHealthcheck = true
-	case obj.Status.Health.Healthy:
-		shouldHealthcheck = healthAge > time.Minute*5 // when healthy, check every 5 mins
-	default:
-		shouldHealthcheck = healthAge > time.Minute // otherwise within a minute
-	}
-
+	// Determine the main triggering condition
 	switch {
 	case hasSpecChanged:
 		logger.Info("spec changed", "Generation", obj.Generation, "ObservedGeneration", obj.Status.ObservedGeneration)
@@ -310,10 +470,10 @@ func (rc *RepositoryController) process(item *queueItem) error {
 			"path":  "/status/observedGeneration",
 			"value": obj.Generation,
 		})
-	case shouldResync && obj.Status.Health.Healthy:
-		logger.Info("sync interval triggered", "sync_age", syncAge, "sync_interval", syncInterval, "sync_status", obj.Status.Sync)
-	case shouldHealthcheck:
-		logger.Info("health check is too old", "heath_age", healthAge, "health_status", obj.Status.Health.Healthy)
+	case shouldResync:
+		logger.Info("sync interval triggered", "sync_interval", time.Duration(obj.Spec.Sync.IntervalSeconds)*time.Second, "sync_status", obj.Status.Sync)
+	case shouldCheckHealth:
+		logger.Info("health is stale", "health_status", obj.Status.Health.Healthy)
 	default:
 		logger.Info("skipping as conditions are not met", "status", obj.Status, "generation", obj.Generation, "sync_spec", obj.Spec.Sync)
 		return nil
@@ -324,173 +484,49 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		return fmt.Errorf("unable to create repository from configuration: %w", err)
 	}
 
-	// Safe to edit the repository from here
-	obj = obj.DeepCopy()
-	hooks, _ := repo.(repository.Hooks)
-
-	var healthStatusChanged bool
-	if shouldHealthcheck {
-		logger.Info("running health check", "healthAge", healthAge)
-		res, err := rc.tester.TestRepository(ctx, repo)
-		if err != nil {
-			res = &provisioning.TestResults{
-				Success: false,
-				Errors: []string{
-					"error running test repository",
-					err.Error(),
-				},
-			}
-		}
-
-		// Create timestamp once and use it consistently
-		now := time.Now().UnixMilli()
-		healthStatus := provisioning.HealthStatus{
-			Healthy: res.Success,
-			Checked: now,
-			Message: res.Errors,
-		}
-		healthStatusChanged = (healthStatus.Healthy != obj.Status.Health.Healthy) || obj.Status.Health.Checked == 0
-		obj.Status.Health = healthStatus
-
-		// Add health status patch operation
+	healthStatus := obj.Status.Health
+	if shouldCheckHealth {
+		healthStatus = rc.runHealthCheck(ctx, repo)
 		patchOperations = append(patchOperations, map[string]interface{}{
 			"op":    "replace",
 			"path":  "/status/health",
 			"value": healthStatus,
 		})
-
-		logger.Info("health check completed",
-			"healthy", res.Success,
-			"checked", now,
-			"errors", len(res.Errors))
 	}
 
-	var (
-		incremental    bool
-		shouldSkipSync bool
-	)
-
-	switch {
-	case !obj.Spec.Sync.Enabled:
-		logger.Info("skip sync as it's disabled")
-		shouldSkipSync = true
-	case !obj.Status.Health.Healthy:
-		logger.Info("skip sync for unhealthy repository")
-		shouldSkipSync = true
-	case obj.Status.ObservedGeneration < 1:
-		logger.Info("handle repository create")
-		if hooks != nil {
-			webhookStatus, err := hooks.OnCreate(ctx)
-			if err != nil {
-				return fmt.Errorf("error running OnCreate: %w", err)
-			}
-			patchOperations = append(patchOperations, map[string]interface{}{
-				"op":    "replace",
-				"path":  "/status/webhook",
-				"value": webhookStatus,
-			})
-		}
-	case hasSpecChanged:
-		logger.Info("handle repository spec update", "Generation", obj.Generation, "ObservedGeneration", obj.Status.ObservedGeneration)
-		if hooks != nil {
-			webhookStatus, err := hooks.OnUpdate(ctx)
-			if err != nil {
-				return fmt.Errorf("error running OnCreate: %w", err)
-			}
-			patchOperations = append(patchOperations, map[string]interface{}{
-				"op":    "replace",
-				"path":  "/status/webhook",
-				"value": webhookStatus,
-			})
-		}
-	case healthStatusChanged:
-		logger.Info("repository became healthy, full resync")
-	case shouldResync:
-		logger.Info("handle repository resync")
-		incremental = true
-	case shouldHealthcheck:
-		logger.Info("skip sync as health didn't change")
-		shouldSkipSync = true
-	default:
-		return errors.New("unknown repository situation")
-	}
-
-	if !shouldSkipSync && dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, rc.dualwrite) {
-		logger.Info("skip sync as we are reading from legacy storage")
-		shouldSkipSync = true
-	}
-
-	isUnhealthyMsg := "Repository is unhealthy"
-	isUnhealthySyncStatus := len(obj.Status.Sync.Message) > 0 && obj.Status.Sync.Message[0] == isUnhealthyMsg && obj.Status.Sync.State == provisioning.JobStateError
-
-	// Preserve last ref as we use replace operation
-	lastRef := obj.Status.Sync.LastRef
-	switch {
-	case !shouldSkipSync:
+	// Run hooks
+	webhookStatus, err := rc.runHooks(ctx, repo, obj)
+	if err != nil {
+		return err
+	} else if webhookStatus != nil {
 		patchOperations = append(patchOperations, map[string]interface{}{
-			"op":   "replace",
-			"path": "/status/sync",
-			"value": provisioning.SyncStatus{
-				LastRef: lastRef,
-				State:   provisioning.JobStatePending,
-				Started: time.Now().UnixMilli(),
-			},
-		})
-	case obj.Status.Health.Healthy && isUnhealthySyncStatus:
-		// clear the sync status
-		// FIXME: is this the clearest way to do this? Should we introduce another status or way of way of handling more
-		// specific errors?
-		patchOperations = append(patchOperations, map[string]interface{}{
-			"op":   "replace",
-			"path": "/status/sync",
-			"value": provisioning.SyncStatus{
-				LastRef: lastRef,
-			},
-		})
-	case !obj.Status.Health.Healthy && !isUnhealthySyncStatus:
-		// If health check fails, add sync state patch operation
-		patchOperations = append(patchOperations, map[string]interface{}{
-			"op":   "replace",
-			"path": "/status/sync",
-			"value": provisioning.SyncStatus{
-				LastRef: lastRef,
-				State:   provisioning.JobStateError,
-				Message: []string{isUnhealthyMsg},
-			},
+			"op":    "replace",
+			"path":  "/status/webhook",
+			"value": webhookStatus,
 		})
 	}
 
-	// Apply all collected patch operations if we have any
-	if len(patchOperations) > 0 {
-		patch, err := json.Marshal(patchOperations)
-		if err != nil {
-			return fmt.Errorf("error encoding status patch: %w", err)
-		}
+	// determine the sync strategy
+	syncOptions := rc.determineSyncStrategy(ctx, obj, shouldResync, healthStatus)
+	// determine the sync status
+	if syncStatus := rc.determineSyncStatus(obj, syncOptions); syncStatus != nil {
+		patchOperations = append(patchOperations, map[string]interface{}{
+			"op":    "replace",
+			"path":  "/status/sync",
+			"value": syncStatus,
+		})
+	}
 
-		_, err = rc.client.Repositories(obj.GetNamespace()).
-			Patch(ctx, obj.Name, types.JSONPatchType, patch, v1.PatchOptions{}, "status")
-		if err != nil {
-			return fmt.Errorf("error applying status patch: %w", err)
-		}
+	// Apply all patch operations
+	if err := rc.patchStatus(ctx, obj, patchOperations); err != nil {
+		return err
 	}
 
 	// Trigger sync job after we have applied all patch operations
-	if !shouldSkipSync {
-		job, err := rc.jobs.Add(ctx, &provisioning.Job{
-			ObjectMeta: v1.ObjectMeta{
-				Namespace: obj.Namespace,
-			},
-			Spec: provisioning.JobSpec{
-				Repository: obj.GetName(),
-				Action:     provisioning.JobActionSync,
-				Sync:       &provisioning.SyncJobOptions{Incremental: incremental},
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("error adding sync job: %w", err)
+	if syncOptions != nil {
+		if err := rc.addSyncJob(ctx, obj, syncOptions); err != nil {
+			return err
 		}
-
-		logger.Info("sync job triggered", "job", job.Name)
 	}
 
 	return nil


### PR DESCRIPTION
# Why?

The current code is hard to read and understand. It's hard to follow the logic of the code. The number of conditions and code paths is too high.

# How?

- Create smaller methods to encapsulate the logic of the code.
- Remove object copy operation as we don't modify it.
- Make the controller logic trigger in 4 situations: spec changed, object deleted, re-sync and health check.
