### PR TITLE
K8s: Schema v2: Return 406 in /api

### DIFF
--- a/pkg/api/swagger_responses.go
+++ b/pkg/api/swagger_responses.go
@@ -52,6 +52,11 @@ type NotFoundError GenericError
 // swagger:response badRequestError
 type BadRequestError GenericError
 
+// NotAcceptableError is returned when the server cannot produce a response matching the accepted formats.
+//
+// swagger:response notAcceptableError
+type NotAcceptableError GenericError
+
 // ConflictError
 //
 // swagger:response conflictError

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -334,10 +334,10 @@ func TestIntegrationLegacySupport(t *testing.T) {
 	require.Equal(t, 200, rsp.Response.StatusCode)
 	require.Equal(t, "v1alpha1", rsp.Result.Meta.APIVersion)
 
-	// V2 should send a redirect
+	// V2 should send a not acceptable
 	rsp = apis.DoRequest(helper, apis.RequestParams{
 		User: helper.Org1.Admin,
 		Path: "/api/dashboards/uid/test-v2",
 	}, &dtos.DashboardFullWithMeta{})
-	require.Equal(t, 302, rsp.Response.StatusCode) // redirect
+	require.Equal(t, 406, rsp.Response.StatusCode) // not acceptable
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3356,6 +3356,9 @@
           "404": {
             "$ref": "#/responses/notFoundError"
           },
+          "406": {
+            "$ref": "#/responses/notAcceptableError"
+          },
           "500": {
             "$ref": "#/responses/internalServerError"
           }
@@ -24438,6 +24441,12 @@
       "description": "(empty)",
       "schema": {
         "type": "object"
+      }
+    },
+    "notAcceptableError": {
+      "description": "NotAcceptableError is returned when the server cannot produce a response matching the accepted formats.",
+      "schema": {
+        "$ref": "#/definitions/ErrorResponseBody"
       }
     },
     "notFoundError": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1641,6 +1641,16 @@
         },
         "description": "(empty)"
       },
+      "notAcceptableError": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponseBody"
+            }
+          }
+        },
+        "description": "NotAcceptableError is returned when the server cannot produce a response matching the accepted formats."
+      },
       "notFoundError": {
         "content": {
           "application/json": {
@@ -16996,6 +17006,9 @@
           },
           "404": {
             "$ref": "#/components/responses/notFoundError"
+          },
+          "406": {
+            "$ref": "#/components/responses/notAcceptableError"
           },
           "500": {
             "$ref": "#/components/responses/internalServerError"


### PR DESCRIPTION
**What is this feature?**

This PR changes our response in `/api` for schema v2 to be a 406 error instead. [From decision here](https://raintank-corp.slack.com/archives/C07QVGH37D4/p1741065179169539)

Closes https://github.com/grafana/app-platform-wg/issues/228