### PR TITLE
Alerting: Add rule group name to the rule title when converting Prometheus rules

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -203,6 +203,13 @@ func (p *Converter) convertRule(orgID int64, namespaceUID, group string, rule Pr
 		title = rule.Alert
 	}
 
+	// Temporary workaround for avoiding the uniqueness check for the rule title.
+	// In Grafana alert rule titles must be unique within the same org and folder,
+	// but Prometheus allows multiple rules with the same name. By adding the group name
+	// to the title we ensure that the title is unique within the group.
+	// TODO: Remove this workaround when we have a proper solution for handling rule title uniqueness.
+	title = fmt.Sprintf("[%s] %s", group, title)
+
 	labels := make(map[string]string, len(rule.Labels)+1)
 	for k, v := range rule.Labels {
 		labels[k] = v

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -132,12 +132,12 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				grafanaRule := grafanaGroup.Rules[j]
 
 				if promRule.Record != "" {
-					require.Equal(t, promRule.Record, grafanaRule.Title)
+					require.Equal(t, fmt.Sprintf("[%s] %s", tc.promGroup.Name, promRule.Record), grafanaRule.Title)
 					require.NotNil(t, grafanaRule.Record)
 					require.Equal(t, grafanaRule.Record.From, queryRefID)
 					require.Equal(t, promRule.Record, grafanaRule.Record.Metric)
 				} else {
-					require.Equal(t, promRule.Alert, grafanaRule.Title)
+					require.Equal(t, fmt.Sprintf("[%s] %s", tc.promGroup.Name, promRule.Alert), grafanaRule.Title)
 				}
 
 				var expectedFor time.Duration
@@ -205,10 +205,10 @@ func TestPrometheusRulesToGrafanaWithDuplicateRuleNames(t *testing.T) {
 
 	require.Equal(t, "test-group-1", group.Title)
 	require.Len(t, group.Rules, 4)
-	require.Equal(t, "alert", group.Rules[0].Title)
-	require.Equal(t, "alert (2)", group.Rules[1].Title)
-	require.Equal(t, "another alert", group.Rules[2].Title)
-	require.Equal(t, "alert (3)", group.Rules[3].Title)
+	require.Equal(t, "[test-group-1] alert", group.Rules[0].Title)
+	require.Equal(t, "[test-group-1] alert (2)", group.Rules[1].Title)
+	require.Equal(t, "[test-group-1] another alert", group.Rules[2].Title)
+	require.Equal(t, "[test-group-1] alert (3)", group.Rules[3].Title)
 }
 
 func TestCreateMathNode(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Add rule group name to the rule title when converting Prometheus rules: `[{group}] {rule_title}`.

**Why do we need this feature?**

In Grafana alert rule titles must be unique within the same org and folder, but Prometheus allows multiple rules with the same name. By using this temporary workaround we ensure that the title is unique within the group. When we make a better solution for this issue, we will remove this one.

Part of https://github.com/grafana/alerting-squad/issues/1054