### PR TITLE
Profiles: Handle labels clashing with JS method names

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
@@ -46,7 +46,7 @@ export function nestedSetToLevels(
   let offset = 0;
 
   let parent: LevelItem | undefined = undefined;
-  const uniqueLabels: Record<string, LevelItem[]> = {};
+  const uniqueLabels: Record<string, LevelItem[]> = Object.create(null);
 
   for (let i = 0; i < container.data.length; i++) {
     const currentLevel = container.getLevel(i);


### PR DESCRIPTION
Fixes #101551

Please use the file attached in #101551 to reproduce the issue.

The code fails at https://github.com/grafana/grafana/blob/1b92ef5a2dd194d9cd9280712fd6618cb7add91c/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts#L81 when checking for `toString` label which clashes with an existing name. Removing prototype methods from the map allows to store it properly but the result in the flame graph doesn't seem to be correctly calculated for `toString` (takes more than `total` usage) so this needs further investigation.

Apart from that it seems that tests for the package are never being run (?)