### PR TITLE
Dashboards: redesign dashboard edit pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
@@ -6,7 +6,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { DashboardScene } from '../scene/DashboardScene';
-import { useLayoutCategory } from '../scene/layouts-shared/DashboardLayoutSelector';
+import { DashboardLayoutSelector } from '../scene/layouts-shared/DashboardLayoutSelector';
 import { EditableDashboardElement } from '../scene/types/EditableDashboardElement';
 
 export class DashboardEditableElement implements EditableDashboardElement {
@@ -26,6 +26,7 @@ export class DashboardEditableElement implements EditableDashboardElement {
         title: t('dashboard.options.title', 'Dashboard options'),
         id: 'dashboard-options',
         isOpenDefault: true,
+        alwaysExpanded: true,
       })
         .addItem(
           new OptionsPaneItemDescriptor({
@@ -42,12 +43,18 @@ export class DashboardEditableElement implements EditableDashboardElement {
               return <DashboardDescriptionInput dashboard={dashboard} />;
             },
           })
+        )
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.layout.common.layout', 'Layout'),
+            render: function renderTitle() {
+              return <DashboardLayoutSelector layoutManager={body} />;
+            },
+          })
         );
-    }, [dashboard]);
+    }, [body, dashboard]);
 
-    const layoutCategory = useLayoutCategory(body);
-
-    return [dashboardOptions, layoutCategory];
+    return [dashboardOptions];
   }
 }
 

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
@@ -31,25 +31,19 @@ export class DashboardEditableElement implements EditableDashboardElement {
         .addItem(
           new OptionsPaneItemDescriptor({
             title: t('dashboard.options.title-option', 'Title'),
-            render: function renderTitle() {
-              return <DashboardTitleInput dashboard={dashboard} />;
-            },
+            render: () => <DashboardTitleInput dashboard={dashboard} />,
           })
         )
         .addItem(
           new OptionsPaneItemDescriptor({
             title: t('dashboard.options.description', 'Description'),
-            render: function renderTitle() {
-              return <DashboardDescriptionInput dashboard={dashboard} />;
-            },
+            render: () => <DashboardDescriptionInput dashboard={dashboard} />,
           })
         )
         .addItem(
           new OptionsPaneItemDescriptor({
             title: t('dashboard.layout.common.layout', 'Layout'),
-            render: function renderTitle() {
-              return <DashboardLayoutSelector layoutManager={body} />;
-            },
+            render: () => <DashboardLayoutSelector layoutManager={body} />,
           })
         );
     }, [body, dashboard]);

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { Select } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -55,10 +56,8 @@ export function useLayoutCategory(layoutManager: DashboardLayoutManager) {
 
     layoutCategory.addItem(
       new OptionsPaneItemDescriptor({
-        title: 'Grid',
-        render: function renderTitle() {
-          return <DashboardLayoutSelector layoutManager={layoutManager} />;
-        },
+        title: t('dashboard.layout.common.layout', 'Layout'),
+        render: () => <DashboardLayoutSelector layoutManager={layoutManager} />,
       })
     );
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -55,7 +55,7 @@ export function useLayoutCategory(layoutManager: DashboardLayoutManager) {
 
     layoutCategory.addItem(
       new OptionsPaneItemDescriptor({
-        title: 'Type',
+        title: 'Grid',
         render: function renderTitle() {
           return <DashboardLayoutSelector layoutManager={layoutManager} />;
         },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1040,6 +1040,15 @@
       "rows": "Total number rows",
       "table-title": "Stats"
     },
+    "layout": {
+      "common": {
+        "copy": "Copy",
+        "copy-or-duplicate": "Copy or Duplicate",
+        "delete": "Delete",
+        "duplicate": "Duplicate",
+        "layout": "Layout"
+      }
+    },
     "options": {
       "description": "Description",
       "title": "Dashboard options",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1040,6 +1040,15 @@
       "rows": "Ŧőŧäľ ŉūmþęř řőŵş",
       "table-title": "Ŝŧäŧş"
     },
+    "layout": {
+      "common": {
+        "copy": "Cőpy",
+        "copy-or-duplicate": "Cőpy őř Đūpľįčäŧę",
+        "delete": "Đęľęŧę",
+        "duplicate": "Đūpľįčäŧę",
+        "layout": "Ŀäyőūŧ"
+      }
+    },
     "options": {
       "description": "Đęşčřįpŧįőŉ",
       "title": "Đäşĥþőäřđ őpŧįőŉş",


### PR DESCRIPTION
Add changes for the dashboard edit pane header redesign. Quite a small chagne:

Before
<img width="271" alt="Screenshot 2025-02-26 at 14 07 57" src="https://github.com/user-attachments/assets/d745b292-d8d3-4a39-b080-f79c811dd6f2" />

After
<img width="287" alt="Screenshot 2025-02-26 at 14 07 43" src="https://github.com/user-attachments/assets/60db8755-856e-44a2-ac02-c1b2ab71e9ea" />
