### PR TITLE
Anon: Deprecation notice for Editor, Admin anonymous org role usage

### DIFF
--- a/pkg/setting/setting_anonymous.go
+++ b/pkg/setting/setting_anonymous.go
@@ -17,7 +17,7 @@ func (cfg *Cfg) readAnonymousSettings() {
 	// Deprecated:
 	// only viewer role is supported
 	anonSettings.OrgRole = valueAsString(anonSection, "org_role", "")
-	if anonSettings.OrgRole == "Viewer" {
+	if anonSettings.OrgRole != "Viewer" {
 		cfg.Logger.Warn("auth.anonymous.org_role is deprecated, only viewer role is supported")
 	}
 	anonSettings.HideVersion = anonSection.Key("hide_version").MustBool(false)

--- a/pkg/setting/setting_anonymous.go
+++ b/pkg/setting/setting_anonymous.go
@@ -14,7 +14,12 @@ func (cfg *Cfg) readAnonymousSettings() {
 	anonSettings := AnonymousSettings{}
 	anonSettings.Enabled = anonSection.Key("enabled").MustBool(false)
 	anonSettings.OrgName = valueAsString(anonSection, "org_name", "")
+	// Deprecated:
+	// only viewer role is supported
 	anonSettings.OrgRole = valueAsString(anonSection, "org_role", "")
+	if anonSettings.OrgRole == "Viewer" {
+		cfg.Logger.Warn("auth.anonymous.org_role is deprecated, only viewer role is supported")
+	}
 	anonSettings.HideVersion = anonSection.Key("hide_version").MustBool(false)
 	anonSettings.DeviceLimit = anonSection.Key("device_limit").MustInt64(0)
 	cfg.Anonymous = anonSettings


### PR DESCRIPTION
We are deprecating the use of the anonymous org role for anything other than Viewer. This change is part of our effort to simplify Grafana’s configuration and enhance security by limiting options for anonymous access.