### PR TITLE
Dashboards: Use same behavior for hiding the header for library panels as for normal panels

### DIFF
--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
@@ -164,9 +164,34 @@ describe('LibraryPanelBehavior', () => {
     expect(behaviorClone.state._loadedPanel?.name).toBe('LibraryPanel A');
     expect(behaviorClone.state._loadedPanel?.uid).toBe('111');
   });
+
+  it('should use library panel title and disable hover header when panel has no custom title', async () => {
+    const { scene, vizPanel } = constructSceneWithLibraryPanel();
+    vizPanel.setState({ title: undefined, hoverHeader: true });
+
+    activateFullSceneTree(scene);
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    const panel = sceneGraph.findByKey(scene, 'panel-1') as VizPanel;
+    expect(panel.state.title).toBe('LibraryPanel A title');
+    expect(panel.state.hoverHeader).toBe(false);
+  });
+
+  it('should preserve custom panel title when using library panel', async () => {
+    const { scene, vizPanel } = constructSceneWithLibraryPanel();
+    vizPanel.setState({ title: 'test123', hoverHeader: false });
+
+    activateFullSceneTree(scene);
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    const panel = sceneGraph.findByKey(scene, 'panel-1') as VizPanel;
+    expect(panel.state.title).toBe('test123');
+  });
 });
 
-async function buildTestSceneWithLibraryPanel() {
+function constructSceneWithLibraryPanel() {
   const behavior = new LibraryPanelBehavior({ name: 'LibraryPanel A', uid: '111' });
 
   const vizPanel = new VizPanel({
@@ -215,6 +240,11 @@ async function buildTestSceneWithLibraryPanel() {
       }),
     }),
   });
+  return { scene, gridItem, spy, behavior, vizPanel };
+}
+
+async function buildTestSceneWithLibraryPanel() {
+  const { scene, gridItem, spy, behavior } = constructSceneWithLibraryPanel();
 
   activateFullSceneTree(scene);
 

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -63,8 +63,12 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     );
     titleItems.push(new PanelNotices());
 
+    const timeOverrideShown = (libPanelModel.timeFrom || libPanelModel.timeShift) && !libPanelModel.hideTimeOverride;
+    const title = vizPanel.state.title ?? libPanelModel.title;
+
     const vizPanelState: VizPanelState = {
-      title: vizPanel.state.title ?? libPanelModel.title,
+      title,
+      hoverHeader: !title && !timeOverrideShown,
       options: libPanelModel.options ?? {},
       fieldConfig: libPanelModel.fieldConfig,
       pluginId: libPanelModel.type,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -324,7 +324,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
 
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(panel.id),
-    title: panel.title,
+    title: panel.title ?? '',
     description: panel.description,
     pluginId: panel.type ?? 'timeseries',
     options: panel.options ?? {},

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -128,7 +128,7 @@ export class UnthemedDashboardRow extends Component<DashboardRowProps> {
         {canEdit && (
           <div className={styles.actions}>
             <RowOptionsButton
-              title={this.props.panel.title}
+              title={this.props.panel.title ?? ''}
               repeat={this.props.panel.repeat}
               onUpdate={this.onUpdate}
               warning={this.getWarning()}

--- a/public/app/features/dashboard/components/GenAI/utils.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.ts
@@ -164,7 +164,7 @@ export function getPanelStrings(dashboard: DashboardModel): string[] {
   const panelStrings = dashboard.panels
     .filter(
       (panel) =>
-        (panel.title.length > 0 && panel.title !== NEW_PANEL_TITLE) ||
+        (panel.title && panel.title.length > 0 && panel.title !== NEW_PANEL_TITLE) ||
         (panel.description && panel.description.length > 0)
     )
     .map(getPanelString);

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -48,7 +48,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
   constructor(panel: PanelModel) {
     super({
       panel,
-      panelTitle: panel.replaceVariables(panel.title, undefined, 'text') || 'Panel',
+      panelTitle: panel.replaceVariables(panel.title ?? '', undefined, 'text') || 'Panel',
       currentTab: SnapshotTab.Support,
       showMessage: ShowMessage.GithubComment,
       snapshotText: '',

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -198,7 +198,7 @@ describe('OptionsPaneOptions', () => {
     const scenario = new OptionsPaneOptionsTestScenario();
     scenario.render();
 
-    const input = screen.getByDisplayValue(scenario.panel.title);
+    const input = screen.getByDisplayValue(scenario.panel.title ?? '');
     fireEvent.change(input, { target: { value: 'New' } });
     fireEvent.blur(input);
 

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -136,7 +136,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       if (!panelFilter) {
         layout.push(panelPos);
       } else {
-        if (panelFilter.test(panel.title)) {
+        if (panelFilter.test(panel.title ?? '')) {
           panelPos.isResizable = false;
           panelPos.isDraggable = false;
           panelPos.x = (count % 2) * GRID_COLUMN_COUNT;
@@ -242,7 +242,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       if (!panelFilter) {
         panelElements.push(p);
       } else {
-        if (panelFilter.test(panel.title)) {
+        if (panelFilter.test(panel.title ?? '')) {
           panelElements.push(p);
         }
       }

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuProvider.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuProvider.tsx
@@ -47,7 +47,7 @@ function createExtensionContext(panel: PanelModel, dashboard: DashboardModel): P
   return {
     id: panel.id,
     pluginId: panel.type,
-    title: panel.title,
+    title: panel.title ?? '',
     timeRange: dashboard.time,
     timeZone: getTimeZone({
       timeZone: dashboard.timezone,

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -526,7 +526,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
           <PanelComponent
             id={panel.id}
             data={data}
-            title={panel.title}
+            title={panel.title ?? ''}
             timeRange={timeRange}
             timeZone={this.props.dashboard.getTimezone()}
             options={panelOptions}
@@ -542,7 +542,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
             eventBus={dashboard.events}
           />
           {config.featureToggles.panelMonitoring && this.state.errorMessage === undefined && (
-            <PanelLoadTimeMonitor panelType={plugin.meta.id} panelId={panel.id} panelTitle={panel.title} />
+            <PanelLoadTimeMonitor panelType={plugin.meta.id} panelId={panel.id} panelTitle={panel.title ?? ''} />
           )}
         </PanelContextProvider>
       </>

--- a/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
+++ b/public/app/features/dashboard/dashgrid/panelOptionsLogger.ts
@@ -6,7 +6,7 @@ import { FIELD_CONFIG_CUSTOM_KEY, FIELD_CONFIG_OVERRIDES_KEY, PanelLogEvents } f
 interface PanelLogInfo {
   panelId: string;
   panelType: string;
-  panelTitle: string;
+  panelTitle?: string;
 }
 
 export class PanelOptionsLogger {
@@ -37,7 +37,7 @@ export class PanelOptionsLogger {
       key: newKey,
       newValue: newVal,
       oldValue: oldVal ?? '',
-      panelTitle: this.panelLogInfo.panelTitle,
+      panelTitle: this.panelLogInfo.panelTitle ?? '',
       panelId: this.panelLogInfo.panelId,
       panelType: this.panelLogInfo.panelType,
     };

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -130,7 +130,6 @@ const defaults: any = {
     defaults: {},
     overrides: [],
   },
-  title: '',
 };
 
 export const explicitlyControlledMigrationPanels = [
@@ -160,7 +159,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   id!: number;
   gridPos!: GridPos;
   type!: string;
-  title!: string;
+  title?: string;
   alert?: any;
   scopedVars?: ScopedVars;
   repeat?: string;
@@ -684,7 +683,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
    * If you need the raw title without interpolation use title property instead.
    * */
   getDisplayTitle(): string {
-    return this.replaceVariables(this.title, undefined, 'text');
+    return this.replaceVariables(this.title ?? '', undefined, 'text');
   }
 
   initLibraryPanel(libPanel: LibraryPanel) {

--- a/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
@@ -35,7 +35,7 @@ export const AddLibraryPanelContents = ({
   const { saveLibraryPanel } = usePanelSave();
 
   const onCreate = useCallback(() => {
-    panel.libraryPanel = { uid: '', name: panelName };
+    panel.libraryPanel = { uid: '', name: panelName ?? '' };
 
     saveLibraryPanel(panel, folderUid!).then((res: LibraryPanel | FetchError) => {
       if (!isFetchError(res)) {
@@ -49,7 +49,7 @@ export const AddLibraryPanelContents = ({
 
   const isValidName = useAsync(async () => {
     try {
-      return !(await getLibraryPanelByName(panelName)).some((lp) => lp.folderUid === folderUid);
+      return !(await getLibraryPanelByName(panelName ?? '')).some((lp) => lp.folderUid === folderUid);
     } catch (err) {
       if (isFetchError(err)) {
         err.isHandled = true;


### PR DESCRIPTION
**What is this feature?**

When a library panel has no title set in the dashboard we will use the title from the library panel. Unfortunately we have already set the hoverHeader to true because the placeholder panel didn't have a title. The hoverHeader is never updated after we load the library panel. This will keep the panel header hidden.
