### PR TITLE
[release-11.3.5] Service Accounts: Do not show error pop-ups for Service Account and Renderer UI flows

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -150,7 +150,7 @@ func (hs *HTTPServer) UpdateSignedInUser(c *contextmodel.ReqContext) response.Re
 	cmd.Email = strings.TrimSpace(cmd.Email)
 	cmd.Login = strings.TrimSpace(cmd.Login)
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -350,7 +350,7 @@ func (hs *HTTPServer) UpdateUserEmail(c *contextmodel.ReqContext) response.Respo
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) GetSignedInUserOrgList(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -370,7 +370,7 @@ func (hs *HTTPServer) GetSignedInUserOrgList(c *contextmodel.ReqContext) respons
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) GetSignedInUserTeamList(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -480,7 +480,7 @@ func (hs *HTTPServer) UserSetUsingOrg(c *contextmodel.ReqContext) response.Respo
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -505,6 +505,7 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 	}
 
 	if !c.SignedInUser.IsIdentityType(claims.TypeUser) {
+		hs.log.Debug("Requested endpoint only available to users")
 		c.JsonApiErr(http.StatusForbidden, "Endpoint only available for users", nil)
 		return
 	}
@@ -549,7 +550,7 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -585,7 +586,7 @@ func (hs *HTTPServer) SetHelpFlag(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -615,7 +616,7 @@ func (hs *HTTPServer) SetHelpFlag(c *contextmodel.ReqContext) response.Response 
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -628,8 +629,9 @@ func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Respon
 	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": flags})
 }
 
-func getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {
+func (hs *HTTPServer) getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {
 	if !c.SignedInUser.IsIdentityType(claims.TypeUser) {
+		hs.log.Debug("Requested endpoint only available to users")
 		return 0, response.Error(http.StatusForbidden, "Endpoint only available for users", nil)
 	}
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -506,7 +506,7 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 
 	if !c.SignedInUser.IsIdentityType(claims.TypeUser) {
 		hs.log.Debug("Requested endpoint only available to users")
-		c.JsonApiErr(http.StatusForbidden, "Endpoint only available for users", nil)
+		c.JsonApiErr(http.StatusNotModified, "Endpoint only available for users", nil)
 		return
 	}
 
@@ -632,7 +632,7 @@ func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Respon
 func (hs *HTTPServer) getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {
 	if !c.SignedInUser.IsIdentityType(claims.TypeUser) {
 		hs.log.Debug("Requested endpoint only available to users")
-		return 0, response.Error(http.StatusForbidden, "Endpoint only available for users", nil)
+		return 0, response.Error(http.StatusNotModified, "Endpoint only available for users", nil)
 	}
 
 	userID, err := c.SignedInUser.GetInternalID()

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -269,6 +269,15 @@ export class BackendSrv implements BackendService {
   }
 
   showErrorAlert(config: BackendSrvRequest, err: FetchError) {
+    // do not show error alerts for api keys or render tokens, they are used for kiosk mode and reporting and can't react to error pop-ups
+    if (
+      this.dependencies.contextSrv.isSignedIn &&
+      (this.dependencies.contextSrv.user.authenticatedBy === 'apikey' ||
+        this.dependencies.contextSrv.user.authenticatedBy === 'render')
+    ) {
+      return;
+    }
+
     if (config.showErrorAlert === false) {
       return;
     }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -269,8 +269,9 @@ export class BackendSrv implements BackendService {
   }
 
   showErrorAlert(config: BackendSrvRequest, err: FetchError) {
-    // do not show error alerts for api keys or render tokens, they are used for kiosk mode and reporting and can't react to error pop-ups
+    // do not show non-user error alerts for api keys or render tokens, they are used for kiosk mode and reporting and can't react to error pop-ups
     if (
+      (err.status < 400 || err.status >= 500) &&
       this.dependencies.contextSrv.isSignedIn &&
       (this.dependencies.contextSrv.user.authenticatedBy === 'apikey' ||
         this.dependencies.contextSrv.user.authenticatedBy === 'render')


### PR DESCRIPTION
Backport 392124de0059f92cbf41c6db84034a84134fa599 from #101776

---

**What is this feature?**

Follow-up on https://github.com/grafana/grafana/pull/101679

Change the code not to show non-user error pop-ups for service accounts and renderer user. These identities are used for reporting and alerting emails, as well as for kiosk mode, and can't react to error pop-ups, so pop-ups lead to bad user experience.

I've made an exception for 4xx errors, as these might display valuable information (eg, access denied or unauthorized).

**Why do we need this feature?**

To not show a pop-up which is not actionable and covers up a part of the dashboard that is being displayed.

**Who is this feature for?**

Users of kiosk mode, reports and alert emails. 

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/94649 and https://github.com/grafana/grafana-kiosk/issues/146

**Special notes for your reviewer:**

Other options considered:
* do not display error pop-ups for certain (eg, <4xx) error codes - but this is a larger change and it's hard to think through all the side-effects of it;
* cover all the endpoints which might cause an error pop-up when SA/renderer is used to display a dashboard - possible, but feels like a temporary fix, as UI changes fast and we don't always take SA/renderer workflows into account. This approach was attempted in https://github.com/grafana/grafana/pull/97162, but it's difficult to find and patch all cases.
