### PR TITLE
Add tabs and features tab to listing page

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5708,14 +5708,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
     ],
     "public/app/features/provisioning/RepositoryOverview.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5767,9 +5769,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
-    ],
-    "public/app/features/provisioning/Setup/FeatureList.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/provisioning/Setup/SetupModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/provisioning/RepositoryListPage.tsx
+++ b/public/app/features/provisioning/RepositoryListPage.tsx
@@ -15,6 +15,8 @@ import {
   Text,
   Alert,
   ConfirmModal,
+  Tab,
+  TabsBar,
 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
@@ -25,6 +27,7 @@ import { SyncRepository } from './SyncRepository';
 import { Repository, ResourceCount, useDeletecollectionRepositoryMutation, useGetFrontendSettingsQuery } from './api';
 import { NEW_URL, PROVISIONING_URL } from './constants';
 import { useRepositoryList } from './hooks';
+import { FeatureList } from './Setup/FeatureList';
 
 const appEvents = getAppEvents();
 
@@ -33,6 +36,7 @@ export default function RepositoryListPage() {
   const settings = useGetFrontendSettingsQuery();
   const [deleteAll, deleteAllResult] = useDeletecollectionRepositoryMutation();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [activeTab, setActiveTab] = useState<string>('repositories');
 
   useEffect(() => {
     if (deleteAllResult.isSuccess) {
@@ -52,6 +56,17 @@ export default function RepositoryListPage() {
     setShowDeleteModal(false);
   };
 
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'repositories':
+        return <RepositoryListPageContent items={items} />;
+      case 'features':
+        return <FeatureList />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Page navId="provisioning" subTitle="View and manage your configured repositories">
       <Page.Contents isLoading={isLoading}>
@@ -67,7 +82,17 @@ export default function RepositoryListPage() {
             Configured repositories will not work while running legacy storage.
           </Alert>
         )}
-        <RepositoryListPageContent items={items} />
+        <Stack direction="column" gap={2}>
+          <TabsBar>
+            <Tab
+              label="Repositories"
+              active={activeTab === 'repositories'}
+              onChangeTab={() => setActiveTab('repositories')}
+            />
+            <Tab label="Features" active={activeTab === 'features'} onChangeTab={() => setActiveTab('features')} />
+          </TabsBar>
+          {renderTabContent()}
+        </Stack>
         <ConfirmModal
           isOpen={showDeleteModal}
           title="Delete all configured repositories"


### PR DESCRIPTION
## Why?

For when the instance is totally or partially configured to let users know about the features and configure the missing ones.

## What?

- Add tabs to the listing page `Repositories`.
- Add a new tab `Features` to show the features, configuration status and how to configure them.

## Remarks

This must be redesigned but the idea is to have a page that shows the features that are not configured and the ones that are configured.

This could be very similar to the onboarding page or be some kind of getting started page.

## Screenshots
![Screenshot 2025-03-04 at 19 01 56](https://github.com/user-attachments/assets/667272b1-3364-4808-9cfe-9690c29e38b2)
![Screenshot 2025-03-04 at 19 02 02](https://github.com/user-attachments/assets/0b27edc0-fcab-4db1-9918-8b1c396ec3c1)

