### PR TITLE
Alerting: Get alert rule versions by GUID

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -339,7 +339,7 @@ func (srv RulerSrv) RouteGetRuleByUID(c *contextmodel.ReqContext, ruleUID string
 func (srv RulerSrv) RouteGetRuleVersionsByUID(c *contextmodel.ReqContext, ruleUID string) response.Response {
 	ctx := c.Req.Context()
 	// make sure the user has access to the current version of the rule. Also, check if it exists
-	_, err := srv.getAuthorizedRuleByUid(ctx, c, ruleUID)
+	rule, err := srv.getAuthorizedRuleByUid(ctx, c, ruleUID)
 	if err != nil {
 		if errors.Is(err, ngmodels.ErrAlertRuleNotFound) {
 			return response.Empty(http.StatusNotFound)
@@ -347,7 +347,7 @@ func (srv RulerSrv) RouteGetRuleVersionsByUID(c *contextmodel.ReqContext, ruleUI
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get rule by UID", err)
 	}
 
-	rules, err := srv.store.GetAlertRuleVersions(ctx, ngmodels.AlertRuleKey{OrgID: c.OrgID, UID: ruleUID})
+	rules, err := srv.store.GetAlertRuleVersions(ctx, rule.OrgID, rule.GUID)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get rule history", err)
 	}

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -486,7 +487,7 @@ func TestRouteGetRuleHistoryByUID(t *testing.T) {
 		}
 
 		ruleStore.PutRule(context.Background(), rule)
-		ruleStore.History[rule.GetKey()] = append(ruleStore.History[rule.GetKey()], history...)
+		ruleStore.History[rule.GUID] = append(ruleStore.History[rule.GUID], history...)
 
 		perms := createPermissionsForRules([]*models.AlertRule{rule}, orgID)
 		req := createRequestContextWithPerms(orgID, perms, nil)
@@ -516,8 +517,9 @@ func TestRouteGetRuleHistoryByUID(t *testing.T) {
 			OrgID: orgID,
 			UID:   "test",
 		}
-		history := gen.With(gen.WithKey(ruleKey)).GenerateManyRef(3)
-		ruleStore.History[ruleKey] = append(ruleStore.History[ruleKey], history...) // even if history is full of records
+		guid := uuid.NewString()
+		history := gen.With(gen.WithGUID(guid), gen.WithKey(ruleKey)).GenerateManyRef(3)
+		ruleStore.History[guid] = append(ruleStore.History[guid], history...) // even if history is full of records
 
 		perms := createPermissionsForRules(history, orgID)
 		req := createRequestContextWithPerms(orgID, perms, nil)
@@ -533,9 +535,10 @@ func TestRouteGetRuleHistoryByUID(t *testing.T) {
 			OrgID: orgID,
 			UID:   "test",
 		}
-		rule := gen.With(gen.WithKey(ruleKey)).GenerateRef()
+		guid := uuid.NewString()
+		rule := gen.With(gen.WithKey(ruleKey), gen.WithGUID(guid)).GenerateRef()
 		ruleStore.PutRule(context.Background(), rule)
-		ruleStore.History[ruleKey] = nil
+		ruleStore.History[guid] = nil
 
 		perms := createPermissionsForRules([]*models.AlertRule{rule}, orgID)
 		req := createRequestContextWithPerms(orgID, perms, nil)
@@ -556,10 +559,11 @@ func TestRouteGetRuleHistoryByUID(t *testing.T) {
 			OrgID: orgID,
 			UID:   "test",
 		}
-		rule := gen.With(gen.WithKey(ruleKey), gen.WithNamespaceUID(anotherFolder.UID)).GenerateRef()
+		guid := uuid.NewString()
+		rule := gen.With(gen.WithGUID(guid), gen.WithKey(ruleKey), gen.WithNamespaceUID(anotherFolder.UID)).GenerateRef()
 		ruleStore.PutRule(context.Background(), rule)
-		history := gen.With(gen.WithKey(ruleKey)).GenerateManyRef(3)
-		ruleStore.History[ruleKey] = history
+		history := gen.With(gen.WithGUID(guid), gen.WithKey(ruleKey)).GenerateManyRef(3)
+		ruleStore.History[guid] = history
 
 		perms := createPermissionsForRules(history, orgID) // grant permissions to all records in history but not the rule itself
 		req := createRequestContextWithPerms(orgID, perms, nil)

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -30,6 +30,6 @@ type RuleStore interface {
 
 	// IncreaseVersionForAllRulesInNamespaces Increases version for all rules that have specified namespace uids
 	IncreaseVersionForAllRulesInNamespaces(ctx context.Context, orgID int64, namespaceUIDs []string) ([]ngmodels.AlertRuleKeyWithVersion, error)
-	GetAlertRuleVersions(ctx context.Context, key ngmodels.AlertRuleKey) ([]*ngmodels.AlertRule, error)
+	GetAlertRuleVersions(ctx context.Context, orgID int64, guid string) ([]*ngmodels.AlertRule, error)
 	accesscontrol.RuleUIDToNamespaceStore
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -125,10 +125,10 @@ func (st DBstore) GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAler
 	return result, err
 }
 
-func (st DBstore) GetAlertRuleVersions(ctx context.Context, key ngmodels.AlertRuleKey) ([]*ngmodels.AlertRule, error) {
+func (st DBstore) GetAlertRuleVersions(ctx context.Context, orgID int64, guid string) ([]*ngmodels.AlertRule, error) {
 	alertRules := make([]*ngmodels.AlertRule, 0)
 	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
-		rows, err := sess.Table(new(alertRuleVersion)).Where("rule_org_id = ? AND rule_uid = ?", key.OrgID, key.UID).Asc("id").Rows(new(alertRuleVersion))
+		rows, err := sess.Table(new(alertRuleVersion)).Where("rule_org_id = ? AND rule_guid = ?", orgID, guid).Asc("id").Rows(new(alertRuleVersion))
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -330,7 +330,7 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, 
 				return fmt.Errorf("failed to convert alert rule %s to storage model: %w", r.New.UID, err)
 			}
 			// no way to update multiple rules at once
-			if updated, err := sess.ID(r.Existing.ID).AllCols().Update(converted); err != nil || updated == 0 {
+			if updated, err := sess.ID(r.Existing.ID).AllCols().Omit("rule_guid").Update(converted); err != nil || updated == 0 {
 				if err != nil {
 					if st.SQLStore.GetDialect().IsUniqueConstraintViolation(err) {
 						return ruleConstraintViolationToErr(sess, r.New, err, st.Logger)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1599,7 +1599,7 @@ func TestGetRuleVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should return rule versions sorted in decreasing order", func(t *testing.T) {
-		versions, err := store.GetAlertRuleVersions(context.Background(), ruleV2.GetKey())
+		versions, err := store.GetAlertRuleVersions(context.Background(), ruleV2.OrgID, ruleV2.GUID)
 		require.NoError(t, err)
 		assert.Len(t, versions, 2)
 		assert.IsDecreasing(t, versions[0].ID, versions[1].ID)
@@ -1630,7 +1630,7 @@ func TestGetRuleVersions(t *testing.T) {
 			},
 		})
 
-		versions, err := store.GetAlertRuleVersions(context.Background(), ruleV3.GetKey())
+		versions, err := store.GetAlertRuleVersions(context.Background(), ruleV3.OrgID, ruleV3.GUID)
 		require.NoError(t, err)
 		assert.Len(t, versions, 3)
 		diff := versions[0].Diff(versions[1], AlertRuleFieldsToIgnoreInDiff[:]...)


### PR DESCRIPTION
**What is this feature?**
Follow up for https://github.com/grafana/grafana/pull/101321 that converts API controller and db store to retrieve rule history by GUID instead of UID.
Also, the Update rule method was updated to omit the guid field from update clause, which adds additional protection against accidental changing GUID.

**Why do we need this feature?**
Makes sure that history of a deleted rule will not be available if another rule with the same UID is created.
