### PR TITLE
Alerting: Change default for ha_redis_prefix.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1293,7 +1293,7 @@ ha_redis_db =
 
 # A prefix that is used for every key or channel that is created on the redis server
 # as part of HA for alerting.
-ha_redis_prefix =
+ha_redis_prefix = alerting
 
 # The name of the cluster peer that will be used as identifier. If none is
 # provided, a random one will be generated.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1276,7 +1276,7 @@
 
 # A prefix that is used for every key or channel that is created on the redis server
 # as part of HA for alerting.
-;ha_redis_prefix =
+;ha_redis_prefix = alerting
 
 # The name of the cluster peer that will be used as identifier. If none is
 # provided, a random one will be generated.

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -74,7 +74,7 @@ database for HA and cannot support the meshing of all Grafana servers.
 1. In your custom configuration file ($WORKING_DIR/conf/custom.ini), go to the `[unified_alerting]` section.
 1. Set `ha_redis_address` to the Redis server address Grafana should connect to.
 1. Optional: Set the username and password if authentication is enabled on the Redis server using `ha_redis_username` and `ha_redis_password`.
-1. Optional: Set `ha_redis_prefix` to something unique if you plan to share the Redis server with multiple Grafana instances.
+1. Optional: Set `ha_redis_prefix` to something unique if you plan to share the Redis server with multiple Grafana instances. If not set, defaults to `alerting`.
 1. Optional: Set `ha_redis_tls_enabled` to `true` and configure the corresponding `ha_redis_tls_*` fields to secure communications between Grafana and Redis with Transport Layer Security (TLS).
 1. Set `[ha_advertise_address]` to `ha_advertise_address = "${POD_IP}:9094"` This is required if the instance doesn't have an IP address that is part of RFC 6890 with a default route.
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -269,7 +269,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.HARedisClusterModeEnabled = ua.Key("ha_redis_cluster_mode_enabled").MustBool(false)
 	uaCfg.HARedisAddr = ua.Key("ha_redis_address").MustString("")
 	uaCfg.HARedisPeerName = ua.Key("ha_redis_peer_name").MustString("")
-	uaCfg.HARedisPrefix = ua.Key("ha_redis_prefix").MustString("")
+	uaCfg.HARedisPrefix = ua.Key("ha_redis_prefix").MustString("alerting")
 	uaCfg.HARedisUsername = ua.Key("ha_redis_username").MustString("")
 	uaCfg.HARedisPassword = ua.Key("ha_redis_password").MustString("")
 	uaCfg.HARedisDB = ua.Key("ha_redis_db").MustInt(0)


### PR DESCRIPTION
Having the default as an empty string makes it hard to share a single Redis instance amongst the various Grafana components, so it would be better to have a default. This is safe to do because we do not store any state in Redis, we only use it for PUB/SUB. This is however technically a breaking change, as when a user upgrades, and the default changes, so the prefix is different. In practice, the worst that can happen is some duplicate notifications until all replicas are using the new prefix.

# Release notice breaking change

The default value for `[unified_alerting] ha_redis_prefix` had been changed from an empty string to `alerting`. If you are using this feature, and are using the default value, then some duplicate alert notifications may be witnessed whilst upgrading.