### PR TITLE
SecretsService: load secure value status from db

### DIFF
--- a/pkg/apis/secret/v0alpha1/register.go
+++ b/pkg/apis/secret/v0alpha1/register.go
@@ -31,6 +31,7 @@ var SecureValuesResourceInfo = utils.NewResourceInfo(
 			{Name: "Title", Type: "string", Format: "string", Description: "The display name of the secure value"},
 			{Name: "Keeper", Type: "string", Format: "string", Description: "Storage of the secure value"},
 			{Name: "Ref", Type: "string", Format: "string", Description: "If present, the reference to a secret"},
+			{Name: "Status", Type: "string", Format: "string", Description: "The status of the secure value"},
 		},
 		// Decodes the object into a concrete type. Return order in the slice must be the same as in `Definition`.
 		Reader: func(obj any) ([]interface{}, error) {
@@ -41,6 +42,7 @@ var SecureValuesResourceInfo = utils.NewResourceInfo(
 					r.Spec.Title,
 					r.Spec.Keeper,
 					r.Spec.Ref,
+					r.Status.Phase,
 				}, nil
 			}
 

--- a/pkg/storage/secret/metadata/secure_value_model.go
+++ b/pkg/storage/secret/metadata/secure_value_model.go
@@ -71,9 +71,15 @@ func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
 			Keeper:     sv.Keeper,
 			Decrypters: decrypters,
 		},
+		Status: secretv0alpha1.SecureValueStatus{
+			Phase: secretv0alpha1.SecureValuePhase(sv.Phase),
+		},
 	}
 	if sv.Ref != nil {
 		resource.Spec.Ref = *sv.Ref
+	}
+	if sv.Message != nil && *sv.Message != "" {
+		resource.Status.Message = *sv.Message
 	}
 
 	// Set all meta fields here for consistency.

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -78,6 +78,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 		require.NotEmpty(t, secureValue.Spec.Title)
 		require.NotEmpty(t, secureValue.Spec.Keeper)
 		require.NotEmpty(t, secureValue.Spec.Decrypters)
+		require.NotEmpty(t, secureValue.Status.Phase)
 
 		t.Run("and creating another secure value with the same name in the same namespace returns an error", func(t *testing.T) {
 			testSecureValue := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")


### PR DESCRIPTION
**What is this feature?**

Loads secure value status from metadata db when needed in GET or LIST operations over secure values.

It also adds the status phase in the output of the `kubectl get securevalues`.

![image](https://github.com/user-attachments/assets/eefe490e-750e-44c7-82cc-b02decb64c1e)


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1254
