### PR TITLE
Plugins: Update all core plugins with raise issue and docs links

### DIFF
--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -88,6 +88,9 @@ func TestLoader_Load(t *testing.T) {
 								Small: "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png",
 								Large: "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png",
 							},
+							Links: []plugins.InfoLink{
+								{Name: "Raise issue", URL: "https://github.com/grafana/grafana/issues/new"},
+							},
 						},
 						Includes: []*plugins.Includes{
 							{Name: "EC2", Path: "dashboards/ec2.json", Type: "dashboard", Role: "Viewer"},

--- a/pkg/services/pluginsintegration/loader/loader_test.go
+++ b/pkg/services/pluginsintegration/loader/loader_test.go
@@ -87,6 +87,9 @@ func TestLoader_Load(t *testing.T) {
 								Small: "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png",
 								Large: "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png",
 							},
+							Links: []plugins.InfoLink{
+								{Name: "Raise issue", URL: "https://github.com/grafana/grafana/issues/new"},
+							},
 						},
 						Includes: []*plugins.Includes{
 							{Name: "EC2", Path: "dashboards/ec2.json", Type: "dashboard", Role: "Viewer"},

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -11,7 +11,16 @@
         "url": "https://grafana.com"
       },
       "description": "Shows list of alerts and their current status",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/alert-list/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/alertlist/img/icn-singlestat-panel.svg",
         "large": "public/app/plugins/panel/alertlist/img/icn-singlestat-panel.svg"
@@ -56,6 +65,14 @@
         {
           "name": "Learn more",
           "url": "https://prometheus.io/docs/alerting/latest/alertmanager/"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/alertmanager/"
         }
       ],
       "logos": {
@@ -105,7 +122,16 @@
         "url": "https://grafana.com"
       },
       "description": "List annotations",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/annotations/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/annolist/img/icn-annolist-panel.svg",
         "large": "public/app/plugins/panel/annolist/img/icn-annolist-panel.svg"
@@ -154,6 +180,14 @@
         {
           "name": "Apache License",
           "url": "https://github.com/grafana/azure-monitor-datasource/blob/master/LICENSE"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/azure-monitor/"
         }
       ],
       "logos": {
@@ -175,7 +209,7 @@
           "path": "public/app/plugins/datasource/azuremonitor/img/azure_monitor_cpu.png"
         }
       ],
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": [
         "azure",
@@ -215,7 +249,16 @@
         "url": "https://grafana.com"
       },
       "description": "Categorical charts with group support",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/barchart/img/barchart.svg",
         "large": "public/app/plugins/panel/barchart/img/barchart.svg"
@@ -256,7 +299,16 @@
         "url": "https://grafana.com"
       },
       "description": "Horizontal and vertical gauges",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-gauge/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/bargauge/img/icon_bar_gauge.svg",
         "large": "public/app/plugins/panel/bargauge/img/icon_bar_gauge.svg"
@@ -297,7 +349,16 @@
         "url": "https://grafana.com"
       },
       "description": "Graphical representation of price movements of a security, derivative, or currency.",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/candlestick/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/candlestick/img/candlestick.svg",
         "large": "public/app/plugins/panel/candlestick/img/candlestick.svg"
@@ -343,7 +404,16 @@
         "url": "https://grafana.com"
       },
       "description": "Explicit element placement",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/canvas/img/icn-canvas.svg",
         "large": "public/app/plugins/panel/canvas/img/icn-canvas.svg"
@@ -384,7 +454,12 @@
         "url": "https://grafana.com"
       },
       "description": "Data source for Amazon AWS monitoring service",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png",
         "large": "public/app/plugins/datasource/cloudwatch/img/amazon-web-services.png"
@@ -428,7 +503,16 @@
         "url": "https://grafana.com"
       },
       "description": "List of dynamic links to other dashboards",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/dashboard-list/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/dashlist/img/icn-dashlist-panel.svg",
         "large": "public/app/plugins/panel/dashlist/img/icn-dashlist-panel.svg"
@@ -469,7 +553,16 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/datagrid/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/datagrid/img/icn-table-panel.svg",
         "large": "public/app/plugins/panel/datagrid/img/icn-table-panel.svg"
@@ -514,6 +607,14 @@
         {
           "name": "Learn more",
           "url": "https://grafana.com/docs/features/datasources/elasticsearch/"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/elasticsearch/"
         }
       ],
       "logos": {
@@ -563,7 +664,16 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/flame-graph/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/flamegraph/img/icn-flamegraph.svg",
         "large": "public/app/plugins/panel/flamegraph/img/icn-flamegraph.svg"
@@ -604,7 +714,16 @@
         "url": "https://grafana.com"
       },
       "description": "Standard gauge visualization",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/gauge/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/gauge/img/icon_gauge.svg",
         "large": "public/app/plugins/panel/gauge/img/icon_gauge.svg"
@@ -645,7 +764,16 @@
         "url": "https://grafana.com"
       },
       "description": "Geomap panel",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/geomap/img/icn-geomap.svg",
         "large": "public/app/plugins/panel/geomap/img/icn-geomap.svg"
@@ -686,7 +814,12 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/gettingstarted/img/icn-dashlist-panel.svg",
         "large": "public/app/plugins/panel/gettingstarted/img/icn-dashlist-panel.svg"
@@ -727,14 +860,19 @@
         "url": "https://grafana.com"
       },
       "description": "Data source for Google's monitoring service (formerly named Stackdriver)",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/cloud-monitoring/img/cloud_monitoring_logo.svg",
         "large": "public/app/plugins/datasource/cloud-monitoring/img/cloud_monitoring_logo.svg"
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -772,6 +910,14 @@
         {
           "name": "GitHub Project",
           "url": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/pyroscope/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/pyroscope/"
         }
       ],
       "logos": {
@@ -780,7 +926,7 @@
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": [
         "grafana",
@@ -822,7 +968,12 @@
         "url": "https://grafana.com"
       },
       "description": "The old default graph panel",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/graph/img/icn-graph-panel.svg",
         "large": "public/app/plugins/panel/graph/img/icn-graph-panel.svg"
@@ -871,6 +1022,14 @@
         {
           "name": "Graphite 1.1 Release",
           "url": "https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/graphite/"
         }
       ],
       "logos": {
@@ -913,7 +1072,16 @@
         "url": "https://grafana.com"
       },
       "description": "Like a histogram over time",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/heatmap/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/heatmap/img/icn-heatmap-panel.svg",
         "large": "public/app/plugins/panel/heatmap/img/icn-heatmap-panel.svg"
@@ -954,7 +1122,16 @@
         "url": "https://grafana.com"
       },
       "description": "Distribution of values presented as a bar chart.",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/histogram/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/histogram/img/histogram.svg",
         "large": "public/app/plugins/panel/histogram/img/histogram.svg"
@@ -1000,7 +1177,16 @@
         "url": "https://grafana.com"
       },
       "description": "Open source time series database",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/influxdb/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/influxdb/img/influxdb_logo.svg",
         "large": "public/app/plugins/datasource/influxdb/img/influxdb_logo.svg"
@@ -1049,6 +1235,14 @@
         {
           "name": "GitHub Project",
           "url": "https://github.com/jaegertracing/jaeger"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/jaegertracing/jaeger/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/jaeger/"
         }
       ],
       "logos": {
@@ -1057,7 +1251,7 @@
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1091,7 +1285,16 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/logs/img/icn-logs-panel.svg",
         "large": "public/app/plugins/panel/logs/img/icn-logs-panel.svg"
@@ -1140,6 +1343,14 @@
         {
           "name": "GitHub Project",
           "url": "https://github.com/grafana/loki"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/loki/"
         }
       ],
       "logos": {
@@ -1182,14 +1393,19 @@
         "url": "https://grafana.com"
       },
       "description": "Data source for Microsoft SQL Server compatible databases",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/mssql/img/sql_server_logo.svg",
         "large": "public/app/plugins/datasource/mssql/img/sql_server_logo.svg"
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1223,14 +1439,23 @@
         "url": "https://grafana.com"
       },
       "description": "Data source for MySQL databases",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/mysql/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/mysql/img/mysql_logo.svg",
         "large": "public/app/plugins/datasource/mysql/img/mysql_logo.svg"
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1264,7 +1489,16 @@
         "url": "https://grafana.com"
       },
       "description": "RSS feed reader",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/news/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/news/img/news.svg",
         "large": "public/app/plugins/panel/news/img/news.svg"
@@ -1305,7 +1539,16 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/node-graph/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/nodeGraph/img/icn-node-graph.svg",
         "large": "public/app/plugins/panel/nodeGraph/img/icn-node-graph.svg"
@@ -1346,7 +1589,16 @@
         "url": "https://grafana.com"
       },
       "description": "Open source time series database",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/opentsdb/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/opentsdb/img/opentsdb_logo.png",
         "large": "public/app/plugins/datasource/opentsdb/img/opentsdb_logo.png"
@@ -1391,6 +1643,14 @@
         {
           "name": "GitHub Project",
           "url": "https://github.com/parca-dev/parca"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/parca/"
         }
       ],
       "logos": {
@@ -1399,7 +1659,7 @@
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": [
         "grafana",
@@ -1438,7 +1698,16 @@
         "url": "https://grafana.com"
       },
       "description": "The new core pie chart visualization",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/pie-chart/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/piechart/img/icon_piechart.svg",
         "large": "public/app/plugins/panel/piechart/img/icon_piechart.svg"
@@ -1479,14 +1748,23 @@
         "url": "https://grafana.com"
       },
       "description": "Data source for PostgreSQL and compatible databases",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/postgres/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/grafana-postgresql-datasource/img/postgresql_logo.svg",
         "large": "public/app/plugins/datasource/grafana-postgresql-datasource/img/postgresql_logo.svg"
       },
       "build": {},
       "screenshots": null,
-      "version": "",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1524,6 +1802,14 @@
         {
           "name": "Learn more",
           "url": "https://prometheus.io/"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/prometheus/"
         }
       ],
       "logos": {
@@ -1566,7 +1852,16 @@
         "url": "https://grafana.com"
       },
       "description": "Big stat values \u0026 sparklines",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/stat/img/icn-singlestat-panel.svg",
         "large": "public/app/plugins/panel/stat/img/icn-singlestat-panel.svg"
@@ -1607,7 +1902,16 @@
         "url": "https://grafana.com"
       },
       "description": "State changes and durations",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/state-timeline/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/state-timeline/img/timeline.svg",
         "large": "public/app/plugins/panel/state-timeline/img/timeline.svg"
@@ -1648,7 +1952,16 @@
         "url": "https://grafana.com"
       },
       "description": "Periodic status history",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/status-history/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/status-history/img/status.svg",
         "large": "public/app/plugins/panel/status-history/img/status.svg"
@@ -1689,7 +2002,16 @@
         "url": "https://grafana.com"
       },
       "description": "Supports many column styles",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/table/img/icn-table-panel.svg",
         "large": "public/app/plugins/panel/table/img/icn-table-panel.svg"
@@ -1730,7 +2052,12 @@
         "url": "https://grafana.com"
       },
       "description": "Table Panel for Grafana",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/table-old/img/icn-table-panel.svg",
         "large": "public/app/plugins/panel/table-old/img/icn-table-panel.svg"
@@ -1775,6 +2102,14 @@
         {
           "name": "GitHub Project",
           "url": "https://github.com/grafana/tempo"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/tempo/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/tempo/"
         }
       ],
       "logos": {
@@ -1783,7 +2118,7 @@
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1817,14 +2152,23 @@
         "url": "https://grafana.com"
       },
       "description": "Generates test data in different forms",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/testdata/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/datasource/grafana-testdata-datasource/img/testdata.svg",
         "large": "public/app/plugins/datasource/grafana-testdata-datasource/img/testdata.svg"
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },
@@ -1858,7 +2202,16 @@
         "url": "https://grafana.com"
       },
       "description": "Supports markdown and html content",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/text/img/icn-text-panel.svg",
         "large": "public/app/plugins/panel/text/img/icn-text-panel.svg"
@@ -1899,7 +2252,12 @@
         "url": "https://grafana.com"
       },
       "description": "Time based line, area and bar charts",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/timeseries/img/icn-timeseries-panel.svg",
         "large": "public/app/plugins/panel/timeseries/img/icn-timeseries-panel.svg"
@@ -1940,7 +2298,16 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/traces/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/traces/img/traces-panel.svg",
         "large": "public/app/plugins/panel/traces/img/traces-panel.svg"
@@ -1981,7 +2348,16 @@
         "url": "https://grafana.com"
       },
       "description": "Like timeseries, but when x != time",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/trend/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/trend/img/trend.svg",
         "large": "public/app/plugins/panel/trend/img/trend.svg"
@@ -2022,7 +2398,12 @@
         "url": "https://grafana.com"
       },
       "description": "",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/welcome/img/icn-dashlist-panel.svg",
         "large": "public/app/plugins/panel/welcome/img/icn-dashlist-panel.svg"
@@ -2063,7 +2444,16 @@
         "url": "https://grafana.com"
       },
       "description": "Supports arbitrary X vs Y in a graph to visualize the relationship between two variables.",
-      "links": null,
+      "links": [
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/xy-chart/"
+        }
+      ],
       "logos": {
         "small": "public/app/plugins/panel/xychart/img/icn-xychart.svg",
         "large": "public/app/plugins/panel/xychart/img/icn-xychart.svg"
@@ -2111,6 +2501,14 @@
         {
           "name": "Learn more",
           "url": "https://zipkin.io"
+        },
+        {
+          "name": "Raise issue",
+          "url": "https://github.com/grafana/grafana/issues/new"
+        },
+        {
+          "name": "Documentation",
+          "url": "https://grafana.com/docs/grafana/latest/datasources/zipkin/"
         }
       ],
       "logos": {
@@ -2119,7 +2517,7 @@
       },
       "build": {},
       "screenshots": null,
-      "version": "11.3.0-pre",
+      "version": "11.6.0-pre",
       "updated": "",
       "keywords": null
     },

--- a/public/app/plugins/datasource/alertmanager/plugin.json
+++ b/public/app/plugins/datasource/alertmanager/plugin.json
@@ -57,6 +57,14 @@
       {
         "name": "Learn more",
         "url": "https://prometheus.io/docs/alerting/latest/alertmanager/"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/grafana/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/alertmanager/"
       }
     ]
   }

--- a/public/app/plugins/datasource/azuremonitor/plugin.json
+++ b/public/app/plugins/datasource/azuremonitor/plugin.json
@@ -111,7 +111,9 @@
     },
     "links": [
       { "name": "Learn more", "url": "https://grafana.com/docs/grafana/latest/datasources/azuremonitor/" },
-      { "name": "Apache License", "url": "https://github.com/grafana/azure-monitor-datasource/blob/master/LICENSE" }
+      { "name": "Apache License", "url": "https://github.com/grafana/azure-monitor-datasource/blob/master/LICENSE" },
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/azure-monitor/" }
     ],
     "screenshots": [
       { "name": "Azure Contoso Loans", "path": "img/contoso_loans_grafana_dashboard.png" },

--- a/public/app/plugins/datasource/cloud-monitoring/plugin.json
+++ b/public/app/plugins/datasource/cloud-monitoring/plugin.json
@@ -91,6 +91,9 @@
     "author": {
       "name": "Grafana Labs",
       "url": "https://grafana.com"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/datasource/cloud-monitoring/plugin.json
+++ b/public/app/plugins/datasource/cloud-monitoring/plugin.json
@@ -92,8 +92,6 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -31,8 +31,6 @@
       "small": "img/amazon-web-services.png",
       "large": "img/amazon-web-services.png"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -30,6 +30,9 @@
     "logos": {
       "small": "img/amazon-web-services.png",
       "large": "img/amazon-web-services.png"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/datasource/dashboard/plugin.json
+++ b/public/app/plugins/datasource/dashboard/plugin.json
@@ -14,9 +14,7 @@
       "small": "img/icn-reusequeries.svg",
       "large": "img/icn-reusequeries.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   },
 
   "metrics": true

--- a/public/app/plugins/datasource/dashboard/plugin.json
+++ b/public/app/plugins/datasource/dashboard/plugin.json
@@ -13,7 +13,10 @@
     "logos": {
       "small": "img/icn-reusequeries.svg",
       "large": "img/icn-reusequeries.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   },
 
   "metrics": true

--- a/public/app/plugins/datasource/elasticsearch/plugin.json
+++ b/public/app/plugins/datasource/elasticsearch/plugin.json
@@ -18,6 +18,14 @@
       {
         "name": "Learn more",
         "url": "https://grafana.com/docs/features/datasources/elasticsearch/"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/grafana/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/elasticsearch/"
       }
     ]
   },

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/plugin.json
@@ -15,7 +15,11 @@
       "small": "img/postgresql_logo.svg",
       "large": "img/postgresql_logo.svg"
     },
-    "version": "%VERSION%"
+    "version": "%VERSION%",
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/postgres/" }
+    ]
   },
 
   "alerting": true,

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/plugin.json
@@ -29,6 +29,14 @@
       {
         "name": "GitHub Project",
         "url": "https://github.com/grafana/pyroscope"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/pyroscope/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/pyroscope/"
       }
     ],
     "version": "%VERSION%"

--- a/public/app/plugins/datasource/grafana-testdata-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/plugin.json
@@ -26,7 +26,11 @@
       "small": "img/testdata.svg",
       "large": "img/testdata.svg"
     },
-    "version": "%VERSION%"
+    "version": "%VERSION%",
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/testdata/" }
+    ]
   },
 
   "includes": [

--- a/public/app/plugins/datasource/grafana/plugin.json
+++ b/public/app/plugins/datasource/grafana/plugin.json
@@ -13,7 +13,10 @@
     "logos": {
       "small": "img/icn-grafanadb.svg",
       "large": "img/icn-grafanadb.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   },
   "backend": true,
   "annotations": true,

--- a/public/app/plugins/datasource/grafana/plugin.json
+++ b/public/app/plugins/datasource/grafana/plugin.json
@@ -14,9 +14,7 @@
       "small": "img/icn-grafanadb.svg",
       "large": "img/icn-grafanadb.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   },
   "backend": true,
   "annotations": true,

--- a/public/app/plugins/datasource/graphite/plugin.json
+++ b/public/app/plugins/datasource/graphite/plugin.json
@@ -34,7 +34,9 @@
       {
         "name": "Graphite 1.1 Release",
         "url": "https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/"
-      }
+      },
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/graphite/" }
     ]
   }
 }

--- a/public/app/plugins/datasource/influxdb/plugin.json
+++ b/public/app/plugins/datasource/influxdb/plugin.json
@@ -24,6 +24,10 @@
     "logos": {
       "small": "img/influxdb_logo.svg",
       "large": "img/influxdb_logo.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/influxdb/" }
+    ]
   }
 }

--- a/public/app/plugins/datasource/jaeger/plugin.json
+++ b/public/app/plugins/datasource/jaeger/plugin.json
@@ -30,6 +30,14 @@
       {
         "name": "GitHub Project",
         "url": "https://github.com/jaegertracing/jaeger"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/jaegertracing/jaeger/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/jaeger/"
       }
     ],
     "version": "%VERSION%"

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -33,6 +33,14 @@
       {
         "name": "GitHub Project",
         "url": "https://github.com/grafana/loki"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/loki/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/loki/"
       }
     ]
   }

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -36,7 +36,7 @@
       },
       {
         "name": "Raise issue",
-        "url": "https://github.com/grafana/loki/issues/new"
+        "url": "https://github.com/grafana/grafana/issues/new"
       },
       {
         "name": "Documentation",

--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -14,9 +14,7 @@
       "small": "img/icn-mixeddatasources.svg",
       "large": "img/icn-mixeddatasources.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   },
 
   "mixed": true,

--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -13,7 +13,10 @@
     "logos": {
       "small": "img/icn-mixeddatasources.svg",
       "large": "img/icn-mixeddatasources.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   },
 
   "mixed": true,

--- a/public/app/plugins/datasource/mssql/plugin.json
+++ b/public/app/plugins/datasource/mssql/plugin.json
@@ -16,9 +16,7 @@
       "large": "img/sql_server_logo.svg"
     },
     "version": "%VERSION%",
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   },
   "dependencies": {
     "grafanaDependency": ">=10.4.0"

--- a/public/app/plugins/datasource/mssql/plugin.json
+++ b/public/app/plugins/datasource/mssql/plugin.json
@@ -15,7 +15,10 @@
       "small": "img/sql_server_logo.svg",
       "large": "img/sql_server_logo.svg"
     },
-    "version": "%VERSION%"
+    "version": "%VERSION%",
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   },
   "dependencies": {
     "grafanaDependency": ">=10.4.0"

--- a/public/app/plugins/datasource/mysql/plugin.json
+++ b/public/app/plugins/datasource/mysql/plugin.json
@@ -15,7 +15,11 @@
       "small": "img/mysql_logo.svg",
       "large": "img/mysql_logo.svg"
     },
-    "version": "%VERSION%"
+    "version": "%VERSION%",
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/mysql/" }
+    ]
   },
   "dependencies": {
     "grafanaDependency": ">=10.4.0"

--- a/public/app/plugins/datasource/opentsdb/plugin.json
+++ b/public/app/plugins/datasource/opentsdb/plugin.json
@@ -19,6 +19,10 @@
     "logos": {
       "small": "img/opentsdb_logo.png",
       "large": "img/opentsdb_logo.png"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/datasources/opentsdb/" }
+    ]
   }
 }

--- a/public/app/plugins/datasource/parca/plugin.json
+++ b/public/app/plugins/datasource/parca/plugin.json
@@ -21,6 +21,14 @@
       {
         "name": "GitHub Project",
         "url": "https://github.com/parca-dev/parca"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/grafana/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/parca/"
       }
     ],
     "version": "%VERSION%"

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -104,6 +104,14 @@
       {
         "name": "Learn more",
         "url": "https://prometheus.io/"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/grafana/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/prometheus/"
       }
     ]
   }

--- a/public/app/plugins/datasource/tempo/plugin.json
+++ b/public/app/plugins/datasource/tempo/plugin.json
@@ -27,6 +27,14 @@
       {
         "name": "GitHub Project",
         "url": "https://github.com/grafana/tempo"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/tempo/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/tempo/"
       }
     ],
     "version": "%VERSION%"

--- a/public/app/plugins/datasource/zipkin/plugin.json
+++ b/public/app/plugins/datasource/zipkin/plugin.json
@@ -26,6 +26,14 @@
       {
         "name": "Learn more",
         "url": "https://zipkin.io"
+      },
+      {
+        "name": "Raise issue",
+        "url": "https://github.com/grafana/grafana/issues/new"
+      },
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/datasources/zipkin/"
       }
     ],
     "version": "%VERSION%"

--- a/public/app/plugins/panel/alertlist/plugin.json
+++ b/public/app/plugins/panel/alertlist/plugin.json
@@ -17,7 +17,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/alert-list/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/alert-list/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/alertlist/plugin.json
+++ b/public/app/plugins/panel/alertlist/plugin.json
@@ -14,6 +14,10 @@
     "logos": {
       "small": "img/icn-singlestat-panel.svg",
       "large": "img/icn-singlestat-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/alert-list/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/annolist/plugin.json
+++ b/public/app/plugins/panel/annolist/plugin.json
@@ -15,6 +15,10 @@
     "logos": {
       "small": "img/icn-annolist-panel.svg",
       "large": "img/icn-annolist-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/annotations/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/annolist/plugin.json
+++ b/public/app/plugins/panel/annolist/plugin.json
@@ -18,7 +18,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/annotations/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/annotations/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/barchart/plugin.json
+++ b/public/app/plugins/panel/barchart/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/barchart.svg",
       "large": "img/barchart.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/barchart/plugin.json
+++ b/public/app/plugins/panel/barchart/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icon_bar_gauge.svg",
       "large": "img/icon_bar_gauge.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-gauge/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-gauge/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-gauge/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/candlestick/plugin.json
+++ b/public/app/plugins/panel/candlestick/plugin.json
@@ -13,6 +13,10 @@
     "logos": {
       "small": "img/candlestick.svg",
       "large": "img/candlestick.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/candlestick/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/candlestick/plugin.json
+++ b/public/app/plugins/panel/candlestick/plugin.json
@@ -16,7 +16,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/candlestick/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/candlestick/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/canvas/plugin.json
+++ b/public/app/plugins/panel/canvas/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/canvas/plugin.json
+++ b/public/app/plugins/panel/canvas/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-canvas.svg",
       "large": "img/icn-canvas.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/canvas/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/dashlist/plugin.json
+++ b/public/app/plugins/panel/dashlist/plugin.json
@@ -17,7 +17,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/dashboard-list/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/dashboard-list/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/dashlist/plugin.json
+++ b/public/app/plugins/panel/dashlist/plugin.json
@@ -14,6 +14,10 @@
     "logos": {
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/dashboard-list/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/datagrid/plugin.json
+++ b/public/app/plugins/panel/datagrid/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-table-panel.svg",
       "large": "img/icn-table-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/datagrid/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/datagrid/plugin.json
+++ b/public/app/plugins/panel/datagrid/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/datagrid/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/datagrid/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/debug/plugin.json
+++ b/public/app/plugins/panel/debug/plugin.json
@@ -14,6 +14,9 @@
     "logos": {
       "small": "img/icn-debug.svg",
       "large": "img/icn-debug.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/debug/plugin.json
+++ b/public/app/plugins/panel/debug/plugin.json
@@ -15,8 +15,6 @@
       "small": "img/icn-debug.svg",
       "large": "img/icn-debug.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/flamegraph/plugin.json
+++ b/public/app/plugins/panel/flamegraph/plugin.json
@@ -11,6 +11,10 @@
     "logos": {
       "small": "img/icn-flamegraph.svg",
       "large": "img/icn-flamegraph.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/flame-graph/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/flamegraph/plugin.json
+++ b/public/app/plugins/panel/flamegraph/plugin.json
@@ -14,7 +14,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/flame-graph/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/flame-graph/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/gauge/plugin.json
+++ b/public/app/plugins/panel/gauge/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/gauge/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/gauge/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/gauge/plugin.json
+++ b/public/app/plugins/panel/gauge/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icon_gauge.svg",
       "large": "img/icon_gauge.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/gauge/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/geomap/plugin.json
+++ b/public/app/plugins/panel/geomap/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-geomap.svg",
       "large": "img/icn-geomap.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/geomap/plugin.json
+++ b/public/app/plugins/panel/geomap/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/gettingstarted/plugin.json
+++ b/public/app/plugins/panel/gettingstarted/plugin.json
@@ -15,8 +15,6 @@
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/gettingstarted/plugin.json
+++ b/public/app/plugins/panel/gettingstarted/plugin.json
@@ -14,6 +14,9 @@
     "logos": {
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/graph/plugin.json
+++ b/public/app/plugins/panel/graph/plugin.json
@@ -13,6 +13,9 @@
     "logos": {
       "small": "img/icn-graph-panel.svg",
       "large": "img/icn-graph-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/graph/plugin.json
+++ b/public/app/plugins/panel/graph/plugin.json
@@ -14,8 +14,6 @@
       "small": "img/icn-graph-panel.svg",
       "large": "img/icn-graph-panel.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/heatmap/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/heatmap/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-heatmap-panel.svg",
       "large": "img/icn-heatmap-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/heatmap/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/histogram/plugin.json
+++ b/public/app/plugins/panel/histogram/plugin.json
@@ -16,7 +16,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/histogram/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/histogram/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/histogram/plugin.json
+++ b/public/app/plugins/panel/histogram/plugin.json
@@ -13,6 +13,10 @@
     "logos": {
       "small": "img/histogram.svg",
       "large": "img/histogram.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/histogram/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/live/plugin.json
+++ b/public/app/plugins/panel/live/plugin.json
@@ -16,8 +16,6 @@
       "small": "img/live.svg",
       "large": "img/live.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/live/plugin.json
+++ b/public/app/plugins/panel/live/plugin.json
@@ -15,6 +15,9 @@
     "logos": {
       "small": "img/live.svg",
       "large": "img/live.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/logs-new/plugin.json
+++ b/public/app/plugins/panel/logs-new/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-logs-panel.svg",
       "large": "img/icn-logs-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/logs-new/plugin.json
+++ b/public/app/plugins/panel/logs-new/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/logs/plugin.json
+++ b/public/app/plugins/panel/logs/plugin.json
@@ -11,6 +11,10 @@
     "logos": {
       "small": "img/icn-logs-panel.svg",
       "large": "img/icn-logs-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/logs/plugin.json
+++ b/public/app/plugins/panel/logs/plugin.json
@@ -14,7 +14,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/logs/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/news/plugin.json
+++ b/public/app/plugins/panel/news/plugin.json
@@ -16,6 +16,10 @@
     "logos": {
       "small": "img/news.svg",
       "large": "img/news.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/news/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/news/plugin.json
+++ b/public/app/plugins/panel/news/plugin.json
@@ -19,7 +19,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/news/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/news/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/nodeGraph/plugin.json
+++ b/public/app/plugins/panel/nodeGraph/plugin.json
@@ -11,6 +11,10 @@
     "logos": {
       "small": "img/icn-node-graph.svg",
       "large": "img/icn-node-graph.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/node-graph/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/nodeGraph/plugin.json
+++ b/public/app/plugins/panel/nodeGraph/plugin.json
@@ -14,7 +14,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/node-graph/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/node-graph/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/pie-chart/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/pie-chart/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icon_piechart.svg",
       "large": "img/icon_piechart.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/pie-chart/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/stat/plugin.json
+++ b/public/app/plugins/panel/stat/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-singlestat-panel.svg",
       "large": "img/icn-singlestat-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/stat/plugin.json
+++ b/public/app/plugins/panel/stat/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/state-timeline/plugin.json
+++ b/public/app/plugins/panel/state-timeline/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/state-timeline/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/state-timeline/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/state-timeline/plugin.json
+++ b/public/app/plugins/panel/state-timeline/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/timeline.svg",
       "large": "img/timeline.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/state-timeline/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/status-history/plugin.json
+++ b/public/app/plugins/panel/status-history/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/status.svg",
       "large": "img/status.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/status-history/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/status-history/plugin.json
+++ b/public/app/plugins/panel/status-history/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/status-history/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/status-history/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/table-old/plugin.json
+++ b/public/app/plugins/panel/table-old/plugin.json
@@ -14,6 +14,9 @@
     "logos": {
       "small": "img/icn-table-panel.svg",
       "large": "img/icn-table-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/table-old/plugin.json
+++ b/public/app/plugins/panel/table-old/plugin.json
@@ -15,8 +15,6 @@
       "small": "img/icn-table-panel.svg",
       "large": "img/icn-table-panel.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -15,7 +15,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -12,6 +12,10 @@
     "logos": {
       "small": "img/icn-table-panel.svg",
       "large": "img/icn-table-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -17,7 +17,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -14,6 +14,10 @@
     "logos": {
       "small": "img/icn-text-panel.svg",
       "large": "img/icn-text-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/timeseries/plugin.json
+++ b/public/app/plugins/panel/timeseries/plugin.json
@@ -12,6 +12,9 @@
     "logos": {
       "small": "img/icn-timeseries-panel.svg",
       "large": "img/icn-timeseries-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/timeseries/plugin.json
+++ b/public/app/plugins/panel/timeseries/plugin.json
@@ -13,8 +13,6 @@
       "small": "img/icn-timeseries-panel.svg",
       "large": "img/icn-timeseries-panel.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/traces/plugin.json
+++ b/public/app/plugins/panel/traces/plugin.json
@@ -14,7 +14,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/traces/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/traces/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/traces/plugin.json
+++ b/public/app/plugins/panel/traces/plugin.json
@@ -11,6 +11,10 @@
     "logos": {
       "small": "img/traces-panel.svg",
       "large": "img/traces-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/traces/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/trend/plugin.json
+++ b/public/app/plugins/panel/trend/plugin.json
@@ -14,6 +14,10 @@
     "logos": {
       "small": "img/trend.svg",
       "large": "img/trend.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/trend/" }
+    ]
   }
 }

--- a/public/app/plugins/panel/trend/plugin.json
+++ b/public/app/plugins/panel/trend/plugin.json
@@ -17,7 +17,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/trend/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/trend/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/welcome/plugin.json
+++ b/public/app/plugins/panel/welcome/plugin.json
@@ -15,8 +15,6 @@
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
     },
-    "links": [
-      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
-    ]
+    "links": [{ "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }]
   }
 }

--- a/public/app/plugins/panel/welcome/plugin.json
+++ b/public/app/plugins/panel/welcome/plugin.json
@@ -14,6 +14,9 @@
     "logos": {
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" }
+    ]
   }
 }

--- a/public/app/plugins/panel/xychart/plugin.json
+++ b/public/app/plugins/panel/xychart/plugin.json
@@ -16,7 +16,10 @@
     },
     "links": [
       { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
-      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/xy-chart/" }
+      {
+        "name": "Documentation",
+        "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/xy-chart/"
+      }
     ]
   }
 }

--- a/public/app/plugins/panel/xychart/plugin.json
+++ b/public/app/plugins/panel/xychart/plugin.json
@@ -13,6 +13,10 @@
     "logos": {
       "small": "img/icn-xychart.svg",
       "large": "img/icn-xychart.svg"
-    }
+    },
+    "links": [
+      { "name": "Raise issue", "url": "https://github.com/grafana/grafana/issues/new" },
+      { "name": "Documentation", "url": "https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/xy-chart/" }
+    ]
   }
 }


### PR DESCRIPTION
To be able to show correct docs and raise an issue links for core plugins at plugin details page we need to update their plugin.json files
Documentations links from https://grafana.com/docs/grafana/latest/datasources/ and https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/

Raise an issue should be 
https://github.com/grafana/grafana/issues/new

Except couple of plugins which have separate repository like https://github.com/grafana/pyroscope/issues/new

Fixes #101868

