### PR TITLE
Drilldown: Require `datasources:explore` RBAC action

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -66,9 +66,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				{
 					Action: ac.ActionDatasourcesExplore,
 				},
-				{
-					Action: ac.ActionDatasourcesDrilldown,
-				},
 			},
 		},
 		Grants: []string{string(org.RoleEditor)},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -183,7 +183,7 @@ func (hs *HTTPServer) registerRoutes() {
 	}
 
 	r.Get("/explore", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
-	r.Get("/drilldown", authorize(ac.EvalPermission(ac.ActionDatasourcesDrilldown)), hs.Index)
+	r.Get("/drilldown", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
 
 	r.Get("/playlists/", reqSignedIn, hs.Index)
 	r.Get("/playlists/*", reqSignedIn, hs.Index)

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -386,8 +386,7 @@ const (
 	ActionSettingsWrite = "settings:write"
 
 	// Datasources actions
-	ActionDatasourcesExplore   = "datasources:explore"
-	ActionDatasourcesDrilldown = "datasources:drilldown"
+	ActionDatasourcesExplore = "datasources:explore"
 
 	// Global Scopes
 	ScopeGlobalUsersAll = "global.users:*"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -130,7 +130,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
-	if hasAccess(ac.EvalPermission(ac.ActionDatasourcesDrilldown)) {
+	if hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
 		drilldownChildNavLinks := s.buildDrilldownNavLinks(c)
 		treeRoot.AddSection(&navtree.NavLink{
 			Text:       "Drilldown",


### PR DESCRIPTION
**What is this feature?**

Requiring `datasources:drilldown` will block Viewers with Explore from accessing Drilldown. Until we've figured out a better way, we should rollback the `datasources:drilldown` to `datasources:explore`.

Related: https://github.com/grafana/grafana/pull/100409