### PR TITLE
fix(unified-storage): break dependency from dualwriter in resource module

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -43,7 +43,7 @@ type SearchHandler struct {
 }
 
 func NewSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyDashboardSearcher resource.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles) *SearchHandler {
-	searchClient := resource.NewSearchClient(dual, dashboardv0alpha1.DashboardResourceInfo.GroupResource(), resourceClient, legacyDashboardSearcher)
+	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), dashboardv0alpha1.DashboardResourceInfo.GroupResource(), resourceClient, legacyDashboardSearcher)
 	return &SearchHandler{
 		client:   searchClient,
 		log:      log.New("grafana-apiserver.dashboards.search"),

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -53,7 +53,7 @@ type k8sHandler struct {
 func NewK8sHandler(dual dualwrite.Service, namespacer request.NamespaceMapper, gvr schema.GroupVersionResource,
 	restConfig func(context.Context) (*rest.Config, error), dashStore dashboards.Store, userSvc user.Service, resourceClient resource.ResourceClient, sorter sort.Service) K8sHandler {
 	legacySearcher := legacysearcher.NewDashboardSearchClient(dashStore, sorter)
-	searchClient := resource.NewSearchClient(dual, gvr.GroupResource(), resourceClient, legacySearcher)
+	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), gvr.GroupResource(), resourceClient, legacySearcher)
 
 	return &k8sHandler{
 		namespacer:  namespacer,

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -64,9 +64,3 @@ func (d *SearchAdapter) IsEnabled(gr schema.GroupResource) bool {
 	status, _ := d.Status(context.Background(), gr)
 	return status.Runtime && d.Service.ShouldManage(gr)
 }
-
-func (d *SearchAdapter) ReadUnified(gr schema.GroupResource) bool {
-	//nolint:errcheck
-	status, _ := d.Status(context.Background(), gr)
-	return status.ReadUnified
-}

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -50,3 +50,27 @@ type Service interface {
 	// change the status (finish migration etc)
 	Update(ctx context.Context, status StorageStatus) (StorageStatus, error)
 }
+
+type SearchAdapter struct {
+	Service
+}
+
+func NewSearchAdapter(s Service) *SearchAdapter {
+	return &SearchAdapter{Service: s}
+}
+
+func (d *SearchAdapter) IsEnabled(gr schema.GroupResource) bool {
+	status, err := d.Status(context.Background(), gr)
+	if err != nil {
+		return false
+	}
+	return status.Runtime && d.Service.ShouldManage(gr)
+}
+
+func (d *SearchAdapter) ReadUnified(gr schema.GroupResource) bool {
+	status, err := d.Status(context.Background(), gr)
+	if err != nil {
+		return false
+	}
+	return status.ReadUnified
+}

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -60,17 +60,13 @@ func NewSearchAdapter(s Service) *SearchAdapter {
 }
 
 func (d *SearchAdapter) IsEnabled(gr schema.GroupResource) bool {
-	status, err := d.Status(context.Background(), gr)
-	if err != nil {
-		return false
-	}
+	//nolint:errcheck
+	status, _ := d.Status(context.Background(), gr)
 	return status.Runtime && d.Service.ShouldManage(gr)
 }
 
 func (d *SearchAdapter) ReadUnified(gr schema.GroupResource) bool {
-	status, err := d.Status(context.Background(), gr)
-	if err != nil {
-		return false
-	}
+	//nolint:errcheck
+	status, _ := d.Status(context.Background(), gr)
 	return status.ReadUnified
 }

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -9,7 +9,6 @@ import (
 
 type DualWriter interface {
 	IsEnabled(schema.GroupResource) bool
-	ReadUnified(schema.GroupResource) bool
 	ReadFromUnified(context.Context, schema.GroupResource) (bool, error)
 }
 
@@ -22,7 +21,8 @@ func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient Res
 			legacyClient:  legacyClient,
 		}
 	}
-	if dual.ReadUnified(gr) {
+	//nolint:errcheck
+	if ok, _ := dual.ReadFromUnified(context.Background(), gr); ok {
 		return unifiedClient
 	}
 	return legacyClient

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -5,13 +5,18 @@ import (
 
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 )
 
-func NewSearchClient(dual dualwrite.Service, gr schema.GroupResource, unifiedClient ResourceIndexClient, legacyClient ResourceIndexClient) ResourceIndexClient {
-	status, _ := dual.Status(context.Background(), gr)
-	if status.Runtime && dual.ShouldManage(gr) {
+type DualWriter interface {
+	IsEnabled(schema.GroupResource) bool
+	ReadUnified(schema.GroupResource) bool
+	ReadFromUnified(context.Context, schema.GroupResource) (bool, error)
+}
+
+func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient ResourceIndexClient, legacyClient ResourceIndexClient) ResourceIndexClient {
+	//status, _ := dual.Status(context.Background(), gr)
+	//if status.Runtime && dual.ShouldManage(gr) {
+	if dual.IsEnabled(gr) {
 		return &searchWrapper{
 			dual:          dual,
 			groupResource: gr,
@@ -19,14 +24,14 @@ func NewSearchClient(dual dualwrite.Service, gr schema.GroupResource, unifiedCli
 			legacyClient:  legacyClient,
 		}
 	}
-	if status.ReadUnified {
+	if dual.ReadUnified(gr) {
 		return unifiedClient
 	}
 	return legacyClient
 }
 
 type searchWrapper struct {
-	dual          dualwrite.Service
+	dual          DualWriter
 	groupResource schema.GroupResource
 
 	unifiedClient ResourceIndexClient

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -14,8 +14,6 @@ type DualWriter interface {
 }
 
 func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient ResourceIndexClient, legacyClient ResourceIndexClient) ResourceIndexClient {
-	//status, _ := dual.Status(context.Background(), gr)
-	//if status.Runtime && dual.ShouldManage(gr) {
 	if dual.IsEnabled(gr) {
 		return &searchWrapper{
 			dual:          dual,


### PR DESCRIPTION
This PR breaks the depedency from the resource module to one of the `grafana/grafana` depdencies. We plan to remove all `grafana/grafana` depdencies to make the usage of the module easier, as right now it's broken.

This PR removes the direct dependency to the `github.com/grafana/grafana/pkg/storage/legacysql/dualwrite` package.

See https://github.com/grafana/search-and-storage-team/issues/220