### PR TITLE
Playlists: Add support for back button

### DIFF
--- a/public/app/features/playlist/PlaylistSrv.test.ts
+++ b/public/app/features/playlist/PlaylistSrv.test.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import { Location } from 'history';
 import { Store } from 'redux';
 import configureMockStore from 'redux-mock-store';
 

--- a/public/app/features/playlist/PlaylistSrv.test.ts
+++ b/public/app/features/playlist/PlaylistSrv.test.ts
@@ -1,4 +1,5 @@
 // @ts-ignore
+import { Location } from 'history';
 import { Store } from 'redux';
 import configureMockStore from 'redux-mock-store';
 
@@ -9,7 +10,6 @@ import { DashboardQueryResult } from '../search/service/types';
 
 import { PlaylistSrv } from './PlaylistSrv';
 import { Playlist, PlaylistItem } from './types';
-import { Location } from 'history';
 
 jest.mock('./api', () => ({
   getPlaylistAPI: () => ({

--- a/public/app/features/playlist/PlaylistSrv.test.ts
+++ b/public/app/features/playlist/PlaylistSrv.test.ts
@@ -9,6 +9,7 @@ import { DashboardQueryResult } from '../search/service/types';
 
 import { PlaylistSrv } from './PlaylistSrv';
 import { Playlist, PlaylistItem } from './types';
+import { Location } from 'history';
 
 jest.mock('./api', () => ({
   getPlaylistAPI: () => ({
@@ -138,5 +139,30 @@ describe('PlaylistSrv', () => {
     // eslint-disable-next-line
     expect((srv as any).validPlaylistUrl).toBe('/url/to/bbb');
     expect(srv.state.isPlaying).toBe(true);
+  });
+
+  it('should replace playlist start page in history when starting playlist', async () => {
+    // Start at playlists page
+    locationService.push('/playlists');
+
+    // Navigate to playlist start page
+    locationService.push('/playlists/play/foo');
+
+    // Start the playlist
+    await srv.start('foo');
+
+    // Get history entries
+    const history = locationService.getHistory();
+    const entries = (history as unknown as { entries: Location[] }).entries;
+
+    // The current entry should be the first dashboard
+    expect(entries[entries.length - 1].pathname).toBe('/url/to/aaa');
+
+    // The previous entry should be the playlists page, not the start page
+    expect(entries[entries.length - 2].pathname).toBe('/playlists');
+
+    // Verify the start page (/playlists/play/foo) is not in history
+    const hasStartPage = entries.some((entry: { pathname: string }) => entry.pathname === '/playlists/play/foo');
+    expect(hasStartPage).toBe(false);
   });
 });


### PR DESCRIPTION
**What is this feature?**

This PR brings back the functionality introduced on [this PR](https://github.com/grafana/grafana/pull/99401) without the side effect of not being able to start a playlist from the URL.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/101165

**Special notes for your reviewer:**
This solution takes a different approach from the first one.
The `PlaylistStartPage` is only used to start a Playlist but it's route `/playlists/play/:uid` shouldn't be part of the history.
In this PR, we remove this URL from the history so when a back button is hit in the browser it goes to the previous history.

What to test:
* Start a Playlist from the Playlist start modal with different parameters and go back
* Start a Playlist using the direct URL (grab it from the share button in the Playlist card) and go back 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
