### PR TITLE
[release-11.3.5] Alerting: Fix token-based Slack image upload to work with channel names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.13.0 // @grafana/grafana-backend-group
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0 // @grafana/alerting-backend
+	github.com/grafana/alerting v0.0.0-20250228212059-bc4a3c128098 // @grafana/alerting-backend
 	github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 // @grafana/identity-access-team
 	github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd // @grafana/identity-access-team
 	github.com/grafana/codejen v0.0.3 // @grafana/dataviz-squad

--- a/go.sum
+++ b/go.sum
@@ -2255,6 +2255,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0 h1:6C4sCdsM/TPKNom1tlR0wFBiFfSbEmSTEKS6q7MeqpU=
 github.com/grafana/alerting v0.0.0-20250123200839-b4623c6a41a0/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
+github.com/grafana/alerting v0.0.0-20250228212059-bc4a3c128098 h1:S3tbGVSVAVLBKalWKUYRrXu63tAxXzYEA9n8Att9uzw=
+github.com/grafana/alerting v0.0.0-20250228212059-bc4a3c128098/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 h1:zYF/RBulpvMqPYR3gbzJZ8t/j/Eymn5FNidSYkueNCA=
 github.com/grafana/authlib v0.0.0-20240919120951-58259833c564/go.mod h1:PFzXbCrn0GIpN4KwT6NP1l5Z1CPLfmKHnYx8rZzQcyY=
 github.com/grafana/authlib/claims v0.0.0-20240827210201-19d5347dd8dd h1:sIlR7n38/MnZvX2qxDEszywXdI5soCwQ78aTDSARvus=


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/97985 and https://github.com/grafana/grafana/pull/100988

---

**What is this feature?**

Upgrades grafana/alerting to https://github.com/grafana/alerting/commit/bc4a3c1280989930ee5bdf479df0e092ec25b411 which includes the fix:

https://github.com/grafana/alerting/pull/284

> Fixes `channel_not_found` error when finalizing an image upload for a Slack integration that uses both `Token` and channel `Name` (`#example`) as the recipient instead of channel `ID` (`C123ABC456`).
> 
> The cause was a previous [change](https://github.com/grafana/alerting/pull/256) to support `files_upload_v2` that required the use of the [files.completUploadExternal](https://api.slack.com/methods/files.completeUploadExternal) endpoint which does not support referencing channels by name, only ID.
> 
> Now we obtain the channel ID from the `chat.postMessage` response specifically for these bot token image uploads.

**Who is this feature for?**

Users with Slack contact points using Bot Tokens combined with Recipients defined as the Channel Name instead of Channel ID.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/100283

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.

