### PR TITLE
Dashboard: Fixes issue with tabs with rows and default grid

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -19,8 +19,8 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
   const { isEditing } = dashboard.useState();
 
   return (
-    <>
-      <TabsBar className={styles.tabsWrapper}>
+    <div className={styles.tabLayoutContainer}>
+      <TabsBar className={styles.tabsBar}>
         <div className={styles.tabsRow}>
           <div className={styles.tabsContainer}>
             {tabs.map((tab) => (
@@ -35,12 +35,17 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
       <TabContent className={styles.tabContentContainer}>
         {currentTab && <layout.Component model={layout} />}
       </TabContent>
-    </>
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  tabsWrapper: css({
+  tabLayoutContainer: css({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '1 1 auto',
+  }),
+  tabsBar: css({
     overflow: 'hidden',
   }),
   tabsRow: css({
@@ -60,9 +65,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: 'transparent',
     display: 'flex',
     flex: 1,
-    height: '100%',
-    overflow: 'auto',
-    scrollbarWidth: 'thin',
+    minHeight: 0,
     padding: '2px 2px 0 2px',
   }),
 });


### PR DESCRIPTION

* Fixes issue with default grid inside rows inside tabs. The default grid extended outside the row bounds 
* Removes scrolling of tab content (this was only working in edit mode and need more work to make it work in both and with this fix, could not make it work, so needs more time) 

