### PR TITLE
[Chore] Mark CodeQL warning as safe

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
       - '**/*.md'
       - '**/*.txt'
       - '**/*.yml'
+      - pkg/storage/unified/sql/db/dbimpl/db.go # Ignoring warnings on the whole file for now while inline comments is not supported in Go (https://github.com/github/codeql/issues/11427)
   schedule:
     - cron: '0 4 * * 6'
 

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -48,10 +48,14 @@ type sqlTx struct {
 	*sql.Tx
 }
 
-func (d sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
-	return d.Tx.QueryContext(ctx, query, args...)
+func (tx sqlTx) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
+	// // codeql-suppress go/sql-query-built-from-user-controlled-sources "The query comes from a safe template source
+	// and the parameters are passed as arguments."
+	return tx.Tx.QueryContext(ctx, query, args...)
 }
 
-func (d sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
-	return d.Tx.QueryRowContext(ctx, query, args...)
+func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
+	// // codeql-suppress go/sql-query-built-from-user-controlled-sources "The query comes from a safe template source
+	// and the parameters are passed as arguments."
+	return tx.Tx.QueryRowContext(ctx, query, args...)
 }


### PR DESCRIPTION
Relates to https://github.com/grafana/grafana/security/code-scanning/941,  https://github.com/grafana/grafana/security/code-scanning/940

Relates as well with https://github.com/grafana/search-and-storage-team/issues/198

This PR doesn't fix errors in `db/dbimpl` but I believe they are safe to be ignored as I believe they have been falsely flagged by the bot from lack of context. Explaining:

We are wrapping `QueryContext` and `QueryRowContext` in a wrapper of our own type, as we need to append the [SQL driver name](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/sql/db/dbimpl/db.go#L21) as a field.
This causes the bot to loose the context from where the query initially comes from. We are injecting it on the layer above where we safely import it as a text template (for example in [here](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/sql/dbutil/dbutil.go#L129)). The risk of doing any sort of SQL injection would happen in case the source of the template was unknown and / or if the query would not consider placeholders, which is not the case. Besides, by using [tx.QueryContext](https://pkg.go.dev/database/sql#Tx.QueryContext) we are already following the good practice of splitting the query from args as internally tx.QueryContext will only consider the second argument as a query: the third argument will be treated as data and not as a SQL executable.
I also considered using a prepared statement as the autofix suggests but I decided against it for the following reasons:

if the query source is known and already uses placeholders, using a prepared statement won't add any extra layer of security: the only benefit it brings is in case this query is reused very frequently to increase driver's performance.
closing the statement ends up closing the DB connection: I haven't fully investigated why, and it's something we could consider doing in the future, but my initial thought is that it could go against the List / Watch pattern we are following
an argument with less weight but still worth considering is that we would need to modify all expectations for tests in dbutil package as we would need to assert on the prepared SQL statement and not on the correct used SQL template.

**A note about ignoring CodeSQL warnings**
For cases where we are sure warnings can be ignored, currently the only way we can do that is by dismissing them in the GH UI. There isn't currently any way to do this inline (https://github.com/github/codeql/issues/11427) but there are third party libs we can use to help us ignore these warnings if they become too annoying.

**Special notes for your reviewer:**

How to run CodeQL scans currently
Go to the [CodeQL action](https://github.com/grafana/grafana/actions/workflows/codeql-analysis.yml) and click on run workflow dropdown. Select your branch and click on Run Workflow green button. Results will be shown on your PR and also in [here](https://github.com/grafana/grafana/security/code-scanning?query=is%3Aopen+branch%3Amain+language%3Ago+tool%3ACodeQL). Select by your branch to see all the potential vulnerabilities there.
