### PR TITLE
Alerting: Refactor NewPrometheusWriter function.

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -758,7 +758,7 @@ func createRecordingWriter(featureToggles featuremgmt.FeatureToggles, settings s
 	logger := log.New("ngalert.writer")
 
 	if settings.Enabled {
-		return writer.NewPrometheusWriter(settings, httpClientProvider, clock, logger, m)
+		return writer.NewPrometheusWriterWithSettings(settings, httpClientProvider, clock, logger, m)
 	}
 
 	return writer.NoopWriter{}, nil

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -546,7 +546,7 @@ func withQueryForHealth(health string) models.AlertRuleMutator {
 func setupWriter(t *testing.T, target *writer.TestRemoteWriteTarget, reg prometheus.Registerer) *writer.PrometheusWriter {
 	provider := testClientProvider{}
 	m := metrics.NewNGAlert(reg)
-	wr, err := writer.NewPrometheusWriter(target.ClientSettings(), provider, clock.NewMock(), log.NewNopLogger(), m.GetRemoteWriterMetrics())
+	wr, err := writer.NewPrometheusWriterWithSettings(target.ClientSettings(), provider, clock.NewMock(), log.NewNopLogger(), m.GetRemoteWriterMetrics())
 	require.NoError(t, err)
 	return wr
 }

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -161,7 +161,6 @@ func NewPrometheusWriter(
 	l log.Logger,
 	metrics *metrics.RemoteWriter,
 ) (*PrometheusWriter, error) {
-
 	cl, err := httpClientProvider.New(cfg.HTTPOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -120,7 +120,13 @@ type PrometheusWriter struct {
 	metrics *metrics.RemoteWriter
 }
 
-func NewPrometheusWriter(
+type PrometheusWriterConfig struct {
+	URL         string
+	HTTPOptions httpclient.Options
+	Timeout     time.Duration
+}
+
+func NewPrometheusWriterWithSettings(
 	settings setting.RecordingRuleSettings,
 	httpClientProvider HttpClientProvider,
 	clock clock.Clock,
@@ -136,18 +142,35 @@ func NewPrometheusWriter(
 		headers.Add(k, v)
 	}
 
-	cl, err := httpClientProvider.New(httpclient.Options{
-		BasicAuth: createAuthOpts(settings.BasicAuthUsername, settings.BasicAuthPassword),
-		Header:    headers,
-	})
+	cfg := PrometheusWriterConfig{
+		URL: settings.URL,
+		HTTPOptions: httpclient.Options{
+			BasicAuth: createAuthOpts(settings.BasicAuthUsername, settings.BasicAuthPassword),
+			Header:    headers,
+		},
+		Timeout: settings.Timeout,
+	}
+
+	return NewPrometheusWriter(cfg, httpClientProvider, clock, l, metrics)
+}
+
+func NewPrometheusWriter(
+	cfg PrometheusWriterConfig,
+	httpClientProvider HttpClientProvider,
+	clock clock.Clock,
+	l log.Logger,
+	metrics *metrics.RemoteWriter,
+) (*PrometheusWriter, error) {
+
+	cl, err := httpClientProvider.New(cfg.HTTPOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	clientCfg := promremote.NewConfig(
 		promremote.UserAgent("grafana-recording-rule"),
-		promremote.WriteURLOption(settings.URL),
-		promremote.HTTPClientTimeoutOption(settings.Timeout),
+		promremote.WriteURLOption(cfg.URL),
+		promremote.HTTPClientTimeoutOption(cfg.Timeout),
 		promremote.HTTPClientOption(cl),
 	)
 


### PR DESCRIPTION
In order to re-use PrometheusWriter, changing the function take a
PrometheusWriterConfig instead of RecordingRulesSettings, and adapt the old
interface onto the new interface.
