### PR TITLE
Return possible value suggestions, excluding label name from scopes

### DIFF
--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -20,7 +20,7 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 		return "", err
 	}
 
-	matchers, err := FiltersToMatchers(scopeFilters, adHocFilters)
+	matchers, err := FiltersToMatchers(scopeFilters, adHocFilters, "")
 	if err != nil {
 		return "", err
 	}
@@ -75,11 +75,15 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 	return expr.String(), nil
 }
 
-func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matcher, error) {
+func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter, labelName string) ([]*labels.Matcher, error) {
 	filterMap := make(map[string]*labels.Matcher)
 
 	// scope filters are applied first
 	for _, filter := range scopeFilters {
+		if filter.Key == labelName {
+			continue
+		}
+
 		matcher, err := filterToMatcher(filter)
 		if err != nil {
 			return nil, err

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -162,7 +162,7 @@ func (r *Resource) GetSuggestions(ctx context.Context, req *backend.CallResource
 	slices.Sort(selectorList)
 	selectorList = slices.Compact(selectorList)
 
-	matchers, err := models.FiltersToMatchers(sugReq.Scopes, sugReq.AdhocFilters)
+	matchers, err := models.FiltersToMatchers(sugReq.Scopes, sugReq.AdhocFilters, sugReq.LabelName)
 	if err != nil {
 		return nil, fmt.Errorf("error converting filters to matchers: %v", err)
 	}

--- a/pkg/tsdb/loki/scopes.go
+++ b/pkg/tsdb/loki/scopes.go
@@ -52,7 +52,7 @@ func GetSuggestions(ctx context.Context, lokiAPI *LokiAPI, req *backend.CallReso
 			}
 		}
 	} else if len(sugReq.Scopes) > 0 {
-		matchers, err := models.FiltersToMatchers(sugReq.Scopes, sugReq.AdhocFilters)
+		matchers, err := models.FiltersToMatchers(sugReq.Scopes, sugReq.AdhocFilters, sugReq.LabelName)
 		if err != nil {
 			return RawLokiResponse{}, fmt.Errorf("error converting filters to matchers: %v", err)
 		}
@@ -84,7 +84,7 @@ func ApplyScopes(rawExpr string, scopeFilters []models.ScopeFilter) (string, err
 		return rawExpr, nil
 	}
 
-	scopeMatchers, err := models.FiltersToMatchers(scopeFilters, nil)
+	scopeMatchers, err := models.FiltersToMatchers(scopeFilters, nil, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to convert filters to matchers: %w", err)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ignores scope filters with the currently given label name so that the correct values can be returned. Currently, without scope injected filters, the UI allows a user to add a new filter with a label that exists in a scope filter, but won't properly query for values, instead it will return the values of the scopes themselves, which seems unexpected from a user pov.

With the arrival of scope injected filters, the scope filter label will be injected into the adhoc filter thus trying to add a new filter with a label name from a scope will not return any valid label names, so the values query is a non-issue.

**Why do we need this feature?**

This fixes an issue for the upcoming editing functionality on injected filters. So when we edit an injected filter we only receive the values that are set in the scopes themselves, instead of the entire list of possible values. To fix this, this PR ignores the scope filters that use the same label key as the one currently called on `getSuggestions`.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

TODO:
- [ ] Write some tests

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
