### PR TITLE
Rename to push / pull everything user-facing

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -30,10 +30,10 @@ const (
 	JobActionPullRequest JobAction = "pr"
 
 	// Sync the remote branch with the grafana instance
-	JobActionSync JobAction = "sync"
+	JobActionSync JobAction = "pull"
 
 	// Export from grafana into the remote repository
-	JobActionExport JobAction = "export"
+	JobActionExport JobAction = "push"
 
 	// Migration task -- this will migrate an full instance from SQL > Git
 	JobActionMigrate JobAction = "migrate"

--- a/public/app/features/provisioning/ConfigForm.tsx
+++ b/public/app/features/provisioning/ConfigForm.tsx
@@ -223,8 +223,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
         />
       )}
 
-      <ControlledCollapse label="Automatic Pull Settings" isOpen={false}>
-        <Field label={'Enabled'} description={'Once automatic pull is enabled, the target cannot be changed.'}>
+      <ControlledCollapse label="Automatic pulling" isOpen={false}>
+        <Field label={'Enabled'} description={'Once automatic pulling is enabled, the target cannot be changed.'}>
           <Switch {...register('sync.enabled')} id={'sync.enabled'} />
         </Field>
         <Field label={'Target'} required error={errors?.sync?.target?.message} invalid={!!errors?.sync?.target}>

--- a/public/app/features/provisioning/ConfigForm.tsx
+++ b/public/app/features/provisioning/ConfigForm.tsx
@@ -223,8 +223,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
         />
       )}
 
-      <ControlledCollapse label="Sync Settings" isOpen={false}>
-        <Field label={'Enabled'} description={'Once sync is enabled, the target cannot be changed.'}>
+      <ControlledCollapse label="Automatic Pull Settings" isOpen={false}>
+        <Field label={'Enabled'} description={'Once automatic pull is enabled, the target cannot be changed.'}>
           <Switch {...register('sync.enabled')} id={'sync.enabled'} />
         </Field>
         <Field label={'Target'} required error={errors?.sync?.target?.message} invalid={!!errors?.sync?.target}>

--- a/public/app/features/provisioning/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/RepositoryOverview.tsx
@@ -119,7 +119,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
           )}
           <div className={styles.cardContainer}>
             <Card className={styles.card}>
-              <Card.Heading>Sync status</Card.Heading>
+              <Card.Heading>Pull status</Card.Heading>
               <Card.Description>
                 <Grid columns={12} gap={1} alignItems="baseline">
                   <div className={styles.labelColumn}>

--- a/public/app/features/provisioning/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/RepositoryStatusPage.tsx
@@ -91,12 +91,12 @@ export default function RepositoryStatusPage() {
             )}
             <SyncRepository repository={data} />
             {settings.data?.legacyStorage ? (
-              <Button variant="secondary" icon="upload" onClick={() => setShowMigrateModal(true)}>
+              <Button variant="secondary" icon="cloud-upload" onClick={() => setShowMigrateModal(true)}>
                 Migrate
               </Button>
             ) : (
-              <Button variant="secondary" icon="upload" onClick={() => setShowExportModal(true)}>
-                Export
+              <Button variant="secondary" icon="cloud-upload" onClick={() => setShowExportModal(true)}>
+                Push
               </Button>
             )}
             <LinkButton variant="secondary" icon="cog" href={`${PROVISIONING_URL}/${name}/edit`}>

--- a/public/app/features/provisioning/StatusBadge.tsx
+++ b/public/app/features/provisioning/StatusBadge.tsx
@@ -22,7 +22,7 @@ export function StatusBadge({ enabled, state, name }: StatusBadgeProps) {
   switch (state) {
     case 'success':
       icon = 'check';
-      text = 'In sync';
+      text = 'Up-to-date';
       color = 'green';
       break;
     case null:
@@ -36,7 +36,7 @@ export function StatusBadge({ enabled, state, name }: StatusBadgeProps) {
     case 'working':
     case 'pending':
       color = 'orange';
-      text = 'Syncing';
+      text = 'Pulling';
       icon = 'spinner';
       break;
     case 'error':
@@ -50,7 +50,7 @@ export function StatusBadge({ enabled, state, name }: StatusBadgeProps) {
 
   if (!enabled) {
     color = 'red';
-    text = 'Sync disabled';
+    text = 'Automatic pull disabled';
     icon = 'info-circle';
   }
   return (

--- a/public/app/features/provisioning/StatusBadge.tsx
+++ b/public/app/features/provisioning/StatusBadge.tsx
@@ -50,7 +50,7 @@ export function StatusBadge({ enabled, state, name }: StatusBadgeProps) {
 
   if (!enabled) {
     color = 'red';
-    text = 'Automatic pull disabled';
+    text = 'Automatic pulling disabled';
     icon = 'info-circle';
   }
   return (

--- a/public/app/features/provisioning/SyncRepository.tsx
+++ b/public/app/features/provisioning/SyncRepository.tsx
@@ -23,12 +23,12 @@ export function SyncRepository({ repository }: Props) {
     if (syncQuery.isSuccess) {
       appEvents.publish({
         type: AppEvents.alertSuccess.name,
-        payload: ['Sync started'],
+        payload: ['Pull started'],
       });
     } else if (syncQuery.isError) {
       appEvents.publish({
         type: AppEvents.alertError.name,
-        payload: ['Error importing resources', syncQuery.error],
+        payload: ['Error pulling resources', syncQuery.error],
       });
     }
   }, [syncQuery.error, syncQuery.isError, syncQuery.isSuccess]);
@@ -46,18 +46,18 @@ export function SyncRepository({ repository }: Props) {
   return (
     <>
       <Button
-        icon="sync"
+        icon="cloud-download"
         variant={'secondary'}
-        tooltip={isHealthy ? undefined : 'Unable to sync an unhealthy repository'}
+        tooltip={isHealthy ? undefined : 'Unable to pull an unhealthy repository'}
         disabled={syncQuery.isLoading || !name || !isHealthy}
         onClick={onClick}
       >
-        Sync
+        Pull
       </Button>
       {!repository.spec?.sync.enabled && (
         <ConfirmModal
           isOpen={isModalOpen}
-          title={'Sync is not enabled'}
+          title={'Pull is not enabled'}
           body={`Edit the configuration`}
           confirmText={'Edit'}
           onConfirm={() => navigate(`${PROVISIONING_URL}/${name}/edit`)}

--- a/public/app/features/provisioning/Wizard/RepositoryStep.tsx
+++ b/public/app/features/provisioning/Wizard/RepositoryStep.tsx
@@ -189,10 +189,10 @@ export function RepositoryStep({ onStatusChange }: Props) {
         )}
 
         <ControlledCollapse label="Advanced settings" isOpen={false}>
-          <Field label={'Enable sync'} description="The repository will periodically pull changes">
+          <Field label={'Enable automatic pull'} description="The repository will periodically pull changes">
             <Switch {...register('repository.sync.enabled')} />
           </Field>
-          <Field label={'Sync interval (seconds)'}>
+          <Field label={'Interval (seconds)'}>
             <Input
               {...register('repository.sync.intervalSeconds', { valueAsNumber: true })}
               type={'number'}

--- a/public/app/features/provisioning/Wizard/RepositoryStep.tsx
+++ b/public/app/features/provisioning/Wizard/RepositoryStep.tsx
@@ -189,7 +189,7 @@ export function RepositoryStep({ onStatusChange }: Props) {
         )}
 
         <ControlledCollapse label="Advanced settings" isOpen={false}>
-          <Field label={'Enable automatic pull'} description="The repository will periodically pull changes">
+          <Field label={'Enable automatic pulling'} description="The repository will periodically pull changes">
             <Switch {...register('repository.sync.enabled')} />
           </Field>
           <Field label={'Interval (seconds)'}>


### PR DESCRIPTION
## Why?

We want to move away from the export/import wording in favour of push / pull.

## How?

- Simply change the wording in anything that the user sees.

## Remarks

- I ran out of time today, so I will continue with refactoring in the code tomorrow.
- I don't like the wording in some spots (Pull Status) or the `Push` button in the RepositoryStatus page.
- Sync to "Automatic Pulling" maybe?

## Screenshots


![Screenshot 2025-03-04 at 20 30 49](https://github.com/user-attachments/assets/fe00d875-22ba-407a-8bf5-7ea74cf71725)
![Screenshot 2025-03-04 at 20 31 33](https://github.com/user-attachments/assets/afed08d8-d543-47fd-b646-dc7ec276ac96)
![Screenshot 2025-03-04 at 20 31 53](https://github.com/user-attachments/assets/845df469-e8c4-4f43-8e70-ba14e9404fb1)
![Screenshot 2025-03-04 at 20 31 56](https://github.com/user-attachments/assets/ae372ad6-4b79-44d5-ab5a-d95fd20c0c4d)
![Screenshot 2025-03-04 at 20 32 52](https://github.com/user-attachments/assets/90fd038a-9f44-4454-a820-23ef34222460)

