### PR TITLE
SQL Expressions: Simplify test code

### DIFF
--- a/pkg/expr/service_sql_test.go
+++ b/pkg/expr/service_sql_test.go
@@ -26,7 +26,7 @@ func TestSQLService(t *testing.T) {
 	}
 
 	newABSQLQueries := func(q string) []Query {
-		q, err := jsonEscape(q)
+		escaped, err := json.Marshal(q)
 		require.NoError(t, err)
 		return []Query{
 			{
@@ -45,7 +45,7 @@ func TestSQLService(t *testing.T) {
 			{
 				RefID:      "B",
 				DataSource: dataSourceModel(),
-				JSON:       json.RawMessage(fmt.Sprintf(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "sql", "expression": "%s" }`, q)),
+				JSON:       json.RawMessage(fmt.Sprintf(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "sql", "expression": %s }`, escaped)),
 				TimeRange: AbsoluteTimeRange{
 					From: time.Time{},
 					To:   time.Time{},
@@ -109,13 +109,4 @@ func TestSQLService(t *testing.T) {
 		require.Error(t, rsp.Responses["B"].Error, "should return sql error on parsing")
 		require.ErrorContains(t, rsp.Responses["B"].Error, "limit expression expected to be numeric")
 	})
-}
-
-func jsonEscape(input string) (string, error) {
-	escaped, err := json.Marshal(input)
-	if err != nil {
-		return "", err
-	}
-	// json.Marshal returns the escaped string with quotes, so we need to trim them
-	return string(escaped[1 : len(escaped)-1]), nil
 }


### PR DESCRIPTION
Simplify, by retaining quotes when escaping query

We also don't need to convert to string when passing to `fmt.Sprintf`
a slice of Bytes is accepted by Sprintf instead.
