### PR TITLE
pyroscope: clarifies that grafana-flamegraph is Apache 2

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -11,6 +11,7 @@ The following directories and their subdirectories are licensed under Apache-2.0
 ```
 packages/grafana-data/
 packages/grafana-e2e-selectors/
+packages/grafana-flamegraph/
 packages/grafana-runtime/
 packages/grafana-ui/
 packaging/


### PR DESCRIPTION
Wanted to clarify that `grafana-flamegraph` is Apache 2.

It is mentioned in other places that it is Apache 2, e.g:
* https://github.com/grafana/grafana/blob/main/packages/grafana-flamegraph/LICENSE_APACHE2
* https://www.npmjs.com/package/@grafana/flamegraph