### PR TITLE
docs(alerting): clarify behaviour when provisioning the policy tree

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -197,11 +197,7 @@ However, you can export it by manually copying the content and name of the notif
 
 All notification policies are provisioned through a single resource: the root of the notification policy tree.
 
-{{% admonition type="warning" %}}
-
-Since the policy tree is a single resource, provisioning it overwrites a policy tree created through any other means.
-
-{{< /admonition >}}
+{{< docs/shared lookup="alerts/warning-provisioning-tree.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 To export the notification policy tree from the Grafana UI, complete the following steps.
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -702,11 +702,7 @@ Create or reset the notification policy tree using provisioning files in your Gr
 
 In Grafana, the entire notification policy tree is considered a single, large resource. Add new specific policies as sub-policies under the root policy. Since specific policies may depend on each other, you cannot provision subsets of the policy tree; the entire tree must be defined in a single place.
 
-{{% admonition type="warning" %}}
-
-Since the policy tree is a single resource, provisioning it will overwrite a policy tree created through any other means.
-
-{{< /admonition >}}
+{{< docs/shared lookup="alerts/warning-provisioning-tree.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 1. Find the notification policy tree in Grafana.
 1. [Export](ref:export_policies) and download a provisioning file for your notification policy tree.

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -341,11 +341,7 @@ In this section, we'll create Terraform configurations for each alerting resourc
 
 [Notification policies](ref:notification-policy) defines how to route alert instances to your contact points.
 
-{{% admonition type="warning" %}}
-
-Since the policy tree is a single resource, provisioning the `grafana_notification_policy` resource will overwrite a policy tree created through any other means.
-
-{{< /admonition >}}
+{{< docs/shared lookup="alerts/warning-provisioning-tree.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 1. Find the default notification policy tree. Alternatively, consider writing the resource in code as demonstrated in the example below.
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -1386,6 +1386,8 @@ Status: Conflict
 
 ### <span id="route-put-policy-tree"></span> Sets the notification policy tree. (_RoutePutPolicyTree_)
 
+{{< docs/shared lookup="alerts/warning-provisioning-tree.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ```
 PUT /api/v1/provisioning/policies
 ```

--- a/docs/sources/shared/alerts/warning-provisioning-tree.md
+++ b/docs/sources/shared/alerts/warning-provisioning-tree.md
@@ -1,0 +1,9 @@
+---
+title: 'Warning Provisioning Tree'
+---
+
+{{% admonition type="warning" %}}
+
+Since the policy tree is a single resource, provisioning it will overwrite all policies in the notification policy tree. However, it does not affect internal policies created when alert rules directly select a contact point.
+
+{{< /admonition >}}


### PR DESCRIPTION
Clarify behaviour when provisioning the policy tree:

> Since the policy tree is a single resource, provisioning it will overwrite all policies in the notification policy tree. However, it does not affect internal policies created when alert rules directly select a contact point.


TODOs
- [ ] Update Terraform docs
