### PR TITLE
QueryOptions: Handle invalid time shift values

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.test.tsx
@@ -111,6 +111,31 @@ describe('PanelTimeRange', () => {
     expect(panelTime.state.value.from.format('Z')).toBe('+00:00'); // UTC
     expect(panelTime.state.value.to.format('Z')).toBe('+00:00'); // UTC
   });
+
+  it('should handle invalid time reference in timeShift', () => {
+    const panelTime = new PanelTimeRange({ timeShift: 'now-1d' });
+
+    buildAndActivateSceneFor(panelTime);
+
+    expect(panelTime.state.timeInfo).toBe('invalid timeshift');
+    // Should not be affected by invalid timeShift
+    expect(panelTime.state.from).toBe('now-6h');
+    expect(panelTime.state.to).toBe('now');
+  });
+
+  it('should handle invalid time reference in timeShift combined with timeFrom', () => {
+    const panelTime = new PanelTimeRange({
+      timeFrom: 'now-2h',
+      timeShift: 'now-1d',
+    });
+
+    buildAndActivateSceneFor(panelTime);
+
+    expect(panelTime.state.timeInfo).toBe('invalid timeshift');
+    // Should not be affected by invalid timeShift
+    expect(panelTime.state.from).toBe('now-2h');
+    expect(panelTime.state.to).toBe('now');
+  });
 });
 
 function buildAndActivateSceneFor(panelTime: PanelTimeRange) {

--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
@@ -105,6 +105,11 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
       const from = dateMath.parseDateMath(timeShift, newTimeData.timeRange.from, false)!;
       const to = dateMath.parseDateMath(timeShift, newTimeData.timeRange.to, true)!;
 
+      if (!from || !to) {
+        newTimeData.timeInfo = 'invalid timeshift';
+        return newTimeData;
+      }
+
       newTimeData.timeRange = { from, to, raw: { from, to } };
     }
 


### PR DESCRIPTION
**Problem**
For an invalid time shift, the panel breaks, and it bubbles up to the dashboard error, crashing the entire dashboard.

**Solution**
Handle an unparseable timeshift value and inform the user it is invalid

|Before|After|
|-|-|
![Captura de pantalla 2025-03-06 a las 8 09 04](https://github.com/user-attachments/assets/458a644a-864d-4808-8165-3a55ff35bb63)|![Captura de pantalla 2025-03-06 a las 8 06 51](https://github.com/user-attachments/assets/6249d990-5c07-4687-8b42-cdfa07867d92)

