### PR TITLE
Docs: Fix typo in Drilldown note

### DIFF
--- a/docs/sources/shared/plugins/rename-note.md
+++ b/docs/sources/shared/plugins/rename-note.md
@@ -15,5 +15,5 @@ labels:
 {{< admonition type="note" >}}
 The Grafana Explore apps have changed to Grafana Drilldown apps.
 For example, Explore Logs is now Logs Drilldown.
-To learn more, read [Grafana Drilldown apps: the improved queryless experience known as the Explore apps](https://grafana.com/blog/2025/02/20/grafana-drilldown-apps-the-improved-queryless-experience-formerly-known-as-the-explore-apps/).
+To learn more, read [Grafana Drilldown apps: the improved queryless experience formerly known as the Explore apps](https://grafana.com/blog/2025/02/20/grafana-drilldown-apps-the-improved-queryless-experience-formerly-known-as-the-explore-apps/).
 {{< /admonition >}}


### PR DESCRIPTION

**What is this feature?**

Fixes a typo in the shared note about Explore apps being renamed to Drilldown.  Reported in Slack.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
