### PR TITLE
Alerting: Fix state reason

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -833,7 +833,7 @@ func (a *State) transition(alertRule *models.AlertRule, result eval.Result, extr
 
 func resultStateReason(result eval.Result, rule *models.AlertRule) string {
 	if result.State == eval.Error && rule.ExecErrState == models.KeepLastErrState ||
-		result.State == eval.NoData && rule.NoDataState == models.KeepLast{
+		result.State == eval.NoData && rule.NoDataState == models.KeepLast {
 		return models.ConcatReasons(result.State.String(), models.StateReasonKeepLast)
 	}
 	return result.State.String()

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -832,9 +832,9 @@ func (a *State) transition(alertRule *models.AlertRule, result eval.Result, extr
 }
 
 func resultStateReason(result eval.Result, rule *models.AlertRule) string {
-	if rule.ExecErrState == models.KeepLastErrState || rule.NoDataState == models.KeepLast {
+	if result.State == eval.Error && rule.ExecErrState == models.KeepLastErrState ||
+		result.State == eval.NoData && rule.NoDataState == models.KeepLast{
 		return models.ConcatReasons(result.State.String(), models.StateReasonKeepLast)
 	}
-
 	return result.State.String()
 }


### PR DESCRIPTION
**What is this feature?**
This PR fixes a bug when NoData and Error state transitions are incorrectly set with reason "keep last" when either of options of executing no data and error is set to KeepLast. In other words, if, for example, No data is executed as Alerting and Error is - as "keep last", and result is NoData, the state transition will be `Alerting, KeepLast`, which is not correct.
