### PR TITLE
Alerting: Add locking to avoid race conditions when creating alert rule folders

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
@@ -880,6 +881,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool, cfgOverrides ...conf
 		secretsService, nil, alertMetrics, mockFolder, fakeAccessControl, dashboardService, nil, bus, fakeAccessControlService,
 		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore,
 		httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
+		serverlock.ProvideService(sqlStore, tracer),
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -51,35 +51,36 @@ type RuleAccessControlService interface {
 
 // API handlers.
 type API struct {
-	Cfg                  *setting.Cfg
-	DatasourceCache      datasources.CacheService
-	DatasourceService    datasources.DataSourceService
-	RouteRegister        routing.RouteRegister
-	QuotaService         quota.Service
-	TransactionManager   provisioning.TransactionManager
-	ProvenanceStore      provisioning.ProvisioningStore
-	RuleStore            RuleStore
-	AlertingStore        store.AlertingStore
-	AdminConfigStore     store.AdminConfigurationStore
-	DataProxy            *datasourceproxy.DataSourceProxyService
-	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
-	StateManager         *state.Manager
-	Scheduler            StatusReader
-	AccessControl        ac.AccessControl
-	Policies             *provisioning.NotificationPolicyService
-	ReceiverService      *notifier.ReceiverService
-	ContactPointService  *provisioning.ContactPointService
-	Templates            *provisioning.TemplateService
-	MuteTimings          *provisioning.MuteTimingService
-	AlertRules           *provisioning.AlertRuleService
-	AlertsRouter         *sender.AlertsRouter
-	EvaluatorFactory     eval.EvaluatorFactory
-	ConditionValidator   *eval.ConditionValidator
-	FeatureManager       featuremgmt.FeatureToggles
-	Historian            Historian
-	Tracer               tracing.Tracer
-	AppUrl               *url.URL
-	UserService          user.Service
+	Cfg                   *setting.Cfg
+	DatasourceCache       datasources.CacheService
+	DatasourceService     datasources.DataSourceService
+	RouteRegister         routing.RouteRegister
+	QuotaService          quota.Service
+	TransactionManager    provisioning.TransactionManager
+	ProvenanceStore       provisioning.ProvisioningStore
+	RuleStore             RuleStore
+	AlertingStore         store.AlertingStore
+	AdminConfigStore      store.AdminConfigurationStore
+	DataProxy             *datasourceproxy.DataSourceProxyService
+	MultiOrgAlertmanager  *notifier.MultiOrgAlertmanager
+	StateManager          *state.Manager
+	Scheduler             StatusReader
+	AccessControl         ac.AccessControl
+	Policies              *provisioning.NotificationPolicyService
+	ReceiverService       *notifier.ReceiverService
+	ContactPointService   *provisioning.ContactPointService
+	Templates             *provisioning.TemplateService
+	MuteTimings           *provisioning.MuteTimingService
+	AlertRules            *provisioning.AlertRuleService
+	AlertsRouter          *sender.AlertsRouter
+	EvaluatorFactory      eval.EvaluatorFactory
+	ConditionValidator    *eval.ConditionValidator
+	FeatureManager        featuremgmt.FeatureToggles
+	Historian             Historian
+	Tracer                tracing.Tracer
+	AppUrl                *url.URL
+	UserService           user.Service
+	AlertingFolderService alertingFolderService
 
 	// Hooks can be used to replace API handlers for specific paths.
 	Hooks *Hooks
@@ -188,7 +189,13 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 
 	if api.FeatureManager.IsEnabledGlobally(featuremgmt.FlagAlertingConversionAPI) {
 		api.RegisterConvertPrometheusApiEndpoints(NewConvertPrometheusApi(
-			NewConvertPrometheusSrv(&api.Cfg.UnifiedAlerting, logger, api.RuleStore, api.DatasourceCache, api.AlertRules),
+			NewConvertPrometheusSrv(
+				&api.Cfg.UnifiedAlerting,
+				logger,
+				api.AlertingFolderService,
+				api.DatasourceCache,
+				api.AlertRules,
+			),
 		), m)
 	}
 }

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -52,6 +54,13 @@ var (
 
 func errInvalidHeaderValue(header string) error {
 	return errInvalidHeaderValueBase.Build(errutil.TemplateData{Public: map[string]any{"Header": header}})
+}
+
+type alertingFolderService interface {
+	GetNamespaceByTitle(ctx context.Context, fullpath string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
+	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
+	// GetNamespaceChildren returns all children (first level) of the namespace with the given id.
+	GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error)
 }
 
 // ConvertPrometheusSrv converts Prometheus rules to Grafana rules
@@ -95,16 +104,22 @@ func errInvalidHeaderValue(header string) error {
 type ConvertPrometheusSrv struct {
 	cfg              *setting.UnifiedAlertingSettings
 	logger           log.Logger
-	ruleStore        RuleStore
+	folderService    alertingFolderService
 	datasourceCache  datasources.CacheService
 	alertRuleService *provisioning.AlertRuleService
 }
 
-func NewConvertPrometheusSrv(cfg *setting.UnifiedAlertingSettings, logger log.Logger, ruleStore RuleStore, datasourceCache datasources.CacheService, alertRuleService *provisioning.AlertRuleService) *ConvertPrometheusSrv {
+func NewConvertPrometheusSrv(
+	cfg *setting.UnifiedAlertingSettings,
+	logger log.Logger,
+	folderService alertingFolderService,
+	datasourceCache datasources.CacheService,
+	alertRuleService *provisioning.AlertRuleService,
+) *ConvertPrometheusSrv {
 	return &ConvertPrometheusSrv{
 		cfg:              cfg,
 		logger:           logger,
-		ruleStore:        ruleStore,
+		folderService:    folderService,
 		datasourceCache:  datasourceCache,
 		alertRuleService: alertRuleService,
 	}
@@ -119,7 +134,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetRules(c *contextmodel.
 	workingFolderUID := getWorkingFolderUID(c)
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
-	folders, err := srv.ruleStore.GetNamespaceChildren(c.Req.Context(), workingFolderUID, c.SignedInUser.GetOrgID(), c.SignedInUser)
+	folders, err := srv.folderService.GetNamespaceChildren(c.Req.Context(), workingFolderUID, c.SignedInUser.GetOrgID(), c.SignedInUser)
 	if len(folders) == 0 || errors.Is(err, dashboards.ErrFolderNotFound) {
 		// If there is no such folder or no children, return empty response
 		// because mimirtool expects 200 OK response in this case.
@@ -162,7 +177,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteNamespace(c *contex
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
-	namespace, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
+	namespace, err := srv.folderService.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
 		return namespaceErrorResponse(err)
 	}
@@ -192,7 +207,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteRuleGroup(c *contex
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
-	folder, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
+	folder, err := srv.folderService.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
 		return namespaceErrorResponse(err)
 	}
@@ -219,7 +234,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetNamespace(c *contextmo
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
-	namespace, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
+	namespace, err := srv.folderService.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
 		logger.Error("Failed to get folder", "error", err)
 		return namespaceErrorResponse(err)
@@ -253,7 +268,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetRuleGroup(c *contextmo
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
-	namespace, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
+	namespace, err := srv.folderService.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
 		logger.Error("Failed to get folder", "error", err)
 		return namespaceErrorResponse(err)
@@ -303,11 +318,6 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroup(c *contextm
 
 	logger.Info("Converting Prometheus rule group", "rules", len(promGroup.Rules))
 
-	ns, errResp := srv.getOrCreateNamespace(c, namespaceTitle, logger, workingFolderUID)
-	if errResp != nil {
-		return errResp
-	}
-
 	datasourceUID := strings.TrimSpace(c.Req.Header.Get(datasourceUIDHeader))
 	if datasourceUID == "" {
 		return response.Err(errDatasourceUIDHeaderMissing)
@@ -316,6 +326,11 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroup(c *contextm
 	if err != nil {
 		logger.Error("Failed to get datasource", "datasource_uid", datasourceUID, "error", err)
 		return errorToResponse(err)
+	}
+
+	ns, errResp := srv.getOrCreateNamespace(c, namespaceTitle, logger, workingFolderUID)
+	if errResp != nil {
+		return errResp
 	}
 
 	group, err := srv.convertToGrafanaRuleGroup(c, ds, ns.UID, promGroup, logger)
@@ -336,7 +351,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroup(c *contextm
 func (srv *ConvertPrometheusSrv) getOrCreateNamespace(c *contextmodel.ReqContext, title string, logger log.Logger, workingFolderUID string) (*folder.Folder, response.Response) {
 	logger.Debug("Getting or creating a new folder")
 
-	ns, err := srv.ruleStore.GetOrCreateNamespaceByTitle(
+	ns, err := srv.folderService.GetOrCreateNamespaceByTitle(
 		c.Req.Context(),
 		title,
 		c.SignedInUser.GetOrgID(),

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -15,10 +15,6 @@ type RuleStore interface {
 	// by returning map[string]struct{} instead of map[string]*folder.Folder
 	GetUserVisibleNamespaces(context.Context, int64, identity.Requester) (map[string]*folder.Folder, error)
 	GetNamespaceByUID(ctx context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error)
-	GetNamespaceByTitle(ctx context.Context, fullpath string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
-	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
-	// GetNamespaceChildren returns all children (first level) of the namespace with the given id.
-	GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error)
 
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmodels.GetAlertRulesGroupByRuleUIDQuery) ([]*ngmodels.AlertRule, error)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations"
@@ -80,6 +81,7 @@ func ProvideService(
 	httpClientProvider httpclient.Provider,
 	resourcePermissions accesscontrol.ReceiverPermissionsService,
 	userService user.Service,
+	serverLockService *serverlock.ServerLockService,
 ) (*AlertNG, error) {
 	ng := &AlertNG{
 		Cfg:                  cfg,
@@ -109,6 +111,7 @@ func ProvideService(
 		httpClientProvider:   httpClientProvider,
 		ResourcePermissions:  resourcePermissions,
 		userService:          userService,
+		serverLockService:    serverLockService,
 	}
 
 	if ng.IsDisabled() {
@@ -161,9 +164,10 @@ type AlertNG struct {
 	store                *store.DBstore
 	userService          user.Service
 
-	bus          bus.Bus
-	pluginsStore pluginstore.Store
-	tracer       tracing.Tracer
+	bus               bus.Bus
+	pluginsStore      pluginstore.Store
+	tracer            tracing.Tracer
+	serverLockService *serverlock.ServerLockService
 }
 
 func (ng *AlertNG) init() error {
@@ -406,6 +410,8 @@ func (ng *AlertNG) init() error {
 		return err
 	}
 
+	alertingFolderService := store.NewAlertingFolderService(ng.folderService, ng.Log, ng.serverLockService)
+
 	ng.InstanceStore, ng.StartupInstanceReader = initInstanceStore(ng.store.SQLStore, ng.Log, ng.FeatureToggles)
 
 	stateManagerCfg := state.ManagerCfg{
@@ -472,36 +478,37 @@ func (ng *AlertNG) init() error {
 		ac.NewRuleService(ng.accesscontrol))
 
 	ng.Api = &api.API{
-		Cfg:                  ng.Cfg,
-		DatasourceCache:      ng.DataSourceCache,
-		DatasourceService:    ng.DataSourceService,
-		RouteRegister:        ng.RouteRegister,
-		DataProxy:            ng.DataProxy,
-		QuotaService:         ng.QuotaService,
-		TransactionManager:   ng.store,
-		RuleStore:            ng.store,
-		AlertingStore:        ng.store,
-		AdminConfigStore:     ng.store,
-		ProvenanceStore:      ng.store,
-		MultiOrgAlertmanager: ng.MultiOrgAlertmanager,
-		StateManager:         ng.stateManager,
-		Scheduler:            scheduler,
-		AccessControl:        ng.accesscontrol,
-		Policies:             policyService,
-		ReceiverService:      receiverService,
-		ContactPointService:  contactPointService,
-		Templates:            templateService,
-		MuteTimings:          muteTimingService,
-		AlertRules:           alertRuleService,
-		AlertsRouter:         alertsRouter,
-		EvaluatorFactory:     evalFactory,
-		ConditionValidator:   conditionValidator,
-		FeatureManager:       ng.FeatureToggles,
-		AppUrl:               appUrl,
-		Historian:            history,
-		Hooks:                api.NewHooks(ng.Log),
-		Tracer:               ng.tracer,
-		UserService:          ng.userService,
+		Cfg:                   ng.Cfg,
+		DatasourceCache:       ng.DataSourceCache,
+		DatasourceService:     ng.DataSourceService,
+		RouteRegister:         ng.RouteRegister,
+		DataProxy:             ng.DataProxy,
+		QuotaService:          ng.QuotaService,
+		TransactionManager:    ng.store,
+		RuleStore:             ng.store,
+		AlertingStore:         ng.store,
+		AdminConfigStore:      ng.store,
+		ProvenanceStore:       ng.store,
+		MultiOrgAlertmanager:  ng.MultiOrgAlertmanager,
+		StateManager:          ng.stateManager,
+		Scheduler:             scheduler,
+		AccessControl:         ng.accesscontrol,
+		Policies:              policyService,
+		ReceiverService:       receiverService,
+		ContactPointService:   contactPointService,
+		Templates:             templateService,
+		MuteTimings:           muteTimingService,
+		AlertRules:            alertRuleService,
+		AlertsRouter:          alertsRouter,
+		EvaluatorFactory:      evalFactory,
+		ConditionValidator:    conditionValidator,
+		FeatureManager:        ng.FeatureToggles,
+		AppUrl:                appUrl,
+		Historian:             history,
+		Hooks:                 api.NewHooks(ng.Log),
+		Tracer:                ng.tracer,
+		UserService:           ng.userService,
+		AlertingFolderService: alertingFolderService,
 	}
 	ng.Api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -508,15 +508,15 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 
 	parentFolderUid := uuid.NewString()
 	parentFolderTitle := "Very Parent Folder"
-	createFolder(t, store, parentFolderUid, parentFolderTitle, rule1.OrgID, "")
+	createFolder(t, store.FolderService, parentFolderUid, parentFolderTitle, rule1.OrgID, "")
 	rule1FolderTitle := "folder-" + rule1.Title
 	rule2FolderTitle := "folder-" + rule2.Title
 	rule3FolderTitle := "folder-" + rule3.Title
-	createFolder(t, store, rule1.NamespaceUID, rule1FolderTitle, rule1.OrgID, parentFolderUid)
-	createFolder(t, store, rule2.NamespaceUID, rule2FolderTitle, rule2.OrgID, "")
-	createFolder(t, store, rule3.NamespaceUID, rule3FolderTitle, rule3.OrgID, "")
+	createFolder(t, store.FolderService, rule1.NamespaceUID, rule1FolderTitle, rule1.OrgID, parentFolderUid)
+	createFolder(t, store.FolderService, rule2.NamespaceUID, rule2FolderTitle, rule2.OrgID, "")
+	createFolder(t, store.FolderService, rule3.NamespaceUID, rule3FolderTitle, rule3.OrgID, "")
 
-	createFolder(t, store, rule2.NamespaceUID, "same UID folder", gen.GenerateRef().OrgID, "") // create a folder with the same UID but in the different org
+	createFolder(t, store.FolderService, rule2.NamespaceUID, "same UID folder", gen.GenerateRef().OrgID, "") // create a folder with the same UID but in the different org
 
 	tc := []struct {
 		name         string
@@ -1739,7 +1739,7 @@ func createRule(t *testing.T, store *DBstore, generator *models.AlertRuleGenerat
 	return rule
 }
 
-func createFolder(t *testing.T, store *DBstore, uid, title string, orgID int64, parentUID string) {
+func createFolder(t *testing.T, folderService folder.Service, uid, title string, orgID int64, parentUID string) {
 	t.Helper()
 	u := &user.SignedInUser{
 		UserID:         1,
@@ -1748,7 +1748,7 @@ func createFolder(t *testing.T, store *DBstore, uid, title string, orgID int64, 
 		IsGrafanaAdmin: true,
 	}
 
-	_, err := store.FolderService.Create(context.Background(), &folder.CreateFolderCommand{
+	_, err := folderService.Create(context.Background(), &folder.CreateFolderCommand{
 		UID:          uid,
 		OrgID:        orgID,
 		Title:        title,

--- a/pkg/services/ngalert/store/namespace.go
+++ b/pkg/services/ngalert/store/namespace.go
@@ -3,11 +3,28 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"hash/fnv"
 	"sort"
+	"time"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+)
+
+const (
+	// folderOperationTimeout is the timeout for individual folder operations (get or create)
+	// in the GetOrCreateNamespaceByTitle method. The lock timeout is longer to accommodate
+	// both operations.
+	folderOperationTimeout = 60 * time.Second
+
+	// getOrCreateFolderMaxRetries is the maximum number of retries allowed when
+	// trying to acquire a lock for folder creation. After this many failed attempts,
+	// the operation will fail with a "max retries exceeded" error.
+	getOrCreateFolderMaxRetries = 10
 )
 
 // GetUserVisibleNamespaces returns the folders that are visible to the user
@@ -40,14 +57,34 @@ func (st DBstore) GetNamespaceByUID(ctx context.Context, uid string, orgID int64
 	return f[0], nil
 }
 
+// ServerLockService defines the interface for distributed locking functionality
+type ServerLockService interface {
+	// LockExecuteAndReleaseWithRetries acquires a lock, executes a function, and releases the lock with retries
+	LockExecuteAndReleaseWithRetries(ctx context.Context, actionName string, timeConfig serverlock.LockTimeConfig, fn func(ctx context.Context), retryOpts ...serverlock.RetryOpt) error
+}
+
+type AlertingFolderService struct {
+	FolderService     folder.Service
+	Logger            log.Logger
+	ServerLockService ServerLockService
+}
+
+func NewAlertingFolderService(fs folder.Service, logger log.Logger, serverLockService ServerLockService) *AlertingFolderService {
+	return &AlertingFolderService{
+		FolderService:     fs,
+		Logger:            logger,
+		ServerLockService: serverLockService,
+	}
+}
+
 // GetNamespaceChildren gets namespace (folder) children (first level) by its UID.
-func (st DBstore) GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error) {
+func (s AlertingFolderService) GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error) {
 	q := &folder.GetChildrenQuery{
 		UID:          uid,
 		OrgID:        orgID,
 		SignedInUser: user,
 	}
-	folders, err := st.FolderService.GetChildren(ctx, q)
+	folders, err := s.FolderService.GetChildren(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +100,8 @@ func (st DBstore) GetNamespaceChildren(ctx context.Context, uid string, orgID in
 }
 
 // GetNamespaceByTitle gets namespace by its title in the specified folder.
-func (st DBstore) GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
-	folders, err := st.GetNamespaceChildren(ctx, parentUID, orgID, user)
+func (s AlertingFolderService) GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	folders, err := s.GetNamespaceChildren(ctx, parentUID, orgID, user)
 	if err != nil {
 		return nil, err
 	}
@@ -88,28 +125,102 @@ func (st DBstore) GetNamespaceByTitle(ctx context.Context, title string, orgID i
 	return foundByTitle[0], nil
 }
 
-// GetOrCreateNamespaceByTitle gets or creates a namespace by title in the specified folder.
-func (st DBstore) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
-	var f *folder.Folder
-	var err error
+// GetOrCreateNamespaceByTitle retrieves a folder with the given title from the specified parent,
+// or creates it if it doesn't exist.
+//
+// This method uses locking to prevent race conditions when multiple
+// requests attempt to create the same folder simultaneously. The lock is based on
+// the combination of parent folder UID, title, and organization ID.
+func (s AlertingFolderService) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	logger := s.Logger.New("parentUID", parentUID, "title", title, "orgID", orgID)
 
-	f, err = st.GetNamespaceByTitle(ctx, title, orgID, user, parentUID)
-	if err != nil && !errors.Is(err, dashboards.ErrFolderNotFound) {
-		return nil, err
+	// Configure lock retry behavior
+	// Make sure the lock timeout (MaxInterval) is enough for both operations.
+	timeConfig := serverlock.LockTimeConfig{
+		MaxInterval: folderOperationTimeout*2 + 10*time.Second,
+		MinWait:     100 * time.Millisecond,
+		MaxWait:     1 * time.Second,
 	}
 
-	if f == nil {
-		cmd := &folder.CreateFolderCommand{
-			OrgID:        orgID,
-			Title:        title,
-			SignedInUser: user,
-			ParentUID:    parentUID,
+	var folder *folder.Folder
+	var folderErr error
+
+	retryLimiter := func(attempt int) error {
+		if attempt > getOrCreateFolderMaxRetries {
+			return errors.New("unable to lock: max retries exceeded")
 		}
-		f, err = st.FolderService.Create(ctx, cmd)
-		if err != nil {
-			return nil, err
-		}
+		return nil
 	}
 
-	return f, nil
+	// Execute the folder get/create operation with a lock
+	lockName, err := lockName(parentUID, title, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate lock name: %w", err)
+	}
+	logger.Debug("Acquiring lock for folder creation", "lockName", lockName)
+	errLock := s.ServerLockService.LockExecuteAndReleaseWithRetries(ctx, lockName, timeConfig, func(ctx context.Context) {
+		// Try to get the folder
+		logger.Debug("Trying to get existing folder")
+		folder, folderErr = s.getFolder(ctx, title, orgID, user, parentUID, folderOperationTimeout)
+		if folder != nil {
+			return
+		}
+		// If this is not the folder not found error, return
+		if !errors.Is(folderErr, dashboards.ErrFolderNotFound) {
+			return
+		}
+
+		// Folder doesn't exist, create a new one
+		logger.Debug("Folder not found, creating a new one")
+		folder, folderErr = s.createFolder(ctx, title, orgID, user, parentUID, folderOperationTimeout)
+	}, []serverlock.RetryOpt{retryLimiter}...)
+
+	// Handle lock acquisition failures
+	if errLock != nil {
+		logger.Error("Failed to acquire or execute with lock", "error", errLock)
+		return nil, fmt.Errorf("failed to acquire lock: %w", errLock)
+	}
+
+	// Handle folder operation errors
+	if folderErr != nil {
+		return nil, folderErr
+	}
+
+	if folder == nil {
+		// This should never happen if the code is correct
+		logger.Error("Both error and folder are nil after GetOrCreateNamespaceByTitle execution")
+		return nil, fmt.Errorf("unexpected error: could not get or create a folder")
+	}
+
+	return folder, nil
+}
+
+func (s AlertingFolderService) getFolder(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string, timeout time.Duration) (*folder.Folder, error) {
+	getCtx, getCancel := context.WithTimeout(ctx, timeout)
+	defer getCancel()
+	return s.GetNamespaceByTitle(getCtx, title, orgID, user, parentUID)
+}
+
+func (s AlertingFolderService) createFolder(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string, timeout time.Duration) (*folder.Folder, error) {
+	createCtx, createCancel := context.WithTimeout(ctx, timeout)
+	defer createCancel()
+
+	cmd := &folder.CreateFolderCommand{
+		OrgID:        orgID,
+		Title:        title,
+		SignedInUser: user,
+		ParentUID:    parentUID,
+	}
+
+	return s.FolderService.Create(createCtx, cmd)
+}
+
+func lockName(parentUID, title string, orgID int64) (string, error) {
+	h := fnv.New64a()
+	data := fmt.Sprintf("%s|%s|%d", parentUID, title, orgID)
+	_, err := h.Write([]byte(data))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("alerting-folder-create-%x", h.Sum64()), nil
 }

--- a/pkg/services/ngalert/tests/fakes/namespaces.go
+++ b/pkg/services/ngalert/tests/fakes/namespaces.go
@@ -1,0 +1,135 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type FakeAlertingFolderService struct {
+	t           *testing.T
+	mtx         sync.Mutex
+	Hook        func(cmd any) error // use Hook if you need to intercept some query and return an error
+	RecordedOps []any
+	Folders     map[int64][]*folder.Folder
+}
+
+func NewFakeAlertingFolderService(t *testing.T) *FakeAlertingFolderService {
+	return &FakeAlertingFolderService{
+		t: t,
+		Hook: func(any) error {
+			return nil
+		},
+		Folders: map[int64][]*folder.Folder{},
+	}
+}
+
+// GetRecordedCommands filters recorded commands using predicate function. Returns the subset of the recorded commands that meet the predicate
+func (f *FakeAlertingFolderService) GetRecordedCommands(predicate func(cmd any) (any, bool)) []any {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	result := make([]any, 0, len(f.RecordedOps))
+	for _, op := range f.RecordedOps {
+		cmd, ok := predicate(op)
+		if !ok {
+			continue
+		}
+		result = append(result, cmd)
+	}
+	return result
+}
+
+func (f *FakeAlertingFolderService) GetUserVisibleNamespaces(_ context.Context, orgID int64, _ identity.Requester) (map[string]*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	namespacesMap := map[string]*folder.Folder{}
+
+	for _, folder := range f.Folders[orgID] {
+		namespacesMap[folder.UID] = folder
+	}
+	return namespacesMap, nil
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceByUID(_ context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error) {
+	q := GenericRecordedQuery{
+		Name:   "GetNamespaceByUID",
+		Params: []any{orgID, uid, user},
+	}
+	defer func() {
+		f.RecordedOps = append(f.RecordedOps, q)
+	}()
+	err := f.Hook(q)
+	if err != nil {
+		return nil, err
+	}
+	folders := f.Folders[orgID]
+	for _, folder := range folders {
+		if folder.UID == uid {
+			return folder, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (f *FakeAlertingFolderService) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.Title == title && folder.ParentUID == parentUID {
+			return folder, nil
+		}
+	}
+
+	newFolder := &folder.Folder{
+		ID:        rand.Int63(), // nolint:staticcheck
+		UID:       util.GenerateShortUID(),
+		Title:     title,
+		ParentUID: parentUID,
+		Fullpath:  "fullpath_" + title,
+	}
+
+	f.Folders[orgID] = append(f.Folders[orgID], newFolder)
+	return newFolder, nil
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.Title == title && folder.ParentUID == parentUID {
+			return folder, nil
+		}
+	}
+
+	return nil, dashboards.ErrFolderNotFound
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	result := []*folder.Folder{}
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.ParentUID == uid {
+			result = append(result, folder)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, dashboards.ErrFolderNotFound
+	}
+
+	return result, nil
+}

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	pluginfakes "github.com/grafana/grafana/pkg/plugins/manager/fakes"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
@@ -516,7 +517,8 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	_, err = ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, ngalertfakes.NewFakeKVStore(t), nil, nil, quotaService,
 		secretsService, nil, m, &foldertest.FakeService{}, &acmock.Mock{}, &dashboards.FakeDashboardService{}, nil, b, &acmock.Mock{},
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(),
+		ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(), serverlock.ProvideService(sqlStore, tracer),
 	)
 	require.NoError(t, err)
 	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), cfg, quotaService, storesrv.ProvideSystemUsersService())


### PR DESCRIPTION
**What is this feature?**

This PR adds locking to prevent race conditions when multiple requests to Prometheus conversion API attempt to create the same alert rule folder simultaneously.

**Why do we need this feature?**

Currently, simultaneous calls to GetOrCreateNamespaceByTitle with the same folder name can result in two different folders because both calls can try to find an existing namespace, but they don't find it and then create two new ones.

**Special notes for your reviewer:**

I also moved folder methods used by the conversion API to a separate structure. I think it makes sense to move the remaining methods, too, instead of keeping them in the DBstore, but it requires much more refactoring of other parts of the code, I'll do it in a future PR. 

To avoid the lock becoming stale while the enclosed operations are still running, I added a hardcoded timeout for folder search and creation operations.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
