### PR TITLE
Documentation: Add instructions for node version mismatches

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -79,7 +79,7 @@ After the command has finished, you can start building the source code:
 yarn start
 ```
 
-> If you get the error `[webpack-cli] Failed to load '/Users/marcodeabreu/git_projects/grafana_org/grafana/public/app/plugins/datasource/tempo/webpack.config.ts' config - cannot find module` with a reference to grafana-plugins, verify that your node version `node --version` is matching the one defined in `.nvmrc`. You might have to delete your `node-modules` & `yarn.lock` and rerun the installation.
+> If you get the error `[webpack-cli] Failed to load './public/app/plugins/datasource/tempo/webpack.config.ts' config - cannot find module` with a reference to grafana-plugins, verify that your node version `node --version` is matching the one defined in `.nvmrc`. You might have to delete your `node-modules` & `yarn.lock` and rerun the installation.
 
 This command generates SASS theme files, builds all external plugins, and then builds the frontend assets.
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -79,6 +79,8 @@ After the command has finished, you can start building the source code:
 yarn start
 ```
 
+> If you get the error `[webpack-cli] Failed to load '/Users/marcodeabreu/git_projects/grafana_org/grafana/public/app/plugins/datasource/tempo/webpack.config.ts' config - cannot find module` with a reference to grafana-plugins, verify that your node version `node --version` is matching the one defined in `.nvmrc`. You might have to delete your `node-modules` & `yarn.lock` and rerun the installation.
+
 This command generates SASS theme files, builds all external plugins, and then builds the frontend assets.
 
 After `yarn start` has built the assets, it will continue to do so whenever any of the files change. This means you don't have to manually build the assets every time you change the code.


### PR DESCRIPTION
**What is this feature?**

This PR enhances the developer documentation for an error case that is caused by using a more recent Node version. 

**Why do we need this feature?**

Developers using the latest node version will not be able to compile Grafana and complete the guide.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Didn't create one.

