### PR TITLE
Alerting: Return 400 if the Prometheus rule has unsupported options

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -98,10 +98,8 @@ func NewConverter(cfg Config) (*Converter, error) {
 
 // PrometheusRulesToGrafana converts a Prometheus rule group into Grafana Alerting rule group.
 func (p *Converter) PrometheusRulesToGrafana(orgID int64, namespaceUID string, group PrometheusRuleGroup) (*models.AlertRuleGroup, error) {
-	for _, rule := range group.Rules {
-		if err := rule.Validate(); err != nil {
-			return nil, err
-		}
+	if err := group.Validate(); err != nil {
+		return nil, err
 	}
 
 	grafanaGroup, err := p.convertRuleGroup(orgID, namespaceUID, group)


### PR DESCRIPTION
**What is this feature?**

Return a conversion error if the rule group has unsupported options:

- `query_offset`
- `limit`
- `labels`

**Why do we need this feature?**

Currently, if you try to import a rule group with unsupported options, for example, `limit`, no error is returned, and the group is imported without the limit.