### PR TITLE
Alerting: Set MissingSeriesEvalsToResolve to 1 for Prometheus-imported rules

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -241,6 +241,12 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 		RuleGroup:    promGroup.Name,
 		IsPaused:     isPaused,
 		Record:       record,
+
+		// MissingSeriesEvalsToResolve is set to 1 to match the Prometheus behaviour.
+		// Prometheus resolves alerts as soon as the series disappears.
+		// By setting this value to 1 we ensure that the alert is resolved on the first evaluation
+		// that doesn't have the series.
+		MissingSeriesEvalsToResolve: util.Pointer(1),
 	}
 
 	if p.cfg.KeepOriginalRuleDefinition != nil && *p.cfg.KeepOriginalRuleDefinition {

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -280,6 +280,7 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 
 				require.Equal(t, models.Duration(evalOffset), grafanaRule.Data[0].RelativeTimeRange.To)
 				require.Equal(t, models.Duration(10*time.Minute+evalOffset), grafanaRule.Data[0].RelativeTimeRange.From)
+				require.Equal(t, util.Pointer(1), grafanaRule.MissingSeriesEvalsToResolve)
 
 				originalRuleDefinition, err := yaml.Marshal(promRule)
 				require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Set MissingSeriesEvalsToResolve to 1 for rules imported from Prometheus.

**Why do we need this feature?**

Alert rules imported from Prometheus should resolve immediately when the series disappears, to match Prometheus behaviour.

Part of https://github.com/grafana/alerting-squad/issues/987
