### PR TITLE
Provisioning: Add folder prefix for git

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -40,8 +40,14 @@ type GitHubRepositoryConfig struct {
 
 	// The branch to use in the repository.
 	Branch string `json:"branch"`
+
+	// Optional folder prefix within the repo.
+	// When configured, files outside this folder will be ignored
+	Folder string `json:"folder"`
+
 	// Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.
 	Token string `json:"token,omitempty"`
+
 	// Token for accessing the repository, but encrypted. This is not possible to read back to a user decrypted.
 	// +listType=atomic
 	EncryptedToken []byte `json:"encryptedToken,omitempty"`

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -247,6 +247,14 @@ func schema_pkg_apis_provisioning_v0alpha1_GitHubRepositoryConfig(ref common.Ref
 							Format:      "",
 						},
 					},
+					"folder": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional folder prefix within the repo. When configured, files outside this folder will be ignored",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"token": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.",
@@ -274,7 +282,7 @@ func schema_pkg_apis_provisioning_v0alpha1_GitHubRepositoryConfig(ref common.Ref
 						},
 					},
 				},
-				Required: []string{"branch"},
+				Required: []string{"branch", "folder"},
 			},
 		},
 	}

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubrepositoryconfig.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubrepositoryconfig.go
@@ -9,6 +9,7 @@ package v0alpha1
 type GitHubRepositoryConfigApplyConfiguration struct {
 	URL                       *string `json:"url,omitempty"`
 	Branch                    *string `json:"branch,omitempty"`
+	Folder                    *string `json:"folder,omitempty"`
 	Token                     *string `json:"token,omitempty"`
 	EncryptedToken            []byte  `json:"encryptedToken,omitempty"`
 	GenerateDashboardPreviews *bool   `json:"generateDashboardPreviews,omitempty"`
@@ -33,6 +34,14 @@ func (b *GitHubRepositoryConfigApplyConfiguration) WithURL(value string) *GitHub
 // If called multiple times, the Branch field is set to the value of the last call.
 func (b *GitHubRepositoryConfigApplyConfiguration) WithBranch(value string) *GitHubRepositoryConfigApplyConfiguration {
 	b.Branch = &value
+	return b
+}
+
+// WithFolder sets the Folder field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Folder field is set to the value of the last call.
+func (b *GitHubRepositoryConfigApplyConfiguration) WithFolder(value string) *GitHubRepositoryConfigApplyConfiguration {
+	b.Folder = &value
 	return b
 }
 

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -2626,7 +2626,8 @@
       "com.github.grafana.grafana.pkg.apis.provisioning.v0alpha1.GitHubRepositoryConfig": {
         "type": "object",
         "required": [
-          "branch"
+          "branch",
+          "folder"
         ],
         "properties": {
           "branch": {
@@ -2639,6 +2640,11 @@
             "type": "string",
             "format": "byte",
             "x-kubernetes-list-type": "atomic"
+          },
+          "folder": {
+            "description": "Optional folder prefix within the repo. When configured, files outside this folder will be ignored",
+            "type": "string",
+            "default": ""
           },
           "generateDashboardPreviews": {
             "description": "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",

--- a/pkg/tests/apis/provisioning/testdata/github-example.json
+++ b/pkg/tests/apis/provisioning/testdata/github-example.json
@@ -11,6 +11,7 @@
         "github": {
             "url": "https://github.com/grafana/git-ui-sync-demo",
             "branch": "dummy-branch",
+            "folder": "grafana",
             "generateDashboardPreviews": true,
             "token": "github_pat_dummy"
         },

--- a/public/app/features/provisioning/api/endpoints.gen.ts
+++ b/public/app/features/provisioning/api/endpoints.gen.ts
@@ -846,6 +846,8 @@ export type GitHubRepositoryConfig = {
   branch: string;
   /** Token for accessing the repository, but encrypted. This is not possible to read back to a user decrypted. */
   encryptedToken?: string;
+  /** Optional folder prefix within the repo. When configured, files outside this folder will be ignored */
+  folder: string;
   /** Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews). */
   generateDashboardPreviews?: boolean;
   /** Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again. */


### PR DESCRIPTION
adds a folder prefix in git -- so we could manage dashboards next to other things


🤔  should this be git only?  For local it seems weird when the root could point anywhere