### PR TITLE
K8s: Folders: Fix not found errors

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -137,12 +137,12 @@ func (s *legacyStorage) Get(ctx context.Context, name string, options *metav1.Ge
 		UID:          &name,
 		OrgID:        info.OrgID,
 	})
-	if err != nil || dto == nil {
-		if err == nil {
-			err = dashboards.ErrFolderNotFound
-		}
-
+	if err != nil {
 		statusErr := apierrors.ToFolderStatusError(err)
+		return nil, &statusErr
+	}
+	if dto == nil {
+		statusErr := apierrors.ToFolderStatusError(dashboards.ErrFolderNotFound)
 		return nil, &statusErr
 	}
 

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -2,7 +2,6 @@ package folders
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -139,9 +138,10 @@ func (s *legacyStorage) Get(ctx context.Context, name string, options *metav1.Ge
 		OrgID:        info.OrgID,
 	})
 	if err != nil || dto == nil {
-		if errors.Is(err, dashboards.ErrFolderNotFound) || err == nil {
-			err = resourceInfo.NewNotFound(name)
+		if err == nil {
+			err = dashboards.ErrFolderNotFound
 		}
+
 		statusErr := apierrors.ToFolderStatusError(err)
 		return nil, &statusErr
 	}

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/stretchr/testify/mock"
@@ -16,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -170,6 +172,16 @@ func TestGetParents(t *testing.T) {
 		require.Len(t, result, 1)
 		require.Equal(t, "parenttwo", result[0].UID)
 	})
+	t.Run("should stop if parent folder is not found", func(t *testing.T) {
+		mockCli.On("Get", mock.Anything, "parentone", orgID, mock.Anything, mock.Anything).Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "folders.folder.grafana.app", Resource: "folder"}, "parentone")).Once()
+
+		_, err := store.GetParents(ctx, folder.GetParentsQuery{
+			UID:   "parentone",
+			OrgID: orgID,
+		})
+
+		require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
+	})
 }
 
 func TestGetChildren(t *testing.T) {
@@ -213,6 +225,11 @@ func TestGetChildren(t *testing.T) {
 			},
 			TotalHits: 1,
 		}, nil).Once()
+		mockCli.On("Get", mock.Anything, "folder1", orgID, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "folder1"},
+			},
+		}, nil).Once()
 		mockCli.On("Get", mock.Anything, "folder2", orgID, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"metadata": map[string]interface{}{"name": "folder2"},
@@ -233,6 +250,47 @@ func TestGetChildren(t *testing.T) {
 		require.Len(t, result, 2)
 		require.Equal(t, "folder2", result[0].UID)
 		require.Equal(t, "folder3", result[1].UID)
+	})
+
+	t.Run("should return an error if the folder is not found", func(t *testing.T) {
+		mockCli.On("Search", mock.Anything, orgID, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Fields: []*resource.Requirement{
+					{
+						Key:      resource.SEARCH_FIELD_FOLDER,
+						Operator: string(selection.In),
+						Values:   []string{"folder1"},
+					},
+				},
+			},
+			Limit:  folderSearchLimit, // should default to folderSearchLimit
+			Offset: 0,                 // should be set as limit * (page - 1)
+			Page:   1,                 // should be set to 1 by default
+		}).Return(&resource.ResourceSearchResponse{
+			Results: &resource.ResourceTable{
+				Columns: []*resource.ResourceTableColumnDefinition{
+					{Name: "folder", Type: resource.ResourceTableColumnDefinition_STRING},
+				},
+				Rows: []*resource.ResourceTableRow{
+					{
+						Key:   &resource.ResourceKey{Name: "folder2", Resource: "folder"},
+						Cells: [][]byte{[]byte("folder1")},
+					},
+					{
+						Key:   &resource.ResourceKey{Name: "folder3", Resource: "folder"},
+						Cells: [][]byte{[]byte("folder1")},
+					},
+				},
+			},
+			TotalHits: 1,
+		}, nil).Once()
+		mockCli.On("Get", mock.Anything, "folder1", orgID, mock.Anything, mock.Anything).Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "folders.folder.grafana.app", Resource: "folder"}, "folder1")).Once()
+
+		_, err := store.GetChildren(ctx, folder.GetChildrenQuery{
+			UID:   "folder1",
+			OrgID: orgID,
+		})
+		require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
 	})
 
 	t.Run("pages should be able to be set, general folder should be turned to empty string, and folder uids should be passed in", func(t *testing.T) {
@@ -300,6 +358,11 @@ func TestGetChildren(t *testing.T) {
 				},
 			},
 			TotalHits: 1,
+		}, nil)
+		mockCli.On("Get", mock.Anything, "folder", orgID, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "folder"},
+			},
 		}, nil)
 		mockCli.On("Get", mock.Anything, accesscontrol.K6FolderUID, orgID, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{


### PR DESCRIPTION
**What is this feature?**

This PR fixes the not found errors when getting folders:
1. GetChildren was not returning `not found` when the parent uid supplied did not exist, because it was not querying for the folder in the guardian like it does in legacy. This caused a difference in behavior [test instance](https://dashboardsmode0.grafana-dev.net/dashboards/f/doesnotexist) vs [ops](https://ops.grafana-ops.net/dashboards/f/doesnotexist). With this PR, the behavior is the same:

<img width="1311" alt="Screenshot 2025-03-04 at 1 22 50 PM" src="https://github.com/user-attachments/assets/97aedf77-30fe-45f2-b991-6e038b15cb81" />

2. Get folders was returning an internal error instead of a 404, because it converted the error via `resourceInfo.NewNotFound(name)`, but then called [ToFolderStatusError](https://github.com/grafana/grafana/blob/7c35d741ba665235c15cda5b0de44a2525706ba1/pkg/api/apierrors/folder.go#L55), which calls [ToFolderErrorResponse](https://github.com/grafana/grafana/blob/7c35d741ba665235c15cda5b0de44a2525706ba1/pkg/api/apierrors/folder.go#L18) and then converts it back to an internal server error.

3. Anytime the k8s Get client is used, it should check for a not found error & convert. Where possible, it updates the folder service to use one function to reduce repeated code.

Closes https://github.com/grafana/app-platform-wg/issues/229