### PR TITLE
Alerting: Extend recording rules test to exercise writing with data sources.

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -49,7 +49,6 @@ type RulesStore interface {
 }
 
 type RecordingWriter interface {
-	Write(ctx context.Context, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
 	WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
 }
 

--- a/pkg/services/ngalert/writer/fake.go
+++ b/pkg/services/ngalert/writer/fake.go
@@ -12,14 +12,6 @@ type FakeWriter struct {
 	WriteFunc func(ctx context.Context, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
 }
 
-func (w FakeWriter) Write(ctx context.Context, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error {
-	if w.WriteFunc == nil {
-		return nil
-	}
-
-	return w.WriteFunc(ctx, name, t, frames, orgID, extraLabels)
-}
-
 func (w FakeWriter) WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error {
 	if w.WriteFunc == nil {
 		return nil

--- a/pkg/services/ngalert/writer/testing.go
+++ b/pkg/services/ngalert/writer/testing.go
@@ -12,7 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const RemoteWriteEndpoint = "/api/v1/write"
+const RemoteWritePrefix = "/api/v1"
+const RemoteWriteSuffix = "/write"
+
+const RemoteWriteEndpoint = RemoteWritePrefix + RemoteWriteSuffix
 
 type TestRemoteWriteTarget struct {
 	srv *httptest.Server
@@ -57,6 +60,10 @@ func NewTestRemoteWriteTarget(t *testing.T) *TestRemoteWriteTarget {
 
 func (s *TestRemoteWriteTarget) Close() {
 	s.srv.Close()
+}
+
+func (s *TestRemoteWriteTarget) DatasourceURL() string {
+	return s.srv.URL + RemoteWritePrefix
 }
 
 func (s *TestRemoteWriteTarget) ClientSettings() setting.RecordingRuleSettings {


### PR DESCRIPTION
The change to use WriteDatasource was done in a previous commit, this adds a
test case using DatasourceWriter, in addition to the one using PrometheusWriter.

Also removes the `Write` method from the `RecordingWriter` interface, it's unused.