### PR TITLE
Add OpenAPI annotations for query params of `getOrgUsersForCurrentOrg` API route

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -542,6 +542,16 @@ type AddOrgUserParams struct {
 	OrgID int64 `json:"org_id"`
 }
 
+// swagger:parameters getOrgUsersForCurrentOrg
+type GetOrgUsersForCurrentOrgParams struct {
+	// in:query
+	// required:false
+	Query string `json:"query"`
+	// in:query
+	// required:false
+	Limit int `json:"limit"`
+}
+
 // swagger:parameters getOrgUsersForCurrentOrgLookup
 type LookupOrgUsersParams struct {
 	// in:query

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -6457,6 +6457,19 @@
         ],
         "summary": "Get all users within the current organization.",
         "operationId": "getOrgUsersForCurrentOrg",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "query",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "name": "limit",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getOrgUsersForCurrentOrgResponse"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -20307,6 +20307,23 @@
       "get": {
         "description": "Returns all org users within the current organization. Accessible to users with org admin role.\nIf you are running Grafana Enterprise and have Fine-grained access control enabled\nyou need to have a permission with action: `org.users:read` with scope `users:*`.",
         "operationId": "getOrgUsersForCurrentOrg",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/getOrgUsersForCurrentOrgResponse"


### PR DESCRIPTION
While working on https://github.com/grafana/terraform-provider-grafana/issues/1984, I just noticed that the [OpenAPI spec](https://github.com/grafana/grafana/blob/98dd977fabd06a6ef650c3f2d8894fe428dee541/public/openapi3.json#L20306-L20328) is missing the query params for `GET /api/org/users` ([code](https://github.com/grafana/grafana/blob/2ffb397fa8861977497a586359802e1df37d74d1/pkg/api/org_users.go#L105-L118)), which is impeding us from using that route through the auto-generated OpenAPI client.

