### PR TITLE
Revert "Authz: Removes setting `viewers_can_edit`"

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -71,6 +71,10 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(org.RoleEditor)},
 	}
 
+	if hs.Cfg.ViewersCanEdit {
+		datasourcesExplorerRole.Grants = append(datasourcesExplorerRole.Grants, string(org.RoleViewer))
+	}
+
 	datasourcesReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Name:        "fixed:datasources:reader",

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -221,6 +221,10 @@ func (a *accessControlDashboardGuardian) CanEdit() (bool, error) {
 		return false, ErrGuardianDashboardNotFound.Errorf("failed to check edit permissions for dashboard")
 	}
 
+	if a.cfg.ViewersCanEdit {
+		return a.CanView()
+	}
+
 	return a.evaluate(
 		accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(a.dashboard.UID)),
 	)
@@ -229,6 +233,10 @@ func (a *accessControlDashboardGuardian) CanEdit() (bool, error) {
 func (a *accessControlFolderGuardian) CanEdit() (bool, error) {
 	if a.folder == nil {
 		return false, ErrGuardianFolderNotFound.Errorf("failed to check edit permissions for folder")
+	}
+
+	if a.cfg.ViewersCanEdit {
+		return a.CanView()
 	}
 
 	return a.evaluate(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(a.folder.UID)))

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -36,10 +36,11 @@ var (
 )
 
 type accessControlGuardianTestCase struct {
-	desc        string
-	dashboard   *dashboards.Dashboard
-	permissions []accesscontrol.Permission
-	expected    bool
+	desc           string
+	dashboard      *dashboards.Dashboard
+	permissions    []accesscontrol.Permission
+	viewersCanEdit bool
+	expected       bool
 }
 
 func TestAccessControlDashboardGuardian_CanSave(t *testing.T) {
@@ -257,6 +258,18 @@ func TestAccessControlDashboardGuardian_CanEdit(t *testing.T) {
 			expected: false,
 		},
 		{
+			desc:      "should be able to edit dashboard with read action when viewer_can_edit is true",
+			dashboard: dashboard,
+			permissions: []accesscontrol.Permission{
+				{
+					Action: dashboards.ActionDashboardsRead,
+					Scope:  "dashboards:uid:1",
+				},
+			},
+			viewersCanEdit: true,
+			expected:       true,
+		},
+		{
 			desc:      "should not be able to edit folder with folder write and dashboard wildcard scope",
 			dashboard: fldr,
 			permissions: []accesscontrol.Permission{
@@ -311,11 +324,24 @@ func TestAccessControlDashboardGuardian_CanEdit(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			desc:      "should be able to edit folder with folder read action when viewer_can_edit is true",
+			dashboard: fldr,
+			permissions: []accesscontrol.Permission{
+				{
+					Action: dashboards.ActionFoldersRead,
+					Scope:  folderUIDScope,
+				},
+			},
+			viewersCanEdit: true,
+			expected:       true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			cfg := setting.NewCfg()
+			cfg.ViewersCanEdit = tt.viewersCanEdit
 			guardian := setupAccessControlGuardianTest(t, tt.dashboard, tt.permissions, cfg)
 
 			can, err := guardian.CanEdit()

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -30,7 +30,7 @@ type CallbackHandler func(c *contextmodel.ReqContext) response.Response
 func (s *QueryHistoryService) permissionsMiddleware(handler CallbackHandler, errorMessage string) CallbackHandler {
 	return func(c *contextmodel.ReqContext) response.Response {
 		hasAccess := ac.HasAccess(s.accessControl, c)
-		if c.GetOrgRole() == org.RoleViewer && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
+		if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
 			return response.Error(http.StatusUnauthorized, errorMessage, nil)
 		}
 		return handler(c)

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -20,7 +20,6 @@ import {
 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
-import grafanaConfig from 'app/core/config';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 import { contextSrv } from 'app/core/core';
 import { Trans, t } from 'app/core/internationalization';
@@ -78,11 +77,6 @@ export function ToolbarActions({ dashboard }: Props) {
   const isEditingAndShowingDashboard = isEditing && isShowingDashboard;
   const showScopesSelector = config.featureToggles.scopeFilters && !isEditing;
   const dashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
-
-  // Internal only;
-  // allows viewer editing without ability to save
-  // used for grafana play
-  const canEdit = grafanaConfig.viewersCanEdit;
 
   if (!isEditingPanel) {
     // This adds the presence indicators in enterprise
@@ -360,7 +354,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'main-buttons',
-    condition: !isEditing && (dashboard.canEditDashboard() || canEdit) && !isViewingPanel && !isPlaying && editable,
+    condition: !isEditing && dashboard.canEditDashboard() && !isViewingPanel && !isPlaying && editable,
     render: () => (
       <Button
         onClick={() => {


### PR DESCRIPTION
Reverts grafana/grafana#101265 - we intend to merge this change into Grafana 12.0 major release, but not 11.6.0 minor.