### PR TITLE
Combobox: Grafana-ui components change from using `Select` to use `Combobox`

### DIFF
--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -1,5 +1,5 @@
+import { ComboboxOption } from '../../../grafana-ui/src/components/Combobox/types';
 import { PluginState } from '../types/plugin';
-import { SelectableValue } from '../types/select';
 
 export interface RegistryItem {
   id: string; // Unique Key -- saved in configs
@@ -32,8 +32,8 @@ export interface RegistryItemWithOptions<TOptions = any> extends RegistryItem {
 }
 
 interface RegistrySelectInfo {
-  options: Array<SelectableValue<string>>;
-  current: Array<SelectableValue<string>>;
+  options: Array<ComboboxOption<string>>;
+  current: Array<ComboboxOption<string>>;
 }
 
 export class Registry<T extends RegistryItem> {
@@ -92,10 +92,10 @@ export class Registry<T extends RegistryItem> {
       current: [],
     };
 
-    const currentOptions: Record<string, SelectableValue<string>> = {};
+    const currentOptions: Record<string, ComboboxOption<string>> = {};
     if (current) {
       for (const id of current) {
-        currentOptions[id] = {};
+        currentOptions[id] = { value: currentOptions[id].value };
       }
     }
 

--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -95,7 +95,7 @@ export class Registry<T extends RegistryItem> {
     const currentOptions: Record<string, ComboboxOption<string>> = {};
     if (current) {
       for (const id of current) {
-        currentOptions[id] = { value: currentOptions[id].value };
+        currentOptions[id] = { value: id };
       }
     }
 

--- a/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.story.tsx
+++ b/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.story.tsx
@@ -1,10 +1,10 @@
 import { StoryFn, Meta } from '@storybook/react';
 import { useState } from 'react';
 
+import { Combobox } from '../Combobox/Combobox';
 import { Checkbox } from '../Forms/Checkbox';
 import { RadioButtonGroup } from '../Forms/RadioButtonGroup/RadioButtonGroup';
 import { Input } from '../Input/Input';
-import { Select } from '../Select/Select';
 import { Switch } from '../Switch/Switch';
 import { TextArea } from '../TextArea/TextArea';
 
@@ -102,6 +102,7 @@ export const AllComponents: StoryFn = (args) => {
   const [textAreaValue, setTextAreaValue] = useState('');
   const [inputTextValue, setInputTextValue] = useState('');
   const [switchTest, setSwitchTest] = useState(false);
+  const [comboboxSelected, setComboboxSelected] = useState('');
 
   return (
     <div>
@@ -117,13 +118,14 @@ export const AllComponents: StoryFn = (args) => {
           />
         )}
       </AutoSaveField>
-      <AutoSaveField onFinishChange={args.inputSuccessful ? getSuccess : getError} label="Select as child" {...args}>
+      <AutoSaveField onFinishChange={args.inputSuccessful ? getSuccess : getError} label="Combobox as child" {...args}>
         {(onChange) => (
-          <Select
+          <Combobox
             options={themeOptions}
-            value={args.weekPickerValue}
+            value={comboboxSelected}
             onChange={(v) => {
               onChange(v.value);
+              setComboboxSelected(v.value);
             }}
           />
         )}

--- a/packages/grafana-ui/src/components/Forms/Field.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/Field.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { Combobox } from '../Combobox/Combobox';
 import { Input } from '../Input/Input';
-import { Select } from '../Select/Select';
 
 import { Field } from './Field';
 
@@ -27,9 +27,13 @@ describe('Field', () => {
   });
 
   it('renders with the inputId of its children', () => {
+    const comboboxOptions = [
+      { label: 'Option 1', value: 'option-1' },
+      { label: 'Option 2', value: 'option-2' },
+    ];
     render(
       <Field label="My other label">
-        <Select inputId="my-select-input" onChange={() => {}} />
+        <Combobox id="my-select-input" options={comboboxOptions} onChange={() => {}} />
       </Field>
     );
 

--- a/packages/grafana-ui/src/components/Forms/InlineField.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.story.tsx
@@ -1,8 +1,8 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 
+import { Combobox } from '../Combobox/Combobox';
 import { Input } from '../Input/Input';
-import { Select } from '../Select/Select';
 
 import { InlineField } from './InlineField';
 import mdx from './InlineField.mdx';
@@ -75,10 +75,10 @@ grow.args = {
   grow: true,
 };
 
-export const withSelect: StoryFn<typeof InlineField> = (args) => {
+export const withCombobox: StoryFn<typeof InlineField> = (args) => {
   return (
     <InlineField {...args}>
-      <Select
+      <Combobox
         width={16}
         onChange={action('item selected')}
         options={[
@@ -90,7 +90,7 @@ export const withSelect: StoryFn<typeof InlineField> = (args) => {
   );
 };
 
-withSelect.args = {
+withCombobox.args = {
   ...basic.args,
   label: 'Select option',
 };

--- a/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { Combobox } from '../Combobox/Combobox';
 import { Input } from '../Input/Input';
-import { Select } from '../Select/Select';
 
 import { InlineField } from './InlineField';
 
@@ -27,9 +27,13 @@ describe('InlineField', () => {
   });
 
   it('renders with the inputId of its children', () => {
+    const comboboxOptions = [
+      { label: 'Option 1', value: 'option-1' },
+      { label: 'Option 2', value: 'option-2' },
+    ];
     render(
       <InlineField label="My other label">
-        <Select inputId="my-select-input" onChange={() => {}} />
+        <Combobox id="my-select-input" options={comboboxOptions} onChange={() => {}} />
       </InlineField>
     );
 

--- a/packages/grafana-ui/src/components/MatchersUI/FieldNameMatcherEditor.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNameMatcherEditor.tsx
@@ -1,8 +1,9 @@
 import { memo, useCallback } from 'react';
 
-import { FieldMatcherID, fieldMatchers, SelectableValue } from '@grafana/data';
+import { FieldMatcherID, fieldMatchers } from '@grafana/data';
 
-import { Select } from '../Select/Select';
+import { Combobox } from '../Combobox/Combobox';
+import { ComboboxOption } from '../Combobox/types';
 
 import { MatcherUIProps, FieldMatcherUIRegistryItem } from './types';
 import { useFieldDisplayNames, useSelectOptions, frameHasName } from './utils';
@@ -10,10 +11,13 @@ import { useFieldDisplayNames, useSelectOptions, frameHasName } from './utils';
 export const FieldNameMatcherEditor = memo<MatcherUIProps<string>>((props) => {
   const { data, options, onChange: onChangeFromProps, id } = props;
   const names = useFieldDisplayNames(data);
-  const selectOptions = useSelectOptions(names, options);
+  const selectOptions: Array<ComboboxOption<string>> = useSelectOptions(names, options).map((option) => ({
+    ...option,
+    value: option.value || '',
+  }));
 
   const onChange = useCallback(
-    (selection: SelectableValue<string>) => {
+    (selection: ComboboxOption<string>) => {
       if (!frameHasName(selection.value, names)) {
         return;
       }
@@ -23,7 +27,7 @@ export const FieldNameMatcherEditor = memo<MatcherUIProps<string>>((props) => {
   );
 
   const selectedOption = selectOptions.find((v) => v.value === options);
-  return <Select value={selectedOption} options={selectOptions} onChange={onChange} inputId={id} />;
+  return <Combobox value={selectedOption?.value} options={selectOptions} onChange={onChange} id={id} />;
 });
 FieldNameMatcherEditor.displayName = 'FieldNameMatcherEditor';
 

--- a/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
@@ -8,14 +8,14 @@ import {
   FieldValueMatcherConfig,
   fieldReducers,
   ReducerID,
-  SelectableValue,
   GrafanaTheme2,
 } from '@grafana/data';
 import { ComparisonOperation } from '@grafana/schema';
 
 import { useStyles2 } from '../../themes';
+import { Combobox } from '../Combobox/Combobox';
+import { ComboboxOption } from '../Combobox/types';
 import { Input } from '../Input/Input';
-import { Select } from '../Select/Select';
 
 import { MatcherUIProps, FieldMatcherUIRegistryItem } from './types';
 
@@ -40,14 +40,14 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
   const reducer = useMemo(() => fieldReducers.selectOptions([options?.reducer]), [options?.reducer]);
 
   const onSetReducer = useCallback(
-    (selection: SelectableValue<string>) => {
+    (selection: ComboboxOption<string>) => {
       return onChange({ ...options, reducer: selection.value! as ReducerID });
     },
     [options, onChange]
   );
 
   const onChangeOp = useCallback(
-    (v: SelectableValue<ComparisonOperation>) => {
+    (v: ComboboxOption<ComparisonOperation>) => {
       return onChange({ ...options, op: v.value! });
     },
     [options, onChange]
@@ -66,15 +66,15 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
 
   return (
     <div className={styles.spot}>
-      <Select
-        value={reducer.current}
+      <Combobox
+        value={reducer.current[0]?.value}
         options={reducer.options}
         onChange={onSetReducer}
         placeholder="Select field reducer"
       />
       {opts.reducer && !isBool && (
         <>
-          <Select
+          <Combobox
             value={comparisonOperationOptions.find((v) => v.value === opts.op)}
             options={comparisonOperationOptions}
             onChange={onChangeOp}

--- a/packages/grafana-ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher.tsx
@@ -1,23 +1,18 @@
 import { useMemo, useState, useCallback } from 'react';
 
-import {
-  DataFrame,
-  getFrameDisplayName,
-  FieldMatcherID,
-  fieldMatchers,
-  SelectableValue,
-  toOption,
-} from '@grafana/data';
+import { DataFrame, getFrameDisplayName, FieldMatcherID, fieldMatchers } from '@grafana/data';
 
-import { MultiSelect, Select } from '../Select/Select';
+import { Combobox } from '../Combobox/Combobox';
+import { MultiCombobox } from '../Combobox/MultiCombobox';
+import { ComboboxOption } from '../Combobox/types';
 
 import { FieldMatcherUIRegistryItem, MatcherUIProps } from './types';
 
 const recoverRefIdMissing = (
-  newRefIds: SelectableValue[],
-  oldRefIds: SelectableValue[],
+  newRefIds: ComboboxOption[],
+  oldRefIds: ComboboxOption[],
   previousValue: string | undefined
-): SelectableValue | undefined => {
+): ComboboxOption | undefined => {
   if (!previousValue) {
     return;
   }
@@ -47,7 +42,7 @@ export function RefIDPicker({ value, data, onChange, placeholder }: Props) {
   const listOfRefIds = useMemo(() => getListOfQueryRefIds(data), [data]);
 
   const [priorSelectionState, updatePriorSelectionState] = useState<{
-    refIds: SelectableValue[];
+    refIds: ComboboxOption[];
     value: string | undefined;
   }>({
     refIds: [],
@@ -62,8 +57,8 @@ export function RefIDPicker({ value, data, onChange, placeholder }: Props) {
   }, [value, listOfRefIds, priorSelectionState]);
 
   const onFilterChange = useCallback(
-    (v: SelectableValue<string>) => {
-      onChange(v?.value!);
+    (v: ComboboxOption<string> | null) => {
+      v ? onChange(v.value!) : onChange('');
     },
     [onChange]
   );
@@ -75,7 +70,7 @@ export function RefIDPicker({ value, data, onChange, placeholder }: Props) {
     });
   }
   return (
-    <Select
+    <Combobox
       options={listOfRefIds}
       onChange={onFilterChange}
       isClearable={true}
@@ -86,10 +81,10 @@ export function RefIDPicker({ value, data, onChange, placeholder }: Props) {
 }
 
 const recoverMultiRefIdMissing = (
-  newRefIds: Array<SelectableValue<string>>,
-  oldRefIds: Array<SelectableValue<string>>,
-  previousValue: Array<SelectableValue<string>> | undefined
-): Array<SelectableValue<string>> | undefined => {
+  newRefIds: Array<ComboboxOption<string>>,
+  oldRefIds: Array<ComboboxOption<string>>,
+  previousValue: Array<ComboboxOption<string>> | undefined
+): Array<ComboboxOption<string>> | undefined => {
   if (!previousValue || !previousValue.length) {
     return;
   }
@@ -119,8 +114,8 @@ export function RefIDMultiPicker({ value, data, onChange, placeholder }: MultiPr
   const listOfRefIds = useMemo(() => getListOfQueryRefIds(data), [data]);
 
   const [priorSelectionState, updatePriorSelectionState] = useState<{
-    refIds: SelectableValue[];
-    value: Array<SelectableValue<string>> | undefined;
+    refIds: ComboboxOption[];
+    value: Array<ComboboxOption<string>> | undefined;
   }>({
     refIds: [],
     value: undefined,
@@ -149,6 +144,7 @@ export function RefIDMultiPicker({ value, data, onChange, placeholder }: MultiPr
     if (matchedRefIds.length) {
       return matchedRefIds;
     }
+    const toOption = (value: string): ComboboxOption<string> => ({ label: value, value });
 
     const newRefIds = [...extractedRefIds].map(toOption);
 
@@ -156,7 +152,7 @@ export function RefIDMultiPicker({ value, data, onChange, placeholder }: MultiPr
   }, [value, listOfRefIds, priorSelectionState]);
 
   const onFilterChange = useCallback(
-    (v: Array<SelectableValue<string>>) => {
+    (v: Array<ComboboxOption<string>>) => {
       onChange(v.map((v) => v.value!));
     },
     [onChange]
@@ -169,7 +165,7 @@ export function RefIDMultiPicker({ value, data, onChange, placeholder }: MultiPr
     });
   }
   return (
-    <MultiSelect
+    <MultiCombobox
       options={listOfRefIds}
       onChange={onFilterChange}
       isClearable={true}
@@ -179,7 +175,7 @@ export function RefIDMultiPicker({ value, data, onChange, placeholder }: MultiPr
   );
 }
 
-function getListOfQueryRefIds(data: DataFrame[]): Array<SelectableValue<string>> {
+function getListOfQueryRefIds(data: DataFrame[]): Array<ComboboxOption<string>> {
   const queries = new Map<string, DataFrame[]>();
 
   for (const frame of data) {
@@ -193,7 +189,7 @@ function getListOfQueryRefIds(data: DataFrame[]): Array<SelectableValue<string>>
     frames.push(frame);
   }
 
-  const values: Array<SelectableValue<string>> = [];
+  const values: Array<ComboboxOption<string>> = [];
 
   for (const [refId, frames] of queries.entries()) {
     values.push({

--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -9,6 +9,7 @@ import { useTheme2 } from '../../themes/ThemeContext';
 import { allButtonVariants, Button } from '../Button';
 import { Card } from '../Card/Card';
 import { CollapsableSection } from '../Collapse/CollapsableSection';
+import { Combobox } from '../Combobox/Combobox';
 import { Field } from '../Forms/Field';
 import { InlineField } from '../Forms/InlineField';
 import { InlineFieldRow } from '../Forms/InlineFieldRow';
@@ -17,7 +18,6 @@ import { Icon } from '../Icon/Icon';
 import { Input } from '../Input/Input';
 import { BackgroundColor, BorderColor, Box, BoxShadow } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
-import { Select } from '../Select/Select';
 import { Switch } from '../Switch/Switch';
 import { Text, TextProps } from '../Text/Text';
 
@@ -150,8 +150,8 @@ export const ThemeDemo = () => {
             <Field label="Input disabled" disabled>
               <Input placeholder="Placeholder" value="Disabled value" />
             </Field>
-            <Field label="Select">
-              <Select options={selectOptions} value={selectValue} onChange={(v) => setSelectValue(v?.value!)} />
+            <Field label="Combobox">
+              <Combobox options={selectOptions} value={selectValue} onChange={(v) => setSelectValue(v?.value!)} />
             </Field>
             <Field label="Radio label">
               <RadioButtonGroup options={radioOptions} value={radioValue} onChange={setRadioValue} />

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -7,11 +7,11 @@ import {
 } from '@grafana/data';
 import { AxisColorMode, AxisConfig, AxisPlacement, ScaleDistribution, ScaleDistributionConfig } from '@grafana/schema';
 
+import { Combobox } from '../../components/Combobox/Combobox';
 import { Field } from '../../components/Forms/Field';
 import { RadioButtonGroup } from '../../components/Forms/RadioButtonGroup/RadioButtonGroup';
 import { Input } from '../../components/Input/Input';
 import { Stack } from '../../components/Layout/Stack/Stack';
-import { Select } from '../../components/Select/Select';
 import { graphFieldOptions } from '../../components/uPlot/config';
 
 const category = ['Axis'];
@@ -130,7 +130,7 @@ const DISTRIBUTION_OPTIONS: Array<SelectableValue<ScaleDistribution>> = [
   },
 ];
 
-const LOG_DISTRIBUTION_OPTIONS: Array<SelectableValue<number>> = [
+const LOG_DISTRIBUTION_OPTIONS: Array<Required<Pick<SelectableValue<number>, 'label' | 'value'>>> = [
   {
     label: '2',
     value: 2,
@@ -163,7 +163,7 @@ export const ScaleDistributionEditor = ({ value, onChange }: StandardEditorProps
       />
       {(type === ScaleDistribution.Log || type === ScaleDistribution.Symlog) && (
         <Field label="Log base">
-          <Select
+          <Combobox
             options={LOG_DISTRIBUTION_OPTIONS}
             value={log}
             onChange={(v) => {

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -1,10 +1,6 @@
-import {
-  FieldConfigEditorBuilder,
-  FieldType,
-  identityOverrideProcessor,
-  SelectableValue,
-  StandardEditorProps,
-} from '@grafana/data';
+import { ComboboxOption } from 'src/components';
+
+import { FieldConfigEditorBuilder, FieldType, identityOverrideProcessor, StandardEditorProps } from '@grafana/data';
 import { AxisColorMode, AxisConfig, AxisPlacement, ScaleDistribution, ScaleDistributionConfig } from '@grafana/schema';
 
 import { Combobox } from '../../components/Combobox/Combobox';
@@ -115,7 +111,7 @@ export function addAxisConfig(builder: FieldConfigEditorBuilder<AxisConfig>, def
     });
 }
 
-const DISTRIBUTION_OPTIONS: Array<SelectableValue<ScaleDistribution>> = [
+const DISTRIBUTION_OPTIONS: Array<ComboboxOption<ScaleDistribution>> = [
   {
     label: 'Linear',
     value: ScaleDistribution.Linear,
@@ -130,7 +126,7 @@ const DISTRIBUTION_OPTIONS: Array<SelectableValue<ScaleDistribution>> = [
   },
 ];
 
-const LOG_DISTRIBUTION_OPTIONS: Array<Required<Pick<SelectableValue<number>, 'label' | 'value'>>> = [
+const LOG_DISTRIBUTION_OPTIONS: Array<Required<Pick<ComboboxOption<number>, 'label' | 'value'>>> = [
   {
     label: '2',
     value: 2,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Since `Select` component has been deprecated, checked `grafana-ui` components to replace it with `Combobox` wherever is possible.

**Why do we need this feature?**
To avoid using a `deprecated` component in `grafana-ui`

**Who is this feature for?**
Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

List of files using `Select`:
- AutoSaveField.story.tsx #101922 
- DataSourceHttpSettings.tsx
   > has a `className` not supported by `Combobox`
- Cascader.tsx
   > `onBlur`, `onCreateOption`, `formatCreateLabel`, `onInputChange` props are not supported by `Combobox`
- TimeZonePicker.tsx
   > `menuShouldPortal`, `openMenuOnFocus`, `filterOption`, `onBlur`, `components` props are not supported by `Combobox`
- Field.test.tsx #101928 
- InlineField.story.tsx #101923 
- InlineField.test.tsx #101923
- FieldNameMatcherEditor.tsx 
- FieldNamePicker.tsx
   > `noOptionsMessage` is not supported by `Combobox`
- FieldsByFrameRefIdMatcher.tsx 
- FieldTypeMatcherEditor.tsx
   > The options contain an icon #line30
- FieldValueMatcher.tsx 
- StatsPicker.tsx
   > `isSearchable` and `menuPlacement` props are not supported by `Combobox`
- ThemeDemo.tsx #101947 
- ValuePicker.tsx:
   > `menuPlacement` prop is not supported by `Combobox`
- axis.tsx 


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
