### PR TITLE
Frontend Sandbox: Do not perform authenticated queries for non authenticated users

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.test.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.test.ts
@@ -1,5 +1,6 @@
 import { PluginMeta, PluginSignatureStatus, PluginSignatureType } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { getPluginDetails } from '../admin/api';
 import { CatalogPluginDetails } from '../admin/types';
@@ -30,6 +31,7 @@ jest.mock('../admin/api', () => ({
 
 const getPluginSettingsMock = jest.mocked(getPluginSettings);
 const getPluginDetailsMock = jest.mocked(getPluginDetails);
+const mockContextSrv = jest.mocked(contextSrv);
 
 const fakePluginSettings: PluginMeta = {
   id: 'test-plugin',
@@ -45,6 +47,7 @@ describe('Sandbox eligibility checks', () => {
     jest.clearAllMocks();
     getPluginDetailsMock.mockReset();
     getPluginSettingsMock.mockReset();
+    mockContextSrv.isSignedIn = true;
 
     // restore default check
     setSandboxEnabledCheck(isPluginFrontendSandboxEnabled);
@@ -61,6 +64,12 @@ describe('Sandbox eligibility checks', () => {
   test('shouldLoadPluginInFrontendSandbox returns false for Angular plugins', async () => {
     const result = await shouldLoadPluginInFrontendSandbox({ isAngular: true, pluginId: 'test-plugin' });
     expect(result).toBe(false);
+  });
+
+  test('isPluginFrontendSandboxEligible returns false for unsigned users', async () => {
+    mockContextSrv.isSignedIn = false;
+    const isEligible = await isPluginFrontendSandboxEligible({ pluginId: 'test-plugin' });
+    expect(isEligible).toBe(false);
   });
 
   test('shouldLoadPluginInFrontendSandbox returns false when feature toggle is off', async () => {

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader_registry.ts
@@ -1,5 +1,6 @@
 import { PluginSignatureType } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/core';
 
 import { getPluginDetails } from '../admin/api';
 import { getPluginSettings } from '../pluginSettings';
@@ -59,6 +60,10 @@ export async function isPluginFrontendSandboxEligible({
 
   // no sandbox in test mode. it often breaks e2e tests
   if (process.env.NODE_ENV === 'test') {
+    return false;
+  }
+
+  if (!contextSrv.isSignedIn) {
     return false;
   }
 


### PR DESCRIPTION
**What is this feature?**

make sure the frontend sandbox doesn't try to fetch plugin details from authenticated endpoints when the user is not authenticated

**Why do we need this feature?**

To prevent unanthenticathed requests from fetching plugin details

**Who is this feature for?**

All uesrs of dashboards with plugin frontend sandbox enabled

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
