### PR TITLE
User: Handle unique constraints errors

### DIFF
--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -605,7 +605,7 @@ func isUniqueConstraintError(err error) bool {
 	}
 
 	var se sqlite3.Error
-	if errors.As(err, &se) && se.Code == sqlite3.ErrConstraint {
+	if errors.As(err, &se) && se.ExtendedCode == sqlite3.ErrConstraintUnique {
 		return true
 	}
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -2,6 +2,7 @@ package userimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -593,7 +594,8 @@ func handleSQLError(err error) error {
 
 func isUniqueConstraintError(err error) bool {
 	// check mysql error code
-	if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1062 {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) && me.Number == 1062 {
 		return true
 	}
 
@@ -602,8 +604,8 @@ func isUniqueConstraintError(err error) bool {
 		return true
 	}
 
-	if se, ok := err.(sqlite3.Error); ok && se.Code == sqlite3.ErrConstraint {
-		fmt.Println(se.Code)
+	var se sqlite3.Error
+	if errors.As(err, &se) && se.Code == sqlite3.ErrConstraint {
 		return true
 	}
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -597,7 +597,7 @@ func isUniqueConstraintError(err error) bool {
 		return true
 	}
 
-	// for posgres we check the error message
+	// for postgres we check the error message
 	if strings.Contains(err.Error(), "duplicate key value") {
 		return true
 	}

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -68,6 +68,19 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("error on duplicated user", func(t *testing.T) {
+		_, err := userStore.Insert(context.Background(),
+			&user.User{
+				Email:   "test@email.com",
+				Name:    "test1",
+				Login:   "test1",
+				Created: time.Now(),
+				Updated: time.Now(),
+			},
+		)
+		require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+	})
+
 	t.Run("get user", func(t *testing.T) {
 		_, err := userStore.GetByEmail(context.Background(),
 			&user.GetUserByEmailQuery{Email: "test@email.com"},


### PR DESCRIPTION
**What is this feature?**
Followup to https://github.com/grafana/grafana/pull/100346#discussion_r1954508652. We should return `user.ErrUserAlreadyExists` whenever we get a unique constraint error when trying to insert a user.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1212

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
