### PR TITLE
Provisioning: Update token instructions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5884,7 +5884,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
     ],
     "public/app/features/provisioning/Wizard/ConnectionStep.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/provisioning/TokenPermissionsInfo.tsx
+++ b/public/app/features/provisioning/TokenPermissionsInfo.tsx
@@ -5,22 +5,31 @@ export function TokenPermissionsInfo() {
     <ControlledCollapse collapsible label="Access Token Permissions">
       <div>
         To create a new Access Token, navigate to{' '}
-        <TextLink external href="https://github.com/settings/tokens">
+        <TextLink external href="https://github.com/settings/personal-access-tokens/new">
           Personal Access Tokens
         </TextLink>{' '}
-        and click &quot;Generate new token.&quot;
       </div>
 
-      <p>Ensure that your token has the following permissions:</p>
-
-      <p>For all repositories:</p>
-      <pre>public_repo, repo:status, repo_deployment, read:packages, read:user, user:email</pre>
-
-      <p>For GitHub projects:</p>
-      <pre>read:org, read:project</pre>
-
-      <p>An extra setting is required for private repositories:</p>
-      <pre>repo (Full control of private repositories)</pre>
+      <p>Select the appropriate owner and repository. Then expand Repository permissions, granting</p>
+      <table>
+        <tr>
+          <td>Content</td>
+          <td>Read and write</td>
+        </tr>
+        <tr>
+          <td>Metadata</td>
+          <td>Read only</td>
+        </tr>
+        <tr>
+          <td>Pull requests&nbsp;</td>
+          <td>Read and write</td>
+        </tr>
+        <tr>
+          <td>Webhooks</td>
+          <td>Read and write &nbsp;&nbsp;</td>
+          <td>If this instance has a public URL, and should be notified of changes</td>
+        </tr>
+      </table>
     </ControlledCollapse>
   );
 }


### PR DESCRIPTION
The current instructions do not seem accurate -- this is a step towards having them a bit better... but I think we still need attention on this!

<img width="590" alt="image" src="https://github.com/user-attachments/assets/8eb62e7b-1640-4834-affa-d5885d6ceb1b" />

Linking to:
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/6f26d867-9534-4d24-b056-4e5655b4ba56" />


Before:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/a7f02652-2f30-4149-8a7d-a3ca2e31caf5" />
