### PR TITLE
Transformations: Pass through simple data instead of displaying as 'Not Found'

### DIFF
--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -197,6 +197,58 @@ describe('Fields from JSON', () => {
     `);
   });
 
+  it('Will still pass along simple values', () => {
+    const testFieldJSONWithNumber: Field = {
+      config: {},
+      name: 'JSON',
+      type: FieldType.frame,
+      values: [
+        JSON.stringify({
+          value: 6,
+        }),
+        0,
+        true,
+        JSON.stringify({
+          badPath: 23,
+        }),
+      ],
+    };
+
+    const testDataFrameWithNumber: DataFrame = {
+      fields: [testFieldTime, testFieldJSONWithNumber],
+      length: 4,
+    };
+
+    const cfg: ExtractFieldsOptions = {
+      replace: true,
+      source: 'JSON',
+      format: FieldExtractorID.JSON,
+      jsonPaths: [{ path: 'value' }],
+    };
+    const ctx = { interpolate: (v: string) => v };
+
+    const frames = extractFieldsTransformer.transformer(cfg, ctx)([testDataFrameWithNumber]);
+    expect(frames.length).toEqual(1);
+    expect(frames[0]).toMatchInlineSnapshot(`
+      {
+        "fields": [
+          {
+            "config": {},
+            "name": "value",
+            "type": "number",
+            "values": [
+              6,
+              0,
+              true,
+              "Not Found",
+            ],
+          },
+        ],
+        "length": 4,
+      }
+    `);
+  });
+
   it('skips null values', async () => {
     const cfg: ExtractFieldsOptions = {
       source: 'line',

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -48,7 +48,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
 
   const ext = fieldExtractors.getIfExists(options.format ?? FieldExtractorID.Auto);
   if (!ext) {
-    throw new Error('unkonwn extractor');
+    throw new Error('unknown extractor');
   }
 
   const count = frame.length;

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -1,4 +1,4 @@
-import { isString, get } from 'lodash';
+import { isString, get, isNumber } from 'lodash';
 import { map } from 'rxjs/operators';
 
 import {
@@ -79,7 +79,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
       if (filteredPaths.length > 0) {
         filteredPaths.forEach((path: JSONPath) => {
           const key = path.alias && path.alias.length > 0 ? path.alias : path.path;
-          newObj[key] = get(obj, path.path) ?? 'Not Found';
+          newObj[key] = get(obj, path.path) ?? (isNumber(obj) || isString(obj) ? obj : 'Not Found');
         });
 
         obj = newObj;

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -1,4 +1,4 @@
-import { isString, get, isNumber } from 'lodash';
+import { isString, get, isNumber, isBoolean } from 'lodash';
 import { map } from 'rxjs/operators';
 
 import {
@@ -79,7 +79,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
       if (filteredPaths.length > 0) {
         filteredPaths.forEach((path: JSONPath) => {
           const key = path.alias && path.alias.length > 0 ? path.alias : path.path;
-          newObj[key] = get(obj, path.path) ?? (isNumber(obj) ? obj : 'Not Found');
+          newObj[key] = get(obj, path.path) ?? (isNumber(obj) || isBoolean(obj) ? obj : 'Not Found');
         });
 
         obj = newObj;

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -79,7 +79,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
       if (filteredPaths.length > 0) {
         filteredPaths.forEach((path: JSONPath) => {
           const key = path.alias && path.alias.length > 0 ? path.alias : path.path;
-          newObj[key] = get(obj, path.path) ?? (isNumber(obj) || isString(obj) ? obj : 'Not Found');
+          newObj[key] = get(obj, path.path) ?? (isNumber(obj) ? obj : 'Not Found');
         });
 
         obj = newObj;


### PR DESCRIPTION
**What is this feature?**

When using the "Group to matrix" transformation, the user can choose how to represent empty values. In many cases, one would select 0.

When this 0 value is passed to the extract fields transformation, it is evaluated to be a string or null - both false, and then passed into the logic to set the data. The selected formatter's `get` logic is applied - in this case JSON - and if that is not resolved properly the string "Not Found" is applied".

However, in the case of our 0 value, the value is there, it just was added outside of the context of the extraction.

This logic will, if the extraction cannot find the value, see if the value is a number or a boolean, and display that instead. It's worth noting that the logic will already handle if the value is a string by trying to parse it with the extractor earlier in the function, and any other value is a bit more ambiguous, so "Not found" most likely applies. 

**Why do we need this feature?**

Trying to aggregate numbers from data that is grouped to matrix, then extracted, will lead to a scenario where you can't handle non existent data

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/15110

**Special notes for your reviewer:**

The scenario is rather niche, and I had a hard time reproing it faithfully with a novel dataset. I have a sample dashboard available with redacted data, however I still don't feel comfortable posting it publicly. Please see the escalation for this. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
