### PR TITLE
ContextHandler: unexport cfg

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -29,7 +29,7 @@ import (
 func ProvideService(cfg *setting.Cfg, authenticator authn.Authenticator, features featuremgmt.FeatureToggles,
 ) *ContextHandler {
 	return &ContextHandler{
-		Cfg:           cfg,
+		cfg:           cfg,
 		authenticator: authenticator,
 		features:      features,
 	}
@@ -37,7 +37,7 @@ func ProvideService(cfg *setting.Cfg, authenticator authn.Authenticator, feature
 
 // ContextHandler is a middleware.
 type ContextHandler struct {
-	Cfg           *setting.Cfg
+	cfg           *setting.Cfg
 	authenticator authn.Authenticator
 	features      featuremgmt.FeatureToggles
 }
@@ -104,7 +104,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		// inject ReqContext in the context
 		ctx = context.WithValue(ctx, reqContextKey{}, reqContext)
 		// store list of possible auth header in context
-		ctx = WithAuthHTTPHeaders(ctx, h.Cfg)
+		ctx = WithAuthHTTPHeaders(ctx, h.cfg)
 		// Set the context for the http.Request.Context
 		// This modifies both r and reqContext.Req since they point to the same value
 		*reqContext.Req = *reqContext.Req.WithContext(ctx)
@@ -137,7 +137,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			attribute.Int64("userId", reqContext.UserID),
 		))
 
-		if h.Cfg.IDResponseHeaderEnabled && reqContext.SignedInUser != nil {
+		if h.cfg.IDResponseHeaderEnabled && reqContext.SignedInUser != nil {
 			reqContext.Resp.Before(h.addIDHeaderEndOfRequestFunc(reqContext.SignedInUser))
 		}
 
@@ -167,11 +167,11 @@ func (h *ContextHandler) addIDHeaderEndOfRequestFunc(ident identity.Requester) w
 			return
 		}
 
-		if _, ok := h.Cfg.IDResponseHeaderNamespaces[string(ident.GetIdentityType())]; !ok {
+		if _, ok := h.cfg.IDResponseHeaderNamespaces[string(ident.GetIdentityType())]; !ok {
 			return
 		}
 
-		headerName := fmt.Sprintf("%s-Identity-Id", h.Cfg.IDResponseHeaderPrefix)
+		headerName := fmt.Sprintf("%s-Identity-Id", h.cfg.IDResponseHeaderPrefix)
 		w.Header().Add(headerName, ident.GetID())
 	}
 }


### PR DESCRIPTION
**What is this feature?**
Noticed this when looking at context handler, no need to export cfg.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
