### PR TITLE
AuthZClient: Read config outside of Provide

### DIFF
--- a/pkg/services/authz/rbac_settings.go
+++ b/pkg/services/authz/rbac_settings.go
@@ -21,7 +21,7 @@ const (
 	clientModeInproc clientMode = "inproc"
 )
 
-type authzClientSettings struct {
+type AuthzClientSettings struct {
 	remoteAddress string
 	mode          clientMode
 
@@ -30,7 +30,7 @@ type authzClientSettings struct {
 	tokenNamespace   string
 }
 
-func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
+func ExtractAuthzClientSettings(cfg *setting.Cfg) (*AuthzClientSettings, error) {
 	authzSection := cfg.SectionWithEnvOverrides("authorization")
 	grpcClientAuthSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 
@@ -39,7 +39,7 @@ func readAuthzClientSettings(cfg *setting.Cfg) (*authzClientSettings, error) {
 		return nil, fmt.Errorf("authorization: invalid mode %q", mode)
 	}
 
-	s := &authzClientSettings{}
+	s := &AuthzClientSettings{}
 	s.mode = mode
 	if s.mode == clientModeInproc {
 		return s, nil

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -102,7 +102,12 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) start(ctx context.Context) error {
-	authzClient, err := authz.ProvideStandaloneAuthZClient(s.cfg, s.features, s.tracing)
+	authzClientCfg, err := authz.ExtractAuthzClientSettings(s.cfg)
+	if err != nil {
+		return err
+	}
+
+	authzClient, err := authz.NewRemoteAuthZClient(authzClientCfg, s.features, s.tracing)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes the config reading from the constructor in order for standalone services to populate the configuration as they wish.

Might not be the final decision, I'm looking into another proposal :)