### PR TITLE
K8s: Dashboards: Add useful error message for too large

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -80,6 +80,8 @@ var (
 	ready      = make(chan struct{})
 )
 
+const MaxRequestBodyBytes = 16 * 1024 * 1024 // 16MB - determined by the size of `mediumtext` on mysql, which is used to save dashboard data
+
 func init() {
 	// we need to add the options to empty v1
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Group: "", Version: "v1"})
@@ -335,7 +337,7 @@ func (s *service) start(ctx context.Context) error {
 	transport := &roundTripperFunc{ready: make(chan struct{})}
 	serverConfig.LoopbackClientConfig.Transport = transport
 	serverConfig.LoopbackClientConfig.TLSClientConfig = clientrest.TLSClientConfig{}
-	serverConfig.MaxRequestBodyBytes = 16 * 1024 * 1024 // 16MB - determined by the size of `mediumtext` on mysql, which is used to save dashboard data
+	serverConfig.MaxRequestBodyBytes = MaxRequestBodyBytes
 
 	var optsregister apistore.StorageOptionsRegister
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes the error in k8s when the dashboard responds with dashboard too large. Before it would fail with a generic error, now it will say why it is failing

Before:
<img width="488" alt="Screenshot 2025-03-04 at 2 55 13 PM" src="https://github.com/user-attachments/assets/a836c323-054d-4a73-983b-ec91275e9317" />

After (modified the code to be a max of 3MB for easier testing):
![screenshot_2025-03-04_at_2 52 09___pm](https://github.com/user-attachments/assets/43972195-54b3-4ef8-a679-b910418de349)

As a follow-up, in `/apis`, we will also likely want to override this error message, otherwise it says `request entity`, which will likely be confusing for users (screenshot from when I had a max size of 100 bytes locally 😅 ):
![screenshot_2025-03-04_at_2 45 18___pm](https://github.com/user-attachments/assets/6536bde6-b0cf-40e6-b030-217fd10de749)

Relates to https://github.com/grafana/app-platform-wg/issues/233