### PR TITLE
Transformations: Improve groupBy field selection and aggregated field types

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -131,6 +131,14 @@ export enum ReducerID {
   p99 = 'p99',
 }
 
+export function getFieldTypeForReducer(id: ReducerID, fallback: FieldType): FieldType {
+  return id === ReducerID.count
+    ? FieldType.number
+    : id === ReducerID.allIsNull || id === ReducerID.allIsZero
+      ? FieldType.boolean
+      : fallback;
+}
+
 export function isReducerID(id: string): id is ReducerID {
   return Object.keys(ReducerID).includes(id);
 }

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -414,4 +414,50 @@ describe('GroupBy transformer', () => {
       expect(result[0].fields).toEqual(expected);
     });
   });
+
+  it('should retain "time" field type when used as aggregation (max, etc)', async () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'user', type: FieldType.string, values: ['A', 'B', 'A', 'B'] },
+        { name: 'time', type: FieldType.time, values: [7, 2, 1, 5] },
+      ],
+    });
+
+    const cfg: DataTransformerConfig<GroupByTransformerOptions> = {
+      id: DataTransformerID.groupBy,
+      options: {
+        fields: {
+          user: {
+            operation: GroupByOperationID.groupBy,
+            aggregations: [],
+          },
+          time: {
+            operation: GroupByOperationID.aggregate,
+            aggregations: [ReducerID.max],
+          },
+        },
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [testSeries])).toEmitValuesWith((received) => {
+      const result = received[0];
+      const expected: Field[] = [
+        {
+          name: 'user',
+          type: FieldType.string,
+          values: ['A', 'B'],
+          config: {},
+        },
+        {
+          name: 'time (max)',
+          type: FieldType.time,
+          values: [7, 5],
+          config: {},
+        },
+      ];
+
+      expect(result[0].fields).toEqual(expected);
+    });
+  });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -417,7 +417,7 @@ describe('GroupBy transformer', () => {
 
   it('should retain "time" field type when used as aggregation (max, etc)', async () => {
     const testSeries = toDataFrame({
-      name: 'A',
+      refId: 'A',
       fields: [
         { name: 'user', type: FieldType.string, values: ['A', 'B', 'A', 'B'] },
         { name: 'time', type: FieldType.time, values: [7, 2, 1, 5] },
@@ -457,6 +457,7 @@ describe('GroupBy transformer', () => {
         },
       ];
 
+      expect(result[0].refId).toEqual('A');
       expect(result[0].fields).toEqual(expected);
     });
   });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -368,4 +368,50 @@ describe('GroupBy transformer', () => {
       expect(result[0].fields).toEqual(expected);
     });
   });
+
+  it('should retain "time" field type when used as aggregation (max, etc)', async () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'user', type: FieldType.string, values: ['A', 'B', 'A', 'B'] },
+        { name: 'time', type: FieldType.time, values: [7, 2, 1, 5] },
+      ],
+    });
+
+    const cfg: DataTransformerConfig<GroupByTransformerOptions> = {
+      id: DataTransformerID.groupBy,
+      options: {
+        fields: {
+          user: {
+            operation: GroupByOperationID.groupBy,
+            aggregations: [],
+          },
+          time: {
+            operation: GroupByOperationID.aggregate,
+            aggregations: [ReducerID.max],
+          },
+        },
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [testSeries])).toEmitValuesWith((received) => {
+      const result = received[0];
+      const expected: Field[] = [
+        {
+          name: 'user',
+          type: FieldType.string,
+          values: ['A', 'B'],
+          config: {},
+        },
+        {
+          name: 'time (max)',
+          type: FieldType.time,
+          values: [7, 5],
+          config: {},
+        },
+      ];
+
+      expect(result[0].fields).toEqual(expected);
+    });
+  });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -120,7 +120,7 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
           }
 
           processed.push({
-            refId: frame.refId,
+            ...frame,
             fields,
             length: valuesByGroupKey.size,
           });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -1,10 +1,9 @@
 import { map } from 'rxjs/operators';
 
-import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
 import { getFieldDisplayName } from '../../field/fieldState';
-import { DataFrame, Field, FieldType } from '../../types/dataFrame';
+import { DataFrame, Field } from '../../types/dataFrame';
 import { DataTransformerInfo, TransformationApplicabilityLevels } from '../../types/transformations';
-import { reduceField, ReducerID } from '../fieldReducer';
+import { getFieldTypeForReducer, reduceField, ReducerID } from '../fieldReducer';
 
 import { DataTransformerID } from './ids';
 import { findMaxFields } from './utils';
@@ -112,16 +111,16 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
               const aggregationField: Field = {
                 name: `${fieldName} (${aggregation})`,
                 values: valuesByAggregation[aggregation] ?? [],
-                type: FieldType.other,
+                type: getFieldTypeForReducer(aggregation, field.type),
                 config: {},
               };
 
-              aggregationField.type = detectFieldType(aggregation, field, aggregationField);
               fields.push(aggregationField);
             }
           }
 
           processed.push({
+            refId: frame.refId,
             fields,
             length: valuesByGroupKey.size,
           });
@@ -145,20 +144,6 @@ const shouldCalculateField = (field: Field, options: GroupByTransformerOptions):
     options?.fields[fieldName].aggregations.length > 0
   );
 };
-
-function detectFieldType(aggregation: string, sourceField: Field, targetField: Field): FieldType {
-  switch (aggregation) {
-    case ReducerID.allIsNull:
-      return FieldType.boolean;
-    case ReducerID.last:
-    case ReducerID.lastNotNull:
-    case ReducerID.first:
-    case ReducerID.firstNotNull:
-      return sourceField.type;
-    default:
-      return guessFieldTypeForField(targetField) ?? FieldType.string;
-  }
-}
 
 /**
  * Groups values together by key. This will create a mapping of strings

--- a/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
@@ -32,7 +32,7 @@ export const GroupByTransformerEditor = ({
   options,
   onChange,
 }: TransformerUIProps<GroupByTransformerOptions>) => {
-  const fieldNames = useAllFieldNamesFromDataFrames(input);
+  const fieldNames = useAllFieldNamesFromDataFrames(input, true);
 
   const onConfigChange = useCallback(
     (fieldName: string) => (config: GroupByFieldOptions) => {

--- a/public/app/features/transformers/utils.test.ts
+++ b/public/app/features/transformers/utils.test.ts
@@ -1,4 +1,6 @@
-import { numberOrVariableValidator } from './utils';
+import { FieldType, toDataFrame } from '@grafana/data';
+
+import { getAllFieldNamesFromDataFrames, numberOrVariableValidator } from './utils';
 
 describe('validator', () => {
   it('validates a positive number', () => {
@@ -51,5 +53,41 @@ describe('validator', () => {
 
   it('fails a string that has multiple variables', () => {
     expect(numberOrVariableValidator('$foo$asd')).toBe(false);
+  });
+});
+
+describe('useAllFieldNamesFromDataFrames', () => {
+  it('gets base and full field names', () => {
+    let frames = [
+      toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'T', type: FieldType.time, values: [1, 2, 3] },
+          { name: 'N', type: FieldType.number, values: [100, 200, 300] },
+          { name: 'S', type: FieldType.string, values: ['1', '2', '3'] },
+        ],
+      }),
+      toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: 'T', type: FieldType.time, values: [1, 2, 3] },
+          { name: 'N', type: FieldType.number, values: [100, 200, 300] },
+          { name: 'S', type: FieldType.string, values: ['1', '2', '3'] },
+        ],
+      }),
+    ].map((frame) => ({
+      ...frame,
+      fields: frame.fields.map((field) => ({
+        ...field,
+        state: {
+          multipleFrames: true,
+          displayName: `${field.name} (${frame.refId})`,
+        },
+      })),
+    }));
+
+    const names = getAllFieldNamesFromDataFrames(frames, true);
+
+    expect(names).toEqual(['T', 'N', 'S', 'T (A)', 'N (A)', 'S (A)', 'T (B)', 'N (B)', 'S (B)']);
   });
 });

--- a/public/app/features/transformers/utils.ts
+++ b/public/app/features/transformers/utils.ts
@@ -11,26 +11,20 @@ import {
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
-export function useAllFieldNamesFromDataFrames(input: DataFrame[]): string[] {
+export function useAllFieldNamesFromDataFrames(frames: DataFrame[], withBaseFieldNames = false): string[] {
   return useMemo(() => {
-    if (!Array.isArray(input)) {
-      return [];
+    // get full names
+    let names = frames.flatMap((frame) => frame.fields.map((field) => getFieldDisplayName(field, frame, frames)));
+
+    if (withBaseFieldNames) {
+      let baseNames = frames.flatMap((frame) => frame.fields.map((field) => field.name));
+
+      // prepend base names + uniquify
+      names = [...new Set(baseNames.concat(names))];
     }
 
-    return Object.keys(
-      input.reduce<Record<string, boolean>>((names, frame) => {
-        if (!frame || !Array.isArray(frame.fields)) {
-          return names;
-        }
-
-        return frame.fields.reduce((names, field) => {
-          const t = getFieldDisplayName(field, frame, input);
-          names[t] = true;
-          return names;
-        }, names);
-      }, {})
-    );
-  }, [input]);
+    return names;
+  }, [frames, withBaseFieldNames]);
 }
 
 export function getDistinctLabels(input: DataFrame[]): Set<string> {

--- a/public/app/features/transformers/utils.ts
+++ b/public/app/features/transformers/utils.ts
@@ -11,20 +11,22 @@ import {
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
+export const getAllFieldNamesFromDataFrames = (frames: DataFrame[], withBaseFieldNames = false) => {
+  // get full names
+  let names = frames.flatMap((frame) => frame.fields.map((field) => getFieldDisplayName(field, frame, frames)));
+
+  if (withBaseFieldNames) {
+    let baseNames = frames.flatMap((frame) => frame.fields.map((field) => field.name));
+
+    // prepend base names + uniquify
+    names = [...new Set(baseNames.concat(names))];
+  }
+
+  return names;
+};
+
 export function useAllFieldNamesFromDataFrames(frames: DataFrame[], withBaseFieldNames = false): string[] {
-  return useMemo(() => {
-    // get full names
-    let names = frames.flatMap((frame) => frame.fields.map((field) => getFieldDisplayName(field, frame, frames)));
-
-    if (withBaseFieldNames) {
-      let baseNames = frames.flatMap((frame) => frame.fields.map((field) => field.name));
-
-      // prepend base names + uniquify
-      names = [...new Set(baseNames.concat(names))];
-    }
-
-    return names;
-  }, [frames, withBaseFieldNames]);
+  return useMemo(() => getAllFieldNamesFromDataFrames(frames, withBaseFieldNames), [frames, withBaseFieldNames]);
 }
 
 export function getDistinctLabels(input: DataFrame[]): Set<string> {


### PR DESCRIPTION
found some easy quality of life improvements to the `groupBy` transformer while working on https://github.com/grafana/support-escalations/issues/14816

1. previously, there were no base field names listed in the field selection, so if you had `Email` and `LastSeenAt` fields in five different queries and you would have to select each of the five `Email` fields for grouping, and each of the five `LastSeenAt` fields for calculation with a reducer, and then click five more times to select the reducer(s) you wanted, like `Max`. now we list identical base field names at the top, so you only have to select each of those only once.
2. previously, when using a calculation/reducer on a Time field, it would convert the resulting field to a number, so you would have to add another "Convert field type" transformation to reverse the process. now the original field types are retained for the calculations, except for Count => number, allIsNull => boolean, allIsZero => boolean.
3. previously, we were not setting the original frame refIds or metadata on the resulting frames, causing the queries filters in subsequent transformations to be empty in the selector. we now pass through the original refIds