### PR TITLE
Azure: Resource picker improvements

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -66,7 +66,7 @@ describe('AzureMonitor resourcePickerData', () => {
       });
     });
 
-    it('makes multiple requests when arg returns a skipToken and passes the right skipToken to each subsequent call', async () => {
+    it('makes multiple requests for subscriptions when arg returns a skipToken and passes the right skipToken to each subsequent call', async () => {
       const response1 = {
         ...createMockARGSubscriptionResponse(),
         $skipToken: 'skipfirst100',
@@ -78,6 +78,48 @@ describe('AzureMonitor resourcePickerData', () => {
 
       expect(postResource).toHaveBeenCalledTimes(2);
       const secondCall = postResource.mock.calls[1];
+      const [_, postBody] = secondCall;
+      expect(postBody.options.$skipToken).toEqual('skipfirst100');
+    });
+
+    it('makes multiple requests for resource groups when arg returns a skipToken and passes the right skipToken to each subsequent call', async () => {
+      const subscriptionResponse = createMockARGSubscriptionResponse();
+      const resourceGroupResponse1 = {
+        ...createMockARGResourceGroupsResponse(),
+        $skipToken: 'skipfirst100',
+      };
+      const resourceGroupResponse2 = createMockARGResourceGroupsResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([
+        subscriptionResponse,
+        resourceGroupResponse1,
+        resourceGroupResponse2,
+      ]);
+
+      await resourcePickerData.getResourceGroupsBySubscriptionId('1', 'metrics');
+
+      expect(postResource).toHaveBeenCalledTimes(3);
+      const secondCall = postResource.mock.calls[2];
+      const [_, postBody] = secondCall;
+      expect(postBody.options.$skipToken).toEqual('skipfirst100');
+    });
+
+    it('makes multiple requests for resources when arg returns a skipToken and passes the right skipToken to each subsequent call', async () => {
+      const subscriptionResponse = createMockARGSubscriptionResponse();
+      const resourcesResponse1 = {
+        ...createARGResourcesResponse(),
+        $skipToken: 'skipfirst100',
+      };
+      const resourcesResponse2 = createARGResourcesResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([
+        subscriptionResponse,
+        resourcesResponse1,
+        resourcesResponse2,
+      ]);
+
+      await resourcePickerData.getResourcesForResourceGroup('resourceGroupURI', 'metrics');
+
+      expect(postResource).toHaveBeenCalledTimes(3);
+      const secondCall = postResource.mock.calls[2];
       const [_, postBody] = secondCall;
       expect(postBody.options.$skipToken).toEqual('skipfirst100');
     });

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -171,7 +171,9 @@ describe('AzureMonitor resourcePickerData', () => {
       const firstCall = postResource.mock.calls[0];
       const [path, postBody] = firstCall;
       expect(path).toEqual('resourcegraph/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01');
-      expect(postBody.query).toContain("type == 'microsoft.resources/subscriptions/resourcegroups'");
+      expect(postBody.query).toContain(
+        'extend resourceGroupURI = strcat("/subscriptions/", subscriptionId, "/resourcegroups/", resourceGroup)'
+      );
       expect(postBody.query).toContain("where subscriptionId == '123'");
     });
 


### PR DESCRIPTION
This PR adds two improvements to the resource picker:

1. Users or app registrations with restricted permissions can now appropriately be used with the resource picker. Previously, those with restricted permissions could not display resource groups correctly and therefore could not select resources using the picker. This change modifies the query used to fetch resource groups. Resource groups are now fetched based on the underlying resources a user has access to.
2. Currently, the number of resources returned was capped at 1000 due to the API limits of resource graph queries and the fact that pagination was not implemented on resource queries. Pagination support has now been added and resource groups with more than 1000 resources will appropriately return data.

Fixes #73969 
Partial fix for #94500 (this improves the resource picker situation but does not resolve the issue for template variables yet)