### PR TITLE
[release-11.1.13] Service Accounts: Do not show error pop-ups for Service Account and Renderer UI flows

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -508,7 +508,8 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 
 	namespace, identifier := c.SignedInUser.GetNamespacedID()
 	if namespace != identity.NamespaceUser {
-		c.JsonApiErr(http.StatusForbidden, "Endpoint only available for users", nil)
+		hs.log.Debug("Requested endpoint only available to users")
+		c.JsonApiErr(http.StatusNotModified, "Endpoint only available for users", nil)
 		return
 	}
 
@@ -631,10 +632,11 @@ func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Respon
 	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": flags})
 }
 
-func getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {
+func (hs *HTTPServer) getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {
 	namespace, identifier := c.SignedInUser.GetNamespacedID()
 	if namespace != identity.NamespaceUser {
-		return 0, response.Error(http.StatusForbidden, "Endpoint only available for users", nil)
+		hs.log.Debug("Requested endpoint only available to users")
+		return 0, response.Error(http.StatusNotModified, "Endpoint only available for users", nil)
 	}
 
 	userID, err := identity.IntIdentifier(namespace, identifier)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -352,7 +352,7 @@ func (hs *HTTPServer) UpdateUserEmail(c *contextmodel.ReqContext) response.Respo
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) GetSignedInUserOrgList(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -372,7 +372,7 @@ func (hs *HTTPServer) GetSignedInUserOrgList(c *contextmodel.ReqContext) respons
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) GetSignedInUserTeamList(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -482,7 +482,7 @@ func (hs *HTTPServer) UserSetUsingOrg(c *contextmodel.ReqContext) response.Respo
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -553,7 +553,7 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -589,7 +589,7 @@ func (hs *HTTPServer) SetHelpFlag(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -619,7 +619,7 @@ func (hs *HTTPServer) SetHelpFlag(c *contextmodel.ReqContext) response.Response 
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Response {
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -151,7 +151,7 @@ func (hs *HTTPServer) UpdateSignedInUser(c *contextmodel.ReqContext) response.Re
 	cmd.Email = strings.TrimSpace(cmd.Email)
 	cmd.Login = strings.TrimSpace(cmd.Login)
 
-	userID, errResponse := getUserID(c)
+	userID, errResponse := hs.getUserID(c)
 	if errResponse != nil {
 		return errResponse
 	}

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -274,6 +274,16 @@ export class BackendSrv implements BackendService {
   }
 
   showErrorAlert(config: BackendSrvRequest, err: FetchError) {
+    // do not show non-user error alerts for api keys or render tokens, they are used for kiosk mode and reporting and can't react to error pop-ups
+    if (
+      (err.status < 400 || err.status >= 500) &&
+      this.dependencies.contextSrv.isSignedIn &&
+      (this.dependencies.contextSrv.user.authenticatedBy === 'apikey' ||
+        this.dependencies.contextSrv.user.authenticatedBy === 'render')
+    ) {
+      return;
+    }
+
     if (config.showErrorAlert === false) {
       return;
     }


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/392124de0059f92cbf41c6db84034a84134fa599 from https://github.com/grafana/grafana/pull/101776 and https://github.com/grafana/grafana/commit/f0d260ba5bfb288fa1b921b7657f67f91c2729f7 from https://github.com/grafana/grafana/pull/101679

---

**What is this feature?**

Follow-up on https://github.com/grafana/grafana/pull/101679

Change the code not to show non-user error pop-ups for service accounts and renderer user. These identities are used for reporting and alerting emails, as well as for kiosk mode, and can't react to error pop-ups, so pop-ups lead to bad user experience.

I've made an exception for 4xx errors, as these might display valuable information (eg, access denied or unauthorized).

**Why do we need this feature?**

To not show a pop-up which is not actionable and covers up a part of the dashboard that is being displayed.

**Who is this feature for?**

Users of kiosk mode, reports and alert emails. 

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/94649 and https://github.com/grafana/grafana-kiosk/issues/146

**Special notes for your reviewer:**

Other options considered:
* do not display error pop-ups for certain (eg, <4xx) error codes - but this is a larger change and it's hard to think through all the side-effects of it;
* cover all the endpoints which might cause an error pop-up when SA/renderer is used to display a dashboard - possible, but feels like a temporary fix, as UI changes fast and we don't always take SA/renderer workflows into account. This approach was attempted in https://github.com/grafana/grafana/pull/97162, but it's difficult to find and patch all cases.
