### PR TITLE
Dashboards: Disable flaky import dashboard test in old architecture.

### DIFF
--- a/e2e/old-arch/dashboards-suite/import-dashboard.spec.ts
+++ b/e2e/old-arch/dashboards-suite/import-dashboard.spec.ts
@@ -8,5 +8,5 @@ describe('Import Dashboards Test', () => {
 
   it('Ensure you can import a number of json test dashboards from a specific test directory', () => {
     e2e.flows.importDashboard(testDashboard, 1000);
-  });
+  }).skip();
 });

--- a/e2e/old-arch/dashboards-suite/import-dashboard.spec.ts
+++ b/e2e/old-arch/dashboards-suite/import-dashboard.spec.ts
@@ -6,7 +6,7 @@ describe('Import Dashboards Test', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
-  it('Ensure you can import a number of json test dashboards from a specific test directory', () => {
+  it.skip('Ensure you can import a number of json test dashboards from a specific test directory', () => {
     e2e.flows.importDashboard(testDashboard, 1000);
-  }).skip();
+  });
 });


### PR DESCRIPTION
**What is this feature?**

Skips a flaky test in the import feature of the old architecture.


https://github.com/user-attachments/assets/b3771eb5-bd49-4156-9c97-eaddeef63281

