### PR TITLE
UniStore/Large Objects: Make threshold configurable

### DIFF
--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -14,15 +14,15 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 )
 
-func NewDashboardLargeObjectSupport(scheme *runtime.Scheme, ts int) *apistore.BasicLargeObjectSupport {
+func NewDashboardLargeObjectSupport(scheme *runtime.Scheme, threshold int) *apistore.BasicLargeObjectSupport {
 	return &apistore.BasicLargeObjectSupport{
 		TheGroupResource: dashboardV0.DashboardResourceInfo.GroupResource(),
 
 		// Byte size above which an object is considered large.
-		ThresholdSizeBytes: ts,
+		ThresholdBytes: threshold,
 
 		// 10mb -- we should check what the largest ones are... might be bigger
-		MaxByteSize: 10 * 1024 * 1024,
+		MaxBytes: 10 * 1024 * 1024,
 
 		ReduceSpec: func(obj runtime.Object) error {
 			meta, err := utils.MetaAccessor(obj)

--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -14,12 +14,12 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 )
 
-func NewDashboardLargeObjectSupport(scheme *runtime.Scheme) *apistore.BasicLargeObjectSupport {
+func NewDashboardLargeObjectSupport(scheme *runtime.Scheme, ts int) *apistore.BasicLargeObjectSupport {
 	return &apistore.BasicLargeObjectSupport{
 		TheGroupResource: dashboardV0.DashboardResourceInfo.GroupResource(),
 
 		// byte size, while testing lets do almost everything (10bytes)
-		ThresholdSize: 10,
+		ThresholdSize: ts,
 
 		// 10mb -- we should check what the largest ones are... might be bigger
 		MaxByteSize: 10 * 1024 * 1024,

--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -18,8 +18,8 @@ func NewDashboardLargeObjectSupport(scheme *runtime.Scheme, ts int) *apistore.Ba
 	return &apistore.BasicLargeObjectSupport{
 		TheGroupResource: dashboardV0.DashboardResourceInfo.GroupResource(),
 
-		// Byte size after which an object is considered large.
-		ThresholdSize: ts,
+		// Byte size above which an object is considered large.
+		ThresholdSizeBytes: ts,
 
 		// 10mb -- we should check what the largest ones are... might be bigger
 		MaxByteSize: 10 * 1024 * 1024,

--- a/pkg/registry/apis/dashboard/large.go
+++ b/pkg/registry/apis/dashboard/large.go
@@ -18,7 +18,7 @@ func NewDashboardLargeObjectSupport(scheme *runtime.Scheme, ts int) *apistore.Ba
 	return &apistore.BasicLargeObjectSupport{
 		TheGroupResource: dashboardV0.DashboardResourceInfo.GroupResource(),
 
-		// byte size, while testing lets do almost everything (10bytes)
+		// Byte size after which an object is considered large.
 		ThresholdSize: ts,
 
 		// 10mb -- we should check what the largest ones are... might be bigger

--- a/pkg/registry/apis/dashboard/large_test.go
+++ b/pkg/registry/apis/dashboard/large_test.go
@@ -41,7 +41,7 @@ func TestLargeDashboardSupport(t *testing.T) {
 	err = dashboardv1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
 
-	largeObject := NewDashboardLargeObjectSupport(scheme)
+	largeObject := NewDashboardLargeObjectSupport(scheme, 0)
 
 	// Convert the dashboard to a small value
 	err = largeObject.ReduceSpec(dash)

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -390,7 +390,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	// Split dashboards when they are large
 	var largeObjects apistore.LargeObjectSupport
 	if b.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
-		largeObjects = NewDashboardLargeObjectSupport(opts.Scheme, opts.StorageOpts.BlobThreshold)
+		largeObjects = NewDashboardLargeObjectSupport(opts.Scheme, opts.StorageOpts.BlobThresholdBytes)
 		storageOpts.LargeObjectSupport = largeObjects
 	}
 	opts.StorageOptsRegister(v0alpha1.DashboardResourceInfo.GroupResource(), storageOpts)

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -390,10 +390,10 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	// Split dashboards when they are large
 	var largeObjects apistore.LargeObjectSupport
 	if b.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
-		largeObjects = NewDashboardLargeObjectSupport(opts.Scheme)
+		largeObjects = NewDashboardLargeObjectSupport(opts.Scheme, opts.StorageOpts.BlobThreshold)
 		storageOpts.LargeObjectSupport = largeObjects
 	}
-	opts.StorageOptions(v0alpha1.DashboardResourceInfo.GroupResource(), storageOpts)
+	opts.StorageOptsRegister(v0alpha1.DashboardResourceInfo.GroupResource(), storageOpts)
 
 	// v0alpha1
 	if err := b.storageForVersion(apiGroupInfo, opts, largeObjects,

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -155,7 +155,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		cfg:            b.cfg,
 	}
 
-	opts.StorageOptions(resourceInfo.GroupResource(), apistore.StorageOptions{
+	opts.StorageOptsRegister(resourceInfo.GroupResource(), apistore.StorageOptions{
 		EnableFolderSupport:         true,
 		RequireDeprecatedInternalID: true})
 

--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kube-openapi/pkg/spec3"
 
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 )
 
@@ -73,11 +74,12 @@ type APIGroupPostStartHookProvider interface {
 }
 
 type APIGroupOptions struct {
-	Scheme           *runtime.Scheme
-	OptsGetter       generic.RESTOptionsGetter
-	DualWriteBuilder grafanarest.DualWriteBuilder
-	MetricsRegister  prometheus.Registerer
-	StorageOptions   apistore.StorageOptionsRegister
+	Scheme              *runtime.Scheme
+	OptsGetter          generic.RESTOptionsGetter
+	DualWriteBuilder    grafanarest.DualWriteBuilder
+	MetricsRegister     prometheus.Registerer
+	StorageOptsRegister apistore.StorageOptionsRegister
+	StorageOpts         *options.StorageOptions
 }
 
 // Builders that implement OpenAPIPostProcessor are given a chance to modify the schema directly

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -396,11 +396,12 @@ func InstallAPIs(
 		g := genericapiserver.NewDefaultAPIGroupInfo(group, scheme, metav1.ParameterCodec, codecs)
 		for _, b := range buildersForGroup {
 			if err := b.UpdateAPIGroupInfo(&g, APIGroupOptions{
-				Scheme:           scheme,
-				OptsGetter:       optsGetter,
-				DualWriteBuilder: dualWrite,
-				MetricsRegister:  reg,
-				StorageOptions:   optsregister,
+				Scheme:              scheme,
+				OptsGetter:          optsGetter,
+				DualWriteBuilder:    dualWrite,
+				MetricsRegister:     reg,
+				StorageOptsRegister: optsregister,
+				StorageOpts:         storageOpts,
 			}); err != nil {
 				return err
 			}

--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -56,7 +56,7 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	o.StorageOptions.DataPath = apiserverCfg.Key("storage_path").MustString(filepath.Join(cfg.DataPath, "grafana-apiserver"))
 	o.StorageOptions.Address = apiserverCfg.Key("address").MustString(o.StorageOptions.Address)
 	o.StorageOptions.BlobStoreURL = apiserverCfg.Key("blob_url").MustString(o.StorageOptions.BlobStoreURL)
-	o.StorageOptions.BlobThreshold = apiserverCfg.Key("blob_threshold").MustInt(o.StorageOptions.BlobThreshold)
+	o.StorageOptions.BlobThresholdBytes = apiserverCfg.Key("blob_threshold_bytes").MustInt(o.StorageOptions.BlobThresholdBytes)
 
 	// unified storage configs look like
 	// [unified_storage.<group>.<resource>]

--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -56,6 +56,7 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	o.StorageOptions.DataPath = apiserverCfg.Key("storage_path").MustString(filepath.Join(cfg.DataPath, "grafana-apiserver"))
 	o.StorageOptions.Address = apiserverCfg.Key("address").MustString(o.StorageOptions.Address)
 	o.StorageOptions.BlobStoreURL = apiserverCfg.Key("blob_url").MustString(o.StorageOptions.BlobStoreURL)
+	o.StorageOptions.BlobThreshold = apiserverCfg.Key("blob_threshold").MustInt(o.StorageOptions.BlobThreshold)
 
 	// unified storage configs look like
 	// [unified_storage.<group>.<resource>]

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -28,6 +28,8 @@ const (
 
 	// Deprecated: legacy is a shim that is no longer necessary
 	StorageTypeLegacy StorageType = "legacy"
+
+	BlobThresholdDefault int = 0
 )
 
 type StorageOptions struct {
@@ -50,6 +52,9 @@ type StorageOptions struct {
 	// s3://my-bucket?region=us-west-1 (using default credentials)
 	// azblob://my-container
 	BlobStoreURL string
+	// Optional blob storage field. When an object's size exceeds the threshold
+	// value, it is considered large and gets partially stored in blob storage.
+	BlobThreshold int
 
 	// {resource}.{group} = 1|2|3|4
 	UnifiedStorageConfig map[string]setting.UnifiedStorageConfig
@@ -61,6 +66,7 @@ func NewStorageOptions() *StorageOptions {
 		Address:                                "localhost:10000",
 		GrpcClientAuthenticationTokenNamespace: "*",
 		GrpcClientAuthenticationAllowInsecure:  false,
+		BlobThreshold:                          BlobThresholdDefault,
 	}
 }
 

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -52,9 +52,9 @@ type StorageOptions struct {
 	// s3://my-bucket?region=us-west-1 (using default credentials)
 	// azblob://my-container
 	BlobStoreURL string
-	// Optional blob storage field. When an object's size exceeds the threshold
+	// Optional blob storage field. When an object's size in bytes exceeds the threshold
 	// value, it is considered large and gets partially stored in blob storage.
-	BlobThreshold int
+	BlobThresholdBytes int
 
 	// {resource}.{group} = 1|2|3|4
 	UnifiedStorageConfig map[string]setting.UnifiedStorageConfig
@@ -66,7 +66,7 @@ func NewStorageOptions() *StorageOptions {
 		Address:                                "localhost:10000",
 		GrpcClientAuthenticationTokenNamespace: "*",
 		GrpcClientAuthenticationAllowInsecure:  false,
-		BlobThreshold:                          BlobThresholdDefault,
+		BlobThresholdBytes:                     BlobThresholdDefault,
 	}
 }
 

--- a/pkg/storage/unified/apistore/fake_large.go
+++ b/pkg/storage/unified/apistore/fake_large.go
@@ -1,0 +1,38 @@
+package apistore
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	dashboardV0 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type LargeObjectSupportFake struct {
+	threshold     int
+	deconstructed bool
+	reconstructed bool
+}
+
+func (s *LargeObjectSupportFake) GroupResource() schema.GroupResource {
+	return dashboardV0.DashboardResourceInfo.GroupResource()
+}
+
+func (s *LargeObjectSupportFake) Threshold() int {
+	return s.threshold
+}
+
+func (s *LargeObjectSupportFake) MaxSize() int {
+	return 10 * 1024 * 1024
+}
+
+func (s *LargeObjectSupportFake) Deconstruct(ctx context.Context, key *resource.ResourceKey, client resource.BlobStoreClient, obj utils.GrafanaMetaAccessor, raw []byte) error {
+	s.deconstructed = true
+	return nil
+}
+
+func (s *LargeObjectSupportFake) Reconstruct(ctx context.Context, key *resource.ResourceKey, client resource.BlobStoreClient, obj utils.GrafanaMetaAccessor) error {
+	s.reconstructed = true
+	return nil
+}

--- a/pkg/storage/unified/apistore/fake_large.go
+++ b/pkg/storage/unified/apistore/fake_large.go
@@ -3,8 +3,8 @@ package apistore
 import (
 	"context"
 
+	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	dashboardV0 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -16,7 +16,7 @@ type LargeObjectSupportFake struct {
 }
 
 func (s *LargeObjectSupportFake) GroupResource() schema.GroupResource {
-	return dashboardV0.DashboardResourceInfo.GroupResource()
+	return dashboardv1alpha1.DashboardResourceInfo.GroupResource()
 }
 
 func (s *LargeObjectSupportFake) Threshold() int {

--- a/pkg/storage/unified/apistore/large.go
+++ b/pkg/storage/unified/apistore/large.go
@@ -37,9 +37,9 @@ type LargeObjectSupport interface {
 var _ LargeObjectSupport = (*BasicLargeObjectSupport)(nil)
 
 type BasicLargeObjectSupport struct {
-	TheGroupResource   schema.GroupResource
-	ThresholdSizeBytes int
-	MaxByteSize        int
+	TheGroupResource schema.GroupResource
+	ThresholdBytes   int
+	MaxBytes         int
 
 	// Mutate the spec so it only has the small properties
 	ReduceSpec func(obj runtime.Object) error
@@ -55,12 +55,12 @@ func (s *BasicLargeObjectSupport) GroupResource() schema.GroupResource {
 
 // Threshold implements LargeObjectSupport.
 func (s *BasicLargeObjectSupport) Threshold() int {
-	return s.ThresholdSizeBytes
+	return s.ThresholdBytes
 }
 
 // MaxSize implements LargeObjectSupport.
 func (s *BasicLargeObjectSupport) MaxSize() int {
-	return s.MaxByteSize
+	return s.MaxBytes
 }
 
 // Deconstruct implements LargeObjectSupport.

--- a/pkg/storage/unified/apistore/large.go
+++ b/pkg/storage/unified/apistore/large.go
@@ -37,9 +37,9 @@ type LargeObjectSupport interface {
 var _ LargeObjectSupport = (*BasicLargeObjectSupport)(nil)
 
 type BasicLargeObjectSupport struct {
-	TheGroupResource schema.GroupResource
-	ThresholdSize    int
-	MaxByteSize      int
+	TheGroupResource   schema.GroupResource
+	ThresholdSizeBytes int
+	MaxByteSize        int
 
 	// Mutate the spec so it only has the small properties
 	ReduceSpec func(obj runtime.Object) error
@@ -55,7 +55,7 @@ func (s *BasicLargeObjectSupport) GroupResource() schema.GroupResource {
 
 // Threshold implements LargeObjectSupport.
 func (s *BasicLargeObjectSupport) Threshold() int {
-	return s.ThresholdSize
+	return s.ThresholdSizeBytes
 }
 
 // MaxSize implements LargeObjectSupport.

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -175,12 +175,10 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 
 func (s *Storage) handleLargeResources(ctx context.Context, obj utils.GrafanaMetaAccessor, buf bytes.Buffer) ([]byte, error) {
 	support := s.opts.LargeObjectSupport
-	if support != nil {
-		size := buf.Len()
-		if size > support.Threshold() {
-			if support.MaxSize() > 0 && size > support.MaxSize() {
-				return nil, fmt.Errorf("request object is too big (%s > %s)", formatBytes(size), formatBytes(support.MaxSize()))
-			}
+	size := buf.Len()
+	if support != nil && size > support.Threshold() {
+		if support.MaxSize() > 0 && size > support.MaxSize() {
+			return nil, fmt.Errorf("request object is too big (%s > %s)", formatBytes(size), formatBytes(support.MaxSize()))
 		}
 
 		key := &resource.ResourceKey{

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -299,13 +299,13 @@ func getPreparedObject(t *testing.T, ctx context.Context, s *Storage, obj runtim
 }
 
 func TestPrepareLargeObjectForStorage(t *testing.T) {
-	_ = v0alpha1.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
 	node, err := snowflake.NewNode(rand.Int63n(1024))
 	require.NoError(t, err)
 
 	ctx := authtypes.WithAuthInfo(context.Background(), &identity.StaticRequester{UserID: 1, UserUID: "user-uid", Type: authtypes.TypeUser})
 
-	dashboard := v0alpha1.Dashboard{}
+	dashboard := v1alpha1.Dashboard{}
 	dashboard.Name = "test-name"
 	t.Run("Should deconstruct object if size is over threshold", func(t *testing.T) {
 		los := LargeObjectSupportFake{
@@ -313,7 +313,7 @@ func TestPrepareLargeObjectForStorage(t *testing.T) {
 		}
 
 		f := &Storage{
-			codec:     apitesting.TestCodec(codecs, v0alpha1.DashboardResourceInfo.GroupVersion()),
+			codec:     apitesting.TestCodec(codecs, v1alpha1.DashboardResourceInfo.GroupVersion()),
 			snowflake: node,
 			opts: StorageOptions{
 				LargeObjectSupport: &los,
@@ -331,7 +331,7 @@ func TestPrepareLargeObjectForStorage(t *testing.T) {
 		}
 
 		f := &Storage{
-			codec:     apitesting.TestCodec(codecs, v0alpha1.DashboardResourceInfo.GroupVersion()),
+			codec:     apitesting.TestCodec(codecs, v1alpha1.DashboardResourceInfo.GroupVersion()),
 			snowflake: node,
 			opts: StorageOptions{
 				LargeObjectSupport: &los,

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -320,7 +320,8 @@ func TestPrepareLargeObjectForStorage(t *testing.T) {
 			},
 		}
 
-		f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		_, err := f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		require.Nil(t, err)
 		require.True(t, los.deconstructed)
 	})
 
@@ -337,7 +338,8 @@ func TestPrepareLargeObjectForStorage(t *testing.T) {
 			},
 		}
 
-		f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		_, err := f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		require.Nil(t, err)
 		require.False(t, los.deconstructed)
 	})
 }

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -297,3 +297,47 @@ func getPreparedObject(t *testing.T, ctx context.Context, s *Storage, obj runtim
 	require.NoError(t, err)
 	return meta
 }
+
+func TestPrepareLargeObjectForStorage(t *testing.T) {
+	_ = v0alpha1.AddToScheme(scheme)
+	node, err := snowflake.NewNode(rand.Int63n(1024))
+	require.NoError(t, err)
+
+	ctx := authtypes.WithAuthInfo(context.Background(), &identity.StaticRequester{UserID: 1, UserUID: "user-uid", Type: authtypes.TypeUser})
+
+	dashboard := v0alpha1.Dashboard{}
+	dashboard.Name = "test-name"
+	t.Run("Should deconstruct object if size is over threshold", func(t *testing.T) {
+		los := LargeObjectSupportFake{
+			threshold: 0,
+		}
+
+		f := &Storage{
+			codec:     apitesting.TestCodec(codecs, v0alpha1.DashboardResourceInfo.GroupVersion()),
+			snowflake: node,
+			opts: StorageOptions{
+				LargeObjectSupport: &los,
+			},
+		}
+
+		f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		require.True(t, los.deconstructed)
+	})
+
+	t.Run("Should not deconstruct object if size is under threshold", func(t *testing.T) {
+		los := LargeObjectSupportFake{
+			threshold: 1000,
+		}
+
+		f := &Storage{
+			codec:     apitesting.TestCodec(codecs, v0alpha1.DashboardResourceInfo.GroupVersion()),
+			snowflake: node,
+			opts: StorageOptions{
+				LargeObjectSupport: &los,
+			},
+		}
+
+		f.prepareObjectForStorage(ctx, dashboard.DeepCopyObject())
+		require.False(t, los.deconstructed)
+	})
+}

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -55,10 +55,11 @@ func ProvideUnifiedStorageClient(opts *Options, storageMetrics *resource.Storage
 	// See: apiserver.ApplyGrafanaConfig(cfg, features, o)
 	apiserverCfg := opts.Cfg.SectionWithEnvOverrides("grafana-apiserver")
 	client, err := newClient(options.StorageOptions{
-		StorageType:  options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeUnified))),
-		DataPath:     apiserverCfg.Key("storage_path").MustString(filepath.Join(opts.Cfg.DataPath, "grafana-apiserver")),
-		Address:      apiserverCfg.Key("address").MustString(""), // client address
-		BlobStoreURL: apiserverCfg.Key("blob_url").MustString(""),
+		StorageType:   options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeUnified))),
+		DataPath:      apiserverCfg.Key("storage_path").MustString(filepath.Join(opts.Cfg.DataPath, "grafana-apiserver")),
+		Address:       apiserverCfg.Key("address").MustString(""), // client address
+		BlobStoreURL:  apiserverCfg.Key("blob_url").MustString(""),
+		BlobThreshold: apiserverCfg.Key("blob_threshold").MustInt(options.BlobThresholdDefault),
 	}, opts.Cfg, opts.Features, opts.DB, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics)
 	if err == nil {
 		// Used to get the folder stats

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -55,11 +55,11 @@ func ProvideUnifiedStorageClient(opts *Options, storageMetrics *resource.Storage
 	// See: apiserver.ApplyGrafanaConfig(cfg, features, o)
 	apiserverCfg := opts.Cfg.SectionWithEnvOverrides("grafana-apiserver")
 	client, err := newClient(options.StorageOptions{
-		StorageType:   options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeUnified))),
-		DataPath:      apiserverCfg.Key("storage_path").MustString(filepath.Join(opts.Cfg.DataPath, "grafana-apiserver")),
-		Address:       apiserverCfg.Key("address").MustString(""), // client address
-		BlobStoreURL:  apiserverCfg.Key("blob_url").MustString(""),
-		BlobThreshold: apiserverCfg.Key("blob_threshold").MustInt(options.BlobThresholdDefault),
+		StorageType:        options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeUnified))),
+		DataPath:           apiserverCfg.Key("storage_path").MustString(filepath.Join(opts.Cfg.DataPath, "grafana-apiserver")),
+		Address:            apiserverCfg.Key("address").MustString(""), // client address
+		BlobStoreURL:       apiserverCfg.Key("blob_url").MustString(""),
+		BlobThresholdBytes: apiserverCfg.Key("blob_threshold_bytes").MustInt(options.BlobThresholdDefault),
 	}, opts.Cfg, opts.Features, opts.DB, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics)
 	if err == nil {
 		// Used to get the folder stats


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a `blob_threshold_bytes` field in the config section `[grafana-apiserver]` which makes it possible to configure the bite size threshold for when an object is considered large. This threshold determines whether the storage of an object's `spec` field gets delegated to blob storage (also known as large object support). 

Example config:

```
[grafana-apiserver]
storage_type = unified
blob_url = ./data/unified-blob-store
blob_threshold_bytes = 10
```

**Why do we need this feature?**

This will be helpful for tests as well as to try out large object support when it is deployed in dev. The default threshold value is 0 so that we don't need to initialise large object support separately in integration tests such as [TestIntegrationDashboardsAppV1Alpha1LargeObjects](https://github.com/grafana/grafana/pull/100492/files#diff-86155633eb94d4fcf2eaaf65805de73c77f908394cfbe75008d6191652dbc34f). 

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/219

**Special notes for your reviewer:**

This will be fully testable only once https://github.com/grafana/grafana/pull/100492 is also merged. There will still be UI issues until then. For now, the main thing to test locally is whether an object gets added to blob storage as expected when modifying the `blob_threshold_bytes` value in the config.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
