### PR TITLE
Dashboard: Redesign row edit panes

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -4,6 +4,7 @@ import { SceneObjectState, SceneObjectBase, sceneGraph, VariableDependencyConfig
 import { t } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
+import { renderTitle } from '../../edit-pane/shared';
 import { getDefaultVizPanel } from '../../utils/utils';
 import { ResponsiveGridLayoutManager } from '../layout-responsive-grid/ResponsiveGridLayoutManager';
 import { BulkActionElement } from '../types/BulkActionElement';
@@ -11,7 +12,7 @@ import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { EditableDashboardElement } from '../types/EditableDashboardElement';
 import { LayoutParent } from '../types/LayoutParent';
 
-import { getEditOptions, renderActions } from './RowItemEditor';
+import { getEditOptions } from './RowItemEditor';
 import { RowItemRenderer } from './RowItemRenderer';
 import { RowItemRepeaterBehavior } from './RowItemRepeaterBehavior';
 import { RowItems } from './RowItems';
@@ -70,13 +71,17 @@ export class RowItem
     return getEditOptions(this);
   }
 
-  public renderActions(): ReactNode {
-    return renderActions(this);
-  }
+  // public renderActions(): ReactNode {
+  //   return renderActions(this);
+  // }
 
-  public onDelete() {
+  public renderTitle: () => ReactNode = () => {
+    return renderTitle({ title: `Row`, onDelete: this.onDelete });
+  };
+
+  public onDelete = () => {
     this._getParentLayout().removeRow(this);
-  }
+  };
 
   public createMultiSelectedElement(items: SceneObject[]): RowItems {
     return new RowItems(items.filter((item) => item instanceof RowItem));
@@ -94,13 +99,13 @@ export class RowItem
     this._getParentLayout().addRowBelow(this);
   }
 
-  public onMoveUp() {
+  public onMoveUp = () => {
     this._getParentLayout().moveRowUp(this);
-  }
+  };
 
-  public onMoveDown() {
+  public onMoveDown = () => {
     this._getParentLayout().moveRowDown(this);
-  }
+  };
 
   public isFirstRow(): boolean {
     return this._getParentLayout().isFirstRow(this);

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 
-import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Alert, Button, Input, RadioButtonGroup, Switch, TextLink } from '@grafana/ui';
+import { Alert, Input, Switch, TextLink } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -10,18 +9,28 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
+import { renderTitle } from '../../edit-pane/shared';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 import { DashboardScene } from '../DashboardScene';
-import { useLayoutCategory } from '../layouts-shared/DashboardLayoutSelector';
+import { DashboardLayoutSelector } from '../layouts-shared/DashboardLayoutSelector';
 
 import { RowItem } from './RowItem';
 
 export function getEditOptions(model: RowItem): OptionsPaneCategoryDescriptor[] {
+  const { layout } = model.useState();
   const rowOptions = useMemo(() => {
+    const dashboard = getDashboardSceneFor(model);
+
     return new OptionsPaneCategoryDescriptor({
-      title: t('dashboard.rows-layout.row-options.title', 'Row options'),
+      title: t('dashboard.rows-layout.row-options.title', 'Row'),
       id: 'row-options',
       isOpenDefault: true,
+      alwaysExpanded: true,
+      renderTitle: () =>
+        renderTitle({
+          title: t('dashboard.rows-layout.row-options.title', 'Row'),
+          onDelete: model.onDelete,
+        }),
     })
       .addItem(
         new OptionsPaneItemDescriptor({
@@ -31,8 +40,16 @@ export function getEditOptions(model: RowItem): OptionsPaneCategoryDescriptor[] 
       )
       .addItem(
         new OptionsPaneItemDescriptor({
-          title: t('dashboard.rows-layout.row-options.height.title', 'Height'),
-          render: () => <RowHeightSelect row={model} />,
+          title: t('dashboard.layout.common.layout', 'Layout'),
+          render: function renderTitle() {
+            return <DashboardLayoutSelector layoutManager={layout} />;
+          },
+        })
+      )
+      .addItem(
+        new OptionsPaneItemDescriptor({
+          title: t('dashboard.rows-layout.row-options.repeat.variable.title', 'Repeat for'),
+          render: () => <RowRepeatSelect row={model} dashboard={dashboard} />,
         })
       )
       .addItem(
@@ -41,59 +58,33 @@ export function getEditOptions(model: RowItem): OptionsPaneCategoryDescriptor[] 
           render: () => <RowHeaderSwitch row={model} />,
         })
       );
-  }, [model]);
+  }, [layout, model]);
 
-  const rowRepeatOptions = useMemo(() => {
-    const dashboard = getDashboardSceneFor(model);
-
-    return new OptionsPaneCategoryDescriptor({
-      title: t('dashboard.rows-layout.row-options.repeat.title', 'Repeat options'),
-      id: 'row-repeat-options',
-      isOpenDefault: true,
-    }).addItem(
-      new OptionsPaneItemDescriptor({
-        title: t('dashboard.rows-layout.row-options.repeat.variable.title', 'Variable'),
-        render: () => <RowRepeatSelect row={model} dashboard={dashboard} />,
-      })
-    );
-  }, [model]);
-
-  const { layout } = model.useState();
-  const layoutOptions = useLayoutCategory(layout);
-
-  return [rowOptions, rowRepeatOptions, layoutOptions];
+  return [rowOptions];
 }
 
 export function renderActions(model: RowItem) {
-  return (
-    <>
-      <Button size="sm" variant="secondary" icon="copy" />
-      <Button size="sm" variant="destructive" fill="outline" onClick={() => model.onDelete()} icon="trash-alt" />
-    </>
-  );
+  const categories = getEditOptions(model);
+
+  return categories.map((cat) => cat.render());
 }
 
 function RowTitleInput({ row }: { row: RowItem }) {
   const { title } = row.useState();
 
-  return <Input value={title} onChange={(e) => row.onChangeTitle(e.currentTarget.value)} />;
+  return (
+    <Input
+      title={t('dashboard.rows-layout.row-options.title-option', 'Title')}
+      value={title}
+      onChange={(e) => row.onChangeTitle(e.currentTarget.value)}
+    />
+  );
 }
 
 function RowHeaderSwitch({ row }: { row: RowItem }) {
   const { isHeaderHidden = false } = row.useState();
 
   return <Switch value={isHeaderHidden} onChange={() => row.onHeaderHiddenToggle()} />;
-}
-
-function RowHeightSelect({ row }: { row: RowItem }) {
-  const { height = 'expand' } = row.useState();
-
-  const options: Array<SelectableValue<'expand' | 'min'>> = [
-    { label: t('dashboard.rows-layout.row-options.height.expand', 'Expand'), value: 'expand' },
-    { label: t('dashboard.rows-layout.row-options.height.min', 'Min'), value: 'min' },
-  ];
-
-  return <RadioButtonGroup options={options} value={height} onChange={(option) => row.onChangeHeight(option)} />;
 }
 
 function RowRepeatSelect({ row, dashboard }: { row: RowItem; dashboard: DashboardScene }) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemMenu.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemMenu.tsx
@@ -12,6 +12,7 @@ interface RowItemMenuProps {
 
 export function RowItemMenu({ model }: RowItemMenuProps) {
   const styles = useStyles2(getStyles);
+  const {} = model.useState();
 
   return (
     <ToolbarButtonRow className={styles.container}>
@@ -39,43 +40,45 @@ export function RowItemMenu({ model }: RowItemMenuProps) {
         )}
       >
         <ToolbarButton
-          aria-label={t('dashboard.rows-layout.row.menu.add', 'Add')}
-          title={t('dashboard.rows-layout.row.menu.add', 'Add')}
+          aria-label={t('dashboard.rows-layout.row.menu.add', 'Add row')}
+          title={t('dashboard.rows-layout.row.menu.add', 'Add row')}
+          tooltip={t('dashboard.rows-layout.row.menu.add', 'Add row')}
           icon="plus"
           iconSize="sm"
-          variant="primary"
+          variant="default"
         >
-          <Trans i18nKey="dashboard.rows-layout.row.menu.add">Add</Trans>
+          <Trans i18nKey="grafana-ui.tags-input.add">Add</Trans>
         </ToolbarButton>
       </Dropdown>
-      <ToolbarButton
-        aria-label={t('dashboard.rows-layout.row.menu.delete', 'Delete')}
-        title={t('dashboard.rows-layout.row.menu.delete', 'Delete')}
-        icon="trash-alt"
-        iconSize="sm"
-        variant="destructive"
-        onClick={() => model.onDelete()}
-      />
-      {!model.isFirstRow() && (
+      <Dropdown
+        placement="bottom-end"
+        overlay={() => (
+          <Menu>
+            <Menu.Item
+              aria-label={t('dashboard.rows-layout.row.menu.move-up', 'Move row up')}
+              label={t('dashboard.rows-layout.row.menu.move-up', 'Move row up')}
+              onClick={() => model.onMoveUp()}
+              disabled={model.isFirstRow()}
+            />
+            <Menu.Divider />
+            <Menu.Item
+              aria-label={t('dashboard.rows-layout.row.menu.move-down', 'Move row down')}
+              label={t('dashboard.rows-layout.row.menu.move-down', 'Move row down')}
+              onClick={() => model.onMoveDown()}
+              disabled={model.isLastRow()}
+            />
+          </Menu>
+        )}
+      >
         <ToolbarButton
-          aria-label={t('dashboard.rows-layout.row.menu.move-up', 'Move up')}
-          title={t('dashboard.rows-layout.row.menu.move-up', 'Move up')}
-          icon="arrow-up"
-          iconSize="sm"
-          variant="canvas"
-          onClick={() => model.onMoveUp()}
+          aria-label={t('dashboard.rows-layout.row.menu.move-row', 'Move row')}
+          title={t('dashboard.rows-layout.row.menu.move-row', 'Move row')}
+          tooltip={t('dashboard.rows-layout.row.menu.move-row', 'Move row')}
+          icon="arrows-v"
+          iconSize="md"
+          variant="default"
         />
-      )}
-      {!model.isLastRow() && (
-        <ToolbarButton
-          aria-label={t('dashboard.rows-layout.row.menu.move-down', 'Move down')}
-          title={t('dashboard.rows-layout.row.menu.move-down', 'Move down')}
-          icon="arrow-down"
-          iconSize="sm"
-          variant="canvas"
-          onClick={() => model.onMoveDown()}
-        />
-      )}
+      </Dropdown>
     </ToolbarButtonRow>
   );
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -38,9 +38,9 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
       {(!isHeaderHidden || (isEditing && showHiddenElements)) && (
         <div className={styles.rowHeader}>
           {!isClone && isEditing && (
-            <span onPointerDown={onSelect}>
+            <div className={styles.checkboxWrapper} onPointerDown={onSelect}>
               <Checkbox value={!!isSelected} />
-            </span>
+            </div>
           )}
           <button
             onClick={() => model.onCollapseToggle()}
@@ -111,6 +111,10 @@ function getStyles(theme: GrafanaTheme2) {
     rowActions: css({
       display: 'flex',
       opacity: 0,
+    }),
+    checkboxWrapper: css({
+      display: 'flex',
+      alignItems: 'center',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItems.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItems.tsx
@@ -3,15 +3,17 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
+import { renderTitle } from '../../edit-pane/shared';
 import { MultiSelectedEditableDashboardElement } from '../types/MultiSelectedEditableDashboardElement';
 
 import { RowItem } from './RowItem';
-import { getEditOptions, renderActions } from './RowItemsEditor';
+import { getEditOptions } from './RowItemsEditor';
 
 export class RowItems implements MultiSelectedEditableDashboardElement {
   public readonly isMultiSelectedEditableDashboardElement = true;
   public readonly typeName = 'Rows';
   public readonly key: string;
+  public readonly alwaysExpanded = true;
 
   public constructor(private _rows: RowItem[]) {
     this.key = uuidv4();
@@ -21,19 +23,21 @@ export class RowItems implements MultiSelectedEditableDashboardElement {
     return getEditOptions(this);
   }
 
-  public renderActions(): ReactNode {
-    return renderActions(this);
-  }
+  public renderTitle: () => ReactNode = () => {
+    return renderTitle({ title: `${this._rows.length} Selected`, onDelete: this.onDelete });
+  };
 
   public getRows(): RowItem[] {
     return this._rows;
   }
 
-  public onDelete() {
+  public onDelete = () => {
     this._rows.forEach((row) => row.onDelete());
-  }
+  };
 
   public onHeaderHiddenToggle(value: boolean, indeterminate: boolean) {
     this._rows.forEach((row) => row.onHeaderHiddenToggle(indeterminate ? true : !value));
   }
+
+  public getNumberOfRowsSelected = () => this._rows.length;
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemsEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemsEditor.tsx
@@ -3,6 +3,8 @@ import { t, Trans } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
+import { renderTitle } from '../../edit-pane/shared';
+
 import { RowItems } from './RowItems';
 
 export function getEditOptions(model: RowItems): OptionsPaneCategoryDescriptor[] {
@@ -10,6 +12,9 @@ export function getEditOptions(model: RowItems): OptionsPaneCategoryDescriptor[]
     title: t('dashboard.edit-pane.row.multi-select.options-header', 'Multi-selected Row options'),
     id: `ms-row-options-${model.key}`,
     isOpenDefault: true,
+    alwaysExpanded: true,
+    renderTitle: () =>
+      renderTitle({ title: `${model.getNumberOfRowsSelected()} Rows Selected`, onDelete: model.onDelete }),
   }).addItem(
     new OptionsPaneItemDescriptor({
       title: t('dashboard.edit-pane.row.header.title', 'Row header'),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1040,6 +1040,15 @@
       "rows": "Total number rows",
       "table-title": "Stats"
     },
+    "layout": {
+      "common": {
+        "copy": "Copy",
+        "copy-or-duplicate": "Copy or Duplicate",
+        "delete": "Delete",
+        "duplicate": "Duplicate",
+        "layout": "Layout"
+      }
+    },
     "options": {
       "description": "Description",
       "title": "Dashboard options",
@@ -1075,13 +1084,13 @@
         "collapse": "Collapse row",
         "expand": "Expand row",
         "menu": {
-          "add": "Add",
+          "add": "Add row",
           "add-panel": "Panel",
           "add-row-above": "Row above",
           "add-row-below": "Row below",
-          "delete": "Delete",
-          "move-down": "Move down",
-          "move-up": "Move up"
+          "move-down": "Move row down",
+          "move-row": "Move row",
+          "move-up": "Move row up"
         },
         "new": "New row",
         "repeat": {
@@ -1091,18 +1100,14 @@
       },
       "row-options": {
         "height": {
-          "expand": "Expand",
-          "hide-row-header": "Hide row header",
-          "min": "Min",
-          "title": "Height"
+          "hide-row-header": "Hide row header"
         },
         "repeat": {
-          "title": "Repeat options",
           "variable": {
-            "title": "Variable"
+            "title": "Repeat for"
           }
         },
-        "title": "Row options",
+        "title": "Row",
         "title-option": "Title"
       }
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1040,6 +1040,15 @@
       "rows": "Ŧőŧäľ ŉūmþęř řőŵş",
       "table-title": "Ŝŧäŧş"
     },
+    "layout": {
+      "common": {
+        "copy": "Cőpy",
+        "copy-or-duplicate": "Cőpy őř Đūpľįčäŧę",
+        "delete": "Đęľęŧę",
+        "duplicate": "Đūpľįčäŧę",
+        "layout": "Ŀäyőūŧ"
+      }
+    },
     "options": {
       "description": "Đęşčřįpŧįőŉ",
       "title": "Đäşĥþőäřđ őpŧįőŉş",
@@ -1075,13 +1084,13 @@
         "collapse": "Cőľľäpşę řőŵ",
         "expand": "Ēχpäŉđ řőŵ",
         "menu": {
-          "add": "Åđđ",
+          "add": "Åđđ řőŵ",
           "add-panel": "Päŉęľ",
           "add-row-above": "Ŗőŵ äþővę",
           "add-row-below": "Ŗőŵ þęľőŵ",
-          "delete": "Đęľęŧę",
-          "move-down": "Mővę đőŵŉ",
-          "move-up": "Mővę ūp"
+          "move-down": "Mővę řőŵ đőŵŉ",
+          "move-row": "Mővę řőŵ",
+          "move-up": "Mővę řőŵ ūp"
         },
         "new": "Ńęŵ řőŵ",
         "repeat": {
@@ -1091,18 +1100,14 @@
       },
       "row-options": {
         "height": {
-          "expand": "Ēχpäŉđ",
-          "hide-row-header": "Ħįđę řőŵ ĥęäđęř",
-          "min": "Mįŉ",
-          "title": "Ħęįģĥŧ"
+          "hide-row-header": "Ħįđę řőŵ ĥęäđęř"
         },
         "repeat": {
-          "title": "Ŗępęäŧ őpŧįőŉş",
           "variable": {
-            "title": "Väřįäþľę"
+            "title": "Ŗępęäŧ ƒőř"
           }
         },
-        "title": "Ŗőŵ őpŧįőŉş",
+        "title": "Ŗőŵ",
         "title-option": "Ŧįŧľę"
       }
     },


### PR DESCRIPTION
Adding changes related to Row edit pane / header redesigns:

Before:
<img width="274" alt="Screenshot 2025-02-26 at 14 18 32" src="https://github.com/user-attachments/assets/b55dfbaa-ffc4-4b27-8f53-ea5cadf53863" />
<img width="270" alt="Screenshot 2025-02-26 at 14 18 41" src="https://github.com/user-attachments/assets/5f8a3afc-7737-4b99-a11c-8fda3dcc831f" />

After:
<img width="298" alt="Screenshot 2025-02-26 at 14 19 28" src="https://github.com/user-attachments/assets/e672e6b9-195a-48de-a450-10cf25976dfb" />
<img width="294" alt="Screenshot 2025-02-26 at 14 19 35" src="https://github.com/user-attachments/assets/790b8ac0-b1ea-48d2-aa38-84303f1f6ab9" />
<img width="675" alt="image" src="https://github.com/user-attachments/assets/81c7a3fe-019e-4619-a5fa-0e05c1a3bb5c" />
