### PR TITLE
Authz: Pass correct property

### DIFF
--- a/pkg/registry/apis/folders/authorizer.go
+++ b/pkg/registry/apis/folders/authorizer.go
@@ -88,8 +88,8 @@ func newMultiTenantAuthorizer(ac types.AccessClient) authorizer.Authorizer {
 			Verb:        a.GetVerb(),
 			Group:       a.GetAPIGroup(),
 			Resource:    a.GetResource(),
+			Name:        a.GetName(),
 			Namespace:   a.GetNamespace(),
-			Name:        a.GetNamespace(),
 			Subresource: a.GetSubresource(),
 		})
 


### PR DESCRIPTION
**What is this feature?**
Noticed this mistake, right now only access tokens can authorize with mt folder api so this property is not used but we should pass the correct one anyway


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
