### PR TITLE
Alerting: Fix evaluation of rules with no-op math expressions

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -501,7 +501,7 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 			if frame.Fields[0].Len() == 1 {
 				v = frame.At(0, 0).(*float64) // type checked above
 			}
-			captureFn(frame.RefID, frame.Fields[0].Labels, v)
+			captureFn(refID, frame.Fields[0].Labels, v)
 		}
 
 		if refID == c.Condition {


### PR DESCRIPTION
When you use a math expression with out any operators, the dataFrame pointer is identical between the expression result and the input query/expression.

This was resulting in the values returned from an evaluation overshadowing each other, depending on the order of the processing of the result map.

For example:
```
A: some_metric
B: reduce of A
C: math expression -> "${B}"
D: Threshold evaluation of C -> "C > 0"
```
With a value of 1 for `some_metric`, might result in a evaluation result of one of the following (somewhat at random):
1. { B: 1, D: 1 }
2. { C: 1, D: 1}

While you would expect to see:
{ B: 1, C: 1, D: 1 }

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
