### PR TITLE
[getTagValues] Ensure we're not using suggestions when no scopes are present

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -691,7 +691,7 @@ export class PrometheusDatasource
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   async getTagValues(options: DataSourceGetTagValuesOptions<PromQuery>) {
     const requestId = `[${this.uid}][${options.key}]`;
-    if (config.featureToggles.promQLScope) {
+    if (config.featureToggles.promQLScope && (options?.scopes?.length ?? 0) > 0) {
       return (
         await this.languageProvider.fetchSuggestions(
           options.timeRange,


### PR DESCRIPTION
**What is this feature?**

Ensure we're not using the suggestions feature when no scopes are present.

**Why do we need this feature?**

We need this feature because right now, when calling `getTagValues` with filters present, the result we're getting back is not being filtered.

**Who is this feature for?**

- People calling the `getTagValues` method with filters
- People using the AdhocVariableFilter from scenes

**Which issue(s) does this PR fix?**:

Related to [#1613](https://github.com/grafana/app-observability-plugin/issues/1613)

**Special notes for your reviewer:**

Related PR, but for `getTagKeys`: #97353 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
