### PR TITLE
improve the debugging experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,11 @@
       "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev", "cfg:app_mode=development"]
     },
     {
+      "name": "Attach to Go Process",
+      "type": "go",
+      "request": "attach"
+    },
+    {
       "name": "Attach to Test Process",
       "type": "go",
       "request": "attach",

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -185,6 +185,11 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 
 	args := []string{"build", "-ldflags", lf}
 
+	if opts.isDev {
+		// disable optimizations, so debugger will work
+		args = append(args, "-gcflags", "all=-N -l")
+	}
+
 	if opts.goos == GoOSWindows {
 		// Work around a linking error on Windows: "export ordinal too large"
 		args = append(args, "-buildmode=exe")


### PR DESCRIPTION
i find it often very useful to be able to attach a debugger to the grafana process while it is running.
we do have a vscode-config already for the scenario where vscode will start the debugged process, but that's not always efficient, for example when you are already running a grafana process with custom command line parameters. much easier to just attach to the running process.

the vscode-config part of the diff adds the debug option `Attach to Go process`,  when you choose it, vscode will open a process-list, entering `grafana` will quickly narrow it down to the process we are interested in. there are more ways how to improve this, but i find it useful to leave it "open ended", because i am often running multiple grafana processes at the same time, and being able to choose between them is useful.

the `builg/cmd.go` part of the diff will tell `go` to disable optimizations when in dev-mode. this is needed so that the debugger can correctly find the info it needs (for more details see https://go.dev/doc/gdb#Introduction).

WDYT?