### PR TITLE
Dashboard: Fix the unintentional time range and variables updates on saving

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -54,6 +54,7 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
     const result = await onSaveDashboard(dashboard, {
       overwrite,
       folderUid: data.folder.uid,
+      rawDashboardJSON: changedSaveModel,
 
       // save as config
       saveAsCopy: true,

--- a/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
@@ -25,7 +25,7 @@ export interface Props {
 }
 
 export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
-  const { hasChanges } = changeInfo;
+  const { hasChanges, changedSaveModel } = changeInfo;
 
   const { state, onSaveDashboard } = useSaveDashboard(false);
   const [options, setOptions] = useState<SaveDashboardOptions>({
@@ -38,7 +38,7 @@ export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
   });
 
   const onSave = async (overwrite: boolean) => {
-    const result = await onSaveDashboard(dashboard, { ...options, overwrite });
+    const result = await onSaveDashboard(dashboard, { ...options, rawDashboardJSON: changedSaveModel, overwrite });
     if (result.status === 'success') {
       dashboard.closeModal();
       drawer.state.onSaveSuccess?.();

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -3,6 +3,7 @@ import { useAsyncFn } from 'react-use';
 import { locationUtil } from '@grafana/data';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0';
 import appEvents from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';
@@ -25,7 +26,7 @@ export function useSaveDashboard(isCopy = false) {
       options: SaveDashboardOptions &
         SaveDashboardAsOptions & {
           // When provided, will take precedence over the scene's save model
-          rawDashboardJSON?: Dashboard;
+          rawDashboardJSON?: Dashboard | DashboardV2Spec;
         }
     ) => {
       {


### PR DESCRIPTION
Fixes the bug where time range and variables would update when saving dashboard although the checkboxes to update the time range and variables were not ticked.

The issue was that when saving we were relying on the saveModel which will always take the most recent state from the dashboard https://github.com/grafana/grafana/blob/2466685a41a8722335c3d81697b848fba31b50cd/public/app/features/dashboard-scene/saving/useSaveDashboard.ts#L32

I considered using [scene.getDashboardChanges](https://github.com/grafana/grafana/blob/2466685a41a8722335c3d81697b848fba31b50cd/public/app/features/dashboard-scene/scene/DashboardScene.tsx#L741C3-L743C4) but we don't have access to the state needed from SaveDashboardDrawer, so I considered extending scene.getDashboardChanges to something like this:
```ts
  getDashboardChanges(saveTimeRange?: boolean, saveVariables?: boolean, saveRefresh?: boolean): DashboardChangeInfo {
    if (this.state.overlay instanceof SaveDashboardDrawer) {
      const { saveTimeRange, saveVariables, saveRefresh } = this.state.overlay.state;
      return this._serializer.getDashboardChangesFromScene(this, { saveTimeRange, saveVariables, saveRefresh });
    }
    return this._serializer.getDashboardChangesFromScene(this, { saveTimeRange, saveVariables, saveRefresh });
  }
```
But this seems a bit hacky

