### PR TITLE
Alerting: API to return deleted rules

### DIFF
--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -23,6 +23,7 @@ type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmodels.GetAlertRulesGroupByRuleUIDQuery) ([]*ngmodels.AlertRule, error)
 	ListAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) (ngmodels.RulesGroup, error)
+	ListDeletedRules(ctx context.Context, orgID int64) ([]*ngmodels.AlertRule, error)
 
 	// InsertAlertRules will insert all alert rules passed into the function
 	// and return the map of uuid to id.

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1954,6 +1954,61 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 	})
 }
 
+func TestIntegration_ListDeletedRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	cfg := setting.NewCfg()
+	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{
+		BaseInterval:           1 * time.Second,
+		RuleVersionRecordLimit: -1,
+	}
+	sqlStore := db.InitTestDB(t)
+	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+	b := &fakeBus{}
+	store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+	orgID := int64(1)
+	gen := models.RuleGen
+	gen = gen.With(gen.WithIntervalMatching(store.Cfg.BaseInterval), gen.WithOrgID(orgID))
+
+	result, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, []models.AlertRule{gen.Generate()})
+	require.NoError(t, err)
+	rule, err := store.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{UID: result[0].UID})
+	require.NoError(t, err)
+
+	rule2 := models.CopyRule(rule, gen.WithTitle(util.GenerateShortUID()))
+	err = store.UpdateAlertRules(context.Background(), &models.AlertingUserUID, []models.UpdateRule{
+		{
+			Existing: rule,
+			New:      *rule2,
+		},
+	})
+	rule2, err = store.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{UID: result[0].UID})
+	require.NoError(t, err)
+
+	versions, err := store.GetAlertRuleVersions(context.Background(), orgID, rule.GUID)
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+
+	t.Run("should not return if rule is not deleted", func(t *testing.T) {
+		list, err := store.ListDeletedRules(context.Background(), orgID)
+		require.NoError(t, err)
+		require.Empty(t, list)
+	})
+
+	err = store.DeleteAlertRulesByUID(context.Background(), orgID, &models.AlertingUserUID, rule.UID)
+	require.NoError(t, err)
+
+	t.Run("should return the last deleted rule", func(t *testing.T) {
+		list, err := store.ListDeletedRules(context.Background(), orgID)
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+		assert.Empty(t, list[0].UID)
+		assert.Empty(t, rule2.Diff(list[0], "ID", "UID", "DashboardUID", "PanelID"))
+	})
+}
+
 func createTestStore(
 	sqlStore db.DB,
 	folderService folder.Service,

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1984,6 +1984,7 @@ func TestIntegration_ListDeletedRules(t *testing.T) {
 			New:      *rule2,
 		},
 	})
+	require.NoError(t, err)
 	rule2, err = store.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{UID: result[0].UID})
 	require.NoError(t, err)
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1967,6 +1967,7 @@ func TestIntegration_ListDeletedRules(t *testing.T) {
 	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 	b := &fakeBus{}
 	store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+	store.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
 
 	orgID := int64(1)
 	gen := models.RuleGen

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -647,6 +647,16 @@ func (a apiClient) GetAllRulesWithStatus(t *testing.T) (apimodels.NamespaceConfi
 	return result, resp.StatusCode, b
 }
 
+func (a apiClient) GetDeletedRulesWithStatus(t *testing.T) (apimodels.NamespaceConfigResponse, int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/ruler/grafana/api/v1/rules", a.url), nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("deleted", "true")
+	req.URL.RawQuery = q.Encode()
+	return sendRequestJSON[apimodels.NamespaceConfigResponse](t, req, http.StatusOK)
+}
+
 func (a apiClient) ExportRulesWithStatus(t *testing.T, params *apimodels.AlertRulesExportParameters) (int, string) {
 	t.Helper()
 	u, err := url.Parse(fmt.Sprintf("%s/api/ruler/grafana/api/v1/export/rules", a.url))


### PR DESCRIPTION
**What is this feature?**
This PR extends existing API endpoint `GET /api/ruler/grafana/api/v1/rules` with a query parameter `deleted`. When request has parameter `deleted=true` the response will contain only rules that were deleted.  
- This mode is available to administrators only. Other users will get 403 Forbidden
- The response has the same format as regular one (without flag) but all rules are put into single folder, single group with empty name (original namespace UID and group name are set per rule).
- The response's `updated_by`  contains information about user that deleted the rule. `updated` - timestamp of the operation.
- All rules have empty UID. 
- API available only when feature flag `alertingRestore` is enabled.

**Why do we need this feature?**
Support recovery of rules

**Who is this feature for?**
UI only


**NOTE**: this API is not stable, it can be changed or removed without prior notice. Do not use it directly!