### PR TITLE
fix(timeseries): allow annotations without color/isRegion/timeEnd

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -142,7 +142,7 @@ export const AnnotationsPlugin2 = ({
           let yKey = config.scales[1].props.scaleKey;
 
           for (let i = 0; i < frame.length; i++) {
-            let color = getColorByName(vals.color[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
+            let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
 
             let x0 = u.valToPos(vals.xMin[i], xKey, true);
             let x1 = u.valToPos(vals.xMax[i], xKey, true);
@@ -173,12 +173,12 @@ export const AnnotationsPlugin2 = ({
           ctx.setLineDash([5, 5]);
 
           for (let i = 0; i < vals.time.length; i++) {
-            let color = getColorByName(vals.color[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
+            let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
 
             let x0 = u.valToPos(vals.time[i], 'x', true);
             renderLine(ctx, y0, y1, x0, color);
 
-            if (vals.isRegion[i]) {
+            if (vals.isRegion?.[i]) {
               let x1 = u.valToPos(vals.timeEnd[i], 'x', true);
               renderLine(ctx, y0, y1, x1, color);
 
@@ -216,14 +216,14 @@ export const AnnotationsPlugin2 = ({
       let markers: React.ReactNode[] = [];
 
       for (let i = 0; i < vals.time.length; i++) {
-        let color = getColorByName(vals.color[i] || DEFAULT_ANNOTATION_COLOR);
+        let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR);
         let left = Math.round(plot.valToPos(vals.time[i], 'x')) || 0; // handles -0
         let style: React.CSSProperties | null = null;
         let className = '';
         let isVisible = true;
 
-        if (vals.isRegion[i]) {
-          let right = Math.round(plot.valToPos(vals.timeEnd[i], 'x')) || 0; // handles -0
+        if (vals.isRegion?.[i]) {
+          let right = Math.round(plot.valToPos(vals.timeEnd?.[i], 'x')) || 0; // handles -0
 
           isVisible = left < plot.rect.width && right > 0;
 


### PR DESCRIPTION
**What is this feature?**

This PR adds the optional chaining ops back in to the relevant places so the defaults are used where needed.

**Why do we need this feature?**

Prior to #99480, frames could choose to omit the color, isRegion and timeEnd fields when representing annotations, and the default values would be used instead. That PR accidentally removed the optional chaining operators when accessing those fields, which causes the annotations plugin to throw an error if they're missing.

**Who is this feature for?**

Users of annotations in the time series panel.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/14881

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
