### PR TITLE
Alerting: Support group-level labels in Prometheus to Grafana conversion

### DIFF
--- a/pkg/services/ngalert/prom/models.go
+++ b/pkg/services/ngalert/prom/models.go
@@ -33,10 +33,6 @@ func (g *PrometheusRuleGroup) Validate() error {
 		return ErrPrometheusRuleGroupValidationFailed.Errorf("limit is not supported")
 	}
 
-	if len(g.Labels) > 0 {
-		return ErrPrometheusRuleGroupValidationFailed.Errorf("labels are not supported")
-	}
-
 	for _, rule := range g.Rules {
 		if err := rule.Validate(); err != nil {
 			return err

--- a/pkg/services/ngalert/prom/models_test.go
+++ b/pkg/services/ngalert/prom/models_test.go
@@ -23,6 +23,9 @@ func TestPrometheusRuleGroup_Validate(t *testing.T) {
 			group: PrometheusRuleGroup{
 				Name:     "test_group",
 				Interval: prommodel.Duration(60),
+				Labels: map[string]string{
+					"label-1": "value-1",
+				},
 				Rules: []PrometheusRule{
 					{
 						Alert: "test_alert",
@@ -51,16 +54,6 @@ func TestPrometheusRuleGroup_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "limit is not supported",
-		},
-		{
-			name: "invalid group with labels",
-			group: PrometheusRuleGroup{
-				Name:     "test_group",
-				Interval: prommodel.Duration(60),
-				Labels:   map[string]string{"foo": "bar"},
-			},
-			expectError: true,
-			errorMsg:    "labels are not supported",
 		},
 		{
 			name: "invalid group with invalid rule",


### PR DESCRIPTION
**What is this feature?**

This PR adds support for the group-level `labels` definition. 

* [Prometheus PR](https://github.com/prometheus/prometheus/pull/11474)
* [Documentation](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group)

`labels` can be defined on the group level too and will be merged with the labels for both alerting and recording rules (rule-level labels take precedence):

```
groups:
  - name: group-1
    interval: 10s
    labels:
      group_label: "group_value"
      common_label: "group_value"
    rules:
      - record: vector1
        expr: vector(1)
        labels:
          common_label: "rule_value"
          rule_label: "rule_value"
```

This will create a recording rule with labels `group_label=group_value common_label=rule_value rule_label=rule_value`.

Part of https://github.com/grafana/alerting-squad/issues/971

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
