### PR TITLE
Alerting: Select remote write path dependent on metrics backend type.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1527,9 +1527,6 @@ timeout = 10s
 # Only has effect if the grafanaManagedRecordRulesDatasources feature toggle is enabled.
 default_datasource_uid = 
 
-# Suffix to apply to the data source URL for remote write requests.
-remote_write_path_suffix = /push
-
 # Optional custom headers to include in recording rule write requests.
 [recording_rules.custom_headers]
 # exampleHeader = exampleValue

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1509,9 +1509,6 @@ timeout = 30s
 # Only has effect if the grafanaManagedRecordRulesDatasources feature toggle is enabled.
 default_datasource_uid = 
 
-# Suffix to apply to the data source URL for remote write requests.
-remote_write_path_suffix = /push
-
 # Optional custom headers to include in recording rule write requests.
 [recording_rules.custom_headers]
 # exampleHeader = exampleValue

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -74,11 +74,12 @@ func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasour
 		s.lastID = int64(len(s.DataSources) - 1)
 	}
 	dataSource := &datasources.DataSource{
-		ID:    s.lastID + 1,
-		Name:  cmd.Name,
-		Type:  cmd.Type,
-		UID:   cmd.UID,
-		OrgID: cmd.OrgID,
+		ID:       s.lastID + 1,
+		Name:     cmd.Name,
+		Type:     cmd.Type,
+		UID:      cmd.UID,
+		OrgID:    cmd.OrgID,
+		JsonData: cmd.JsonData,
 	}
 	s.DataSources = append(s.DataSources, dataSource)
 	return dataSource, nil

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -760,14 +760,12 @@ func createRecordingWriter(featureToggles featuremgmt.FeatureToggles, settings s
 	if settings.Enabled {
 		if featureToggles.IsEnabledGlobally(featuremgmt.FlagGrafanaManagedRecordingRulesDatasources) {
 			cfg := writer.DatasourceWriterConfig{
-				Timeout:               settings.Timeout,
-				DefaultDatasourceUID:  settings.DefaultDatasourceUID,
-				RemoteWritePathSuffix: settings.RemoteWritePathSuffix,
+				Timeout:              settings.Timeout,
+				DefaultDatasourceUID: settings.DefaultDatasourceUID,
 			}
 
 			logger.Info("Setting up remote write using data sources",
-				"timeout", cfg.Timeout, "default_datasource_uid", cfg.DefaultDatasourceUID,
-				"remote_write_path_suffix", cfg.RemoteWritePathSuffix)
+				"timeout", cfg.Timeout, "default_datasource_uid", cfg.DefaultDatasourceUID)
 
 			return writer.NewDatasourceWriter(cfg, datasourceService, httpClientProvider, clock, logger, m), nil
 		} else {

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -574,15 +575,15 @@ func setupDatasourceWriter(t *testing.T, target *writer.TestRemoteWriteTarget, r
 
 	dss := &dsfakes.FakeDataSourceService{}
 	p1, _ := dss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
-		UID:  dsUID,
-		Type: datasources.DS_PROMETHEUS,
+		UID:      dsUID,
+		Type:     datasources.DS_PROMETHEUS,
+		JsonData: simplejson.MustJson([]byte(`{"prometheusType":"Prometheus"}`)),
 	})
 	p1.URL = target.DatasourceURL()
 
 	cfg := writer.DatasourceWriterConfig{
-		Timeout:               time.Second * 5,
-		DefaultDatasourceUID:  "",
-		RemoteWritePathSuffix: writer.RemoteWriteSuffix,
+		Timeout:              time.Second * 5,
+		DefaultDatasourceUID: "",
 	}
 
 	return writer.NewDatasourceWriter(cfg, dss, provider, clock.NewMock(),

--- a/pkg/services/ngalert/writer/testing.go
+++ b/pkg/services/ngalert/writer/testing.go
@@ -12,10 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const RemoteWritePrefix = "/api/v1"
-const RemoteWriteSuffix = "/write"
-
-const RemoteWriteEndpoint = RemoteWritePrefix + RemoteWriteSuffix
+const RemoteWriteEndpoint = "/api/v1/write"
 
 type TestRemoteWriteTarget struct {
 	srv *httptest.Server
@@ -23,6 +20,8 @@ type TestRemoteWriteTarget struct {
 	mtx             sync.Mutex
 	RequestsCount   int
 	LastRequestBody string
+
+	ExpectedPath string
 }
 
 func NewTestRemoteWriteTarget(t *testing.T) *TestRemoteWriteTarget {
@@ -31,10 +30,11 @@ func NewTestRemoteWriteTarget(t *testing.T) *TestRemoteWriteTarget {
 	target := &TestRemoteWriteTarget{
 		RequestsCount:   0,
 		LastRequestBody: "",
+		ExpectedPath:    RemoteWriteEndpoint,
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != RemoteWriteEndpoint {
+		if r.URL.Path != target.ExpectedPath {
 			require.Fail(t, "Received unexpected request for endpoint %s", r.URL.Path)
 		}
 
@@ -63,7 +63,7 @@ func (s *TestRemoteWriteTarget) Close() {
 }
 
 func (s *TestRemoteWriteTarget) DatasourceURL() string {
-	return s.srv.URL + RemoteWritePrefix
+	return s.srv.URL
 }
 
 func (s *TestRemoteWriteTarget) ClientSettings() setting.RecordingRuleSettings {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -132,14 +132,13 @@ type UnifiedAlertingSettings struct {
 }
 
 type RecordingRuleSettings struct {
-	Enabled               bool
-	URL                   string
-	BasicAuthUsername     string
-	BasicAuthPassword     string
-	CustomHeaders         map[string]string
-	Timeout               time.Duration
-	DefaultDatasourceUID  string
-	RemoteWritePathSuffix string
+	Enabled              bool
+	URL                  string
+	BasicAuthUsername    string
+	BasicAuthPassword    string
+	CustomHeaders        map[string]string
+	Timeout              time.Duration
+	DefaultDatasourceUID string
 }
 
 // RemoteAlertmanagerSettings contains the configuration needed
@@ -437,13 +436,12 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	rr := iniFile.Section("recording_rules")
 	uaCfgRecordingRules := RecordingRuleSettings{
-		Enabled:               rr.Key("enabled").MustBool(false),
-		URL:                   rr.Key("url").MustString(""),
-		BasicAuthUsername:     rr.Key("basic_auth_username").MustString(""),
-		BasicAuthPassword:     rr.Key("basic_auth_password").MustString(""),
-		Timeout:               rr.Key("timeout").MustDuration(defaultRecordingRequestTimeout),
-		DefaultDatasourceUID:  rr.Key("default_datasource_uid").MustString(""),
-		RemoteWritePathSuffix: rr.Key("remote_write_path_suffix").MustString("/push"),
+		Enabled:              rr.Key("enabled").MustBool(false),
+		URL:                  rr.Key("url").MustString(""),
+		BasicAuthUsername:    rr.Key("basic_auth_username").MustString(""),
+		BasicAuthPassword:    rr.Key("basic_auth_password").MustString(""),
+		Timeout:              rr.Key("timeout").MustDuration(defaultRecordingRequestTimeout),
+		DefaultDatasourceUID: rr.Key("default_datasource_uid").MustString(""),
 	}
 
 	rrHeaders := iniFile.Section("recording_rules.custom_headers")


### PR DESCRIPTION
The remote write path differs based on whether the data source is actually
Prometheus, Mimir, Cortex, or an older version of Cortex. We do not want
users to have to specify the path, so this change determines the path as
best it can.

It may be in the future we have to make this configurable per-datasource
to cater for setups where it's impossible to determine the correct path.
