### PR TITLE
K8s: Increase max request body

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -335,6 +335,7 @@ func (s *service) start(ctx context.Context) error {
 	transport := &roundTripperFunc{ready: make(chan struct{})}
 	serverConfig.LoopbackClientConfig.Transport = transport
 	serverConfig.LoopbackClientConfig.TLSClientConfig = clientrest.TLSClientConfig{}
+	serverConfig.MaxRequestBodyBytes = 16 * 1024 * 1024 // 16MB - determined by the size of `mediumtext` on mysql, which is used to save dashboard data
 
 	var optsregister apistore.StorageOptionsRegister
 


### PR DESCRIPTION
**What is this feature?**

This PR increases the max request body size in k8s, so we can support large dashboards that already exist in the Grafana DB.

Note: this may still cause issues in postgres & sqlite, as they do not have mediumtext, and we thus use `text`, which has a max size of 1GB does not have mediumtext - so we use [text](https://github.com/grafana/grafana/blob/7b9970f1e77db866efa430e4ee4b251656d70d6c/pkg/services/sqlstore/migrator/postgres_dialect.go#L73), [which has a max size of 1GB](https://www.sqlines.com/postgresql/datatypes/text)

Closes https://github.com/grafana/app-platform-wg/issues/232