### PR TITLE
Spanner: Add trivial sequence number generator.

### DIFF
--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -42,7 +42,8 @@ type Engine struct {
 
 	tagHandlers map[string]tagHandler
 
-	defaultContext context.Context
+	defaultContext    context.Context
+	sequenceGenerator *sequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
 }
 
 // CondDeleted returns the conditions whether a record is soft deleted.
@@ -237,6 +238,9 @@ func (engine *Engine) NewSession() *Session {
 
 // Close the engine
 func (engine *Engine) Close() error {
+	if engine.sequenceGenerator != nil {
+		engine.sequenceGenerator.close()
+	}
 	return engine.db.Close()
 }
 

--- a/pkg/util/xorm/sequence.go
+++ b/pkg/util/xorm/sequence.go
@@ -1,0 +1,69 @@
+package xorm
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type sequenceGenerator struct {
+	db             *sql.DB
+	sequencesTable string
+}
+
+func newSequenceGenerator(db *sql.DB) *sequenceGenerator {
+	return &sequenceGenerator{
+		db:             db,
+		sequencesTable: "autoincrement_sequences",
+	}
+}
+
+func (sg *sequenceGenerator) Next(ctx context.Context, table, column string) (int64, error) {
+	// Current implementation fetches new value for each Next call.
+	key := fmt.Sprintf("%s:%s", table, column)
+
+	tx, err := sg.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return 0, err
+	}
+
+	// TODO: "FOR UPDATE". (Somehow this doesn't seem to be supported in Spanner emulator?)
+	r, err := tx.QueryContext(ctx, "SELECT next_value FROM "+sg.sequencesTable+" WHERE name = ?", key)
+	if err != nil {
+		err2 := tx.Rollback()
+		return 0, errors.Join(err, err2)
+	}
+	defer r.Close()
+
+	// Sequence doesn't exist yet. Return 1, and put 2 into the table.
+	if !r.Next() {
+		if err := r.Err(); err != nil {
+			return 0, errors.Join(err, tx.Rollback())
+		}
+		val := int64(1)
+
+		_, err := tx.ExecContext(ctx, "INSERT INTO "+sg.sequencesTable+" (name, next_value) VALUES(?, ?)", key, val+1)
+		if err != nil {
+			return 0, errors.Join(err, tx.Rollback())
+		}
+
+		return val, tx.Commit()
+	}
+
+	var val int64
+	if err := r.Scan(&val); err != nil {
+		return 0, errors.Join(err, tx.Rollback())
+	}
+
+	_, err = tx.ExecContext(ctx, "UPDATE "+sg.sequencesTable+" SET next_value = ? WHERE name = ?", val+1, key)
+	if err != nil {
+		return 0, errors.Join(err, tx.Rollback())
+	}
+
+	return val, tx.Commit()
+}
+
+func (sg *sequenceGenerator) close() {
+	// Nothing to do just yet.
+}

--- a/pkg/util/xorm/sequence_test.go
+++ b/pkg/util/xorm/sequence_test.go
@@ -1,0 +1,31 @@
+package xorm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequenceGenerator(t *testing.T) {
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, eng)
+	require.Equal(t, "sqlite3", eng.DriverName())
+
+	_, err = eng.Exec("CREATE TABLE `autoincrement_sequences` (`name` STRING(128) NOT NULL PRIMARY KEY, `next_value` INT64 NOT NULL)")
+	require.NoError(t, err)
+
+	sg := newSequenceGenerator(eng.db.DB)
+	val, err := sg.Next(context.Background(), "test", "test")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), val)
+
+	val, err = sg.Next(context.Background(), "test", "different")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), val)
+
+	val, err = sg.Next(context.Background(), "test", "different")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), val)
+}

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -346,7 +346,7 @@ func (session *Session) innerInsert(bean any) (int64, error) {
 	}
 
 	// If engine has a sequence number generator, use it to produce values for auto-increment columns.
-	if len(table.AutoIncrement) > 0 && session.engine.dialect.DBType() == "spanner" {
+	if len(table.AutoIncrement) > 0 && session.engine.sequenceGenerator != nil {
 		var found bool
 		for _, col := range colNames {
 			if col == table.AutoIncrement {

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -345,20 +345,25 @@ func (session *Session) innerInsert(bean any) (int64, error) {
 		return 0, err
 	}
 
-	//// XXX: hack to handle autoincrement in spanner
-	//if len(table.AutoIncrement) > 0 && session.engine.dialect.DBType() == "spanner" {
-	//	var found bool
-	//	for _, col := range colNames {
-	//		if col == table.AutoIncrement {
-	//			found = true
-	//			break
-	//		}
-	//	}
-	//	if !found {
-	//		colNames = append(colNames, table.AutoIncrement)
-	//		args = append(args, rand.Int63n(9e15))
-	//	}
-	//}
+	// If engine has a sequence number generator, use it to produce values for auto-increment columns.
+	if len(table.AutoIncrement) > 0 && session.engine.dialect.DBType() == "spanner" {
+		var found bool
+		for _, col := range colNames {
+			if col == table.AutoIncrement {
+				found = true
+				break
+			}
+		}
+		if !found {
+			seq, err := session.engine.sequenceGenerator.Next(session.ctx, table.Name, table.AutoIncrement)
+			if err != nil {
+				return 0, fmt.Errorf("failed to generate next value for auto_increment columns: %v", err)
+			}
+
+			colNames = append(colNames, table.AutoIncrement)
+			args = append(args, seq)
+		}
+	}
 
 	exprs := session.statement.exprColumns
 	colPlaces := strings.Repeat("?, ", len(colNames))

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -106,5 +106,9 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 
 	runtime.SetFinalizer(engine, close)
 
+	if dialect.DBType() == "spanner" {
+		engine.sequenceGenerator = newSequenceGenerator(db.DB)
+	}
+
 	return engine, nil
 }


### PR DESCRIPTION
This PR adds support for client-generated values when inserting values into tables with auto-increment columns.

Spanner doesn't support auto-increment values, but has support for generated identity columns. However the generator produces sequence of numbers like 1585267068834414592, 8502796096475496448, 2738188573441261568. These values are not monotonic, and they are also larger than max safe Javascript integer (2^53 – 1).

Generator in this PR is the simplest generator possible (https://cloud.google.com/solutions/sequence-generation-in-cloud-spanner#sequence_generators_using_database_table_rows), with no extra features. It's primarily intended to help with integration tests that expect sequential IDs, but we will eventually need to improve the generator's performance.