### PR TITLE
Alerting: Enable the remote Alertmanager feature using only feature toggles

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1558,13 +1558,7 @@ default_datasource_uid =
 [recording_rules.custom_headers]
 # exampleHeader = exampleValue
 
-# NOTE: this configuration options are not used yet.
 [remote.alertmanager]
-
-# Enable the use of the configured remote Alertmanager and disable the internal one.
-# The default value is `false`.
-enabled = false
-
 # URL of the remote Alertmanager that will replace the internal one.
 # This URL should be the root path, Grafana will automatically append an "/alertmanager" suffix for certain HTTP calls.
 # Required if `enabled` is set to `true`.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -188,7 +188,7 @@ func (ng *AlertNG) init() error {
 	remoteOnly := ng.FeatureToggles.IsEnabled(initCtx, featuremgmt.FlagAlertmanagerRemoteOnly)
 	remotePrimary := ng.FeatureToggles.IsEnabled(initCtx, featuremgmt.FlagAlertmanagerRemotePrimary)
 	remoteSecondary := ng.FeatureToggles.IsEnabled(initCtx, featuremgmt.FlagAlertmanagerRemoteSecondary)
-	if ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Enable {
+	if remoteOnly || remotePrimary || remoteSecondary {
 		autogenFn := remote.NoopAutogenFn
 		if ng.FeatureToggles.IsEnabled(initCtx, featuremgmt.FlagAlertingSimplifiedRouting) {
 			autogenFn = func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, skipInvalid bool) error {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -148,7 +148,6 @@ type RecordingRuleSettings struct {
 // RemoteAlertmanagerSettings contains the configuration needed
 // to disable the internal Alertmanager and use an external one instead.
 type RemoteAlertmanagerSettings struct {
-	Enable       bool
 	URL          string
 	TenantID     string
 	Password     string
@@ -389,7 +388,6 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	remoteAlertmanager := iniFile.Section("remote.alertmanager")
 	uaCfgRemoteAM := RemoteAlertmanagerSettings{
-		Enable:   remoteAlertmanager.Key("enabled").MustBool(false),
 		URL:      remoteAlertmanager.Key("url").MustString(""),
 		TenantID: remoteAlertmanager.Key("tenant").MustString(""),
 		Password: remoteAlertmanager.Key("password").MustString(""),


### PR DESCRIPTION
Delete the `[remote.alertmanager][enabled]` setting, use only feature toggles to determine whether the feature should be enabled or not.