### PR TITLE
Alerting: Fix updating Prometheus definition in the metadata

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -314,7 +314,7 @@ func ValidateRuleGroup(
 			uids[rule.UID] = idx
 		}
 
-		var hasPause, isPaused, hasMetadata bool
+		var hasPause, isPaused, hasEditorSettings bool
 		original := ruleGroupConfig.Rules[idx]
 		if alert := original.GrafanaManagedAlert; alert != nil {
 			if alert.IsPaused != nil {
@@ -322,7 +322,7 @@ func ValidateRuleGroup(
 				hasPause = true
 			}
 			if alert.Metadata != nil {
-				hasMetadata = true
+				hasEditorSettings = true
 			}
 		}
 
@@ -331,7 +331,7 @@ func ValidateRuleGroup(
 		rule.RuleGroupIndex = idx + 1
 		ruleWithOptionals.AlertRule = *rule
 		ruleWithOptionals.HasPause = hasPause
-		ruleWithOptionals.HasMetadata = hasMetadata
+		ruleWithOptionals.HasEditorSettings = hasEditorSettings
 
 		result = append(result, &ruleWithOptionals)
 	}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -327,8 +327,8 @@ type AlertRuleWithOptionals struct {
 	AlertRule
 	// This parameter is to know if an optional API field was sent and, therefore, patch it with the current field from
 	// DB in case it was not sent.
-	HasPause    bool
-	HasMetadata bool
+	HasPause          bool
+	HasEditorSettings bool
 }
 
 // AlertsRulesBy is a function that defines the ordering of alert rules.
@@ -902,9 +902,10 @@ func (c Condition) IsValid() bool {
 
 // PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
 // There are several exceptions:
-// 1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated, AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations and AlertRule.Labels
-// 2. There are fields that are patched together:
-//   - AlertRule.Condition and AlertRule.Data
+//  1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated, AlertRule.Version,
+//     AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations, AlertRule.Labels, AlertRule.Metadata (except for EditorSettings)
+//  2. There are fields that are patched together:
+//     - AlertRule.Condition and AlertRule.Data
 //
 // If either of the pair is specified, neither is patched.
 func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOptionals) {
@@ -936,12 +937,8 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused
 	}
-
-	// Currently metadata contains only editor settings, so we can just copy it.
-	// If we add more fields to metadata, we might need to handle them separately,
-	// and/or merge or update their values.
-	if !ruleToPatch.HasMetadata {
-		ruleToPatch.Metadata = existingRule.Metadata
+	if !ruleToPatch.HasEditorSettings {
+		ruleToPatch.Metadata.EditorSettings = existingRule.Metadata.EditorSettings
 	}
 }
 

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -263,7 +263,7 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				name: "No metadata",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.Metadata = AlertRuleMetadata{}
-					r.HasMetadata = false
+					r.HasEditorSettings = false
 				},
 			},
 		}

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -229,6 +229,97 @@ func TestAlertRuleService(t *testing.T) {
 		require.Equal(t, ruleMetadata, readGroup.Rules[0].Metadata)
 	})
 
+	t.Run("updating a group with editor settings should override its prometheus rule definition", func(t *testing.T) {
+		namespaceUID := "my-namespace"
+		groupTitle := "test-group-123"
+
+		// create the rule group via the rule store, to persist the editor settings
+		rule := createTestRule(util.GenerateShortUID(), groupTitle, orgID, namespaceUID)
+		ruleMetadata := models.AlertRuleMetadata{
+			EditorSettings: models.EditorSettings{
+				SimplifiedQueryAndExpressionsSection: true,
+			},
+			PrometheusStyleRule: &models.PrometheusStyleRule{
+				OriginalRuleDefinition: "old",
+			},
+		}
+		rule.Metadata = ruleMetadata
+		r, err := ruleService.ruleStore.InsertAlertRules(context.Background(), models.NewUserUID(u), []models.AlertRule{rule})
+		require.NoError(t, err)
+		require.Len(t, r, 1)
+
+		// Set the UID for the rule to update it
+		rule.UID = r[0].UID
+		// clear the editor settings in the metadata to check that the existing setting is not overridden
+		rule.Metadata = models.AlertRuleMetadata{
+			PrometheusStyleRule: &models.PrometheusStyleRule{
+				OriginalRuleDefinition: "new",
+			},
+		}
+
+		// Now update the rule group with the rule to update its metadata
+		group := models.AlertRuleGroup{
+			Title:     groupTitle,
+			Interval:  60,
+			FolderUID: namespaceUID,
+			Rules:     []models.AlertRule{rule},
+		}
+
+		err = ruleService.ReplaceRuleGroup(context.Background(), u, group, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), u, namespaceUID, groupTitle)
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 1)
+
+		// check that the editor settings are still there
+		require.True(t, readGroup.Rules[0].Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		// check the new prometheus rule definition
+		require.Equal(t, "new", readGroup.Rules[0].Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("updating a group should override its prometheus rule definition", func(t *testing.T) {
+		namespaceUID := "my-namespace"
+		groupTitle := "test-group-123"
+
+		// create the rule group via the rule store, to persist the editor settings
+		rule := createTestRule(util.GenerateShortUID(), groupTitle, orgID, namespaceUID)
+		ruleMetadata := models.AlertRuleMetadata{
+			PrometheusStyleRule: &models.PrometheusStyleRule{
+				OriginalRuleDefinition: "old",
+			},
+		}
+		rule.Metadata = ruleMetadata
+		r, err := ruleService.ruleStore.InsertAlertRules(context.Background(), models.NewUserUID(u), []models.AlertRule{rule})
+		require.NoError(t, err)
+		require.Len(t, r, 1)
+
+		// Set the UID for the rule to update it
+		rule.UID = r[0].UID
+		// make the metadata empty
+		rule.Metadata = models.AlertRuleMetadata{}
+
+		// Now update the rule group with the rule to update its metadata
+		group := models.AlertRuleGroup{
+			Title:     groupTitle,
+			Interval:  60,
+			FolderUID: namespaceUID,
+			Rules:     []models.AlertRule{rule},
+		}
+
+		err = ruleService.ReplaceRuleGroup(context.Background(), u, group, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), u, namespaceUID, groupTitle)
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 1)
+
+		// check that the prometheus rule definition is empty
+		require.Nil(t, readGroup.Rules[0].Metadata.PrometheusStyleRule)
+	})
+
 	t.Run("updating a rule should not override its editor settings", func(t *testing.T) {
 		rule := createTestRule(util.GenerateShortUID(), "my-group", orgID, "my-folder")
 		ruleMetadata := models.AlertRuleMetadata{

--- a/pkg/services/ngalert/store/deltas_test.go
+++ b/pkg/services/ngalert/store/deltas_test.go
@@ -81,7 +81,7 @@ func TestCalculateChanges(t *testing.T) {
 		submittedMap := groupByUID(t, rules)
 		submitted := make([]*models.AlertRuleWithOptionals, 0, len(rules))
 		for _, rule := range rules {
-			submitted = append(submitted, &models.AlertRuleWithOptionals{AlertRule: *rule, HasMetadata: true})
+			submitted = append(submitted, &models.AlertRuleWithOptionals{AlertRule: *rule, HasEditorSettings: true})
 		}
 
 		fakeStore := fakes.NewRuleStore(t)
@@ -216,7 +216,7 @@ func TestCalculateChanges(t *testing.T) {
 		submittedMap := groupByUID(t, rules)
 		submitted := make([]*models.AlertRuleWithOptionals, 0, len(rules))
 		for _, rule := range rules {
-			submitted = append(submitted, &models.AlertRuleWithOptionals{AlertRule: *rule, HasMetadata: true})
+			submitted = append(submitted, &models.AlertRuleWithOptionals{AlertRule: *rule, HasEditorSettings: true})
 		}
 
 		changes, err := CalculateChanges(context.Background(), fakeStore, groupKey, submitted)


### PR DESCRIPTION
**What is this feature?**

Currently, the AlertRuleService supports a complete overwrite of the Metadata field if AlertRuleWithOptionals.HasMetadata is set to true. Instead, rename this field to HasEditorSettings for the API used by the frontend. This change still allows partial rule updates to change the EditorSettings but also ensures the PrometheusStyleDefinition is always updated with the new version if the field is present.

With this change, updates through the current rules API (used by the frontend) will clear the PrometheusStyleDefinition field, as this field is not present in the API. This is fine because the PrometheusStyleDefinition is set explicitly by the converter, and if a rule is updated via any other way, the PrometheusStyleDefinition should be cleared anyway