### PR TITLE
Prometheus: Add SpanID while clicking on TraceID datalink for Exemplar

### DIFF
--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -278,6 +278,11 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
         url: '',
         internal: {
           query: { query: '${__value.raw}', queryType: 'traceql' },
+          panelsState: {
+            trace: {
+              spanId: '${__data.fields["span_id"]}',
+            },
+          },
           datasourceUid: options.datasourceUid,
           datasourceName: dsSettings?.name ?? 'Data source not found',
         },


### PR DESCRIPTION
This fix is to add `SpanID` to the query while we click on the data link in Exemplars. 

Fixes: https://github.com/grafana/grafana/issues/99114