### PR TITLE
Permissions: Stop auto-assigning Admin rights to creators of nested dashboards/folders

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -220,8 +220,7 @@ func (hs *HTTPServer) CreateFolder(c *contextmodel.ReqContext) response.Response
 }
 
 func (hs *HTTPServer) setDefaultFolderPermissions(ctx context.Context, orgID int64, user identity.Requester, folder *folder.Folder) error {
-	isNested := folder.ParentUID != ""
-	if (isNested && hs.Features.IsEnabled(ctx, featuremgmt.FlagNestedFolders)) || !hs.Cfg.RBAC.PermissionsOnCreation("folder") {
+	if folder.ParentUID != "" || !hs.Cfg.RBAC.PermissionsOnCreation("folder") {
 		return nil
 	}
 

--- a/pkg/registry/apis/folders/folder_storage.go
+++ b/pkg/registry/apis/folders/folder_storage.go
@@ -133,8 +133,7 @@ func (s *folderStorage) DeleteCollection(ctx context.Context, deleteValidation r
 }
 
 func (s *folderStorage) setDefaultFolderPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string, parentUID string) error {
-	isNested := parentUID != ""
-	if (isNested && s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders)) || !s.cfg.RBAC.PermissionsOnCreation("folder") {
+	if parentUID != "" || !s.cfg.RBAC.PermissionsOnCreation("folder") {
 		return nil
 	}
 


### PR DESCRIPTION
**What is this feature?**

Creators of nested dashboards/folders will not automatically get Admin permissions on the resource. The inherited permissions from the parent folder still apply, and creators of root level resources still get automatically assigned Admin rights to the created resource.

**Why do we need this feature?**

To reduce the amount of automatically created permissions and improve performance.

# Release notice breaking change
Creators of nested dashboards and folders will no longer automatically receive Admin permissions on the created resource. Inherited permissions from the parent folder will still apply, and creators of root-level resources will continue to be automatically assigned Admin rights. This change only affects newly created dashboards and folders — existing resources remain unchanged.

If you want resource creators to have Admin access on new nested dashboards and folders, we recommend granting them Admin access to the parent folder.