### PR TITLE
Dashboards tabs: If trying to navigate to non existing tab with url, default to the first tab

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -56,7 +56,12 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
       return;
     }
     if (typeof values.tab === 'string') {
-      this.setState({ currentTabIndex: parseInt(values.tab, 10) });
+      const tabIndex = parseInt(values.tab, 10);
+      if (this.state.tabs[tabIndex]) {
+        this.setState({ currentTabIndex: tabIndex });
+      } else {
+        this.setState({ currentTabIndex: 0 });
+      }
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -12,7 +12,7 @@ import { TabsLayoutManager } from './TabsLayoutManager';
 
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
   const styles = useStyles2(getStyles);
-  const { tabs, currentTabIndex } = model.useState();
+  const { tabs } = model.useState();
   const currentTab = model.getCurrentTab();
   const { layout } = currentTab.useState();
   const dashboard = getDashboardSceneFor(model);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -13,7 +13,7 @@ import { TabsLayoutManager } from './TabsLayoutManager';
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
   const styles = useStyles2(getStyles);
   const { tabs, currentTabIndex } = model.useState();
-  const currentTab = tabs[currentTabIndex];
+  const currentTab = model.getCurrentTab();
   const { layout } = currentTab.useState();
   const dashboard = getDashboardSceneFor(model);
   const { isEditing } = dashboard.useState();


### PR DESCRIPTION
**What is this feature?**

Navigating to a tab that does not exist crashes the page.

By checking if the tab we're getting from the url exists before setting the state, and if it doesn't we update the state with currentTab = 0 we get the url updated to the first tab for free.