### PR TITLE
SQL Expressions: Resizable code-editor

### DIFF
--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useRef, useEffect, useState } from 'react';
 import { css } from '@emotion/css';
+import { useMemo, useRef, useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { SQLEditor } from '@grafana/plugin-ui';
@@ -32,7 +32,9 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
 
   // Set up resize observer to handle container resizing
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current) {
+      return;
+    }
 
     const resizeObserver = new ResizeObserver((entries) => {
       const { height } = entries[0].contentRect;

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef, useEffect } from 'react';
+import { useMemo, useState, useRef, useLayoutEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { SQLEditor } from '@grafana/plugin-ui';
@@ -14,7 +14,8 @@ interface Props {
 export const SqlExpr = ({ onChange, refIds, query }: Props) => {
   const vars = useMemo(() => refIds.map((v) => v.value!), [refIds]);
   const initialQuery = `select * from ${vars[0]} limit 1`;
-  const [height, setHeight] = useState(300); // Initial height
+  const initialHeight = 200; // Consistent initial height
+  const [height, setHeight] = useState(initialHeight);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const onEditorChange = (expression: string) => {
@@ -24,18 +25,26 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
     });
   };
 
-  // Set up resize observer to catch container height changes
-  useEffect(() => {
+  // Using useLayoutEffect to avoid visual flashing
+  useLayoutEffect(() => {
     if (!containerRef.current) return;
 
+    // Set initial height explicitly
+    if (containerRef.current.clientHeight !== initialHeight) {
+      containerRef.current.style.height = `${initialHeight}px`;
+    }
+
     const resizeObserver = new ResizeObserver((entries) => {
-      const { height } = entries[0].contentRect;
-      setHeight(height);
+      const newHeight = entries[0].contentRect.height;
+      // Only update height state if it actually changed
+      if (Math.abs(newHeight - height) > 1) {
+        setHeight(newHeight);
+      }
     });
 
     resizeObserver.observe(containerRef.current);
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [height]);
 
   return (
     <div
@@ -43,7 +52,8 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
       style={{
         resize: 'vertical',
         overflow: 'auto',
-        minHeight: '200px',
+        height: `${initialHeight}px`, // Set explicit initial height
+        minHeight: '100px',
       }}
     >
       <SQLEditor query={query.expression || initialQuery} onChange={onEditorChange} height={height} />

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { SQLEditor } from '@grafana/plugin-ui';
@@ -13,8 +13,9 @@ interface Props {
 
 export const SqlExpr = ({ onChange, refIds, query }: Props) => {
   const vars = useMemo(() => refIds.map((v) => v.value!), [refIds]);
-
   const initialQuery = `select * from ${vars[0]} limit 1`;
+  const [height, setHeight] = useState(300); // Initial height
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const onEditorChange = (expression: string) => {
     onChange({
@@ -23,5 +24,29 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
     });
   };
 
-  return <SQLEditor query={query.expression || initialQuery} onChange={onEditorChange}></SQLEditor>;
+  // Set up resize observer to catch container height changes
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      const { height } = entries[0].contentRect;
+      setHeight(height);
+    });
+
+    resizeObserver.observe(containerRef.current);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        resize: 'vertical',
+        overflow: 'auto',
+        minHeight: '200px',
+      }}
+    >
+      <SQLEditor query={query.expression || initialQuery} onChange={onEditorChange} height={height} />
+    </div>
+  );
 };

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -49,7 +49,7 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
 
 const getStyles = () => ({
   editorContainer: css({
-    height: '200px',
+    height: '240px',
     resize: 'vertical',
     overflow: 'auto',
     minHeight: '100px',

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -7,6 +7,9 @@ import { useStyles2 } from '@grafana/ui';
 
 import { ExpressionQuery } from '../types';
 
+// Account for Monaco editor's border to prevent clipping
+const EDITOR_BORDER_ADJUSTMENT = 2; // 1px border on top and bottom
+
 interface Props {
   refIds: Array<SelectableValue<string>>;
   query: ExpressionQuery;
@@ -42,7 +45,11 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
 
   return (
     <div ref={containerRef} className={styles.editorContainer}>
-      <SQLEditor query={query.expression || initialQuery} onChange={onEditorChange} height={dimensions.height} />
+      <SQLEditor
+        query={query.expression || initialQuery}
+        onChange={onEditorChange}
+        height={dimensions.height - EDITOR_BORDER_ADJUSTMENT}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/100196

CodeOwners is getting updated in https://github.com/grafana/grafana/pull/101611

**What is this feature?**

Make the SQL Expressions query-input field resizable (vertically) via mouse-drag:

https://github.com/user-attachments/assets/5574425a-e440-4dd5-ac49-0422a26f4de0

I used an LLM to write this code. I found that InfluxDB has the same vertical-resizing functionality, so I copied the implementation from there.
