### PR TITLE
Pass BOOL values as real types (int/bool) instead of strings to SQL parameters.

### DIFF
--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -319,7 +319,7 @@ func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.User
 	now := getTime()
 	var affected int64
 	err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-		res, err := dbSession.Exec(sql, userAgent, clientIPStr, hashedToken, s.sqlStore.GetDialect().BooleanStr(false), now.Unix(), token.Id)
+		res, err := dbSession.Exec(sql, userAgent, clientIPStr, hashedToken, s.sqlStore.GetDialect().BooleanValue(false), now.Unix(), token.Id)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/dashboards/database/migrations/folder_uid_migrator.go
+++ b/pkg/services/dashboards/database/migrations/folder_uid_migrator.go
@@ -40,7 +40,7 @@ func (m *FolderUIDMigration) Exec(sess *xorm.Session, mgrtr *migrator.Migrator) 
 		WHERE d.is_folder = ?`
 	}
 
-	r, err := sess.Exec(q, mgrtr.Dialect.BooleanStr(false))
+	r, err := sess.Exec(q, mgrtr.Dialect.BooleanValue(false))
 	if err != nil {
 		mgrtr.Logger.Error("Failed to migrate dashboard folder_uid for dashboards", "error", err)
 		return err
@@ -68,7 +68,7 @@ func (m *FolderUIDMigration) Exec(sess *xorm.Session, mgrtr *migrator.Migrator) 
 		)
 		WHERE is_folder = ?`
 	}
-	r, err = sess.Exec(q, mgrtr.Dialect.BooleanStr(true))
+	r, err = sess.Exec(q, mgrtr.Dialect.BooleanValue(true))
 	if err != nil {
 		mgrtr.Logger.Error("Failed to migrate dashboard folder_uid for folders", "error", err)
 		return err

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -138,7 +138,7 @@ func (ss *SqlStore) GetPrunableProvisionedDataSources(ctx context.Context) ([]*d
 
 	dataSources := make([]*datasources.DataSource, 0)
 	return dataSources, ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		return sess.Where(prunableQuery, ss.db.GetDialect().BooleanStr(true)).Asc("id").Find(&dataSources)
+		return sess.Where(prunableQuery, ss.db.GetDialect().BooleanValue(true)).Asc("id").Find(&dataSources)
 	})
 }
 

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -569,7 +569,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 		}
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")
-		whereParams = append(whereParams, ss.dialect.BooleanStr(false))
+		whereParams = append(whereParams, ss.dialect.BooleanValue(false))
 
 		if query.User == nil {
 			ss.log.Warn("Query user not set for filtering.")

--- a/pkg/services/secrets/database/database.go
+++ b/pkg/services/secrets/database/database.go
@@ -63,7 +63,7 @@ func (ss *SecretsStoreImpl) GetCurrentDataKey(ctx context.Context, label string)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var err error
 		exists, err = sess.Table(ss.table).
-			Where("label = ? AND active = ?", label, ss.db.GetDialect().BooleanStr(true)).
+			Where("label = ? AND active = ?", label, ss.db.GetDialect().BooleanValue(true)).
 			Get(dataKey)
 		return err
 	})
@@ -109,7 +109,7 @@ func (ss *SecretsStoreImpl) CreateDataKey(ctx context.Context, dataKey *secrets.
 func (ss *SecretsStoreImpl) DisableDataKeys(ctx context.Context) error {
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.Table(ss.table).
-			Where("active = ?", ss.db.GetDialect().BooleanStr(true)).
+			Where("active = ?", ss.db.GetDialect().BooleanValue(true)).
 			UseBool("active").Update(&secrets.DataKey{Active: false})
 		return err
 	})

--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -169,7 +169,7 @@ func (s *ServiceAccountsStoreImpl) DeleteServiceAccount(ctx context.Context, org
 func (s *ServiceAccountsStoreImpl) deleteServiceAccount(sess *db.Session, orgId, serviceAccountId int64) error {
 	user := user.User{}
 	has, err := sess.Where(`org_id = ? and id = ? and is_service_account = ?`,
-		orgId, serviceAccountId, s.sqlStore.GetDialect().BooleanStr(true)).Get(&user)
+		orgId, serviceAccountId, s.sqlStore.GetDialect().BooleanValue(true)).Get(&user)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (s *ServiceAccountsStoreImpl) SearchOrgServiceAccounts(ctx context.Context,
 			whereConditions = append(
 				whereConditions,
 				"is_disabled = ?")
-			whereParams = append(whereParams, s.sqlStore.GetDialect().BooleanStr(true))
+			whereParams = append(whereParams, s.sqlStore.GetDialect().BooleanValue(true))
 		case serviceaccounts.FilterOnlyExternal:
 			whereConditions = append(
 				whereConditions,

--- a/pkg/services/serviceaccounts/database/token_store.go
+++ b/pkg/services/serviceaccounts/database/token_store.go
@@ -96,7 +96,7 @@ func (s *ServiceAccountsStoreImpl) RevokeServiceAccountToken(ctx context.Context
 	rawSQL := "UPDATE api_key SET is_revoked = ? WHERE id=? and org_id=? and service_account_id=?"
 
 	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		result, err := sess.Exec(rawSQL, s.sqlStore.GetDialect().BooleanStr(true), tokenId, orgId, serviceAccountId)
+		result, err := sess.Exec(rawSQL, s.sqlStore.GetDialect().BooleanValue(true), tokenId, orgId, serviceAccountId)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -29,6 +29,10 @@ type Dialect interface {
 	SupportEngine() bool
 	LikeStr() string
 	Default(col *Column) string
+	// BooleanValue can be used as an argument in SELECT or INSERT statements. For constructing
+	// raw SQL queries, please use BooleanStr instead.
+	BooleanValue(bool) any
+	// BooleanStr should only be used to construct SQL statements (strings). For arguments to queries, use BooleanValue instead.
 	BooleanStr(bool) string
 	DateTimeFunc(string) string
 	BatchSize() int

--- a/pkg/services/sqlstore/migrator/dialect_test.go
+++ b/pkg/services/sqlstore/migrator/dialect_test.go
@@ -1,9 +1,13 @@
 package migrator
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
 )
 
 func TestInsertQuery(t *testing.T) {
@@ -114,4 +118,79 @@ func TestUpdateQuery(t *testing.T) {
 			require.Equal(t, tc.expectedSQLiteArgs, args, "SQLite args incorrect")
 		})
 	}
+}
+
+const boolTestTableName = "bool_test"
+
+var boolTestTable = Table{
+	Name: boolTestTableName,
+	Columns: []*Column{
+		{Name: "id", Type: DB_Int, IsPrimaryKey: true, IsAutoIncrement: true},
+		{Name: "name", Type: DB_Text},
+		{Name: "value", Type: DB_Bool},
+	},
+}
+
+func setupTestDB(t *testing.T) (Dialect, *xorm.Engine) {
+	t.Helper()
+	dbType := sqlutil.GetTestDBType()
+	testDB, err := sqlutil.GetTestDB(dbType)
+	require.NoError(t, err)
+
+	t.Cleanup(testDB.Cleanup)
+
+	x, err := xorm.NewEngine(testDB.DriverName, testDB.ConnStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := x.Close(); err != nil {
+			fmt.Printf("failed to close xorm engine: %v", err)
+		}
+	})
+
+	exists, err := x.IsTableExist(boolTestTableName)
+	require.NoError(t, err)
+
+	d := NewDialect(testDB.DriverName)
+	if !exists {
+		_, err := x.Exec(NewAddTableMigration(boolTestTable).SQL(d))
+		require.NoError(t, err)
+	} else {
+		_, err := x.Exec("DELETE FROM " + boolTestTableName + " WHERE true")
+		require.NoError(t, err)
+	}
+
+	return d, x
+}
+
+func TestIntegration_Dialect(t *testing.T) {
+	d, x := setupTestDB(t)
+
+	t.Run("bool values", func(t *testing.T) {
+		tv := &BoolTest{Name: "true value", Value: true}
+		_, err := x.Insert(tv)
+		require.NoError(t, err)
+
+		fv := &BoolTest{Name: "false value", Value: false}
+		_, err = x.Insert(fv)
+		require.NoError(t, err)
+
+		var found []*BoolTest
+		require.NoError(t, x.Where("value = ?", d.BooleanValue(true)).Find(&found))
+		require.Len(t, found, 1)
+		require.True(t, found[0].Value)
+		require.Equal(t, tv.ID, found[0].ID)
+
+		found = nil
+		require.NoError(t, x.Where("value = ?", d.BooleanValue(false)).Find(&found))
+		require.Len(t, found, 1)
+		require.False(t, found[0].Value)
+		require.Equal(t, fv.ID, found[0].ID)
+	})
+}
+
+type BoolTest struct {
+	ID    int `xorm:"pk autoincr 'id'"`
+	Name  string
+	Value bool
 }

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/VividCortex/mysqlerr"
 	"github.com/go-sql-driver/mysql"
+
 	"xorm.io/xorm"
 )
 
@@ -33,6 +34,13 @@ func (db *MySQLDialect) Quote(name string) string {
 
 func (db *MySQLDialect) AutoIncrStr() string {
 	return "AUTO_INCREMENT"
+}
+
+func (db *MySQLDialect) BooleanValue(value bool) interface{} {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func (db *MySQLDialect) BooleanStr(value bool) string {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
+
 	"xorm.io/xorm"
 )
 
@@ -36,6 +37,10 @@ func (db *PostgresDialect) LikeStr() string {
 
 func (db *PostgresDialect) AutoIncrStr() string {
 	return ""
+}
+
+func (db *PostgresDialect) BooleanValue(value bool) any {
+	return value
 }
 
 func (db *PostgresDialect) BooleanStr(value bool) string {

--- a/pkg/services/sqlstore/migrator/spanner_dialect.go
+++ b/pkg/services/sqlstore/migrator/spanner_dialect.go
@@ -55,6 +55,11 @@ func (s *SpannerDialect) SQLType(col *Column) string {
 }
 
 func (s *SpannerDialect) BatchSize() int { return 1000 }
+
+func (s *SpannerDialect) BooleanValue(b bool) any {
+	return b
+}
+
 func (s *SpannerDialect) BooleanStr(b bool) string {
 	if b {
 		return "true"

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-sqlite3"
+
 	"xorm.io/xorm"
 )
 
@@ -30,6 +31,13 @@ func (db *SQLite3) Quote(name string) string {
 
 func (db *SQLite3) AutoIncrStr() string {
 	return "AUTOINCREMENT"
+}
+
+func (db *SQLite3) BooleanValue(value bool) any {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func (db *SQLite3) BooleanStr(value bool) string {

--- a/pkg/services/ssosettings/database/database_test.go
+++ b/pkg/services/ssosettings/database/database_test.go
@@ -479,11 +479,11 @@ func populateSSOSettings(sqlStore db.DB, template models.SSOSettings, providers 
 
 func getSSOSettingsCountByDeleted(sqlStore db.DB) (deleted, notDeleted int64, err error) {
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		deleted, err = sess.Table("sso_setting").Where("is_deleted = ?", sqlStore.GetDialect().BooleanStr(true)).Count()
+		deleted, err = sess.Table("sso_setting").Where("is_deleted = ?", sqlStore.GetDialect().BooleanValue(true)).Count()
 		if err != nil {
 			return err
 		}
-		notDeleted, err = sess.Table("sso_setting").Where("is_deleted = ?", sqlStore.GetDialect().BooleanStr(false)).Count()
+		notDeleted, err = sess.Table("sso_setting").Where("is_deleted = ?", sqlStore.GetDialect().BooleanValue(false)).Count()
 		return err
 	})
 
@@ -495,7 +495,7 @@ func getSSOSettingsByProvider(sqlStore db.DB, provider string, deleted bool) (*m
 	var err error
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		_, err = sess.Table("sso_setting").Where("provider = ? AND is_deleted = ?", provider, sqlStore.GetDialect().BooleanStr(deleted)).Get(&model)
+		_, err = sess.Table("sso_setting").Where("provider = ? AND is_deleted = ?", provider, sqlStore.GetDialect().BooleanValue(deleted)).Get(&model)
 		return err
 	})
 

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -166,8 +166,8 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		}
 		// currently not supported when dashboards are in unified storage
 		if !ss.features.IsEnabledGlobally(featuremgmt.FlagKubernetesClientDashboardsFolders) {
-			sb.Write(`(SELECT SUM(LENGTH(data)) FROM `+dialect.Quote("dashboard")+` WHERE is_folder = ?) AS dashboard_bytes_total,`, dialect.BooleanStr(false))
-			sb.Write(`(SELECT MAX(LENGTH(data)) FROM `+dialect.Quote("dashboard")+` WHERE is_folder = ?) AS dashboard_bytes_max,`, dialect.BooleanStr(false))
+			sb.Write(`(SELECT SUM(LENGTH(data)) FROM `+dialect.Quote("dashboard")+` WHERE is_folder = ?) AS dashboard_bytes_total,`, dialect.BooleanValue(false))
+			sb.Write(`(SELECT MAX(LENGTH(data)) FROM `+dialect.Quote("dashboard")+` WHERE is_folder = ?) AS dashboard_bytes_max,`, dialect.BooleanValue(false))
 		}
 
 		sb.Write(ss.roleCounterSQL(ctx))

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -521,7 +521,7 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 		sess.Join("INNER", "team", "team.id=team_member.team_id")
 
 		// explicitly check for serviceaccounts
-		sess.Where(fmt.Sprintf("%s.is_service_account=?", ss.db.GetDialect().Quote("user")), ss.db.GetDialect().BooleanStr(false))
+		sess.Where(fmt.Sprintf("%s.is_service_account=?", ss.db.GetDialect().Quote("user")), ss.db.GetDialect().BooleanValue(false))
 
 		if acUserFilter != nil {
 			sess.Where(acUserFilter.Where, acUserFilter.Args...)
@@ -549,7 +549,7 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 			sess.Where("team_member.user_id=?", query.UserID)
 		}
 		if query.External {
-			sess.Where("team_member.external=?", ss.db.GetDialect().BooleanStr(true))
+			sess.Where("team_member.external=?", ss.db.GetDialect().BooleanValue(true))
 		}
 		sess.Cols(
 			"team_member.org_id",

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -468,7 +468,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		sess := dbSess.Table("user").Alias("u")
 
 		whereConditions = append(whereConditions, "u.is_service_account = ?")
-		whereParams = append(whereParams, ss.dialect.BooleanStr(false))
+		whereParams = append(whereParams, ss.dialect.BooleanValue(false))
 
 		// Join with only most recent auth module
 		joinCondition := `(


### PR DESCRIPTION
Spanner requires values of type `bool` (Go type) to be used for BOOL typed columns. This PR fixes two places where that was not true before. (Error: `No matching signature for operator = for argument types: BOOL, STRING`)

Fixes following integration tests when running with Spanner:

* TestIntegrationDataAccess:
    * GetDataSourcesByType/Get_prunable_data_sources
* TestIntegrationUserAuthToken:
    * expires_correctly
    * can_properly_rotate_tokens
    * keeps_prev_token_valid_for_1_minute_after_it_is_confirmed
* TestIntegrationDashboardDataAccess:
  * Can_count_dashboards_by_parent_folder
* TestIntegration_SQLStore_GetOrgUsers:
  * should_return_all_users
  * should_return_no_users
  * should_return_some_users
* TestIntegrationStore_DeleteServiceAccount:
  * service_accounts_should_exist_and_get_deleted
  * service_accounts_is_false_should_not_delete_the_user
* TestStore_RevokeServiceAccountToken
* TestIntegrationSQLStore_GetTeamMembers_ACFilter
  * should_return_all_team_members
  * should_return_no_team_members
  * should_return_some_team_members
* TestIntegrationUserDataAccess
  * multiple tests
