### PR TITLE
SSE: Group queries only for supported data sources

### DIFF
--- a/pkg/expr/graph_test.go
+++ b/pkg/expr/graph_test.go
@@ -284,6 +284,32 @@ func TestGetCommandsFromPipeline(t *testing.T) {
 	})
 }
 
+func TestIsGroupingSupportedDataSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsType   string
+		expected bool
+	}{
+		{
+			name:     "supported datasource should return true",
+			dsType:   "cloudwatch",
+			expected: true,
+		},
+		{
+			name:     "unsupported datasource should return false",
+			dsType:   "prometheus",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isGroupByDSSupported(tt.dsType)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func getRefIDOrder(nodes []Node) []string {
 	ids := make([]string, 0, len(nodes))
 	for _, n := range nodes {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Group alerting/expression queries only for data sources that support it (currently only CloudWatch), when `sseGroupByDatasource` is enabled.

**Why do we need this feature?**

When the `sseGroupByDatasource` toggle was enabled it caused issues with some alerts due to the fact that the some data sources didn't support running a query where the different sub-queries had different ranges. This was fixed in Elastic, but we're likely to have this issue with other datasources if we just toggle it on.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #85558

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
