### PR TITLE
Folders: Add validation that folder is not a parent of itself

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -297,6 +297,10 @@ func (b *FolderAPIBuilder) validateOnCreate(ctx context.Context, id string, obj 
 		return dashboards.ErrFolderTitleEmpty
 	}
 
+	if f.Name == getParent(obj) {
+		return folder.ErrFolderCannotBeParentOfItself
+	}
+
 	_, err := b.checkFolderMaxDepth(ctx, obj)
 	if err != nil {
 		return err

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -27,7 +27,9 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 		name        string
 	}
 
+	initialMaxDepth := folderValidationRules.maxDepth
 	folderValidationRules.maxDepth = 2
+	defer func() { folderValidationRules.maxDepth = initialMaxDepth }()
 	deepFolder := &v0alpha1.Folder{
 		Spec: v0alpha1.Spec{
 			Title: "foo",

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -26,13 +27,20 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 		name        string
 	}
 
-	circularObj := &v0alpha1.Folder{
+	folderValidationRules.maxDepth = 2
+	deepFolder := &v0alpha1.Folder{
 		Spec: v0alpha1.Spec{
 			Title: "foo",
 		},
 	}
-	circularObj.Name = "valid-name"
-	circularObj.Annotations = map[string]string{"grafana.app/folder": "valid-name"}
+	deepFolder.Name = "valid-parent"
+	deepFolder.Annotations = map[string]string{"grafana.app/folder": "valid-grandparent"}
+	parentFolder := &v0alpha1.Folder{
+		Spec: v0alpha1.Spec{
+			Title: "foo-grandparent",
+		},
+	}
+	deepFolder.Name = "valid-grandparent"
 
 	tests := []struct {
 		name    string
@@ -71,12 +79,15 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 						Title: "foo",
 					},
 				},
-				annotations: map[string]string{"grafana.app/folder": "valid-name"},
+				annotations: map[string]string{"grafana.app/folder": "valid-parent"},
 				name:        "valid-name",
 			},
 			setupFn: func(m *mock.Mock) {
-				m.On("Get", mock.Anything, "valid-name", mock.Anything).Return(
-					circularObj,
+				m.On("Get", mock.Anything, "valid-parent", mock.Anything).Return(
+					deepFolder,
+					nil)
+				m.On("Get", mock.Anything, "valid-grandparent", mock.Anything).Return(
+					parentFolder,
 					nil)
 			},
 			err: folder.ErrMaximumDepthReached,
@@ -92,6 +103,19 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 				name: "foo",
 			},
 			err: dashboards.ErrFolderTitleEmpty,
+		},
+		{
+			name: "should return error if folder is a parent of itself",
+			input: input{
+				annotations: map[string]string{utils.AnnoKeyFolder: "myself"},
+				obj: &v0alpha1.Folder{
+					Spec: v0alpha1.Spec{
+						Title: "title",
+					},
+				},
+				name: "myself",
+			},
+			err: folder.ErrFolderCannotBeParentOfItself,
 		},
 	}
 

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -39,6 +39,10 @@ func (ss *FolderStoreImpl) Create(ctx context.Context, cmd folder.CreateFolderCo
 		return nil, folder.ErrBadRequest.Errorf("missing UID")
 	}
 
+	if cmd.UID == cmd.ParentUID {
+		return nil, folder.ErrFolderCannotBeParentOfItself
+	}
+
 	var foldr *folder.Folder
 	/*
 		version := 1

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -60,6 +60,18 @@ func TestIntegrationCreate(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("creating a folder with itself as a parent should fail", func(t *testing.T) {
+		uid := util.GenerateShortUID()
+		_, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{
+			Title:       folderTitle,
+			OrgID:       orgID,
+			ParentUID:   uid,
+			Description: folderDsc,
+			UID:         uid,
+		})
+		require.ErrorIs(t, err, folder.ErrFolderCannotBeParentOfItself)
+	})
+
 	t.Run("creating a folder without providing a parent should default to the empty parent folder", func(t *testing.T) {
 		uid := util.GenerateShortUID()
 		f, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -1,6 +1,7 @@
 package folder
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ var ErrInternal = errutil.Internal("folder.internal")
 var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
+var ErrFolderCannotBeParentOfItself = errors.New("folder cannot be parent of itself")
 
 const (
 	GeneralFolderUID      = "general"


### PR DESCRIPTION
**What is this feature?**

Currently, you can set a folder as parent of itself, which causes infinite loops in Grafana. For example, trying to access it in the UI will create a maximum call stack size error: [see demo from @IevaVasiljeva  here](https://raintank-corp.slack.com/archives/C07SB1G4BC1/p1741096433243139?thread_ts=1740408562.766299&cid=C07SB1G4BC1)

This PR adds a validation check, both in k8s and in legacy, that the folder is not setting itself as a parent.


Closes https://github.com/grafana/app-platform-wg/issues/230