### PR TITLE
[release-11.5.3] Alerting docs: clarify the `export` JSON format are for file provisioning

### DIFF
--- a/docs/sources/shared/alerts/alerting-provisioning-export-produces.md
+++ b/docs/sources/shared/alerts/alerting-provisioning-export-produces.md
@@ -1,0 +1,13 @@
+---
+title: 'Alerting Produces '
+---
+
+#### Produces
+
+- `application/json`
+- `application/yaml`
+- `application/terraform+hcl`
+- `text/yaml`
+- `text/hcl`
+
+These outputs are for [file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning) or [Terraform provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning), and they-including the JSON output—cannot be used to update resources via the HTTP API.

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -14,7 +14,12 @@ For more information on the differences between Grafana-managed and data source-
 
 ## Grafana-managed endpoints
 
-Note that the JSON format from most of the following endpoints is not fully compatible with [provisioning via configuration JSON files](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/).
+{{< admonition type="note" >}}
+In the Alerting provisioning HTTP API, the endpoints use a JSON format that differs from the format returned by the `export` endpoints.
+
+The `export` endpoints allow you to export alerting resources in a JSON format suitable for [provisioning via files](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/). However, this format cannot be used to update resources via the HTTP API.
+
+{{< /admonition >}}
 
 ### Alert rules
 
@@ -373,16 +378,21 @@ Content-Type: application/json
 
 ### Edit resources in the Grafana UI
 
-By default, you cannot edit API-provisioned alerting resources in Grafana. To enable editing these resources in the Grafana UI, add the `X-Disable-Provenance` header to the following requests in the API:
+By default, you cannot edit API-provisioned alerting resources in Grafana.
+
+To enable editing these resources in the Grafana UI, add the **`X-Disable-Provenance: true`** header to the following API requests:
 
 - `POST /api/v1/provisioning/alert-rules`
-- `PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}` (calling this endpoint will change provenance for all alert rules within the alert group)
+- `PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}` _(This endpoint changes provenance for all alert rules in the alert group)_
+
 - `POST /api/v1/provisioning/contact-points`
 - `POST /api/v1/provisioning/mute-timings`
-- `PUT /api/v1/provisioning/policies`
 - `PUT /api/v1/provisioning/templates/{name}`
+- `PUT /api/v1/provisioning/policies`
 
-To reset the notification policy tree to the default and unlock it for editing in the Grafana UI, use the `DELETE /api/v1/provisioning/policies` endpoint.
+To reset the notification policy tree to the default and unlock it for editing in the Grafana UI, use:
+
+- `DELETE /api/v1/provisioning/policies`
 
 ## Data source-managed resources
 
@@ -408,10 +418,10 @@ DELETE /api/v1/provisioning/alert-rules/:uid
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type   | Go type  | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ------ | -------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| UID                        | `path`   | string | `string` |           |    ✓     |         | Alert rule UID                                            |
-| X-Disable-Provenance: true | `header` | string | `string` |           |          |         | Allows editing of provisioned resources in the Grafana UI |
+| Name                         | Source | Type   | Go type | Required | Default | Description                                               |
+| ---------------------------- | ------ | ------ | ------- | :------: | ------- | --------------------------------------------------------- |
+| `UID`                        | path   | string | string  |    ✓     |         | Alert rule UID                                            |
+| `X-Disable-Provenance: true` | header | string | string  |          |         | Allows editing of provisioned resources in the Grafana UI |
 
 {{% /responsive-table %}}
 
@@ -437,9 +447,9 @@ DELETE /api/v1/provisioning/contact-points/:uid
 
 #### Parameters
 
-| Name | Source | Type   | Go type  | Separator | Required | Default | Description                                |
-| ---- | ------ | ------ | -------- | --------- | :------: | ------- | ------------------------------------------ |
-| UID  | `path` | string | `string` |           |    ✓     |         | UID is the contact point unique identifier |
+| Name  | Source | Type   | Go type | Required | Default | Description                                |
+| ----- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------ |
+| `UID` | path   | string | string  |    ✓     |         | UID is the contact point unique identifier |
 
 #### All responses
 
@@ -463,10 +473,10 @@ DELETE /api/v1/provisioning/mute-timings/:name
 
 #### Parameters
 
-| Name    | Source  | Type   | Go type  | Separator | Required | Default | Description                                                                                                   |
-| ------- | ------- | ------ | -------- | --------- | :------: | ------- | ------------------------------------------------------------------------------------------------------------- |
-| name    | `path`  | string | `string` |           |    ✓     |         | Mute timing name                                                                                              |
-| version | `query` | string | `string` |           |          |         | Current version of the resource. Used for optimistic concurrency validation. Keep empty to bypass validation. |
+| Name      | Source | Type   | Go type | Required | Default | Description                                                                                                   |
+| --------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `name`    | path   | string | string  |    ✓     |         | Mute timing name                                                                                              |
+| `version` | query  | string | string  |          |         | Current version of the resource. Used for optimistic concurrency validation. Keep empty to bypass validation. |
 
 #### All responses
 
@@ -499,10 +509,10 @@ DELETE /api/v1/provisioning/templates/:name
 
 #### Parameters
 
-| Name    | Source  | Type   | Go type  | Separator | Required | Default | Description                                                                                                   |
-| ------- | ------- | ------ | -------- | --------- | :------: | ------- | ------------------------------------------------------------------------------------------------------------- |
-| name    | `path`  | string | `string` |           |    ✓     |         | Name of the template group                                                                                    |
-| version | `query` | string | `string` |           |          |         | Current version of the resource. Used for optimistic concurrency validation. Keep empty to bypass validation. |
+| Name      | Source | Type   | Go type | Required | Default | Description                                                                                                   |
+| --------- | ------ | ------ | ------- | :------: | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `name`    | path   | string | string  |    ✓     |         | Name of the template group                                                                                    |
+| `version` | query  | string | string  |          |         | Current version of the resource. Used for optimistic concurrency validation. Keep empty to bypass validation. |
 
 #### All responses
 
@@ -535,9 +545,9 @@ GET /api/v1/provisioning/alert-rules/:uid
 
 #### Parameters
 
-| Name | Source | Type   | Go type  | Separator | Required | Default | Description    |
-| ---- | ------ | ------ | -------- | --------- | :------: | ------- | -------------- |
-| UID  | `path` | string | `string` |           |    ✓     |         | Alert rule UID |
+| Name  | Source | Type   | Go type | Required | Default | Description    |
+| ----- | ------ | ------ | ------- | :------: | ------- | -------------- |
+| `UID` | path   | string | string  |    ✓     |         | Alert rule UID |
 
 #### All responses
 
@@ -568,21 +578,15 @@ Status: Not Found
 GET /api/v1/provisioning/alert-rules/:uid/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| UID      | `path`  | string  | `string` |           |    ✓     |          | Alert rule UID                                                                                                                         |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ---------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UID`      | path   | string  | string  |    ✓     |         | Alert rule UID                                                                                                                               |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -615,10 +619,10 @@ GET /api/v1/provisioning/folder/:folderUid/rule-groups/:group
 
 #### Parameters
 
-| Name      | Source | Type   | Go type  | Separator | Required | Default | Description |
-| --------- | ------ | ------ | -------- | --------- | :------: | ------- | ----------- |
-| FolderUID | `path` | string | `string` |           |    ✓     |         |             |
-| Group     | `path` | string | `string` |           |    ✓     |         |             |
+| Name        | Source | Type   | Go type | Required | Default | Description |
+| ----------- | ------ | ------ | ------- | :------: | ------- | ----------- |
+| `FolderUID` | path   | string | string  |    ✓     |         |             |
+| `Group`     | path   | string | string  |    ✓     |         |             |
 
 #### All responses
 
@@ -649,22 +653,16 @@ Status: Not Found
 GET /api/v1/provisioning/folder/:folderUid/rule-groups/:group/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name      | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| --------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| FolderUID | `path`  | string  | `string` |           |    ✓     |          |                                                                                                                                        |
-| Group     | `path`  | string  | `string` |           |    ✓     |          |                                                                                                                                        |
-| download  | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format    | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name        | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ----------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FolderUID` | path   | string  | string  |    ✓     |         |                                                                                                                                              |
+| `Group`     | path   | string  | string  |    ✓     |         |                                                                                                                                              |
+| `download`  | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`    | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -717,20 +715,14 @@ Status: OK
 GET /api/v1/provisioning/alert-rules/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ---------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -763,9 +755,9 @@ GET /api/v1/provisioning/contact-points
 
 #### Parameters
 
-| Name | Source  | Type   | Go type  | Separator | Required | Default | Description    |
-| ---- | ------- | ------ | -------- | --------- | :------: | ------- | -------------- |
-| name | `query` | string | `string` |           |          |         | Filter by name |
+| Name   | Source | Type   | Go type | Required | Default | Description    |
+| ------ | ------ | ------ | ------- | :------: | ------- | -------------- |
+| `name` | query  | string | string  |          |         | Filter by name |
 
 #### All responses
 
@@ -789,22 +781,16 @@ Status: OK
 GET /api/v1/provisioning/contact-points/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                                                                                     |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| decrypt  | `query` | boolean | `bool`   |           |          |          | Whether any contained secure settings should be decrypted or left redacted. Redacted settings will contain RedactedValue instead. Currently, only org admin can view decrypted secure settings. |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                                                                              |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence.                                                          |
-| name     | `query` | string  | `string` |           |          |          | Filter by name                                                                                                                                                                                  |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                                                                     |
+| ---------- | ------ | ------- | ------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `decrypt`  | query  | boolean | `bool`  |          |         | Whether any contained secure settings should be decrypted or left redacted. Redacted settings will contain RedactedValue instead. Currently, only org admin can view decrypted secure settings. |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                                                                              |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence.                                                    |
+| `name`     | query  | string  | string  |          |         | Filter by name                                                                                                                                                                                  |
 
 #### All responses
 
@@ -839,9 +825,9 @@ GET /api/v1/provisioning/mute-timings/:name
 
 #### Parameters
 
-| Name | Source | Type   | Go type  | Separator | Required | Default | Description      |
-| ---- | ------ | ------ | -------- | --------- | :------: | ------- | ---------------- |
-| name | `path` | string | `string` |           |    ✓     |         | Mute timing name |
+| Name   | Source | Type   | Go type | Required | Default | Description      |
+| ------ | ------ | ------ | ------- | :------: | ------- | ---------------- |
+| `name` | path   | string | string  |    ✓     |         | Mute timing name |
 
 #### All responses
 
@@ -894,20 +880,14 @@ Status: OK
 GET /api/v1/provisioning/mute-timings/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ---------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -940,21 +920,15 @@ Status: Forbidden
 GET /api/v1/provisioning/mute-timings/:name/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| name     | `path`  | string  | `string` |           |    ✓     |          | Mute timing name.                                                                                                                      |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ---------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | path   | string  | string  |    ✓     |         | Mute timing name.                                                                                                                            |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -1009,20 +983,14 @@ Status: OK
 GET /api/v1/provisioning/policies/export
 ```
 
-#### Produces
-
-- application/json
-- application/yaml
-- application/terraform+hcl
-- text/yaml
-- text/hcl
+{{< docs/shared lookup="alerts/alerting-provisioning-export-produces.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 #### Parameters
 
-| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                            |
-| -------- | ------- | ------- | -------- | --------- | :------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                     |
-| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. |
+| Name       | Source | Type    | Go type | Required | Default | Description                                                                                                                                  |
+| ---------- | ------ | ------- | ------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `download` | query  | boolean | `bool`  |          |         | Whether to initiate a download of the file or not.                                                                                           |
+| `format`   | query  | string  | string  |          | `yaml`  | Format of the downloaded file, either `yaml`, `json` or `hcl`. Accept header can also be used, but the query parameter will take precedence. |
 
 #### All responses
 
@@ -1057,9 +1025,9 @@ GET /api/v1/provisioning/templates/:name
 
 #### Parameters
 
-| Name | Source | Type   | Go type  | Separator | Required | Default | Description                |
-| ---- | ------ | ------ | -------- | --------- | :------: | ------- | -------------------------- |
-| name | `path` | string | `string` |           |    ✓     |         | Name of the template group |
+| Name   | Source | Type   | Go type | Required | Default | Description                |
+| ------ | ------ | ------ | ------- | :------: | ------- | -------------------------- |
+| `name` | path   | string | string  |    ✓     |         | Name of the template group |
 
 #### All responses
 
@@ -1116,10 +1084,10 @@ POST /api/v1/provisioning/alert-rules
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| X-Disable-Provenance: true | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                                                           |
+| Name                         | Source | Type                                            | Go type                       | Required | Default | Description                                               |
+| ---------------------------- | ------ | ----------------------------------------------- | ----------------------------- | :------: | ------- | --------------------------------------------------------- |
+| `X-Disable-Provenance: true` | header | string                                          | string                        |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -1160,10 +1128,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| X-Disable-Provenance: true | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                                           |
+| Name                         | Source | Type                                            | Go type                       | Required | Default | Description                                               |
+| ---------------------------- | ------ | ----------------------------------------------- | ----------------------------- | :------: | ------- | --------------------------------------------------------- |
+| `X-Disable-Provenance: true` | header | string                                          | string                        |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -1202,10 +1170,10 @@ POST /api/v1/provisioning/mute-timings
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                    | Go type                   | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| X-Disable-Provenance: true | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                                                           |
+| Name                         | Source | Type                                    | Go type                   | Required | Default | Description                                               |
+| ---------------------------- | ------ | --------------------------------------- | ------------------------- | :------: | ------- | --------------------------------------------------------- |
+| `X-Disable-Provenance: true` | header | string                                  | string                    |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -1244,11 +1212,11 @@ PUT /api/v1/provisioning/alert-rules/:uid
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| UID                        | `path`   | string                                          | `string`                      |           |    ✓     |         | Alert rule UID                                            |
-| X-Disable-Provenance: true | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                                                           |
+| Name                         | Source | Type                                            | Go type                       | Required | Default | Description                                               |
+| ---------------------------- | ------ | ----------------------------------------------- | ----------------------------- | :------: | ------- | --------------------------------------------------------- | --- |
+| `UID`                        | path   | string                                          | string                        |    ✓     |         | Alert rule UID                                            |
+| `X-Disable-Provenance: true` | header | string                                          | string                        |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |          |         |                                                           |     |
 
 {{% /responsive-table %}}
 
@@ -1287,12 +1255,12 @@ PUT /api/v1/provisioning/folder/:folderUid/rule-groups/:group
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                | Go type                 | Separator | Required | Default | Description                                                                                             |
-| -------------------------- | -------- | ----------------------------------- | ----------------------- | --------- | :------: | ------- | ------------------------------------------------------------------------------------------------------- |
-| FolderUID                  | `path`   | string                              | `string`                |           |    ✓     |         |                                                                                                         |
-| Group                      | `path`   | string                              | `string`                |           |    ✓     |         |                                                                                                         |
-| X-Disable-Provenance: true | `header` | string                              | `string`                |           |          |         | Allows editing of provisioned resources in the Grafana UI                                               |
-| Body                       | `body`   | [AlertRuleGroup](#alert-rule-group) | `models.AlertRuleGroup` |           |          |         | This action is idempotent and rules included in this body will overwrite configured rules for the group |
+| Name                         | Source | Type                                | Go type                 | Required | Default | Description                                                                                             |
+| ---------------------------- | ------ | ----------------------------------- | ----------------------- | :------: | ------- | ------------------------------------------------------------------------------------------------------- |
+| `FolderUID`                  | path   | string                              | string                  |    ✓     |         |                                                                                                         |
+| `Group`                      | path   | string                              | string                  |    ✓     |         |                                                                                                         |
+| `X-Disable-Provenance: true` | header | string                              | string                  |          |         | Allows editing of provisioned resources in the Grafana UI                                               |
+| `Body`                       | body   | [AlertRuleGroup](#alert-rule-group) | `models.AlertRuleGroup` |          |         | This action is idempotent and rules included in this body will overwrite configured rules for the group |
 
 {{% /responsive-table %}}
 
@@ -1331,11 +1299,11 @@ PUT /api/v1/provisioning/contact-points/:uid
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| UID                        | `path`   | string                                          | `string`                      |           |    ✓     |         | UID is the contact point unique identifier                |
-| X-Disable-Provenance: true | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                                           |
+| Name                         | Source | Type                                            | Go type                       | Required | Default | Description                                               |
+| ---------------------------- | ------ | ----------------------------------------------- | ----------------------------- | :------: | ------- | --------------------------------------------------------- |
+| `UID`                        | path   | string                                          | string                        |    ✓     |         | UID is the contact point unique identifier                |
+| `X-Disable-Provenance: true` | header | string                                          | string                        |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -1374,11 +1342,11 @@ PUT /api/v1/provisioning/mute-timings/:name
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type                                    | Go type                   | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| name                       | `path`   | string                                  | `string`                  |           |    ✓     |         | Mute timing name                                          |
-| X-Disable-Provenance: true | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                                                           |
+| Name                         | Source | Type                                    | Go type                   | Required | Default | Description                                               |
+| ---------------------------- | ------ | --------------------------------------- | ------------------------- | -------- | :-----: | --------------------------------------------------------- |
+| `name`                       | path   | string                                  | string                    | ✓        |         | Mute timing name                                          |
+| `X-Disable-Provenance: true` | header | string                                  | string                    |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -1426,10 +1394,10 @@ PUT /api/v1/provisioning/policies
 
 {{% responsive-table %}}
 
-| Name                       | Source   | Type            | Go type        | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | --------------- | -------------- | --------- | :------: | ------- | --------------------------------------------------------- |
-| X-Disable-Provenance: true | `header` | string          | `string`       |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [Route](#route) | `models.Route` |           |          |         | The new notification routing tree to use                  |
+| Name                         | Source | Type            | Go type        | Required | Default | Description                                               |
+| ---------------------------- | ------ | --------------- | -------------- | :------: | ------- | --------------------------------------------------------- |
+| `X-Disable-Provenance: true` | header | string          | string         |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [Route](#route) | `models.Route` |          |         | The new notification routing tree to use                  |
 
 {{% /responsive-table %}}
 
@@ -1468,11 +1436,11 @@ PUT /api/v1/provisioning/templates/:name
 
 #### Parameters
 
-| Name                       | Source   | Type                                                          | Go type                              | Separator | Required | Default | Description                                               |
-| -------------------------- | -------- | ------------------------------------------------------------- | ------------------------------------ | --------- | :------: | ------- | --------------------------------------------------------- |
-| name                       | `path`   | string                                                        | `string`                             |           |    ✓     |         | Name of the template group                                |
-| X-Disable-Provenance: true | `header` | string                                                        | `string`                             |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                       | `body`   | [NotificationTemplateContent](#notification-template-content) | `models.NotificationTemplateContent` |           |          |         |                                                           |
+| Name                         | Source | Type                                                          | Go type                              | Required | Default | Description                                               |
+| ---------------------------- | ------ | ------------------------------------------------------------- | ------------------------------------ | -------- | :-----: | --------------------------------------------------------- | --- |
+| `name`                       | path   | string                                                        | string                               | ✓        |         | Name of the template group                                |
+| `X-Disable-Provenance: true` | header | string                                                        | string                               |          |         | Allows editing of provisioned resources in the Grafana UI |
+| `Body`                       | body   | [NotificationTemplateContent](#notification-template-content) | `models.NotificationTemplateContent` |          |         |                                                           |     |
 
 {{% /responsive-table %}}
 
@@ -1544,14 +1512,13 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name                                                      | Type                                      | Go type             | Required | Default | Description                                                                                            | Example |
-| --------------------------------------------------------- | ----------------------------------------- | ------------------- | :------: | ------- | ------------------------------------------------------------------------------------------------------ | ------- |
-| datasourceUid                                             | string                                    | `string`            |          |         | Grafana data source unique identifier; it should be '**expr**' for a Server Side Expression operation. |         |
-| model                                                     | [interface{}](#interface)                 | `interface{}`       |          |         | JSON is the raw JSON query and includes the above properties as well as custom properties.             |         |
-| queryType                                                 | string                                    | `string`            |          |         | QueryType is an optional identifier for the type of query.                                             |
-| It can be used to distinguish different types of queries. |                                           |
-| refId                                                     | string                                    | `string`            |          |         | RefID is the unique identifier of the query, set by the frontend call.                                 |         |
-| relativeTimeRange                                         | [RelativeTimeRange](#relative-time-range) | `RelativeTimeRange` |          |         |                                                                                                        |         |
+| Name                | Type                                      | Go type             | Required | Default | Description                                                                                                          | Example |
+| ------------------- | ----------------------------------------- | ------------------- | :------: | ------- | -------------------------------------------------------------------------------------------------------------------- | ------- |
+| `datasourceUid`     | string                                    | string              |          |         | Grafana data source unique identifier; it should be '**expr**' for a Server Side Expression operation.               |         |
+| `model`             | [interface{}](#interface)                 | `interface{}`       |          |         | JSON is the raw JSON query and includes the above properties as well as custom properties.                           |         |
+| `queryType`         | string                                    | string              |          |         | QueryType is an optional identifier for the type of query. It can be used to distinguish different types of queries. |         |
+| `refId`             | string                                    | string              |          |         | RefID is the unique identifier of the query, set by the frontend call.                                               |         |
+| `relativeTimeRange` | [RelativeTimeRange](#relative-time-range) | `RelativeTimeRange` |          |         |                                                                                                                      |         |
 
 {{% /responsive-table %}}
 
@@ -1561,13 +1528,13 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name              | Type                                      | Go type             | Required | Default | Description | Example |
-| ----------------- | ----------------------------------------- | ------------------- | :------: | ------- | ----------- | ------- |
-| datasourceUid     | string                                    | `string`            |          |         |             |         |
-| model             | [interface{}](#interface)                 | `interface{}`       |          |         |             |         |
-| queryType         | string                                    | `string`            |          |         |             |         |
-| refId             | string                                    | `string`            |          |         |             |         |
-| relativeTimeRange | [RelativeTimeRange](#relative-time-range) | `RelativeTimeRange` |          |         |             |         |
+| Name                | Type                                      | Go type             | Required | Default | Description | Example |
+| ------------------- | ----------------------------------------- | ------------------- | :------: | ------- | ----------- | ------- |
+| `datasourceUid`     | string                                    | string              |          |         |             |         |
+| `model`             | [interface{}](#interface)                 | `interface{}`       |          |         |             |         |
+| `queryType`         | string                                    | string              |          |         |             |         |
+| `refId`             | string                                    | string              |          |         |             |         |
+| `relativeTimeRange` | [RelativeTimeRange](#relative-time-range) | `RelativeTimeRange` |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1577,20 +1544,20 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name         | Type                                      | Go type               | Required | Default | Description | Example |
-| ------------ | ----------------------------------------- | --------------------- | :------: | ------- | ----------- | ------- |
-| annotations  | map of string                             | `map[string]string`   |          |         |             |         |
-| condition    | string                                    | `string`              |          |         |             |         |
-| dashboardUid | string                                    | `string`              |          |         |             |         |
-| data         | [][alertqueryexport](#alert-query-export) | `[]*AlertQueryExport` |          |         |             |         |
-| execErrState | string                                    | `string`              |          |         |             |         |
-| for          | [Duration](#duration)                     | `Duration`            |          |         |             |         |
-| isPaused     | boolean                                   | `bool`                |          |         |             |         |
-| labels       | map of string                             | `map[string]string`   |          |         |             |         |
-| noDataState  | string                                    | `string`              |          |         |             |         |
-| panelId      | int64 (formatted integer)                 | `int64`               |          |         |             |         |
-| title        | string                                    | `string`              |          |         |             |         |
-| uid          | string                                    | `string`              |          |         |             |         |
+| Name           | Type                                      | Go type               | Required | Default | Description | Example |
+| -------------- | ----------------------------------------- | --------------------- | :------: | ------- | ----------- | ------- |
+| `annotations`  | map of string                             | `map[string]string`   |          |         |             |         |
+| `condition`    | string                                    | string                |          |         |             |         |
+| `dashboardUid` | string                                    | string                |          |         |             |         |
+| `data`         | [][AlertQueryExport](#alert-query-export) | `[]*AlertQueryExport` |          |         |             |         |
+| `execErrState` | string                                    | string                |          |         |             |         |
+| `for`          | [Duration](#duration)                     | Duration              |          |         |             |         |
+| `isPaused`     | boolean                                   | `bool`                |          |         |             |         |
+| `labels`       | map of string                             | `map[string]string`   |          |         |             |         |
+| `noDataState`  | string                                    | string                |          |         |             |         |
+| `panelId`      | int64 (formatted integer)                 | int64                 |          |         |             |         |
+| `title`        | string                                    | string                |          |         |             |         |
+| `uid`          | string                                    | string                |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1600,12 +1567,12 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name      | Type                                              | Go type                   | Required | Default | Description | Example |
-| --------- | ------------------------------------------------- | ------------------------- | :------: | ------- | ----------- | ------- |
-| folderUid | string                                            | `string`                  |          |         |             |         |
-| interval  | int64 (formatted integer)                         | `int64`                   |          |         |             |         |
-| rules     | [][provisionedalertrule](#provisioned-alert-rule) | `[]*ProvisionedAlertRule` |          |         |             |         |
-| title     | string                                            | `string`                  |          |         |             |         |
+| Name        | Type                                              | Go type                   | Required | Default | Description | Example |
+| ----------- | ------------------------------------------------- | ------------------------- | :------: | ------- | ----------- | ------- |
+| `folderUid` | string                                            | string                    |          |         |             |         |
+| `interval`  | int64 (formatted integer)                         | int64                     |          |         |             |         |
+| `rules`     | [][ProvisionedAlertRule](#provisioned-alert-rule) | `[]*ProvisionedAlertRule` |          |         |             |         |
+| `title`     | string                                            | string                    |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1615,13 +1582,13 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name     | Type                                    | Go type              | Required | Default | Description | Example |
-| -------- | --------------------------------------- | -------------------- | :------: | ------- | ----------- | ------- |
-| folder   | string                                  | `string`             |          |         |             |         |
-| interval | [Duration](#duration)                   | `Duration`           |          |         |             |         |
-| name     | string                                  | `string`             |          |         |             |         |
-| orgId    | int64 (formatted integer)               | `int64`              |          |         |             |         |
-| rules    | [][alertruleexport](#alert-rule-export) | `[]*AlertRuleExport` |          |         |             |         |
+| Name       | Type                                    | Go type              | Required | Default | Description | Example |
+| ---------- | --------------------------------------- | -------------------- | :------: | ------- | ----------- | ------- |
+| `folder`   | string                                  | string               |          |         |             |         |
+| `interval` | [Duration](#duration)                   | Duration             |          |         |             |         |
+| `name`     | string                                  | string               |          |         |             |         |
+| `orgId`    | int64 (formatted integer)               | int64                |          |         |             |         |
+| `rules`    | [][AlertRuleExport](#alert-rule-export) | `[]*AlertRuleExport` |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1631,12 +1598,12 @@ Status: Accepted
 
 {{% responsive-table %}}
 
-| Name          | Type                                                      | Go type                       | Required | Default | Description | Example |
-| ------------- | --------------------------------------------------------- | ----------------------------- | :------: | ------- | ----------- | ------- |
-| apiVersion    | int64 (formatted integer)                                 | `int64`                       |          |         |             |         |
-| contactPoints | [][contactpointexport](#contact-point-export)             | `[]*ContactPointExport`       |          |         |             |         |
-| groups        | [][alertrulegroupexport](#alert-rule-group-export)        | `[]*AlertRuleGroupExport`     |          |         |             |         |
-| policies      | [][notificationpolicyexport](#notification-policy-export) | `[]*NotificationPolicyExport` |          |         |             |         |
+| Name            | Type                                                      | Go type                       | Required | Default | Description | Example |
+| --------------- | --------------------------------------------------------- | ----------------------------- | :------: | ------- | ----------- | ------- |
+| `apiVersion`    | int64 (formatted integer)                                 | int64                         |          |         |             |         |
+| `contactPoints` | [][ContactPointExport](#contact-point-export)             | `[]*ContactPointExport`       |          |         |             |         |
+| `groups`        | [][AlertRuleGroupExport](#alert-rule-group-export)        | `[]*AlertRuleGroupExport`     |          |         |             |         |
+| `policies`      | [][NotificationPolicyExport](#notification-policy-export) | `[]*NotificationPolicyExport` |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1644,11 +1611,11 @@ Status: Accepted
 
 **Properties**
 
-| Name      | Type                                 | Go type             | Required | Default | Description | Example |
-| --------- | ------------------------------------ | ------------------- | :------: | ------- | ----------- | ------- |
-| name      | string                               | `string`            |          |         |             |         |
-| orgId     | int64 (formatted integer)            | `int64`             |          |         |             |         |
-| receivers | [][receiverexport](#receiver-export) | `[]*ReceiverExport` |          |         |             |         |
+| Name        | Type                                 | Go type             | Required | Default | Description | Example |
+| ----------- | ------------------------------------ | ------------------- | :------: | ------- | ----------- | ------- |
+| `name`      | string                               | string              |          |         |             |         |
+| `orgId`     | int64 (formatted integer)            | int64               |          |         |             |         |
+| `receivers` | [][ReceiverExport](#receiver-export) | `[]*ReceiverExport` |          |         |             |         |
 
 ### <span id="contact-points"></span> ContactPoints
 
@@ -1656,9 +1623,9 @@ Status: Accepted
 
 ### <span id="duration"></span> Duration
 
-| Name     | Type   | Go type | Default | Description | Example |
-| -------- | ------ | ------- | ------- | ----------- | ------- |
-| Duration | string | int64   |         |             |         |
+| Name       | Type   | Go type | Default | Description | Example |
+| ---------- | ------ | ------- | ------- | ----------- | ------- |
+| `Duration` | string | int64   |         |             |         |
 
 ### <span id="embedded-contact-point"></span> EmbeddedContactPoint
 
@@ -1670,14 +1637,14 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name                  | Type          | Go type  | Required | Default | Description                                                                        | Example                 |
-| --------------------- | ------------- | -------- | :------: | ------- | ---------------------------------------------------------------------------------- | ----------------------- |
-| disableResolveMessage | boolean       | `bool`   |          |         |                                                                                    | `false`                 |
-| name                  | string        | `string` |          |         | `name` groups multiple contact points with the same name in the UI.                | `webhook_1`             |
-| provenance            | string        | `string` |          |         |                                                                                    |                         |
-| settings              | [JSON](#json) | `JSON`   |    ✓     |         |                                                                                    |                         |
-| type                  | string        | `string` |    ✓     |         |                                                                                    | `webhook`               |
-| uid                   | string        | `string` |          |         | UID is the unique identifier of the contact point. The UID can be set by the user. | `my_external_reference` |
+| Name                    | Type          | Go type | Required | Default | Description                                                                        | Example                 |
+| ----------------------- | ------------- | ------- | :------: | ------- | ---------------------------------------------------------------------------------- | ----------------------- |
+| `disableResolveMessage` | boolean       | `bool`  |          |         |                                                                                    | false                   |
+| `name`                  | string        | string  |          |         | `name` groups multiple contact points with the same name in the UI.                | `webhook_1`             |
+| `provenance`            | string        | string  |          |         |                                                                                    |                         |
+| `settings`              | [JSON](#json) | JSON    |    ✓     |         |                                                                                    |                         |
+| `type`                  | string        | string  |    ✓     |         |                                                                                    | `webhook`               |
+| `uid`                   | string        | string  |          |         | UID is the unique identifier of the contact point. The UID can be set by the user. | `my_external_reference` |
 
 {{% /responsive-table %}}
 
@@ -1691,9 +1658,9 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 ### <span id="match-type"></span> MatchType
 
-| Name      | Type                      | Go type | Default | Description | Example |
-| --------- | ------------------------- | ------- | ------- | ----------- | ------- |
-| MatchType | int64 (formatted integer) | int64   |         |             |         |
+| Name        | Type                      | Go type | Default | Description | Example |
+| ----------- | ------------------------- | ------- | ------- | ----------- | ------- |
+| `MatchType` | int64 (formatted integer) | int64   |         |             |         |
 
 ### <span id="matcher"></span> Matcher
 
@@ -1701,11 +1668,11 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name  | Type                     | Go type     | Required | Default | Description | Example |
-| ----- | ------------------------ | ----------- | :------: | ------- | ----------- | ------- |
-| Name  | string                   | `string`    |          |         |             |         |
-| Type  | [MatchType](#match-type) | `MatchType` |          |         |             |         |
-| Value | string                   | `string`    |          |         |             |         |
+| Name    | Type                     | Go type   | Required | Default | Description | Example |
+| ------- | ------------------------ | --------- | :------: | ------- | ----------- | ------- |
+| `Name`  | string                   | string    |          |         |             |         |
+| `Type`  | [MatchType](#match-type) | MatchType |          |         |             |         |
+| `Value` | string                   | string    |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1723,11 +1690,11 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name           | Type                             | Go type           | Required | Default | Description         | Example |
-| -------------- | -------------------------------- | ----------------- | :------: | ------- | ------------------- | ------- |
-| name           | string                           | `string`          |          |         |                     |         |
-| time_intervals | [][timeinterval](#time-interval) | `[]*TimeInterval` |          |         |                     |         |
-| version        | string                           | `string`          |          |         | Version of resource |         |
+| Name             | Type                             | Go type           | Required | Default | Description         | Example |
+| ---------------- | -------------------------------- | ----------------- | :------: | ------- | ------------------- | ------- |
+| `name`           | string                           | string            |          |         |                     |         |
+| `time_intervals` | [][TimeInterval](#time-interval) | `[]*TimeInterval` |          |         |                     |         |
+| `version`        | string                           | string            |          |         | Version of resource |         |
 
 {{% /responsive-table %}}
 
@@ -1751,10 +1718,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 **Properties**
 
-| Name   | Type                         | Go type       | Required | Default | Description | Example |
-| ------ | ---------------------------- | ------------- | :------: | ------- | ----------- | ------- |
-| Policy | [RouteExport](#route-export) | `RouteExport` |          |         | inline      |         |
-| orgId  | int64 (formatted integer)    | `int64`       |          |         |             |         |
+| Name     | Type                         | Go type                      | Required | Default | Description | Example |
+| -------- | ---------------------------- | ---------------------------- | :------: | ------- | ----------- | ------- |
+| `Policy` | [RouteExport](#route-export) | [RouteExport](#route-export) |          |         | inline      |         |
+| `orgId`  | int64 (formatted integer)    | int64                        |          |         |             |         |
 
 ### <span id="notification-template"></span> NotificationTemplate
 
@@ -1762,12 +1729,12 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name       | Type                      | Go type      | Required | Default | Description         | Example |
-| ---------- | ------------------------- | ------------ | :------: | ------- | ------------------- | ------- |
-| name       | string                    | `string`     |          |         |                     |         |
-| provenance | [Provenance](#provenance) | `Provenance` |          |         |                     |         |
-| template   | string                    | `string`     |          |         |                     |         |
-| version    | string                    | `string`     |          |         | Version of resource |         |
+| Name         | Type                      | Go type                   | Required | Default | Description         | Example |
+| ------------ | ------------------------- | ------------------------- | :------: | ------- | ------------------- | ------- |
+| `name`       | string                    | string                    |          |         |                     |         |
+| `provenance` | [Provenance](#provenance) | [Provenance](#provenance) |          |         |                     |         |
+| `template`   | string                    | string                    |          |         |                     |         |
+| `version`    | string                    | string                    |          |         | Version of resource |         |
 
 {{% /responsive-table %}}
 
@@ -1777,10 +1744,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name     | Type   | Go type  | Required | Default | Description                                             | Example |
-| -------- | ------ | -------- | :------: | ------- | ------------------------------------------------------- | ------- |
-| template | string | `string` |          |         |                                                         |         |
-| version  | string | `string` |          |         | Version of resource. Should be empty for new templates. |         |
+| Name       | Type   | Go type | Required | Default | Description                                             | Example |
+| ---------- | ------ | ------- | :------: | ------- | ------------------------------------------------------- | ------- |
+| `template` | string | string  |          |         |                                                         |         |
+| `version`  | string | string  |          |         | Version of resource. Should be empty for new templates. |         |
 
 {{% /responsive-table %}}
 
@@ -1800,9 +1767,9 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 ### <span id="provenance"></span> Provenance
 
-| Name       | Type   | Go type | Default | Description | Example |
-| ---------- | ------ | ------- | ------- | ----------- | ------- |
-| Provenance | string | string  |         |             |         |
+| Name         | Type   | Go type | Default | Description | Example |
+| ------------ | ------ | ------- | ------- | ----------- | ------- |
+| `Provenance` | string | string  |         |             |         |
 
 ### <span id="provisioned-alert-rule"></span> ProvisionedAlertRule
 
@@ -1810,24 +1777,24 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name         | Type                         | Go type             | Required | Default | Description                                                                                                       | Example                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| ------------ | ---------------------------- | ------------------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| annotations  | map of string                | `map[string]string` |          |         | Optional key-value pairs. `dashboardUId` and `panelId` must be set together; one cannot be set without the other. | `{"runbook_url":"https://supercoolrunbook.com/page/13"}`                                                                                                                                                                                                                                                                                                                                                                         |
-| condition    | string                       | `string`            |    ✓     |         |                                                                                                                   | `A`                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| data         | [][alertquery](#alert-query) | `[]*AlertQuery`     |    ✓     |         |                                                                                                                   | `[{"datasourceUid":"__expr__","model":{"conditions":[{"evaluator":{"params":[0,0],"type":"gt"},"operator":{"type":"and"},"query":{"params":[]},"reducer":{"params":[],"type":"avg"},"type":"query"}],"datasource":{"type":"__expr__","uid":"__expr__"},"expression":"1 == 1","hide":false,"intervalMs":1000,"maxDataPoints":43200,"refId":"A","type":"math"},"queryType":"","refId":"A","relativeTimeRange":{"from":0,"to":0}}]` |
-| execErrState | string                       | `string`            |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| folderUID    | string                       | `string`            |    ✓     |         |                                                                                                                   | `project_x`                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| for          | [Duration](#duration)        | `Duration`          |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| id           | int64 (formatted integer)    | `int64`             |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| isPaused     | boolean                      | `bool`              |          |         |                                                                                                                   | `false`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| labels       | map of string                | `map[string]string` |          |         |                                                                                                                   | `{"team":"sre-team-1"}`                                                                                                                                                                                                                                                                                                                                                                                                          |
-| noDataState  | string                       | `string`            |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| orgID        | int64 (formatted integer)    | `int64`             |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| provenance   | [Provenance](#provenance)    | `Provenance`        |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ruleGroup    | string                       | `string`            |    ✓     |         |                                                                                                                   | `eval_group_1`                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| title        | string                       | `string`            |    ✓     |         |                                                                                                                   | `Always firing`                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| uid          | string                       | `string`            |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| updated      | date-time (formatted string) | `strfmt.DateTime`   |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Name          | Type                         | Go type                   | Required | Default | Description                                                                                                       | Example                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ------------- | ---------------------------- | ------------------------- | :------: | ------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `annotations` | map of string                | `map[string]string`       |          |         | Optional key-value pairs. `dashboardUId` and `panelId` must be set together; one cannot be set without the other. | `{"runbook_url":"https://supercoolrunbook.com/page/13"}`                                                                                                                                                                                                                                                                                                                                                                         |
+| `condition`   | string                       | string                    |    ✓     |         |                                                                                                                   | `A`                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `data`        | [][AlertQuery](#alert-query) | `[]*AlertQuery`           |    ✓     |         |                                                                                                                   | `[{"datasourceUid":"__expr__","model":{"conditions":[{"evaluator":{"params":[0,0],"type":"gt"},"operator":{"type":"and"},"query":{"params":[]},"reducer":{"params":[],"type":"avg"},"type":"query"}],"datasource":{"type":"__expr__","uid":"__expr__"},"expression":"1 == 1","hide":false,"intervalMs":1000,"maxDataPoints":43200,"refId":"A","type":"math"},"queryType":"","refId":"A","relativeTimeRange":{"from":0,"to":0}}]` |
+| execErrState  | string                       | string                    |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `folderUID`   | string                       | string                    |    ✓     |         |                                                                                                                   | `project_x`                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `for`         | [Duration](#duration)        | [Duration](#duration)     |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `id`          | int64 (formatted integer)    | int64                     |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `isPaused`    | boolean                      | `bool`                    |          |         |                                                                                                                   | `false`                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `labels`      | map of string                | `map[string]string`       |          |         |                                                                                                                   | `{"team":"sre-team-1"}`                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `noDataState` | string                       | string                    |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `orgID`       | int64 (formatted integer)    | `int64                    |    ✓     |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `provenance`  | [Provenance](#provenance)    | [Provenance](#provenance) |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `ruleGroup`   | string                       | string                    |    ✓     |         |                                                                                                                   | `eval_group_1`                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `title`       | string                       | string                    |    ✓     |         |                                                                                                                   | `Always firing`                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `uid`         | string                       | string                    |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `updated`     | date-time (formatted string) | `strfmt.DateTime`         |          |         |                                                                                                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 {{% /responsive-table %}}
 
@@ -1843,12 +1810,12 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 **Properties**
 
-| Name                  | Type                       | Go type      | Required | Default | Description | Example |
-| --------------------- | -------------------------- | ------------ | :------: | ------- | ----------- | ------- |
-| disableResolveMessage | boolean                    | `bool`       |          |         |             |         |
-| settings              | [RawMessage](#raw-message) | `RawMessage` |          |         |             |         |
-| type                  | string                     | `string`     |          |         |             |         |
-| uid                   | string                     | `string`     |          |         |             |         |
+| Name                    | Type                       | Go type    | Required | Default | Description | Example |
+| ----------------------- | -------------------------- | ---------- | :------: | ------- | ----------- | ------- |
+| `disableResolveMessage` | boolean                    | `bool`     |          |         |             |         |
+| `settings`              | [RawMessage](#raw-message) | RawMessage |          |         |             |         |
+| `type`                  | string                     | string     |          |         |             |         |
+| `uid`                   | string                     | string     |          |         |             |         |
 
 ### <span id="regexp"></span> Regexp
 
@@ -1866,10 +1833,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name | Type                  | Go type    | Required | Default | Description | Example |
-| ---- | --------------------- | ---------- | :------: | ------- | ----------- | ------- |
-| from | [Duration](#duration) | `Duration` |          |         |             |         |
-| to   | [Duration](#duration) | `Duration` |          |         |             |         |
+| Name   | Type                  | Go type  | Required | Default | Description | Example |
+| ------ | --------------------- | -------- | :------: | ------- | ----------- | ------- |
+| `from` | [Duration](#duration) | Duration |          |         |             |         |
+| `to`   | [Duration](#duration) | Duration |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1882,21 +1849,21 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name                | Type                               | Go type             | Required | Default | Description                             | Example |
-| ------------------- | ---------------------------------- | ------------------- | :------: | ------- | --------------------------------------- | ------- |
-| continue            | boolean                            | `bool`              |          |         |                                         |         |
-| group_by            | []string                           | `[]string`          |          |         |                                         |         |
-| group_interval      | string                             | `string`            |          |         |                                         |         |
-| group_wait          | string                             | `string`            |          |         |                                         |         |
-| match               | map of string                      | `map[string]string` |          |         | Deprecated. Remove before v1.0 release. |         |
-| match_re            | [MatchRegexps](#match-regexps)     | `MatchRegexps`      |          |         |                                         |         |
-| matchers            | [Matchers](#matchers)              | `Matchers`          |          |         |                                         |         |
-| mute_time_intervals | []string                           | `[]string`          |          |         |                                         |         |
-| object_matchers     | [ObjectMatchers](#object-matchers) | `ObjectMatchers`    |          |         |                                         |         |
-| provenance          | [Provenance](#provenance)          | `Provenance`        |          |         |                                         |         |
-| receiver            | string                             | `string`            |          |         |                                         |         |
-| repeat_interval     | string                             | `string`            |          |         |                                         |         |
-| routes              | [][route](#route)                  | `[]*Route`          |          |         |                                         |         |
+| Name                  | Type                               | Go type             | Required | Default | Description                             | Example |
+| --------------------- | ---------------------------------- | ------------------- | :------: | ------- | --------------------------------------- | ------- |
+| `continue`            | boolean                            | `bool`              |          |         |                                         |         |
+| `group_by`            | []string                           | `[]string`          |          |         |                                         |         |
+| `group_interval`      | string                             | string              |          |         |                                         |         |
+| `group_wait`          | string                             | string              |          |         |                                         |         |
+| `match`               | map of string                      | `map[string]string` |          |         | Deprecated. Remove before v1.0 release. |         |
+| `match_re`            | [MatchRegexps](#match-regexps)     | `MatchRegexps`      |          |         |                                         |         |
+| `matchers`            | [Matchers](#matchers)              | `Matchers`          |          |         |                                         |         |
+| `mute_time_intervals` | []string                           | `[]string`          |          |         |                                         |         |
+| `object_matchers`     | [ObjectMatchers](#object-matchers) | `ObjectMatchers`    |          |         |                                         |         |
+| `provenance`          | [Provenance](#provenance)          | Provenance          |          |         |                                         |         |
+| `receiver`            | string                             | string              |          |         |                                         |         |
+| `repeat_interval`     | string                             | string              |          |         |                                         |         |
+| `routes`              | [][Route](#route)                  | `[]*Route`          |          |         |                                         |         |
 
 {{% /responsive-table %}}
 
@@ -1907,20 +1874,20 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 **Properties**
 
-| Name                | Type                               | Go type             | Required | Default | Description                             | Example |
-| ------------------- | ---------------------------------- | ------------------- | :------: | ------- | --------------------------------------- | ------- |
-| continue            | boolean                            | `bool`              |          |         |                                         |         |
-| group_by            | []string                           | `[]string`          |          |         |                                         |         |
-| group_interval      | string                             | `string`            |          |         |                                         |         |
-| group_wait          | string                             | `string`            |          |         |                                         |         |
-| match               | map of string                      | `map[string]string` |          |         | Deprecated. Remove before v1.0 release. |         |
-| match_re            | [MatchRegexps](#match-regexps)     | `MatchRegexps`      |          |         |                                         |         |
-| matchers            | [Matchers](#matchers)              | `Matchers`          |          |         |                                         |         |
-| mute_time_intervals | []string                           | `[]string`          |          |         |                                         |         |
-| object_matchers     | [ObjectMatchers](#object-matchers) | `ObjectMatchers`    |          |         |                                         |         |
-| receiver            | string                             | `string`            |          |         |                                         |         |
-| repeat_interval     | string                             | `string`            |          |         |                                         |         |
-| routes              | [][routeexport](#route-export)     | `[]*RouteExport`    |          |         |                                         |         |
+| Name                  | Type                               | Go type             | Required | Default | Description                             | Example |
+| --------------------- | ---------------------------------- | ------------------- | :------: | ------- | --------------------------------------- | ------- |
+| `continue`            | boolean                            | `bool`              |          |         |                                         |         |
+| `group_by`            | []string                           | `[]string`          |          |         |                                         |         |
+| `group_interval`      | string                             | string              |          |         |                                         |         |
+| `group_wait`          | string                             | string              |          |         |                                         |         |
+| `match`               | map of string                      | `map[string]string` |          |         | Deprecated. Remove before v1.0 release. |         |
+| `match_re`            | [MatchRegexps](#match-regexps)     | `MatchRegexps`      |          |         |                                         |         |
+| `matchers`            | [Matchers](#matchers)              | `Matchers`          |          |         |                                         |         |
+| `mute_time_intervals` | []string                           | `[]string`          |          |         |                                         |         |
+| `object_matchers`     | [ObjectMatchers](#object-matchers) | `ObjectMatchers`    |          |         |                                         |         |
+| `receiver`            | string                             | string              |          |         |                                         |         |
+| `repeat_interval`     | string                             | string              |          |         |                                         |         |
+| `routes`              | [][RouteExport](#route-export)     | `[]*RouteExport`    |          |         |                                         |         |
 
 ### <span id="time-interval"></span> TimeInterval
 
@@ -1931,14 +1898,14 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name          | Type                       | Go type        | Required | Default | Description | Example |
-| ------------- | -------------------------- | -------------- | :------: | ------- | ----------- | ------- |
-| days_of_month | []string                   | `[]string`     |          |         |             |         |
-| location      | string                     | `string`       |          |         |             |         |
-| months        | []string                   | `[]string`     |          |         |             |         |
-| times         | [][timerange](#time-range) | `[]*TimeRange` |          |         |             |         |
-| weekdays      | []string                   | `[]string`     |          |         |             |         |
-| years         | []string                   | `[]string`     |          |         |             |         |
+| Name            | Type                       | Go type        | Required | Default | Description | Example |
+| --------------- | -------------------------- | -------------- | :------: | ------- | ----------- | ------- |
+| `days_of_month` | []string                   | []string       |          |         |             |         |
+| `location`      | string                     | string         |          |         |             |         |
+| `months`        | []string                   | []string       |          |         |             |         |
+| `times`         | [][TimeRange](#time-range) | `[]*TimeRange` |          |         |             |         |
+| `weekdays`      | []string                   | []string       |          |         |             |         |
+| `years`         | []string                   | []string       |          |         |             |         |
 
 {{% /responsive-table %}}
 
@@ -1950,10 +1917,10 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name       | Type   | Go type  | Required | Default | Description | Example                 |
-| ---------- | ------ | -------- | :------: | ------- | ----------- | ----------------------- |
-| end_time   | string | `string` |          |         |             | `"end_time": "24:00"`   |
-| start_time | string | `string` |          |         |             | `"start_time": "18:00"` |
+| Name         | Type   | Go type | Required | Default | Description | Example                 |
+| ------------ | ------ | ------- | :------: | ------- | ----------- | ----------------------- |
+| `end_time`   | string | string  |          |         |             | `"end_time": "24:00"`   |
+| `start_time` | string | string  |          |         |             | `"start_time": "18:00"` |
 
 {{% /responsive-table %}}
 
@@ -1963,9 +1930,9 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name | Type   | Go type  | Required | Default | Description | Example         |
-| ---- | ------ | -------- | :------: | ------- | ----------- | --------------- |
-| msg  | string | `string` |          |         |             | `error message` |
+| Name  | Type   | Go type | Required | Default | Description | Example         |
+| ----- | ------ | ------- | :------: | ------- | ----------- | --------------- |
+| `msg` | string | string  |          |         |             | `error message` |
 
 {{% /responsive-table %}}
 
@@ -1975,11 +1942,11 @@ When creating a contact point, the `EmbeddedContactPoint.name` property determin
 
 {{% responsive-table %}}
 
-| Name       | Type       | Go type          | Required | Default | Description                                                              | Example |
-| ---------- | ---------- | ---------------- | :------: | ------- | ------------------------------------------------------------------------ | ------- |
-| statusCode | string     | `string`         |    ✓     |         | HTTP Status Code                                                         |         |
-| messageId  | string     | `string`         |    ✓     |         | Unique code of the error                                                 |         |
-| message    | string     | `string`         |          |         | Error message                                                            |         |
-| extra      | map of any | `map[string]any` |          |         | Extra information about the error. Format is specific to the error code. |         |
+| Name         | Type       | Go type          | Required | Default | Description                                                              | Example |
+| ------------ | ---------- | ---------------- | :------: | ------- | ------------------------------------------------------------------------ | ------- |
+| `statusCode` | string     | string           |    ✓     |         | HTTP Status Code                                                         |         |
+| `messageId`  | string     | string           |    ✓     |         | Unique code of the error                                                 |         |
+| `message`    | string     | string           |          |         | Error message                                                            |         |
+| `extra`      | map of any | `map[string]any` |          |         | Extra information about the error. Format is specific to the error code. |         |
 
 {{% /responsive-table %}}


### PR DESCRIPTION
Backport 97d16c7a7b23c2a7bb2b3ae97bbdf76a06c4aee0 from #101617\n\n---\n\nFAQ - Users often try using the `export` endpoints to update alerting resources via the Alerting HTTP API, which is not possible.

Changes include:

- clarify that the JSON format is for file provisioning, and updating resources via HTTP API is not allowed
- remove the unused `Separator` column
- specify the whole value of the provenance header
- fix vale/linting errors


Here's the [current version](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/), and here's the  [⭐  Preview](https://deploy-preview-grafana-101617-zb444pucvq-vp.a.run.app/docs/grafana/latest/developers/http_api/alerting_provisioning/).
