### PR TITLE
Provisioning: Avoid localhost error loop

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -819,13 +819,23 @@ func (r *githubRepository) deleteWebhook(ctx context.Context) error {
 	return nil
 }
 
+func (r *githubRepository) supportsWebhook() bool {
+	u, err := url.Parse(r.webhookURL)
+	if err != nil || u.Hostname() == "localhost" {
+		return false
+	}
+	return true
+}
+
 func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.WebhookStatus, error) {
+	if !r.supportsWebhook() {
+		return nil, nil
+	}
 	ctx, _ = r.logger(ctx, "")
 	hook, err := r.createWebhook(ctx)
 	if err != nil {
 		return nil, err
 	}
-
 	return &provisioning.WebhookStatus{
 		ID:               hook.ID,
 		URL:              hook.URL,
@@ -835,6 +845,9 @@ func (r *githubRepository) OnCreate(ctx context.Context) (*provisioning.WebhookS
 }
 
 func (r *githubRepository) OnUpdate(ctx context.Context) (*provisioning.WebhookStatus, error) {
+	if !r.supportsWebhook() {
+		return nil, nil
+	}
 	ctx, _ = r.logger(ctx, "")
 	hook, _, err := r.updateWebhook(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently if you have not configured a valid public URL, the instance can end up in a healthcheck cycle.

This PR avoids the issue -- we should follow up with making it more clear in the UI what is missing!