### PR TITLE
Alerting: Move namespace-related functions to a separate service

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -51,35 +51,36 @@ type RuleAccessControlService interface {
 
 // API handlers.
 type API struct {
-	Cfg                  *setting.Cfg
-	DatasourceCache      datasources.CacheService
-	DatasourceService    datasources.DataSourceService
-	RouteRegister        routing.RouteRegister
-	QuotaService         quota.Service
-	TransactionManager   provisioning.TransactionManager
-	ProvenanceStore      provisioning.ProvisioningStore
-	RuleStore            RuleStore
-	AlertingStore        store.AlertingStore
-	AdminConfigStore     store.AdminConfigurationStore
-	DataProxy            *datasourceproxy.DataSourceProxyService
-	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
-	StateManager         *state.Manager
-	Scheduler            StatusReader
-	AccessControl        ac.AccessControl
-	Policies             *provisioning.NotificationPolicyService
-	ReceiverService      *notifier.ReceiverService
-	ContactPointService  *provisioning.ContactPointService
-	Templates            *provisioning.TemplateService
-	MuteTimings          *provisioning.MuteTimingService
-	AlertRules           *provisioning.AlertRuleService
-	AlertsRouter         *sender.AlertsRouter
-	EvaluatorFactory     eval.EvaluatorFactory
-	ConditionValidator   *eval.ConditionValidator
-	FeatureManager       featuremgmt.FeatureToggles
-	Historian            Historian
-	Tracer               tracing.Tracer
-	AppUrl               *url.URL
-	UserService          user.Service
+	Cfg                   *setting.Cfg
+	DatasourceCache       datasources.CacheService
+	DatasourceService     datasources.DataSourceService
+	RouteRegister         routing.RouteRegister
+	QuotaService          quota.Service
+	TransactionManager    provisioning.TransactionManager
+	ProvenanceStore       provisioning.ProvisioningStore
+	RuleStore             RuleStore
+	AlertingStore         store.AlertingStore
+	AdminConfigStore      store.AdminConfigurationStore
+	DataProxy             *datasourceproxy.DataSourceProxyService
+	MultiOrgAlertmanager  *notifier.MultiOrgAlertmanager
+	StateManager          *state.Manager
+	Scheduler             StatusReader
+	AccessControl         ac.AccessControl
+	Policies              *provisioning.NotificationPolicyService
+	ReceiverService       *notifier.ReceiverService
+	ContactPointService   *provisioning.ContactPointService
+	Templates             *provisioning.TemplateService
+	MuteTimings           *provisioning.MuteTimingService
+	AlertRules            *provisioning.AlertRuleService
+	AlertsRouter          *sender.AlertsRouter
+	EvaluatorFactory      eval.EvaluatorFactory
+	ConditionValidator    *eval.ConditionValidator
+	FeatureManager        featuremgmt.FeatureToggles
+	Historian             Historian
+	Tracer                tracing.Tracer
+	AppUrl                *url.URL
+	UserService           user.Service
+	AlertingFolderService alertingFolderService
 
 	// Hooks can be used to replace API handlers for specific paths.
 	Hooks *Hooks
@@ -188,7 +189,13 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 
 	if api.FeatureManager.IsEnabledGlobally(featuremgmt.FlagAlertingConversionAPI) {
 		api.RegisterConvertPrometheusApiEndpoints(NewConvertPrometheusApi(
-			NewConvertPrometheusSrv(&api.Cfg.UnifiedAlerting, logger, api.RuleStore, api.DatasourceCache, api.AlertRules),
+			NewConvertPrometheusSrv(
+				&api.Cfg.UnifiedAlerting,
+				logger,
+				api.AlertingFolderService,
+				api.DatasourceCache,
+				api.AlertRules,
+			),
 		), m)
 	}
 }

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -15,10 +15,6 @@ type RuleStore interface {
 	// by returning map[string]struct{} instead of map[string]*folder.Folder
 	GetUserVisibleNamespaces(context.Context, int64, identity.Requester) (map[string]*folder.Folder, error)
 	GetNamespaceByUID(ctx context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error)
-	GetNamespaceByTitle(ctx context.Context, fullpath string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
-	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error)
-	// GetNamespaceChildren returns all children (first level) of the namespace with the given id.
-	GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error)
 
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmodels.GetAlertRulesGroupByRuleUIDQuery) ([]*ngmodels.AlertRule, error)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -406,6 +406,8 @@ func (ng *AlertNG) init() error {
 		return err
 	}
 
+	alertingFolderService := store.NewAlertingFolderService(ng.folderService, ng.Log)
+
 	ng.InstanceStore, ng.StartupInstanceReader = initInstanceStore(ng.store.SQLStore, ng.Log, ng.FeatureToggles)
 
 	stateManagerCfg := state.ManagerCfg{
@@ -472,36 +474,37 @@ func (ng *AlertNG) init() error {
 		ac.NewRuleService(ng.accesscontrol))
 
 	ng.Api = &api.API{
-		Cfg:                  ng.Cfg,
-		DatasourceCache:      ng.DataSourceCache,
-		DatasourceService:    ng.DataSourceService,
-		RouteRegister:        ng.RouteRegister,
-		DataProxy:            ng.DataProxy,
-		QuotaService:         ng.QuotaService,
-		TransactionManager:   ng.store,
-		RuleStore:            ng.store,
-		AlertingStore:        ng.store,
-		AdminConfigStore:     ng.store,
-		ProvenanceStore:      ng.store,
-		MultiOrgAlertmanager: ng.MultiOrgAlertmanager,
-		StateManager:         ng.stateManager,
-		Scheduler:            scheduler,
-		AccessControl:        ng.accesscontrol,
-		Policies:             policyService,
-		ReceiverService:      receiverService,
-		ContactPointService:  contactPointService,
-		Templates:            templateService,
-		MuteTimings:          muteTimingService,
-		AlertRules:           alertRuleService,
-		AlertsRouter:         alertsRouter,
-		EvaluatorFactory:     evalFactory,
-		ConditionValidator:   conditionValidator,
-		FeatureManager:       ng.FeatureToggles,
-		AppUrl:               appUrl,
-		Historian:            history,
-		Hooks:                api.NewHooks(ng.Log),
-		Tracer:               ng.tracer,
-		UserService:          ng.userService,
+		Cfg:                   ng.Cfg,
+		DatasourceCache:       ng.DataSourceCache,
+		DatasourceService:     ng.DataSourceService,
+		RouteRegister:         ng.RouteRegister,
+		DataProxy:             ng.DataProxy,
+		QuotaService:          ng.QuotaService,
+		TransactionManager:    ng.store,
+		RuleStore:             ng.store,
+		AlertingStore:         ng.store,
+		AdminConfigStore:      ng.store,
+		ProvenanceStore:       ng.store,
+		MultiOrgAlertmanager:  ng.MultiOrgAlertmanager,
+		StateManager:          ng.stateManager,
+		Scheduler:             scheduler,
+		AccessControl:         ng.accesscontrol,
+		Policies:              policyService,
+		ReceiverService:       receiverService,
+		ContactPointService:   contactPointService,
+		Templates:             templateService,
+		MuteTimings:           muteTimingService,
+		AlertRules:            alertRuleService,
+		AlertsRouter:          alertsRouter,
+		EvaluatorFactory:      evalFactory,
+		ConditionValidator:    conditionValidator,
+		FeatureManager:        ng.FeatureToggles,
+		AppUrl:                appUrl,
+		Historian:             history,
+		Hooks:                 api.NewHooks(ng.Log),
+		Tracer:                ng.tracer,
+		UserService:           ng.userService,
+		AlertingFolderService: alertingFolderService,
 	}
 	ng.Api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -508,15 +508,15 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 
 	parentFolderUid := uuid.NewString()
 	parentFolderTitle := "Very Parent Folder"
-	createFolder(t, store, parentFolderUid, parentFolderTitle, rule1.OrgID, "")
+	createFolder(t, store.FolderService, parentFolderUid, parentFolderTitle, rule1.OrgID, "")
 	rule1FolderTitle := "folder-" + rule1.Title
 	rule2FolderTitle := "folder-" + rule2.Title
 	rule3FolderTitle := "folder-" + rule3.Title
-	createFolder(t, store, rule1.NamespaceUID, rule1FolderTitle, rule1.OrgID, parentFolderUid)
-	createFolder(t, store, rule2.NamespaceUID, rule2FolderTitle, rule2.OrgID, "")
-	createFolder(t, store, rule3.NamespaceUID, rule3FolderTitle, rule3.OrgID, "")
+	createFolder(t, store.FolderService, rule1.NamespaceUID, rule1FolderTitle, rule1.OrgID, parentFolderUid)
+	createFolder(t, store.FolderService, rule2.NamespaceUID, rule2FolderTitle, rule2.OrgID, "")
+	createFolder(t, store.FolderService, rule3.NamespaceUID, rule3FolderTitle, rule3.OrgID, "")
 
-	createFolder(t, store, rule2.NamespaceUID, "same UID folder", gen.GenerateRef().OrgID, "") // create a folder with the same UID but in the different org
+	createFolder(t, store.FolderService, rule2.NamespaceUID, "same UID folder", gen.GenerateRef().OrgID, "") // create a folder with the same UID but in the different org
 
 	tc := []struct {
 		name         string
@@ -1739,7 +1739,7 @@ func createRule(t *testing.T, store *DBstore, generator *models.AlertRuleGenerat
 	return rule
 }
 
-func createFolder(t *testing.T, store *DBstore, uid, title string, orgID int64, parentUID string) {
+func createFolder(t *testing.T, folderService folder.Service, uid, title string, orgID int64, parentUID string) {
 	t.Helper()
 	u := &user.SignedInUser{
 		UserID:         1,
@@ -1748,7 +1748,7 @@ func createFolder(t *testing.T, store *DBstore, uid, title string, orgID int64, 
 		IsGrafanaAdmin: true,
 	}
 
-	_, err := store.FolderService.Create(context.Background(), &folder.CreateFolderCommand{
+	_, err := folderService.Create(context.Background(), &folder.CreateFolderCommand{
 		UID:          uid,
 		OrgID:        orgID,
 		Title:        title,

--- a/pkg/services/ngalert/store/namespace_test.go
+++ b/pkg/services/ngalert/store/namespace_test.go
@@ -7,16 +7,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/util"
-
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestIntegration_GetUserVisibleNamespaces(t *testing.T) {
@@ -49,7 +48,7 @@ func TestIntegration_GetUserVisibleNamespaces(t *testing.T) {
 	}
 
 	for _, f := range folders {
-		createFolder(t, store, f.uid, f.title, 1, f.parentUid)
+		createFolder(t, folderService, f.uid, f.title, 1, f.parentUid)
 	}
 
 	t.Run("returns all folders", func(t *testing.T) {
@@ -89,8 +88,8 @@ func TestIntegration_GetNamespaceByUID(t *testing.T) {
 	parentUid := uuid.NewString()
 	title := "folder/title"
 	parentTitle := "parent-title"
-	createFolder(t, store, parentUid, parentTitle, 1, "")
-	createFolder(t, store, uid, title, 1, parentUid)
+	createFolder(t, folderService, parentUid, parentTitle, 1, "")
+	createFolder(t, folderService, uid, title, 1, parentUid)
 
 	actual, err := store.GetNamespaceByUID(context.Background(), uid, 1, u)
 	require.NoError(t, err)
@@ -132,10 +131,7 @@ func TestIntegration_GetNamespaceByTitle(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
-	b := &fakeBus{}
-	logger := log.New("test-dbstore")
-	store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-	store.FolderService = setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders))
+	service := NewAlertingFolderService(folderService, log.NewNopLogger())
 
 	u := &user.SignedInUser{
 		UserID:         1,
@@ -147,19 +143,19 @@ func TestIntegration_GetNamespaceByTitle(t *testing.T) {
 	// Create parent folder
 	parentUID := uuid.NewString()
 	parentTitle := "parent-folder"
-	createFolder(t, store, parentUID, parentTitle, 1, "")
+	createFolder(t, folderService, parentUID, parentTitle, 1, "")
 
 	// Create child folder under parent
 	childUID := uuid.NewString()
 	childTitle := "child-folder"
-	createFolder(t, store, childUID, childTitle, 1, parentUID)
+	createFolder(t, folderService, childUID, childTitle, 1, parentUID)
 
 	// Create another folder with same title but under root
 	sameTitleInRoot := uuid.NewString()
-	createFolder(t, store, sameTitleInRoot, childTitle, 1, "")
+	createFolder(t, folderService, sameTitleInRoot, childTitle, 1, "")
 
 	t.Run("should find folder by title and parent UID", func(t *testing.T) {
-		actual, err := store.GetNamespaceByTitle(context.Background(), childTitle, 1, u, parentUID)
+		actual, err := service.GetNamespaceByTitle(context.Background(), childTitle, 1, u, parentUID)
 		require.NoError(t, err)
 		require.Equal(t, childTitle, actual.Title)
 		require.Equal(t, childUID, actual.UID)
@@ -167,7 +163,7 @@ func TestIntegration_GetNamespaceByTitle(t *testing.T) {
 	})
 
 	t.Run("should find folder by title in root", func(t *testing.T) {
-		actual, err := store.GetNamespaceByTitle(context.Background(), childTitle, 1, u, folder.RootFolderUID)
+		actual, err := service.GetNamespaceByTitle(context.Background(), childTitle, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 		require.Equal(t, childTitle, actual.Title)
 		require.Equal(t, sameTitleInRoot, actual.UID)
@@ -176,7 +172,7 @@ func TestIntegration_GetNamespaceByTitle(t *testing.T) {
 
 	t.Run("should return ErrFolderNotFound when folder with title doesn't exist under specified parent", func(t *testing.T) {
 		nonExistentTitle := "non-existent-folder"
-		f, err := store.GetNamespaceByTitle(context.Background(), nonExistentTitle, 1, u, parentUID)
+		f, err := service.GetNamespaceByTitle(context.Background(), nonExistentTitle, 1, u, parentUID)
 		require.Nil(t, f)
 		require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
 	})
@@ -194,28 +190,23 @@ func TestIntegration_GetOrCreateNamespaceByTitle(t *testing.T) {
 		IsGrafanaAdmin: true,
 	}
 
-	setupStore := func(t *testing.T) *DBstore {
+	setupService := func(t *testing.T) *AlertingFolderService {
 		sqlStore := db.InitTestDB(t)
 		cfg := setting.NewCfg()
 		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
-		b := &fakeBus{}
-		logger := log.New("test-dbstore")
-		store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-		store.FolderService = setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders))
-
-		return store
+		return NewAlertingFolderService(folderService, log.NewNopLogger())
 	}
 
 	t.Run("should create folder when it does not exist", func(t *testing.T) {
-		store := setupStore(t)
+		service := setupService(t)
 
-		f, err := store.GetOrCreateNamespaceByTitle(context.Background(), "new folder", 1, u, folder.RootFolderUID)
+		f, err := service.GetOrCreateNamespaceByTitle(context.Background(), "new folder", 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 		require.Equal(t, "new folder", f.Title)
 		require.NotEmpty(t, f.UID)
 		require.Equal(t, folder.RootFolderUID, f.ParentUID)
 
-		folders, err := store.FolderService.GetFolders(
+		folders, err := service.FolderService.GetFolders(
 			context.Background(),
 			folder.GetFoldersQuery{
 				OrgID:        1,
@@ -228,15 +219,15 @@ func TestIntegration_GetOrCreateNamespaceByTitle(t *testing.T) {
 	})
 
 	t.Run("should return existing folder when it exists", func(t *testing.T) {
-		store := setupStore(t)
+		service := setupService(t)
 
 		title := "existing folder"
-		createFolder(t, store, "", title, 1, "")
-		f, err := store.GetOrCreateNamespaceByTitle(context.Background(), title, 1, u, folder.RootFolderUID)
+		createFolder(t, service.FolderService, "", title, 1, "")
+		f, err := service.GetOrCreateNamespaceByTitle(context.Background(), title, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 		require.Equal(t, title, f.Title)
 
-		folders, err := store.FolderService.GetFolders(
+		folders, err := service.FolderService.GetFolders(
 			context.Background(),
 			folder.GetFoldersQuery{
 				OrgID:        1,
@@ -249,70 +240,70 @@ func TestIntegration_GetOrCreateNamespaceByTitle(t *testing.T) {
 	})
 
 	t.Run("should create folder under specified parent when it does not exist", func(t *testing.T) {
-		store := setupStore(t)
+		service := setupService(t)
 
 		// Create parent folder first
 		parentTitle := "parent folder"
-		parentFolder, err := store.GetOrCreateNamespaceByTitle(context.Background(), parentTitle, 1, u, folder.RootFolderUID)
+		parentFolder, err := service.GetOrCreateNamespaceByTitle(context.Background(), parentTitle, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 
 		// Now create a child folder under the parent
 		childTitle := "child folder"
-		childFolder, err := store.GetOrCreateNamespaceByTitle(context.Background(), childTitle, 1, u, parentFolder.UID)
+		childFolder, err := service.GetOrCreateNamespaceByTitle(context.Background(), childTitle, 1, u, parentFolder.UID)
 		require.NoError(t, err)
 
 		// Verify the child folder was created under the parent
-		folders, err := store.FolderService.GetChildren(context.Background(), &folder.GetChildrenQuery{UID: parentFolder.UID, OrgID: 1, SignedInUser: u})
+		folders, err := service.FolderService.GetChildren(context.Background(), &folder.GetChildrenQuery{UID: parentFolder.UID, OrgID: 1, SignedInUser: u})
 		require.NoError(t, err)
 		require.Len(t, folders, 1)
 		require.Equal(t, childFolder.UID, folders[0].UID)
 
-		folders, err = store.FolderService.GetChildren(context.Background(), &folder.GetChildrenQuery{UID: folder.RootFolderUID, OrgID: 1, SignedInUser: u})
+		folders, err = service.FolderService.GetChildren(context.Background(), &folder.GetChildrenQuery{UID: folder.RootFolderUID, OrgID: 1, SignedInUser: u})
 		require.NoError(t, err)
 		require.Len(t, folders, 1)
 		require.Equal(t, parentFolder.UID, folders[0].UID)
 	})
 
 	t.Run("should get correct folder when same title exists under different parents", func(t *testing.T) {
-		store := setupStore(t)
+		service := setupService(t)
 
 		// Create first parent folder
 		parent1Title := "parent folder 1"
-		parent1, err := store.GetOrCreateNamespaceByTitle(context.Background(), parent1Title, 1, u, folder.RootFolderUID)
+		parent1, err := service.GetOrCreateNamespaceByTitle(context.Background(), parent1Title, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 
 		// Create second parent folder
 		parent2Title := "parent folder 2"
-		parent2, err := store.GetOrCreateNamespaceByTitle(context.Background(), parent2Title, 1, u, folder.RootFolderUID)
+		parent2, err := service.GetOrCreateNamespaceByTitle(context.Background(), parent2Title, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 
 		// Create folders with same title under different parents
 		sameTitle := "same title folder"
 
 		// Create under first parent
-		folder1, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent1.UID)
+		folder1, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent1.UID)
 		require.NoError(t, err)
 
 		// Create under second parent
-		folder2, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent2.UID)
+		folder2, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent2.UID)
 		require.NoError(t, err)
 
 		// Create under root
-		folder3, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, folder.RootFolderUID)
+		folder3, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 
 		// Verify we get the correct folders when specifying the parent
-		gotFolder1, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent1.UID)
+		gotFolder1, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent1.UID)
 		require.NoError(t, err)
 		require.Equal(t, folder1.UID, gotFolder1.UID)
 		require.Equal(t, parent1.UID, gotFolder1.ParentUID)
 
-		gotFolder2, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent2.UID)
+		gotFolder2, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, parent2.UID)
 		require.NoError(t, err)
 		require.Equal(t, folder2.UID, gotFolder2.UID)
 		require.Equal(t, parent2.UID, gotFolder2.ParentUID)
 
-		gotFolder3, err := store.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, folder.RootFolderUID)
+		gotFolder3, err := service.GetOrCreateNamespaceByTitle(context.Background(), sameTitle, 1, u, folder.RootFolderUID)
 		require.NoError(t, err)
 		require.Equal(t, folder3.UID, gotFolder3.UID)
 		require.Equal(t, folder.RootFolderUID, gotFolder3.ParentUID)
@@ -327,10 +318,8 @@ func TestIntegration_GetNamespaceChildren(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
-	b := &fakeBus{}
-	logger := log.New("test-dbstore")
-	store := createTestStore(sqlStore, folderService, logger, cfg.UnifiedAlerting, b)
-	store.FolderService = setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders))
+
+	service := NewAlertingFolderService(folderService, log.NewNopLogger())
 
 	admin := &user.SignedInUser{
 		UserID:         1,
@@ -342,21 +331,21 @@ func TestIntegration_GetNamespaceChildren(t *testing.T) {
 	// Create root folders
 	rootFolder1 := uuid.NewString()
 	rootFolder2 := uuid.NewString()
-	createFolder(t, store, rootFolder1, "Root Folder 1", 1, "")
-	createFolder(t, store, rootFolder2, "Root Folder 2", 1, "")
+	createFolder(t, folderService, rootFolder1, "Root Folder 1", 1, "")
+	createFolder(t, folderService, rootFolder2, "Root Folder 2", 1, "")
 
 	// Create child folders under root folder 1
 	child1 := uuid.NewString()
 	child2 := uuid.NewString()
-	createFolder(t, store, child1, "Child Folder 1", 1, rootFolder1)
-	createFolder(t, store, child2, "Child Folder 2", 1, rootFolder1)
+	createFolder(t, folderService, child1, "Child Folder 1", 1, rootFolder1)
+	createFolder(t, folderService, child2, "Child Folder 2", 1, rootFolder1)
 
 	// Create nested child under child1
 	nestedChild := uuid.NewString()
-	createFolder(t, store, nestedChild, "Nested Child", 1, child1)
+	createFolder(t, folderService, nestedChild, "Nested Child", 1, child1)
 
 	differentOrgID := int64(999)
-	createFolder(t, store, util.GenerateShortUID(), "Root Folder 1", differentOrgID, "")
+	createFolder(t, folderService, util.GenerateShortUID(), "Root Folder 1", differentOrgID, "")
 
 	/*
 	 * Folder structure:
@@ -369,7 +358,7 @@ func TestIntegration_GetNamespaceChildren(t *testing.T) {
 	 */
 
 	t.Run("should return direct children of a folder", func(t *testing.T) {
-		children, err := store.GetNamespaceChildren(context.Background(), rootFolder1, 1, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), rootFolder1, 1, admin)
 		require.NoError(t, err)
 		require.Len(t, children, 2)
 
@@ -382,7 +371,7 @@ func TestIntegration_GetNamespaceChildren(t *testing.T) {
 	})
 
 	t.Run("should return direct children of a nested folder", func(t *testing.T) {
-		children, err := store.GetNamespaceChildren(context.Background(), child1, 1, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), child1, 1, admin)
 		require.NoError(t, err)
 		require.Len(t, children, 1)
 		require.Equal(t, nestedChild, children[0].UID)
@@ -391,27 +380,27 @@ func TestIntegration_GetNamespaceChildren(t *testing.T) {
 
 	t.Run("should return nil when folder does not exist", func(t *testing.T) {
 		nonExistentUID := uuid.NewString()
-		children, err := store.GetNamespaceChildren(context.Background(), nonExistentUID, 1, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), nonExistentUID, 1, admin)
 		require.NotNil(t, children)
 		require.Empty(t, children)
 		require.Nil(t, err)
 	})
 
 	t.Run("should return empty array for folders with no children", func(t *testing.T) {
-		children, err := store.GetNamespaceChildren(context.Background(), rootFolder2, 1, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), rootFolder2, 1, admin)
 		require.Empty(t, children)
 		require.NotNil(t, children)
 		require.Nil(t, err)
 	})
 
 	t.Run("should return no children for a different org", func(t *testing.T) {
-		children, err := store.GetNamespaceChildren(context.Background(), rootFolder1, differentOrgID, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), rootFolder1, differentOrgID, admin)
 		require.Empty(t, children)
 		require.Nil(t, err)
 	})
 
 	t.Run("should return children from root folder", func(t *testing.T) {
-		children, err := store.GetNamespaceChildren(context.Background(), "", 1, admin)
+		children, err := service.GetNamespaceChildren(context.Background(), "", 1, admin)
 		require.NoError(t, err)
 		require.Equal(t, len(children), 2)
 		require.ElementsMatch(t, []string{rootFolder1, rootFolder2}, []string{children[0].UID, children[1].UID})

--- a/pkg/services/ngalert/tests/fakes/namespaces.go
+++ b/pkg/services/ngalert/tests/fakes/namespaces.go
@@ -1,0 +1,135 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type FakeAlertingFolderService struct {
+	t           *testing.T
+	mtx         sync.Mutex
+	Hook        func(cmd any) error // use Hook if you need to intercept some query and return an error
+	RecordedOps []any
+	Folders     map[int64][]*folder.Folder
+}
+
+func NewFakeAlertingFolderService(t *testing.T) *FakeAlertingFolderService {
+	return &FakeAlertingFolderService{
+		t: t,
+		Hook: func(any) error {
+			return nil
+		},
+		Folders: map[int64][]*folder.Folder{},
+	}
+}
+
+// GetRecordedCommands filters recorded commands using predicate function. Returns the subset of the recorded commands that meet the predicate
+func (f *FakeAlertingFolderService) GetRecordedCommands(predicate func(cmd any) (any, bool)) []any {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	result := make([]any, 0, len(f.RecordedOps))
+	for _, op := range f.RecordedOps {
+		cmd, ok := predicate(op)
+		if !ok {
+			continue
+		}
+		result = append(result, cmd)
+	}
+	return result
+}
+
+func (f *FakeAlertingFolderService) GetUserVisibleNamespaces(_ context.Context, orgID int64, _ identity.Requester) (map[string]*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	namespacesMap := map[string]*folder.Folder{}
+
+	for _, folder := range f.Folders[orgID] {
+		namespacesMap[folder.UID] = folder
+	}
+	return namespacesMap, nil
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceByUID(_ context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error) {
+	q := GenericRecordedQuery{
+		Name:   "GetNamespaceByUID",
+		Params: []any{orgID, uid, user},
+	}
+	defer func() {
+		f.RecordedOps = append(f.RecordedOps, q)
+	}()
+	err := f.Hook(q)
+	if err != nil {
+		return nil, err
+	}
+	folders := f.Folders[orgID]
+	for _, folder := range folders {
+		if folder.UID == uid {
+			return folder, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (f *FakeAlertingFolderService) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.Title == title && folder.ParentUID == parentUID {
+			return folder, nil
+		}
+	}
+
+	newFolder := &folder.Folder{
+		ID:        rand.Int63(), // nolint:staticcheck
+		UID:       util.GenerateShortUID(),
+		Title:     title,
+		ParentUID: parentUID,
+		Fullpath:  "fullpath_" + title,
+	}
+
+	f.Folders[orgID] = append(f.Folders[orgID], newFolder)
+	return newFolder, nil
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.Title == title && folder.ParentUID == parentUID {
+			return folder, nil
+		}
+	}
+
+	return nil, dashboards.ErrFolderNotFound
+}
+
+func (f *FakeAlertingFolderService) GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.Folder, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	result := []*folder.Folder{}
+
+	for _, folder := range f.Folders[orgID] {
+		if folder.ParentUID == uid {
+			result = append(result, folder)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, dashboards.ErrFolderNotFound
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
**What is this feature?**

This small refactoring moves namespace-related functions into a separate service outside of DBstore. 

This is preparation for a fix that requires a new service to be available for the folders. This refactoring makes it easier to add it here instead of to the DBstore, which is initialized in many services across Grafana.

I moved all methods that the Prometheus conversion API uses, but there are two more functions related to namespaces: GetNamespaceByUID and GetUserVisibleNamespaces. They are more complicated to move because they are used in more places and coupled with the rules in the tests.