### PR TITLE
K8s: Fix plugin updater

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -66,10 +67,11 @@ func (du *DashboardUpdater) updateAppDashboards() {
 		if !pluginSetting.Enabled {
 			continue
 		}
+		ctx, _ := identity.WithServiceIdentity(context.Background(), pluginSetting.OrgID)
 
-		if pluginDef, exists := du.pluginStore.Plugin(context.Background(), pluginSetting.PluginID); exists {
+		if pluginDef, exists := du.pluginStore.Plugin(ctx, pluginSetting.PluginID); exists {
 			if pluginDef.Info.Version != pluginSetting.PluginVersion {
-				du.syncPluginDashboards(context.Background(), pluginDef, pluginSetting.OrgID)
+				du.syncPluginDashboards(ctx, pluginDef, pluginSetting.OrgID)
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

This PR adds a service account to the context of the `updateAppDashboards` function, which is needed once the requests start going through k8s for dashboards. 

Otherwise, we get the error:
```
logger=plugindashboards t=2025-03-05T19:13:25.739757176Z level=error msg="Failed to load app dashboards" error="a Requester was not found in the context"
```

from [here](https://github.com/grafana/grafana/blob/ce0d48746f85448478031f840b0e247d6631b816/pkg/services/apiserver/client/client.go#L245)