### PR TITLE
Backend Service: support getting HTTP response back as a stream

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -68,7 +68,7 @@ export type BackendSrvRequest = {
    *
    * By default values are json parsed from text
    */
-  responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
+  responseType?: 'json' | 'text' | 'arraybuffer' | 'blob' | 'stream';
 
   /**
    * Used to cancel an open connection

--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -184,6 +184,12 @@ describe('parseResponseBody', () => {
     expect(body).toEqual(value);
   });
 
+  it('parses stream', async () => {
+    const value = new ReadableStream();
+    const body = await parseResponseBody({ ...rsp, body: value }, 'stream');
+    expect(body).toEqual(value);
+  });
+
   it('undefined text', async () => {
     const value = 'RAW TEXT';
     const body = await parseResponseBody({

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -115,7 +115,7 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
 
 export async function parseResponseBody<T>(
   response: Response,
-  responseType?: 'json' | 'text' | 'arraybuffer' | 'blob'
+  responseType?: 'json' | 'text' | 'arraybuffer' | 'blob' | 'stream'
 ): Promise<T> {
   if (responseType) {
     switch (responseType) {
@@ -142,6 +142,9 @@ export async function parseResponseBody<T>(
         // this specifically returns a Promise<string>
         // TODO refactor this function to remove the type assertions
         return response.text() as Promise<T>;
+
+      case 'stream':
+        return response.body as unknown as Promise<T>;
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

hello and thanks in advance for spending the time to look at this PR! this feature creates a new `stream` responseType for `backendSrv.get`. When passed this response type, the backend service won't do any parsing and instead return the raw body to the caller as a `ReadableStream`.

**Why do we need this feature?**

I am building a backend datasource plugin for querying logs, and I want log results to be streamed back. It's possible to use JS built-in `window.fetch` directly to make HTTP requests and receive the result back as a stream, but that means I'm missing all the nice things like query cancellation.

I've checked out [this guide](https://grafana.com/developers/plugin-tools/tutorials/build-a-streaming-data-source-plugin) and using web sockets doesn't seem to do what I want. Websockets seem to be for keeping a persistent connection to tail live results on the client. However, I want to make a single one-and-done query that incrementally streams its results back

**Who is this feature for?**

People who build streaming plugins.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
