### PR TITLE
Transformations: Avoid mutation during variable interpolation

### DIFF
--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { MonoTypeOperatorFunction, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -29,7 +30,7 @@ const getOperator =
 
     const interpolated = isScenes
       ? options
-      : deepIterate(options, (v) => {
+      : deepIterate(cloneDeep(options), (v) => {
           if (typeof v === 'string') {
             return ctx.interpolate(v);
           }

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -13,9 +13,6 @@ import {
 import { getFrameMatchers } from './matchers';
 import { standardTransformersRegistry, TransformerRegistryItem } from './standardTransformersRegistry';
 
-// when running within Scenes, we can skip var interpolation, since it's already handled upstream
-const isScenes = window.__grafanaSceneContext != null;
-
 const getOperator =
   (config: DataTransformerConfig, ctx: DataTransformContext): MonoTypeOperatorFunction<DataFrame[]> =>
   (source) => {
@@ -27,6 +24,9 @@ const getOperator =
 
     const defaultOptions = info.transformation.defaultOptions ?? {};
     const options = { ...defaultOptions, ...config.options };
+
+    // when running within Scenes, we can skip var interpolation, since it's already handled upstream
+    const isScenes = window.__grafanaSceneContext != null;
 
     const interpolated = isScenes
       ? options


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/101593

follow-up to https://github.com/grafana/grafana/pull/101438

this avoids mutating the transformation options during var interpolation (similar to https://github.com/grafana/scenes/pull/1064).