### PR TITLE
[release-10.4.17] Alerting: Update slack image upload to use new API 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/google/uuid v1.6.0 // @grafana/backend-platform
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.3 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20250123202046-ece9bb928fa4 // @grafana/alerting-squad-backend
+	github.com/grafana/alerting v0.0.0-20250228212120-8dc9701ba5f4 // @grafana/alerting-squad-backend
 	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.25.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.12.0 // @grafana/partner-datasources

--- a/go.sum
+++ b/go.sum
@@ -2168,10 +2168,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/alerting v0.0.0-20240712183458-ce0d024b67ea h1:Ao9ZOl2coIN83rIfT4jfVauvwCQcsRwQPK4y68QJvRA=
-github.com/grafana/alerting v0.0.0-20240712183458-ce0d024b67ea/go.mod h1:brTFeACal/cSZAR8XO/4LPKs7rzNfS86okl6QjSP1eY=
-github.com/grafana/alerting v0.0.0-20250123202046-ece9bb928fa4 h1:dDLBPOgs+dR26FuNvqSphYsCpnIugPVbhdsiRqSmmv4=
-github.com/grafana/alerting v0.0.0-20250123202046-ece9bb928fa4/go.mod h1:brTFeACal/cSZAR8XO/4LPKs7rzNfS86okl6QjSP1eY=
+github.com/grafana/alerting v0.0.0-20250228212120-8dc9701ba5f4 h1:G7zjdfJeZ93adt+fjU+us7m67pIp2+xpSDupD11goug=
+github.com/grafana/alerting v0.0.0-20250228212120-8dc9701ba5f4/go.mod h1:brTFeACal/cSZAR8XO/4LPKs7rzNfS86okl6QjSP1eY=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cue v0.0.0-20230926092038-971951014e3f h1:TmYAMnqg3d5KYEAaT6PtTguL2GjLfvr6wnAX8Azw6tQ=


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/97985 and https://github.com/grafana/grafana/pull/100988

---

**What is this feature?**

Upgrades grafana/alerting to https://github.com/grafana/alerting/commit/8dc9701ba5f4 which includes the fix:

https://github.com/grafana/alerting/pull/284

> Fixes `channel_not_found` error when finalizing an image upload for a Slack integration that uses both `Token` and channel `Name` (`#example`) as the recipient instead of channel `ID` (`C123ABC456`).
> 
> The cause was a previous [change](https://github.com/grafana/alerting/pull/256) to support `files_upload_v2` that required the use of the [files.completUploadExternal](https://api.slack.com/methods/files.completeUploadExternal) endpoint which does not support referencing channels by name, only ID.
> 
> Now we obtain the channel ID from the `chat.postMessage` response specifically for these bot token image uploads.

**Who is this feature for?**

Users with Slack contact points using Bot Tokens combined with Recipients defined as the Channel Name instead of Channel ID.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/100283

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.

