### PR TITLE
Dynamic dashboards: Make rows easier to select

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -34,8 +34,15 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
       ref={ref}
     >
       {(!isHeaderHidden || (isEditing && showHiddenElements)) && (
-        <div className={styles.rowHeader}>
+        <div
+          className={styles.rowHeader}
+          onPointerDown={(evt) => {
+            onSelect?.(evt);
+            evt.preventDefault();
+          }}
+        >
           <button
+            onPointerDown={(evt) => evt.stopPropagation()}
             onClick={() => model.onCollapseToggle()}
             className={styles.rowTitleButton}
             aria-label={


### PR DESCRIPTION
Makes it easier to select rows by making the whole empty area above the content clickable.

https://github.com/user-attachments/assets/d3a25cca-b0bc-40cc-980a-ad885563ac04

