### PR TITLE
fix(unified-storage): add missing dashboard legacy_id when in legacy read mode

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -214,6 +214,11 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 				searchFields.Field(resource.SEARCH_FIELD_FOLDER),
 				searchFields.Field(resource.SEARCH_FIELD_TAGS),
 				{
+					Name:        unisearch.DASHBOARD_LEGACY_ID,
+					Type:        resource.ResourceTableColumnDefinition_INT64,
+					Description: "Deprecated legacy id of the dashboard",
+				},
+				{
 					Name: sortByField,
 					Type: resource.ResourceTableColumnDefinition_INT64,
 				},
@@ -270,7 +275,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 
 		list.Results.Rows = append(list.Results.Rows, &resource.ResourceTableRow{
 			Key:   getResourceKey(dashboard, req.Options.Key.Namespace),
-			Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), tags, []byte(strconv.FormatInt(dashboard.SortMeta, 10))},
+			Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), tags, []byte(strconv.FormatInt(dashboard.ID, 10)), []byte(strconv.FormatInt(dashboard.SortMeta, 10))},
 		})
 	}
 
@@ -306,6 +311,7 @@ func formatQueryResult(res []dashboards.DashboardSearchProjection) []*dashboards
 		hit, exists := hits[key]
 		if !exists {
 			hit = &dashboards.DashboardSearchProjection{
+				ID:        item.ID,
 				UID:       item.UID,
 				Title:     item.Title,
 				FolderUID: item.FolderUID,

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -43,8 +43,8 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db", // should set type based off of key
 			Sort:         sorter,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{UID: "uid", Title: "Test Dashboard", FolderUID: "folder1", Term: "term"},
-			{UID: "uid2", Title: "Test Dashboard2", FolderUID: "folder2"},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder1", Term: "term"},
+			{ID: 2, UID: "uid2", Title: "Test Dashboard2", FolderUID: "folder2"},
 		}, nil).Once()
 
 		req := &resource.ResourceSearchRequest{
@@ -73,6 +73,11 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 					searchFields.Field(resource.SEARCH_FIELD_FOLDER),
 					searchFields.Field(resource.SEARCH_FIELD_TAGS),
 					{
+						Name:        unisearch.DASHBOARD_LEGACY_ID,
+						Type:        resource.ResourceTableColumnDefinition_INT64,
+						Description: "Deprecated legacy id of the dashboard",
+					},
+					{
 						Name: "", // sort by should be empty if title is what we sorted by
 						Type: resource.ResourceTableColumnDefinition_INT64,
 					},
@@ -88,6 +93,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 							[]byte("Test Dashboard"),
 							[]byte("folder1"),
 							tags,
+							[]byte("1"),
 							[]byte(strconv.FormatInt(0, 10)),
 						},
 					},
@@ -101,6 +107,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 							[]byte("Test Dashboard2"),
 							[]byte("folder2"),
 							emptyTags,
+							[]byte("2"),
 							[]byte(strconv.FormatInt(0, 10)),
 						},
 					},
@@ -120,7 +127,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db",
 			Sort:         sortOptionAsc,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(50)},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(50)},
 		}, nil).Once()
 
 		req := &resource.ResourceSearchRequest{
@@ -146,6 +153,11 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 					searchFields.Field(resource.SEARCH_FIELD_FOLDER),
 					searchFields.Field(resource.SEARCH_FIELD_TAGS),
 					{
+						Name:        unisearch.DASHBOARD_LEGACY_ID,
+						Type:        resource.ResourceTableColumnDefinition_INT64,
+						Description: "Deprecated legacy id of the dashboard",
+					},
+					{
 						Name: "views_total",
 						Type: resource.ResourceTableColumnDefinition_INT64,
 					},
@@ -161,6 +173,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 							[]byte("Test Dashboard"),
 							[]byte("folder"),
 							emptyTags,
+							[]byte("1"),
 							[]byte(strconv.FormatInt(50, 10)),
 						},
 					},
@@ -180,7 +193,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db",
 			Sort:         sortOptionAsc,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(2)},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(2)},
 		}, nil).Once()
 
 		req := &resource.ResourceSearchRequest{
@@ -206,6 +219,11 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 					searchFields.Field(resource.SEARCH_FIELD_FOLDER),
 					searchFields.Field(resource.SEARCH_FIELD_TAGS),
 					{
+						Name:        unisearch.DASHBOARD_LEGACY_ID,
+						Type:        resource.ResourceTableColumnDefinition_INT64,
+						Description: "Deprecated legacy id of the dashboard",
+					},
+					{
 						Name: "errors_last_30_days",
 						Type: resource.ResourceTableColumnDefinition_INT64,
 					},
@@ -221,6 +239,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 							[]byte("Test Dashboard"),
 							[]byte("folder"),
 							emptyTags,
+							[]byte("1"),
 							[]byte(strconv.FormatInt(2, 10)),
 						},
 					},


### PR DESCRIPTION
We're returning `0` for dashboard ID in modes 1 and 2 instead of the dashboard ID.