### PR TITLE
Alerting: Allow administrators delete rules permanently via UI

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -420,6 +420,14 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *contextmodel.ReqContext, ruleGro
 	return srv.updateAlertRulesInGroup(c, groupKey, rules, deletePermanently)
 }
 
+func (srv RulerSrv) RouteDeleteAlertRuleFromTrashByGUID(ctx *contextmodel.ReqContext, guid string) response.Response {
+	_, err := srv.store.DeleteRuleFromTrashByGUID(ctx.Req.Context(), ctx.SignedInUser.GetOrgID(), guid)
+	if err != nil {
+		return ErrResp(http.StatusInternalServerError, err, "failed to delete rule from trash")
+	}
+	return response.Empty(http.StatusOK)
+}
+
 func (srv RulerSrv) checkGroupLimits(group apimodels.PostableRuleGroupConfig) error {
 	if srv.cfg.RulesPerRuleGroupLimit > 0 && int64(len(group.Rules)) > srv.cfg.RulesPerRuleGroupLimit {
 		srv.log.Warn("Large rule group was edited. Large groups are discouraged and may be rejected in the future.",

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -643,6 +643,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			NotificationSettings: AlertRuleNotificationSettingsFromNotificationSettings(r.NotificationSettings),
 			Record:               ApiRecordFromModelRecord(r.Record),
 			Metadata:             AlertRuleMetadataFromModelMetadata(r.Metadata),
+			GUID:                 r.GUID,
 		},
 	}
 	forDuration := model.Duration(r.For)

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -74,6 +74,14 @@ var ignoreFieldsForValidate = [...]string{"RuleGroupIndex"}
 // Returns http.StatusForbidden if user does not have access to any of the rules that match the filter.
 // Returns http.StatusBadRequest if all rules that match the filter and the user is authorized to delete are provisioned.
 func (srv RulerSrv) RouteDeleteAlertRules(c *contextmodel.ReqContext, namespaceUID string, group string) response.Response {
+	var permanently bool
+	if c.QueryBool("deletePermanently") {
+		if !c.SignedInUser.HasRole(identity.RoleAdmin) {
+			return ErrResp(http.StatusForbidden, errors.New("only administrators can delete rules permanently"), "")
+		}
+		permanently = true
+	}
+
 	namespace, err := srv.store.GetNamespaceByUID(c.Req.Context(), namespaceUID, c.SignedInUser.GetOrgID(), c.SignedInUser)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -157,7 +165,7 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *contextmodel.ReqContext, namespaceU
 			rulesToDelete = append(rulesToDelete, uid...)
 		}
 		if len(rulesToDelete) > 0 {
-			err := srv.store.DeleteAlertRulesByUID(ctx, c.SignedInUser.GetOrgID(), ngmodels.NewUserUID(c.SignedInUser), rulesToDelete...)
+			err := srv.store.DeleteAlertRulesByUID(ctx, c.SignedInUser.GetOrgID(), ngmodels.NewUserUID(c.SignedInUser), permanently, rulesToDelete...)
 			if err != nil {
 				return err
 			}
@@ -381,6 +389,14 @@ func (srv RulerSrv) RouteGetRuleVersionsByUID(c *contextmodel.ReqContext, ruleUI
 }
 
 func (srv RulerSrv) RoutePostNameRulesConfig(c *contextmodel.ReqContext, ruleGroupConfig apimodels.PostableRuleGroupConfig, namespaceUID string) response.Response {
+	var deletePermanently bool
+	if c.QueryBool("deletePermanently") {
+		if !c.SignedInUser.HasRole(identity.RoleAdmin) {
+			return ErrResp(http.StatusForbidden, errors.New("only administrators can delete rules permanently"), "")
+		}
+		deletePermanently = true
+	}
+
 	namespace, err := srv.store.GetNamespaceByUID(c.Req.Context(), namespaceUID, c.SignedInUser.GetOrgID(), c.SignedInUser)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -401,7 +417,7 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *contextmodel.ReqContext, ruleGro
 		RuleGroup:    ruleGroupConfig.Name,
 	}
 
-	return srv.updateAlertRulesInGroup(c, groupKey, rules)
+	return srv.updateAlertRulesInGroup(c, groupKey, rules, deletePermanently)
 }
 
 func (srv RulerSrv) checkGroupLimits(group apimodels.PostableRuleGroupConfig) error {
@@ -420,7 +436,7 @@ func (srv RulerSrv) checkGroupLimits(group apimodels.PostableRuleGroupConfig) er
 // All operations are performed in a single transaction
 //
 //nolint:gocyclo
-func (srv RulerSrv) updateAlertRulesInGroup(c *contextmodel.ReqContext, groupKey ngmodels.AlertRuleGroupKey, rules []*ngmodels.AlertRuleWithOptionals) response.Response {
+func (srv RulerSrv) updateAlertRulesInGroup(c *contextmodel.ReqContext, groupKey ngmodels.AlertRuleGroupKey, rules []*ngmodels.AlertRuleWithOptionals, deletePermanently bool) response.Response {
 	var finalChanges *store.GroupDelta
 	var dbConfig *ngmodels.AlertConfiguration
 	err := srv.xactManager.InTransaction(c.Req.Context(), func(tranCtx context.Context) error {
@@ -481,7 +497,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *contextmodel.ReqContext, groupKey
 				UIDs = append(UIDs, rule.UID)
 			}
 
-			if err = srv.store.DeleteAlertRulesByUID(tranCtx, c.SignedInUser.GetOrgID(), ngmodels.NewUserUID(c.SignedInUser), UIDs...); err != nil {
+			if err = srv.store.DeleteAlertRulesByUID(tranCtx, c.SignedInUser.GetOrgID(), ngmodels.NewUserUID(c.SignedInUser), deletePermanently, UIDs...); err != nil {
 				return fmt.Errorf("failed to delete rules: %w", err)
 			}
 		}

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -421,9 +421,12 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *contextmodel.ReqContext, ruleGro
 }
 
 func (srv RulerSrv) RouteDeleteAlertRuleFromTrashByGUID(ctx *contextmodel.ReqContext, guid string) response.Response {
-	_, err := srv.store.DeleteRuleFromTrashByGUID(ctx.Req.Context(), ctx.SignedInUser.GetOrgID(), guid)
+	deleted, err := srv.store.DeleteRuleFromTrashByGUID(ctx.Req.Context(), ctx.SignedInUser.GetOrgID(), guid)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to delete rule from trash")
+	}
+	if deleted == 0 {
+		return response.Empty(http.StatusNotFound)
 	}
 	return response.Empty(http.StatusOK)
 }

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -60,7 +60,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 		deleteCommands := getRecordedCommand(ruleStore)
 		require.Len(t, deleteCommands, 1)
 		cmd := deleteCommands[0]
-		actualUIDs := cmd.Params[2].([]string)
+		actualUIDs := cmd.Params[3].([]string)
 		require.Len(t, actualUIDs, len(expectedRules))
 		for _, rule := range expectedRules {
 			require.Containsf(t, actualUIDs, rule.UID, "Rule %s was expected to be deleted but it wasn't", rule.UID)

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -65,6 +65,8 @@ func (api *API) authorize(method, path string) web.Handler {
 				ac.EvalPermission(ac.ActionAlertingRuleDelete, scope),
 			),
 		)
+	case http.MethodDelete + "/api/ruler/grafana/api/v1/trash/rule/guid/{RuleGUID}":
+		return middleware.ReqOrgAdmin
 
 	// Grafana rule state history paths
 	case http.MethodGet + "/api/v1/rules/history":

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -41,7 +41,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 66)
+	require.Len(t, paths, 67)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac, FeatureManager: featuremgmt.WithFeatures()}

--- a/pkg/services/ngalert/api/forking_ruler.go
+++ b/pkg/services/ngalert/api/forking_ruler.go
@@ -128,3 +128,7 @@ func (f *RulerApiHandler) getService(ctx *contextmodel.ReqContext) (*LotexRuler,
 func (f *RulerApiHandler) handleRouteGetRuleVersionsByUID(ctx *contextmodel.ReqContext, ruleUID string) response.Response {
 	return f.GrafanaRuler.RouteGetRuleVersionsByUID(ctx, ruleUID)
 }
+
+func (f *RulerApiHandler) handleRouteDeleteRuleFromTrashByGUID(ctx *contextmodel.ReqContext, ruleGUID string) response.Response {
+	return f.GrafanaRuler.RouteDeleteAlertRuleFromTrashByGUID(ctx, ruleGUID)
+}

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -29,7 +29,7 @@ type RuleStore interface {
 	// and return the map of uuid to id.
 	InsertAlertRules(ctx context.Context, user *ngmodels.UserUID, rules []ngmodels.AlertRule) ([]ngmodels.AlertRuleKeyWithId, error)
 	UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, rules []ngmodels.UpdateRule) error
-	DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *ngmodels.UserUID, ruleUID ...string) error
+	DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *ngmodels.UserUID, permanently bool, ruleUID ...string) error
 
 	// IncreaseVersionForAllRulesInNamespaces Increases version for all rules that have specified namespace uids
 	IncreaseVersionForAllRulesInNamespaces(ctx context.Context, orgID int64, namespaceUIDs []string) ([]ngmodels.AlertRuleKeyWithVersion, error)

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -30,6 +30,7 @@ type RuleStore interface {
 	InsertAlertRules(ctx context.Context, user *ngmodels.UserUID, rules []ngmodels.AlertRule) ([]ngmodels.AlertRuleKeyWithId, error)
 	UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, rules []ngmodels.UpdateRule) error
 	DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *ngmodels.UserUID, permanently bool, ruleUID ...string) error
+	DeleteRuleFromTrashByGUID(ctx context.Context, orgID int64, ruleGUID string) (int64, error)
 
 	// IncreaseVersionForAllRulesInNamespaces Increases version for all rules that have specified namespace uids
 	IncreaseVersionForAllRulesInNamespaces(ctx context.Context, orgID int64, namespaceUIDs []string) ([]ngmodels.AlertRuleKeyWithVersion, error)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -396,6 +396,9 @@
     },
     "metric": {
      "type": "string"
+    },
+    "targetDatasourceUid": {
+     "type": "string"
     }
    },
    "title": "Record is the provisioned export of models.Record.",
@@ -1605,6 +1608,9 @@
       "Alerting",
       "Error"
      ],
+     "type": "string"
+    },
+    "guid": {
      "type": "string"
     },
     "intervalSeconds": {
@@ -3492,6 +3498,11 @@
      "description": "Name of the recorded metric.",
      "example": "grafana_alerts_ratio",
      "type": "string"
+    },
+    "target_datasource_uid": {
+     "description": "Which data source should be used to write the output of the recording rule, specified by UID.",
+     "example": "my-prom",
+     "type": "string"
     }
    },
    "required": [
@@ -4355,6 +4366,15 @@
      "description": "Name of the associated template definition for this result.",
      "type": "string"
     },
+    "scope": {
+     "description": "Scope that was successfully used to interpolate the template. If the root scope \".\" fails, more specific\nscopes will be tried, such as \".Alerts', or \".Alert\".",
+     "enum": [
+      ".",
+      ".Alerts",
+      ".Alert"
+     ],
+     "type": "string"
+    },
     "text": {
      "description": "Interpolated value of the template.",
      "type": "string"
@@ -4493,6 +4513,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4528,7 +4549,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -5056,6 +5077,7 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence",
     "type": "object"

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -590,6 +590,7 @@ type GettableGrafanaRule struct {
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings,omitempty" yaml:"notification_settings,omitempty"`
 	Record               *Record                        `json:"record,omitempty" yaml:"record,omitempty"`
 	Metadata             *AlertRuleMetadata             `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	GUID                 string                         `json:"guid" yaml:"guid"`
 }
 
 // UserInfo represents user-related information, including a unique identifier and a name.

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -20,6 +20,18 @@ import (
 //       403: ForbiddenError
 //       404: description: Not found.
 
+// swagger:route Delete /ruler/grafana/api/v1/trash/rule/guid/{RuleGUID} ruler RouteDeleteRuleFromTrashByGUID
+//
+// Permanently delete a rule from trash by GUID
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       202: Ack
+//       403: ForbiddenError
+//       404: description: Not found.
+
 // swagger:route Get /ruler/grafana/api/v1/rule/{RuleUID}/versions ruler RouteGetRuleVersionsByUID
 //
 // Get rule versions by UID
@@ -235,6 +247,12 @@ type PathGetRulesParams struct {
 type PathGetRuleByUIDParams struct {
 	// in: path
 	RuleUID string
+}
+
+// swagger:parameters RouteDeleteRuleFromTrashByGUID
+type PathDeleteRuleFromTrashByGUIDParams struct {
+	// in: path
+	RuleGUID string
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -396,6 +396,9 @@
     },
     "metric": {
      "type": "string"
+    },
+    "targetDatasourceUid": {
+     "type": "string"
     }
    },
    "title": "Record is the provisioned export of models.Record.",
@@ -1605,6 +1608,9 @@
       "Alerting",
       "Error"
      ],
+     "type": "string"
+    },
+    "guid": {
      "type": "string"
     },
     "intervalSeconds": {
@@ -3492,6 +3498,11 @@
      "description": "Name of the recorded metric.",
      "example": "grafana_alerts_ratio",
      "type": "string"
+    },
+    "target_datasource_uid": {
+     "description": "Which data source should be used to write the output of the recording rule, specified by UID.",
+     "example": "my-prom",
+     "type": "string"
     }
    },
    "required": [
@@ -4355,6 +4366,15 @@
      "description": "Name of the associated template definition for this result.",
      "type": "string"
     },
+    "scope": {
+     "description": "Scope that was successfully used to interpolate the template. If the root scope \".\" fails, more specific\nscopes will be tried, such as \".Alerts', or \".Alert\".",
+     "enum": [
+      ".",
+      ".Alerts",
+      ".Alert"
+     ],
+     "type": "string"
+    },
     "text": {
      "description": "Interpolated value of the template.",
      "type": "string"
@@ -4493,7 +4513,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4529,7 +4548,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -5058,7 +5077,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence",
     "type": "object"
@@ -7465,6 +7483,43 @@
       "schema": {
        "$ref": "#/definitions/NotFound"
       }
+     }
+    },
+    "tags": [
+     "ruler"
+    ]
+   }
+  },
+  "/ruler/grafana/api/v1/trash/rule/guid/{RuleGUID}": {
+   "delete": {
+    "description": "Permanently delete a rule from trash by GUID",
+    "operationId": "RouteDeleteRuleFromTrashByGUID",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "RuleGUID",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "404": {
+      "description": " Not found."
      }
     },
     "tags": [

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2173,6 +2173,43 @@
         }
       }
     },
+    "/ruler/grafana/api/v1/trash/rule/guid/{RuleGUID}": {
+      "delete": {
+        "description": "Permanently delete a rule from trash by GUID",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "ruler"
+        ],
+        "operationId": "RouteDeleteRuleFromTrashByGUID",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "RuleGUID",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "403": {
+            "description": "ForbiddenError",
+            "schema": {
+              "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "404": {
+            "description": " Not found."
+          }
+        }
+      }
+    },
     "/ruler/{DatasourceUID}/api/v1/rules": {
       "get": {
         "description": "List rule groups",
@@ -4584,6 +4621,9 @@
         },
         "metric": {
           "type": "string"
+        },
+        "targetDatasourceUid": {
+          "type": "string"
         }
       }
     },
@@ -5794,6 +5834,9 @@
             "Alerting",
             "Error"
           ]
+        },
+        "guid": {
+          "type": "string"
         },
         "intervalSeconds": {
           "type": "integer",
@@ -7685,6 +7728,11 @@
           "description": "Name of the recorded metric.",
           "type": "string",
           "example": "grafana_alerts_ratio"
+        },
+        "target_datasource_uid": {
+          "description": "Which data source should be used to write the output of the recording rule, specified by UID.",
+          "type": "string",
+          "example": "my-prom"
         }
       }
     },
@@ -8544,6 +8592,15 @@
           "description": "Name of the associated template definition for this result.",
           "type": "string"
         },
+        "scope": {
+          "description": "Scope that was successfully used to interpolate the template. If the root scope \".\" fails, more specific\nscopes will be tried, such as \".Alerts', or \".Alert\".",
+          "type": "string",
+          "enum": [
+            ".",
+            ".Alerts",
+            ".Alert"
+          ]
+        },
         "text": {
           "description": "Interpolated value of the template.",
           "type": "string"
@@ -8681,9 +8738,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -9246,7 +9302,6 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "type": "object",

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -782,7 +782,7 @@ func (service *AlertRuleService) deleteRules(ctx context.Context, user identity.
 			uids = append(uids, tgt.UID)
 		}
 	}
-	if err := service.ruleStore.DeleteAlertRulesByUID(ctx, user.GetOrgID(), models.NewUserUID(user), uids...); err != nil {
+	if err := service.ruleStore.DeleteAlertRulesByUID(ctx, user.GetOrgID(), models.NewUserUID(user), false, uids...); err != nil {
 		return err
 	}
 	for _, uid := range uids {

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -2103,7 +2103,7 @@ func getDeletedRules(t *testing.T, ruleStore *fakes.RuleStore) []deleteRuleOpera
 			uid = string(*userUID)
 		}
 
-		uids, ok := q.Params[2].([]string)
+		uids, ok := q.Params[3].([]string)
 		require.True(t, ok, "uids parameter should be []string")
 
 		operations = append(operations, deleteRuleOperation{

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -35,7 +35,7 @@ type RuleStore interface {
 	GetRuleGroupInterval(ctx context.Context, orgID int64, namespaceUID string, ruleGroup string) (int64, error)
 	InsertAlertRules(ctx context.Context, user *models.UserUID, rule []models.AlertRule) ([]models.AlertRuleKeyWithId, error)
 	UpdateAlertRules(ctx context.Context, user *models.UserUID, rule []models.UpdateRule) error
-	DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *models.UserUID, ruleUID ...string) error
+	DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *models.UserUID, permanently bool, ruleUID ...string) error
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *models.GetAlertRulesGroupByRuleUIDQuery) ([]*models.AlertRule, error)
 }
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -745,7 +745,7 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 			called = true
 			return nil
 		}
-		err := store.DeleteAlertRulesByUID(context.Background(), rule.OrgID, &models.AlertingUserUID, rule.UID)
+		err := store.DeleteAlertRulesByUID(context.Background(), rule.OrgID, &models.AlertingUserUID, false, rule.UID)
 		require.NoError(t, err)
 		require.True(t, called)
 	})
@@ -772,7 +772,7 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		require.Len(t, savedInstances, 1)
 
 		// Delete the rule
-		err = store.DeleteAlertRulesByUID(context.Background(), rule.OrgID, &models.AlertingUserUID, rule.UID)
+		err = store.DeleteAlertRulesByUID(context.Background(), rule.OrgID, &models.AlertingUserUID, false, rule.UID)
 		require.NoError(t, err)
 
 		// Now there should be no alert rule state
@@ -820,7 +820,7 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, versions, 2)
 
-		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), uids...)
+		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), false, uids...)
 		require.NoError(t, err)
 
 		guids := make([]string, 0, len(rules))
@@ -887,7 +887,7 @@ func TestIntegration_DeleteAlertRulesByUID(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, versions, 2)
 
-		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), uids...)
+		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), false, uids...)
 		require.NoError(t, err)
 
 		guids := make([]string, 0, len(rules))
@@ -2055,7 +2055,7 @@ func TestIntegration_ListDeletedRules(t *testing.T) {
 		require.Empty(t, list)
 	})
 
-	err = store.DeleteAlertRulesByUID(context.Background(), orgID, &models.AlertingUserUID, rule.UID)
+	err = store.DeleteAlertRulesByUID(context.Background(), orgID, &models.AlertingUserUID, false, rule.UID)
 	require.NoError(t, err)
 
 	t.Run("should return the last deleted rule", func(t *testing.T) {
@@ -2113,7 +2113,7 @@ func TestIntegration_CleanUpDeletedAlertRules(t *testing.T) {
 		TimeNow = func() time.Time {
 			return t0.Add(time.Duration(idx) * 10 * time.Second)
 		}
-		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), uid)
+		err = store.DeleteAlertRulesByUID(context.Background(), orgID, util.Pointer(models.UserUID("test")), false, uid)
 		require.NoError(t, err)
 	}
 

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -103,7 +103,7 @@ func (f *RuleStore) GetRecordedCommands(predicate func(cmd any) (any, bool)) []a
 	return result
 }
 
-func (f *RuleStore) DeleteAlertRulesByUID(_ context.Context, orgID int64, user *models.UserUID, UIDs ...string) error {
+func (f *RuleStore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *models.UserUID, permanently bool, ruleUID ...string) error {
 	f.RecordedOps = append(f.RecordedOps, GenericRecordedQuery{
 		Name:   "DeleteAlertRulesByUID",
 		Params: []any{orgID, user, UIDs},

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -130,6 +130,14 @@ func (f *RuleStore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user
 	return nil
 }
 
+func (f *RuleStore) DeleteRuleFromTrashByGUID(ctx context.Context, orgID int64, ruleGUID string) (int64, error) {
+	f.RecordedOps = append(f.RecordedOps, GenericRecordedQuery{
+		Name:   "DeleteRuleFromTrashByGUID",
+		Params: []any{orgID, ruleGUID},
+	})
+	return 0, nil
+}
+
 func (f *RuleStore) GetAlertRuleByUID(_ context.Context, q *models.GetAlertRuleByUIDQuery) (*models.AlertRule, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -103,10 +103,10 @@ func (f *RuleStore) GetRecordedCommands(predicate func(cmd any) (any, bool)) []a
 	return result
 }
 
-func (f *RuleStore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *models.UserUID, permanently bool, ruleUID ...string) error {
+func (f *RuleStore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user *models.UserUID, permanently bool, UIDs ...string) error {
 	f.RecordedOps = append(f.RecordedOps, GenericRecordedQuery{
 		Name:   "DeleteAlertRulesByUID",
-		Params: []any{orgID, user, UIDs},
+		Params: []any{orgID, user, permanently, UIDs},
 	})
 
 	rules := f.Rules[orgID]

--- a/pkg/tests/api/alerting/api_alertmanager_silence_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_silence_test.go
@@ -60,10 +60,10 @@ func TestIntegrationSilenceAuth(t *testing.T) {
 	group1 := generateAlertRuleGroup(1, alertRuleGen())
 	group2 := generateAlertRuleGroup(1, alertRuleGen())
 
-	respModel, status, _ := adminApiClient.PostRulesGroupWithStatus(t, f1.UID, &group1)
+	respModel, status, _ := adminApiClient.PostRulesGroupWithStatus(t, f1.UID, &group1, false)
 	require.Equal(t, http.StatusAccepted, status)
 	ruleInFolder1UID := respModel.Created[0]
-	respModel, status, _ = adminApiClient.PostRulesGroupWithStatus(t, f2.UID, &group2)
+	respModel, status, _ = adminApiClient.PostRulesGroupWithStatus(t, f2.UID, &group2, false)
 	require.Equal(t, http.StatusAccepted, status)
 	ruleInFolder2UID := respModel.Created[0]
 

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -69,7 +69,7 @@ func createRuleWithNotificationSettings(t *testing.T, client apiClient, folder s
 			},
 		},
 	}
-	resp, status, _ := client.PostRulesGroupWithStatus(t, folder, &rules)
+	resp, status, _ := client.PostRulesGroupWithStatus(t, folder, &rules, false)
 	assert.Equal(t, http.StatusAccepted, status)
 	require.Len(t, resp.Created, 1)
 	return rules, resp.Created[0]

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4775,7 +4775,7 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 		idx := slices.IndexFunc(rules[""][0].Rules, func(node apimodels.GettableExtendedRuleNode) bool {
 			return node.GrafanaManagedAlert.GUID == ruleGUID
 		})
-		require.Equalf(t, -1, idx, "rule with is expected to be deleted but it was returned by list operation")
+		require.Equalf(t, -1, idx, "rule is expected to be deleted but it was returned by list operation")
 	})
 }
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -128,6 +128,7 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 				"GrafanaManagedAlert.Data.Model",
 				"GrafanaManagedAlert.NamespaceUID",
 				"GrafanaManagedAlert.NamespaceID",
+				"GrafanaManagedAlert.GUID",
 			}
 
 			// compare expected and actual and ignore the dynamic fields
@@ -449,6 +450,7 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 				"GrafanaManagedAlert.Data.Model",
 				"GrafanaManagedAlert.NamespaceUID",
 				"GrafanaManagedAlert.NamespaceID",
+				"GrafanaManagedAlert.GUID",
 			}
 
 			// compare expected and actual and ignore the dynamic fields
@@ -1180,6 +1182,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"is_paused": false,
 				"version": 1,
 				"uid": "uid",
+				"guid": "guid",
 				"namespace_uid": "nsuid",
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "NoData",
@@ -1221,6 +1224,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"is_paused": false,
 				"version": 1,
 				"uid": "uid",
+				"guid": "guid",
 				"namespace_uid": "nsuid",
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "Alerting",
@@ -1274,6 +1278,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"is_paused": false,
 				"version": 1,
 				"uid": "uid",
+				"guid": "guid",
 				"namespace_uid": "nsuid",
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "NoData",
@@ -1640,6 +1645,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 				"GrafanaManagedAlert.UID",
 				"GrafanaManagedAlert.ID",
 				"GrafanaManagedAlert.NamespaceID",
+				"GrafanaManagedAlert.GUID",
 			}
 
 			// compare expected and actual and ignore the dynamic fields
@@ -2575,6 +2581,7 @@ func TestIntegrationQuota(t *testing.T) {
 						  "is_paused": false,
 						  "version":2,
 						  "uid":"uid",
+						  "guid": "guid",
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
@@ -2688,6 +2695,7 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 									"is_paused": false,
 									"version": 1,
 									"uid": "uid",
+									"guid": "guid",
 									"namespace_uid": "nsuid",
 									"rule_group": "arulegroup",
 									"no_data_state": "NoData",
@@ -3169,7 +3177,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "intervalSeconds":60,
 						  "is_paused": false,
 						  "version":1,
-						  "uid":"uid",
+						  "uid":"uid", 
+                          "guid": "guid",
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
@@ -3214,6 +3223,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "is_paused": false,
 						  "version":1,
 						  "uid":"uid",
+                          "guid": "guid",
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
@@ -3559,6 +3569,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "is_paused": false,
 						  "version":3,
 						  "uid":"uid",
+						  "guid": "guid",
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
@@ -3603,6 +3614,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "is_paused": false,
 						  "version":3,
 						  "uid":"uid",
+						  "guid": "guid",
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
@@ -3740,6 +3752,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "is_paused": false,
 		                  "version":4,
 		                  "uid":"uid",
+						  "guid": "guid",
 		                  "namespace_uid":"nsuid",
 		                  "rule_group":"arulegroup",
 		                  "no_data_state":"Alerting",
@@ -3857,6 +3870,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "is_paused":false,
 					  "version":5,
 					  "uid":"uid",
+					  "guid": "guid",
 					  "namespace_uid":"nsuid",
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
@@ -3953,6 +3967,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "is_paused":false,
 					  "version":5,
 					  "uid":"uid",
+                      "guid": "guid",
 					  "namespace_uid":"nsuid",
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
@@ -4926,6 +4941,7 @@ func rulesNamespaceWithoutVariableValues(t *testing.T, b []byte) (string, map[st
 				rule.GrafanaManagedAlert.NamespaceUID = "nsuid"
 				rule.GrafanaManagedAlert.Updated = time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 				rule.GrafanaManagedAlert.UpdatedBy.UID = "uid"
+				rule.GrafanaManagedAlert.GUID = "guid"
 			}
 		}
 	}

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -78,7 +78,7 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group1))
 
 	// Create rule under folder1
-	_, status, response := apiClient.PostRulesGroupWithStatus(t, "folder1", &group1)
+	_, status, response := apiClient.PostRulesGroupWithStatus(t, "folder1", &group1, false)
 	require.Equalf(t, http.StatusAccepted, status, response)
 
 	postGroupRaw, err = testData.ReadFile(path.Join("test-data", "rulegroup-2-post.json"))
@@ -87,7 +87,7 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group2))
 
 	// Create rule under folder2
-	_, status, response = apiClient.PostRulesGroupWithStatus(t, "folder2", &group2)
+	_, status, response = apiClient.PostRulesGroupWithStatus(t, "folder2", &group2, false)
 	require.Equalf(t, http.StatusAccepted, status, response)
 
 	// With the rules created, let's make sure that rule definitions are stored.
@@ -384,7 +384,7 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group1))
 
 	// Create rule under folder1
-	_, status, response := apiClient.PostRulesGroupWithStatus(t, "folder1", &group1)
+	_, status, response := apiClient.PostRulesGroupWithStatus(t, "folder1", &group1, false)
 	require.Equalf(t, http.StatusAccepted, status, response)
 
 	postGroupRaw, err = testData.ReadFile(path.Join("test-data", "rulegroup-2-post.json"))
@@ -393,7 +393,7 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group2))
 
 	// Create rule under folder2
-	_, status, response = apiClient.PostRulesGroupWithStatus(t, "folder2", &group2)
+	_, status, response = apiClient.PostRulesGroupWithStatus(t, "folder2", &group2, false)
 	require.Equalf(t, http.StatusAccepted, status, response)
 
 	postGroupRaw, err = testData.ReadFile(path.Join("test-data", "rulegroup-3-post.json"))
@@ -402,7 +402,7 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group3))
 
 	// Create rule under subfolder
-	_, status, response = apiClient.PostRulesGroupWithStatus(t, "subfolder", &group3)
+	_, status, response = apiClient.PostRulesGroupWithStatus(t, "subfolder", &group3, false)
 	require.Equalf(t, http.StatusAccepted, status, response)
 
 	// With the rules created, let's make sure that rule definitions are stored.
@@ -842,7 +842,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 			},
 		}
 
-		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rules)
+		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, respModel.Created, 1)
 
@@ -874,7 +874,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = true
 
-		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		updatedRuleGroup, status := apiClient.GetRulesGroup(t, folderName, groupName)
@@ -896,7 +896,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 		// disabling the editor
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = false
 
-		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		updatedRuleGroup, status := apiClient.GetRulesGroup(t, folderName, groupName)
@@ -916,7 +916,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection = true
 
-		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		updatedRuleGroup, status := apiClient.GetRulesGroup(t, folderName, groupName)
@@ -938,7 +938,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 		// disabling the editor
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection = false
 
-		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		updatedRuleGroup, status := apiClient.GetRulesGroup(t, folderName, groupName)
@@ -988,7 +988,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 
 	rules := newTestingRuleConfig(t)
 
-	respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rules)
+	respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rules, false)
 	require.Equal(t, http.StatusAccepted, status)
 	require.Len(t, respModel.Created, len(rules.Rules))
 
@@ -1002,7 +1002,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup.GettableRuleGroupConfig)
 		rulesWithUID.Rules = append(rulesWithUID.Rules, rules.Rules[0]) // Create new copy of first rule.
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID, false)
 		assert.Equal(t, http.StatusConflict, status)
 
 		var res map[string]any
@@ -1014,7 +1014,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup.GettableRuleGroupConfig)
 		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = "AlwaysFiring"
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID, false)
 		assert.Equal(t, http.StatusConflict, status)
 
 		var res map[string]any
@@ -1024,7 +1024,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 
 	t.Run("trying to create alert with same title under another folder should succeed", func(t *testing.T) {
 		rules := newTestingRuleConfig(t)
-		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder2", &rules)
+		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder2", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, resp.Created, len(rules.Rules))
 	})
@@ -1036,7 +1036,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Title = title1
 		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = title0
 
-		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID)
+		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, resp.Updated, 2)
 	})
@@ -1046,7 +1046,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		rulesWithUID.Rules[0].GrafanaManagedAlert.Title = rulesWithUID.Rules[1].GrafanaManagedAlert.Title
 		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = "something new"
 
-		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID)
+		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "folder1", &rulesWithUID, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, resp.Updated, len(rulesWithUID.Rules))
 	})
@@ -1136,7 +1136,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				},
 			},
 		}
-		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, resp.Created, len(rules.Rules))
 	}
@@ -1443,9 +1443,9 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 	group1 := generateAlertRuleGroup(5, alertRuleGen())
 	group2 := generateAlertRuleGroup(5, alertRuleGen())
 
-	_, status, _ := client.PostRulesGroupWithStatus(t, folderUID, &group1)
+	_, status, _ := client.PostRulesGroupWithStatus(t, folderUID, &group1, false)
 	require.Equal(t, http.StatusAccepted, status)
-	_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &group2)
+	_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &group2, false)
 	require.Equal(t, http.StatusAccepted, status)
 
 	t.Run("should persist order of the rules in a group", func(t *testing.T) {
@@ -1469,7 +1469,7 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 		for _, rule := range postableGroup1.Rules {
 			expectedUids = append(expectedUids, rule.GrafanaManagedAlert.UID)
 		}
-		_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &postableGroup1)
+		_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &postableGroup1, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		group1Get, status = client.GetRulesGroup(t, folderUID, group1.Name)
@@ -1498,7 +1498,7 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 		for _, rule := range postableGroup1.Rules {
 			expectedUids = append(expectedUids, rule.GrafanaManagedAlert.UID)
 		}
-		_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &postableGroup1)
+		_, status, _ = client.PostRulesGroupWithStatus(t, folderUID, &postableGroup1, false)
 		require.Equal(t, http.StatusAccepted, status)
 
 		group1Get, status = client.GetRulesGroup(t, folderUID, group1.Name)
@@ -1627,7 +1627,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, status, _ := client.PostRulesGroupWithStatus(t, namespaceUID, &tc.config)
+			resp, status, _ := client.PostRulesGroupWithStatus(t, namespaceUID, &tc.config, false)
 			require.Equal(t, http.StatusAccepted, status)
 			require.Len(t, resp.Created, 1)
 			require.Len(t, resp.Updated, 0)
@@ -1711,7 +1711,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 		expected := model.Duration(10 * time.Second)
 		group.Rules[0].ApiRuleNode.For = &expected
 
-		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
 		require.Equal(t, http.StatusAccepted, status)
@@ -1720,7 +1720,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 		group = convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
 		expected = 0
 		group.Rules[0].ApiRuleNode.For = &expected
-		_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group)
+		_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 
 		getGroup, status = client.GetRulesGroup(t, folderUID, group.Name)
@@ -1733,7 +1733,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 			ds1 := adminClient.CreateTestDatasource(t)
 			group := generateAlertRuleGroup(3, alertRuleGen(withDatasourceQuery(ds1.Body.Datasource.UID)))
 
-			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 
 			getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
@@ -1755,7 +1755,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 			require.Equal(t, http.StatusAccepted, status)
 			group := convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
 
-			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post noop rule group. Response: %s", body)
 		})
 		t.Run("should not let update rule if it does not fix datasource", func(t *testing.T) {
@@ -1764,7 +1764,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 			group := convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
 
 			group.Rules[0].GrafanaManagedAlert.Title = uuid.NewString()
-			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 
 			if status == http.StatusAccepted {
 				assert.Len(t, resp.Deleted, 1)
@@ -1782,7 +1782,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 
 			// remove the last rule.
 			group.Rules = group.Rules[0 : len(group.Rules)-1]
-			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to delete last rule from group. Response: %s", body)
 			assert.Len(t, resp.Deleted, 1)
 
@@ -1798,7 +1798,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 
 			ds2 := adminClient.CreateTestDatasource(t)
 			withDatasourceQuery(ds2.Body.Datasource.UID)(&group.Rules[0])
-			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post noop rule group. Response: %s", body)
 			assert.Len(t, resp.Deleted, 0)
 			assert.Len(t, resp.Updated, 2)
@@ -1810,7 +1810,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 			require.Equal(t, ds2.Body.Datasource.UID, group.Rules[0].GrafanaManagedAlert.Data[0].DatasourceUID)
 		})
 		t.Run("should let delete group", func(t *testing.T) {
-			status, body := client.DeleteRulesGroup(t, folderUID, groupName)
+			status, body := client.DeleteRulesGroup(t, folderUID, groupName, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post noop rule group. Response: %s", body)
 		})
 	})
@@ -1819,7 +1819,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 		expected := model.Duration(10 * time.Second)
 		group.Rules[0].ApiRuleNode.For = &expected
 
-		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
 		require.Equal(t, http.StatusAccepted, status)
@@ -1955,7 +1955,7 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 			},
 		}
 
-		_, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 	}
 
@@ -2095,7 +2095,7 @@ func TestIntegrationRulerAccess(t *testing.T) {
 					},
 				},
 			}
-			_, status, body := tc.client.PostRulesGroupWithStatus(t, "default", &rules)
+			_, status, body := tc.client.PostRulesGroupWithStatus(t, "default", &rules, false)
 			assert.Equal(t, tc.expStatus, status)
 			res := &Response{}
 			err = json.Unmarshal([]byte(body), &res)
@@ -2476,7 +2476,7 @@ func TestIntegrationQuota(t *testing.T) {
 				},
 			},
 		}
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		assert.Equal(t, http.StatusForbidden, status)
 		var res map[string]any
 		require.NoError(t, json.Unmarshal([]byte(body), &res))
@@ -2513,7 +2513,7 @@ func TestIntegrationQuota(t *testing.T) {
 			},
 		}
 
-		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Len(t, respModel.Updated, 1)
 
@@ -3019,7 +3019,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						tc.rule,
 					},
 				}
-				_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+				_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 				res := &Response{}
 				err = json.Unmarshal([]byte(body), &res)
 				require.NoError(t, err)
@@ -3092,7 +3092,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 				},
 			},
 		}
-		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		resp, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Equal(t, "rule group updated successfully", resp.Message)
 		assert.Len(t, resp.Created, 2)
@@ -3332,7 +3332,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			Interval: interval,
 		}
 
-		response, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		response, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		assert.Equal(t, http.StatusAccepted, status)
 
 		require.Len(t, response.Created, 1)
@@ -3403,7 +3403,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			Interval: interval,
 		}
 
-		response, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		response, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		assert.Equal(t, http.StatusAccepted, status)
 
 		require.Len(t, response.Created, 0)
@@ -3490,7 +3490,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			},
 			Interval: interval,
 		}
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		assert.Equal(t, http.StatusBadRequest, status)
 		var res map[string]any
 		require.NoError(t, json.Unmarshal([]byte(body), &res))
@@ -3669,7 +3669,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			},
 			Interval: interval,
 		}
-		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Equal(t, respModel.Updated, []string{ruleUID})
 		require.Len(t, respModel.Deleted, 1)
@@ -3795,7 +3795,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			},
 			Interval: interval,
 		}
-		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Equal(t, respModel.Updated, []string{ruleUID})
 
@@ -3888,7 +3888,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			},
 			Interval: interval,
 		}
-		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules)
+		respModel, status, _ := apiClient.PostRulesGroupWithStatus(t, "default", &rules, false)
 		require.Equal(t, http.StatusAccepted, status)
 		require.Equal(t, "no changes detected in the rule group", respModel.Message)
 		assert.Empty(t, respModel.Created)
@@ -4040,7 +4040,7 @@ func TestIntegrationRulePause(t *testing.T) {
 		expectedIsPaused := true
 		group.Rules[0].GrafanaManagedAlert.IsPaused = &expectedIsPaused
 
-		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		require.Len(t, resp.Created, 1)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
@@ -4054,7 +4054,7 @@ func TestIntegrationRulePause(t *testing.T) {
 		expectedIsPaused := false
 		group.Rules[0].GrafanaManagedAlert.IsPaused = &expectedIsPaused
 
-		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		require.Len(t, resp.Created, 1)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
@@ -4067,7 +4067,7 @@ func TestIntegrationRulePause(t *testing.T) {
 		group := generateAlertRuleGroup(1, alertRuleGen())
 		group.Rules[0].GrafanaManagedAlert.IsPaused = nil
 
-		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		resp, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		require.Len(t, resp.Created, 1)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
@@ -4125,14 +4125,14 @@ func TestIntegrationRulePause(t *testing.T) {
 			group := generateAlertRuleGroup(1, alertRuleGen())
 			group.Rules[0].GrafanaManagedAlert.IsPaused = &tc.isPausedInDb
 
-			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+			_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 			getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
 			require.Equalf(t, http.StatusAccepted, status, "failed to get rule group. Response: %s", body)
 
 			group = convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
 			group.Rules[0].GrafanaManagedAlert.IsPaused = tc.isPausedInBody
-			_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group)
+			_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 			require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 
 			getGroup, status = client.GetRulesGroup(t, folderUID, group.Name)
@@ -4180,7 +4180,7 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 			rule.GrafanaManagedAlert.Data[i].DatasourceUID = strings.ReplaceAll(rule.GrafanaManagedAlert.Data[i].DatasourceUID, "REPLACE_ME", testDs.Body.Datasource.UID)
 		}
 	}
-	changes, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &postData)
+	changes, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &postData, false)
 	require.Equalf(t, http.StatusAccepted, status, body)
 	require.Len(t, changes.Created, 1)
 	ruleUid := changes.Created[0]
@@ -4265,7 +4265,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		ns := group.Rules[0].GrafanaManagedAlert.NotificationSettings
 		ns.Receiver = "random-receiver"
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group, false)
 		require.Equalf(t, http.StatusBadRequest, status, body)
 		t.Log(body)
 	})
@@ -4277,7 +4277,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		ns := group.Rules[0].GrafanaManagedAlert.NotificationSettings
 		ns.MuteTimeIntervals = []string{"random-time-interval"}
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group, false)
 		require.Equalf(t, http.StatusBadRequest, status, body)
 		t.Log(body)
 	})
@@ -4289,7 +4289,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		ns := group.Rules[0].GrafanaManagedAlert.NotificationSettings
 		ns.GroupBy = []string{"label1"}
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, body)
 
 		cfg, status, body := apiClient.GetAlertmanagerConfigWithStatus(t)
@@ -4313,7 +4313,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		ns := group.Rules[0].GrafanaManagedAlert.NotificationSettings
 		ns.GroupBy = []string{ngmodels.FolderTitleLabel, model.AlertNameLabel, ngmodels.GroupByAll}
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, body)
 
 		// Now update the config with no changes.
@@ -4333,7 +4333,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 	})
 
 	t.Run("should create rule and generate route", func(t *testing.T) {
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &d.RuleGroup)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &d.RuleGroup, false)
 		require.Equalf(t, http.StatusAccepted, status, body)
 		notificationSettings := d.RuleGroup.Rules[0].GrafanaManagedAlert.NotificationSettings
 
@@ -4454,7 +4454,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		notificationSettings := group.Rules[0].GrafanaManagedAlert.NotificationSettings
 		group.Rules[0].GrafanaManagedAlert.NotificationSettings = nil
 
-		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group)
+		_, status, body := apiClient.PostRulesGroupWithStatus(t, folder, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, body)
 
 		var routeBody string
@@ -4524,7 +4524,7 @@ func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
 		group := generateAlertRuleGroup(3, alertRuleGen())
 		groupName := group.Name
 
-		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 		getGroup, status := client.GetRulesGroup(t, folderUID, group.Name)
 		require.Equal(t, http.StatusAccepted, status)
@@ -4534,7 +4534,7 @@ func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
 		group = convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
 		newGroup := strings.ToUpper(group.Name)
 		group.Name = newGroup
-		_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group)
+		_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
 
 		getGroup, status = client.GetRulesGroup(t, folderUID, group.Name)
@@ -4542,7 +4542,7 @@ func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
 		require.Lenf(t, getGroup.Rules, 3, "expected 3 rules in group")
 		require.Equal(t, newGroup, getGroup.Rules[0].GrafanaManagedAlert.RuleGroup)
 
-		status, body = client.DeleteRulesGroup(t, folderUID, groupName)
+		status, body = client.DeleteRulesGroup(t, folderUID, groupName, false)
 		require.Equalf(t, http.StatusAccepted, status, "failed to post noop rule group. Response: %s", body)
 
 		// Old group is gone.
@@ -4588,7 +4588,7 @@ func TestIntegrationRuleVersions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(postGroupRaw, &group1))
 
 	// Create rule under folder1
-	response := apiClient.PostRulesGroup(t, "folder1", &group1)
+	response := apiClient.PostRulesGroup(t, "folder1", &group1, false)
 
 	require.NotEmptyf(t, response.Created, "Expected created to be set")
 	uid := response.Created[0]
@@ -4607,7 +4607,7 @@ func TestIntegrationRuleVersions(t *testing.T) {
 	group1 = convertGettableRuleGroupToPostable(group1Gettable.GettableRuleGroupConfig)
 	group1.Rules[0].Annotations[util.GenerateShortUID()] = util.GenerateShortUID()
 
-	_ = apiClient.PostRulesGroup(t, "folder1", &group1)
+	_ = apiClient.PostRulesGroup(t, "folder1", &group1, false)
 
 	ruleV2 := apiClient.GetRuleByUID(t, uid)
 
@@ -4631,7 +4631,7 @@ func TestIntegrationRuleVersions(t *testing.T) {
 		assert.Empty(t, diff)
 	})
 
-	_ = apiClient.PostRulesGroup(t, "folder1", &group1) // Noop update
+	_ = apiClient.PostRulesGroup(t, "folder1", &group1, false) // Noop update
 
 	t.Run("should not add new version if rule was not changed", func(t *testing.T) {
 		versions, status, raw := apiClient.GetRuleVersionsWithStatus(t, uid)
@@ -4639,7 +4639,7 @@ func TestIntegrationRuleVersions(t *testing.T) {
 		require.Lenf(t, versions, 2, "Expected 2 versions, got %d", len(versions))
 	})
 
-	apiClient.DeleteRulesGroup(t, "folder1", group1.Name)
+	apiClient.DeleteRulesGroup(t, "folder1", group1.Name, false)
 
 	t.Run("should NotFound after rule was deleted", func(t *testing.T) {
 		_, status, raw := apiClient.GetRuleVersionsWithStatus(t, uid)
@@ -4692,7 +4692,7 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 		require.NoError(t, json.Unmarshal(postGroupRaw, &group1))
 
 		// Create rule under folder1
-		response := adminClient.PostRulesGroup(t, "folder1", &group1)
+		response := adminClient.PostRulesGroup(t, "folder1", &group1, false)
 		require.NotEmptyf(t, response.Created, "Expected created to be set")
 
 		// create some versions of the rule
@@ -4701,14 +4701,14 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 			require.Equal(t, http.StatusAccepted, status)
 			group1 = convertGettableRuleGroupToPostable(groups.GettableRuleGroupConfig)
 			group1.Rules[0].Annotations[util.GenerateShortUID()] = util.GenerateShortUID()
-			_ = adminClient.PostRulesGroup(t, "folder1", &group1)
+			_ = adminClient.PostRulesGroup(t, "folder1", &group1, false)
 		}
 		group, status = adminClient.GetRulesGroup(t, "folder1", group1.Name)
 		require.Equal(t, http.StatusAccepted, status)
 	}
 
 	// deleting group by using editor user
-	status, body := editorClient.DeleteRulesGroup(t, "folder1", group.Name)
+	status, body := editorClient.DeleteRulesGroup(t, "folder1", group.Name, false)
 	require.Equalf(t, http.StatusAccepted, status, "failed to delete group. Response: %s", body)
 
 	t.Run("should see deleted rules", func(t *testing.T) {
@@ -4879,7 +4879,7 @@ func createRule(t *testing.T, client apiClient, folder string) (apimodels.Postab
 			},
 		},
 	}
-	resp, status, _ := client.PostRulesGroupWithStatus(t, folder, &rules)
+	resp, status, _ := client.PostRulesGroupWithStatus(t, folder, &rules, false)
 	require.Equal(t, http.StatusAccepted, status)
 	require.Len(t, resp.Created, 1)
 	return rules, resp.Created[0]

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -454,7 +454,7 @@ func (a apiClient) PostConfiguration(t *testing.T, c apimodels.PostableUserConfi
 	return false, errors.New(data.Message)
 }
 
-func (a apiClient) PostRulesGroupWithStatus(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig) (apimodels.UpdateRuleGroupResponse, int, string) {
+func (a apiClient) PostRulesGroupWithStatus(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig, permanentlyDelete bool) (apimodels.UpdateRuleGroupResponse, int, string) {
 	t.Helper()
 	buf := bytes.Buffer{}
 	enc := json.NewEncoder(&buf)
@@ -462,6 +462,14 @@ func (a apiClient) PostRulesGroupWithStatus(t *testing.T, folder string, group *
 	require.NoError(t, err)
 
 	u := fmt.Sprintf("%s/api/ruler/grafana/api/v1/rules/%s", a.url, folder)
+	uri, err := url.Parse(u)
+	require.NoError(t, err)
+	q := uri.Query()
+	if permanentlyDelete {
+		q.Set("deletePermanently", "true")
+	}
+	uri.RawQuery = q.Encode()
+	u = uri.String()
 	// nolint:gosec
 	resp, err := http.Post(u, "application/json", &buf)
 	require.NoError(t, err)
@@ -477,9 +485,9 @@ func (a apiClient) PostRulesGroupWithStatus(t *testing.T, folder string, group *
 	return m, resp.StatusCode, string(b)
 }
 
-func (a apiClient) PostRulesGroup(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig) apimodels.UpdateRuleGroupResponse {
+func (a apiClient) PostRulesGroup(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig, permanentlyDelete bool) apimodels.UpdateRuleGroupResponse {
 	t.Helper()
-	m, status, raw := a.PostRulesGroupWithStatus(t, folder, group)
+	m, status, raw := a.PostRulesGroupWithStatus(t, folder, group, permanentlyDelete)
 	requireStatusCode(t, http.StatusAccepted, status, raw)
 	return m
 }
@@ -520,22 +528,21 @@ func (a apiClient) PostRulesExportWithStatus(t *testing.T, folder string, group 
 	return resp.StatusCode, string(b)
 }
 
-func (a apiClient) DeleteRulesGroup(t *testing.T, folder string, group string) (int, string) {
+func (a apiClient) DeleteRulesGroup(t *testing.T, folder string, group string, permanently bool) (int, string) {
 	t.Helper()
 
 	u := fmt.Sprintf("%s/api/ruler/grafana/api/v1/rules/%s/%s", a.url, folder, group)
 	req, err := http.NewRequest(http.MethodDelete, u, nil)
 	require.NoError(t, err)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	b, err := io.ReadAll(resp.Body)
+
+	if permanently {
+		req.URL.RawQuery = url.Values{"deletePermanently": []string{"true"}}.Encode()
+	}
+
+	resp, status, err := sendRequestRaw(t, req)
 	require.NoError(t, err)
 
-	return resp.StatusCode, string(b)
+	return status, string(resp)
 }
 
 func (a apiClient) PostSilence(t *testing.T, s apimodels.PostableSilence) (apimodels.PostSilencesOKBody, int, string) {

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -664,6 +664,15 @@ func (a apiClient) GetDeletedRulesWithStatus(t *testing.T) (apimodels.NamespaceC
 	return sendRequestJSON[apimodels.NamespaceConfigResponse](t, req, http.StatusOK)
 }
 
+func (a apiClient) DeleteRuleFromTrashByGUID(t *testing.T, ruleGUID string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/ruler/grafana/api/v1/trash/rule/guid/%s", a.url, ruleGUID), nil)
+	require.NoError(t, err)
+	raw, status, err := sendRequestRaw(t, req)
+	require.NoError(t, err)
+	return status, string(raw)
+}
+
 func (a apiClient) ExportRulesWithStatus(t *testing.T, params *apimodels.AlertRulesExportParameters) (int, string) {
 	t.Helper()
 	u, err := url.Parse(fmt.Sprintf("%s/api/ruler/grafana/api/v1/export/rules", a.url))

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -781,7 +781,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 
 	folderUID := "test-folder"
 	legacyCli.CreateFolder(t, folderUID, "TEST")
-	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
 	requestReceivers := func(t *testing.T, title string) (v0alpha1.Receiver, v0alpha1.Receiver) {
@@ -825,7 +825,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 
 	// Remove the extra rules.
 	ruleGroup.Rules = ruleGroup.Rules[:1]
-	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
 	receiverListed, receiverGet = requestReceivers(t, "user-defined")
@@ -840,7 +840,7 @@ func TestIntegrationInUseMetadata(t *testing.T) {
 	require.Truef(t, success, "Failed to post Alertmanager configuration: %s", err)
 
 	ruleGroup.Rules = nil
-	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
 	receiverListed, receiverGet = requestReceivers(t, "user-defined")
@@ -1187,7 +1187,7 @@ func TestIntegrationReferentialIntegrity(t *testing.T) {
 
 	folderUID := "test-folder"
 	legacyCli.CreateFolder(t, folderUID, "TEST")
-	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
 	receivers, err := adminClient.List(ctx, v1.ListOptions{})

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -660,7 +660,7 @@ func TestIntegrationTimeIntervalReferentialIntegrity(t *testing.T) {
 
 	folderUID := "test-folder"
 	legacyCli.CreateFolder(t, folderUID, "TEST")
-	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup, false)
 	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
 
 	currentRoute := legacyCli.GetRoute(t)

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12842,6 +12842,9 @@
         },
         "metric": {
           "type": "string"
+        },
+        "targetDatasourceUid": {
+          "type": "string"
         }
       }
     },
@@ -16088,6 +16091,9 @@
             "Alerting",
             "Error"
           ]
+        },
+        "guid": {
+          "type": "string"
         },
         "intervalSeconds": {
           "type": "integer",
@@ -19417,6 +19423,11 @@
           "description": "Name of the recorded metric.",
           "type": "string",
           "example": "grafana_alerts_ratio"
+        },
+        "target_datasource_uid": {
+          "description": "Which data source should be used to write the output of the recording rule, specified by UID.",
+          "type": "string",
+          "example": "my-prom"
         }
       }
     },
@@ -21451,6 +21462,15 @@
           "description": "Name of the associated template definition for this result.",
           "type": "string"
         },
+        "scope": {
+          "description": "Scope that was successfully used to interpolate the template. If the root scope \".\" fails, more specific\nscopes will be tried, such as \".Alerts', or \".Alert\".",
+          "type": "string",
+          "enum": [
+            ".",
+            ".Alerts",
+            ".Alert"
+          ]
+        },
         "text": {
           "description": "Interpolated value of the template.",
           "type": "string"
@@ -22849,7 +22869,6 @@
       }
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",
@@ -22974,6 +22993,7 @@
       }
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22869,6 +22869,7 @@
       }
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2903,6 +2903,9 @@
           },
           "metric": {
             "type": "string"
+          },
+          "targetDatasourceUid": {
+            "type": "string"
           }
         },
         "title": "Record is the provisioned export of models.Record.",
@@ -6149,6 +6152,9 @@
               "Alerting",
               "Error"
             ],
+            "type": "string"
+          },
+          "guid": {
             "type": "string"
           },
           "intervalSeconds": {
@@ -9475,6 +9481,11 @@
             "description": "Name of the recorded metric.",
             "example": "grafana_alerts_ratio",
             "type": "string"
+          },
+          "target_datasource_uid": {
+            "description": "Which data source should be used to write the output of the recording rule, specified by UID.",
+            "example": "my-prom",
+            "type": "string"
           }
         },
         "required": [
@@ -11512,6 +11523,15 @@
             "description": "Name of the associated template definition for this result.",
             "type": "string"
           },
+          "scope": {
+            "description": "Scope that was successfully used to interpolate the template. If the root scope \".\" fails, more specific\nscopes will be tried, such as \".Alerts', or \".Alert\".",
+            "enum": [
+              ".",
+              ".Alerts",
+              ".Alert"
+            ],
+            "type": "string"
+          },
           "text": {
             "description": "Interpolated value of the template.",
             "type": "string"
@@ -13034,6 +13054,7 @@
         "type": "object"
       },
       "gettableSilences": {
+        "description": "GettableSilences gettable silences",
         "items": {
           "$ref": "#/components/schemas/gettableSilence"
         },


### PR DESCRIPTION
**What is this feature?**
1. adds query parameter `deletePermanently` to the endpoints:
- `POST /api/ruler/grafana/api/v1/rules/{Namespace}`
- `DELETE /api/ruler/grafana/api/v1/rules/{Namespace}`
- `DELETE /api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}`

that tells the back-end to delete rules permanently. This flag is only available to organization administrators. Other roles will get `403 Forbidden`. 

2 Introduces field GUID to rule API model.
3. Introduces a new endpoint `/api/ruler/grafana/api/v1/trash/rule/guid/{RuleGUID}`  that permanently removes a rule from deleted rules. It accepts GUID of the rule. 
  - available to organization administrators
  - returns 200 OK if record was deleted, and 404 if it was not found 

**Why do we need this feature?**
Let administrators delete rules without ability to restore them.
