### PR TITLE
Chore: Add username option for redis remote cache

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -198,7 +198,7 @@ type = database
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
 # memcache: 127.0.0.1:11211
 connstr =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -197,7 +197,7 @@
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
 # memcache: 127.0.0.1:11211
 ;connstr =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -491,7 +491,7 @@ Leave empty when using `database` and Grafana uses the primary database.
 
 ##### `redis`
 
-Example connection string: `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`
+Example connection string: `addr=127.0.0.1:6379,pool_size=100,db=0,username=grafana,password=grafanaRocks,ssl=false`
 
 - `addr` is the host `:` port of the Redis server.
 - `pool_size` (optional) is the number of underlying connections that can be made to Redis.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -496,6 +496,8 @@ Example connection string: `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`
 - `addr` is the host `:` port of the Redis server.
 - `pool_size` (optional) is the number of underlying connections that can be made to Redis.
 - `db` (optional) is the number identifier of the Redis database you want to use.
+- `username` (optional) is the connection identifier to authenticate the current connection.
+- `password` (optional) is the connection secret to authenticate the current connection.
 - `ssl` (optional) is if SSL should be used to connect to Redis server. The value may be `true`, `false`, or `insecure`. Setting the value to `insecure` skips verification of the certificate chain and hostname when making the connection.
 
 ##### `memcache`

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -39,6 +39,8 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 		switch connKey {
 		case "addr":
 			options.Addr = connVal
+		case "username":
+			options.Username = connVal
 		case "password":
 			options.Password = connVal
 		case "db":

--- a/pkg/infra/remotecache/redis_storage_test.go
+++ b/pkg/infra/remotecache/redis_storage_test.go
@@ -16,11 +16,12 @@ func Test_parseRedisConnStr(t *testing.T) {
 		ShouldErr     bool
 	}{
 		"all redis options should parse": {
-			"addr=127.0.0.1:6379,pool_size=100,db=1,password=grafanaRocks,ssl=false",
+			"addr=127.0.0.1:6379,pool_size=100,db=1,username=grafana,password=grafanaRocks,ssl=false",
 			&redis.Options{
 				Addr:      "127.0.0.1:6379",
 				PoolSize:  100,
 				DB:        1,
+				Username:  "grafana",
 				Password:  "grafanaRocks",
 				Network:   "tcp",
 				TLSConfig: nil,


### PR DESCRIPTION
**What is this feature?**

Added 'username' support for Redis remote_cache.

Cherry-picked it from https://github.com/grafana/grafana/pull/97746, I am unable to push to OP's branch.

**Why do we need this feature?**

Currently, we cannot use the remote_cache with Redis 6 configured with ACLs.

**Who is this feature for?**

Users who use Grafana in remote_cache with Redis 6.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Closes #97746 