### PR TITLE
Alerting: Allow disabling provenance in the Prometheus conversion API

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -144,6 +144,11 @@ func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 			promDefinition, err := r.PrometheusRuleDefinition()
 			require.NoError(t, err)
 			require.Equal(t, expectedDef, promDefinition)
+
+			// Verify provenance was set to ProvenanceConvertedPrometheus
+			prov, err := provenanceStore.GetProvenance(context.Background(), r, 1)
+			require.NoError(t, err)
+			require.Equal(t, models.ProvenanceConvertedPrometheus, prov)
 		}
 	})
 
@@ -339,6 +344,41 @@ func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 				response := srv.RouteConvertPrometheusPostRuleGroup(rc, "test", simpleGroup)
 				require.Equal(t, tc.expectedStatus, response.Status())
 			})
+		}
+	})
+
+	t.Run("with disable provenance header should use ProvenanceNone", func(t *testing.T) {
+		provenanceStore := fakes.NewFakeProvisioningStore()
+		srv, _, ruleStore, folderService := createConvertPrometheusSrv(t, withProvenanceStore(provenanceStore))
+
+		// Create a folder in the root
+		fldr := randFolder()
+		fldr.ParentUID = ""
+		folderService.ExpectedFolder = fldr
+		folderService.ExpectedFolders = []*folder.Folder{fldr}
+		ruleStore.Folders[1] = append(ruleStore.Folders[1], fldr)
+
+		// Create request with the X-Disable-Provenance header
+		rc := createRequestCtx()
+		rc.Req.Header.Set("X-Disable-Provenance", "true")
+
+		response := srv.RouteConvertPrometheusPostRuleGroup(rc, fldr.Title, simpleGroup)
+		require.Equal(t, http.StatusAccepted, response.Status())
+
+		// Get the created rules
+		rules, err := ruleStore.ListAlertRules(context.Background(), &models.ListAlertRulesQuery{
+			OrgID: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, rules, 2)
+
+		// Verify provenance was set to ProvenanceNone
+		for _, r := range rules {
+			prov, err := provenanceStore.GetProvenance(context.Background(), r, 1)
+			require.NoError(t, err)
+			require.Equal(t, models.ProvenanceNone, prov, "Provenance should be ProvenanceNone when X-Disable-Provenance header is set")
+			// Prometheus rule definition should not be saved when provenance is disabled
+			require.Nil(t, r.Metadata.PrometheusStyleRule)
 		}
 	})
 }
@@ -743,6 +783,29 @@ func TestRouteConvertPrometheusDeleteNamespace(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, remaining)
 		})
+
+		t.Run("with disable provenance header should still be able to delete rules", func(t *testing.T) {
+			provenanceStore := fakes.NewFakeProvisioningStore()
+			srv, ruleStore, fldr, rule := initNamespace("prometheus definition", withProvenanceStore(provenanceStore))
+
+			// Mark the rule as provisioned with API provenance
+			err := provenanceStore.SetProvenance(context.Background(), rule, 1, models.ProvenanceConvertedPrometheus)
+			require.NoError(t, err)
+
+			rc := createRequestCtx()
+			rc.Req.Header.Set("X-Disable-Provenance", "true")
+
+			response := srv.RouteConvertPrometheusDeleteNamespace(rc, fldr.Title)
+			require.Equal(t, http.StatusAccepted, response.Status())
+
+			// Verify the rule was deleted
+			remaining, err := ruleStore.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{
+				UID:   rule.UID,
+				OrgID: rule.OrgID,
+			})
+			require.Error(t, err)
+			require.Nil(t, remaining)
+		})
 	})
 }
 
@@ -853,6 +916,29 @@ func TestRouteConvertPrometheusDeleteRuleGroup(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, remaining)
+		})
+
+		t.Run("with disable provenance header should still be able to delete rules", func(t *testing.T) {
+			provenanceStore := fakes.NewFakeProvisioningStore()
+			srv, ruleStore, fldr, rule := initGroup("", groupName, withProvenanceStore(provenanceStore))
+
+			// Mark the rule as provisioned with API provenance
+			err := provenanceStore.SetProvenance(context.Background(), rule, 1, models.ProvenanceConvertedPrometheus)
+			require.NoError(t, err)
+
+			rc := createRequestCtx()
+			rc.Req.Header.Set("X-Disable-Provenance", "true")
+
+			response := srv.RouteConvertPrometheusDeleteRuleGroup(rc, fldr.Title, groupName)
+			require.Equal(t, http.StatusAccepted, response.Status())
+
+			// Verify the rule was deleted
+			remaining, err := ruleStore.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{
+				UID:   rule.UID,
+				OrgID: rule.OrgID,
+			})
+			require.Error(t, err)
+			require.Nil(t, remaining)
 		})
 	})
 }
@@ -993,5 +1079,34 @@ func TestGetWorkingFolderUID(t *testing.T) {
 
 		folderUID := getWorkingFolderUID(rc)
 		require.Equal(t, specifiedFolderUID, folderUID)
+	})
+}
+
+func TestGetProvenance(t *testing.T) {
+	t.Run("should return ProvenanceConvertedPrometheus when header is not present", func(t *testing.T) {
+		rc := createRequestCtx()
+		// Ensure the header is not present
+		rc.Req.Header.Del(disableProvenanceHeaderName)
+
+		provenance := getProvenance(rc)
+		require.Equal(t, models.ProvenanceConvertedPrometheus, provenance)
+	})
+
+	t.Run("should return ProvenanceNone when header is present", func(t *testing.T) {
+		rc := createRequestCtx()
+		// Set the disable provenance header
+		rc.Req.Header.Set(disableProvenanceHeaderName, "true")
+
+		provenance := getProvenance(rc)
+		require.Equal(t, models.ProvenanceNone, provenance)
+	})
+
+	t.Run("should return ProvenanceNone when header is present with any value", func(t *testing.T) {
+		rc := createRequestCtx()
+		// Set the disable provenance header with an empty value
+		rc.Req.Header.Set(disableProvenanceHeaderName, "")
+
+		provenance := getProvenance(rc)
+		require.Equal(t, models.ProvenanceNone, provenance)
 	})
 }

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -674,6 +674,42 @@ func TestAlertRuleService(t *testing.T) {
 				to:     models.ProvenanceNone,
 				errNil: false,
 			},
+			{
+				name:   "should be able to update from provenance none to 'converted prometheus'",
+				from:   models.ProvenanceNone,
+				to:     models.ProvenanceConvertedPrometheus,
+				errNil: true,
+			},
+			{
+				name:   "should be able to update from provenance 'converted prometheus' to none",
+				from:   models.ProvenanceConvertedPrometheus,
+				to:     models.ProvenanceNone,
+				errNil: true,
+			},
+			{
+				name:   "should not be able to update from provenance 'converted prometheus' to api",
+				from:   models.ProvenanceConvertedPrometheus,
+				to:     models.ProvenanceAPI,
+				errNil: false,
+			},
+			{
+				name:   "should not be able to update from provenance 'converted prometheus' to file",
+				from:   models.ProvenanceConvertedPrometheus,
+				to:     models.ProvenanceFile,
+				errNil: false,
+			},
+			{
+				name:   "should not be able to update from provenance api to 'converted prometheus'",
+				from:   models.ProvenanceAPI,
+				to:     models.ProvenanceConvertedPrometheus,
+				errNil: false,
+			},
+			{
+				name:   "should not be able to update from provenance file to 'converted prometheus'",
+				from:   models.ProvenanceFile,
+				to:     models.ProvenanceConvertedPrometheus,
+				errNil: false,
+			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {

--- a/pkg/services/ngalert/provisioning/validation/provenance.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance.go
@@ -7,9 +7,23 @@ import (
 // CanUpdateProvenanceInRuleGroup checks if a provenance can be updated for a rule group and its alerts.
 // ReplaceRuleGroup function intends to replace an entire rule group: inserting, updating, and removing rules.
 func CanUpdateProvenanceInRuleGroup(storedProvenance, provenance models.Provenance) bool {
-	return storedProvenance == provenance ||
-		storedProvenance == models.ProvenanceNone ||
-		(storedProvenance == models.ProvenanceAPI && provenance == models.ProvenanceNone)
+	// Same provenance is always allowed
+	if storedProvenance == provenance {
+		return true
+	}
+
+	// Can always update stored ProvenanceNone
+	if storedProvenance == models.ProvenanceNone {
+		return true
+	}
+
+	// Can reset to ProvenanceNone from specific provenances
+	if provenance == models.ProvenanceNone {
+		return storedProvenance == models.ProvenanceAPI ||
+			storedProvenance == models.ProvenanceConvertedPrometheus
+	}
+
+	return false
 }
 
 type ProvenanceStatusTransitionValidator = func(from, to models.Provenance) error

--- a/pkg/services/ngalert/provisioning/validation/provenance_test.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance_test.go
@@ -15,6 +15,7 @@ func TestValidateProvenanceRelaxed(t *testing.T) {
 		models.ProvenanceNone,
 		models.ProvenanceAPI,
 		models.ProvenanceFile,
+		models.ProvenanceConvertedPrometheus,
 		models.Provenance(fmt.Sprintf("random-%s", util.GenerateShortUID())),
 	}
 	t.Run("all transitions from 'none' are allowed", func(t *testing.T) {
@@ -45,6 +46,65 @@ func TestValidateProvenanceRelaxed(t *testing.T) {
 					continue
 				}
 				assert.NoError(t, ValidateProvenanceRelaxed(from, to))
+			}
+		}
+	})
+}
+
+func TestCanUpdateProvenanceInRuleGroup(t *testing.T) {
+	all := []models.Provenance{
+		models.ProvenanceNone,
+		models.ProvenanceAPI,
+		models.ProvenanceFile,
+		models.ProvenanceConvertedPrometheus,
+		models.Provenance(fmt.Sprintf("random-%s", util.GenerateShortUID())),
+	}
+
+	t.Run("same provenance transitions are allowed", func(t *testing.T) {
+		for _, provenance := range all {
+			assert.True(t, CanUpdateProvenanceInRuleGroup(provenance, provenance))
+		}
+	})
+
+	t.Run("all transitions from 'none' are allowed", func(t *testing.T) {
+		for _, provenance := range all {
+			assert.True(t, CanUpdateProvenanceInRuleGroup(models.ProvenanceNone, provenance))
+		}
+	})
+
+	t.Run("only specific provenances can transition to 'none'", func(t *testing.T) {
+		allowed := []models.Provenance{
+			models.ProvenanceAPI,
+			models.ProvenanceConvertedPrometheus,
+		}
+
+		for _, from := range allowed {
+			assert.True(t, CanUpdateProvenanceInRuleGroup(from, models.ProvenanceNone),
+				"transition %s -> 'none' should be allowed", from)
+		}
+
+		notAllowed := []models.Provenance{
+			models.ProvenanceFile,
+			models.Provenance(fmt.Sprintf("random-%s", util.GenerateShortUID())),
+		}
+
+		for _, from := range notAllowed {
+			assert.False(t, CanUpdateProvenanceInRuleGroup(from, models.ProvenanceNone),
+				"transition %s -> 'none' should not be allowed", from)
+		}
+	})
+
+	t.Run("transitions between different provenances are not allowed", func(t *testing.T) {
+		for _, from := range all {
+			if from == models.ProvenanceNone {
+				continue // always allowed
+			}
+			for _, to := range all {
+				if from == to || to == models.ProvenanceNone {
+					continue // always allowed
+				}
+				assert.False(t, CanUpdateProvenanceInRuleGroup(from, to),
+					"transition %s -> '%s' should not be allowed", from, to)
 			}
 		}
 	})


### PR DESCRIPTION
**What is this feature?**

This PR allows disabling provenance when converting Prometheus alert rules to Grafana alert rules by providing the `X-Disable-Provenance` HTTP header in requests.

**Why do we need this feature?**

When creating Grafana-managed alerts from Prometheus rule definitions with mimirtool or cortextool, the rules are marked as "provisioned" and are not editable in the Grafana UI. This PR allows changing this by providing an extra header: `--extra-header="X-Disable-Provenance=true"`.

When provenance is disabled, we do not keep the original rule definition in YAML, so it is impossible to read it back using the Prometheus conversion API (mimirtool/cortextool). This is intentional because if we did keep it and the rule was later changed in the UI, its Prometheus YAML definition would no longer reflect the latest version of the alert rule, as it would be unchanged.

Closes https://github.com/grafana/alerting-squad/issues/1044

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
