### PR TITLE
unistore: close event stream on context cancelation

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -124,11 +124,12 @@ func (b *broadcaster[T]) Subscribe(ctx context.Context) (<-chan T, error) {
 
 	// create the subscription
 	sub := make(chan T, 100)
-
 	select {
 	case <-ctx.Done(): // client canceled
+		close(sub)
 		return nil, ctx.Err()
 	case <-b.terminated: // no more data
+		close(sub)
 		return nil, io.EOF
 	case b.subscribe <- sub: // success submitting subscription
 		return sub, nil

--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -126,10 +126,8 @@ func (b *broadcaster[T]) Subscribe(ctx context.Context) (<-chan T, error) {
 	sub := make(chan T, 100)
 	select {
 	case <-ctx.Done(): // client canceled
-		close(sub)
 		return nil, ctx.Err()
 	case <-b.terminated: // no more data
-		close(sub)
 		return nil, io.EOF
 	case b.subscribe <- sub: // success submitting subscription
 		return sub, nil

--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -124,6 +124,7 @@ func (b *broadcaster[T]) Subscribe(ctx context.Context) (<-chan T, error) {
 
 	// create the subscription
 	sub := make(chan T, 100)
+
 	select {
 	case <-ctx.Done(): // client canceled
 		return nil, ctx.Err()

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,7 +107,7 @@ func TestCache(t *testing.T) {
 }
 
 func TestBroadcaster(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := testutil.NewDefaultTestContext(t)
 	ch := make(chan int)
 	input := []int{1, 2, 3}
 	go func() {
@@ -139,7 +140,7 @@ func TestBroadcaster(t *testing.T) {
 	require.Equal(t, len(input), count)
 
 	// cancel the context should close the stream
-	cancel()
+	ctx.Cancel()
 	_, ok := <-sub
 	require.False(t, ok)
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -919,10 +919,7 @@ func (s *server) initWatcher() error {
 			return err
 		}
 		go func() {
-			for {
-				// pipe all events
-				v := <-events
-
+			for v := range events {
 				if v == nil {
 					s.log.Error("received nil event")
 					continue

--- a/pkg/storage/unified/sql/notifier_sql.go
+++ b/pkg/storage/unified/sql/notifier_sql.go
@@ -120,6 +120,8 @@ func (p *pollingNotifier) poller(ctx context.Context, since groupResourceRV, str
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-p.done:
 			return
 		case <-t.C:

--- a/pkg/storage/unified/sql/notifier_sql_test.go
+++ b/pkg/storage/unified/sql/notifier_sql_test.go
@@ -390,7 +390,7 @@ func TestPollingNotifier(t *testing.T) {
 		select {
 		case _, ok := <-events:
 			require.False(t, ok, "events channel should be closed")
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(time.Second):
 			t.Fatal("timeout waiting for events channel to close")
 		}
 	})

--- a/pkg/storage/unified/sql/notifier_sql_test.go
+++ b/pkg/storage/unified/sql/notifier_sql_test.go
@@ -357,4 +357,41 @@ func TestPollingNotifier(t *testing.T) {
 			t.Fatal("timeout waiting for events channel to close")
 		}
 	})
+
+	t.Run("stops polling when context is cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		cfg := &pollingNotifierConfig{
+			dialect:         sqltemplate.SQLite,
+			pollingInterval: 10 * time.Millisecond,
+			watchBufferSize: 10,
+			log:             log.NewNopLogger(),
+			tracer:          noop.NewTracerProvider().Tracer("test"),
+			batchLock:       &batchLock{},
+			listLatestRVs:   func(ctx context.Context) (groupResourceRV, error) { return nil, nil },
+			historyPoll: func(ctx context.Context, grp string, res string, since int64) ([]*historyPollResponse, error) {
+				return nil, nil
+			},
+			done: make(chan struct{}),
+		}
+
+		notifier, err := newPollingNotifier(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, notifier)
+
+		events, err := notifier.notify(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, events)
+
+		cancel()
+
+		select {
+		case _, ok := <-events:
+			require.False(t, ok, "events channel should be closed")
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("timeout waiting for events channel to close")
+		}
+	})
 }

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -51,7 +51,7 @@ func RunStorageBackendTest(t *testing.T, newBackend NewBackendFunc, opts *TestOp
 		fn   func(*testing.T, resource.StorageBackend)
 	}{
 		{TestHappyPath, runTestIntegrationBackendHappyPath},
-		{TestWatchWriteEvents, runTestIntegrationBackendWatchWriteEventsFromLastest},
+		{TestWatchWriteEvents, runTestIntegrationBackendWatchWriteEvents},
 		{TestList, runTestIntegrationBackendList},
 		{TestBlobSupport, runTestIntegrationBlobSupport},
 		{TestGetResourceStats, runTestIntegrationBackendGetResourceStats},
@@ -272,7 +272,7 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 	})
 }
 
-func runTestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T, backend resource.StorageBackend) {
+func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.StorageBackend) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 
 	// Create a few resources before initing the watch
@@ -287,6 +287,12 @@ func runTestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T, backend 
 	_, err = writeEvent(ctx, backend, "item2", resource.WatchEvent_ADDED)
 	require.NoError(t, err)
 	require.Equal(t, "item2", (<-stream).Key.Name)
+
+	// Sould close the stream
+	ctx.Cancel()
+
+	_, ok := <-stream
+	require.False(t, ok)
 }
 
 func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend) {

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -288,7 +288,7 @@ func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.St
 	require.NoError(t, err)
 	require.Equal(t, "item2", (<-stream).Key.Name)
 
-	// Sould close the stream
+	// Should close the stream
 	ctx.Cancel()
 
 	_, ok := <-stream


### PR DESCRIPTION
Ensure all the streams are closed on context cancelation.

- Add tests for broadcaster.
- Update the Broadcaster to close the subscriber channels on context cancel.
- Update the SQL notifier to close the subscriber channels on context cancel.
