### PR TITLE
[release-11.5.3] Chore: Bump Go to 1.23.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -75,7 +75,7 @@ steps:
   - go install github.com/bazelbuild/buildtools/buildifier@latest
   - buildifier --lint=warn -mode=check -r .
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: lint-starlark
 trigger:
   event:
@@ -427,7 +427,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -436,21 +436,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -459,7 +459,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend-integration
 trigger:
   event:
@@ -513,7 +513,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - echo $(/usr/bin/github-app-external-token) > /github-app/token
@@ -558,16 +558,16 @@ steps:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-openapi-spec
 trigger:
   event:
@@ -643,7 +643,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -653,7 +653,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -662,7 +662,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -700,7 +700,7 @@ steps:
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.5 --yarn-cache=$$YARN_CACHE_FOLDER
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.7 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.21.3
     --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
@@ -1098,7 +1098,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1112,7 +1112,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1121,14 +1121,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -1149,7 +1149,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -1170,7 +1170,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -1186,7 +1186,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -1202,7 +1202,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -1218,7 +1218,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -1300,7 +1300,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 trigger:
   event:
@@ -1421,7 +1421,7 @@ steps:
     && return 1; fi
   depends_on:
   - clone-enterprise
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: swagger-gen
 trigger:
   event:
@@ -1526,7 +1526,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1537,7 +1537,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1547,14 +1547,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - apk add --update build-base
@@ -1562,7 +1562,7 @@ steps:
   - go test -v -run=^$ -benchmem -timeout=1h -count=8 -bench=. ${GO_PACKAGES}
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: sqlite-benchmark-integration-tests
 - commands:
   - apk add --update build-base
@@ -1574,7 +1574,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: postgres-benchmark-integration-tests
 - commands:
   - apk add --update build-base
@@ -1585,7 +1585,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: mysql-8.0-benchmark-integration-tests
 trigger:
   event:
@@ -1657,7 +1657,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 trigger:
   branch: main
@@ -1830,7 +1830,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1839,21 +1839,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -1862,7 +1862,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend-integration
 trigger:
   branch: main
@@ -1907,22 +1907,22 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-openapi-spec
 - commands:
   - ./bin/build verify-drone
@@ -2054,7 +2054,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2064,7 +2064,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2073,7 +2073,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -2110,7 +2110,7 @@ steps:
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.5 --yarn-cache=$$YARN_CACHE_FOLDER
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.7 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.21.3
     --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
@@ -2585,7 +2585,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -2599,7 +2599,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2608,14 +2608,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -2636,7 +2636,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -2657,7 +2657,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -2673,7 +2673,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2689,7 +2689,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -2705,7 +2705,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   branch: main
@@ -2964,7 +2964,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2973,21 +2973,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -2996,7 +2996,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend-integration
 trigger:
   branch:
@@ -3039,22 +3039,22 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: validate-openapi-spec
 trigger:
   branch:
@@ -3133,7 +3133,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -3147,7 +3147,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3156,14 +3156,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -3184,7 +3184,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -3205,7 +3205,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -3221,7 +3221,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -3237,7 +3237,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -3253,7 +3253,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   branch:
@@ -3353,7 +3353,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3485,7 +3485,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3626,7 +3626,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --artifacts-editions=oss --tag $${DRONE_TAG} --src-bucket
@@ -3718,7 +3718,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -3818,7 +3818,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -3915,7 +3915,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss ${DRONE_TAG}
@@ -3977,7 +3977,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4052,7 +4052,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4169,7 +4169,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4320,7 +4320,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4329,21 +4329,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -4352,7 +4352,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: test-backend-integration
 trigger:
   cron:
@@ -4406,7 +4406,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4550,7 +4550,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4657,7 +4657,7 @@ steps:
   - export GITHUB_TOKEN=$(cat /github-app/token)
   - 'dagger run --silent /src/grafana-build artifacts -a $${ARTIFACTS} --grafana-ref=$${GRAFANA_REF}
     --enterprise-ref=$${ENTERPRISE_REF} --grafana-repo=$${GRAFANA_REPO} --version=$${VERSION} '
-  - --go-version=1.23.5
+  - --go-version=1.23.7
   depends_on:
   - github-app-generate-token
   environment:
@@ -4678,7 +4678,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.23.5
+    GO_VERSION: 1.23.7
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4812,7 +4812,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4821,14 +4821,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -4849,7 +4849,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -4870,7 +4870,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -4886,7 +4886,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4902,7 +4902,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -4918,7 +4918,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.23.5-alpine
+  image: golang:1.23.7-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -5221,7 +5221,7 @@ steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM docker:27-cli
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine/git:2.40.1
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.23.5-alpine
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.23.7-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22.11.0-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22-bookworm
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
@@ -5259,7 +5259,7 @@ steps:
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL docker:27-cli
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine/git:2.40.1
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.23.5-alpine
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.23.7-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22.11.0-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22-bookworm
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
@@ -5528,6 +5528,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 31613db102bde38eb42eb143961026c64b2f71cbc707e610714cf798a0c950ea
+hmac: b51b5f33016ede430cd55837b4347ee284d3f9d4ae14ca054daef966b903a7d8
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=alpine:3.21
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.23.5-alpine
+ARG GO_IMAGE=golang:1.23.7-alpine
 
 # Default to building locally
 ARG GO_SRC=go-builder

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .bingo/Variables.mk
 
 GO = go
-GO_VERSION = 1.23.5
+GO_VERSION = 1.23.7
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/notifications
 
-go 1.23.5
+go 1.23.7
 
 replace github.com/grafana/grafana => ../../..
 

--- a/apps/investigation/go.mod
+++ b/apps/investigation/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/investigation
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/grafana/grafana-app-sdk v0.23.1

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/playlist
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/grafana/grafana-app-sdk v0.23.1

--- a/devenv/docker/blocks/prometheus_high_card/go.mod
+++ b/devenv/docker/blocks/prometheus_high_card/go.mod
@@ -1,6 +1,6 @@
 module high-card
 
-go 1.22.4
+go 1.23.7
 
 require (
 	github.com/prometheus/client_golang v1.20.2

--- a/devenv/docker/blocks/prometheus_utf8/go.mod
+++ b/devenv/docker/blocks/prometheus_utf8/go.mod
@@ -1,6 +1,6 @@
 module utf8-support
 
-go 1.22.4
+go 1.23.7
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.23.5
+go 1.23.7
 
 require (
 	buf.build/gen/go/parca-dev/parca/connectrpc/go v1.17.0-20240902100956-02fd72488966.1 // @grafana/observability-traces-and-profiling

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.23.5
+go 1.23.7
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/hack
 
-go 1.23.1
+go 1.23.7
 
 require k8s.io/code-generator v0.32.0
 

--- a/kindsv2/go.mod
+++ b/kindsv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/kindsv2
 
-go 1.23.1
+go 1.23.7
 
 require github.com/grafana/cog v0.0.5
 

--- a/pkg/aggregator/go.mod
+++ b/pkg/aggregator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/aggregator
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/grafana/authlib v0.0.0-20250108202437-7a039176d884 // @grafana/identity-access-team

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/pkg/build/go.mod
+++ b/pkg/build/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build
 
-go 1.23.1
+go 1.23.7
 
 // Override docker/docker to avoid:
 // go: github.com/drone-runners/drone-runner-docker@v1.8.2 requires

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/pkg/codegen/go.mod
+++ b/pkg/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/codegen
 
-go 1.23.1
+go 1.23.7
 
 require (
 	cuelang.org/go v0.11.1

--- a/pkg/plugins/codegen/go.mod
+++ b/pkg/plugins/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/codegen
 
-go 1.23.1
+go 1.23.7
 
 replace github.com/grafana/grafana/pkg/codegen => ../../codegen
 

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/promlib
 
-go 1.23.1
+go 1.23.7
 
 require (
 	github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040

--- a/pkg/semconv/go.mod
+++ b/pkg/semconv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/semconv
 
-go 1.23.1
+go 1.23.7
 
 require go.opentelemetry.io/otel v1.33.0
 

--- a/pkg/storage/unified/apistore/go.mod
+++ b/pkg/storage/unified/apistore/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/apistore
 
-go 1.23.5
+go 1.23.7
 
 replace (
 	github.com/grafana/grafana => ../../../..

--- a/pkg/storage/unified/resource/go.mod
+++ b/pkg/storage/unified/resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resource
 
-go 1.23.5
+go 1.23.7
 
 replace (
 	github.com/grafana/grafana => ../../../..

--- a/pkg/util/xorm/go.mod
+++ b/pkg/util/xorm/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/grafana/pkg/util/xorm
 
-go 1.22
-
-toolchain go1.23.1
+go 1.23.7
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.22

--- a/scripts/build/ci-windows-test/Dockerfile
+++ b/scripts/build/ci-windows-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-windowsservercore-1809
+FROM golang:1.23.7-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 

--- a/scripts/drone/variables.star
+++ b/scripts/drone/variables.star
@@ -3,7 +3,7 @@ global variables
 """
 
 grabpl_version = "v3.1.2"
-golang_version = "1.23.5"
+golang_version = "1.23.7"
 
 # nodejs_version should match what's in ".nvmrc", but without the v prefix.
 nodejs_version = "22.11.0"

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.23.1
+go 1.23.7
 
 require golang.org/x/mod v0.20.0


### PR DESCRIPTION
**What is this feature?**

Upgrades Go to 1.23.7 which fixes CVE-2025-22870

**Why do we need this feature?**

Patching security issue

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
