### PR TITLE
Alerting docs: dynamic label changes

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/_index.md
+++ b/docs/sources/alerting/alerting-rules/templates/_index.md
@@ -190,9 +190,7 @@ low
 
 In this example, the value of the `severity` label is determined by the query value, and the possible options are `critical`, `high`, `medium`, or `low`. You can then use the `severity` label to change their notifications—for instance, sending `critical` alerts immediately or routing `low` alerts to a specific team for further review.
 
-{{% admonition type="note" %}}
-You should avoid displaying query values in labels, as this may create numerous unique alert instances—one for each distinct label value. Instead, use annotations for query values.
-{{% /admonition %}}
+{{< docs/shared lookup="alerts/note-dynamic-labels.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ### How to template a label
 

--- a/docs/sources/alerting/alerting-rules/templates/examples.md
+++ b/docs/sources/alerting/alerting-rules/templates/examples.md
@@ -209,9 +209,7 @@ In this example, the `severity` label is determined by the query value:
 
 You can then use the `severity` label to control how alerts are handled. For instance, you could send `critical` alerts immediately, while routing `low` severity alerts to a team for further investigation.
 
-{{% admonition type="note" %}}
-You should avoid displaying query values in labels, as this may create many alert instances—one for each distinct label value. Instead, use annotations to convey query values.
-{{% /admonition %}}
+{{< docs/shared lookup="alerts/note-dynamic-labels.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ### Based on query label
 

--- a/docs/sources/shared/alerts/note-dynamic-labels.md
+++ b/docs/sources/shared/alerts/note-dynamic-labels.md
@@ -1,0 +1,14 @@
+---
+labels:
+  products:
+    - oss
+title: 'Note Dynamic labels'
+---
+
+{{% admonition type="note" %}}
+
+An alert instance is uniquely identified by its set of labels.
+
+- Avoid displaying query values in labels, as this can create numerous alert instances—one for each distinct label set. Instead, use annotations for query values.
+- If a templated label's value changes, it maps to a different alert instance, and the previous instance transitions to the `No data` state when its label value is no longer present.
+  {{% /admonition %}}


### PR DESCRIPTION
Clarify behaviour when using dynamic labels.




**before**

![Screenshot 2025-03-07 at 13 46 03](https://github.com/user-attachments/assets/34ab2bf5-1dfb-4c58-a97b-e6958975ec7e)



**after**


![Screenshot 2025-03-07 at 13 45 14](https://github.com/user-attachments/assets/c066ae7b-a5eb-4801-9c4a-d7af1f974e74)


Related support issue: https://github.com/grafana/support-escalations/issues/14315
