### PR TITLE
Elasticsearch: Invalid response JSON parsing error should be downstream

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -220,6 +220,10 @@ func (c *baseClientImpl) ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearch
 	} else {
 		dec := json.NewDecoder(res.Body)
 		err = dec.Decode(&msr)
+		if err != nil {
+			// Invalid JSON response from Elasticsearch
+			err = backend.DownstreamError(err)
+		}
 	}
 	if err != nil {
 		c.logger.Error("Failed to decode response from Elasticsearch", "error", err, "duration", time.Since(start), "improvedParsingEnabled", improvedParsingEnabled)
@@ -239,7 +243,8 @@ func StreamMultiSearchResponse(body io.Reader, msr *MultiSearchResponse) error {
 
 	_, err := dec.Token() // reads the `{` opening brace
 	if err != nil {
-		return err
+		// Invalid JSON response from Elasticsearch
+		return backend.DownstreamError(err)
 	}
 
 	for dec.More() {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -445,14 +445,6 @@ func TestStreamMultiSearchResponse_ErrorHandling(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, backend.IsDownstreamError(err))
 		})
-
-		t.Run("When response has invalid structure", func(t *testing.T) {
-			msr := &MultiSearchResponse{}
-			err := StreamMultiSearchResponse(strings.NewReader(`{ "responses": "not-an-array" }`), msr)
-
-			require.Error(t, err)
-			require.True(t, backend.IsDownstreamError(err))
-		})
 	})
 
 	t.Run("Given a client with invalid response", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -182,6 +182,32 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		require.Contains(t, bodyString, "metrics-2018.05.15")
 		require.Contains(t, bodyString, "metrics-2018.05.17")
 	})
+
+	t.Run("Should return DownstreamError when decoding response fails", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("Content-Type", "application/x-ndjson")
+			_, err := rw.Write([]byte(`{"invalid`))
+			require.NoError(t, err)
+			rw.WriteHeader(200)
+		}))
+
+		ds := &DatasourceInfo{
+			URL:        ts.URL,
+			Database:   "[metrics-]YYYY.MM.DD",
+			HTTPClient: ts.Client(),
+		}
+
+		c, err := NewClient(context.Background(), ds, log.NewNullLogger())
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		_, err = c.ExecuteMultisearch(&MultiSearchRequest{})
+		require.Error(t, err)
+		require.True(t, backend.IsDownstreamError(err))
+	})
 }
 
 func TestClient_Index(t *testing.T) {
@@ -408,6 +434,54 @@ func TestStreamMultiSearchResponse_InvalidHitElement(t *testing.T) {
 	if err.Error() != expected {
 		t.Errorf("unexpected error message: expected %v, got %v", expected, err)
 	}
+}
+
+func TestStreamMultiSearchResponse_ErrorHandling(t *testing.T) {
+	t.Run("Given invalid elasticsearch responses", func(t *testing.T) {
+		t.Run("When response is invalid JSON", func(t *testing.T) {
+			msr := &MultiSearchResponse{}
+			err := StreamMultiSearchResponse(strings.NewReader(`abc`), msr)
+
+			require.Error(t, err)
+			require.True(t, backend.IsDownstreamError(err))
+		})
+
+		t.Run("When response has invalid structure", func(t *testing.T) {
+			msr := &MultiSearchResponse{}
+			err := StreamMultiSearchResponse(strings.NewReader(`{ "responses": "not-an-array" }`), msr)
+
+			require.Error(t, err)
+			require.True(t, backend.IsDownstreamError(err))
+		})
+	})
+
+	t.Run("Given a client with invalid response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("Content-Type", "application/x-ndjson")
+			_, err := rw.Write([]byte(`{"invalid`))
+			require.NoError(t, err)
+			rw.WriteHeader(200)
+		}))
+
+		ds := &DatasourceInfo{
+			URL:        ts.URL,
+			Database:   "[metrics-]YYYY.MM.DD",
+			HTTPClient: ts.Client(),
+		}
+
+		c, err := NewClient(context.Background(), ds, log.NewNullLogger())
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			ts.Close()
+		})
+
+		t.Run("When executing multi search with invalid response", func(t *testing.T) {
+			_, err = c.ExecuteMultisearch(&MultiSearchRequest{})
+			require.Error(t, err)
+			require.True(t, backend.IsDownstreamError(err))
+		})
+	})
 }
 
 func createMultisearchForTest(t *testing.T, c Client, timeRange backend.TimeRange) (*MultiSearchRequest, error) {


### PR DESCRIPTION
This PR fixes error source for error caused by parsing of invalid response JSON

Fixed with `elasticsearchImprovedParsing`
<img width="842" alt="image" src="https://github.com/user-attachments/assets/1b819641-f64c-4a80-8c22-d17647c761c5" />

Fixed without `elasticsearchImprovedParsing`
<img width="819" alt="image" src="https://github.com/user-attachments/assets/bde254d5-b6c0-4627-b214-a913b8c7dec9" />

