### PR TITLE
SSE: Label-rewrite, Merge and Join commands

### DIFF
--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -345,6 +345,8 @@ const (
 	TypeSQL
 	// TypeLabelRewrite is the CMDType for label rewriting expressions.
 	TypeLabelRewrite
+	// TypeMerge is CMDType for merging multiple results
+	TypeMerge
 )
 
 func (gt CommandType) String() string {
@@ -363,6 +365,8 @@ func (gt CommandType) String() string {
 		return "sql"
 	case TypeLabelRewrite:
 		return "label_rewrite"
+	case TypeMerge:
+		return "merge"
 	default:
 		return "unknown"
 	}
@@ -385,6 +389,8 @@ func ParseCommandType(s string) (CommandType, error) {
 		return TypeSQL, nil
 	case "label_rewrite":
 		return TypeLabelRewrite, nil
+	case "merge":
+		return TypeMerge, nil
 	default:
 		return TypeUnknown, fmt.Errorf("'%v' is not a recognized expression type", s)
 	}

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -347,6 +347,8 @@ const (
 	TypeLabelRewrite
 	// TypeMerge is CMDType for merging multiple results
 	TypeMerge
+	// TypeJoin is CMDType for joining two results
+	TypeJoin
 )
 
 func (gt CommandType) String() string {
@@ -367,6 +369,8 @@ func (gt CommandType) String() string {
 		return "label_rewrite"
 	case TypeMerge:
 		return "merge"
+	case TypeJoin:
+		return "join"
 	default:
 		return "unknown"
 	}
@@ -391,6 +395,8 @@ func ParseCommandType(s string) (CommandType, error) {
 		return TypeLabelRewrite, nil
 	case "merge":
 		return TypeMerge, nil
+	case "join":
+		return TypeJoin, nil
 	default:
 		return TypeUnknown, fmt.Errorf("'%v' is not a recognized expression type", s)
 	}

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -343,6 +343,8 @@ const (
 	TypeThreshold
 	// TypeSQL is the CMDType for running SQL expressions
 	TypeSQL
+	// TypeLabelRewrite is the CMDType for label rewriting expressions.
+	TypeLabelRewrite
 )
 
 func (gt CommandType) String() string {
@@ -359,6 +361,8 @@ func (gt CommandType) String() string {
 		return "threshold"
 	case TypeSQL:
 		return "sql"
+	case TypeLabelRewrite:
+		return "label_rewrite"
 	default:
 		return "unknown"
 	}
@@ -379,6 +383,8 @@ func ParseCommandType(s string) (CommandType, error) {
 		return TypeThreshold, nil
 	case "sql":
 		return TypeSQL, nil
+	case "label_rewrite":
+		return TypeLabelRewrite, nil
 	default:
 		return TypeUnknown, fmt.Errorf("'%v' is not a recognized expression type", s)
 	}

--- a/pkg/expr/join.go
+++ b/pkg/expr/join.go
@@ -1,0 +1,249 @@
+package expr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"maps"
+	"math"
+	"time"
+	"unsafe"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type joinType string
+
+const (
+	joinTypeInner joinType = "inner"
+	joinTypeLeft  joinType = "outer"
+)
+
+type JoinCommand struct {
+	RefID          string
+	LeftVar        string
+	RightVar       string
+	MathExpression *mathexp.Expr
+	JoinType       joinType
+	Labels         []string
+}
+
+func (cmd JoinCommand) NeedsVars() []string {
+	return []string{cmd.LeftVar, cmd.RightVar}
+}
+
+func (cmd JoinCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error) {
+	left := vars[cmd.LeftVar]
+	right := vars[cmd.RightVar]
+	err := checkTypeCompatibility(left, right)
+	if err != nil {
+		return mathexp.Results{}, err
+	}
+	_, span := tracer.Start(ctx, "SSE.Join")
+	span.SetAttributes(attribute.KeyValue{Key: "joinType", Value: attribute.StringValue(string(cmd.JoinType))})
+	span.SetAttributes(attribute.KeyValue{Key: "leftType", Value: attribute.StringValue(left.Values[0].Type().String())})
+	span.SetAttributes(attribute.KeyValue{Key: "rightType", Value: attribute.StringValue(right.Values[0].Type().String())})
+	defer span.End()
+
+	return cmd.join(left, right)
+}
+
+func (cmd JoinCommand) Type() string {
+	return "join"
+}
+
+func (cmd JoinCommand) join(left, right mathexp.Results) (mathexp.Results, error) {
+	index := make(map[data.Fingerprint][]mathexp.Value, len(left.Values))
+	for i := 0; i < len(right.Values); i++ {
+		v := right.Values[i]
+		fp, good := fingerprint(v.GetLabels(), cmd.Labels)
+		if !good {
+			// Always drop the right part.
+			continue
+		}
+		index[fp] = append(index[fp], v)
+	}
+	result := mathexp.Results{Values: make(mathexp.Values, 0, len(left.Values))}
+	for i := 0; i < len(left.Values); i++ {
+		fp, good := fingerprint(left.Values[i].GetLabels(), cmd.Labels)
+		if good {
+			if values, ok := index[fp]; ok {
+				for _, r := range values {
+					res, err := cmd.evalMath(left.Values[i], r)
+					if err != nil {
+						return mathexp.Results{}, err
+					}
+					result.Values = append(result.Values, res)
+				}
+				continue
+			}
+		}
+		// if left side either does not have all labels or no match from right side
+		// then evaluate it with nil right side
+		if cmd.JoinType == joinTypeLeft {
+			r, err := cmd.evalMath(left.Values[i], mathexp.NewScalar("", util.Pointer(math.NaN())))
+			if err != nil {
+				return mathexp.Results{}, err
+			}
+			result.Values = append(result.Values, r)
+		}
+	}
+	return result, nil
+}
+
+func (cmd JoinCommand) evalMath(left, right mathexp.Value) (mathexp.Value, error) {
+	l, err := getScalar(left)
+	if err != nil {
+		return nil, fmt.Errorf("invalid left side of join: %w", err)
+	}
+	r, err := getScalar(right)
+	if err != nil {
+		return nil, fmt.Errorf("invalid right side of join: %w", err)
+	}
+
+	result, err := cmd.MathExpression.Execute(cmd.RefID, mathexp.Vars{
+		cmd.LeftVar:  mathexp.Results{Values: []mathexp.Value{l}},
+		cmd.RightVar: mathexp.Results{Values: []mathexp.Value{r}},
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	if result.IsNoData() {
+		// TODO ? add NAN or nil?
+		return nil, fmt.Errorf("math expression returned no data")
+	}
+	if len(result.Values) == 0 {
+		return nil, fmt.Errorf("math expression returned no results")
+	}
+	if len(result.Values) > 1 {
+		return nil, fmt.Errorf("math expression returned more than one result")
+	}
+	s, ok := result.Values[0].(mathexp.Scalar)
+	if !ok {
+		return nil, fmt.Errorf("math expression returned non-scalar result")
+	}
+	lbs := cmd.joinLabels(left.GetLabels(), right.GetLabels())
+	n := mathexp.NewNumber(cmd.RefID, lbs)
+	n.SetValue(s.GetFloat64Value())
+	return n, nil
+}
+
+func (cmd JoinCommand) joinLabels(left, right data.Labels) data.Labels {
+	if right == nil {
+		return left
+	}
+	if left == nil {
+		return right
+	}
+	result := make(data.Labels, len(left)+len(right)-len(cmd.Labels))
+	maps.Copy(result, left)
+	for k, v := range right {
+		if _, ok := result[k]; ok {
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
+func getScalar(v mathexp.Value) (mathexp.Scalar, error) {
+	switch expr := v.(type) {
+	case mathexp.Number:
+		return mathexp.NewScalar(expr.Frame.Name, expr.GetFloat64Value()), nil
+	case mathexp.Scalar:
+		return expr, nil
+	default:
+		return mathexp.Scalar{}, fmt.Errorf("unsupported type %s, must be either scalar or number", v.Type())
+	}
+}
+
+func checkTypeCompatibility(left, right mathexp.Results) error {
+	if !left.IsNoData() {
+		if left.Values[0].Type() != parse.TypeNumberSet {
+			return fmt.Errorf("left side of join must be a number set, but got %s", left.Values[0].Type())
+		}
+	}
+	if !right.IsNoData() {
+		if right.Values[0].Type() != parse.TypeNumberSet {
+			return fmt.Errorf("right side of join must be a number set, but got %s", left.Values[0].Type())
+		}
+	}
+	return nil
+}
+
+// fingerprint generates a fingerprint for a given set of labels and subset keys, ensuring all subset keys exist in the labels.
+// Returns the computed fingerprint and a boolean indicating success or failure based on subset existence in the labels.
+func fingerprint(lbls data.Labels, subset []string) (data.Fingerprint, bool) {
+	if len(lbls) < len(subset) {
+		return 0, false
+	}
+	h := fnv.New64()
+	for _, key := range subset {
+		value, ok := lbls[key]
+		if !ok {
+			return 0, false
+		}
+		// avoid an extra allocation of a slice of bytes using unsafe conversions.
+		// The internal structure of the string is almost like a slice (except capacity).
+		_, _ = h.Write(unsafe.Slice(unsafe.StringData(key), len(key))) //nolint:gosec
+		// ignore errors returned by Write method because fnv never returns them.
+		_, _ = h.Write([]byte{255})                                        // use an invalid utf-8 sequence as separator
+		_, _ = h.Write(unsafe.Slice(unsafe.StringData(value), len(value))) //nolint:gosec
+		_, _ = h.Write([]byte{255})
+	}
+	return data.Fingerprint(h.Sum64()), true
+}
+
+func UnmarshalJoinCommand(refID string, rawData []byte) (*JoinCommand, error) {
+	type config struct {
+		Join struct {
+			LeftRefId      string   `json:"leftRefId"`
+			RightRefId     string   `json:"rightRefId"`
+			JoinType       string   `json:"joinType"`
+			Labels         []string `json:"labels"`
+			MathExpression string   `json:"expression"`
+		} `json:"join"`
+	}
+
+	var q config
+	err := json.Unmarshal(rawData, &q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the merge command: %w", err)
+	}
+	cfg := q.Join
+	if cfg.LeftRefId == "" {
+		return nil, fmt.Errorf("no left ref id specified to join")
+	}
+	if cfg.RightRefId == "" {
+		return nil, fmt.Errorf("no right ref id specified to join")
+	}
+	if cfg.JoinType != string(joinTypeInner) && cfg.JoinType != string(joinTypeLeft) {
+		return nil, fmt.Errorf("unsupported join type %s", cfg.JoinType)
+	}
+	if len(cfg.Labels) == 0 {
+		return nil, fmt.Errorf("no labels specified to join")
+	}
+	if cfg.MathExpression == "" {
+		return nil, fmt.Errorf("no math expression specified to join")
+	}
+	parsedExpr, err := mathexp.New(cfg.MathExpression)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse math expression: %w", err)
+	}
+
+	return &JoinCommand{
+		RefID:          refID,
+		LeftVar:        cfg.LeftRefId,
+		RightVar:       cfg.RightRefId,
+		MathExpression: parsedExpr,
+		JoinType:       joinType(cfg.JoinType),
+		Labels:         cfg.Labels,
+	}, nil
+}

--- a/pkg/expr/labels_rewrite.go
+++ b/pkg/expr/labels_rewrite.go
@@ -1,0 +1,249 @@
+package expr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	tmpltext "text/template"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+type labelReplace interface {
+	Eval(v string) string
+}
+
+type constantReplace struct {
+	Constant string
+}
+
+func (l constantReplace) Eval(v string) string {
+	return l.Constant
+}
+
+type regexReplace struct {
+	Regex   *regexp.Regexp
+	Replace string
+}
+
+func (l regexReplace) Eval(v string) string {
+	return l.Regex.ReplaceAllString(v, l.Replace)
+}
+
+type labelAdd interface {
+	Eval(value mathexp.Value) (string, error)
+}
+type constantAdd struct {
+	Constant string
+}
+
+func (l constantAdd) Eval(_ mathexp.Value) (string, error) {
+	return l.Constant, nil
+}
+
+type templateAdd struct {
+	Template *tmpltext.Template
+}
+
+func (t templateAdd) Eval(value mathexp.Value) (string, error) {
+	var intValue int64 = math.MinInt64
+	var v = math.NaN()
+	number, ok := value.(mathexp.Number)
+	if ok && number.GetFloat64Value() != nil {
+		v = *number.GetFloat64Value()
+		intValue = int64(v)
+	}
+	ctx := map[string]any{
+		"labels":   value.GetLabels(),
+		"value":    v,
+		"valueInt": intValue,
+	}
+	var buf bytes.Buffer
+	if err := t.Template.Execute(&buf, ctx); err != nil {
+		return "", fmt.Errorf("expand template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+type LabelsRewriteCommand struct {
+	ReferenceVar string
+	RefID        string
+
+	Add     map[string]labelAdd
+	Remove  map[string]struct{}
+	Replace map[string]labelReplace
+}
+
+type labelsWithOriginalFingerprint struct {
+	Value       mathexp.Value
+	Fingerprint data.Fingerprint
+}
+
+func (l LabelsRewriteCommand) NeedsVars() []string {
+	return []string{l.ReferenceVar}
+}
+
+func (l LabelsRewriteCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error) {
+	_, span := tracer.Start(ctx, "SSE.LabelsRewrite")
+	defer span.End()
+
+	refVarResult := vars[l.ReferenceVar]
+	newRes := mathexp.Results{Values: make(mathexp.Values, 0, len(refVarResult.Values))}
+	seenLabels := make(map[data.Fingerprint]*labelsWithOriginalFingerprint)
+	for _, val := range refVarResult.Values {
+		var result mathexp.Value
+		switch v := val.(type) {
+		case mathexp.Series:
+			s := mathexp.NewSeries(l.RefID, v.GetLabels(), v.Len())
+			for i := 0; i < v.Len(); i++ {
+				t, value := v.GetPoint(i)
+				s.SetPoint(i, t, value)
+			}
+			result = s
+		case mathexp.Number:
+			copyV := mathexp.NewNumber(l.RefID, v.GetLabels())
+			copyV.SetValue(v.GetFloat64Value())
+			result = copyV
+		case mathexp.Scalar:
+			copyV := mathexp.NewScalar(l.RefID, v.GetFloat64Value())
+			result = copyV
+		case mathexp.NoData:
+			result = mathexp.NewNoData()
+		default:
+			return newRes, fmt.Errorf("unsupported format of the input data, got type %v", val.Type())
+		}
+		if result.Type() != parse.TypeNoData {
+			err := l.remapLabels(result, seenLabels)
+			if err != nil {
+				return mathexp.Results{}, err
+			}
+		}
+		newRes.Values = append(newRes.Values, result)
+	}
+	return newRes, nil
+}
+
+func (l LabelsRewriteCommand) remapLabels(value mathexp.Value, seenLabels map[data.Fingerprint]*labelsWithOriginalFingerprint) error {
+	lbls := value.GetLabels()
+	result := make(data.Labels, len(lbls))
+	for k, v := range lbls {
+		if _, ok := l.Remove[k]; ok {
+			continue
+		}
+		if r, ok := l.Replace[k]; ok {
+			result[k] = r.Eval(v)
+			continue
+		}
+		result[k] = v
+	}
+	for k, v := range l.Add {
+		// do not add label if it exists.
+		if _, ok := lbls[k]; ok {
+			continue
+		}
+		val, err := v.Eval(value)
+		if err != nil {
+			return err
+		}
+		result[k] = val
+	}
+
+	fp := result.Fingerprint()
+	if seen, ok := seenLabels[fp]; ok {
+		result["__original_fp__"] = lbls.Fingerprint().String()
+		if seen != nil { // set the dedup label to the first seen label set
+			seenLbls := seen.Value.GetLabels().Copy()
+			seenLbls["__original_fp__"] = seen.Fingerprint.String()
+			seen.Value.SetLabels(seenLbls)
+			// avoid updating many times
+			seenLabels[fp] = nil
+		}
+	} else {
+		seenLabels[fp] = &labelsWithOriginalFingerprint{
+			Value:       value,
+			Fingerprint: lbls.Fingerprint(), // keep fingerprint of original labels
+		}
+	}
+	value.SetLabels(result)
+	return nil
+}
+
+func (l LabelsRewriteCommand) Type() string {
+	return "labels"
+}
+
+func UnmarshalLabelReplaceCommand(refID string, rawData []byte) (*LabelsRewriteCommand, error) {
+	type config struct {
+		Expression string `json:"expression"`
+		Rewrite    struct {
+			Add map[string]struct {
+				Constant string `json:"constant"`
+				Template string `json:"template"`
+			} `json:"add"`
+			Remove  []string `json:"remove"`
+			Replace map[string]struct {
+				Constant string `json:"constant"`
+				Regex    string `json:"regex"`
+				Replace  string `json:"replace"`
+			} `json:"replace"`
+		} `json:"labelRewrite"`
+	}
+	var q config
+	err := json.Unmarshal(rawData, &q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the labels command: %w", err)
+	}
+	cfg := q.Rewrite
+	if len(cfg.Add) == 0 && len(cfg.Remove) == 0 && len(cfg.Replace) == 0 {
+		return nil, fmt.Errorf("no labels specified to replace")
+	}
+	cmd := LabelsRewriteCommand{
+		RefID:        refID,
+		ReferenceVar: q.Expression,
+		Add:          make(map[string]labelAdd, len(cfg.Add)),
+		Remove:       make(map[string]struct{}, len(cfg.Remove)),
+		Replace:      make(map[string]labelReplace, len(cfg.Replace)),
+	}
+	for k, v := range cfg.Add {
+		if v.Constant != "" && v.Template != "" {
+			return nil, fmt.Errorf("cannot specify both constant and template for label %s", k)
+		}
+		if v.Constant != "" {
+			cmd.Add[k] = constantAdd{Constant: v.Constant}
+		}
+		if v.Template != "" {
+			t, err := tmpltext.New(k).Parse(v.Template)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse template for label %s: %w", k, err)
+			}
+			cmd.Add[k] = templateAdd{Template: t}
+		}
+	}
+	for _, k := range cfg.Remove {
+		cmd.Remove[k] = struct{}{}
+	}
+	for k, v := range cfg.Replace {
+		if v.Constant != "" && v.Regex != "" {
+			return nil, fmt.Errorf("cannot specify both constant and regex for label %s", k)
+		}
+		if v.Constant != "" {
+			cmd.Replace[k] = constantReplace{Constant: v.Constant}
+		}
+		if v.Regex != "" {
+			r, err := regexp.Compile(v.Regex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse regex for label %s: %w", k, err)
+			}
+			cmd.Replace[k] = regexReplace{Regex: r, Replace: v.Replace}
+		}
+	}
+	return &cmd, nil
+}

--- a/pkg/expr/merge.go
+++ b/pkg/expr/merge.go
@@ -1,0 +1,142 @@
+package expr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+type ConflictResolution string
+
+var (
+	DropValue ConflictResolution = "drop"
+)
+
+type MergeCommand struct {
+	ReferenceVar       []string
+	RefID              string
+	ConflictResolution ConflictResolution
+}
+
+func (l MergeCommand) NeedsVars() []string {
+	return l.ReferenceVar
+}
+
+type valuesAndRefIDs struct {
+	Values []mathexp.Value
+	RefID  string
+}
+
+func (l MergeCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error) {
+	_, span := tracer.Start(ctx, "SSE.Merge")
+	defer span.End()
+
+	length := 0
+	var expectedType = parse.TypeNoData
+	for _, s := range l.ReferenceVar {
+		length += len(vars[s].Values)
+		if len(vars[s].Values) > 0 {
+			t := vars[s].Values[0].Type()
+			if t == parse.TypeNoData {
+				continue
+			}
+			if expectedType == parse.TypeNoData {
+				expectedType = t
+			} else if t != expectedType {
+				return mathexp.Results{}, fmt.Errorf("format of refID %s %s is different than %s. make sure all input references have the same format", s, t, expectedType)
+			}
+		}
+	}
+
+	if expectedType == parse.TypeNoData {
+		return mathexp.Results{Values: mathexp.Values{mathexp.NewNoData()}}, nil
+	}
+	if expectedType != parse.TypeSeriesSet && expectedType != parse.TypeNumberSet {
+		return mathexp.Results{}, fmt.Errorf("unsupported format of the input data, got type %v", expectedType)
+	}
+
+	newRes := mathexp.Results{Values: make(mathexp.Values, 0, length)}
+	seenLabels := make(map[data.Fingerprint]valuesAndRefIDs, length)
+	dropped := 0
+	for _, s := range l.ReferenceVar {
+		refVarResult := vars[s]
+		for _, val := range refVarResult.Values {
+			// ignore no data values
+			if val.Type() == parse.TypeNoData {
+				continue
+			}
+			if expectedType != val.Type() {
+				return mathexp.Results{}, fmt.Errorf("format of refID %s %s is different than %s. make sure all input references have the same format", s, val.Type(), expectedType)
+			}
+			switch val.(type) {
+			case mathexp.Series:
+			case mathexp.Number:
+			default:
+				return newRes, fmt.Errorf("unsupported format of the input data, got type %v", val.Type())
+			}
+			fp := val.GetLabels().Fingerprint()
+			if seen, ok := seenLabels[fp]; ok && seen.RefID != l.RefID {
+				// TODO add notice to mention dropped
+				if l.ConflictResolution == DropValue {
+					dropped++
+					continue
+				}
+			}
+			seenLabels[fp] = valuesAndRefIDs{
+				Values: nil,
+				RefID:  s,
+			}
+			newRes.Values = append(newRes.Values, val)
+		}
+	}
+	return newRes, nil
+}
+
+func (l MergeCommand) Type() string {
+	return "merge"
+}
+
+func UnmarshalMergeCommand(refID string, rawData []byte) (*MergeCommand, error) {
+	type config struct {
+		Merge struct {
+			RefIDs     []string `json:"refIds"`
+			Resolution string   `json:"resolution"`
+		} `json:"merge"`
+	}
+	var q config
+	err := json.Unmarshal(rawData, &q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the merge command: %w", err)
+	}
+	cfg := q.Merge
+	if len(cfg.RefIDs) == 0 {
+		return nil, fmt.Errorf("no ref ids specified to merge")
+	}
+	refs := make(map[string]struct{}, len(cfg.RefIDs))
+	cmd := MergeCommand{
+		RefID:              refID,
+		ReferenceVar:       make([]string, 0, len(cfg.RefIDs)),
+		ConflictResolution: ConflictResolution(strings.ToLower(cfg.Resolution)),
+	}
+
+	for _, refID := range cfg.RefIDs {
+		if _, ok := refs[refID]; ok {
+			return nil, fmt.Errorf("duplicate refID %s", refID)
+		}
+		refs[refID] = struct{}{}
+		cmd.ReferenceVar = append(cmd.ReferenceVar, refID)
+	}
+
+	if cmd.ConflictResolution != DropValue {
+		return nil, fmt.Errorf("unsupported conflict resolution %s", cmd.ConflictResolution)
+	}
+	return &cmd, nil
+}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -132,6 +132,8 @@ func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles) (*CMDNode, er
 			return nil, err // should not happen because the command was parsed first thing
 		}
 
+		// TODO add new commands
+
 		// NOTE: this structure of this is weird now, because it is targeting a structure
 		// where this is actually run in the root loop, however we want to verify the individual
 		// node parsing before changing the full tree parser
@@ -166,6 +168,8 @@ func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles) (*CMDNode, er
 		node.Command, err = UnmarshalSQLCommand(rn)
 	case TypeLabelRewrite:
 		node.Command, err = UnmarshalLabelReplaceCommand(rn.RefID, rn.QueryRaw)
+	case TypeMerge:
+		node.Command, err = UnmarshalMergeCommand(rn.RefID, rn.QueryRaw)
 	default:
 		return nil, fmt.Errorf("expression command type '%v' in expression '%v' not implemented", commandType, rn.RefID)
 	}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -164,6 +164,8 @@ func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles) (*CMDNode, er
 		node.Command, err = UnmarshalThresholdCommand(rn, toggles)
 	case TypeSQL:
 		node.Command, err = UnmarshalSQLCommand(rn)
+	case TypeLabelRewrite:
+		node.Command, err = UnmarshalLabelReplaceCommand(rn.RefID, rn.QueryRaw)
 	default:
 		return nil, fmt.Errorf("expression command type '%v' in expression '%v' not implemented", commandType, rn.RefID)
 	}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -170,6 +170,8 @@ func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles) (*CMDNode, er
 		node.Command, err = UnmarshalLabelReplaceCommand(rn.RefID, rn.QueryRaw)
 	case TypeMerge:
 		node.Command, err = UnmarshalMergeCommand(rn.RefID, rn.QueryRaw)
+	case TypeJoin:
+		node.Command, err = UnmarshalJoinCommand(rn.RefID, rn.QueryRaw)
 	default:
 		return nil, fmt.Errorf("expression command type '%v' in expression '%v' not implemented", commandType, rn.RefID)
 	}

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -28,6 +28,7 @@ import {
 import { AlertQuery, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import LabelRewrite from '../../../../expressions/components/LabelRewrite';
+import Merge from '../../../../expressions/components/Merge';
 import { usePagination } from '../../hooks/usePagination';
 import { RuleFormValues } from '../../types/rule-form';
 import { isGrafanaRecordingRuleByType } from '../../utils/rules';
@@ -136,6 +137,8 @@ export const Expression: FC<ExpressionProps> = ({
           return <SqlExpr onChange={onChangeQuery} query={query} refIds={availableRefIds} />;
         case ExpressionQueryType.labelRewrite:
           return <LabelRewrite refIds={availableRefIds} expression={query} onChange={onChangeQuery} />;
+        case ExpressionQueryType.merge:
+          return <Merge refIds={availableRefIds} expression={query} onChange={onChangeQuery} />;
         default:
           return <>Expression not supported: {query.type}</>;
       }

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -22,11 +22,13 @@ import { Threshold } from 'app/features/expressions/components/Threshold';
 import {
   ExpressionQuery,
   ExpressionQueryType,
+  defaultJoin,
   expressionTypes,
   getExpressionLabel,
 } from 'app/features/expressions/types';
 import { AlertQuery, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
+import Join from '../../../../expressions/components/Join';
 import LabelRewrite from '../../../../expressions/components/LabelRewrite';
 import Merge from '../../../../expressions/components/Merge';
 import { usePagination } from '../../hooks/usePagination';
@@ -139,6 +141,18 @@ export const Expression: FC<ExpressionProps> = ({
           return <LabelRewrite refIds={availableRefIds} expression={query} onChange={onChangeQuery} />;
         case ExpressionQueryType.merge:
           return <Merge refIds={availableRefIds} expression={query} onChange={onChangeQuery} />;
+        case ExpressionQueryType.join:
+          return (
+            <Join
+              refIds={availableRefIds}
+              expression={query.join ?? defaultJoin()}
+              onChange={(e) => {
+                onChangeQuery({ ...query, join: e });
+              }}
+              onRunQuery={() => {}}
+              labelWidth={'auto'}
+            />
+          );
         default:
           return <>Expression not supported: {query.type}</>;
       }

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -27,6 +27,7 @@ import {
 } from 'app/features/expressions/types';
 import { AlertQuery, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
+import LabelRewrite from '../../../../expressions/components/LabelRewrite';
 import { usePagination } from '../../hooks/usePagination';
 import { RuleFormValues } from '../../types/rule-form';
 import { isGrafanaRecordingRuleByType } from '../../utils/rules';
@@ -133,7 +134,8 @@ export const Expression: FC<ExpressionProps> = ({
 
         case ExpressionQueryType.sql:
           return <SqlExpr onChange={onChangeQuery} query={query} refIds={availableRefIds} />;
-
+        case ExpressionQueryType.labelRewrite:
+          return <LabelRewrite refIds={availableRefIds} expression={query} onChange={onChangeQuery} />;
         default:
           return <>Expression not supported: {query.type}</>;
       }

--- a/public/app/features/alerting/unified/utils/timeRange.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.ts
@@ -34,6 +34,7 @@ const getReferencedIds = (model: ExpressionQuery, queries: AlertQuery[]): string
     case ExpressionQueryType.resample:
     case ExpressionQueryType.reduce:
     case ExpressionQueryType.threshold:
+    case ExpressionQueryType.labelRewrite:
       return getReferencedIdsForReduce(model);
   }
 };

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -4,6 +4,7 @@ import { DataSourceApi, QueryEditorProps, SelectableValue } from '@grafana/data'
 import { InlineField, Select } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
+import LabelRewrite from './components/LabelRewrite';
 import { Math } from './components/Math';
 import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
@@ -29,6 +30,7 @@ function useExpressionsCache() {
       case ExpressionQueryType.resample:
       case ExpressionQueryType.threshold:
       case ExpressionQueryType.sql:
+      case ExpressionQueryType.labelRewrite:
         return expressionCache.current[queryType];
       case ExpressionQueryType.classic:
         return undefined;
@@ -96,6 +98,9 @@ export function ExpressionQueryEditor(props: Props) {
 
       case ExpressionQueryType.sql:
         return <SqlExpr onChange={onChange} query={query} refIds={refIds} />;
+
+      case ExpressionQueryType.labelRewrite:
+        return <LabelRewrite refIds={refIds} expression={query} onChange={onChange} />;
     }
   };
 

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -4,6 +4,7 @@ import { DataSourceApi, QueryEditorProps, SelectableValue } from '@grafana/data'
 import { InlineField, Select } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
+import Join from './components/Join';
 import LabelRewrite from './components/LabelRewrite';
 import { Math } from './components/Math';
 import Merge from './components/Merge';
@@ -11,7 +12,7 @@ import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
 import { SqlExpr } from './components/SqlExpr';
 import { Threshold } from './components/Threshold';
-import { ExpressionQuery, ExpressionQueryType, expressionTypes } from './types';
+import { defaultJoin, ExpressionQuery, ExpressionQueryType, expressionTypes } from './types';
 import { getDefaults } from './utils/expressionTypes';
 
 type Props = QueryEditorProps<DataSourceApi<ExpressionQuery>, ExpressionQuery>;
@@ -33,6 +34,7 @@ function useExpressionsCache() {
       case ExpressionQueryType.sql:
       case ExpressionQueryType.labelRewrite:
       case ExpressionQueryType.merge:
+      case ExpressionQueryType.join:
         return expressionCache.current[queryType];
       case ExpressionQueryType.classic:
         return undefined;
@@ -105,6 +107,18 @@ export function ExpressionQueryEditor(props: Props) {
         return <LabelRewrite refIds={refIds} expression={query} onChange={onChange} />;
       case ExpressionQueryType.merge:
         return <Merge refIds={refIds} expression={query} onChange={onChange} />;
+      case ExpressionQueryType.join:
+        return (
+          <Join
+            refIds={refIds}
+            expression={query.join ?? defaultJoin()}
+            onChange={(e) => {
+              onChange({ ...query, join: e });
+            }}
+            onRunQuery={onRunQuery}
+            labelWidth={labelWidth}
+          />
+        );
     }
   };
 

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -6,6 +6,7 @@ import { InlineField, Select } from '@grafana/ui';
 import { ClassicConditions } from './components/ClassicConditions';
 import LabelRewrite from './components/LabelRewrite';
 import { Math } from './components/Math';
+import Merge from './components/Merge';
 import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
 import { SqlExpr } from './components/SqlExpr';
@@ -31,6 +32,7 @@ function useExpressionsCache() {
       case ExpressionQueryType.threshold:
       case ExpressionQueryType.sql:
       case ExpressionQueryType.labelRewrite:
+      case ExpressionQueryType.merge:
         return expressionCache.current[queryType];
       case ExpressionQueryType.classic:
         return undefined;
@@ -101,6 +103,8 @@ export function ExpressionQueryEditor(props: Props) {
 
       case ExpressionQueryType.labelRewrite:
         return <LabelRewrite refIds={refIds} expression={query} onChange={onChange} />;
+      case ExpressionQueryType.merge:
+        return <Merge refIds={refIds} expression={query} onChange={onChange} />;
     }
   };
 

--- a/public/app/features/expressions/components/Join.tsx
+++ b/public/app/features/expressions/components/Join.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+
+import { JoinSettings } from '../types';
+
+import { MathExpressionInput } from './Math';
+
+interface JoinProps {
+  labelWidth: number | 'auto';
+  refIds: Array<SelectableValue<string>>;
+  expression: JoinSettings;
+  onChange: (query: JoinSettings) => void;
+  onError?: (error: string | undefined) => void;
+  onRunQuery: () => void;
+}
+
+const types: Array<SelectableValue<string>> = [
+  { label: 'LEFT OUTER', value: 'outer' },
+  { label: 'INNER', value: 'inner' },
+];
+
+const Join: React.FC<JoinProps> = ({ labelWidth, refIds, onError, onChange, expression, onRunQuery }) => {
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="Left RefID" labelWidth={labelWidth}>
+          <Select
+            options={refIds}
+            value={expression.leftRefId}
+            width={20}
+            onChange={(e) => {
+              onChange({ ...expression, leftRefId: e.value ?? '' });
+            }}
+          />
+        </InlineField>
+        <InlineField label="Join Type" labelWidth={labelWidth}>
+          <Select
+            options={types}
+            value={expression.joinType}
+            width="auto"
+            onChange={(e) => {
+              onChange({ ...expression, joinType: e.value ?? '' });
+            }}
+          />
+        </InlineField>
+        <InlineField label="Right RefID" labelWidth={labelWidth}>
+          <Select
+            options={refIds}
+            value={expression.rightRefId}
+            width={20}
+            onChange={(e) => {
+              onChange({ ...expression, rightRefId: e.value ?? '' });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="By Labels" labelWidth={labelWidth}>
+          <Select
+            allowCustomValue
+            value={expression.labels.map((l) => {
+              return {
+                label: l,
+                value: l,
+              };
+            })}
+            onChange={(e) => {
+              onChange({ ...expression, labels: e.map((v: SelectableValue) => v.value) });
+            }}
+            onCreateOption={(e) => {
+              onChange({ ...expression, labels: expression.labels.concat(e) });
+            }}
+            multi={true}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <MathExpressionInput
+          expression={expression.expression}
+          onChange={(exp) => {
+            onChange({ ...expression, expression: exp });
+          }}
+          labelWidth={labelWidth}
+          onRunQuery={onRunQuery}
+        />
+      </InlineFieldRow>
+    </>
+  );
+};
+
+export default Join;

--- a/public/app/features/expressions/components/LabelAddInput.tsx
+++ b/public/app/features/expressions/components/LabelAddInput.tsx
@@ -1,0 +1,230 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Button, Input, Select, Stack, useStyles2 } from '@grafana/ui';
+
+import { ActionIcon } from '../../alerting/unified/components/rules/ActionIcon';
+import { LabelAdd } from '../types';
+
+interface LabelAddInputProps {
+  value?: Record<string, LabelAdd>;
+  onChange: (value: Record<string, LabelAdd>) => void;
+}
+
+interface AddLine {
+  key: string;
+  type: string;
+  value: string;
+}
+
+export const LabelAddInput = ({ value, onChange }: LabelAddInputProps) => {
+  const styles = useStyles2(getStyles);
+  const [pairs, setPairs] = useState(recordToPairs(value));
+  const [current, setCurrent] = useState<AddLine | undefined>(undefined);
+
+  const types: Array<SelectableValue<string>> = [
+    { label: 'Constant', value: 'constant' },
+    { label: 'Template', value: 'template' },
+  ];
+
+  const editPair = (index: number, r: AddLine) => {
+    const newPairs = pairs.slice();
+    newPairs[index] = r;
+    setPairs(newPairs);
+    emitChange(newPairs);
+  };
+
+  const emitChange = (pairs: AddLine[]) => {
+    onChange(pairsToRecord(pairs));
+  };
+
+  const deleteItem = (index: number) => {
+    const newPairs = pairs.slice();
+    const removed = newPairs.splice(index, 1);
+    setPairs(newPairs);
+    if (removed[0]) {
+      emitChange(newPairs);
+    }
+  };
+
+  return (
+    <div>
+      {!!pairs.length && (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map(({ key, value, type }: AddLine, index) => (
+              <tr key={index}>
+                <td>
+                  <Input value={key} disabled />
+                </td>
+                <td>
+                  <Select
+                    options={types}
+                    value={type}
+                    onChange={(value) => {
+                      editPair(index, {
+                        ...pairs[index],
+                        type: value.value ?? 'constant',
+                        value: '',
+                      });
+                    }}
+                  />
+                </td>
+                <td>
+                  <Input
+                    value={value}
+                    onChange={(e) =>
+                      editPair(index, {
+                        ...pairs[index],
+                        value: e.currentTarget.value,
+                      })
+                    }
+                  />
+                </td>
+                <td>
+                  <ActionIcon icon="trash-alt" tooltip="Delete" onClick={() => deleteItem(index)} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {current && (
+        <table className={styles.table}>
+          <tr>
+            <Stack gap={1}>
+              <td>
+                <Input
+                  value={current.key}
+                  onChange={(e) =>
+                    setCurrent({
+                      ...current,
+                      key: e.currentTarget.value,
+                    })
+                  }
+                />
+              </td>
+              <td>
+                <Select
+                  options={types}
+                  value={current.type}
+                  onChange={(value) => {
+                    setCurrent({
+                      ...current,
+                      type: value.value ?? 'constant',
+                      value: '',
+                    });
+                  }}
+                />
+              </td>
+              <td>
+                <Input
+                  value={current.value}
+                  onChange={(e) =>
+                    setCurrent({
+                      ...current,
+                      value: e.currentTarget.value,
+                    })
+                  }
+                />
+              </td>
+              <td>
+                <Stack gap={1}>
+                  <ActionIcon
+                    icon="check"
+                    tooltip="Confirm to add"
+                    onClick={() => {
+                      setPairs([...pairs, current]);
+                      setCurrent(undefined);
+                      emitChange([...pairs, current]);
+                    }}
+                  />
+                  <ActionIcon icon="times" tooltip="Cancel" onClick={() => setCurrent(undefined)} />
+                </Stack>
+              </td>
+            </Stack>
+          </tr>
+        </table>
+      )}
+      <Button
+        className={styles.addButton}
+        type="button"
+        variant="secondary"
+        icon="plus"
+        size="sm"
+        disabled={!!current}
+        onClick={() => setCurrent({ key: '', type: 'constant', value: '' })}
+      >
+        Add
+      </Button>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  addButton: css({
+    marginTop: theme.spacing(1),
+  }),
+  table: css({
+    'tbody td': {
+      padding: `0 ${theme.spacing(1)} ${theme.spacing(1)} 0`,
+    },
+  }),
+});
+
+const pairsToRecord = (pairs: AddLine[]): Record<string, LabelAdd> => {
+  const record: Record<string, LabelAdd> = {};
+  for (const value of pairs) {
+    if (value.type === 'constant') {
+      record[value.key] = {
+        constant: value.value,
+        template: null,
+      };
+      continue;
+    }
+    if (value.type === 'template') {
+      record[value.key] = {
+        template: value.value,
+        constant: null,
+      };
+    }
+  }
+  return record;
+};
+
+const recordToPairs = (obj?: Record<string, LabelAdd>): AddLine[] => {
+  if (!obj) {
+    return [];
+  }
+  const pairs: AddLine[] = [];
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (!val) {
+      continue;
+    }
+    if (val.constant && val.constant !== '') {
+      pairs.push({
+        key: key,
+        type: 'constant',
+        value: val.constant,
+      });
+      continue;
+    }
+    if (val.template && val.template !== '') {
+      pairs.push({
+        key: key,
+        type: 'template',
+        value: val.template,
+      });
+    }
+  }
+  return pairs;
+};

--- a/public/app/features/expressions/components/LabelReplaceInput.tsx
+++ b/public/app/features/expressions/components/LabelReplaceInput.tsx
@@ -1,0 +1,257 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Button, Input, Select, Stack, useStyles2 } from '@grafana/ui';
+
+import { ActionIcon } from '../../alerting/unified/components/rules/ActionIcon';
+import { LabelReplace } from '../types';
+
+interface LabelReplaceInputProps {
+  value?: Record<string, LabelReplace>;
+  onChange: (value: Record<string, LabelReplace>) => void;
+}
+
+interface ReplaceLine {
+  key: string;
+  type: string;
+  value: string[];
+}
+
+export const LabelReplaceInput = ({ value, onChange }: LabelReplaceInputProps) => {
+  const styles = useStyles2(getStyles);
+  const [pairs, setPairs] = useState(recordToPairs(value));
+  const [current, setCurrent] = useState<ReplaceLine | undefined>(undefined);
+
+  const types: Array<SelectableValue<string>> = [
+    { label: 'Constant', value: 'constant' },
+    { label: 'Regex', value: 'regex' },
+  ];
+
+  const editPair = (index: number, r: ReplaceLine) => {
+    const newPairs = pairs.slice();
+    newPairs[index] = r;
+    setPairs(newPairs);
+    emitChange(newPairs);
+  };
+
+  const emitChange = (pairs: ReplaceLine[]) => {
+    onChange(pairsToRecord(pairs));
+  };
+
+  const deleteItem = (index: number) => {
+    const newPairs = pairs.slice();
+    const removed = newPairs.splice(index, 1);
+    setPairs(newPairs);
+    if (removed[0]) {
+      emitChange(newPairs);
+    }
+  };
+
+  return (
+    <div>
+      {!!pairs.length && (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map(({ key, value, type }: ReplaceLine, index) => (
+              <tr key={index}>
+                <td>
+                  <Input value={key} disabled />
+                </td>
+                <td>
+                  <Select
+                    options={types}
+                    value={type}
+                    onChange={(value) => {
+                      editPair(index, {
+                        ...pairs[index],
+                        type: value.value ?? 'constant',
+                        value: value.value === 'constant' ? [''] : ['', ''],
+                      });
+                    }}
+                  />
+                </td>
+                <td>
+                  <Input
+                    value={value[0]}
+                    onChange={(e) => {
+                      editPair(index, {
+                        ...pairs[index],
+                        value: type === 'constant' ? [e.currentTarget.value] : [e.currentTarget.value, value[1]],
+                      });
+                    }}
+                  />
+                  {type === 'regex' && (
+                    <Input
+                      value={value[1]}
+                      onChange={(e) => {
+                        editPair(index, {
+                          ...pairs[index],
+                          value: [value[0], e.currentTarget.value],
+                        });
+                      }}
+                    />
+                  )}
+                </td>
+                <td>
+                  <ActionIcon icon="trash-alt" tooltip="Delete" onClick={() => deleteItem(index)} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {current && (
+        <table className={styles.table}>
+          <tr>
+            <Stack gap={1}>
+              <td>
+                <Input
+                  value={current.key}
+                  onChange={(e) =>
+                    setCurrent({
+                      ...current,
+                      key: e.currentTarget.value,
+                    })
+                  }
+                />
+              </td>
+              <td>
+                <Select
+                  options={types}
+                  value={current.type}
+                  onChange={(value) => {
+                    setCurrent({
+                      ...current,
+                      type: value.value ?? 'constant',
+                      value: value.value === 'constant' ? [''] : ['', ''],
+                    });
+                  }}
+                />
+              </td>
+              <td>
+                <Input
+                  value={current.value[0]}
+                  onChange={(e) =>
+                    setCurrent({
+                      ...current,
+                      value:
+                        current?.type === 'constant'
+                          ? [e.currentTarget.value]
+                          : [e.currentTarget.value, current?.value[1]],
+                    })
+                  }
+                />
+                {current.type === 'regex' && (
+                  <Input
+                    value={current.value[1]}
+                    onChange={(e) =>
+                      setCurrent({
+                        ...current,
+                        value: [current?.value[0], e.currentTarget.value],
+                      })
+                    }
+                  />
+                )}
+              </td>
+              <td>
+                <Stack gap={1}>
+                  <ActionIcon
+                    icon="check"
+                    tooltip="Confirm to add"
+                    onClick={() => {
+                      setPairs([...pairs, current]);
+                      setCurrent(undefined);
+                      emitChange([...pairs, current]);
+                    }}
+                  />
+                  <ActionIcon icon="times" tooltip="Cancel" onClick={() => setCurrent(undefined)} />
+                </Stack>
+              </td>
+            </Stack>
+          </tr>
+        </table>
+      )}
+      <Button
+        className={styles.addButton}
+        type="button"
+        variant="secondary"
+        icon="plus"
+        size="sm"
+        disabled={!!current}
+        onClick={() => setCurrent({ key: '', type: 'constant', value: [''] })}
+      >
+        Add
+      </Button>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  addButton: css({
+    marginTop: theme.spacing(1),
+  }),
+  table: css({
+    'tbody td': {
+      padding: `0 ${theme.spacing(1)} ${theme.spacing(1)} 0`,
+    },
+  }),
+});
+
+const pairsToRecord = (pairs: ReplaceLine[]): Record<string, LabelReplace> => {
+  const record: Record<string, LabelReplace> = {};
+  for (const value of pairs) {
+    if (value.type === 'constant') {
+      record[value.key] = {
+        constant: value.value[0],
+        regex: null,
+        replace: null,
+      };
+      continue;
+    }
+    if (value.type === 'regex') {
+      record[value.key] = {
+        constant: null,
+        regex: value.value[0],
+        replace: value.value[1],
+      };
+    }
+  }
+  return record;
+};
+
+const recordToPairs = (obj?: Record<string, LabelReplace>): ReplaceLine[] => {
+  if (!obj) {
+    return [];
+  }
+  const pairs: ReplaceLine[] = [];
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (!val) {
+      continue;
+    }
+    if (val.constant && val.constant !== '') {
+      pairs.push({
+        key: key,
+        type: 'constant',
+        value: [val.constant],
+      });
+      continue;
+    }
+    if (val.regex && val.regex !== '') {
+      pairs.push({
+        key: key,
+        type: 'regex',
+        value: [val.regex, val.replace ?? ''],
+      });
+    }
+  }
+  return pairs;
+};

--- a/public/app/features/expressions/components/LabelRewrite.tsx
+++ b/public/app/features/expressions/components/LabelRewrite.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+
+import { StringArrayInput } from '../../alerting/unified/components/receivers/form/fields/StringArrayInput';
+import { ExpressionQuery } from '../types';
+
+import { LabelAddInput } from './LabelAddInput';
+import { LabelReplaceInput } from './LabelReplaceInput';
+
+interface LabelRewriteProps {
+  labelWidth?: number | 'auto';
+  refIds: Array<SelectableValue<string>>;
+  expression: ExpressionQuery;
+  onChange: (query: ExpressionQuery) => void;
+  onError?: (error: string | undefined) => void;
+}
+
+const LabelRewrite: React.FC<LabelRewriteProps> = ({ labelWidth, refIds, onError, onChange, expression }) => {
+  const onRefIdChange = (value: SelectableValue<string>) => {
+    onChange({ ...expression, expression: value.value });
+  };
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="input" labelWidth={labelWidth}>
+          <Select options={refIds} value={expression.expression} width={20} onChange={onRefIdChange} />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Add" grow>
+          <LabelAddInput
+            value={expression.labelRewrite?.add}
+            onChange={(e) => {
+              onChange({ ...expression, labelRewrite: { ...expression.labelRewrite, add: e } });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Replace" grow>
+          <LabelReplaceInput
+            value={expression.labelRewrite?.replace}
+            onChange={(e) => {
+              onChange({ ...expression, labelRewrite: { ...expression.labelRewrite, replace: e } });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Remove" grow>
+          <StringArrayInput
+            value={expression.labelRewrite?.remove}
+            onChange={(e) => {
+              onChange({ ...expression, labelRewrite: { ...expression.labelRewrite, remove: e } });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
+  );
+};
+
+export default LabelRewrite;

--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -19,120 +19,142 @@ const mathPlaceholder =
   'The sum of two scalar values: $A + $B > 10';
 
 export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
+  const onExpressionChange = (exp: string) => {
+    onChange({ ...query, expression: exp });
+  };
+
+  return (
+    <Stack>
+      <MathExpressionInput
+        labelWidth={labelWidth}
+        expression={query.expression}
+        onChange={onExpressionChange}
+        onRunQuery={onRunQuery}
+      />
+    </Stack>
+  );
+};
+
+interface MathExpressionInputProps {
+  labelWidth: number | 'auto';
+  expression: string | undefined;
+  onChange: (query: string) => void;
+  onRunQuery: () => void;
+}
+
+export const MathExpressionInput = ({ labelWidth, onChange, expression, onRunQuery }: MathExpressionInputProps) => {
   const onExpressionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    onChange({ ...query, expression: event.target.value });
+    onChange(event.target.value);
   };
 
   const styles = useStyles2(getStyles);
 
   const executeQuery = () => {
-    if (query.expression) {
+    if (expression) {
       onRunQuery();
     }
   };
 
   return (
-    <Stack>
-      <InlineField
-        label={
-          <InlineLabel width="auto">
-            <Toggletip
-              fitContent
-              content={
-                <div className={styles.documentationContainer}>
-                  <div>
-                    Run math operations on one or more queries. You reference the query by {'${refId}'} ie. $A, $B, $C
-                    etc.
-                    <br />
-                    Example: <code>$A + $B</code>
-                  </div>
-                  <header className={styles.documentationHeader}>Available Math functions</header>
-                  <div className={styles.documentationFunctions}>
-                    <DocumentedFunction
-                      name="abs"
-                      description="returns the absolute value of its argument which can be a number or a series"
-                    />
-                    <DocumentedFunction
-                      name="is_inf"
-                      description="returns 1 for Inf values (negative or positive) and 0 for other values. It's able to operate on series or scalar values."
-                    />
-                    <DocumentedFunction
-                      name="is_nan"
-                      description="returns 1 for NaN values and 0 for other values. It's able to operate on series or scalar values."
-                    />
-                    <DocumentedFunction
-                      name="is_null"
-                      description="returns 1 for null values and 0 for other values. It's able to operate on series or scalar values."
-                    />
-                    <DocumentedFunction
-                      name="is_number"
-                      description="returns 1 for all real number values and 0 for non-number. It's able to operate on series or scalar values."
-                    />
-                    <DocumentedFunction
-                      name="log"
-                      description="returns the natural logarithm of its argument, which can be a number or a series"
-                    />
-                    <DocumentedFunction
-                      name="inf, infn, nan, and null"
-                      description="The inf for infinity positive, infn for infinity negative, nan, and null functions all return a single scalar value that matches its name."
-                    />
-                    <DocumentedFunction
-                      name="round"
-                      description="returns a rounded integer value. It's able to operate on series or escalar values."
-                    />
-                    <DocumentedFunction
-                      name="ceil"
-                      description="rounds the number up to the nearest integer value. It's able to operate on series or escalar values."
-                    />
-                    <DocumentedFunction
-                      name="floor"
-                      description="rounds the number down to the nearest integer value. It's able to operate on series or escalar values."
-                    />
-                  </div>
-                </div>
-              }
-              title={
-                <Stack gap={1} direction="row">
-                  <Icon name="book-open" /> Math operator
-                </Stack>
-              }
-              footer={
+    <InlineField
+      label={
+        <InlineLabel width="auto">
+          <Toggletip
+            fitContent
+            content={
+              <div className={styles.documentationContainer}>
                 <div>
-                  See our additional documentation on{' '}
-                  <a
-                    className={styles.documentationLink}
-                    target="_blank"
-                    href="https://grafana.com/docs/grafana/latest/panels/query-a-data-source/use-expressions-to-manipulate-data/about-expressions/#math"
-                    rel="noreferrer"
-                  >
-                    <Icon size="xs" name="external-link-alt" /> Math expressions
-                  </a>
-                  .
+                  Run math operations on one or more queries. You reference the query by {'${refId}'} ie. $A, $B, $C
+                  etc.
+                  <br />
+                  Example: <code>$A + $B</code>
                 </div>
-              }
-              closeButton={true}
-              placement="bottom-start"
-            >
-              <div className={styles.info}>
-                Expression <Icon name="info-circle" />
+                <header className={styles.documentationHeader}>Available Math functions</header>
+                <div className={styles.documentationFunctions}>
+                  <DocumentedFunction
+                    name="abs"
+                    description="returns the absolute value of its argument which can be a number or a series"
+                  />
+                  <DocumentedFunction
+                    name="is_inf"
+                    description="returns 1 for Inf values (negative or positive) and 0 for other values. It's able to operate on series or scalar values."
+                  />
+                  <DocumentedFunction
+                    name="is_nan"
+                    description="returns 1 for NaN values and 0 for other values. It's able to operate on series or scalar values."
+                  />
+                  <DocumentedFunction
+                    name="is_null"
+                    description="returns 1 for null values and 0 for other values. It's able to operate on series or scalar values."
+                  />
+                  <DocumentedFunction
+                    name="is_number"
+                    description="returns 1 for all real number values and 0 for non-number. It's able to operate on series or scalar values."
+                  />
+                  <DocumentedFunction
+                    name="log"
+                    description="returns the natural logarithm of its argument, which can be a number or a series"
+                  />
+                  <DocumentedFunction
+                    name="inf, infn, nan, and null"
+                    description="The inf for infinity positive, infn for infinity negative, nan, and null functions all return a single scalar value that matches its name."
+                  />
+                  <DocumentedFunction
+                    name="round"
+                    description="returns a rounded integer value. It's able to operate on series or escalar values."
+                  />
+                  <DocumentedFunction
+                    name="ceil"
+                    description="rounds the number up to the nearest integer value. It's able to operate on series or escalar values."
+                  />
+                  <DocumentedFunction
+                    name="floor"
+                    description="rounds the number down to the nearest integer value. It's able to operate on series or escalar values."
+                  />
+                </div>
               </div>
-            </Toggletip>
-          </InlineLabel>
-        }
-        labelWidth={labelWidth}
-        grow={true}
-        shrink={true}
-      >
-        <TextArea
-          value={query.expression}
-          onChange={onExpressionChange}
-          rows={1}
-          placeholder={mathPlaceholder}
-          onBlur={executeQuery}
-          style={{ minWidth: 250, lineHeight: '26px', minHeight: 32 }}
-        />
-      </InlineField>
-    </Stack>
+            }
+            title={
+              <Stack gap={1} direction="row">
+                <Icon name="book-open" /> Math operator
+              </Stack>
+            }
+            footer={
+              <div>
+                See our additional documentation on{' '}
+                <a
+                  className={styles.documentationLink}
+                  target="_blank"
+                  href="https://grafana.com/docs/grafana/latest/panels/query-a-data-source/use-expressions-to-manipulate-data/about-expressions/#math"
+                  rel="noreferrer"
+                >
+                  <Icon size="xs" name="external-link-alt" /> Math expressions
+                </a>
+                .
+              </div>
+            }
+            closeButton={true}
+            placement="bottom-start"
+          >
+            <div className={styles.info}>
+              Expression <Icon name="info-circle" />
+            </div>
+          </Toggletip>
+        </InlineLabel>
+      }
+      labelWidth={labelWidth}
+      grow={true}
+      shrink={true}
+    >
+      <TextArea
+        value={expression}
+        onChange={onExpressionChange}
+        rows={1}
+        placeholder={mathPlaceholder}
+        onBlur={executeQuery}
+        style={{ minWidth: 250, lineHeight: '26px', minHeight: 32 }}
+      />
+    </InlineField>
   );
 };
 
@@ -140,7 +162,8 @@ interface DocumentedFunctionProps {
   name: string;
   description: React.ReactNode;
 }
-const DocumentedFunction = ({ name, description }: DocumentedFunctionProps) => {
+
+export const DocumentedFunction = ({ name, description }: DocumentedFunctionProps) => {
   const styles = useStyles2(getDocumentedFunctionStyles);
 
   return (
@@ -151,7 +174,7 @@ const DocumentedFunction = ({ name, description }: DocumentedFunctionProps) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+export const getStyles = (theme: GrafanaTheme2) => ({
   documentationHeader: css({
     fontSize: theme.typography.h5.fontSize,
     fontWeight: theme.typography.h5.fontWeight,

--- a/public/app/features/expressions/components/Merge.tsx
+++ b/public/app/features/expressions/components/Merge.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+
+import { ExpressionQuery } from '../types';
+
+interface MergeProps {
+  labelWidth?: number | 'auto';
+  refIds: Array<SelectableValue<string>>;
+  expression: ExpressionQuery;
+  onChange: (query: ExpressionQuery) => void;
+  onError?: (error: string | undefined) => void;
+}
+
+const types: Array<SelectableValue<string>> = [{ label: 'Drop Duplicates', value: 'drop' }];
+
+const Merge: React.FC<MergeProps> = ({ labelWidth, refIds, onError, onChange, expression }) => {
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="input" labelWidth={labelWidth}>
+          <Select
+            onChange={(e) => {
+              onChange({
+                ...expression,
+                merge: {
+                  refids: e.map((v: SelectableValue) => v.value),
+                  resolution: expression.merge?.resolution ?? 'drop',
+                },
+              });
+            }}
+            options={refIds}
+            isMulti={true}
+            value={expression.merge?.refids}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Add" grow>
+          <Select
+            options={types}
+            value={expression.merge?.resolution ?? 'drop'}
+            onChange={(e) => {
+              onChange({
+                ...expression,
+                merge: { refids: expression.merge?.refids ?? [], resolution: e.value ?? 'drop' },
+              });
+            }}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
+  );
+};
+
+export default Merge;

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -17,6 +17,7 @@ export enum ExpressionQueryType {
   sql = 'sql',
   labelRewrite = 'label_rewrite',
   merge = 'merge',
+  join = 'join',
 }
 
 export const getExpressionLabel = (type: ExpressionQueryType) => {
@@ -37,6 +38,8 @@ export const getExpressionLabel = (type: ExpressionQueryType) => {
       return 'Rewrite Labels';
     case ExpressionQueryType.merge:
       return 'Merge Results';
+    case ExpressionQueryType.join:
+      return 'Join';
   }
 };
 
@@ -83,6 +86,11 @@ export const expressionTypes: Array<SelectableValue<ExpressionQueryType>> = [
     value: ExpressionQueryType.merge,
     label: 'Merge Results',
     description: 'Allows to merge results of other expressions into one set',
+  },
+  {
+    value: ExpressionQueryType.join,
+    label: 'Join',
+    description: 'Allows to join results of other expressions by labels into one set',
   },
 ].filter((expr) => {
   if (expr.value === ExpressionQueryType.sql) {
@@ -167,6 +175,7 @@ export interface ExpressionQuery extends DataQuery {
   settings?: ExpressionQuerySettings;
   labelRewrite?: LabelRewriteSettings;
   merge?: MergeSettings;
+  join?: JoinSettings;
 }
 
 export interface ThresholdExpressionQuery extends ExpressionQuery {
@@ -234,3 +243,21 @@ export interface MergeSettings {
   refids: string[];
   resolution: string;
 }
+
+export interface JoinSettings {
+  joinType: string;
+  leftRefId: string;
+  rightRefId: string;
+  expression: string;
+  labels: string[];
+}
+
+export const defaultJoin = (): JoinSettings => {
+  return {
+    joinType: 'inner',
+    leftRefId: '',
+    rightRefId: '',
+    expression: '',
+    labels: [],
+  };
+};

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -15,6 +15,7 @@ export enum ExpressionQueryType {
   classic = 'classic_conditions',
   threshold = 'threshold',
   sql = 'sql',
+  labelRewrite = 'label_rewrite',
 }
 
 export const getExpressionLabel = (type: ExpressionQueryType) => {
@@ -31,6 +32,8 @@ export const getExpressionLabel = (type: ExpressionQueryType) => {
       return 'Threshold';
     case ExpressionQueryType.sql:
       return 'SQL';
+    case ExpressionQueryType.labelRewrite:
+      return 'Rewrite Labels';
   }
 };
 
@@ -67,6 +70,11 @@ export const expressionTypes: Array<SelectableValue<ExpressionQueryType>> = [
     value: ExpressionQueryType.sql,
     label: 'SQL',
     description: 'Transform data using SQL. Supports Aggregate/Analytics functions from DuckDB',
+  },
+  {
+    value: ExpressionQueryType.labelRewrite,
+    label: 'Label Rewrite',
+    description: 'Add, remove and replace labels in the series',
   },
 ].filter((expr) => {
   if (expr.value === ExpressionQueryType.sql) {
@@ -149,6 +157,7 @@ export interface ExpressionQuery extends DataQuery {
   upsampler?: string;
   conditions?: ClassicCondition[];
   settings?: ExpressionQuerySettings;
+  labelRewrite?: LabelRewriteSettings;
 }
 
 export interface ThresholdExpressionQuery extends ExpressionQuery {
@@ -194,3 +203,20 @@ export type ReducerType =
   | 'percent_diff'
   | 'percent_diff_abs'
   | 'count_non_null';
+
+export interface LabelRewriteSettings {
+  add?: Record<string, LabelAdd>;
+  remove?: string[];
+  replace?: Record<string, LabelReplace>;
+}
+
+export interface LabelAdd {
+  constant: string | null;
+  template: string | null;
+}
+
+export interface LabelReplace {
+  constant: string | null;
+  regex: string | null;
+  replace: string | null;
+}

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -16,6 +16,7 @@ export enum ExpressionQueryType {
   threshold = 'threshold',
   sql = 'sql',
   labelRewrite = 'label_rewrite',
+  merge = 'merge',
 }
 
 export const getExpressionLabel = (type: ExpressionQueryType) => {
@@ -34,6 +35,8 @@ export const getExpressionLabel = (type: ExpressionQueryType) => {
       return 'SQL';
     case ExpressionQueryType.labelRewrite:
       return 'Rewrite Labels';
+    case ExpressionQueryType.merge:
+      return 'Merge Results';
   }
 };
 
@@ -75,6 +78,11 @@ export const expressionTypes: Array<SelectableValue<ExpressionQueryType>> = [
     value: ExpressionQueryType.labelRewrite,
     label: 'Label Rewrite',
     description: 'Add, remove and replace labels in the series',
+  },
+  {
+    value: ExpressionQueryType.merge,
+    label: 'Merge Results',
+    description: 'Allows to merge results of other expressions into one set',
   },
 ].filter((expr) => {
   if (expr.value === ExpressionQueryType.sql) {
@@ -158,6 +166,7 @@ export interface ExpressionQuery extends DataQuery {
   conditions?: ClassicCondition[];
   settings?: ExpressionQuerySettings;
   labelRewrite?: LabelRewriteSettings;
+  merge?: MergeSettings;
 }
 
 export interface ThresholdExpressionQuery extends ExpressionQuery {
@@ -219,4 +228,9 @@ export interface LabelReplace {
   constant: string | null;
   regex: string | null;
   replace: string | null;
+}
+
+export interface MergeSettings {
+  refids: string[];
+  resolution: string;
 }


### PR DESCRIPTION
**What is this feature?**
This is experimental PR that explores possibilities of new expressions:

### Label Rewrite 
allows to rewrite labels of a result. The sequence of operations (remove -> replace -> add )
  - add: can add label _if it does not exist_ . It supports templates with context `.labels` that includes all original labels and `.value` (float) that contains value of the dimension as well as `.valueInt` which is integer representation of the value. NOTE: value is only available if the input RefID is a number vector (not time-series).
  - replace: allows to replace the labels, supports regular expresisons.
  - remove: removes the label if it exists.

Expression does some safety-check after rewriting: there are two or many dimensions with the same labels after rewriting, it adds label `__original_fp__` that contains a hash of the original labels to each duplicated dimension.

### Merge:
Allows merge results of many expressions into one set. Supports only number vector, i.e. the timeseries must be reduced. In the case of collision (when two expressions have the dimensions with the same lables) the expression that goes first in the list - wins. All duplicates from other expressions are dropped.

### Join:
Allows joining two results by specific subset of labels and execute a math expression. This is alternative to math expression that does not offer control over the join operation. 
The expression matches dimensions from left side with ones on the right side by using the subset of the labels that must exist on both sides. 
For example, 
```
A { "label": "a", "foo": "bar",  "data": "b"} 
B { "label": "a", "foo": "bar", "another": "label"} 
```
can be joined by labels `["foo", "label"]`. But join by `["foo", "label", "data"]` won't return any results. 

The operation offers two types of join: outer and inner. 
- inner join returns only results that have matches on both sides. The resulting label set will have labels from the left + all unique from the right. In the example above, the resulting labels will be `{ "label": "a", "foo": "bar",  "data": "b", "another": "label"} `.
- in the case of outer join, the result contains all dimensions from the left side. If left dimension does not have the match on the right the math expression will still be evaluated but the value of the right side will be `NaN`.

<details> <summary> Example: Join </summary>

![image](https://github.com/user-attachments/assets/ee9b7983-3a80-48cc-9fed-0988f8e5ec08)

</details>

<details> <summary> Example: Label Rewrite + Merge </summary>

![image](https://github.com/user-attachments/assets/01dab3d8-2d25-4ffe-81f3-43514223c945)

</details>

**Why do we need this feature?**
This will allow more flexibility in writing server side expressions and queries. 
