### PR TITLE
ExploreMetrics: Safer routing to externalized app

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -27,10 +27,12 @@ const isDevEnv = config.buildInfo.env === 'development';
 export const extraRoutes: RouteDescriptor[] = [];
 
 export function getAppRoutes(): RouteDescriptor[] {
+  const appPluginRoutes = getAppPluginRoutes();
+
   return [
     // Based on the Grafana configuration standalone plugin pages can even override and extend existing core pages, or they can register new routes under existing ones.
     // In order to make it possible we need to register them first due to how `<Switch>` is evaluating routes. (This will be unnecessary once/when we upgrade to React Router v6 and start using `<Routes>` instead.)
-    ...getAppPluginRoutes(),
+    ...appPluginRoutes,
     {
       path: '/',
       pageClass: 'page-dashboard',
@@ -522,7 +524,8 @@ export function getAppRoutes(): RouteDescriptor[] {
     config.featureToggles.exploreMetrics && {
       path: '/explore/metrics/*',
       roles: () => contextSrv.evaluatePermission([AccessControlAction.DataSourcesExplore]),
-      ...(config.featureToggles.exploreMetricsUseExternalAppPlugin
+      ...(config.featureToggles.exploreMetricsUseExternalAppPlugin &&
+      Boolean(appPluginRoutes.find(({ path }) => path === '/a/grafana-metricsdrilldown-app/*'))
         ? {
             component: SafeDynamicImport(
               () =>

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -525,7 +525,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       path: '/explore/metrics/*',
       roles: () => contextSrv.evaluatePermission([AccessControlAction.DataSourcesExplore]),
       ...(config.featureToggles.exploreMetricsUseExternalAppPlugin &&
-      Boolean(appPluginRoutes.find(({ path }) => path === '/a/grafana-metricsdrilldown-app/*'))
+      appPluginRoutes.some(({ path }) => path === '/a/grafana-metricsdrilldown-app/*')
         ? {
             component: SafeDynamicImport(
               () =>


### PR DESCRIPTION
## Related issue

This supports #100096.

## What does this do?

It adds another layer of safety to our handling of the redirect of `/explore/metrics/*` to `/a/grafana-metricsdrilldown-app/*`. This protects against a scenario in which the `exploreMetricsUseExternalAppPlugin` feature toggle is enabled, but the app isn't installed for some reason. This will make it easier for us to roll out the `exploreMetricsUseExternalAppPlugin` feature toggle, as it removes the requirement that `grafana-metricsdrilldown-app` must be installed/provisioned before the feature toggle can be enabled.

What this boils down to: we should have an easier time switching users over to `grafana-metricsdrilldown-app` in a seamless way.

## How to test

1. If you've not yet installed `grafana-metricsdrilldown-app`, proceed to the next step. If you have installed the app, add `grafana-metricsdrilldown-app` to `plugins.disable_plugins` in `conf/custom.ini`

```
# custom.ini

[plugins]
# ...
# Enter a comma-separated list of plugin identifiers to avoid loading (including core plugins). These plugins will be hidden in the catalog.
disable_plugins = grafana-metricsdrilldown-app
```

2. Also in `conf/custom.ini`, enable the 

```
# custom.ini

[feature_toggles]
# ...
exploreMetricsUseExternalAppPlugin = true
```

3. Start/restart Grafana. In the sidebar, navigate to **Drilldown** > **Metrics**. This should take you to `/explore/metrics` without any errors.