### PR TITLE
Dashboard: Redesign viz panel edit panes

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { VizPanel } from '@grafana/scenes';
 import { t } from 'app/core/internationalization';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
 import { MultiSelectedEditableDashboardElement } from '../scene/types/MultiSelectedEditableDashboardElement';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
@@ -13,27 +13,33 @@ export class MultiSelectedVizPanelsEditableElement implements MultiSelectedEdita
   public readonly isMultiSelectedEditableDashboardElement = true;
   public readonly typeName = 'Panels';
   public readonly key: string;
-  public readonly alwaysExpanded = true;
 
   constructor(private _panels: VizPanel[]) {
     this.key = uuidv4();
   }
 
-  public renderActions(): ReactNode {
-    return <></>;
+  public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {
+    const header = new OptionsPaneCategoryDescriptor({
+      title: ``,
+      id: 'panel-header',
+      isOpenDefault: true,
+      alwaysExpanded: true,
+      renderTitle: () =>
+        renderTitle({
+          title: t('dashboard.layout.common.panels-title', '{{length}} Panels Selected', {
+            length: this._panels.length,
+          }),
+          onDelete: () => this.onDelete(),
+        }),
+    });
+
+    return [header];
   }
 
-  public renderTitle: () => ReactNode = () => {
-    return renderTitle({
-      title: `${this._panels.length} ${t('dashboard.layout.common.panels', 'Panels')} ${t('dashboard.layout.common.selected', 'Selected')}`,
-      onDelete: this.onDelete,
-    });
-  };
-
-  public onDelete = () => {
+  public onDelete() {
     this._panels.forEach((panel) => {
       const layout = dashboardSceneGraph.getLayoutManagerFor(panel);
       layout.removePanel?.(panel);
     });
-  };
+  }
 }

--- a/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
@@ -2,44 +2,38 @@ import { ReactNode } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { VizPanel } from '@grafana/scenes';
-import { Button, Stack, Text } from '@grafana/ui';
-import { Trans } from 'app/core/internationalization';
+import { t } from 'app/core/internationalization';
 
 import { MultiSelectedEditableDashboardElement } from '../scene/types/MultiSelectedEditableDashboardElement';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+
+import { renderTitle } from './shared';
 
 export class MultiSelectedVizPanelsEditableElement implements MultiSelectedEditableDashboardElement {
   public readonly isMultiSelectedEditableDashboardElement = true;
   public readonly typeName = 'Panels';
   public readonly key: string;
+  public readonly alwaysExpanded = true;
 
   constructor(private _panels: VizPanel[]) {
     this.key = uuidv4();
   }
 
-  renderActions(): ReactNode {
-    return (
-      <Stack direction="column">
-        <Text>
-          <Trans
-            i18nKey="dashboard.edit-pane.panels.multi-select.selection-number"
-            values={{ length: this._panels.length }}
-          >
-            No. of panels selected: {{ length }}
-          </Trans>
-        </Text>
-        <Stack direction="row">
-          <Button size="sm" variant="secondary" icon="copy" />
-          <Button size="sm" variant="destructive" fill="outline" onClick={() => this.onDelete()} icon="trash-alt" />
-        </Stack>
-      </Stack>
-    );
+  public renderActions(): ReactNode {
+    return <></>;
   }
 
-  public onDelete() {
+  public renderTitle: () => ReactNode = () => {
+    return renderTitle({
+      title: `${this._panels.length} ${t('dashboard.layout.common.panels', 'Panels')} ${t('dashboard.layout.common.selected', 'Selected')}`,
+      onDelete: this.onDelete,
+    });
+  };
+
+  public onDelete = () => {
     this._panels.forEach((panel) => {
       const layout = dashboardSceneGraph.getLayoutManagerFor(panel);
       layout.removePanel?.(panel);
     });
-  }
+  };
 }

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -27,11 +27,7 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
   public readonly typeName = 'Panel';
   public readonly alwaysExpanded = true;
 
-  public constructor(private panel: VizPanel) {}
-
-  public getPanel = () => {
-    return this.panel;
-  };
+  public constructor(public panel: VizPanel) {}
 
   public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {
     const panel = this.panel;
@@ -40,15 +36,16 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     const panelOptions = useMemo(() => {
       return new OptionsPaneCategoryDescriptor({
         title: ``,
-        id: 'panel-options',
+        id: 'panel-header',
         isOpenDefault: true,
         alwaysExpanded: true,
-        renderTitle: () => renderTitle({ title: 'Panel', onDelete: this.onDelete }),
+        renderTitle: () =>
+          renderTitle({ title: t('dashboard.viz-panel.options.title', 'Panel'), onDelete: this.onDelete }),
       })
         .addItem(
           new OptionsPaneItemDescriptor({
             title: '',
-            render: () => <OpenPanelEditViz model={this} />,
+            render: () => <OpenPanelEditViz panel={this.panel} />,
           })
         )
         .addItem(
@@ -95,11 +92,41 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     return categories;
   }
 
-  public onDelete = () => {
+  public onDelete() {
     const layout = dashboardSceneGraph.getLayoutManagerFor(this.panel);
     layout.removePanel?.(this.panel);
-  };
+  }
 }
+
+type OpenPanelEditVizProps = {
+  panel: VizPanel;
+};
+
+const OpenPanelEditViz = ({ panel }: OpenPanelEditVizProps) => {
+  const styles = useStyles2(getStyles);
+
+  const plugin = panel.getPlugin();
+  const imgSrc = plugin?.meta.info.logos.small;
+
+  return (
+    <>
+      <Stack alignItems="center" width="100%">
+        {plugin ? (
+          <Tooltip content={t('dashboard.viz-panel.options.open-edit', 'Open Panel Edit')}>
+            <a
+              href={textUtil.sanitizeUrl(getEditPanelUrl(getPanelIdForVizPanel(panel)))}
+              className={cx(styles.pluginDescriptionWrapper)}
+            >
+              <img className={styles.panelVizImg} src={imgSrc} alt="Image of plugin type" />
+              <Text truncate>{plugin.meta.name}</Text>
+              <Icon className={styles.panelVizIcon} name="sliders-v-alt" />
+            </a>
+          </Tooltip>
+        ) : null}
+      </Stack>
+    </>
+  );
+};
 
 const getStyles = (theme: GrafanaTheme2) => ({
   pluginDescriptionWrapper: css({
@@ -125,34 +152,3 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginLeft: 'auto',
   }),
 });
-
-type OpenPanelEditVizProps = {
-  model: VizPanelEditableElement;
-};
-
-const OpenPanelEditViz = ({ model }: OpenPanelEditVizProps) => {
-  const styles = useStyles2(getStyles);
-
-  const plugin = model.getPanel().getPlugin();
-  const imgSrc = plugin?.meta.info.logos.small;
-
-  return (
-    <>
-      <Stack alignItems="center" width="100%">
-        {plugin ? (
-          <Tooltip content="Open Panel Edit">
-            <a
-              href={textUtil.sanitizeUrl(getEditPanelUrl(getPanelIdForVizPanel(model.getPanel())))}
-              className={cx(styles.pluginDescriptionWrapper)}
-              onClick={() => {}}
-            >
-              <img className={styles.panelVizImg} src={imgSrc} alt="Image of plugin type" />
-              <Text truncate>{plugin.meta.name}</Text>
-              <Icon className={styles.panelVizIcon} name="sliders-v-alt" />
-            </a>
-          </Tooltip>
-        ) : null}
-      </Stack>
-    </>
-  );
-};

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -1,11 +1,12 @@
-import { ReactNode, useMemo } from 'react';
+import { css, cx } from '@emotion/css';
+import { useMemo } from 'react';
 
-import { sceneGraph, VizPanel } from '@grafana/scenes';
-import { Button } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { GrafanaTheme2, textUtil } from '@grafana/data';
+import { VizPanel } from '@grafana/scenes';
+import { useStyles2, Text, Icon, Stack, Tooltip } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-import { getVisualizationOptions2 } from 'app/features/dashboard/components/PanelEditor/getVisualizationOptions';
 
 import {
   PanelBackgroundSwitch,
@@ -16,12 +17,21 @@ import { BulkActionElement } from '../scene/types/BulkActionElement';
 import { isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
 import { EditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { getEditPanelUrl } from '../utils/urlBuilders';
+import { getPanelIdForVizPanel } from '../utils/utils';
+
+import { renderTitle } from './shared';
 
 export class VizPanelEditableElement implements EditableDashboardElement, BulkActionElement {
   public readonly isEditableDashboardElement = true;
   public readonly typeName = 'Panel';
+  public readonly alwaysExpanded = true;
 
   public constructor(private panel: VizPanel) {}
+
+  public getPanel = () => {
+    return this.panel;
+  };
 
   public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {
     const panel = this.panel;
@@ -29,10 +39,18 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
 
     const panelOptions = useMemo(() => {
       return new OptionsPaneCategoryDescriptor({
-        title: t('dashboard.viz-panel.options.title', 'Panel options'),
+        title: ``,
         id: 'panel-options',
         isOpenDefault: true,
+        alwaysExpanded: true,
+        renderTitle: () => renderTitle({ title: 'Panel', onDelete: this.onDelete }),
       })
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: '',
+            render: () => <OpenPanelEditViz model={this} />,
+          })
+        )
         .addItem(
           new OptionsPaneItemDescriptor({
             title: t('dashboard.viz-panel.options.title-option', 'Title'),
@@ -69,32 +87,10 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
       return undefined;
     }, [layoutElement]);
 
-    const { options, fieldConfig, _pluginInstanceState } = panel.useState();
-    const dataProvider = sceneGraph.getData(panel);
-    const { data } = dataProvider.useState();
-
-    const visualizationOptions = useMemo(() => {
-      const plugin = panel.getPlugin();
-      if (!plugin) {
-        return [];
-      }
-
-      return getVisualizationOptions2({
-        panel,
-        data,
-        plugin: plugin,
-        eventBus: panel.getPanelContext().eventBus,
-        instanceState: _pluginInstanceState,
-      });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data, panel, options, fieldConfig, _pluginInstanceState]);
-
     const categories = [panelOptions];
     if (layoutCategory) {
       categories.push(layoutCategory);
     }
-
-    categories.push(...visualizationOptions);
 
     return categories;
   }
@@ -103,16 +99,60 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     const layout = dashboardSceneGraph.getLayoutManagerFor(this.panel);
     layout.removePanel?.(this.panel);
   };
-
-  public renderActions(): ReactNode {
-    return (
-      <>
-        <Button size="sm" variant="secondary">
-          <Trans i18nKey="panel.header-menu.edit">Edit</Trans>
-        </Button>
-        <Button size="sm" variant="secondary" icon="copy" />
-        <Button size="sm" variant="destructive" fill="outline" onClick={this.onDelete} icon="trash-alt" />
-      </>
-    );
-  }
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  pluginDescriptionWrapper: css({
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(0.5),
+    minHeight: theme.spacing(4),
+    backgroundColor: theme.components.input.background,
+    border: `1px solid ${theme.colors.border.strong}`,
+    borderRadius: theme.shape.radius.default,
+    paddingInline: theme.spacing(1),
+    paddingBlock: theme.spacing(0.5),
+    flexGrow: 1,
+  }),
+  panelVizImg: css({
+    width: '16px',
+    height: '16px',
+    marginRight: theme.spacing(1),
+  }),
+  panelVizIcon: css({
+    marginLeft: 'auto',
+  }),
+});
+
+type OpenPanelEditVizProps = {
+  model: VizPanelEditableElement;
+};
+
+const OpenPanelEditViz = ({ model }: OpenPanelEditVizProps) => {
+  const styles = useStyles2(getStyles);
+
+  const plugin = model.getPanel().getPlugin();
+  const imgSrc = plugin?.meta.info.logos.small;
+
+  return (
+    <>
+      <Stack alignItems="center" width="100%">
+        {plugin ? (
+          <Tooltip content="Open Panel Edit">
+            <a
+              href={textUtil.sanitizeUrl(getEditPanelUrl(getPanelIdForVizPanel(model.getPanel())))}
+              className={cx(styles.pluginDescriptionWrapper)}
+              onClick={() => {}}
+            >
+              <img className={styles.panelVizImg} src={imgSrc} alt="Image of plugin type" />
+              <Text truncate>{plugin.meta.name}</Text>
+              <Icon className={styles.panelVizIcon} name="sliders-v-alt" />
+            </a>
+          </Tooltip>
+        ) : null}
+      </Stack>
+    </>
+  );
+};

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1041,8 +1041,7 @@
         "copy-or-duplicate": "Copy or Duplicate",
         "delete": "Delete",
         "duplicate": "Duplicate",
-        "panels": "Panels",
-        "selected": "Selected"
+        "panels-title": "{{length}} Panels Selected"
       }
     },
     "options": {
@@ -1201,6 +1200,8 @@
     "viz-panel": {
       "options": {
         "description": "Description",
+        "open-edit": "Open Panel Edit",
+        "title": "Panel",
         "title-option": "Title",
         "transparent-background": "Transparent background"
       }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -952,11 +952,6 @@
         }
       },
       "open": "Open options pane",
-      "panels": {
-        "multi-select": {
-          "selection-number": "No. of panels selected: {{length}}"
-        }
-      },
       "row": {
         "header": {
           "hide": "Hide",
@@ -1039,6 +1034,16 @@
       "request-time": "Total request time",
       "rows": "Total number rows",
       "table-title": "Stats"
+    },
+    "layout": {
+      "common": {
+        "copy": "Copy",
+        "copy-or-duplicate": "Copy or Duplicate",
+        "delete": "Delete",
+        "duplicate": "Duplicate",
+        "panels": "Panels",
+        "selected": "Selected"
+      }
     },
     "options": {
       "description": "Description",
@@ -1196,7 +1201,6 @@
     "viz-panel": {
       "options": {
         "description": "Description",
-        "title": "Panel options",
         "title-option": "Title",
         "transparent-background": "Transparent background"
       }

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1041,8 +1041,7 @@
         "copy-or-duplicate": "Cőpy őř Đūpľįčäŧę",
         "delete": "Đęľęŧę",
         "duplicate": "Đūpľįčäŧę",
-        "panels": "Päŉęľş",
-        "selected": "Ŝęľęčŧęđ"
+        "panels-title": "{{length}} Päŉęľş Ŝęľęčŧęđ"
       }
     },
     "options": {
@@ -1201,6 +1200,8 @@
     "viz-panel": {
       "options": {
         "description": "Đęşčřįpŧįőŉ",
+        "open-edit": "Øpęŉ Päŉęľ Ēđįŧ",
+        "title": "Päŉęľ",
         "title-option": "Ŧįŧľę",
         "transparent-background": "Ŧřäŉşpäřęŉŧ þäčĸģřőūŉđ"
       }

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -952,11 +952,6 @@
         }
       },
       "open": "Øpęŉ őpŧįőŉş päŉę",
-      "panels": {
-        "multi-select": {
-          "selection-number": "Ńő. őƒ päŉęľş şęľęčŧęđ: {{length}}"
-        }
-      },
       "row": {
         "header": {
           "hide": "Ħįđę",
@@ -1039,6 +1034,16 @@
       "request-time": "Ŧőŧäľ řęqūęşŧ ŧįmę",
       "rows": "Ŧőŧäľ ŉūmþęř řőŵş",
       "table-title": "Ŝŧäŧş"
+    },
+    "layout": {
+      "common": {
+        "copy": "Cőpy",
+        "copy-or-duplicate": "Cőpy őř Đūpľįčäŧę",
+        "delete": "Đęľęŧę",
+        "duplicate": "Đūpľįčäŧę",
+        "panels": "Päŉęľş",
+        "selected": "Ŝęľęčŧęđ"
+      }
     },
     "options": {
       "description": "Đęşčřįpŧįőŉ",
@@ -1196,7 +1201,6 @@
     "viz-panel": {
       "options": {
         "description": "Đęşčřįpŧįőŉ",
-        "title": "Päŉęľ őpŧįőŉş",
         "title-option": "Ŧįŧľę",
         "transparent-background": "Ŧřäŉşpäřęŉŧ þäčĸģřőūŉđ"
       }


### PR DESCRIPTION
Adding changes related to viz panel and multi viz panel edit pane redesigns.

Before:
<img width="272" alt="Screenshot 2025-02-26 at 14 13 47" src="https://github.com/user-attachments/assets/33deefa0-0057-48f2-8126-a79c7bb845ea" />
<img width="279" alt="Screenshot 2025-02-26 at 14 14 12" src="https://github.com/user-attachments/assets/fab28a93-a0a8-4d81-8025-2ca8659ab9da" />

After:
<img width="299" alt="Screenshot 2025-02-26 at 14 13 33" src="https://github.com/user-attachments/assets/c5f0b9f4-46ca-45ed-ba96-5f6366db7773" />
<img width="298" alt="Screenshot 2025-02-26 at 14 14 21" src="https://github.com/user-attachments/assets/710a0ebb-3227-4985-bf80-6489358dbfa8" />
