### PR TITLE
SecureValues: add temporary allow list for decrypters

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -190,7 +191,7 @@ func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidat
 }
 
 // ValidateSecureValue does basic spec validation of a securevalue.
-func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admission.Operation) field.ErrorList {
+func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admission.Operation, decryptersAllowList []string) field.ErrorList {
 	errs := make(field.ErrorList, 0)
 
 	// Operation-specific field validation.
@@ -211,6 +212,16 @@ func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admiss
 
 	// If populated, `Decrypters` must match "{group}/{name OR *}" and must be unique.
 	for i, decrypter := range sv.Spec.Decrypters {
+		// Allow List: decrypters must match exactly and be in the allowed list to be able to decrypt.
+		if len(decryptersAllowList) > 0 && !slices.Contains(decryptersAllowList, decrypter) {
+			errs = append(
+				errs,
+				field.Invalid(field.NewPath("spec", "decrypters", "["+strconv.Itoa(i)+"]"), decrypter, fmt.Sprintf("allowed values: %v", decryptersAllowList)),
+			)
+
+			return errs
+		}
+
 		group, name, found := strings.Cut(decrypter, "/")
 		if !found {
 			errs = append(

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -116,7 +116,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 			newRaw.Object["spec"].(map[string]any)["title"] = "New title"
 			newRaw.Object["spec"].(map[string]any)["keeper"] = newKeeper.GetName()
 			newRaw.Object["spec"].(map[string]any)["value"] = "New secure value"
-			newRaw.Object["spec"].(map[string]any)["decrypters"] = []string{"decrypter1/name1", "decrypter2/*"}
+			newRaw.Object["spec"].(map[string]any)["decrypters"] = []string{}
 			newRaw.Object["metadata"].(map[string]any)["annotations"] = map[string]any{"newAnnotation": "newValue"}
 
 			updatedRaw, err := client.Resource.Update(ctx, newRaw, metav1.UpdateOptions{})

--- a/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
@@ -12,6 +12,5 @@ spec:
   keeper: my-keeper-1
   value: super duper secure
   decrypters:
-    - k6.grafana.app/app-name-1
-    - k6.grafana.app/app-name-2
-    - entity.grafana.app/*
+    - secrets/k6:decrypt
+    - secrets/synthetic-monitoring:decrypt

--- a/pkg/tests/apis/secret/testdata/secure-value-xyz.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-xyz.yaml
@@ -13,6 +13,4 @@ spec:
   keeper: my-keeper-1
   value: super duper secure
   decrypters:
-    - k6.grafana.app/app-name-1
-    - k6.grafana.app/app-name-2
-    - entity.grafana.app/*
+    - secrets/k6:decrypt


### PR DESCRIPTION
This PR adds a temporary hardcoded allow list for services that can decrypt `SecureValues`. 

Final names are not known yet, but this is a start.

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1186