### PR TITLE
New Logs Panel: Log line tokenization and syntax highlighting 

### DIFF
--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -45,7 +45,6 @@ export const createLogLine = (
     escape: false,
     order: LogsSortOrder.Descending,
     timeZone: 'browser',
-    wrap: false,
   }
 ): LogListModel => {
   const logs = preProcessLogs([createLogRow(overrides)], processOptions);

--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -19,7 +19,7 @@ export const createLogRow = (overrides?: Partial<LogRowModel>): LogRowModel => {
           type: FieldType.string,
           values: ['line1', 'line2'],
         },
-        { name: 'labels', type: FieldType.other, values: [{ app: 'app01' }, { app: 'app02' }] },
+        { name: 'labels', type: FieldType.other, values: [] },
       ],
     }),
     uid,

--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -19,7 +19,7 @@ export const createLogRow = (overrides?: Partial<LogRowModel>): LogRowModel => {
           type: FieldType.string,
           values: ['line1', 'line2'],
         },
-        { name: 'labels', type: FieldType.other, values: [] },
+        { name: 'labels', type: FieldType.other, values: [{ app: 'app01' }, { app: 'app02' }] },
       ],
     }),
     uid,

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -15,7 +15,7 @@ const styles = getStyles(theme);
 describe('LogLine', () => {
   let log: LogListModel;
   beforeEach(() => {
-    log = createLogLine({ labels: { place: 'luna' } });
+    log = createLogLine({ labels: { place: 'luna' }, entry: `log message 1` });
   });
 
   test('Renders a log line', () => {
@@ -31,7 +31,8 @@ describe('LogLine', () => {
       />
     );
     expect(screen.getByText(log.timestamp)).toBeInTheDocument();
-    expect(screen.getByText(log.body)).toBeInTheDocument();
+    expect(screen.getByText('log message')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
   test('Renders a log line with no timestamp', () => {
@@ -47,7 +48,8 @@ describe('LogLine', () => {
       />
     );
     expect(screen.queryByText(log.timestamp)).not.toBeInTheDocument();
-    expect(screen.getByText(log.body)).toBeInTheDocument();
+    expect(screen.getByText('log message')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
   test('Renders a log line with displayed fields', () => {
@@ -80,7 +82,8 @@ describe('LogLine', () => {
       />
     );
     expect(screen.getByText(log.timestamp)).toBeInTheDocument();
-    expect(screen.getByText(log.body)).toBeInTheDocument();
+    expect(screen.getByText('log message')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.getByText('luna')).toBeInTheDocument();
   });
 

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -31,8 +31,7 @@ describe('LogLine', () => {
       />
     );
     expect(screen.getByText(log.timestamp)).toBeInTheDocument();
-    expect(screen.getByText('log message')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('log message 1')).toBeInTheDocument();
   });
 
   test('Renders a log line with no timestamp', () => {
@@ -48,8 +47,7 @@ describe('LogLine', () => {
       />
     );
     expect(screen.queryByText(log.timestamp)).not.toBeInTheDocument();
-    expect(screen.getByText('log message')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('log message 1')).toBeInTheDocument();
   });
 
   test('Renders a log line with displayed fields', () => {
@@ -82,8 +80,7 @@ describe('LogLine', () => {
       />
     );
     expect(screen.getByText(log.timestamp)).toBeInTheDocument();
-    expect(screen.getByText('log message')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('log message 1')).toBeInTheDocument();
     expect(screen.getByText('luna')).toBeInTheDocument();
   });
 

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -77,7 +77,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
-            <span className="field prism-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+            <span className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
           ) : (
             <span className="field" title={field} key={field}>
               {getDisplayedFieldValue(field, log)}
@@ -85,7 +85,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
           )
         )
       ) : (
-        <span className="field prism-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+        <span className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
       )}
     </>
   );
@@ -142,6 +142,17 @@ export const getStyles = (theme: GrafanaTheme2) => {
           position: 'absolute',
           top: -3,
           width: '100%',
+        },
+      },
+      '& .log-syntax-highlight': {
+        '.token.log-token-string': {
+          color: theme.colors.text.maxContrast,
+        },
+        '.token.log-token-number': {
+          color: theme.colors.success.text,
+        },
+        '.token.log-token-label': {
+          color: theme.colors.text.secondary,
         },
       },
     }),

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -145,14 +145,27 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
       },
       '& .log-syntax-highlight': {
+        '.token.log-token-timestamp': {
+          color: theme.colors.text.disabled,
+        },
         '.token.log-token-string': {
-          color: theme.colors.text.maxContrast,
+          color: theme.colors.text.primary,
         },
         '.token.log-token-number': {
           color: theme.colors.success.text,
         },
-        '.token.log-token-label': {
+        '.token.log-token-size': {
+          color: theme.colors.success.text,
+        },
+        '.token.log-token-key': {
           color: theme.colors.text.secondary,
+        },
+        '.token.log-token-json-key': {
+          color: theme.colors.text.secondary,
+        },
+        '.token.log-token-label': {
+          color: theme.colors.text.maxContrast,
+          fontWeight: theme.typography.fontWeightMedium,
         },
       },
     }),

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -75,13 +75,17 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
       <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
       {displayedFields.length > 0 ? (
-        displayedFields.map((field) => (
-          <span className="field" title={field} key={field}>
-            {getDisplayedFieldValue(field, log)}
-          </span>
-        ))
+        displayedFields.map((field) =>
+          field === LOG_LINE_BODY_FIELD_NAME ? (
+            <span className="field prism-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+          ) : (
+            <span className="field" title={field} key={field}>
+              {getDisplayedFieldValue(field, log)}
+            </span>
+          )
+        )
       ) : (
-        <span className="field">{log.body}</span>
+        <span className="field prism-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
       )}
     </>
   );

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -5,6 +5,7 @@ import tinycolor from 'tinycolor2';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { LogMessageAnsi } from '../LogMessageAnsi';
 
 import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
@@ -77,7 +78,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
-            <span className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+            <LogLineBody log={log} />
           ) : (
             <span className="field" title={field} key={field}>
               {getDisplayedFieldValue(field, log)}
@@ -85,10 +86,25 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
           )
         )
       ) : (
-        <span className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+        <LogLineBody log={log} />
       )}
     </>
   );
+};
+
+const LogLineBody = ({ log }: { log: LogListModel }) => {
+  if (log.hasAnsi) {
+    const needsHighlighter =
+      log.searchWords && log.searchWords.length > 0 && log.searchWords[0] && log.searchWords[0].length > 0;
+    const highlight = needsHighlighter ? { searchWords: log.searchWords ?? [], highlightClassName: '' } : undefined;
+    return (
+      <span className="field">
+        <LogMessageAnsi value={log.body} highlight={highlight} />
+      </span>
+    );
+  }
+
+  return <span className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />;
 };
 
 export function getDisplayedFieldValue(fieldName: string, log: LogListModel): string {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -11,7 +11,6 @@ import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
 import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
-import { italic } from 'ansicolor';
 
 interface Props {
   displayedFields: string[];
@@ -82,7 +81,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
             <LogLineBody log={log} />
           ) : (
             <span className="field" title={field} key={field}>
-              {getDisplayedFieldValue(field, log)}ß
+              {getDisplayedFieldValue(field, log)}
             </span>
           )
         )

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -78,7 +78,7 @@ const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
-            <LogLineBody log={log} />
+            <LogLineBody log={log} key={field} />
           ) : (
             <span className="field" title={field} key={field}>
               {getDisplayedFieldValue(field, log)}

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -176,9 +176,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
       },
       '& .log-syntax-highlight': {
-        '.log-token-timestamp': {
-          color: theme.colors.text.disabled,
-        },
         '.log-token-string': {
           color: alpha(theme.colors.text.secondary, 0.75),
         },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -168,7 +168,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
         '.token.log-token-string': {
           color: theme.colors.text.secondary,
-
         },
         '.token.log-token-number': {
           color: theme.colors.success.text,

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -11,6 +11,7 @@ import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
 import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
+import { italic } from 'ansicolor';
 
 interface Props {
   displayedFields: string[];
@@ -73,15 +74,15 @@ interface LogProps {
 const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
   return (
     <>
-      {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
-      <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
+     {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
+     <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
             <LogLineBody log={log} />
           ) : (
             <span className="field" title={field} key={field}>
-              {getDisplayedFieldValue(field, log)}
+              {getDisplayedFieldValue(field, log)}ß
             </span>
           )
         )
@@ -129,17 +130,19 @@ export function getGridTemplateColumns(dimensions: LogFieldDimension[]) {
 export type LogLineStyles = ReturnType<typeof getStyles>;
 export const getStyles = (theme: GrafanaTheme2) => {
   const colors = {
-    critical: '#B877D9',
-    error: '#FF5286',
+    critical: '#f22f44',
+    error: '#f22f44',
     warning: '#FBAD37',
     debug: '#6CCF8E',
     trace: '#6ed0e0',
     info: '#6E9FFF',
+    metadata:  `rgba(204, 204, 220, 0.9)`,
+    parsedField: `rgba(204, 204, 220, 0.8)`,
   };
 
   return {
     logLine: css({
-      color: theme.colors.text.primary,
+      color: theme.colors.text.secondary,
       display: 'flex',
       gap: theme.spacing(0.5),
       flexDirection: 'row',
@@ -165,7 +168,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
           color: theme.colors.text.disabled,
         },
         '.token.log-token-string': {
-          color: theme.colors.text.primary,
+          color: theme.colors.text.secondary,
+
         },
         '.token.log-token-number': {
           color: theme.colors.success.text,
@@ -174,14 +178,16 @@ export const getStyles = (theme: GrafanaTheme2) => {
           color: theme.colors.success.text,
         },
         '.token.log-token-key': {
-          color: theme.colors.text.secondary,
+          color: colors.parsedField,
+          fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-json-key': {
-          color: theme.colors.text.secondary,
+          color: colors.parsedField,
+          fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-label': {
-          color: theme.colors.text.maxContrast,
-          fontWeight: theme.typography.fontWeightMedium,
+          color: colors.metadata,
+          fontWeight: theme.typography.fontWeightBold,
         },
       },
     }),
@@ -198,12 +204,13 @@ export const getStyles = (theme: GrafanaTheme2) => {
       textAlign: 'center',
     }),
     timestamp: css({
-      color: theme.colors.text.secondary,
+      color: theme.colors.text.disabled,
       display: 'inline-block',
     }),
     level: css({
       color: theme.colors.text.secondary,
       fontWeight: theme.typography.fontWeightBold,
+      textTransform:'uppercase',
       display: 'inline-block',
       textTransform: 'uppercase',
       '&.level-critical': {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -73,8 +73,8 @@ interface LogProps {
 const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
   return (
     <>
-     {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
-     <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
+      {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
+      <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
@@ -135,7 +135,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     debug: '#6CCF8E',
     trace: '#6ed0e0',
     info: '#6E9FFF',
-    metadata:  `rgba(204, 204, 220, 0.9)`,
+    metadata: `rgba(204, 204, 220, 0.9)`,
     parsedField: `rgba(204, 204, 220, 0.8)`,
   };
 
@@ -208,7 +208,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     level: css({
       color: theme.colors.text.secondary,
       fontWeight: theme.typography.fontWeightBold,
-      textTransform:'uppercase',
+      textTransform: 'uppercase',
       display: 'inline-block',
       '&.level-critical': {
         color: colors.critical,

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -161,7 +161,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.fontSize,
       wordBreak: 'break-all',
       '&:hover': {
-        opacity: 0.7,
+        background: `hsla(0, 0%, 0%, 0.1)`,
       },
       '&.infinite-scroll': {
         '&::before': {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -142,7 +142,7 @@ export function getGridTemplateColumns(dimensions: LogFieldDimension[]) {
 export type LogLineStyles = ReturnType<typeof getStyles>;
 export const getStyles = (theme: GrafanaTheme2) => {
   const colors = {
-    critical: '#f22f44',
+    critical: '#B877D9',
     error: '#f22f44',
     warning: '#FBAD37',
     debug: '#6CCF8E',

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -220,6 +220,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.secondary,
       fontWeight: theme.typography.fontWeightBold,
       display: 'inline-block',
+      textTransform: 'uppercase',
       '&.level-critical': {
         color: colors.critical,
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -193,19 +193,21 @@ export const getStyles = (theme: GrafanaTheme2) => {
         '.token.log-token-uuid': {
           color: theme.colors.success.text,
         },
+        '.token.log-token-url': {
+          color: theme.colors.primary.shade,
+        },
         '.token.log-token-key': {
           color: colors.parsedField,
-          opacity: 0.8,
+          opacity: 0.9,
           fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-json-key': {
           color: colors.parsedField,
-          opacity: 0.8,
+          opacity: 0.9,
           fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-label': {
           color: colors.metadata,
-          opacity: 0.9,
           fontWeight: theme.typography.fontWeightBold,
         },
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -135,8 +135,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
     debug: '#6CCF8E',
     trace: '#6ed0e0',
     info: '#6E9FFF',
-    metadata: `rgba(204, 204, 220, 0.9)`,
-    parsedField: `rgba(204, 204, 220, 0.8)`,
+    metadata: theme.colors.text.primary,
+    parsedField: theme.colors.text.primary,
   };
 
   return {
@@ -180,14 +180,17 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
         '.token.log-token-key': {
           color: colors.parsedField,
+          opacity: 0.8,
           fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-json-key': {
           color: colors.parsedField,
+          opacity: 0.8,
           fontWeight: theme.typography.fontWeightMedium,
         },
         '.token.log-token-label': {
           color: colors.metadata,
+          opacity: 0.9,
           fontWeight: theme.typography.fontWeightBold,
         },
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -57,7 +57,13 @@ export const LogLine = ({
     >
       <LogLineMenu styles={styles} log={log} />
       <div className={`${wrapLogMessage ? styles.wrappedLogLine : `${styles.unwrappedLogLine} unwrapped-log-line`}`}>
-        <Log displayedFields={displayedFields} log={log} showTime={showTime} styles={styles} />
+        <Log
+          displayedFields={displayedFields}
+          log={log}
+          showTime={showTime}
+          styles={styles}
+          wrapLogMessage={wrapLogMessage}
+        />
       </div>
     </div>
   );
@@ -68,13 +74,19 @@ interface LogProps {
   log: LogListModel;
   showTime: boolean;
   styles: LogLineStyles;
+  wrapLogMessage: boolean;
 }
 
-const Log = ({ displayedFields, log, showTime, styles }: LogProps) => {
+const Log = ({ displayedFields, log, showTime, styles, wrapLogMessage }: LogProps) => {
   return (
     <>
       {showTime && <span className={`${styles.timestamp} level-${log.logLevel} field`}>{log.timestamp}</span>}
-      <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
+      {
+        // When logs are unwrapped, we want an empty column space to align with other log lines.
+      }
+      {(log.displayLevel || !wrapLogMessage) && (
+        <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
+      )}
       {displayedFields.length > 0 ? (
         displayedFields.map((field) =>
           field === LOG_LINE_BODY_FIELD_NAME ? (
@@ -176,6 +188,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
           color: theme.colors.success.text,
         },
         '.token.log-token-size': {
+          color: theme.colors.success.text,
+        },
+        '.token.log-token-uuid': {
           color: theme.colors.success.text,
         },
         '.token.log-token-key': {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -211,7 +211,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       fontWeight: theme.typography.fontWeightBold,
       textTransform:'uppercase',
       display: 'inline-block',
-      textTransform: 'uppercase',
       '&.level-critical': {
         color: colors.critical,
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -3,7 +3,6 @@ import { CSSProperties, useEffect, useRef } from 'react';
 import tinycolor from 'tinycolor2';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogMessageAnsi } from '../LogMessageAnsi';
@@ -154,7 +153,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
 
   return {
     logLine: css({
-      color: alpha(theme.colors.text.secondary, 0.75),
+      color: tinycolor(theme.colors.text.secondary).setAlpha(0.75).toRgbString(),
       display: 'flex',
       gap: theme.spacing(0.5),
       flexDirection: 'row',
@@ -177,7 +176,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       },
       '& .log-syntax-highlight': {
         '.log-token-string': {
-          color: alpha(theme.colors.text.secondary, 0.75),
+          color: tinycolor(theme.colors.text.secondary).setAlpha(0.75).toRgbString(),
         },
         '.log-token-duration': {
           color: theme.colors.success.text,

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -220,7 +220,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     logLineMessage: css({
       fontFamily: theme.typography.fontFamily,
-      textAlign: 'center',
+      justifyContent: 'center',
     }),
     timestamp: css({
       color: theme.colors.text.disabled,

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -11,6 +11,7 @@ import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
 import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
+import { alpha } from '@grafana/data/src/themes/colorManipulator';
 
 interface Props {
   displayedFields: string[];
@@ -153,7 +154,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
 
   return {
     logLine: css({
-      color: theme.colors.text.secondary,
+      color: alpha(theme.colors.text.secondary, 0.75),
       display: 'flex',
       gap: theme.spacing(0.5),
       flexDirection: 'row',
@@ -179,10 +180,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
           color: theme.colors.text.disabled,
         },
         '.token.log-token-string': {
-          color: theme.colors.text.secondary,
-        },
-        '.token.log-token-number': {
-          color: theme.colors.success.text,
+          color: alpha(theme.colors.text.secondary, 0.75),
         },
         '.token.log-token-duration': {
           color: theme.colors.success.text,
@@ -192,9 +190,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
         '.token.log-token-uuid': {
           color: theme.colors.success.text,
-        },
-        '.token.log-token-url': {
-          color: theme.colors.primary.shade,
         },
         '.token.log-token-key': {
           color: colors.parsedField,
@@ -209,6 +204,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
         '.token.log-token-label': {
           color: colors.metadata,
           fontWeight: theme.typography.fontWeightBold,
+        },
+        '.token.log-token-method': {
+          color: theme.colors.info.shade,
         },
       },
     }),

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -241,8 +241,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
       paddingBottom: theme.spacing(0.75),
     }),
     wrappedLogLine: css({
-      whiteSpace: 'pre-wrap',
+      alignSelf: 'flex-start',
       paddingBottom: theme.spacing(0.75),
+      whiteSpace: 'pre-wrap',
       '& .field': {
         marginRight: theme.spacing(FIELD_GAP_MULTIPLIER),
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -10,8 +10,8 @@ import { LogMessageAnsi } from '../LogMessageAnsi';
 
 import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
-import { LogFieldDimension, LogListModel } from './processing';
-import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
+import { LogListModel } from './processing';
+import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight, LogFieldDimension } from './virtualization';
 
 interface Props {
   displayedFields: string[];

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -176,36 +176,36 @@ export const getStyles = (theme: GrafanaTheme2) => {
         },
       },
       '& .log-syntax-highlight': {
-        '.token.log-token-timestamp': {
+        '.log-token-timestamp': {
           color: theme.colors.text.disabled,
         },
-        '.token.log-token-string': {
+        '.log-token-string': {
           color: alpha(theme.colors.text.secondary, 0.75),
         },
-        '.token.log-token-duration': {
+        '.log-token-duration': {
           color: theme.colors.success.text,
         },
-        '.token.log-token-size': {
+        '.log-token-size': {
           color: theme.colors.success.text,
         },
-        '.token.log-token-uuid': {
+        '.log-token-uuid': {
           color: theme.colors.success.text,
         },
-        '.token.log-token-key': {
+        '.log-token-key': {
           color: colors.parsedField,
           opacity: 0.9,
           fontWeight: theme.typography.fontWeightMedium,
         },
-        '.token.log-token-json-key': {
+        '.log-token-json-key': {
           color: colors.parsedField,
           opacity: 0.9,
           fontWeight: theme.typography.fontWeightMedium,
         },
-        '.token.log-token-label': {
+        '.log-token-label': {
           color: colors.metadata,
           fontWeight: theme.typography.fontWeightBold,
         },
-        '.token.log-token-method': {
+        '.log-token-method': {
           color: theme.colors.info.shade,
         },
       },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -3,6 +3,7 @@ import { CSSProperties, useEffect, useRef } from 'react';
 import tinycolor from 'tinycolor2';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { alpha } from '@grafana/data/src/themes/colorManipulator';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogMessageAnsi } from '../LogMessageAnsi';
@@ -11,7 +12,6 @@ import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPinned } from './LogListContext';
 import { LogFieldDimension, LogListModel } from './processing';
 import { FIELD_GAP_MULTIPLIER, hasUnderOrOverflow, getLineHeight } from './virtualization';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
 
 interface Props {
   displayedFields: string[];

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -172,6 +172,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
         '.token.log-token-number': {
           color: theme.colors.success.text,
         },
+        '.token.log-token-duration': {
+          color: theme.colors.success.text,
+        },
         '.token.log-token-size': {
           color: theme.colors.success.text,
         },

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -200,21 +200,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
     timestamp: css({
       color: theme.colors.text.secondary,
       display: 'inline-block',
-      '&.level-critical': {
-        color: colors.critical,
-      },
-      '&.level-error': {
-        color: colors.error,
-      },
-      '&.level-info': {
-        color: colors.info,
-      },
-      '&.level-warning': {
-        color: colors.warning,
-      },
-      '&.level-debug': {
-        color: colors.debug,
-      },
     }),
     level: css({
       color: theme.colors.text.secondary,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -99,11 +99,13 @@ export const LogList = ({
   }, [eventBus, logs.length]);
 
   useEffect(() => {
-    setProcessedLogs(
-      preProcessLogs(logs, { getFieldLinks, escape: forceEscape, order: sortOrder, timeZone })
-    );
+    setProcessedLogs(preProcessLogs(logs, { getFieldLinks, escape: forceEscape, order: sortOrder, timeZone }));
     listRef.current?.resetAfterIndex(0);
   }, [forceEscape, getFieldLinks, logs, sortOrder, timeZone]);
+
+  useEffect(() => {
+    listRef.current?.resetAfterIndex(0);
+  }, [wrapLogMessage]);
 
   useEffect(() => {
     const handleResize = debounce(() => {

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -100,12 +100,12 @@ export const LogList = ({
 
   useEffect(() => {
     setProcessedLogs(preProcessLogs(logs, { getFieldLinks, escape: forceEscape, order: sortOrder, timeZone }));
-    listRef.current?.resetAfterIndex(0);
   }, [forceEscape, getFieldLinks, logs, sortOrder, timeZone]);
 
   useEffect(() => {
+    resetLogLineSizes();
     listRef.current?.resetAfterIndex(0);
-  }, [wrapLogMessage]);
+  }, [wrapLogMessage, processedLogs]);
 
   useEffect(() => {
     const handleResize = debounce(() => {

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -100,10 +100,10 @@ export const LogList = ({
 
   useEffect(() => {
     setProcessedLogs(
-      preProcessLogs(logs, { getFieldLinks, wrap: wrapLogMessage, escape: forceEscape, order: sortOrder, timeZone })
+      preProcessLogs(logs, { getFieldLinks, escape: forceEscape, order: sortOrder, timeZone })
     );
     listRef.current?.resetAfterIndex(0);
-  }, [forceEscape, getFieldLinks, logs, sortOrder, timeZone, wrapLogMessage]);
+  }, [forceEscape, getFieldLinks, logs, sortOrder, timeZone]);
 
   useEffect(() => {
     const handleResize = debounce(() => {

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -20,10 +20,12 @@ import { InfiniteScroll } from './InfiniteScroll';
 import { getGridTemplateColumns } from './LogLine';
 import { GetRowContextQueryFn } from './LogLineMenu';
 import { LogListContext } from './LogListContext';
-import { preProcessLogs, LogListModel, calculateFieldDimensions, LogFieldDimension } from './processing';
+import { preProcessLogs, LogListModel } from './processing';
 import {
+  calculateFieldDimensions,
   getLogLineSize,
   init as initVirtualization,
+  LogFieldDimension,
   resetLogLineSizes,
   ScrollToLogsEvent,
   storeLogLineSize,

--- a/public/app/features/logs/components/panel/grammar.test.ts
+++ b/public/app/features/logs/components/panel/grammar.test.ts
@@ -1,0 +1,87 @@
+import Prism, { Token } from 'prismjs';
+
+import { createLogLine } from '../__mocks__/logRow';
+
+import { generateLogGrammar } from './grammar';
+
+describe('generateLogGrammar', () => {
+  function generateScenario(entry: string) {
+    const log = createLogLine({ labels: { place: 'luna', source: 'logs' }, entry });
+    const grammar = generateLogGrammar(log);
+    const tokens = Prism.tokenize(log.entry, grammar);
+    return { log, grammar, tokens };
+  }
+
+  test('Identifies uuid tokens', () => {
+    const { tokens } = generateScenario('15f77b91-aedb-48d2-a551-ca4a7927cea4');
+    if (tokens[0] instanceof Token) {
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].content).toBe('15f77b91-aedb-48d2-a551-ca4a7927cea4');
+      expect(tokens[0].type).toBe('log-token-uuid');
+    }
+    expect.hasAssertions();
+  });
+
+  test('Identifies json keys and quoted values', () => {
+    const { tokens } = generateScenario('{"key":"value", "key2":"value2"}');
+    if (tokens[1] instanceof Token) {
+      expect(tokens[1].content).toBe('"key"');
+      expect(tokens[1].type).toBe('log-token-json-key');
+    }
+    if (tokens[3] instanceof Token) {
+      expect(tokens[3].content).toBe('"value"');
+      expect(tokens[3].type).toBe('log-token-string');
+    }
+    if (tokens[5] instanceof Token) {
+      expect(tokens[5].content).toBe('"key2"');
+      expect(tokens[5].type).toBe('log-token-json-key');
+    }
+    if (tokens[7] instanceof Token) {
+      expect(tokens[7].content).toBe('"value2"');
+      expect(tokens[7].type).toBe('log-token-string');
+    }
+    expect.assertions(8);
+  });
+
+  test('Identifies sizes', () => {
+    const { tokens } = generateScenario('1mb 2 KB');
+    if (tokens[0] instanceof Token) {
+      expect(tokens[0].content).toBe('1mb');
+      expect(tokens[0].type).toBe('log-token-size');
+    }
+    if (tokens[2] instanceof Token) {
+      expect(tokens[2].content).toBe('2 KB');
+      expect(tokens[2].type).toBe('log-token-size');
+    }
+    expect.assertions(4);
+  });
+
+  test('Identifies durations', () => {
+    const { tokens } = generateScenario('1ms 2µs 1h');
+    if (tokens[0] instanceof Token) {
+      expect(tokens[0].content).toBe('1ms');
+      expect(tokens[0].type).toBe('log-token-duration');
+    }
+    if (tokens[2] instanceof Token) {
+      expect(tokens[2].content).toBe('2µs');
+      expect(tokens[2].type).toBe('log-token-duration');
+    }
+    if (tokens[4] instanceof Token) {
+      expect(tokens[4].content).toBe('1h');
+      expect(tokens[4].type).toBe('log-token-duration');
+    }
+    expect.assertions(6);
+  });
+
+  test.each(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'])(
+    'Identifies HTTP methods',
+    (method: string) => {
+      const { tokens } = generateScenario(`200 "${method} /whatever HTTP/1.1" 295`);
+      if (tokens[1] instanceof Token) {
+        expect(tokens[1].content).toBe(method);
+        expect(tokens[1].type).toBe('log-token-method');
+      }
+      expect.assertions(2);
+    }
+  );
+});

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,21 +1,42 @@
 import { Grammar } from 'prismjs';
 
+import { LogListModel } from './processing';
+
 // The Logs grammar is used for highlight in the logs panel
 export const logsGrammar: Grammar = {
-  comment: {
-    pattern: /#.*/,
+  timestamp: /\b\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,9})?([+-]\d{2}:?\d{2}|\d{4})?\b/,
+  timestamp_iso: /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\b/,
+  size: {
+    pattern: /\b\d+(\.\d+)?\s*[kKmMGgPpbB]?\s*[bB]?\b/,
+    alias: 'log-token-number',
+    greedy: true,
   },
   quote: {
-    pattern: /"(?:\\.|[^\\"])*"/,
-    alias: 'string',
+    pattern: /(?::\s*|=)"(?:\\.|[^\\"])*"/,
+    alias: 'log-token-string',
     greedy: true,
   },
   backticks: {
     pattern: /`(?:\\.|[^\\`])*`/,
-    alias: 'string',
+    alias: 'log-token-string',
     greedy: true,
   },
-  number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
-  operator: /\s?(\|[=~]?|!=?|<(?:=>?|<|>)?|>[>=]?)\s?/i,
-  punctuation: /[{}(),.]/,
+  number: {
+    pattern: /\b\d+(?:\.\d+)?\b/,
+    alias: 'log-token-number',
+  },
+};
+
+export const generateLogGrammar = (log: LogListModel) => {
+  const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));
+  const logGrammar: Grammar = {
+    log_field: {
+      pattern: new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
+      alias: 'log-token-label',
+    },
+  };
+  return {
+    ...logGrammar,
+    ...logsGrammar,
+  };
 };

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -4,36 +4,18 @@ import { LogListModel } from './processing';
 
 // The Logs grammar is used for highlight in the logs panel
 export const logsGrammar: Grammar = {
-  timestamp: /\b\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,9})?([+-]\d{2}:?\d{2}|\d{4})?\b/,
-  timestamp_iso: /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\b/,
-  size: {
-    pattern: /\b\d+(\.\d+)?\s*[kKmMGgPpbB]?\s*[bB]?\b/,
-    alias: 'log-token-number',
-    greedy: true,
-  },
-  quote: {
-    pattern: /(?::\s*|=)"(?:\\.|[^\\"])*"/,
-    alias: 'log-token-string',
-    greedy: true,
-  },
-  backticks: {
-    pattern: /`(?:\\.|[^\\`])*`/,
-    alias: 'log-token-string',
-    greedy: true,
-  },
-  number: {
-    pattern: /\b\d+(?:\.\d+)?\b/,
-    alias: 'log-token-number',
-  },
+  'log-token-timestamp': /\b\d{4}-\d{2}-\d{2}[T|\s]{1}\d{1,2}:\d{2}:\d{2}(?:[\.]{0,1}\d{0,9})?(?:Z|\+\d{2}:\d{2}|\b)\b/,
+  'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
+  'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
+  'log-token-size': /"\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}"/g,
+  'log-token-string': /"(?!:)(\\?[^'"])*?"(?!:)/g,
+  'log-token-number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
 };
 
 export const generateLogGrammar = (log: LogListModel) => {
   const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));
   const logGrammar: Grammar = {
-    log_field: {
-      pattern: new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
-      alias: 'log-token-label',
-    },
+    'log-token-label': new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
   };
   return {
     ...logGrammar,

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,0 +1,21 @@
+import { Grammar } from 'prismjs';
+
+// The Logs grammar is used for highlight in the logs panel
+export const logsGrammar: Grammar = {
+  comment: {
+    pattern: /#.*/,
+  },
+  quote: {
+    pattern: /"(?:\\.|[^\\"])*"/,
+    alias: 'string',
+    greedy: true,
+  },
+  backticks: {
+    pattern: /`(?:\\.|[^\\`])*`/,
+    alias: 'string',
+    greedy: true,
+  },
+  number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
+  operator: /\s?(\|[=~]?|!=?|<(?:=>?|<|>)?|>[>=]?)\s?/i,
+  punctuation: /[{}(),.]/,
+};

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -12,6 +12,7 @@ export const logsGrammar: Grammar = {
   'log-token-duration': /(?:\b|")\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b|")/g,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
   'log-token-number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
+  'log-token-url': /(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)/i,
 };
 
 export const generateLogGrammar = (log: LogListModel) => {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -8,7 +8,7 @@ export const logsGrammar: Grammar = {
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-size': /"\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}"/g,
-  'log-token-string': /"(?!:)(\\?[^'"])*?"(?!:)/g,
+  'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
   'log-token-number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
 };
 

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -4,6 +4,7 @@ import { LogListModel } from './processing';
 
 // The Logs grammar is used for highlight in the logs panel
 export const logsGrammar: Grammar = {
+  'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
   'log-token-timestamp': /\b\d{4}-\d{2}-\d{2}[T|\s]{1}\d{1,2}:\d{2}:\d{2}(?:[\.]{0,1}\d{0,9})?(?:Z|\+\d{2}:\d{2}|\b)\b/,
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -5,7 +5,6 @@ import { LogListModel } from './processing';
 // The Logs grammar is used for highlight in the logs panel
 export const logsGrammar: Grammar = {
   'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
-  'log-token-timestamp': /\b\d{4}-\d{2}-\d{2}[T|\s]{1}\d{1,2}:\d{2}:\d{2}(?:[\.]{0,1}\d{0,9})?(?:Z|\+\d{2}:\d{2}|\b)\b/,
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -7,7 +7,8 @@ export const logsGrammar: Grammar = {
   'log-token-timestamp': /\b\d{4}-\d{2}-\d{2}[T|\s]{1}\d{1,2}:\d{2}:\d{2}(?:[\.]{0,1}\d{0,9})?(?:Z|\+\d{2}:\d{2}|\b)\b/,
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
-  'log-token-size': /"\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}"/g,
+  'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
+  'log-token-duration': /(?:\b|")\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b|")/g,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
   'log-token-number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
 };

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -9,10 +9,9 @@ export const logsGrammar: Grammar = {
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
-  'log-token-duration': /(?:\b|")\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b|")/g,
+  'log-token-duration': /(?:\b)\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b)/g,
+  'log-token-method': /\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)\b/g,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
-  'log-token-number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
-  'log-token-url': /(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)/i,
 };
 
 export const generateLogGrammar = (log: LogListModel) => {

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -125,7 +125,6 @@ describe('preProcessLogs', () => {
     expect(processedLogs[0].highlightedBody).toContain('log-token-label');
     expect(processedLogs[0].highlightedBody).toContain('log-token-key');
     expect(processedLogs[0].highlightedBody).toContain('log-token-string');
-    expect(processedLogs[0].highlightedBody).toContain('log-token-timestamp');
     expect(processedLogs[0].highlightedBody).toContain('log-token-uuid');
     expect(processedLogs[0].highlightedBody).not.toContain('log-token-method');
     expect(processedLogs[0].highlightedBody).not.toContain('log-token-json-key');
@@ -137,7 +136,6 @@ describe('preProcessLogs', () => {
 
     expect(processedLogs[2].highlightedBody).toContain('log-token-json-key');
     expect(processedLogs[2].highlightedBody).toContain('log-token-string');
-    expect(processedLogs[2].highlightedBody).toContain('log-token-timestamp');
     expect(processedLogs[2].highlightedBody).not.toContain('log-token-method');
   });
 });

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -1,0 +1,143 @@
+import { Field, FieldType, LogLevel, LogRowModel, LogsSortOrder, toDataFrame } from '@grafana/data';
+
+import { createLogRow } from '../__mocks__/logRow';
+
+import { LogListModel, preProcessLogs } from './processing';
+
+describe('preProcessLogs', () => {
+  let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;
+  let processedLogs: LogListModel[];
+
+  beforeEach(() => {
+    const getFieldLinks = jest.fn().mockImplementationOnce((field: Field) => ({
+      href: '/link',
+      title: 'link',
+      target: '_blank',
+      origin: field,
+    }));
+    logFmtLog = createLogRow({
+      uid: '1',
+      timeEpochMs: 3,
+      labels: { level: 'warn', logger: 'interceptor' },
+      entry: `logger=interceptor t=2025-03-18T08:58:34.820119602Z level=warn msg="calling resource store as the service without id token or marking it as the service identity" subject=:0 uid=43eb4c92-18a0-4060-be96-37af854f0830`,
+      logLevel: LogLevel.warning,
+      rowIndex: 0,
+      dataFrame: toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [3, 2, 1] },
+          {
+            name: 'Line',
+            type: FieldType.string,
+            values: ['log message 1', 'log message 2', 'log message 3'],
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              { level: 'warn', logger: 'interceptor' },
+              { method: 'POST', status: '200' },
+              { kind: 'Event', stage: 'ResponseComplete' },
+            ],
+          },
+          {
+            name: 'link',
+            type: FieldType.string,
+            config: {
+              links: [
+                {
+                  title: 'link1',
+                  url: 'https://example.com',
+                },
+              ],
+            },
+            values: ['link'],
+          },
+        ],
+      }),
+    });
+    nginxLog = createLogRow({
+      uid: '2',
+      timeEpochMs: 2,
+      labels: { method: 'POST', status: '200' },
+      entry: `35.191.12.195 - accounts.google.com:test@grafana.com [18/Mar/2025:08:58:38 +0000] 200 "POST /grafana/api/ds/query?ds_type=prometheus&requestId=SQR461 HTTP/1.1" 59460 "https://test.example.com/?orgId=1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36" "95.91.240.90, 34.107.247.24"`,
+      logLevel: LogLevel.critical,
+    });
+    jsonLog = createLogRow({
+      uid: '3',
+      timeEpochMs: 1,
+      labels: { kind: 'Event', stage: 'ResponseComplete' },
+      entry: `{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"2052d577-3391-4fe7-9fe2-4d6c8cbe398f","stage":"ResponseComplete","requestURI":"/api/v1/test","verb":"list","user":{"username":"system:apiserver","uid":"6f35feec-4522-4f21-8289-668e336967b5","groups":["system:authenticated","system:masters"]},"sourceIPs":["::1"],"userAgent":"kube-apiserver/v1.31.5 (linux/amd64) kubernetes/test","objectRef":{"resource":"resourcequotas","namespace":"test","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2025-03-18T08:58:34.940093Z"}`,
+      logLevel: LogLevel.error,
+    });
+    processedLogs = preProcessLogs([logFmtLog, nginxLog, jsonLog], {
+      escape: false,
+      getFieldLinks,
+      order: LogsSortOrder.Descending,
+      timeZone: 'browser',
+    });
+  });
+
+  test('Orders logs', () => {
+    expect(processedLogs[0].uid).toBe('1');
+    expect(processedLogs[1].uid).toBe('2');
+    expect(processedLogs[2].uid).toBe('3');
+  });
+
+  test('Sets the display level level', () => {
+    expect(processedLogs[0].displayLevel).toBe('warn');
+    expect(processedLogs[1].displayLevel).toBe('crit');
+    expect(processedLogs[2].displayLevel).toBe('error');
+  });
+
+  test('Sets the log fields links', () => {
+    expect(processedLogs[0].fields).toEqual([
+      {
+        fieldIndex: 3,
+        keys: ['link'],
+        links: {
+          href: '/link',
+          origin: {
+            config: {
+              links: [
+                {
+                  title: 'link1',
+                  url: 'https://example.com',
+                },
+              ],
+            },
+            index: 3,
+            name: 'link',
+            type: 'string',
+            values: ['link'],
+          },
+          target: '_blank',
+          title: 'link',
+        },
+        values: ['link'],
+      },
+    ]);
+    expect(processedLogs[1].fields).toEqual([]);
+    expect(processedLogs[2].fields).toEqual([]);
+  });
+
+  test('Highlights tokens in log lines', () => {
+    expect(processedLogs[0].highlightedBody).toContain('log-token-label');
+    expect(processedLogs[0].highlightedBody).toContain('log-token-key');
+    expect(processedLogs[0].highlightedBody).toContain('log-token-string');
+    expect(processedLogs[0].highlightedBody).toContain('log-token-timestamp');
+    expect(processedLogs[0].highlightedBody).toContain('log-token-uuid');
+    expect(processedLogs[0].highlightedBody).not.toContain('log-token-method');
+    expect(processedLogs[0].highlightedBody).not.toContain('log-token-json-key');
+
+    expect(processedLogs[1].highlightedBody).toContain('log-token-method');
+    expect(processedLogs[1].highlightedBody).toContain('log-token-key');
+    expect(processedLogs[1].highlightedBody).toContain('log-token-string');
+    expect(processedLogs[1].highlightedBody).not.toContain('log-token-json-key');
+
+    expect(processedLogs[2].highlightedBody).toContain('log-token-json-key');
+    expect(processedLogs[2].highlightedBody).toContain('log-token-string');
+    expect(processedLogs[2].highlightedBody).toContain('log-token-timestamp');
+    expect(processedLogs[2].highlightedBody).not.toContain('log-token-method');
+  });
+});

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -3,13 +3,10 @@ import Prism from 'prismjs';
 import { dateTimeFormat, LogLevel, LogRowModel, LogsSortOrder } from '@grafana/data';
 
 import { escapeUnescapedString, sortLogRows } from '../../utils';
-import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { FieldDef, getAllFields } from '../logParser';
 
-import { getDisplayedFieldValue } from './LogLine';
 import { GetFieldLinksFn } from './LogList';
 import { generateLogGrammar } from './grammar';
-import { measureTextWidth } from './virtualization';
 
 export interface LogListModel extends LogRowModel {
   body: string;
@@ -18,11 +15,6 @@ export interface LogListModel extends LogRowModel {
   displayLevel: string;
   fields: FieldDef[];
   timestamp: string;
-}
-
-export interface LogFieldDimension {
-  field: string;
-  width: number;
 }
 
 export interface PreProcessOptions {
@@ -86,47 +78,3 @@ function logLevelToDisplayLevel(level = '') {
       return level;
   }
 }
-
-export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
-  if (!logs.length) {
-    return [];
-  }
-  let timestampWidth = 0;
-  let levelWidth = 0;
-  const fieldWidths: Record<string, number> = {};
-  for (let i = 0; i < logs.length; i++) {
-    let width = measureTextWidth(logs[i].timestamp);
-    if (width > timestampWidth) {
-      timestampWidth = Math.round(width);
-    }
-    width = measureTextWidth(logs[i].displayLevel);
-    if (width > levelWidth) {
-      levelWidth = Math.round(width);
-    }
-    for (const field of displayedFields) {
-      width = measureTextWidth(getDisplayedFieldValue(field, logs[i]));
-      fieldWidths[field] = !fieldWidths[field] || width > fieldWidths[field] ? Math.round(width) : fieldWidths[field];
-    }
-  }
-  const dimensions: LogFieldDimension[] = [
-    {
-      field: 'timestamp',
-      width: timestampWidth,
-    },
-    {
-      field: 'level',
-      width: levelWidth,
-    },
-  ];
-  for (const field in fieldWidths) {
-    // Skip the log line when it's a displayed field
-    if (field === LOG_LINE_BODY_FIELD_NAME) {
-      continue;
-    }
-    dimensions.push({
-      field,
-      width: fieldWidths[field],
-    });
-  }
-  return dimensions;
-};

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -46,7 +46,7 @@ interface PreProcessLogOptions {
   timeZone: string;
 }
 const preProcessLog = (log: LogRowModel, { escape, getFieldLinks, timeZone }: PreProcessLogOptions): LogListModel => {
-  let body = log.entry;
+  let body = log.raw;
   const timestamp = dateTimeFormat(log.timeEpochMs, {
     timeZone,
     defaultWithMS: true,

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -176,9 +176,10 @@ export function getLogLineSize(
     optionsWidth += gap;
     textToMeasure += logs[index].timestamp;
   }
-  if (logs[index].logLevel) {
+  // When logs are unwrapped, we want an empty column space to align with other log lines.
+  if (logs[index].logLevel || !wrap) {
     optionsWidth += gap;
-    textToMeasure += logs[index].logLevel;
+    textToMeasure += logs[index].logLevel ?? '';
   }
   for (const field of displayedFields) {
     textToMeasure = getDisplayedFieldValue(field, logs[index]) + textToMeasure;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -157,7 +157,6 @@ export function getLogLineSize(
   { wrap, showTime }: DisplayOptions,
   index: number
 ) {
-  console.log('measuring', index);
   if (!container) {
     return 0;
   }

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -118,12 +118,12 @@ export function measureTextHeight(text: string, maxWidth: number, beforeWidth = 
     };
   }
 
+  const availableWidth = maxWidth - beforeWidth;
   for (const textLine of textLines) {
     for (let start = 0; start < textLine.length; ) {
       let testLogLine: string;
       let width = 0;
       let delta = 0;
-      let availableWidth = maxWidth - beforeWidth;
       do {
         testLogLine = textLine.substring(start, start + logLineCharsLength - delta);
         width = measureTextWidth(testLogLine);

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -157,6 +157,7 @@ export function getLogLineSize(
   { wrap, showTime }: DisplayOptions,
   index: number
 ) {
+  console.log('measuring', index);
   if (!container) {
     return 0;
   }
@@ -177,9 +178,9 @@ export function getLogLineSize(
     textToMeasure += logs[index].timestamp;
   }
   // When logs are unwrapped, we want an empty column space to align with other log lines.
-  if (logs[index].logLevel || !wrap) {
+  if (logs[index].displayLevel || !wrap) {
     optionsWidth += gap;
-    textToMeasure += logs[index].logLevel ?? '';
+    textToMeasure += logs[index].displayLevel ?? '';
   }
   for (const field of displayedFields) {
     textToMeasure = getDisplayedFieldValue(field, logs[index]) + textToMeasure;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,5 +1,7 @@
 import { BusEventWithPayload, GrafanaTheme2 } from '@grafana/data';
 
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+
 import { getDisplayedFieldValue } from './LogLine';
 import { LogListModel } from './processing';
 
@@ -191,6 +193,55 @@ export function getLogLineSize(
   const { height } = measureTextHeight(textToMeasure, getLogContainerWidth(container), optionsWidth);
   return height;
 }
+
+export interface LogFieldDimension {
+  field: string;
+  width: number;
+}
+
+export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
+  if (!logs.length) {
+    return [];
+  }
+  let timestampWidth = 0;
+  let levelWidth = 0;
+  const fieldWidths: Record<string, number> = {};
+  for (let i = 0; i < logs.length; i++) {
+    let width = measureTextWidth(logs[i].timestamp);
+    if (width > timestampWidth) {
+      timestampWidth = Math.round(width);
+    }
+    width = measureTextWidth(logs[i].displayLevel);
+    if (width > levelWidth) {
+      levelWidth = Math.round(width);
+    }
+    for (const field of displayedFields) {
+      width = measureTextWidth(getDisplayedFieldValue(field, logs[i]));
+      fieldWidths[field] = !fieldWidths[field] || width > fieldWidths[field] ? Math.round(width) : fieldWidths[field];
+    }
+  }
+  const dimensions: LogFieldDimension[] = [
+    {
+      field: 'timestamp',
+      width: timestampWidth,
+    },
+    {
+      field: 'level',
+      width: levelWidth,
+    },
+  ];
+  for (const field in fieldWidths) {
+    // Skip the log line when it's a displayed field
+    if (field === LOG_LINE_BODY_FIELD_NAME) {
+      continue;
+    }
+    dimensions.push({
+      field,
+      width: fieldWidths[field],
+    });
+  }
+  return dimensions;
+};
 
 export function hasUnderOrOverflow(element: HTMLDivElement, calculatedHeight?: number): number | null {
   const height = calculatedHeight ?? element.clientHeight;


### PR DESCRIPTION
This PR introduces syntax highlighting to the Logs visualization, with the objective of helping users make sense of their contents.
This has been achieved by defining a custom PrismJS grammar for logs, which currently highlights:

- Durations (1ms, 3h) and sizes (1 kb)
- UUIDs
- JSON object keys
- Logfmt keys
- Parsed fields (same color of JSON and logfmt keys, but subtly more prominent).

Highlighting is defined in the preprocessing part, but it's actually done on demand when the lines are about to be rendered to minimize the impact of doing it all at once on 1/5/10k lines. See https://github.com/grafana/grafana/blob/da785ff7a7d565c40fcc9a9db7007a198dd609a7/public/app/features/logs/components/panel/processing.ts#L65

Other visual changes to the visualization has been made in collaboration with UX, such as:
- Used max contrast color on the Log Line Menu icon
- Added missing support for ANSI log lines
- Color from the timestamps has been removed
- Level is now uppercase
- General color updates

## Some examples

Numbers, ANSI log lines, logfmt keys
 
![demo1](https://github.com/user-attachments/assets/3b827c85-728f-4895-9ae6-078edc5f985e)

Same with parsed fields

![demo2](https://github.com/user-attachments/assets/d0ea8761-1508-4986-a453-ef622ddd79f6)

JSON keys
![demo3](https://github.com/user-attachments/assets/f58ca3f6-be46-47b5-9df7-15cbcb23b959)

Light theme

![demo4](https://github.com/user-attachments/assets/6810c729-4ee7-4466-89da-e75be9d27c79)