### PR TITLE
Remove the area/editor label

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1117,14 +1117,6 @@
   },
   {
     "type": "label",
-    "name": "area/editor",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/grafana/grafana/projects/21"
-    }
-  },
-  {
-    "type": "label",
     "name": "area/data/export",
     "action": "addToProject",
     "addToProject": {

--- a/.github/workflows/auto-triager/labels.txt
+++ b/.github/workflows/auto-triager/labels.txt
@@ -32,7 +32,6 @@ area/dashboard/tv
 area/dashboard/variable
 area/dashboards/panel
 area/data/export
-area/editor
 area/explore
 area/exploremetrics
 area/expressions


### PR DESCRIPTION
The project board github.com/grafana/grafana/projects/21 has been deleted
as far as I can tell (or never existed).

I can't see an obvious candidate-team to receive `area/editor`, so I
propose we delete it instead.
