### PR TITLE
Chore: Add restricted import for utils/i18n and fix last remaining case

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1269,10 +1269,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'@grafana/ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
       [0, 0, 0, "\'@grafana/ui/src/components/JSONFormatter/JSONFormatter\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
       [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Import from the public export instead.", "5"],
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"]
     ],
     "public/app/features/actions/ActionEditorModalContent.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,6 +122,11 @@ module.exports = [
               importNames: ['t'],
               message: 'Please import from app/core/internationalization instead',
             },
+            {
+              name: '@grafana/ui/src/utils/i18n',
+              importNames: ['Trans', 't'],
+              message: 'Please import from app/core/internationalization instead',
+            },
           ],
         },
       ],

--- a/public/app/features/actions/ActionEditor.tsx
+++ b/public/app/features/actions/ActionEditor.tsx
@@ -9,7 +9,7 @@ import { InlineFieldRow } from '@grafana/ui/src/components/Forms/InlineFieldRow'
 import { RadioButtonGroup } from '@grafana/ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup';
 import { JSONFormatter } from '@grafana/ui/src/components/JSONFormatter/JSONFormatter';
 import { useStyles2 } from '@grafana/ui/src/themes';
-import { t } from '@grafana/ui/src/utils/i18n';
+import { t } from 'app/core/internationalization';
 
 import { HTMLElementType, SuggestionsInput } from '../transformers/suggestionsInput/SuggestionsInput';
 


### PR DESCRIPTION
**What is this feature?**
Adds restricted import for '@grafana/ui/src/utils/i18n' into the main eslint config and removes the last offending case

**Why do we need this feature?**

🧹 