### PR TITLE
Alerting: Implement arbitrary data source remote writer.

### DIFF
--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -1,0 +1,170 @@
+package writer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	gocache "github.com/patrickmn/go-cache"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/adapters"
+)
+
+const (
+	// We do not need to aggresively refresh data source settings, because a
+	// typical recording rule only writes every 60 seconds.
+	cacheExpiration = 30 * time.Second
+
+	// Time between cleaning expired data sources.
+	cacheCleanupInterval = 10 * time.Minute
+)
+
+type DatasourceWriterConfig struct {
+	// Timeout is the maximum time to wait for a remote write to succeed.
+	Timeout time.Duration
+
+	// DetaultDatasourceUID is the data source used if no data source is specified.
+	// This exists to cater for upgrading from old versions of Grafana, where rule
+	// definitions may not have a target data source specified.
+	DefaultDatasourceUID string
+
+	// RemoteWritePathSuffix is the path suffix for remote write, normally /push.
+	RemoteWritePathSuffix string
+}
+
+type DatasourceWriter struct {
+	cfg                DatasourceWriterConfig
+	datasources        datasources.DataSourceService
+	httpClientProvider HttpClientProvider
+	clock              clock.Clock
+	l                  log.Logger
+	metrics            *metrics.RemoteWriter
+
+	writers *gocache.Cache
+}
+
+func NewDatasourceWriter(
+	cfg DatasourceWriterConfig,
+	datasources datasources.DataSourceService,
+	httpClientProvider HttpClientProvider,
+	clock clock.Clock,
+	l log.Logger,
+	metrics *metrics.RemoteWriter,
+) *DatasourceWriter {
+	return &DatasourceWriter{
+		cfg:                cfg,
+		datasources:        datasources,
+		httpClientProvider: httpClientProvider,
+		clock:              clock,
+		l:                  l,
+		metrics:            metrics,
+		writers:            gocache.New(cacheExpiration, cacheCleanupInterval),
+	}
+}
+
+func (w *DatasourceWriter) decrypt(ds *datasources.DataSource) (map[string]string, error) {
+	decryptedJsonData, err := w.datasources.DecryptedValues(context.Background(), ds)
+	if err != nil {
+		w.l.Error("Failed to decrypt secure json data", "error", err)
+	}
+	return decryptedJsonData, err
+}
+
+func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID string) (*PrometheusWriter, error) {
+	ds, err := w.datasources.GetDataSource(ctx, &datasources.GetDataSourceQuery{
+		UID:   dsUID,
+		OrgID: orgID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if ds.Type != datasources.DS_PROMETHEUS {
+		return nil, errors.New("can only write to data sources of type prometheus")
+	}
+
+	is, err := adapters.ModelToInstanceSettings(ds, w.decrypt)
+	if err != nil {
+		return nil, err
+	}
+
+	ho, err := is.HTTPClientOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(is.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	u = u.JoinPath(w.cfg.RemoteWritePathSuffix)
+
+	cfg := PrometheusWriterConfig{
+		URL: u.String(),
+		HTTPOptions: httpclient.Options{
+			Timeouts:  ho.Timeouts,
+			TLS:       ho.TLS,
+			BasicAuth: ho.BasicAuth,
+		},
+		Timeout: w.cfg.Timeout,
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return NewPrometheusWriter(
+		cfg,
+		w.httpClientProvider,
+		w.clock,
+		w.l,
+		w.metrics)
+}
+
+func uidKey(orgID int64, uid string) string {
+	return fmt.Sprintf("%d-%s", orgID, uid)
+}
+
+func (w *DatasourceWriter) WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error {
+	if dsUID == "" {
+		if w.cfg.DefaultDatasourceUID == "" {
+			return errors.New("data source uid not specified and no default set")
+		}
+		dsUID = w.cfg.DefaultDatasourceUID
+		w.l.Debug("Using default data source for remote write",
+			"org_id", orgID, "datasource_uid", dsUID)
+	}
+
+	key := uidKey(orgID, dsUID)
+
+	var writer *PrometheusWriter
+
+	val, ok := w.writers.Get(key)
+	if ok {
+		var ok bool
+		writer, ok = val.(*PrometheusWriter)
+		if !ok {
+			return errors.New("type in cache not a Writer")
+		}
+	} else {
+		var err error
+		writer, err = w.makeWriter(ctx, orgID, dsUID)
+		if err != nil {
+			w.l.Error("Failed to create writer for data source",
+				"org_id", orgID, "datasource_uid", dsUID)
+			return err
+		}
+
+		w.writers.Set(key, writer, 0)
+	}
+
+	return writer.Write(ctx, name, t, frames, orgID, extraLabels)
+}

--- a/pkg/services/ngalert/writer/datasourcewriter_test.go
+++ b/pkg/services/ngalert/writer/datasourcewriter_test.go
@@ -1,0 +1,120 @@
+package writer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	dsfakes "github.com/grafana/grafana/pkg/services/datasources/fakes"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+)
+
+type testDataSources struct {
+	dsfakes.FakeDataSourceService
+
+	prom1, prom2 *TestRemoteWriteTarget
+}
+
+func (t *testDataSources) Reset() {
+	t.prom1.Reset()
+	t.prom2.Reset()
+}
+
+func setupDataSources(t *testing.T) *testDataSources {
+	res := &testDataSources{
+		prom1: NewTestRemoteWriteTarget(t),
+		prom2: NewTestRemoteWriteTarget(t),
+	}
+
+	t.Cleanup(func() {
+		res.prom1.Close()
+	})
+	t.Cleanup(func() {
+		res.prom2.Close()
+	})
+
+	p1, _ := res.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		UID:  "prom-1",
+		Type: datasources.DS_PROMETHEUS,
+	})
+	p1.URL = res.prom1.srv.URL + "/api/v1"
+
+	p2, _ := res.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		UID:  "prom-2",
+		Type: datasources.DS_PROMETHEUS,
+	})
+	p2.URL = res.prom2.srv.URL + "/api/v1"
+
+	// Add a non-Prometheus datasource.
+	_, _ = res.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		UID:  "loki-1",
+		Type: datasources.DS_LOKI,
+	})
+
+	return res
+}
+
+func TestDatasourceWriter(t *testing.T) {
+	series := []map[string]string{{"foo": "1"}, {"foo": "2"}, {"foo": "3"}, {"foo": "4"}}
+	frames := frameGenFromLabels(t, data.FrameTypeNumericWide, series)
+
+	datasources := setupDataSources(t)
+
+	cfg := DatasourceWriterConfig{
+		Timeout:               time.Second * 5,
+		DefaultDatasourceUID:  "prom-2",
+		RemoteWritePathSuffix: "/write",
+	}
+
+	met := metrics.NewRemoteWriterMetrics(prometheus.NewRegistry())
+	writer := NewDatasourceWriter(cfg, datasources, httpclient.NewProvider(), clock.New(), log.New("test"), met)
+
+	t.Run("when writing a prometheus datasource then the request is made to the expected endpoint", func(t *testing.T) {
+		datasources.Reset()
+
+		err := writer.WriteDatasource(context.Background(), "prom-1", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, datasources.prom1.RequestsCount)
+		assert.Equal(t, 0, datasources.prom2.RequestsCount)
+
+		err = writer.WriteDatasource(context.Background(), "prom-2", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, datasources.prom1.RequestsCount)
+		assert.Equal(t, 1, datasources.prom2.RequestsCount)
+	})
+
+	t.Run("when writing an unknown datasource then an error is returned", func(t *testing.T) {
+		datasources.Reset()
+
+		err := writer.WriteDatasource(context.Background(), "prom-3", "metric", time.Now(), frames, 1, map[string]string{})
+		require.Error(t, err)
+		require.EqualError(t, err, "data source not found")
+	})
+
+	t.Run("when writing a non-prometheus datasource then an error is returned", func(t *testing.T) {
+		datasources.Reset()
+
+		err := writer.WriteDatasource(context.Background(), "loki-1", "metric", time.Now(), frames, 1, map[string]string{})
+		require.Error(t, err)
+		require.EqualError(t, err, "can only write to data sources of type prometheus")
+	})
+
+	t.Run("when writing with an empty datasource uid then the default is written", func(t *testing.T) {
+		datasources.Reset()
+
+		err := writer.WriteDatasource(context.Background(), "", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+	})
+
+}

--- a/pkg/services/ngalert/writer/datasourcewriter_test.go
+++ b/pkg/services/ngalert/writer/datasourcewriter_test.go
@@ -116,5 +116,4 @@ func TestDatasourceWriter(t *testing.T) {
 		err := writer.WriteDatasource(context.Background(), "", "metric", time.Now(), frames, 1, map[string]string{})
 		require.NoError(t, err)
 	})
-
 }


### PR DESCRIPTION
Recording rules currently remote write to the endpoint speficied in the
configuration file, but we want to change this so that it can be specified
on a per-rule basis. This change implements the updated RemoteWriter
interface, and dispatches writes to the correct data source.

Notes about the implementation:
- There is a defaulting behaviour, because we will need to handle situations
  when upgrading from older Grafana versions, where recording rules do not a
  data source target specified.
- In order to avoid re-creating the remote write clients for every request,
  a cache is used. The entries have a TTL of 30 seconds at which point they
  are recreated; this is the delay for picking up new data source settings.

Known limitations:
- There is no per data source configuration for the remote write path suffix.
- Not all data source settings will be used, but basic auth and TLS will be.
- There is no RBAC. This will be a follow up feature.
