### PR TITLE
SQL Expressions: Add cell-limit for input dataframes

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2753,6 +2753,10 @@ Set the default start of the week, valid values are: `saturday`, `sunday`, `mond
 
 Set this to `false` to disable expressions and hide them in the Grafana UI. Default is `true`.
 
+#### `sql_expression_row_limit`
+
+Set the maximum number of rows that can be passed to a SQL expression. Default is `20000`.
+
 ### `[geomap]`
 
 This section controls the defaults settings for **Geomap Plugin**.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2753,9 +2753,9 @@ Set the default start of the week, valid values are: `saturday`, `sunday`, `mond
 
 Set this to `false` to disable expressions and hide them in the Grafana UI. Default is `true`.
 
-#### `sql_expression_row_limit`
+#### `sql_expression_cell_limit`
 
-Set the maximum number of rows that can be passed to a SQL expression. Default is `20000`.
+Set the maximum number of cells that can be passed to a SQL expression. Default is `100000`.
 
 ### `[geomap]`
 

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -277,7 +277,7 @@ func (s *Service) buildGraph(req *Request) (*simple.DirectedGraph, error) {
 		case TypeDatasourceNode:
 			node, err = s.buildDSNode(dp, rn, req)
 		case TypeCMDNode:
-			node, err = buildCMDNode(rn, s.features)
+			node, err = buildCMDNode(rn, s.features, s.cfg.SQLExpressionCellLimit)
 		case TypeMLNode:
 			if s.features.IsEnabledGlobally(featuremgmt.FlagMlExpressions) {
 				node, err = s.buildMLNode(dp, rn, req)

--- a/pkg/expr/graph_test.go
+++ b/pkg/expr/graph_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestServicebuildPipeLine(t *testing.T) {
@@ -234,6 +235,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 	}
 	s := Service{
 		features: featuremgmt.WithFeatures(featuremgmt.FlagExpressionParser),
+		cfg:      setting.NewCfg(),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -103,6 +103,10 @@ func (gn *CMDNode) NeedsVars() []string {
 // other nodes they must have already been executed and their results must
 // already by in vars.
 func (gn *CMDNode) Execute(ctx context.Context, now time.Time, vars mathexp.Vars, s *Service) (mathexp.Results, error) {
+	// If this is a SQL command, pass the row limit from service config
+	if sqlCmd, ok := gn.Command.(*SQLCommand); ok {
+		sqlCmd.limit = s.cfg.SQLExpressionRowLimit
+	}
 	return gn.Command.Execute(ctx, now, vars, s.tracer)
 }
 
@@ -443,6 +447,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		result.Values = mathexp.Values{
 			mathexp.TableData{Frame: dataFrames[0]},
 		}
+
 		return result, nil
 	}
 

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -447,7 +447,6 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		result.Values = mathexp.Values{
 			mathexp.TableData{Frame: dataFrames[0]},
 		}
-
 		return result, nil
 	}
 

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -103,9 +103,9 @@ func (gn *CMDNode) NeedsVars() []string {
 // other nodes they must have already been executed and their results must
 // already by in vars.
 func (gn *CMDNode) Execute(ctx context.Context, now time.Time, vars mathexp.Vars, s *Service) (mathexp.Results, error) {
-	// If this is a SQL command, pass the row limit from service config
+	// If this is a SQL command, pass the cell limit from service config
 	if sqlCmd, ok := gn.Command.(*SQLCommand); ok {
-		sqlCmd.limit = s.cfg.SQLExpressionRowLimit
+		sqlCmd.limit = s.cfg.SQLExpressionCellLimit
 	}
 	return gn.Command.Execute(ctx, now, vars, s.tracer)
 }

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 type expectedError struct{}
@@ -164,56 +162,6 @@ func TestCheckIfSeriesNeedToBeFixed(t *testing.T) {
 					require.Equal(t, tc.expectedName, getLabelName(fixer))
 				}
 			}
-		})
-	}
-}
-
-func TestCMDNodeExecute_SQLCellLimitFromConfig(t *testing.T) {
-	tests := []struct {
-		name            string
-		configCellLimit int64
-		wantCellLimit   int64
-	}{
-		{
-			name:            "should set SQL command cell limit from service config",
-			configCellLimit: 42,
-			wantCellLimit:   42,
-		},
-		{
-			name:            "should set SQL command cell limit to 0 when config is 0",
-			configCellLimit: 0,
-			wantCellLimit:   0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewSQLCommand("B", "SELECT 1")
-			require.NoError(t, err)
-
-			node := &CMDNode{
-				baseNode: baseNode{
-					id:    1,
-					refID: "B",
-				},
-				CMDType: TypeSQL,
-				Command: cmd,
-			}
-
-			svc := &Service{
-				cfg: &setting.Cfg{
-					SQLExpressionCellLimit: tt.configCellLimit,
-				},
-				tracer: &testTracer{},
-			}
-
-			// Execute node to trigger the cell limit configuration
-			_, err = node.Execute(context.Background(), time.Now(), mathexp.Vars{}, svc)
-			require.NoError(t, err)
-
-			// Verify the SQL command received the correct cell limit from config
-			sqlCmd := node.Command.(*SQLCommand)
-			require.Equal(t, tt.wantCellLimit, sqlCmd.limit)
 		})
 	}
 }

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -168,21 +168,21 @@ func TestCheckIfSeriesNeedToBeFixed(t *testing.T) {
 	}
 }
 
-func TestCMDNodeExecute_SQLRowLimitFromConfig(t *testing.T) {
+func TestCMDNodeExecute_SQLCellLimitFromConfig(t *testing.T) {
 	tests := []struct {
-		name           string
-		configRowLimit int64
-		wantRowLimit   int64
+		name            string
+		configCellLimit int64
+		wantCellLimit   int64
 	}{
 		{
-			name:           "should set SQL command row limit from service config",
-			configRowLimit: 42,
-			wantRowLimit:   42,
+			name:            "should set SQL command cell limit from service config",
+			configCellLimit: 42,
+			wantCellLimit:   42,
 		},
 		{
-			name:           "should set SQL command row limit to 0 when config is 0",
-			configRowLimit: 0,
-			wantRowLimit:   0,
+			name:            "should set SQL command cell limit to 0 when config is 0",
+			configCellLimit: 0,
+			wantCellLimit:   0,
 		},
 	}
 
@@ -202,18 +202,18 @@ func TestCMDNodeExecute_SQLRowLimitFromConfig(t *testing.T) {
 
 			svc := &Service{
 				cfg: &setting.Cfg{
-					SQLExpressionRowLimit: tt.configRowLimit,
+					SQLExpressionCellLimit: tt.configCellLimit,
 				},
 				tracer: &testTracer{},
 			}
 
-			// Execute node to trigger the row limit configuration
+			// Execute node to trigger the cell limit configuration
 			_, err = node.Execute(context.Background(), time.Now(), mathexp.Vars{}, svc)
 			require.NoError(t, err)
 
-			// Verify the SQL command received the correct row limit from config
+			// Verify the SQL command received the correct cell limit from config
 			sqlCmd := node.Command.(*SQLCommand)
-			require.Equal(t, tt.wantRowLimit, sqlCmd.limit)
+			require.Equal(t, tt.wantCellLimit, sqlCmd.limit)
 		})
 	}
 }

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -134,8 +134,9 @@ func (h *ExpressionQueryReader) ReadQuery(
 		err = iter.ReadVal(q)
 		if err == nil {
 			eq.Properties = q
-			// TODO: implement limit in MT DS Querier, and when `expressionParser` flag is enabled
-			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, 0)
+			// TODO: Cascade limit from Grafana config in this (new Expression Parser) branch of the code
+			cellLimit := 0 // zero means no limit
+			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, int64(cellLimit))
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -134,7 +134,8 @@ func (h *ExpressionQueryReader) ReadQuery(
 		err = iter.ReadVal(q)
 		if err == nil {
 			eq.Properties = q
-			eq.Command, err = NewSQLCommand(common.RefID, q.Expression)
+			// TODO: implement limit in MT DS Querier, and when `expressionParser` flag is enabled
+			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, 0)
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -42,12 +42,10 @@ func NewSQLCommand(refID, rawSQL string) (*SQLCommand, error) {
 		logger.Debug("REF tables", "tables", tables, "sql", rawSQL)
 	}
 
-	defaultLimit := int64(20)
 	return &SQLCommand{
 		query:       rawSQL,
 		varsToQuery: tables,
 		refID:       refID,
-		limit:       defaultLimit,
 	}, nil
 }
 

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -93,14 +93,14 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 		allFrames = append(allFrames, frames...)
 	}
 
-	totalRows := totalRows(allFrames)
+	totalCells := totalCells(allFrames)
 	// limit of 0 or less means no limit (following convention)
-	if gr.limit > 0 && totalRows > gr.limit {
+	if gr.limit > 0 && totalCells > gr.limit {
 		return mathexp.Results{},
 			fmt.Errorf(
-				"SQL expression: total row count across all input tables exceeds limit of %d. Total rows: %d",
+				"SQL expression: total cell count across all input tables exceeds limit of %d. Total cells: %d",
 				gr.limit,
-				totalRows,
+				totalCells,
 			)
 	}
 
@@ -135,12 +135,15 @@ func (gr *SQLCommand) Type() string {
 	return TypeSQL.String()
 }
 
-func totalRows(frames []*data.Frame) int64 {
-	total := 0
+func totalCells(frames []*data.Frame) int64 {
+	total := int64(0)
 	for _, frame := range frames {
 		if frame != nil {
-			total += frame.Rows()
+			// Calculate cells as rows × columns
+			rows := int64(frame.Rows())
+			cols := int64(len(frame.Fields))
+			total += rows * cols
 		}
 	}
-	return int64(total)
+	return total
 }

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -135,8 +135,7 @@ func (gr *SQLCommand) Type() string {
 	return TypeSQL.String()
 }
 
-func totalCells(frames []*data.Frame) int64 {
-	total := int64(0)
+func totalCells(frames []*data.Frame) (total int64) {
 	for _, frame := range frames {
 		if frame != nil {
 			// Calculate cells as rows × columns
@@ -145,5 +144,5 @@ func totalCells(frames []*data.Frame) int64 {
 			total += rows * cols
 		}
 	}
-	return total
+	return
 }

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -23,7 +23,7 @@ type SQLCommand struct {
 }
 
 // NewSQLCommand creates a new SQLCommand.
-func NewSQLCommand(refID, rawSQL string) (*SQLCommand, error) {
+func NewSQLCommand(refID, rawSQL string, limit int64) (*SQLCommand, error) {
 	if rawSQL == "" {
 		return nil, errutil.BadRequest("sql-missing-query",
 			errutil.WithPublicMessage("missing SQL query"))
@@ -46,11 +46,12 @@ func NewSQLCommand(refID, rawSQL string) (*SQLCommand, error) {
 		query:       rawSQL,
 		varsToQuery: tables,
 		refID:       refID,
+		limit:       limit,
 	}, nil
 }
 
 // UnmarshalSQLCommand creates a SQLCommand from Grafana's frontend query.
-func UnmarshalSQLCommand(rn *rawNode) (*SQLCommand, error) {
+func UnmarshalSQLCommand(rn *rawNode, limit int64) (*SQLCommand, error) {
 	if rn.TimeRange == nil {
 		logger.Error("time range must be specified for refID", "refID", rn.RefID)
 		return nil, fmt.Errorf("time range must be specified for refID %s", rn.RefID)
@@ -67,7 +68,7 @@ func UnmarshalSQLCommand(rn *rawNode) (*SQLCommand, error) {
 		return nil, fmt.Errorf("expected sql expression to be type string, but got type %T", expressionRaw)
 	}
 
-	return NewSQLCommand(rn.RefID, expression)
+	return NewSQLCommand(rn.RefID, expression, limit)
 }
 
 // NeedsVars returns the variable names (refIds) that are dependencies

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -96,7 +96,8 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 	}
 
 	totalRows := totalRows(allFrames)
-	if totalRows > gr.limit {
+	// limit of 0 or less means no limit (following convention)
+	if gr.limit > 0 && totalRows > gr.limit {
 		return mathexp.Results{},
 			fmt.Errorf(
 				"SQL expression: total row count across all input tables exceeds limit of %d. Total rows: %d",

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -1,12 +1,18 @@
 package expr
 
 import (
+	"context"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewCommand(t *testing.T) {
-	t.Skip()
 	cmd, err := NewSQLCommand("a", "select a from foo, bar")
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
@@ -24,4 +30,116 @@ func TestNewCommand(t *testing.T) {
 		t.Fail()
 		return
 	}
+}
+
+func TestExecuteWithinLimit(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	if err != nil {
+		t.Fatalf("Failed to create SQL command: %v", err)
+	}
+	cmd.limit = 2
+
+	frame := data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))
+	vars := mathexp.Vars{}
+	vars["foo"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame}},
+	}
+
+	_, err = cmd.Execute(context.Background(), time.Now(), vars, &testTracer{})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+func TestExecuteWithinLimitWithMultipleFrames(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	if err != nil {
+		t.Fatalf("Failed to create SQL command: %v", err)
+	}
+	cmd.limit = 4
+
+	frame1 := data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))
+	frame2 := data.NewFrame("b", data.NewField("a", nil, []string{"3", "4"}))
+	vars := mathexp.Vars{}
+	vars["foo"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame1}},
+	}
+	vars["bar"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame2}},
+	}
+
+	_, err = cmd.Execute(context.Background(), time.Now(), vars, &testTracer{})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+}
+
+func TestExecuteExceedsLimit(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	if err != nil {
+		t.Fatalf("Failed to create SQL command: %v", err)
+	}
+	cmd.limit = 1
+
+	frame := data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))
+	vars := mathexp.Vars{}
+	vars["foo"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame}},
+	}
+
+	_, err = cmd.Execute(context.Background(), time.Now(), vars, &testTracer{})
+	if err == nil {
+		t.Fatal("Expected an error when total rows exceeds limit, but got nil")
+	}
+
+	expectedErrMsg := "exceeds limit"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Fatalf("Expected error message to contain '%s', got: '%s'", expectedErrMsg, err.Error())
+	}
+}
+
+func TestExecuteExceedsLimitWithMultipleFrames(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	if err != nil {
+		t.Fatalf("Failed to create SQL command: %v", err)
+	}
+	cmd.limit = 3
+
+	frame1 := data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))
+	frame2 := data.NewFrame("b", data.NewField("a", nil, []string{"3", "4"}))
+	vars := mathexp.Vars{}
+	vars["foo"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame1}},
+	}
+	vars["bar"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame2}},
+	}
+
+	_, err = cmd.Execute(context.Background(), time.Now(), vars, &testTracer{})
+	if err == nil {
+		t.Fatal("Expected an error when total rows exceeds limit, but got nil")
+	}
+
+	expectedErrMsg := "exceeds limit"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Fatalf("Expected error message to contain '%s', got: '%s'", expectedErrMsg, err.Error())
+	}
+}
+
+type testTracer struct {
+	trace.Tracer
+}
+
+func (t *testTracer) Start(ctx context.Context, name string, s ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return ctx, &testSpan{}
+}
+func (t *testTracer) Inject(context.Context, http.Header, trace.Span) {
+
+}
+
+type testSpan struct {
+	trace.Span
+}
+
+func (ts *testSpan) End(opt ...trace.SpanEndOption) {
 }

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -71,6 +71,15 @@ func TestSQLCommandRowLimits(t *testing.T) {
 			expectError:   true,
 			errorContains: "exceeds limit",
 		},
+		{
+			name:  "limit of 0 means no limit: allow multiple large frames",
+			limit: 0,
+			frames: []*data.Frame{
+				createFrameWithRows(100000),
+				createFrameWithRows(100000),
+			},
+			vars: []string{"foo", "bar"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -43,12 +43,6 @@ func TestSQLCommandRowLimits(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name:   "single frame within limit",
-			limit:  2,
-			frames: []*data.Frame{data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))},
-			vars:   []string{"foo"},
-		},
-		{
 			name:  "multiple frames within limit",
 			limit: 4,
 			frames: []*data.Frame{
@@ -56,14 +50,6 @@ func TestSQLCommandRowLimits(t *testing.T) {
 				data.NewFrame("b", data.NewField("a", nil, []string{"3", "4"})),
 			},
 			vars: []string{"foo", "bar"},
-		},
-		{
-			name:          "single frame exceeds limit",
-			limit:         1,
-			frames:        []*data.Frame{data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"}))},
-			vars:          []string{"foo"},
-			expectError:   true,
-			errorContains: "exceeds limit",
 		},
 		{
 			name:  "multiple frames exceed limit",

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -33,6 +33,15 @@ func TestNewCommand(t *testing.T) {
 	}
 }
 
+// Helper functions for creating test data
+func createFrameWithRows(rows int) *data.Frame {
+	values := make([]string, rows)
+	for i := range values {
+		values[i] = "dummy"
+	}
+	return data.NewFrame("dummy", data.NewField("dummy", nil, values))
+}
+
 func TestSQLCommandRowLimits(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -46,8 +55,8 @@ func TestSQLCommandRowLimits(t *testing.T) {
 			name:  "multiple frames within limit",
 			limit: 4,
 			frames: []*data.Frame{
-				data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"})),
-				data.NewFrame("b", data.NewField("a", nil, []string{"3", "4"})),
+				createFrameWithRows(2),
+				createFrameWithRows(2),
 			},
 			vars: []string{"foo", "bar"},
 		},
@@ -55,8 +64,8 @@ func TestSQLCommandRowLimits(t *testing.T) {
 			name:  "multiple frames exceed limit",
 			limit: 3,
 			frames: []*data.Frame{
-				data.NewFrame("a", data.NewField("a", nil, []string{"1", "2"})),
-				data.NewFrame("b", data.NewField("a", nil, []string{"3", "4"})),
+				createFrameWithRows(2),
+				createFrameWithRows(2),
 			},
 			vars:          []string{"foo", "bar"},
 			expectError:   true,

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
-	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", 0)
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
 	}
@@ -123,10 +123,9 @@ func TestSQLCommandCellLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewSQLCommand("a", "select a from foo, bar")
+			cmd, err := NewSQLCommand("a", "select a from foo, bar", tt.limit)
 			require.NoError(t, err, "Failed to create SQL command")
 
-			cmd.limit = tt.limit
 			vars := mathexp.Vars{}
 
 			for i, frame := range tt.frames {

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -40,9 +40,6 @@ func createFrameWithRowsAndCols(rows int, cols int) *data.Frame {
 
 	for c := 0; c < cols; c++ {
 		values := make([]string, rows)
-		for i := range values {
-			values[i] = "dummy"
-		}
 		frame.Fields = append(frame.Fields, data.NewField(fmt.Sprintf("col%d", c), nil, values))
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -419,6 +419,9 @@ type Cfg struct {
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
 
+	// SQLExpressionRowLimit is the maximum number of rows that can be accepted by a SQL expression.
+	SQLExpressionRowLimit int64
+
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -780,6 +783,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
+	cfg.SQLExpressionRowLimit = expressions.Key("sql_expression_row_limit").MustInt64(100000)
 }
 
 type AnnotationCleanupSettings struct {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -783,7 +783,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
-	cfg.SQLExpressionRowLimit = expressions.Key("sql_expression_row_limit").MustInt64(100000)
+	cfg.SQLExpressionRowLimit = expressions.Key("sql_expression_row_limit").MustInt64(20000)
 }
 
 type AnnotationCleanupSettings struct {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -419,8 +419,8 @@ type Cfg struct {
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
 
-	// SQLExpressionRowLimit is the maximum number of rows that can be accepted by a SQL expression.
-	SQLExpressionRowLimit int64
+	// SQLExpressionCellLimit is the maximum number of cells (rows × columns, across all frames) that can be accepted by a SQL expression.
+	SQLExpressionCellLimit int64
 
 	ImageUploadProvider string
 
@@ -783,7 +783,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
-	cfg.SQLExpressionRowLimit = expressions.Key("sql_expression_row_limit").MustInt64(20000)
+	cfg.SQLExpressionCellLimit = expressions.Key("sql_expression_cell_limit").MustInt64(100000)
 }
 
 type AnnotationCleanupSettings struct {


### PR DESCRIPTION
Replaces https://github.com/grafana/grafana/pull/89252 but takes a similar approach.

A few differences from that previous PR:
- Only makes one `if` check, on the sum total of rows (doesn't try to "fail early")
- Tests the behaviour more completely (should I refactor the tests to be shorter?)
- Doesn't add the `engine` interface or inject any dependency in tests
- Limit Cells, not rows

**What is this feature?**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7ff054d9-b012-446d-9816-efcf71538f8c" />


Adds a cell-limit to SQL Expressions. This can be configured from the Grafana config file.

**Why do we need this feature?**

Once SQL Expressions is widely available it will be easy for people to filter data within Grafana itself, rather than in the original datasource via the original DS queries they are writing. We want to discourage this, because filtering in Grafana will mean loading much more data into the Grafana instance, which in turn will increase our costs and hurt our reliability - we may see more OOM kills for example.

So we put a limit on the number of cells you can pass to SQL Expressions in order to discourage people from using it in this way.

**Which issue does this fix?**

Not a fix, but part of https://github.com/grafana/grafana-enterprise/issues/7054

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.