### PR TITLE
Transformations: Fix variable interpolation when Scenes is disabled

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -142,6 +142,14 @@ exports[`better eslint`] = {
     "packages/grafana-data/src/transformations/standardTransformersRegistry.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "packages/grafana-data/src/transformations/transformDataFrame.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+    ],
     "packages/grafana-data/src/transformations/transformers/nulls/nullInsertThreshold.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -12,6 +12,9 @@ import {
 import { getFrameMatchers } from './matchers';
 import { standardTransformersRegistry, TransformerRegistryItem } from './standardTransformersRegistry';
 
+// when running within Scenes, we can skip var interpolation, since it's already handled upstream
+const isScenes = window.__grafanaSceneContext != null;
+
 const getOperator =
   (config: DataTransformerConfig, ctx: DataTransformContext): MonoTypeOperatorFunction<DataFrame[]> =>
   (source) => {
@@ -24,11 +27,19 @@ const getOperator =
     const defaultOptions = info.transformation.defaultOptions ?? {};
     const options = { ...defaultOptions, ...config.options };
 
+    const interpolated = isScenes
+      ? options
+      : deepIterate(options, (v) => {
+          if (typeof v === 'string') {
+            return ctx.interpolate(v);
+          }
+        });
+
     const matcher = config.filter?.options ? getFrameMatchers(config.filter) : undefined;
     return source.pipe(
       mergeMap((before) =>
         of(filterInput(before, matcher)).pipe(
-          info.transformation.operator(options, ctx),
+          info.transformation.operator(interpolated, ctx),
           postProcessTransform(before, info, matcher)
         )
       )
@@ -106,4 +117,22 @@ export function transformDataFrame(
 
 function isCustomTransformation(t: DataTransformerConfig | CustomTransformOperator): t is CustomTransformOperator {
   return typeof t === 'function';
+}
+
+function deepIterate<T extends object>(obj: T, doSomething: (current: any) => any): T;
+// eslint-disable-next-line no-redeclare
+function deepIterate(obj: any, doSomething: (current: any) => any): any {
+  if (Array.isArray(obj)) {
+    return obj.map((o) => deepIterate(o, doSomething));
+  }
+
+  if (typeof obj === 'object') {
+    for (const key in obj) {
+      obj[key] = deepIterate(obj[key], doSomething);
+    }
+
+    return obj;
+  } else {
+    return doSomething(obj) ?? obj;
+  }
 }

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -33,6 +33,7 @@ const getOperator =
           if (typeof v === 'string') {
             return ctx.interpolate(v);
           }
+          return v;
         });
 
     const matcher = config.filter?.options ? getFrameMatchers(config.filter) : undefined;


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/14949

our [original approach](https://github.com/grafana/grafana/pull/100225/commits/deec7c306bff7cf452ccaa49a57284d9c942d014) in https://github.com/grafana/grafana/pull/100225 was omitted in favor of doing this in Scenes. but that left dashboards with Scenes disabled without interpolated transformations :(

this restores the non-scenes interpolation using a variant of the `deepIterate()` approach currently WIP in https://github.com/grafana/scenes/pull/1064

example dash:

<details><summary>var-interp.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 459,
  "links": [],
  "panels": [
    {
      "datasource": {
        "default": true,
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green"
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "11.6.0-pre",
      "targets": [
        {
          "csvContent": "str,val1,val2\na,1,2\nb,3,4\nc,5,6",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "filterByValue",
          "options": {
            "filters": [
              {
                "config": {
                  "id": "equal",
                  "options": {
                    "value": "${myvar}"
                  }
                },
                "fieldName": "str"
              }
            ],
            "match": "any",
            "type": "exclude"
          }
        }
      ],
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "text": [
            "a"
          ],
          "value": [
            "a"
          ]
        },
        "includeAll": false,
        "multi": true,
        "name": "myvar",
        "options": [
          {
            "selected": true,
            "text": "a",
            "value": "a"
          },
          {
            "selected": false,
            "text": "b",
            "value": "b"
          },
          {
            "selected": false,
            "text": "c",
            "value": "c"
          }
        ],
        "query": "a,b,c",
        "type": "custom"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "var-interp",
  "uid": "eeecze27100lcf",
  "version": 2
}
```
</details>