### PR TITLE
Docs: Fix plugin installation title by removing non-breaking space

### DIFF
--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -128,7 +128,7 @@ unzip my-plugin-0.2.0.zip -d YOUR_PLUGIN_DIR/my-plugin
 
 The path to the plugin directory is defined in the configuration file. For more information, refer to [Configuration](../../setup-grafana/configure-grafana/#plugins).
 
-#### Install a plugin using Grafana configuration
+#### Install a plugin using Grafana configuration
 
 {{% admonition type="note" %}}
 This feature requires Grafana 11.5.0 or later.


### PR DESCRIPTION
**What is this feature?**

Replaces NBSP character with whitespace.

Before:
![Screenshot 2025-03-07 at 14 34 42](https://github.com/user-attachments/assets/f36332df-a6d8-49b3-8064-e7a1dbea2ae2)

After:
![image](https://github.com/user-attachments/assets/53d114a4-c764-4ca5-9e93-65a2f423ee41)


**Why do we need this feature?**

Nobody wants badly formatted docs yo.


