### PR TITLE
Revert "K8s: Fix plugin updater"

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -67,11 +66,10 @@ func (du *DashboardUpdater) updateAppDashboards() {
 		if !pluginSetting.Enabled {
 			continue
 		}
-		ctx, _ := identity.WithServiceIdentity(context.Background(), pluginSetting.OrgID)
 
-		if pluginDef, exists := du.pluginStore.Plugin(ctx, pluginSetting.PluginID); exists {
+		if pluginDef, exists := du.pluginStore.Plugin(context.Background(), pluginSetting.PluginID); exists {
 			if pluginDef.Info.Version != pluginSetting.PluginVersion {
-				du.syncPluginDashboards(ctx, pluginDef, pluginSetting.OrgID)
+				du.syncPluginDashboards(context.Background(), pluginDef, pluginSetting.OrgID)
 			}
 		}
 	}


### PR DESCRIPTION
Reverts grafana/grafana#101646

Pods are hanging in dev due to this change, getting stuck on:
```
logger=plugindashboards t=2025-03-06T20:36:16.662145095Z level=info msg="Syncing plugin dashboards to DB" pluginId=grafana-oncall-app
```

Reverting for now while I investigate