### PR TITLE
Same onboarding page regarless of migration

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5686,8 +5686,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/provisioning/RecentJobs.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/provisioning/OnboardingPage.tsx
+++ b/public/app/features/provisioning/OnboardingPage.tsx
@@ -10,55 +10,46 @@ import { NEW_URL, MIGRATE_URL } from './constants';
 export default function OnboardingPage({ legacyStorage }: { legacyStorage?: boolean }) {
   const settingsQuery = useGetFrontendSettingsQuery();
   const navigate = useNavigate();
+
+  const onClick = async () => {
+    if (legacyStorage) {
+      await settingsQuery.refetch();
+      navigate(MIGRATE_URL);
+    } else {
+      navigate(NEW_URL);
+    }
+  };
+
   return (
     <Page
       navId="provisioning"
       pageNav={{ text: 'Setup provisioning', subTitle: 'Configure this instance to use provisioning' }}
     >
       <Page.Contents>
-        {legacyStorage ? (
-          <>
-            <Alert severity="info" title="Setting up this connection could cause a temporary outage">
-              When you connect your whole instance, dashboards will be unavailable while running the migration. We
-              recommend warning your users before starting the process.
-            </Alert>
-            <EmptyState
-              variant="call-to-action"
-              message="Set up your provisioning connection!"
-              image={<SVG src="public/img/provisioning-empty.svg" width={300} />}
-              button={
-                <Button
-                  size="lg"
-                  icon="plus"
-                  onClick={async () => {
-                    await settingsQuery.refetch();
-                    navigate(MIGRATE_URL);
-                  }}
-                >
-                  Connect Grafana to repository
-                </Button>
-              }
-            >
-              <Stack direction="column" alignItems="center">
-                <Text>Store and provision your Grafana resources externally by connecting to a repository.</Text>
-                <Text>We currently support GitHub and local storage.</Text>
-                <LinkButton fill="text" href="#" icon="external-link-alt">
-                  Learn more
-                </LinkButton>
-              </Stack>
-            </EmptyState>
-          </>
-        ) : (
-          <EmptyState
-            variant="call-to-action"
-            message="You haven't created any repository configs yet"
-            button={
-              <LinkButton icon="plus" href={NEW_URL} size="lg">
-                Create repository config
-              </LinkButton>
-            }
-          />
+        {legacyStorage && (
+          <Alert severity="info" title="Setting up this connection could cause a temporary outage">
+            When you connect your whole instance, dashboards will be unavailable while running the migration. We
+            recommend warning your users before starting the process.
+          </Alert>
         )}
+        <EmptyState
+          variant="call-to-action"
+          message="Set up your provisioning connection!"
+          image={<SVG src="public/img/provisioning-empty.svg" width={300} />}
+          button={
+            <Button size="lg" icon="plus" onClick={onClick}>
+              Connect Grafana to repository
+            </Button>
+          }
+        >
+          <Stack direction="column" alignItems="center">
+            <Text>Store and provision your Grafana resources externally by connecting to a repository.</Text>
+            <Text>We currently support GitHub and local storage.</Text>
+            <LinkButton fill="text" href="#" icon="external-link-alt">
+              Learn more
+            </LinkButton>
+          </Stack>
+        </EmptyState>
       </Page.Contents>
     </Page>
   );


### PR DESCRIPTION
Small change to use the same onboarding page style regarless if a migration is needed or not.

# Screenshots

## No migration needed
![Screenshot 2025-03-04 at 16 26 29](https://github.com/user-attachments/assets/557f3e1d-a8ae-4a2e-be4a-521858cd988e)

## Migration needed

![image](https://github.com/user-attachments/assets/76308a77-719a-48cc-a849-81f7f7d9cc31)

