### PR TITLE
Transformations: Add round() to Unary mode of `Add field from calc`

### DIFF
--- a/packages/grafana-data/src/utils/unaryOperators.ts
+++ b/packages/grafana-data/src/utils/unaryOperators.ts
@@ -4,6 +4,7 @@ export enum UnaryOperationID {
   Abs = 'abs',
   Exp = 'exp',
   Ln = 'ln',
+  Round = 'round',
   Floor = 'floor',
   Ceil = 'ceil',
 }
@@ -34,6 +35,12 @@ export const unaryOperators = new Registry<UnaryOperatorInfo>(() => {
       name: 'Natural logarithm',
       operation: (value: number) => Math.log(value),
       unaryOperationID: UnaryOperationID.Ln,
+    },
+    {
+      id: UnaryOperationID.Round,
+      name: 'Ceiling',
+      operation: (value: number) => Math.round(value),
+      unaryOperationID: UnaryOperationID.Round,
     },
     {
       id: UnaryOperationID.Floor,

--- a/packages/grafana-data/src/utils/unaryOperators.ts
+++ b/packages/grafana-data/src/utils/unaryOperators.ts
@@ -38,7 +38,7 @@ export const unaryOperators = new Registry<UnaryOperatorInfo>(() => {
     },
     {
       id: UnaryOperationID.Round,
-      name: 'Ceiling',
+      name: 'Round',
       operation: (value: number) => Math.round(value),
       unaryOperationID: UnaryOperationID.Round,
     },


### PR DESCRIPTION
we had `floor()` and `ceil()` but were somehow missing `round()` :rofl: 

![image](https://github.com/user-attachments/assets/2be334b8-28d4-464d-89db-918c89194df9)