### PR TITLE
Tempo: fallback for intrinsic tags

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
@@ -3,12 +3,14 @@ import { uniq } from 'lodash';
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
 import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
+import { intrinsics } from '../traceql/traceql';
 
 import {
   filterToQuerySection,
   generateQueryFromAdHocFilters,
   getAllTags,
   getFilteredTags,
+  getIntrinsicTags,
   getTagsByScope,
   getUnscopedTags,
 } from './utils';
@@ -105,6 +107,11 @@ describe('gets correct tags', () => {
   it('for tags by span scope', () => {
     const tags = getTagsByScope(v2Tags, TraceqlSearchScope.Span);
     expect(tags).toEqual(['db']);
+  });
+
+  it('for intrinsic tags', () => {
+    const tags = getIntrinsicTags(v2Tags);
+    expect(tags).toEqual(uniq(testIntrinsics.concat(intrinsics)));
   });
 });
 

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
@@ -96,7 +96,7 @@ describe('gets correct tags', () => {
 
   it('for all tags', () => {
     const tags = getAllTags(v2Tags);
-    expect(tags).toEqual(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status']);
+    expect(tags).toEqual(uniq(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status'].concat(intrinsics)));
   });
 
   it('for tags by resource scope', () => {
@@ -111,7 +111,7 @@ describe('gets correct tags', () => {
 
   it('for intrinsic tags', () => {
     const tags = getIntrinsicTags(v2Tags);
-    expect(tags).toEqual(uniq(testIntrinsics.concat(intrinsics)));
+    expect(tags).toEqual(testIntrinsics);
   });
 });
 
@@ -186,7 +186,7 @@ describe('filterToQuerySection returns the correct query section for a filter', 
 });
 
 export const emptyTags = [];
-export const testIntrinsics = ['duration', 'kind', 'name', 'status'];
+export const testIntrinsics = uniq(['duration', 'kind', 'name', 'status'].concat(intrinsics));
 export const v1Tags = ['bar', 'foo'];
 export const v2Tags = [
   {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -7,6 +7,7 @@ import { VariableFormatID } from '@grafana/schema';
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
 import { getEscapedSpanNames } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
+import { intrinsics } from '../traceql/traceql';
 import { Scope } from '../types';
 
 export const interpolateFilters = (filters: TraceqlFilter[], scopedVars?: ScopedVars) => {
@@ -132,13 +133,19 @@ export const getUnscopedTags = (scopes: Scope[]) => {
 };
 
 export const getIntrinsicTags = (scopes: Scope[]) => {
-  return uniq(
+  let tags = uniq(
     scopes
       .map((scope: Scope) =>
         scope.name && scope.name === TraceqlSearchScope.Intrinsic && scope.tags ? scope.tags : []
       )
       .flat()
   );
+  // Add the default intrinsic tags to the list of tags.
+  // This is needed because the /api/v2/search/tags API 
+  // may not always return all the default intrinsic tags
+  // but generally has the most up to date list.
+  tags = uniq(tags.concat(intrinsics));
+  return tags;
 };
 
 export const getAllTags = (scopes: Scope[]) => {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -141,7 +141,7 @@ export const getIntrinsicTags = (scopes: Scope[]) => {
       .flat()
   );
   // Add the default intrinsic tags to the list of tags.
-  // This is needed because the /api/v2/search/tags API 
+  // This is needed because the /api/v2/search/tags API
   // may not always return all the default intrinsic tags
   // but generally has the most up to date list.
   tags = uniq(tags.concat(intrinsics));

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -133,13 +133,10 @@ export const getUnscopedTags = (scopes: Scope[]) => {
 };
 
 export const getIntrinsicTags = (scopes: Scope[]) => {
-  let tags = uniq(
-    scopes
-      .map((scope: Scope) =>
-        scope.name && scope.name === TraceqlSearchScope.Intrinsic && scope.tags ? scope.tags : []
-      )
-      .flat()
-  );
+  let tags = scopes
+    .map((scope: Scope) => (scope.name && scope.name === TraceqlSearchScope.Intrinsic && scope.tags ? scope.tags : []))
+    .flat();
+
   // Add the default intrinsic tags to the list of tags.
   // This is needed because the /api/v2/search/tags API
   // may not always return all the default intrinsic tags

--- a/public/app/plugins/datasource/tempo/language_provider.test.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.test.ts
@@ -108,7 +108,9 @@ describe('Language_provider', () => {
     it('for API v2 tags', async () => {
       const lp = setup(undefined, v2Tags);
       const tags = lp.getAutocompleteTags();
-      expect(tags).toEqual(uniq(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status'].concat(intrinsics)));
+      expect(tags).toEqual(
+        uniq(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status'].concat(intrinsics))
+      );
     });
   });
 

--- a/public/app/plugins/datasource/tempo/language_provider.test.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.test.ts
@@ -1,7 +1,10 @@
+import { uniq } from 'lodash';
+
 import { v1Tags, v2Tags } from './SearchTraceQLEditor/utils.test';
 import { TraceqlSearchScope } from './dataquery.gen';
 import { TempoDatasource } from './datasource';
 import TempoLanguageProvider from './language_provider';
+import { intrinsics } from './traceql/traceql';
 import { Scope } from './types';
 
 describe('Language_provider', () => {
@@ -15,7 +18,7 @@ describe('Language_provider', () => {
     it('for API v2 intrinsic tags', async () => {
       const lp = setup(undefined, v2Tags);
       const tags = lp.getMetricsSummaryTags(TraceqlSearchScope.Intrinsic);
-      expect(tags).toEqual(['duration', 'kind', 'name', 'status']);
+      expect(tags).toEqual(uniq(['duration', 'kind', 'name', 'status'].concat(intrinsics)));
     });
 
     it('for API v2 resource tags', async () => {
@@ -105,7 +108,7 @@ describe('Language_provider', () => {
     it('for API v2 tags', async () => {
       const lp = setup(undefined, v2Tags);
       const tags = lp.getAutocompleteTags();
-      expect(tags).toEqual(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status']);
+      expect(tags).toEqual(uniq(['cluster', 'container', 'db', 'duration', 'kind', 'name', 'status'].concat(intrinsics)));
     });
   });
 


### PR DESCRIPTION
**What is this feature?**

Adds a fallback for intrinsic tags.

**Why do we need this feature?**

So when / if the `/api/v2/search/tags` API does not return any / all of the intrinsic tags, we have a fallback (as the intrinsics are used heavily in Tempo queries).

**Who is this feature for?**

Tempo users.
