### PR TITLE
fix(unified-storage): Fix dualwriter DELETE mode3 not returning error from legacy

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -95,7 +95,7 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 
 	storageObj, errObjectSt := d.unified.Create(ctx, createdCopy, createValidation, options)
 	if errObjectSt != nil {
-		log.Error("unable to create object in unified storage", "err", err)
+		log.Error("unable to create object in unified storage", "err", errObjectSt)
 		if d.errorIsOK {
 			return createdFromLegacy, nil
 		}
@@ -105,6 +105,7 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 		if err != nil {
 			log.Error("unable to cleanup object in legacy storage", "err", err)
 		}
+		return storageObj, errObjectSt
 	}
 
 	if d.readUnified {

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -110,7 +110,7 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 	if d.readUnified {
 		return storageObj, errObjectSt
 	}
-	return createdFromLegacy, errObjectSt
+	return createdFromLegacy, err
 }
 
 func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
@@ -121,7 +121,7 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	// but legacy failed, the user would get a failure, but not be able to retry the delete
 	// as they would not be able to see the object in unistore anymore.
 	objFromLegacy, asyncLegacy, err := d.legacy.Delete(ctx, name, deleteValidation, options)
-	if err != nil && !d.readUnified {
+	if err != nil && !d.readUnified || !d.errorIsOK && !apierrors.IsNotFound(err) {
 		return objFromLegacy, asyncLegacy, err
 	}
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -121,7 +121,7 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	// but legacy failed, the user would get a failure, but not be able to retry the delete
 	// as they would not be able to see the object in unistore anymore.
 	objFromLegacy, asyncLegacy, err := d.legacy.Delete(ctx, name, deleteValidation, options)
-	if err != nil && !d.readUnified || !d.errorIsOK && !apierrors.IsNotFound(err) {
+	if err != nil && (!d.readUnified || !d.errorIsOK && !apierrors.IsNotFound(err)) {
 		return objFromLegacy, asyncLegacy, err
 	}
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
@@ -256,6 +256,16 @@ func TestMode3_Delete(t *testing.T) {
 				},
 				wantErr: true,
 			},
+			{
+				name: "should return an error when deleting an object in the LegacyStorage fails",
+				setupLegacyFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, apierrors.NewInternalError(errors.New("error")))
+				},
+				setupStorageFn: func(m *mock.Mock, input string) {
+					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Panic("i should not be called")
+				},
+				wantErr: true,
+			},
 		}
 
 	name := "foo"


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/101393

There's two changes here:

* make sure `Delete` returns an error if we get a non-not found error from legacy storage
* return correct error object from `Create`

I spotted this while reviewing https://github.com/grafana/grafana/pull/101393. cc @ryantxu 