### PR TITLE
TraceView: Use global config for showing and hiding feedback link in trace view

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -66,18 +66,20 @@ export default function TracePageActions(props: TracePageActionsProps) {
 
   return (
     <div className={styles.TracePageActions}>
-      <div className={styles.feedbackContainer}>
-        <Icon name="comment-alt-message" />
-        <a
-          href="https://forms.gle/RZDEx8ScyZNguDoC8"
-          className={styles.feedback}
-          title="Share your thoughts about tracing in Grafana."
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Give feedback
-        </a>
-      </div>
+      {config.feedbackLinksEnabled && (
+        <div className={styles.feedbackContainer}>
+          <Icon name="comment-alt-message" />
+          <a
+            href="https://forms.gle/RZDEx8ScyZNguDoC8"
+            className={styles.feedback}
+            title="Share your thoughts about tracing in Grafana."
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Give feedback
+          </a>
+        </div>
+      )}
 
       <ActionButton
         onClick={copyTraceId}


### PR DESCRIPTION
**What is this feature?**

Uses global config for showing and hiding feedback link in trace view.

**Why do we need this feature?**

So users can hide feedback links if they wish.

**Who is this feature for?**

Trace view users.

**Special notes for your reviewer:**

Part of https://github.com/grafana/traces-drilldown/issues/290