### PR TITLE
Anonymous: Add 1min leeway in device count + search in tests for MySQL 5.7

### DIFF
--- a/pkg/services/anonymous/anonimpl/impl_test.go
+++ b/pkg/services/anonymous/anonimpl/impl_test.go
@@ -126,9 +126,9 @@ func TestIntegrationDeviceService_tag(t *testing.T) {
 				{
 					httpReq: &http.Request{
 						Header: http.Header{
-							"User-Agent":                            []string{"test"},
-							"X-Forwarded-For":                       []string{"10.30.30.1"},
-							http.CanonicalHeaderKey(deviceIDHeader): []string{"32mdo31deeqwes"},
+							"User-Agent":                            []string{"testdisabled"},
+							"X-Forwarded-For":                       []string{"10.33.33.3"},
+							http.CanonicalHeaderKey(deviceIDHeader): []string{"t35td154b13d1d"},
 						},
 					},
 					kind: anonymous.AnonDeviceUI,
@@ -178,7 +178,8 @@ func TestIntegrationDeviceService_tag(t *testing.T) {
 				assert.Equal(t, tc.expectedDevice, devices[0])
 			}
 
-			to := time.Now()
+			// One minute is added to the end time as mysql 5.7 datetime type has a default precision of seconds and not milis.
+			to := time.Now().Add(time.Minute)
 			from := to.AddDate(0, 0, -1)
 
 			devicesCount, err := anonService.CountDevices(ctx, from, to)


### PR DESCRIPTION
Very interesting, but after merging https://github.com/grafana/grafana/pull/101525 I noticed that MySQL 5.7 integration tests where failing on this.

I was able to reproduce it locally, while MySQL 8 and other databases did not present the same issue.

Changing the query to use `>= AND <=` instead of `BETWEEN ... AND ...` fixed the problem.

But in the effort of NOT trying to change behavior but actually document the existing behavior through tests, I am updating the search window for the devices to include an extra minute since the datatype used `DATETIME` will truncate to second precision on MySQL 5.7 (which does not support millisecond precision anyways).

PS: OSS doesn't run MySQL 5.7 tests anymore so I triggered it here https://drone.grafana.net/grafana/grafana-enterprise/83911/6/17