### PR TITLE
Alerting: Add error handling for missing data source

### DIFF
--- a/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
+++ b/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
@@ -40,7 +40,7 @@ export const featureDiscoveryApi = alertingApi.injectEndpoints({
       queryFn: async (rulesSourceIdentifier) => {
         const dataSourceUID = getDataSourceUID(rulesSourceIdentifier);
         if (!dataSourceUID) {
-          return { error: new Error(`Unable to find data source for ${rulesSourceIdentifier}`) };
+          return { error: new Error(`Unable to find data source for ${JSON.stringify(rulesSourceIdentifier)}`) };
         }
 
         if (dataSourceUID === GrafanaRulesSourceSymbol) {

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
@@ -13,6 +13,7 @@ import { setupDataSources } from '../testSetup/datasources';
 
 import { useFolder } from './useFolder';
 import { useIsRuleEditable } from './useIsRuleEditable';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 jest.mock('./useFolder');
 
@@ -56,7 +57,9 @@ describe('useIsRuleEditable', () => {
 
         const wrapper = getProviderWrapper();
 
-        const { result } = renderHook(() => useIsRuleEditable('grafana', mockRulerGrafanaRule()), { wrapper });
+        const { result } = renderHook(() => useIsRuleEditable(GRAFANA_RULES_SOURCE_NAME, mockRulerGrafanaRule()), {
+          wrapper,
+        });
 
         await waitFor(() => expect(result.current.loading).toBe(false));
         expect(result.current.isRemovable).toBe(true);

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
@@ -10,10 +10,10 @@ import { AccessControlAction, FolderDTO } from 'app/types';
 import { setupMswServer } from '../mockApi';
 import { mockDataSource, mockFolder, mockRulerAlertingRule, mockRulerGrafanaRule } from '../mocks';
 import { setupDataSources } from '../testSetup/datasources';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 import { useFolder } from './useFolder';
 import { useIsRuleEditable } from './useIsRuleEditable';
-import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 jest.mock('./useFolder');
 

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -90,11 +90,3 @@ export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO):
     loading: isLoading,
   };
 }
-
-function useDataSourceUid(rulesSourceName: string): { dataSourceUID?: string; error?: unknown } {
-  try {
-    return { dataSourceUID: getDatasourceAPIUid(rulesSourceName) };
-  } catch (error) {
-    return { error };
-  }
-}

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -1,11 +1,8 @@
-import { skipToken } from '@reduxjs/toolkit/query';
-
 import { contextSrv } from 'app/core/services/context_srv';
 import { RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { featureDiscoveryApi } from '../api/featureDiscoveryApi';
 import { getRulesPermissions } from '../utils/access-control';
-import { getDatasourceAPIUid } from '../utils/datasource';
 import { isGrafanaRulerRule } from '../utils/rules';
 
 import { useFolder } from './useFolder';

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -13,12 +13,28 @@ interface ResultBag {
   isEditable?: boolean;
   isRemovable?: boolean;
   loading: boolean;
+  error?: unknown;
 }
 
 export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO): ResultBag {
-  const { currentData: dsFeatures, isLoading } = featureDiscoveryApi.endpoints.discoverDsFeatures.useQuery({
-    uid: getDatasourceAPIUid(rulesSourceName),
+  let dataSourceUID: string;
+
+  try {
+    dataSourceUID = getDatasourceAPIUid(rulesSourceName);
+  } catch (error) {
+    return { isEditable: false, isRemovable: false, loading: false, isRulerAvailable: false, error };
+  }
+
+  const {
+    currentData: dsFeatures,
+    isLoading,
+    error,
+  } = featureDiscoveryApi.endpoints.discoverDsFeatures.useQuery({
+    uid: dataSourceUID,
   });
+  if (error) {
+    return { isEditable: false, isRemovable: false, loading: false, isRulerAvailable: false, error };
+  }
 
   const folderUID = rule && isGrafanaRulerRule(rule) ? rule.grafana_alert.namespace_uid : undefined;
 

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -19,32 +19,27 @@ interface ResultBag {
 }
 
 export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO): ResultBag {
-  const { dataSourceUID, error: dataSourceError } = useDataSourceUid(rulesSourceName);
-
   const {
     currentData: dsFeatures,
     isLoading,
-    error: discoveryError,
-  } = featureDiscoveryApi.endpoints.discoverDsFeatures.useQuery(
-    dataSourceUID
-      ? {
-          uid: dataSourceUID,
-        }
-      : skipToken
-  );
+    error,
+  } = featureDiscoveryApi.endpoints.discoverDsFeatures.useQuery({
+    rulesSourceName,
+  });
 
   const folderUID = rule && isGrafanaRulerRule(rule) ? rule.grafana_alert.namespace_uid : undefined;
 
   const rulePermission = getRulesPermissions(rulesSourceName);
   const { folder, loading } = useFolder(folderUID);
 
-  if (discoveryError || dataSourceError) {
+  // handle discovery and data source errors
+  if (error) {
     return {
       isEditable: false,
       isRemovable: false,
       loading: false,
       isRulerAvailable: false,
-      error: discoveryError ?? dataSourceError,
+      error,
     };
   }
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -58,6 +58,7 @@ import { DashboardSearchItem, DashboardSearchItemType } from '../../search/types
 
 import { SimpleConditionIdentifier } from './components/rule-editor/query-and-alert-condition/SimpleCondition';
 import { parsePromQLStyleMatcherLooseSafe } from './utils/matchers';
+import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
 let nextDataSourceId = 1;
 
@@ -686,7 +687,7 @@ export function getGrafanaRule(override?: Partial<CombinedRule>, rulerOverride?:
     namespace: {
       groups: [],
       name: 'Grafana',
-      rulesSource: 'grafana',
+      rulesSource: GRAFANA_RULES_SOURCE_NAME,
     },
     rulerRule: mockGrafanaRulerRule(rulerOverride),
     ...override,

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -57,8 +57,8 @@ import {
 import { DashboardSearchItem, DashboardSearchItemType } from '../../search/types';
 
 import { SimpleConditionIdentifier } from './components/rule-editor/query-and-alert-condition/SimpleCondition';
-import { parsePromQLStyleMatcherLooseSafe } from './utils/matchers';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
+import { parsePromQLStyleMatcherLooseSafe } from './utils/matchers';
 
 let nextDataSourceId = 1;
 

--- a/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
@@ -17,30 +17,35 @@ interface ExistingRuleEditorProps {
 }
 
 export function ExistingRuleEditor({ identifier, prefill }: ExistingRuleEditorProps) {
+  const [queryParams] = useQueryParams();
+  const isManualRestore = Boolean(queryParams.isManualRestore);
+
   const {
     loading: loadingAlertRule,
     result: ruleWithLocation,
     error,
   } = useRuleWithLocation({ ruleIdentifier: identifier });
-  const [queryParams] = useQueryParams();
-  const isManualRestore = Boolean(queryParams.isManualRestore);
 
   const ruleSourceName = ruleId.ruleIdentifierToRuleSourceName(identifier);
+  const {
+    isEditable,
+    loading: loadingEditable,
+    error: errorEditable,
+  } = useIsRuleEditable(ruleSourceName, ruleWithLocation?.rule);
 
-  const { isEditable, loading: loadingEditable } = useIsRuleEditable(ruleSourceName, ruleWithLocation?.rule);
+  // error handling for fetching rule and rule RBAC
+  if (error || errorEditable) {
+    return (
+      <Alert severity="error" title="Failed to load rule">
+        {stringifyErrorLike(errorEditable ?? error)}
+      </Alert>
+    );
+  }
 
   const loading = loadingAlertRule || loadingEditable;
 
   if (loading) {
     return <LoadingPlaceholder text="Loading rule..." />;
-  }
-
-  if (error) {
-    return (
-      <Alert severity="error" title="Failed to load rule">
-        {stringifyErrorLike(error)}
-      </Alert>
-    );
   }
 
   if (!ruleWithLocation && !loading) {

--- a/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
@@ -23,7 +23,7 @@ export function ExistingRuleEditor({ identifier, prefill }: ExistingRuleEditorPr
   const {
     loading: loadingAlertRule,
     result: ruleWithLocation,
-    error,
+    error: fetchRuleError,
   } = useRuleWithLocation({ ruleIdentifier: identifier });
 
   const ruleSourceName = ruleId.ruleIdentifierToRuleSourceName(identifier);
@@ -34,10 +34,10 @@ export function ExistingRuleEditor({ identifier, prefill }: ExistingRuleEditorPr
   } = useIsRuleEditable(ruleSourceName, ruleWithLocation?.rule);
 
   // error handling for fetching rule and rule RBAC
-  if (error || errorEditable) {
+  if (fetchRuleError || errorEditable) {
     return (
       <Alert severity="error" title="Failed to load rule">
-        {stringifyErrorLike(errorEditable ?? error)}
+        {stringifyErrorLike(errorEditable ?? fetchRuleError)}
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/rule-editor/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorExisting.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from 'test/test-utils';
 
 import { contextSrv } from 'app/core/services/context_srv';
 import { setFolderResponse } from 'app/features/alerting/unified/mocks/server/configure';
-import { MIMIR_DATASOURCE_UID } from 'app/features/alerting/unified/mocks/server/constants';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
 import { DashboardSearchItemType } from 'app/features/search/types';
 import { AccessControlAction } from 'app/types';
@@ -12,6 +11,7 @@ import { AccessControlAction } from 'app/types';
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions, mockDataSource, mockFolder } from '../mocks';
 import { grafanaRulerRule } from '../mocks/grafanaRulerApi';
+import { MIMIR_DATASOURCE_UID } from '../mocks/server/constants';
 import { setupDataSources } from '../testSetup/datasources';
 import { Annotation } from '../utils/constants';
 
@@ -149,5 +149,17 @@ describe('RuleEditor grafana managed rules', () => {
 
     expect(postBody.name).toBe('new group');
     expect(postBody.interval).toBe('12m');
+  });
+});
+
+describe('Data source managed rules', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleExternalWrite]);
+  });
+
+  it('should show an error if the data source does not exist', async () => {
+    renderRuleEditor('cri%24grafana-cloudd%24delete me%24delete me 3%24recording_rule_delete_2%24-476183141');
+    expect(await screen.findByText(/unable to find data source/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Prior to this PR, a missing data source would cause an uncaught exception when trying to load the detail view for a data source managed alert rule.

This PR now properly bubbles up those exceptions and handles them (see screenshot).

<img width="725" alt="image" src="https://github.com/user-attachments/assets/b540c98b-6307-4135-a057-f0d1b6d36a25" />

- [x] Probably needs a test :)