### PR TITLE
PluginExtensions: Migrate edit profile page to use new plugin components API

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -550,7 +550,7 @@ export {
   type PluginExtensionLink,
   type PluginExtensionComponent,
   type PluginExtensionComponentMeta,
-  type ComponentTypeWithExtensionsMeta,
+  type ComponentTypeWithExtensionMeta,
   type PluginExtensionConfig,
   type PluginExtensionFunction,
   type PluginExtensionLinkConfig,

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -550,6 +550,7 @@ export {
   type PluginExtensionLink,
   type PluginExtensionComponent,
   type PluginExtensionComponentMeta,
+  type ComponentTypeWithMeta,
   type PluginExtensionConfig,
   type PluginExtensionFunction,
   type PluginExtensionLinkConfig,

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -550,7 +550,7 @@ export {
   type PluginExtensionLink,
   type PluginExtensionComponent,
   type PluginExtensionComponentMeta,
-  type ComponentTypeWithMeta,
+  type ComponentTypeWithExtensionsMeta,
   type PluginExtensionConfig,
   type PluginExtensionFunction,
   type PluginExtensionLinkConfig,

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -39,7 +39,7 @@ export type PluginExtensionComponent<Props = {}> = PluginExtensionBase & {
   component: React.ComponentType<Props>;
 };
 
-export type ComponentTypeWithExtensionsMeta<Props = {}> = React.ComponentType<Props> & {
+export type ComponentTypeWithExtensionMeta<Props = {}> = React.ComponentType<Props> & {
   meta: PluginExtensionComponentMeta;
 };
 

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -39,6 +39,8 @@ export type PluginExtensionComponent<Props = {}> = PluginExtensionBase & {
   component: React.ComponentType<Props>;
 };
 
+export type ComponentTypeWithMeta<Props = {}> = React.ComponentType<Props> & { meta: PluginExtensionComponentMeta };
+
 export type PluginExtensionFunction<Signature = () => void> = PluginExtensionBase & {
   type: PluginExtensionTypes.function;
   fn: Signature;

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -39,7 +39,9 @@ export type PluginExtensionComponent<Props = {}> = PluginExtensionBase & {
   component: React.ComponentType<Props>;
 };
 
-export type ComponentTypeWithMeta<Props = {}> = React.ComponentType<Props> & { meta: PluginExtensionComponentMeta };
+export type ComponentTypeWithExtensionsMeta<Props = {}> = React.ComponentType<Props> & {
+  meta: PluginExtensionComponentMeta;
+};
 
 export type PluginExtensionFunction<Signature = () => void> = PluginExtensionBase & {
   type: PluginExtensionTypes.function;

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
@@ -1,4 +1,4 @@
-import { type ComponentTypeWithExtensionsMeta } from '@grafana/data';
+import { type ComponentTypeWithExtensionMeta } from '@grafana/data';
 
 export type UsePluginComponentsOptions = {
   extensionPointId: string;
@@ -6,7 +6,7 @@ export type UsePluginComponentsOptions = {
 };
 
 export type UsePluginComponentsResult<Props = {}> = {
-  components: Array<ComponentTypeWithExtensionsMeta<Props>>;
+  components: Array<ComponentTypeWithExtensionMeta<Props>>;
   isLoading: boolean;
 };
 

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
@@ -1,4 +1,4 @@
-import { type ComponentTypeWithMeta } from '@grafana/data';
+import { type ComponentTypeWithExtensionsMeta } from '@grafana/data';
 
 export type UsePluginComponentsOptions = {
   extensionPointId: string;
@@ -6,7 +6,7 @@ export type UsePluginComponentsOptions = {
 };
 
 export type UsePluginComponentsResult<Props = {}> = {
-  components: Array<ComponentTypeWithMeta<Props>>;
+  components: Array<ComponentTypeWithExtensionsMeta<Props>>;
   isLoading: boolean;
 };
 

--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginComponents.ts
@@ -1,4 +1,4 @@
-import { PluginExtensionComponentMeta } from '@grafana/data';
+import { type ComponentTypeWithMeta } from '@grafana/data';
 
 export type UsePluginComponentsOptions = {
   extensionPointId: string;
@@ -6,7 +6,7 @@ export type UsePluginComponentsOptions = {
 };
 
 export type UsePluginComponentsResult<Props = {}> = {
-  components: Array<React.ComponentType<Props> & { meta: PluginExtensionComponentMeta }>;
+  components: Array<ComponentTypeWithMeta<Props>>;
   isLoading: boolean;
 };
 

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 
 import {
-  type ComponentTypeWithExtensionsMeta,
+  type ComponentTypeWithExtensionMeta,
   type PluginExtensionComponentMeta,
   PluginExtensionTypes,
   usePluginContext,
@@ -30,7 +30,7 @@ export function usePluginComponents<Props extends object = {}>({
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
     const enableRestrictions = isGrafanaDevMode() && pluginContext;
-    const components: Array<ComponentTypeWithExtensionsMeta<Props>> = [];
+    const components: Array<ComponentTypeWithExtensionMeta<Props>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
     const pointLog = log.child({
@@ -89,7 +89,7 @@ export function usePluginComponents<Props extends object = {}>({
 export function createComponentWithMeta<Props extends JSX.IntrinsicAttributes>(
   registryItem: AddedComponentRegistryItem<Props>,
   extensionPointId: string
-): ComponentTypeWithExtensionsMeta<Props> {
+): ComponentTypeWithExtensionMeta<Props> {
   const { component: Component, ...config } = registryItem;
   function ComponentWithMeta(props: Props) {
     return <Component {...props} />;

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 
 import {
-  type ComponentTypeWithMeta,
+  type ComponentTypeWithExtensionsMeta,
   type PluginExtensionComponentMeta,
   PluginExtensionTypes,
   usePluginContext,
@@ -30,7 +30,7 @@ export function usePluginComponents<Props extends object = {}>({
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
     const enableRestrictions = isGrafanaDevMode() && pluginContext;
-    const components: Array<ComponentTypeWithMeta<Props>> = [];
+    const components: Array<ComponentTypeWithExtensionsMeta<Props>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
     const pointLog = log.child({
@@ -89,7 +89,7 @@ export function usePluginComponents<Props extends object = {}>({
 export function createComponentWithMeta<Props extends JSX.IntrinsicAttributes>(
   registryItem: AddedComponentRegistryItem<Props>,
   extensionPointId: string
-): ComponentTypeWithMeta<Props> {
+): ComponentTypeWithExtensionsMeta<Props> {
   const { component: Component, ...config } = registryItem;
   function ComponentWithMeta(props: Props) {
     return <Component {...props} />;

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 
-import { PluginExtensionComponentMeta, PluginExtensionTypes, usePluginContext } from '@grafana/data';
+import {
+  type ComponentTypeWithMeta,
+  type PluginExtensionComponentMeta,
+  PluginExtensionTypes,
+  usePluginContext,
+} from '@grafana/data';
 import { UsePluginComponentsOptions, UsePluginComponentsResult } from '@grafana/runtime';
 
 import { useAddedComponentsRegistry } from './ExtensionRegistriesContext';
@@ -25,7 +30,7 @@ export function usePluginComponents<Props extends object = {}>({
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
     const enableRestrictions = isGrafanaDevMode() && pluginContext;
-    const components: Array<React.ComponentType<Props> & { meta: PluginExtensionComponentMeta }> = [];
+    const components: Array<ComponentTypeWithMeta<Props>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
     const pointLog = log.child({
@@ -84,7 +89,7 @@ export function usePluginComponents<Props extends object = {}>({
 export function createComponentWithMeta<Props extends JSX.IntrinsicAttributes>(
   registryItem: AddedComponentRegistryItem<Props>,
   extensionPointId: string
-): React.ComponentType<Props> & { meta: PluginExtensionComponentMeta } {
+): ComponentTypeWithMeta<Props> {
   const { component: Component, ...config } = registryItem;
   function ComponentWithMeta(props: Props) {
     return <Component {...props} />;

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -1,24 +1,17 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
+import { render } from 'test/test-utils';
 
-import { OrgRole, PluginExtensionComponent, PluginExtensionTypes } from '@grafana/data';
+import { type ComponentTypeWithMeta, OrgRole } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { setPluginExtensionsHook, UsePluginExtensions } from '@grafana/runtime';
-import * as useQueryParams from 'app/core/hooks/useQueryParams';
+import { setPluginComponentsHook, usePluginComponents } from '@grafana/runtime';
 
-import { TestProvider } from '../../../test/helpers/TestProvider';
 import { backendSrv } from '../../core/services/backend_srv';
+import { createComponentWithMeta } from '../plugins/extensions/usePluginComponents';
 import { getMockTeam } from '../teams/__mocks__/teamMocks';
 
 import { Props, UserProfileEditPage } from './UserProfileEditPage';
 import { initialUserState } from './state/reducers';
-
-const mockUseQueryParams = useQueryParams as { useQueryParams: typeof useQueryParams.useQueryParams };
-
-jest.mock('app/core/hooks/useQueryParams', () => ({
-  __esModule: true,
-  useQueryParams: () => [{}],
-}));
 
 jest.mock('app/features/dashboard/api/dashboard_api', () => ({
   getDashboardAPI: () => ({
@@ -136,20 +129,23 @@ const _createTabName = (tab: ExtensionPointComponentTabs) => tab;
 const _createTabContent = (tabId: ExtensionPointComponentId) => `this is settings for component ${tabId}`;
 
 const generalTabName = 'General';
+const generalTestId = 'user-profile-edit-page';
 const tabOneName = _createTabName(ExtensionPointComponentTabs.One);
 const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 
 const _createPluginExtensionPointComponent = (
   id: ExtensionPointComponentId,
   tab: ExtensionPointComponentTabs
-): PluginExtensionComponent => ({
-  id,
-  type: PluginExtensionTypes.component,
-  title: _createTabName(tab),
-  description: '', // description isn't used here..
-  component: () => <p>{_createTabContent(id)}</p>,
-  pluginId: 'grafana-plugin',
-});
+): ComponentTypeWithMeta =>
+  createComponentWithMeta<{}>(
+    {
+      title: _createTabName(tab),
+      description: '', // description isn't used here..
+      component: () => <p>{_createTabContent(id)}</p>,
+      pluginId: 'grafana-plugin',
+    },
+    id
+  );
 
 const PluginExtensionPointComponent1 = _createPluginExtensionPointComponent(
   ExtensionPointComponentId.One,
@@ -164,8 +160,8 @@ const PluginExtensionPointComponent3 = _createPluginExtensionPointComponent(
   ExtensionPointComponentTabs.Two
 );
 
-async function getTestContext(overrides: Partial<Props & { extensions: PluginExtensionComponent[] }> = {}) {
-  const extensions = overrides.extensions || [];
+async function getTestContext(overrides: Partial<Props & { components: ComponentTypeWithMeta[] }> = {}) {
+  const components = overrides.components || [];
 
   jest.clearAllMocks();
   const putSpy = jest.spyOn(backendSrv, 'put');
@@ -174,18 +170,12 @@ async function getTestContext(overrides: Partial<Props & { extensions: PluginExt
     .mockResolvedValue({ timezone: 'UTC', homeDashboardUID: 'home-dashboard', theme: 'dark' });
   const searchSpy = jest.spyOn(backendSrv, 'search').mockResolvedValue([]);
 
-  const getter: UsePluginExtensions<PluginExtensionComponent> = jest
-    .fn()
-    .mockReturnValue({ extensions, isLoading: false });
+  const getter: typeof usePluginComponents = jest.fn().mockReturnValue({ components, isLoading: false });
 
-  setPluginExtensionsHook(getter);
+  setPluginComponentsHook(getter);
 
   const props = { ...defaultProps, ...overrides };
-  const { rerender } = render(
-    <TestProvider>
-      <UserProfileEditPage {...props} />
-    </TestProvider>
-  );
+  const { rerender } = render(<UserProfileEditPage {...props} />);
 
   await waitFor(() => expect(props.initUserProfilePage).toHaveBeenCalledTimes(1));
 
@@ -334,7 +324,7 @@ describe('UserProfileEditPage', () => {
     });
 
     describe('and a plugin registers a component against the user profile settings extension point', () => {
-      const extensions = [
+      const components = [
         PluginExtensionPointComponent1,
         PluginExtensionPointComponent2,
         PluginExtensionPointComponent3,
@@ -347,7 +337,7 @@ describe('UserProfileEditPage', () => {
       });
 
       it('should group registered components into tabs', async () => {
-        await getTestContext({ extensions });
+        await getTestContext({ components });
         const { extensionPointTabs, extensionPointTab } = getSelectors();
 
         const _assertTab = (tabId: string, isDefault = false) => {
@@ -363,10 +353,7 @@ describe('UserProfileEditPage', () => {
       });
 
       it('should change the active tab when a tab is clicked and update the "tab" query param', async () => {
-        const mockUpdateQueryParams = jest.fn();
-        mockUseQueryParams.useQueryParams = () => [{}, mockUpdateQueryParams];
-
-        await getTestContext({ extensions });
+        await getTestContext({ components });
         const { extensionPointTab } = getSelectors();
 
         /**
@@ -378,26 +365,24 @@ describe('UserProfileEditPage', () => {
         const tabTwoContent = _createTabContent(ExtensionPointComponentId.Three);
 
         // "General" should be the default content
+        expect(screen.queryByTestId(generalTestId)).toBeInTheDocument();
         expect(screen.queryByText(tabOneContent1)).toBeNull();
         expect(screen.queryByText(tabOneContent2)).toBeNull();
         expect(screen.queryByText(tabTwoContent)).toBeNull();
 
         await userEvent.click(extensionPointTab(tabOneName.toLowerCase()));
 
-        expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
-        expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabOneName.toLowerCase() });
-        expect(screen.queryByText(tabOneContent1)).not.toBeNull();
-        expect(screen.queryByText(tabOneContent2)).not.toBeNull();
+        expect(screen.queryByTestId(generalTestId)).toBeNull();
+        expect(screen.queryByText(tabOneContent1)).toBeInTheDocument();
+        expect(screen.queryByText(tabOneContent2)).toBeInTheDocument();
         expect(screen.queryByText(tabTwoContent)).toBeNull();
 
-        mockUpdateQueryParams.mockClear();
         await userEvent.click(extensionPointTab(tabTwoName.toLowerCase()));
 
-        expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
-        expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabTwoName.toLowerCase() });
+        expect(screen.queryByTestId(generalTestId)).toBeNull();
         expect(screen.queryByText(tabOneContent1)).toBeNull();
         expect(screen.queryByText(tabOneContent2)).toBeNull();
-        expect(screen.queryByText(tabTwoContent)).not.toBeNull();
+        expect(screen.queryByText(tabTwoContent)).toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
-import { type ComponentTypeWithMeta, OrgRole } from '@grafana/data';
+import { type ComponentTypeWithExtensionsMeta, OrgRole } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { setPluginComponentsHook, usePluginComponents } from '@grafana/runtime';
 
@@ -136,7 +136,7 @@ const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 const _createPluginExtensionPointComponent = (
   id: ExtensionPointComponentId,
   tab: ExtensionPointComponentTabs
-): ComponentTypeWithMeta =>
+): ComponentTypeWithExtensionsMeta =>
   createComponentWithMeta<{}>(
     {
       title: _createTabName(tab),
@@ -160,7 +160,7 @@ const PluginExtensionPointComponent3 = _createPluginExtensionPointComponent(
   ExtensionPointComponentTabs.Two
 );
 
-async function getTestContext(overrides: Partial<Props & { components: ComponentTypeWithMeta[] }> = {}) {
+async function getTestContext(overrides: Partial<Props & { components: ComponentTypeWithExtensionsMeta[] }> = {}) {
   const components = overrides.components || [];
 
   jest.clearAllMocks();

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
-import { type ComponentTypeWithExtensionsMeta, OrgRole } from '@grafana/data';
+import { type ComponentTypeWithExtensionMeta, OrgRole } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { setPluginComponentsHook, usePluginComponents } from '@grafana/runtime';
 
@@ -136,7 +136,7 @@ const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 const _createPluginExtensionPointComponent = (
   id: ExtensionPointComponentId,
   tab: ExtensionPointComponentTabs
-): ComponentTypeWithExtensionsMeta =>
+): ComponentTypeWithExtensionMeta =>
   createComponentWithMeta<{}>(
     {
       title: _createTabName(tab),
@@ -160,7 +160,7 @@ const PluginExtensionPointComponent3 = _createPluginExtensionPointComponent(
   ExtensionPointComponentTabs.Two
 );
 
-async function getTestContext(overrides: Partial<Props & { components: ComponentTypeWithExtensionsMeta[] }> = {}) {
+async function getTestContext(overrides: Partial<Props & { components: ComponentTypeWithExtensionMeta[] }> = {}) {
   const components = overrides.components || [];
 
   jest.clearAllMocks();

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -1,31 +1,19 @@
-import { Fragment, useMemo, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { useMount } from 'react-use';
 
-import { PluginExtensionComponent, PluginExtensionPoints } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
-import { usePluginComponentExtensions, usePluginComponents } from '@grafana/runtime';
-import { Tab, TabsBar, TabContent, Stack } from '@grafana/ui';
+import { PluginExtensionPoints } from '@grafana/data';
+import { usePluginComponents } from '@grafana/runtime';
+import { Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
-import { useQueryParams } from 'app/core/hooks/useQueryParams';
-import { t } from 'app/core/internationalization';
 import { StoreState } from 'app/types';
 
 import UserOrganizations from './UserOrganizations';
 import UserProfileEditForm from './UserProfileEditForm';
+import { UserProfileEditTabs } from './UserProfileEditTabs';
 import UserSessions from './UserSessions';
 import { UserTeams } from './UserTeams';
 import { changeUserOrg, initUserProfilePage, revokeUserSession, updateUserProfile } from './state/actions';
-import { string } from 'yargs';
-
-const TAB_QUERY_PARAM = 'tab';
-const GENERAL_SETTINGS_TAB = 'general';
-
-type TabInfo = {
-  id: string;
-  title: string;
-};
 
 export interface OwnProps {}
 
@@ -69,132 +57,29 @@ export function UserProfileEditPage({
   changeUserOrg,
   updateUserProfile,
 }: Props) {
-  const [queryParams, updateQueryParams] = useQueryParams();
-  const tabQueryParam = queryParams[TAB_QUERY_PARAM];
-  const [activeTab, setActiveTab] = useState<string>(
-    typeof tabQueryParam === 'string' ? tabQueryParam : GENERAL_SETTINGS_TAB
-  );
-
   useMount(() => initUserProfilePage());
 
-  const { extensions } = usePluginComponentExtensions({ extensionPointId: PluginExtensionPoints.UserProfileTab });
-
-  const groupedExtensionComponents = extensions.reduce<Record<string, PluginExtensionComponent[]>>((acc, extension) => {
-    const { title } = extension;
-    if (acc[title]) {
-      acc[title].push(extension);
-    } else {
-      acc[title] = [extension];
-    }
-    return acc;
-  }, {});
-
-  const convertExtensionComponentTitleToTabId = (title: string) => title.toLowerCase();
-
-  const showTabs = extensions.length > 0;
-  const tabs: TabInfo[] = [
-    {
-      id: GENERAL_SETTINGS_TAB,
-      title: t('user-profile.tabs.general', 'General'),
-    },
-    ...Object.keys(groupedExtensionComponents).map((title) => ({
-      id: convertExtensionComponentTitleToTabId(title),
-      title,
-    })),
-  ];
-
-  const UserProfile = () => (
-    <Stack direction="column" gap={2}>
-      <UserProfileEditForm updateProfile={updateUserProfile} isSavingUser={isUpdating} user={user} />
-      <SharedPreferences resourceUri="user" preferenceType="user" />
-      <Stack direction="column" gap={6}>
-        <UserTeams isLoading={teamsAreLoading} teams={teams} />
-        <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
-        <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
-      </Stack>
-    </Stack>
-  );
-
-  const UserProfileWithTabs = () => (
-    <div data-testid={selectors.components.UserProfile.extensionPointTabs}>
-      <Stack direction="column" gap={2}>
-        <TabsBar>
-          {tabs.map(({ id, title }) => {
-            return (
-              <Tab
-                key={id}
-                label={title}
-                active={activeTab === id}
-                onChangeTab={() => {
-                  setActiveTab(id);
-                  updateQueryParams({ [TAB_QUERY_PARAM]: id });
-                }}
-                data-testid={selectors.components.UserProfile.extensionPointTab(id)}
-              />
-            );
-          })}
-        </TabsBar>
-        <TabContent>
-          {activeTab === GENERAL_SETTINGS_TAB && <UserProfile />}
-          {Object.entries(groupedExtensionComponents).map(([title, pluginExtensionComponents]) => {
-            const tabId = convertExtensionComponentTitleToTabId(title);
-
-            if (activeTab === tabId) {
-              return (
-                <Fragment key={tabId}>
-                  {pluginExtensionComponents.map(({ component: Component }, index) => (
-                    <Component key={`${tabId}-${index}`} />
-                  ))}
-                </Fragment>
-              );
-            }
-            return null;
-          })}
-        </TabContent>
-      </Stack>
-    </div>
-  );
+  const { components, isLoading } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.UserProfileTab,
+  });
 
   return (
     <Page navId="profile/settings">
-      <Page.Contents isLoading={!user}>{showTabs ? <UserProfileWithTabs /> : <UserProfile />}</Page.Contents>
+      <Page.Contents isLoading={!user || isLoading}>
+        <UserProfileEditTabs components={components}>
+          <Stack direction="column" gap={2}>
+            <UserProfileEditForm updateProfile={updateUserProfile} isSavingUser={isUpdating} user={user} />
+            <SharedPreferences resourceUri="user" preferenceType="user" />
+            <Stack direction="column" gap={6}>
+              <UserTeams isLoading={teamsAreLoading} teams={teams} />
+              <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
+              <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
+            </Stack>
+          </Stack>
+        </UserProfileEditTabs>
+      </Page.Contents>
     </Page>
   );
 }
 
 export default connector(UserProfileEditPage);
-
-type useProfileTabeExtensionsResult = {
-  components: Record<string, React.ComponentType[]>;
-  tabs: TabInfo[];
-  isLoading: boolean;
-};
-
-function useProfileTabeExtensions(): useProfileTabeExtensionsResult {
-  const { components, isLoading } = usePluginComponents({
-    extensionPointId: PluginExtensionPoints.UserProfileTab,
-  });
-
-  const grouped: Record<string, React.ComponentType[]> = {};
-
-  for (const component of components) {
-    const { title } = component.meta;
-  }
-
-  return useMemo(() => {
-    const grouped = components.reduce<Record<string, React.ComponentType[]>>((acc, component) => {
-      const { title } = component.meta;
-      if (acc[title]) {
-        acc[title].push(component);
-      } else {
-        acc[title] = [component];
-      }
-      return acc;
-    }, {});
-
-    return {
-      components: grouped,
-      isLoading,
-    };
-  }, [components, isLoading]);
-}

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -67,7 +67,7 @@ export function UserProfileEditPage({
     <Page navId="profile/settings">
       <Page.Contents isLoading={!user || isLoading}>
         <UserProfileEditTabs components={components}>
-          <Stack direction="column" gap={2}>
+          <Stack direction="column" gap={2} data-testid="user-profile-edit-page">
             <UserProfileEditForm updateProfile={updateUserProfile} isSavingUser={isUpdating} user={user} />
             <SharedPreferences resourceUri="user" preferenceType="user" />
             <Stack direction="column" gap={6}>

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -1,10 +1,10 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { useMount } from 'react-use';
 
 import { PluginExtensionComponent, PluginExtensionPoints } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { usePluginComponentExtensions } from '@grafana/runtime';
+import { usePluginComponentExtensions, usePluginComponents } from '@grafana/runtime';
 import { Tab, TabsBar, TabContent, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
@@ -17,6 +17,7 @@ import UserProfileEditForm from './UserProfileEditForm';
 import UserSessions from './UserSessions';
 import { UserTeams } from './UserTeams';
 import { changeUserOrg, initUserProfilePage, revokeUserSession, updateUserProfile } from './state/actions';
+import { string } from 'yargs';
 
 const TAB_QUERY_PARAM = 'tab';
 const GENERAL_SETTINGS_TAB = 'general';
@@ -162,3 +163,38 @@ export function UserProfileEditPage({
 }
 
 export default connector(UserProfileEditPage);
+
+type useProfileTabeExtensionsResult = {
+  components: Record<string, React.ComponentType[]>;
+  tabs: TabInfo[];
+  isLoading: boolean;
+};
+
+function useProfileTabeExtensions(): useProfileTabeExtensionsResult {
+  const { components, isLoading } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.UserProfileTab,
+  });
+
+  const grouped: Record<string, React.ComponentType[]> = {};
+
+  for (const component of components) {
+    const { title } = component.meta;
+  }
+
+  return useMemo(() => {
+    const grouped = components.reduce<Record<string, React.ComponentType[]>>((acc, component) => {
+      const { title } = component.meta;
+      if (acc[title]) {
+        acc[title].push(component);
+      } else {
+        acc[title] = [component];
+      }
+      return acc;
+    }, {});
+
+    return {
+      components: grouped,
+      isLoading,
+    };
+  }, [components, isLoading]);
+}

--- a/public/app/features/profile/UserProfileEditTabs.tsx
+++ b/public/app/features/profile/UserProfileEditTabs.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentType, Fragment, type ReactElement, useCallback, useMemo } from 'react';
 
-import { type UrlQueryValue } from '@grafana/data';
+import { type ComponentTypeWithExtensionsMeta, type UrlQueryValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
@@ -11,7 +11,7 @@ const GENERAL_SETTINGS_TAB = 'general';
 
 type Props = {
   children?: React.ReactNode;
-  components: ComponentTypeWithMeta[];
+  components: ComponentTypeWithExtensionsMeta[];
 };
 
 export function UserProfileEditTabs(props: Props): ReactElement {

--- a/public/app/features/profile/UserProfileEditTabs.tsx
+++ b/public/app/features/profile/UserProfileEditTabs.tsx
@@ -1,0 +1,111 @@
+import React, { type ComponentType, Fragment, type ReactElement, useCallback, useMemo } from 'react';
+
+import { type UrlQueryValue } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
+import { useQueryParams } from 'app/core/hooks/useQueryParams';
+import { t } from 'app/core/internationalization';
+
+const TAB_QUERY_PARAM = 'tab';
+const GENERAL_SETTINGS_TAB = 'general';
+
+type Props = {
+  children?: React.ReactNode;
+  components: Array<ComponentType & { meta: { title: string } }>;
+};
+
+export function UserProfileEditTabs(props: Props): ReactElement {
+  const { children, components } = props;
+  const tabsById = useTabInfoById(components, children);
+  const [activeTab, setActiveTab] = useActiveTab(tabsById);
+  const showTabs = components.length > 0;
+
+  if (showTabs === false) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div data-testid={selectors.components.UserProfile.extensionPointTabs}>
+      <Stack direction="column" gap={2}>
+        <TabsBar>
+          {Object.values(tabsById).map(({ tabId, title }) => {
+            return (
+              <Tab
+                key={tabId}
+                label={title}
+                active={activeTab?.tabId === tabId}
+                onChangeTab={() => setActiveTab(tabId)}
+                data-testid={selectors.components.UserProfile.extensionPointTab(tabId)}
+              />
+            );
+          })}
+        </TabsBar>
+        <TabContent>
+          {Boolean(activeTab) && (
+            <Fragment key={activeTab?.tabId}>
+              {activeTab?.components.map((Component, index) => <Component key={`${activeTab?.tabId}-${index}`} />)}
+            </Fragment>
+          )}
+        </TabContent>
+      </Stack>
+    </div>
+  );
+}
+
+type TabInfo = {
+  title: string;
+  tabId: string;
+  components: ComponentType[];
+};
+
+function useTabInfoById(components: Props['components'], general: React.ReactNode): Record<string, TabInfo> {
+  return useMemo(() => {
+    const tabs: Record<string, TabInfo> = {
+      [GENERAL_SETTINGS_TAB]: {
+        title: t('user-profile.tabs.general', 'General'),
+        tabId: GENERAL_SETTINGS_TAB,
+        components: [() => <>{general}</>],
+      },
+    };
+
+    return components.reduce((acc, component) => {
+      const { title } = component.meta;
+      const tabId = convertTitleToTabId(title);
+
+      if (!acc[tabId]) {
+        acc[tabId] = {
+          title,
+          tabId,
+          components: [],
+        };
+      }
+
+      acc[tabId].components.push(component);
+      return acc;
+    }, tabs);
+  }, [components, general]);
+}
+
+function useActiveTab(tabs: Record<string, TabInfo>): [TabInfo | undefined, (tabId: string) => void] {
+  const [queryParams, updateQueryParams] = useQueryParams();
+  const activeTabId = convertQueryParamToTabId(queryParams[TAB_QUERY_PARAM]);
+  const activeTab = tabs[activeTabId];
+
+  const setActiveTab = useCallback(
+    (tabId: string) => updateQueryParams({ [TAB_QUERY_PARAM]: tabId }),
+    [updateQueryParams]
+  );
+
+  return [activeTab, setActiveTab];
+}
+
+function convertQueryParamToTabId(queryParam: UrlQueryValue) {
+  if (typeof queryParam !== 'string') {
+    return GENERAL_SETTINGS_TAB;
+  }
+  return convertTitleToTabId(queryParam);
+}
+
+function convertTitleToTabId(title: string) {
+  return title.toLowerCase();
+}

--- a/public/app/features/profile/UserProfileEditTabs.tsx
+++ b/public/app/features/profile/UserProfileEditTabs.tsx
@@ -11,7 +11,7 @@ const GENERAL_SETTINGS_TAB = 'general';
 
 type Props = {
   children?: React.ReactNode;
-  components: Array<ComponentType & { meta: { title: string } }>;
+  components: ComponentTypeWithMeta[];
 };
 
 export function UserProfileEditTabs(props: Props): ReactElement {

--- a/public/app/features/profile/UserProfileEditTabs.tsx
+++ b/public/app/features/profile/UserProfileEditTabs.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentType, Fragment, type ReactElement, useCallback, useMemo } from 'react';
 
-import { type ComponentTypeWithExtensionsMeta, type UrlQueryValue } from '@grafana/data';
+import { type ComponentTypeWithExtensionMeta, type UrlQueryValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
@@ -11,7 +11,7 @@ const GENERAL_SETTINGS_TAB = 'general';
 
 type Props = {
   children?: React.ReactNode;
-  components: ComponentTypeWithExtensionsMeta[];
+  components: ComponentTypeWithExtensionMeta[];
 };
 
 export function UserProfileEditTabs(props: Props): ReactElement {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR migrates the user profile edit page to use the new `usePluginComponents` API instead of the old one. 

**Why do we need this feature?**

This is some prep work before removing the old deprecated APIs in G12.

**Who is this feature for?**

Our self to be able to remove the old API in G12

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
