### PR TITLE
DS-Querier: Hopefully fix and debug cases where query data response is nil

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -191,7 +191,7 @@ func (b *QueryAPIBuilder) execute(ctx context.Context, req parsedRequestInfo) (q
 	case 1:
 		b.log.Debug("executing single query")
 		qdr, err = b.handleQuerySingleDatasource(ctx, req.Requests[0])
-		if alertQueryWithoutExpression(req) {
+		if err == nil && alertQueryWithoutExpression(req) {
 			b.log.Debug("handling alert query without expression")
 			qdr, err = b.convertQueryWithoutExpression(ctx, req.Requests[0], qdr)
 		}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -419,7 +419,7 @@ func (b *QueryAPIBuilder) convertQueryWithoutExpression(ctx context.Context, req
 		return nil, errors.New("no queries to convert")
 	}
 	if qdr == nil {
-		b.log.Debug("unexpected response of nil from datasource", "datasource.type", req.PluginId, "datasource.uid", req.UID, "request", req.Request)
+		b.log.Debug("unexpected response of nil from datasource", "datasource.type", req.PluginId, "datasource.uid", req.UID)
 		return nil, errors.New("unexpected response of nil from datasource")
 	}
 	refID := req.Request.Queries[0].RefID

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -419,7 +419,8 @@ func (b *QueryAPIBuilder) convertQueryWithoutExpression(ctx context.Context, req
 		return nil, errors.New("no queries to convert")
 	}
 	if qdr == nil {
-		return nil, errors.New("queryDataResponse is nil")
+		b.log.Debug("unexpected response of nil from datasource", "datasource.type", req.PluginId, "datasource.uid", req.UID, "request", req.Request)
+		return nil, errors.New("unexpected response of nil from datasource")
 	}
 	refID := req.Request.Queries[0].RefID
 	if _, exist := qdr.Responses[refID]; !exist {


### PR DESCRIPTION
hopefully fix https://github.com/grafana/grafana-enterprise/issues/8056

Some interesting things I've noticed: 
- if we hit an error while handling a query, we may or may not have a query data response and yet we were trying to craft a response anyway. This instead returns the original error early.
- it seems plausible to me that we could get into a situation where we don't have error but we also don't have a query data response, but if we do that seems pretty unusual and I think we need a debug log line to try to identify how we got here (my guess is we have an issue with the datasource at that point but I'm not sure)
- this error eventually finds it's way back to the client and I thought "queryDataResponse is nil" seemed a bit confusing and so I tried to word it in a way that might be more user-friendly. 