### PR TITLE
Alerting: Fix deadlocks in provenance table

### DIFF
--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -70,21 +70,47 @@ func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, org
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.
-		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
-			provenanceRecord{}.TableName(),
-			[]string{"record_key", "record_type", "org_id"},
-			[]string{"record_key", "record_type", "org_id", "provenance"})
 
-		params := []interface{}{
-			recordKey,
-			recordType,
-			org,
-			p,
+		// Check if the record exists with FOR UPDATE lock.
+		// If it does, we just update, otherwise we upsert the record.
+		// This is done to avoid deadlocks that can occur in MySQL when multiple transactions try to
+		// insert records (even different) because of the gap and insert intention locks.
+		exists, err := sess.Table(provenanceRecord{}).
+			Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+			ForUpdate().
+			Exist()
+		if err != nil {
+			return fmt.Errorf("failed to check if provenance record exists: %w", err)
 		}
 
-		_, err := sess.SQL(upsertSQL, params...).Query()
-		if err != nil {
-			return fmt.Errorf("failed to store provisioning status: %w", err)
+		if exists {
+			// Update existing record
+			_, err = sess.Table(provenanceRecord{}).
+				Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+				Update(map[string]interface{}{
+					"provenance": p,
+				})
+			if err != nil {
+				return fmt.Errorf("failed to update provenance status: %w", err)
+			}
+		} else {
+			// Still upsert in case it was created while we were checking
+			upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
+				provenanceRecord{}.TableName(),
+				[]string{"record_key", "record_type", "org_id"},
+				[]string{"record_key", "record_type", "org_id", "provenance"})
+
+			params := []interface{}{
+				recordKey,
+				recordType,
+				org,
+				p,
+			}
+
+			_, err := sess.SQL(upsertSQL, params...).Query()
+			if err != nil {
+				return fmt.Errorf("failed to store provisioning status: %w", err)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
**What is this feature?**

This PR further improves concurrent updates to the provenance table (a follow-up for https://github.com/grafana/grafana/pull/101688). The fix explicitly checks for a provenance record using `SELECT ... FOR UPDATE` for the databases that support it before performing either an update or upsert operation. This preemptive locking reduces the possibility of deadlocks in MySQL.

**Why do we need this feature?**

The current implementation (directly performing upserts without prior locking) may still encounter deadlocks because of the gap and insert-intention locks in some configurations, for example, with repeatable-read transaction isolation level in MySQL+InnoDB.

This PR fixes this. I ran some tests multiple times on MySQL and PostgreSQL (both repeatable-read, and read-commited for both databases), and in both cases concurrent updates worked fine:

```
# call concurrent inserts/updates of multiple rule groups with 20 rules each
mimirtool rules sync --rule-dirs test-tmp --concurrency 10
...
Sync Summary: 600 Groups Created, 0 Groups Updated, 0 Groups Deleted

# update the folder: add new namespaces and delete some old namespaces

mimirtool rules sync --rule-dirs test-tmp --concurrency 10
...
Sync Summary: 600 Groups Created, 100 Groups Updated, 400 Groups Deleted
```


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
