### PR TITLE
Imports required for Grafana Enterprise are only included when building enterprise version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ profile.cov
 /pkg/extensions/*
 !/pkg/extensions/.keep
 !/pkg/extensions/main.go
+!/pkg/extensions/enterprise_imports.go
 /public/app/extensions
 !/public/app/extensions/.keep
 

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -1,0 +1,39 @@
+//go:build enterprise
+// +build enterprise
+
+package extensions
+
+import (
+	_ "cloud.google.com/go/kms/apiv1"
+	_ "cloud.google.com/go/kms/apiv1/kmspb"
+	_ "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	_ "github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
+	_ "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	_ "github.com/Azure/go-autorest/autorest"
+	_ "github.com/Azure/go-autorest/autorest/adal"
+	_ "github.com/beevik/etree"
+	_ "github.com/blugelabs/bluge"
+	_ "github.com/blugelabs/bluge_segment_api"
+	_ "github.com/crewjam/saml"
+	_ "github.com/go-jose/go-jose/v3"
+	_ "github.com/gobwas/glob"
+	_ "github.com/googleapis/gax-go/v2"
+	_ "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	_ "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	_ "github.com/hashicorp/go-multierror"
+	_ "github.com/hashicorp/golang-lru/v2"
+	_ "github.com/m3db/prometheus_remote_client_golang/promremote"
+	_ "github.com/phpdave11/gofpdi"
+	_ "github.com/robfig/cron/v3"
+	_ "github.com/russellhaering/goxmldsig"
+	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
+	_ "github.com/stretchr/testify/require"
+	_ "golang.org/x/time/rate"
+	_ "xorm.io/builder"
+
+	_ "github.com/grafana/dskit/backoff"
+	_ "github.com/grafana/dskit/flagext"
+	_ "github.com/grafana/e2e"
+	_ "github.com/grafana/gofpdf"
+	_ "github.com/grafana/gomemcache/memcache"
+)

--- a/pkg/extensions/main.go
+++ b/pkg/extensions/main.go
@@ -1,38 +1,5 @@
 package extensions
 
-import (
-	_ "cloud.google.com/go/kms/apiv1"
-	_ "cloud.google.com/go/kms/apiv1/kmspb"
-	_ "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	_ "github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
-	_ "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
-	_ "github.com/Azure/go-autorest/autorest"
-	_ "github.com/Azure/go-autorest/autorest/adal"
-	_ "github.com/beevik/etree"
-	_ "github.com/blugelabs/bluge"
-	_ "github.com/blugelabs/bluge_segment_api"
-	_ "github.com/crewjam/saml"
-	_ "github.com/go-jose/go-jose/v3"
-	_ "github.com/gobwas/glob"
-	_ "github.com/googleapis/gax-go/v2"
-	_ "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	_ "github.com/grpc-ecosystem/go-grpc-middleware/v2"
-	_ "github.com/hashicorp/go-multierror"
-	_ "github.com/hashicorp/golang-lru/v2"
-	_ "github.com/m3db/prometheus_remote_client_golang/promremote"
-	_ "github.com/phpdave11/gofpdi"
-	_ "github.com/robfig/cron/v3"
-	_ "github.com/russellhaering/goxmldsig"
-	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
-	_ "github.com/stretchr/testify/require"
-	_ "golang.org/x/time/rate"
-	_ "xorm.io/builder"
-
-	_ "github.com/grafana/dskit/backoff"
-	_ "github.com/grafana/dskit/flagext"
-	_ "github.com/grafana/e2e"
-	_ "github.com/grafana/gofpdf"
-	_ "github.com/grafana/gomemcache/memcache"
-)
+// Imports used by Grafana enterprise are in enterprise_imports.go (behind a build tag).
 
 var IsEnterprise bool = false


### PR DESCRIPTION
This PR removes imports used by Grafana Enterprise from Grafana OSS binary, making binary a tiny bit smaller (for darwin-arm64/grafana, saving is less than 1MiB or less than 1%). This saving will be bigger (5% or 15.9MiB) once Spanner dependency is added to the list. (PR #101143)