### PR TITLE
Alerting: Fix exporting new rule with a new group

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
@@ -168,7 +168,7 @@ export const getPayloadToExport = (
   } else {
     // we have to create a new group with the updated rule
     return {
-      name: existingGroup?.name ?? '',
+      name: existingGroup?.name ?? formValues.group,
       rules: [updatedRule],
     };
   }


### PR DESCRIPTION
**What is this feature?**

This PR fixes exporting new alert rule when using a new group.

Before the fix, the export drawer was  showing an empty HCL.

**After the fix:**

https://github.com/user-attachments/assets/97894417-a31d-49f8-91ff-f3fa85bbe973

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Related to this [escalation](https://github.com/grafana/support-escalations/issues/14937)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
