### PR TITLE
Chore: Downgrade go-grpc-middleware to fix build in 32-bit systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -583,5 +583,8 @@ exclude github.com/prometheus/prometheus v1.8.2-0.20221021121301-51a44e6657c3
 // otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible
 
-// k8s.io/apiserver fails due to incompatibility with cel-go 0.23
+// k8s.io/apiserver fails due to incompatibility with cel-go 0.23, can be removed once apiserver v0.32.3 is released.
 replace github.com/google/cel-go => github.com/google/cel-go v0.22.1
+
+// fails to compile on 32-bit architectures due to overflow (https://github.com/grpc-ecosystem/go-grpc-middleware/issues/752).
+replace github.com/grpc-ecosystem/go-grpc-middleware/v2 => github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1624,8 +1624,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.0 h1:FbSCl+KggFl+Ocym490i/EyXF4lPgLoUtcSWquBM0Rs=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.0/go.mod h1:qOchhhIlmRcqk/O9uCo/puJlyo07YINaIqdZfZG3Jkc=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0 h1:kQ0NI7W1B3HwiN5gAYtY+XFItDPbLBwYRxAqbFTyDes=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0/go.mod h1:zrT2dxOAjNFPRGjTUe2Xmb4q4YdUwVvQFV6xiCSf+z0=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 h1:uGoIog/wiQHI9GAxXO5TJbT0wWKH3O9HhOJW1F9c3fY=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340/go.mod h1:3bDW6wMZJB7tiONtC/1Xpicra6Wp5GgbTbQWCbI5fkc=

--- a/go.work.sum
+++ b/go.work.sum
@@ -912,6 +912,8 @@ github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0 h1:kQ0NI7W1B3HwiN5gAYtY+XFItDPbLBwYRxAqbFTyDes=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0/go.mod h1:zrT2dxOAjNFPRGjTUe2Xmb4q4YdUwVvQFV6xiCSf+z0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0/go.mod h1:ggCgvZ2r7uOoQjOyu2Y1NhHmEPPzzuhWgcza5M1Ji1I=


### PR DESCRIPTION
From https://github.com/grpc-ecosystem/go-grpc-middleware/issues/752, version v2.3.0 current breaks 32-bit system builds, e.g.:
```
error exporting artifact 'grafana-enterprise_11.6.0-83913_83913_linux_arm-7.docker.tar.gz': input: container.from.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withFile.withWorkdir.withFile.withMountedCache.withFile.withFile.withFile.withExec.withExec.withExec.withExec.directory resolve: process "/bin/sh -c if [ -d pkg/cmd/grafana ]; then go build -ldflags=\"-w -s -X \\\"main.version=11.6.0-83913\\\" -X \\\"main.commit=$(cat ./.buildinfo.commit)\\\" -X \\\"main.buildBranch=$(cat ./.buildinfo.branch)\\\" -X \\\"main.enterpriseCommit=$(cat ./.buildinfo.enterprise-commit)\\\" -linkmode=external -extldflags=-static \" -o=bin/grafana-enterprise/linux/arm/v7/grafana -trimpath -tags=osusergo ./pkg/cmd/grafana; fi" did not complete successfully: exit code: 1

Stderr:
# github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry
/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.0/interceptors/retry/backoff.go:35:10: cannot use 1 << 62 (untyped int constant 4611686018427387904) as uint value in return statement (overflows)
```

This temporarily downgrades it to `v2.2.0` to get a working 32-bit builds again.