### PR TITLE
Dashboards: Rename layout display names: Default grid => Custom, Responsive grid => Auto 

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -47,10 +47,10 @@ export class DefaultGridLayoutManager
 
   public static readonly descriptor: LayoutRegistryItem = {
     get name() {
-      return t('dashboard.default-layout.name', 'Default grid');
+      return t('dashboard.default-layout.name', 'Custom');
     },
     get description() {
-      return t('dashboard.default-layout.description', 'The default grid layout');
+      return t('dashboard.default-layout.description', 'Manually size and position panels');
     },
     id: 'default-grid',
     createFromLayout: DefaultGridLayoutManager.createFromLayout,

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -25,10 +25,10 @@ export class ResponsiveGridLayoutManager
 
   public static readonly descriptor: LayoutRegistryItem = {
     get name() {
-      return t('dashboard.responsive-layout.name', 'Responsive grid');
+      return t('dashboard.responsive-layout.name', 'Auto');
     },
     get description() {
-      return t('dashboard.responsive-layout.description', 'CSS layout that adjusts to the available space');
+      return t('dashboard.responsive-layout.description', 'Automatically positions panels into a grid.');
     },
     id: 'responsive-grid',
     createFromLayout: ResponsiveGridLayoutManager.createFromLayout,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1011,7 +1011,7 @@
       "subtitle": "Alert rules related to this dashboard"
     },
     "default-layout": {
-      "description": "The default grid layout",
+      "description": "Manually size and position panels",
       "item-options": {
         "repeat": {
           "direction": {
@@ -1027,7 +1027,7 @@
           }
         }
       },
-      "name": "Default grid",
+      "name": "Custom",
       "row-actions": {
         "delete": "Delete row",
         "modal": {
@@ -1190,7 +1190,7 @@
       }
     },
     "responsive-layout": {
-      "description": "CSS layout that adjusts to the available space",
+      "description": "Automatically positions panels into a grid.",
       "item-options": {
         "hide-no-data": "Hide when no data",
         "repeat": {
@@ -1201,7 +1201,7 @@
         },
         "title": "Layout options"
       },
-      "name": "Responsive grid",
+      "name": "Auto",
       "options": {
         "columns": "Columns",
         "fixed": "Fixed: {{size}}px",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1011,7 +1011,7 @@
       "subtitle": "Åľęřŧ řūľęş řęľäŧęđ ŧő ŧĥįş đäşĥþőäřđ"
     },
     "default-layout": {
-      "description": "Ŧĥę đęƒäūľŧ ģřįđ ľäyőūŧ",
+      "description": "Mäŉūäľľy şįžę äŉđ pőşįŧįőŉ päŉęľş",
       "item-options": {
         "repeat": {
           "direction": {
@@ -1027,7 +1027,7 @@
           }
         }
       },
-      "name": "Đęƒäūľŧ ģřįđ",
+      "name": "Cūşŧőm",
       "row-actions": {
         "delete": "Đęľęŧę řőŵ",
         "modal": {
@@ -1190,7 +1190,7 @@
       }
     },
     "responsive-layout": {
-      "description": "CŜŜ ľäyőūŧ ŧĥäŧ äđĵūşŧş ŧő ŧĥę äväįľäþľę şpäčę",
+      "description": "Åūŧőmäŧįčäľľy pőşįŧįőŉş päŉęľş įŉŧő ä ģřįđ.",
       "item-options": {
         "hide-no-data": "Ħįđę ŵĥęŉ ŉő đäŧä",
         "repeat": {
@@ -1201,7 +1201,7 @@
         },
         "title": "Ŀäyőūŧ őpŧįőŉş"
       },
-      "name": "Ŗęşpőŉşįvę ģřįđ",
+      "name": "Åūŧő",
       "options": {
         "columns": "Cőľūmŉş",
         "fixed": "Fįχęđ: {{size}}pχ",


### PR DESCRIPTION
With so many open PRs related to layouts (redesign PRs, and the drag and drop) I think we can wait a bit with renaming the classes and files 