### PR TITLE
Add Github Action to run analytics report

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -819,6 +819,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/actions/changelog @zserge
 /.github/workflows/frontend-unit-tests.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform
+/.github/workflows/analytics-events-report.yml @grafana/grafana-frontend-platform
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/analytics-events-report.yml
+++ b/.github/workflows/analytics-events-report.yml
@@ -1,0 +1,23 @@
+name: Analytics Events Report
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate analytics report
+        run: yarn analytics-report


### PR DESCRIPTION
This PR adds a new Github Action for a script we're developing in https://github.com/grafana/grafana/pull/101697. This won't yet be able to run in `main` branch, but it needs to be merged in order to run it from our feature branch.