### PR TITLE
Chore: Prevent `make run` from printing all environment variables

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,6 @@
 [run]
 init_cmds = [
-  ["GO_BUILD_DEV=1", "make", "build-go"],
+  ["make","GO_BUILD_DEV=1", "build-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]
@@ -17,7 +17,7 @@ watch_exts = [".go", ".ini", ".toml", ".template.html"]
 ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
-  ["GO_BUILD_DEV=1", "make", "build-go-fast"],
+  ["make", "GO_BUILD_DEV=1", "build-go-fast"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
**What is this feature?**

`make run` prints all environment variables by default as one of the first steps. This makes sharing the whole log output from a `make run` call, or screensharing what is happening with a `make run` very dangerous. 

The fact that environment variables are printed is due to the use of https://github.com/unknwon/bra. If bra sees the assignment of a variable in the first step of a "command", it will also print all environment variables. 
We only need to pass the `GO_BUILD_DEV=1` variable to the `build-go` and `build-go-fast` make targets and thus can just fallback to the `make`-syntax of passing variables. That way `bra` will not log all other environment variables.