### PR TITLE
AuthZ: Make `NewGrpcTokenAuth` public

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -34,7 +34,7 @@ import (
 )
 
 // `authzService` is hardcoded in authz-service
-const authzServiceAudience = "authzService"
+const AuthzServiceAudience = "authzService"
 
 // ProvideAuthZClient provides an AuthZ client and creates the AuthZ service.
 func ProvideAuthZClient(
@@ -123,7 +123,7 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer tracing.Tracer) 
 		clientCfg.remoteAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithPerRPCCredentials(
-			newGRPCTokenAuth(authzServiceAudience, clientCfg.tokenNamespace, tokenClient),
+			NewGRPCTokenAuth(AuthzServiceAudience, clientCfg.tokenNamespace, tokenClient),
 		),
 	)
 	if err != nil {

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -33,7 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
-// `authzService` is hardcoded in authz-service
+// AuthzServiceAudience is the audience for the authz service.
 const AuthzServiceAudience = "authzService"
 
 // ProvideAuthZClient provides an AuthZ client and creates the AuthZ service.

--- a/pkg/services/authz/token_auth.go
+++ b/pkg/services/authz/token_auth.go
@@ -6,7 +6,8 @@ import (
 	"github.com/grafana/authlib/authn"
 )
 
-func newGRPCTokenAuth(audience, namespace string, tc authn.TokenExchanger) *tokenAuth {
+// TODO: move this to authlib
+func NewGRPCTokenAuth(audience, namespace string, tc authn.TokenExchanger) *tokenAuth {
 	return &tokenAuth{audience, namespace, tc}
 }
 

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -57,7 +57,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features 
 			// TODO: add TLS support
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithPerRPCCredentials(
-				newGRPCTokenAuth(authzServiceAudience, fmt.Sprintf("stacks-%s", cfg.StackID), tokenClient),
+				NewGRPCTokenAuth(AuthzServiceAudience, fmt.Sprintf("stacks-%s", cfg.StackID), tokenClient),
 			),
 		}
 
@@ -172,7 +172,7 @@ func (z *Zanzana) start(ctx context.Context) error {
 
 	authenticator := authnlib.NewAccessTokenAuthenticator(
 		authnlib.NewAccessTokenVerifier(
-			authnlib.VerifierConfig{AllowedAudiences: []string{authzServiceAudience}},
+			authnlib.VerifierConfig{AllowedAudiences: []string{AuthzServiceAudience}},
 			authnlib.NewKeyRetriever(authnlib.KeyRetrieverConfig{
 				SigningKeysURL: z.cfg.ZanzanaServer.SigningKeysURL,
 			}),


### PR DESCRIPTION
This PR makes `NewGrpcTokenAuth` public to be able to use it in other places.