### PR TITLE
Secrets: Mark SecureValues `Succeeded` manually while we await an outbox implementation

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_fake.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_fake.go
@@ -27,6 +27,10 @@ type fakeSecureValueMetadataStorage struct {
 }
 
 func (s *fakeSecureValueMetadataStorage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
+	// TODO: Remove once the outbox is implemented
+	sv.Status.Phase = secretv0alpha1.SecureValuePhaseSucceeded
+	sv.Status.Message = ""
+
 	v := *sv
 	v.SetUID(types.UID(uuid.NewString()))
 	v.ObjectMeta.SetResourceVersion(strconv.FormatInt(metav1.Now().UnixMicro(), 10))
@@ -57,6 +61,10 @@ func (s *fakeSecureValueMetadataStorage) Read(ctx context.Context, namespace xku
 }
 
 func (s *fakeSecureValueMetadataStorage) Update(ctx context.Context, nsv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
+	// TODO: Remove once the outbox is implemented
+	nsv.Status.Phase = secretv0alpha1.SecureValuePhaseSucceeded
+	nsv.Status.Message = ""
+
 	v := *nsv
 	v.Spec.Value = ""
 	v.SetResourceVersion(strconv.FormatInt(metav1.Now().UnixMicro(), 10))

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -60,6 +60,11 @@ func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv0alp
 	// From this point on, we should not have a need to read value.
 	sv.Spec.Value = ""
 
+	// TODO: Remove once the outbox is implemented, as the status will be set to `Succeeded` by a separate process.
+	// Temporarily mark succeeded here since the value is already stored in the keeper.
+	sv.Status.Phase = secretv0alpha1.SecureValuePhaseSucceeded
+	sv.Status.Message = ""
+
 	row, err := toCreateRow(sv, authInfo.GetUID(), externalID.String())
 	if err != nil {
 		return nil, fmt.Errorf("to create row: %w", err)
@@ -163,6 +168,11 @@ func (s *secureValueMetadataStorage) Update(ctx context.Context, newSecureValue 
 
 	// From this point on, we should not have a need to read value.
 	newSecureValue.Spec.Value = ""
+
+	// TODO: Remove once the outbox is implemented, as the status will be set to `Succeeded` by a separate process.
+	// Temporarily mark succeeded here since the value is already stored in the keeper.
+	newSecureValue.Status.Phase = secretv0alpha1.SecureValuePhaseSucceeded
+	newSecureValue.Status.Message = ""
 
 	newRow, err := toUpdateRow(currentRow, newSecureValue, authInfo.GetUID(), currentRow.ExternalID)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**
We are setting the status of secure values to "pending" [here](https://github.com/grafana/grafana/blob/secret-service/feature-branch/pkg/registry/apis/secret/register.go#L278), but until the outbox is implemented, we need to override it to be "succeeded" after the value is stored.

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1255