### PR TITLE
Unistore: Batch write events

### DIFF
--- a/pkg/storage/unified/sql/bulk.go
+++ b/pkg/storage/unified/sql/bulk.go
@@ -245,7 +245,9 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 			}
 
 			// Make sure the collection RV is above our last written event
-			_, err = b.resourceVersionAtomicInc(ctx, tx, key)
+			_, err = b.rvManager.ExecWithRV(ctx, key, func(tx db.Tx) (string, error) {
+				return "", nil
+			})
 			if err != nil {
 				b.log.Warn("error increasing RV", "error", err)
 			}

--- a/pkg/storage/unified/sql/data/resource_history_update_rv.sql
+++ b/pkg/storage/unified/sql/data/resource_history_update_rv.sql
@@ -1,4 +1,12 @@
 UPDATE {{ .Ident "resource_history" }}
-    SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
-    WHERE  {{ .Ident "guid" }} = {{ .Arg .GUID }}
-;
+SET {{ .Ident "resource_version" }} = (
+    CASE
+    {{ range $guid, $rv := .GUIDToRV }}
+    WHEN {{ $.Ident "guid" }} = {{ $.Arg $guid }} THEN CAST({{ $.Arg $rv }} AS {{ if eq $.DialectName "postgres" }}BIGINT{{ else }}SIGNED{{ end }})
+    {{ end }}
+    END
+)
+WHERE {{ .Ident "guid" }} IN (
+    {{$first := true}}
+    {{ range $guid, $rv := .GUIDToRV }}{{if $first}}{{$first = false}}{{else}}, {{end}}{{ $.Arg $guid }}{{ end }}
+);

--- a/pkg/storage/unified/sql/data/resource_update.sql
+++ b/pkg/storage/unified/sql/data/resource_update.sql
@@ -3,7 +3,8 @@ UPDATE {{ .Ident "resource" }}
         {{ .Ident "guid" }}   = {{ .Arg .GUID }},
         {{ .Ident "value" }}  = {{ .Arg .WriteEvent.Value }},
         {{ .Ident "folder" }}  = {{ .Arg .Folder }},
-        {{ .Ident "action" }} = {{ .Arg .WriteEvent.Type }}  
+        {{ .Ident "action" }} = {{ .Arg .WriteEvent.Type }},
+        {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
     WHERE 1 = 1
         AND {{ .Ident "group" }}     = {{ .Arg .WriteEvent.Key.Group }}
         AND {{ .Ident "resource" }}  = {{ .Arg .WriteEvent.Key.Resource }}

--- a/pkg/storage/unified/sql/data/resource_update_rv.sql
+++ b/pkg/storage/unified/sql/data/resource_update_rv.sql
@@ -1,4 +1,12 @@
 UPDATE {{ .Ident "resource" }}
-    SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
-    WHERE  {{ .Ident "guid" }} = {{ .Arg .GUID }}
-;
+SET {{ .Ident "resource_version" }} = (
+    CASE
+    {{ range $guid, $rv := .GUIDToRV }}
+    WHEN {{ $.Ident "guid" }} = {{ $.Arg $guid }} THEN CAST({{ $.Arg $rv }} AS {{ if eq $.DialectName "postgres" }}BIGINT{{ else }}SIGNED{{ end }})
+    {{ end }}
+    END
+)
+WHERE {{ .Ident "guid" }} IN (
+    {{$first := true}}
+    {{ range $guid, $rv := .GUIDToRV }}{{if $first}}{{$first = false}}{{else}}, {{end}}{{ $.Arg $guid }}{{ end }}
+);

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -295,8 +295,7 @@ func (r sqlResourceBlobQueryRequest) Validate() error {
 
 type sqlResourceUpdateRVRequest struct {
 	sqltemplate.SQLTemplate
-	GUID            string
-	ResourceVersion int64
+	GUIDToRV map[string]int64
 }
 
 func (r sqlResourceUpdateRVRequest) Validate() error {

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -136,6 +136,10 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Name: "single path",
 					Data: &sqlResourceUpdateRVRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						GUIDToRV: map[string]int64{
+							"guid1": 123,
+							"guid2": 456,
+						},
 					},
 				},
 			},
@@ -164,6 +168,10 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Name: "single path",
 					Data: &sqlResourceUpdateRVRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						GUIDToRV: map[string]int64{
+							"guid1": 123,
+							"guid2": 456,
+						},
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/rv_manager.go
+++ b/pkg/storage/unified/sql/rv_manager.go
@@ -1,0 +1,265 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// resourceVersionManager handles resource version operations
+type resourceVersionManager struct {
+	dialect sqltemplate.Dialect
+	db      db.DB
+	tracer  trace.Tracer
+	batchMu sync.RWMutex
+	batchCh map[string]chan *writeOp
+
+	maxBatchSize     int
+	maxBatchWaitTime time.Duration
+}
+
+type writeOpResult struct {
+	guid string
+	rv   int64
+	err  error
+}
+
+// writeOp is a write operation that is executed with an incremented resource version
+type writeOp struct {
+	key  *resource.ResourceKey // The key of the resource
+	fn   WriteEventFunc        // The function to execute to write the event
+	done chan writeOpResult    // A channel informing the operation is done
+}
+
+// WriteEventFunc is a function that writes a resource to the database
+// It returns the GUID of the created resource
+// The GUID is used to update the resource version for the resource in the same transaction.
+type WriteEventFunc func(tx db.Tx) (guid string, err error)
+
+type ResourceManagerOptions struct {
+	Dialect          sqltemplate.Dialect // The dialect to use for the database
+	DB               db.DB               // The database to use
+	MaxBatchSize     int                 // The maximum number of operations to batch together
+	MaxBatchWaitTime time.Duration       // The maximum time to wait for a batch to be ready
+	Tracer           trace.Tracer        // The tracer to use for tracing
+}
+
+// NewResourceVersionManager creates a new ResourceVersionManager
+func NewResourceVersionManager(opts ResourceManagerOptions) (*resourceVersionManager, error) {
+	if opts.MaxBatchSize == 0 {
+		opts.MaxBatchSize = 20
+	}
+	if opts.MaxBatchWaitTime == 0 {
+		opts.MaxBatchWaitTime = 5 * time.Millisecond
+	}
+	if opts.Tracer == nil {
+		opts.Tracer = noop.NewTracerProvider().Tracer("resource-version-manager")
+	}
+	if opts.Dialect == nil {
+		return nil, errors.New("dialect is required")
+	}
+	if opts.DB == nil {
+		return nil, errors.New("db is required")
+	}
+	return &resourceVersionManager{
+		dialect:          opts.Dialect,
+		db:               opts.DB,
+		tracer:           opts.Tracer,
+		batchCh:          make(map[string]chan *writeOp),
+		maxBatchSize:     opts.MaxBatchSize,
+		maxBatchWaitTime: opts.MaxBatchWaitTime,
+	}, nil
+}
+
+// ExecWithRV executes the given function with an incremented resource version
+func (m *resourceVersionManager) ExecWithRV(ctx context.Context, key *resource.ResourceKey, fn WriteEventFunc) (rv int64, err error) {
+	ctx, span := m.tracer.Start(ctx, "ExecWithRV")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("group", key.Group),
+		attribute.String("resource", key.Resource),
+	)
+	op := writeOp{key: key, fn: fn, done: make(chan writeOpResult, 1)}
+	batchKey := fmt.Sprintf("%s/%s", key.Group, key.Resource)
+
+	m.batchMu.Lock()
+	ch, ok := m.batchCh[batchKey]
+	if !ok {
+		ch = make(chan *writeOp, m.maxBatchSize)
+		m.batchCh[batchKey] = ch
+		go m.startBatchProcessor(key.Group, key.Resource)
+	}
+	m.batchMu.Unlock()
+	ch <- &op
+	select {
+	case res := <-op.done:
+		if res.err != nil {
+			span.RecordError(res.err)
+		}
+		span.SetAttributes(attribute.String("guid", res.guid))
+		span.SetAttributes(attribute.Int64("resource_version", res.rv))
+		return res.rv, res.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+// startBatchProcessor is responsible for processing batches of write operations
+func (m *resourceVersionManager) startBatchProcessor(group, resource string) {
+	ctx := context.Background() // TODO: use the underlying context
+	batchKey := fmt.Sprintf("%s/%s", group, resource)
+
+	m.batchMu.Lock()
+	ch, ok := m.batchCh[batchKey]
+	if !ok {
+		m.batchMu.Unlock()
+		return
+	}
+	m.batchMu.Unlock()
+
+	for {
+		batch := make([]writeOp, 0, m.maxBatchSize)
+		// wait for a new writeOp
+		select {
+		case op := <-ch:
+			batch = append(batch, *op)
+		case <-ctx.Done():
+			return
+		}
+
+		// wait for the batch to be ready
+		batchReady := false
+		timeout := time.After(m.maxBatchWaitTime)
+		for !batchReady {
+			select {
+			case op := <-ch:
+				batch = append(batch, *op)
+				if len(batch) >= m.maxBatchSize {
+					batchReady = true
+				}
+			case <-timeout:
+				batchReady = true
+			}
+		}
+		go m.execBatch(ctx, group, resource, batch)
+	}
+}
+
+func (m *resourceVersionManager) execBatch(ctx context.Context, group, resource string, batch []writeOp) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	guidToRV := make(map[string]int64, len(batch))
+	guids := make([]string, len(batch)) // The GUIDs of the created resources in the same order as the batch
+	rvs := make([]int64, len(batch))    // The RVs of the created resources in the same order as the batch
+
+	err := m.db.WithTx(ctx, ReadCommitted, func(ctx context.Context, tx db.Tx) error {
+		for i := range batch {
+			guid, err := batch[i].fn(tx)
+			if err != nil {
+				return fmt.Errorf("failed to execute function: %w", err)
+			}
+			guids[i] = guid
+		}
+
+		rv, err := m.lock(ctx, tx, group, resource)
+		if err != nil {
+			return fmt.Errorf("failed to increment resource version: %w", err)
+		}
+		// Allocate the RVs
+		for i, guid := range guids {
+			guidToRV[guid] = rv
+			rvs[i] = rv
+			rv++
+		}
+		// Update the resource version for the created resources in both the resource and the resource history
+		if _, err := dbutil.Exec(ctx, tx, sqlResourceUpdateRV, sqlResourceUpdateRVRequest{
+			SQLTemplate: sqltemplate.New(m.dialect),
+			GUIDToRV:    guidToRV,
+		}); err != nil {
+			return fmt.Errorf("update resource version: %w", err)
+		}
+		if _, err := dbutil.Exec(ctx, tx, sqlResourceHistoryUpdateRV, sqlResourceUpdateRVRequest{
+			SQLTemplate: sqltemplate.New(m.dialect),
+			GUIDToRV:    guidToRV,
+		}); err != nil {
+			return fmt.Errorf("update resource history version: %w", err)
+		}
+		// Record the latest RV in the resource version table
+		return m.saveRV(ctx, tx, group, resource, rv)
+	})
+
+	// notify the caller that the operations are done
+	for i := range batch {
+		batch[i].done <- writeOpResult{
+			guid: guids[i],
+			rv:   rvs[i],
+			err:  err,
+		}
+	}
+}
+
+// lock locks the resource version for the given key
+func (m *resourceVersionManager) lock(ctx context.Context, x db.ContextExecer, group, resource string) (nextRV int64, err error) {
+	// 1. Lock the row and prevent concurrent updates until the transaction is committed
+	res, err := dbutil.QueryRow(ctx, x, sqlResourceVersionGet, sqlResourceVersionGetRequest{
+		SQLTemplate: sqltemplate.New(m.dialect),
+		Group:       group,
+		Resource:    resource,
+		Response:    new(resourceVersionResponse),
+		ReadOnly:    false, // Lock the row for update
+	})
+
+	if errors.Is(err, sql.ErrNoRows) {
+		// If there wasn't a row for this resource, create it
+		if _, err = dbutil.Exec(ctx, x, sqlResourceVersionInsert, sqlResourceVersionUpsertRequest{
+			SQLTemplate: sqltemplate.New(m.dialect),
+			Group:       group,
+			Resource:    resource,
+		}); err != nil {
+			return 0, fmt.Errorf("insert into resource_version: %w", err)
+		}
+
+		// Fetch the newly created resource version
+		res, err = dbutil.QueryRow(ctx, x, sqlResourceVersionGet, sqlResourceVersionGetRequest{
+			SQLTemplate: sqltemplate.New(m.dialect),
+			Group:       group,
+			Resource:    resource,
+			Response:    new(resourceVersionResponse),
+			ReadOnly:    true,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("fetching RV after insert: %w", err)
+		}
+		return res.ResourceVersion, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("lock the resource version: %w", err)
+	}
+
+	return max(res.CurrentEpoch, res.ResourceVersion+1), nil
+}
+
+func (m *resourceVersionManager) saveRV(ctx context.Context, x db.ContextExecer, group, resource string, rv int64) error {
+	_, err := dbutil.Exec(ctx, x, sqlResourceVersionUpdate, sqlResourceVersionUpsertRequest{
+		SQLTemplate:     sqltemplate.New(m.dialect),
+		Group:           group,
+		Resource:        resource,
+		ResourceVersion: rv,
+	})
+	if err != nil {
+		return fmt.Errorf("save resource version: %w", err)
+	}
+	return nil
+}

--- a/pkg/storage/unified/sql/rv_manager.go
+++ b/pkg/storage/unified/sql/rv_manager.go
@@ -160,7 +160,12 @@ func (m *resourceVersionManager) ExecWithRV(ctx context.Context, key *resource.R
 		go m.startBatchProcessor(key.Group, key.Resource)
 	}
 	m.batchMu.Unlock()
-	ch <- &op
+	select {
+	case ch <- &op:
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+
 	select {
 	case res := <-op.done:
 		if res.err != nil {

--- a/pkg/storage/unified/sql/rv_manager.go
+++ b/pkg/storage/unified/sql/rv_manager.go
@@ -56,7 +56,6 @@ var (
 )
 
 const (
-	tracingPrefix           = "sql.rvmanager."
 	defaultMaxBatchSize     = 25
 	defaultMaxBatchWaitTime = 100 * time.Millisecond
 	defaultBatchTimeout     = 5 * time.Second
@@ -143,7 +142,7 @@ func (m *resourceVersionManager) ExecWithRV(ctx context.Context, key *resource.R
 	}))
 	defer timer.ObserveDuration()
 
-	ctx, span := m.tracer.Start(ctx, tracingPrefix+"ExecWithRV")
+	ctx, span := m.tracer.Start(ctx, "sql.rvmanager.ExecWithRV")
 	defer span.End()
 
 	span.SetAttributes(
@@ -218,7 +217,7 @@ func (m *resourceVersionManager) startBatchProcessor(group, resource string) {
 }
 
 func (m *resourceVersionManager) execBatch(ctx context.Context, group, resource string, batch []writeOp) {
-	ctx, span := m.tracer.Start(ctx, tracingPrefix+"execBatch")
+	ctx, span := m.tracer.Start(ctx, "sql.rvmanager.execBatch")
 	defer span.End()
 
 	// Add batch size attribute

--- a/pkg/storage/unified/sql/rv_manager_test.go
+++ b/pkg/storage/unified/sql/rv_manager_test.go
@@ -1,0 +1,64 @@
+package sql
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/test"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func expectSuccessfulResourceVersionLock(t *testing.T, dbp test.TestDBProvider, rv int64, timestamp int64) {
+	dbp.SQLMock.ExpectQuery("select resource_version, unix_timestamp for update").
+		WillReturnRows(sqlmock.NewRows([]string{"resource_version", "unix_timestamp"}).
+			AddRow(rv, timestamp))
+}
+
+func expectSuccessfulResourceVersionSaveRV(t *testing.T, dbp test.TestDBProvider) {
+	dbp.SQLMock.ExpectExec("update resource set resource_version").WillReturnResult(sqlmock.NewResult(1, 1))
+	dbp.SQLMock.ExpectExec("update resource_history set resource_version").WillReturnResult(sqlmock.NewResult(1, 1))
+	dbp.SQLMock.ExpectExec("update resource_version set resource_version").WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func expectSuccessfulResourceVersionExec(t *testing.T, dbp test.TestDBProvider, cbs ...func()) {
+	for _, cb := range cbs {
+		cb()
+	}
+	expectSuccessfulResourceVersionLock(t, dbp, 100, 200)
+	expectSuccessfulResourceVersionSaveRV(t, dbp)
+}
+
+func TestResourceVersionManager(t *testing.T) {
+	ctx := testutil.NewDefaultTestContext(t)
+	dbp := test.NewDBProviderMatchWords(t)
+	dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+	manager, err := NewResourceVersionManager(ResourceManagerOptions{
+		DB:      dbp.DB,
+		Dialect: dialect,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	t.Run("should handle single operation", func(t *testing.T) {
+		key := &resource.ResourceKey{
+			Group:    "test-group",
+			Resource: "test-resource",
+		}
+		dbp.SQLMock.ExpectBegin()
+		expectSuccessfulResourceVersionExec(t, dbp, func() {
+			dbp.SQLMock.ExpectExec("select 1").WillReturnResult(sqlmock.NewResult(1, 1))
+		})
+		dbp.SQLMock.ExpectCommit()
+
+		rv, err := manager.ExecWithRV(ctx, key, func(tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(ctx, "select 1")
+			return "1234", err
+		})
+		require.NoError(t, err)
+		require.Equal(t, rv, int64(200))
+	})
+}

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -23,7 +23,7 @@ func newTestBackend(b *testing.B) resource.StorageBackend {
 	backend, err := sql.NewBackend(sql.BackendOptions{
 		DBProvider:              eDB,
 		IsHA:                    true,
-		SimulatedNetworkLatency: 5 * time.Millisecond, // to simulate some network latency
+		SimulatedNetworkLatency: 2 * time.Millisecond, // to simulate some network latency
 	})
 	require.NoError(b, err)
 	require.NotNil(b, backend)

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE `resource_history`
-    SET `resource_version` = 0
-    WHERE  `guid` = ''
-;
+SET `resource_version` = (
+    CASE
+    WHEN `guid` = 'guid1' THEN CAST(123 AS SIGNED)
+    WHEN `guid` = 'guid2' THEN CAST(456 AS SIGNED)
+    END
+)
+WHERE `guid` IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/sql/testdata/mysql--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_update-single path.sql
@@ -3,7 +3,8 @@ UPDATE `resource`
         `guid`   = '',
         `value`  = '[]',
         `folder`  = 'fldr',
-        `action` = 'UNKNOWN'  
+        `action` = 'UNKNOWN',
+        `resource_version` = 0
     WHERE 1 = 1
         AND `group`     = 'gg'
         AND `resource`  = 'rr'

--- a/pkg/storage/unified/sql/testdata/mysql--resource_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE `resource`
-    SET `resource_version` = 0
-    WHERE  `guid` = ''
-;
+SET `resource_version` = (
+    CASE
+    WHEN `guid` = 'guid1' THEN CAST(123 AS SIGNED)
+    WHEN `guid` = 'guid2' THEN CAST(456 AS SIGNED)
+    END
+)
+WHERE `guid` IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE "resource_history"
-    SET "resource_version" = 0
-    WHERE  "guid" = ''
-;
+SET "resource_version" = (
+    CASE
+    WHEN "guid" = 'guid1' THEN CAST(123 AS BIGINT)
+    WHEN "guid" = 'guid2' THEN CAST(456 AS BIGINT)
+    END
+)
+WHERE "guid" IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/sql/testdata/postgres--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_update-single path.sql
@@ -3,7 +3,8 @@ UPDATE "resource"
         "guid"   = '',
         "value"  = '[]',
         "folder"  = 'fldr',
-        "action" = 'UNKNOWN'  
+        "action" = 'UNKNOWN',
+        "resource_version" = 0
     WHERE 1 = 1
         AND "group"     = 'gg'
         AND "resource"  = 'rr'

--- a/pkg/storage/unified/sql/testdata/postgres--resource_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE "resource"
-    SET "resource_version" = 0
-    WHERE  "guid" = ''
-;
+SET "resource_version" = (
+    CASE
+    WHEN "guid" = 'guid1' THEN CAST(123 AS BIGINT)
+    WHEN "guid" = 'guid2' THEN CAST(456 AS BIGINT)
+    END
+)
+WHERE "guid" IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE "resource_history"
-    SET "resource_version" = 0
-    WHERE  "guid" = ''
-;
+SET "resource_version" = (
+    CASE
+    WHEN "guid" = 'guid1' THEN CAST(123 AS SIGNED)
+    WHEN "guid" = 'guid2' THEN CAST(456 AS SIGNED)
+    END
+)
+WHERE "guid" IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_update-single path.sql
@@ -3,7 +3,8 @@ UPDATE "resource"
         "guid"   = '',
         "value"  = '[]',
         "folder"  = 'fldr',
-        "action" = 'UNKNOWN'  
+        "action" = 'UNKNOWN',
+        "resource_version" = 0
     WHERE 1 = 1
         AND "group"     = 'gg'
         AND "resource"  = 'rr'

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_update_rv-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_update_rv-single path.sql
@@ -1,4 +1,10 @@
 UPDATE "resource"
-    SET "resource_version" = 0
-    WHERE  "guid" = ''
-;
+SET "resource_version" = (
+    CASE
+    WHEN "guid" = 'guid1' THEN CAST(123 AS SIGNED)
+    WHEN "guid" = 'guid2' THEN CAST(456 AS SIGNED)
+    END
+)
+WHERE "guid" IN (
+    'guid1', 'guid2'
+);

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -26,7 +26,7 @@ type BenchmarkOptions struct {
 func DefaultBenchmarkOptions() *BenchmarkOptions {
 	return &BenchmarkOptions{
 		NumResources:     1000,
-		Concurrency:      20,
+		Concurrency:      50,
 		NumNamespaces:    1,
 		NumGroups:        1,
 		NumResourceTypes: 1,


### PR DESCRIPTION
**summary**
Batch Write events into a single transaction to increase write throughput.

**Problem**
In order to ensure resource_versions are increasing with every write event, we use a Row lock in the resource_version table per `resource/group` ([here](https://github.com/grafana/grafana/blob/c6a78978c39df988121b0289b6e039e3872186b6/pkg/storage/unified/sql/data/resource_version_get.sql#L9)). This is essential to guarantee List responses are coherent with Watch events for a given RV. As a result, this leads to a performance bottleneck ; only a single writer at a time in the lock phase.

The max write throughput heavily depends on the DB latency in the lock phase. With a ~10ms per write , so we are capped at 100 wps per resource/group.

**Proposal**

This PR proposes to batch concurrent writes into the same transaction in order to optimise and minimise the time in the lock phase.
 
 Inside one grafana pod
- We batch concurrent write events (CrUD) into a small batch. We only batch requests when we detect contention (one goroutine is in the critical "increase RV" section). A batch write operations up to a max (default 25 ops per batch).
- All the operations inside the batch is processed in a SINGLE transaction.
- Multiple batches can be applied concurrently given they touch different resources.
- At the end of processing the batch, we :
   - increase the RV for the given group/resource (micro-resolution unix timestamp generated by the server) 
   - allocate a uniq RV for each operation in the batch (prevRV +1)
   - the update the RV for each operation in both the resource and resource_history using a single sql statement([example](https://github.com/grafana/grafana/blob/5c00cef1e2c5dd5d0f6e3b1abdfdd442cb732d97/pkg/storage/unified/sql/testdata/mysql--resource_update_rv-single%20path.sql))
   - finally, we save the latest generated rv in the resouce_version table and COMMIT the transaction.

The big performance boost comes from batch updating the RV together. Previously, we would run a few statements for each concurrent transaction. With the proposed change, we increment the RV for all the items in the batch.

**details**

This is the current flow
![image](https://github.com/user-attachments/assets/c5e10ab3-ceca-48c0-a24f-58d2c5b300b6)

This is the new flow
![image](https://github.com/user-attachments/assets/900078d1-1554-4d8e-a3f1-5d2fdf9a4eec)

**benchmark**
```
% GRAFANA_TEST_DB=postgres  go test -benchmem -run=^$ -bench ^BenchmarkSQLStorageBackend$ github.com/grafana/grafana/pkg/storage/unified/sql/test
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/storage/unified/sql/test
cpu: Apple M3 Pro
BenchmarkSQLStorageBackend-12                  1        3246640042 ns/op                79.00 p50-latency-ms           105.0 p90-latency-ms        123.0 p99-latency-ms            776.9 writes/sec 145031768 B/op   2663826 allocs/op
--- BENCH: BenchmarkSQLStorageBackend-12
    benchmark.go:162: Benchmark Configuration: Workers=50, Resources=2000, Namespaces=1, Groups=1, Resource Types=1
    benchmark.go:163: 
    benchmark.go:164: Benchmark Results:
    benchmark.go:165: Total Duration: 2.574184791s
    benchmark.go:166: Write Count: 2000
    benchmark.go:167: Throughput: 776.94 writes/sec
    benchmark.go:168: P50 Latency: 79.05475ms
    benchmark.go:169: P90 Latency: 105.364292ms
    benchmark.go:170: P99 Latency: 123.504083ms
PASS
ok      github.com/grafana/grafana/pkg/storage/unified/sql/test 4.654s
```