### PR TITLE
Dashboard Schema V2: Use the right version of transformer when detecting changes

### DIFF
--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -22,7 +22,6 @@ import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks } from '../scene/PanelLinks';
 import { PanelTimeRange } from '../scene/PanelTimeRange';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
-import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { isSceneVariableInstance } from '../settings/variables/utils';
 
 import { DashboardChangeInfo } from './shared';
@@ -122,7 +121,7 @@ export class DashboardSceneChangeTracker {
   }
 
   private detectSaveModelChanges() {
-    const changedDashboard = transformSceneToSaveModel(this._dashboard);
+    const changedDashboard = this._dashboard.getSaveModel();
     const initialDashboard = this._dashboard.getInitialSaveModel();
 
     // Objects must be stringify to ensure they are clonable, so they don't contain functions


### PR DESCRIPTION
Fixes an issue of always being warned that there are changes after saving a V2 dashboard. The issue was that we were always using V1 dashboard when setting the changed model. 

With the fix: 
1. Make changes in V2 dashboard 
2. Save dashboard 
3. Exit edit mode
4. Navigate out of the dashboard - you shouldn't get a pop up saying there are unsaved changes 