### PR TITLE
K8s: Fix plugin updater

### DIFF
--- a/pkg/registry/backgroundsvcs/background_services.go
+++ b/pkg/registry/backgroundsvcs/background_services.go
@@ -68,10 +68,11 @@ func ProvideBackgroundServiceRegistry(
 	pluginInstaller *plugininstaller.Service,
 	zanzanaReconciler *dualwrite.ZanzanaReconciler,
 	appRegistry *appregistry.Service,
+	pluginDashboardUpdater *plugindashboardsservice.DashboardUpdater,
 	// Need to make sure these are initialized, is there a better place to put them?
 	_ dashboardsnapshots.Service,
 	_ serviceaccounts.Service, _ *guardian.Provider,
-	_ *plugindashboardsservice.DashboardUpdater, _ *sanitizer.Provider,
+	_ *sanitizer.Provider,
 	_ *grpcserver.HealthService, _ *grpcserver.ReflectionService,
 	_ *ldapapi.Service, _ *apiregistry.Service, _ auth.IDService, _ *teamapi.TeamAPI, _ ssosettings.Service,
 	_ cloudmigration.Service, _ authnimpl.Registration,
@@ -113,6 +114,7 @@ func ProvideBackgroundServiceRegistry(
 		pluginInstaller,
 		zanzanaReconciler,
 		appRegistry,
+		pluginDashboardUpdater,
 	)
 }
 

--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -53,11 +53,11 @@ type DashboardUpdater struct {
 }
 
 func (du *DashboardUpdater) Run(ctx context.Context) error {
-	du.updateAppDashboards()
+	du.updateAppDashboards(ctx)
 	return nil
 }
 
-func (du *DashboardUpdater) updateAppDashboards() {
+func (du *DashboardUpdater) updateAppDashboards(ctx context.Context) {
 	du.logger.Debug("Looking for app dashboard updates")
 
 	pluginSettings, err := du.pluginSettingsService.GetPluginSettings(context.Background(), &pluginsettings.GetArgs{OrgID: 0})
@@ -72,10 +72,10 @@ func (du *DashboardUpdater) updateAppDashboards() {
 			continue
 		}
 
-		ctx, _ := identity.WithServiceIdentity(context.Background(), pluginSetting.OrgID)
-		if pluginDef, exists := du.pluginStore.Plugin(ctx, pluginSetting.PluginID); exists {
+		serviceCtx, _ := identity.WithServiceIdentity(ctx, pluginSetting.OrgID)
+		if pluginDef, exists := du.pluginStore.Plugin(serviceCtx, pluginSetting.PluginID); exists {
 			if pluginDef.Info.Version != pluginSetting.PluginVersion {
-				du.syncPluginDashboards(ctx, pluginDef, pluginSetting.OrgID)
+				du.syncPluginDashboards(serviceCtx, pluginDef, pluginSetting.OrgID)
 			}
 		}
 	}

--- a/pkg/services/plugindashboards/service/dashboard_updater_test.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater_test.go
@@ -23,7 +23,7 @@ func TestDashboardUpdater(t *testing.T) {
 	t.Run("updateAppDashboards", func(t *testing.T) {
 		scenario(t, "Without any stored plugin settings shouldn't delete/import any dashboards",
 			scenarioInput{}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.Len(t, ctx.pluginSettingsService.getPluginSettingsArgs, 1)
 				require.Equal(t, int64(0), ctx.pluginSettingsService.getPluginSettingsArgs[0])
@@ -46,7 +46,7 @@ func TestDashboardUpdater(t *testing.T) {
 					},
 				},
 			}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
 				require.Empty(t, ctx.dashboardService.deleteDashboardArgs)
@@ -68,7 +68,7 @@ func TestDashboardUpdater(t *testing.T) {
 					},
 				},
 			}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
 				require.Empty(t, ctx.dashboardService.deleteDashboardArgs)
@@ -100,7 +100,7 @@ func TestDashboardUpdater(t *testing.T) {
 					},
 				},
 			}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
 				require.Empty(t, ctx.dashboardService.deleteDashboardArgs)
@@ -135,7 +135,7 @@ func TestDashboardUpdater(t *testing.T) {
 					},
 				},
 			}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
 				require.Empty(t, ctx.dashboardService.deleteDashboardArgs)
@@ -183,7 +183,7 @@ func TestDashboardUpdater(t *testing.T) {
 					},
 				},
 			}, func(ctx *scenarioContext) {
-				ctx.dashboardUpdater.updateAppDashboards()
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
 
 				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
 				require.Len(t, ctx.dashboardService.deleteDashboardArgs, 1)


### PR DESCRIPTION
**What is this feature?**

This PR adds a service identity into the context for the k8s flow.

It also moves the `updateAppDashboards` function into a background task, rather than being in the wire provide, as that was causing it to hang before.