### PR TITLE
Canvas: Fix no series timestamp

### DIFF
--- a/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
@@ -49,7 +49,7 @@ export const CanvasTooltip = ({ scene }: Props) => {
   }
 
   // Retrieve timestamp of the last data point if available
-  const timeField = scene.data?.series[0].fields?.find((field) => field.type === FieldType.time);
+  const timeField = scene.data?.series[0]?.fields?.find((field) => field.type === FieldType.time);
   const lastTimeValue = timeField?.values[timeField.values.length - 1];
   const shouldDisplayTimeContentItem =
     timeField && lastTimeValue && element.data.field && getFieldDisplayName(timeField) !== element.data.field;


### PR DESCRIPTION
This PR adds a check for series and prevents throwing an error in case it's missing.

Fixes https://github.com/grafana/support-escalations/issues/14935
Fixes https://github.com/grafana/support-escalations/issues/14822


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
