### PR TITLE
SecretsService: Updating the keeper not allowed for securevalues

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -312,7 +312,7 @@ func validateSecureValueCreate(sv *secretv0alpha1.SecureValue) field.ErrorList {
 	}
 
 	if sv.Spec.Value != "" && sv.Spec.Ref != "" {
-		errs = append(errs, field.Required(field.NewPath("spec"), "only one of `value` or `ref` can be set"))
+		errs = append(errs, field.Forbidden(field.NewPath("spec"), "only one of `value` or `ref` can be set"))
 	}
 
 	return errs
@@ -332,12 +332,17 @@ func validateSecureValueUpdate(sv, oldSv *secretv0alpha1.SecureValue) field.Erro
 	// Only validate if one of the fields is being changed/set.
 	if sv.Spec.Value != "" || sv.Spec.Ref != "" {
 		if oldSv.Spec.Ref != "" && sv.Spec.Value != "" {
-			errs = append(errs, field.Required(field.NewPath("spec"), "cannot set `value` when `ref` was already previously set"))
+			errs = append(errs, field.Forbidden(field.NewPath("spec"), "cannot set `value` when `ref` was already previously set"))
 		}
 
 		if oldSv.Spec.Ref == "" && sv.Spec.Ref != "" {
-			errs = append(errs, field.Required(field.NewPath("spec"), "cannot set `ref` when `value` was already previously set"))
+			errs = append(errs, field.Forbidden(field.NewPath("spec"), "cannot set `ref` when `value` was already previously set"))
 		}
+	}
+
+	// Keeper cannot be changed.
+	if sv.Spec.Keeper != oldSv.Spec.Keeper {
+		errs = append(errs, field.Forbidden(field.NewPath("spec"), "the `keeper` cannot be changed"))
 	}
 
 	return errs

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -146,6 +146,24 @@ func TestValidateSecureValue(t *testing.T) {
 			require.Len(t, errs, 1)
 			require.Equal(t, "spec", errs[0].Field)
 		})
+
+		t.Run("when trying to change the `keeper`, it returns an error", func(t *testing.T) {
+			oldSv := &secretv0alpha1.SecureValue{
+				Spec: secretv0alpha1.SecureValueSpec{
+					Keeper: "a-keeper",
+				},
+			}
+
+			sv := &secretv0alpha1.SecureValue{
+				Spec: secretv0alpha1.SecureValueSpec{
+					Keeper: "another-keeper",
+				},
+			}
+
+			errs := ValidateSecureValue(sv, oldSv, admission.Update, nil)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec", errs[0].Field)
+		})
 	})
 
 	t.Run("`decrypters` must have unique items", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Updating the keeper is not allowed for secure values. This work adds that check into the secure value update validation, as well as changing the field error types for some errors.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1222
