### PR TITLE
SQL Expressions: Allow more functions

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -136,16 +136,54 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 	b = true // so don't have to return true in every case but default
 
 	switch strings.ToLower(f.Name.String()) {
-	case "if":
+	// Conditional functions
+	case "if", "coalesce", "ifnull", "nullif":
 		return
 
+	// Aggregation functions
 	case "sum", "avg", "count", "min", "max":
 		return
-
-	case "coalesce":
+	case "stddev", "std", "stddev_pop":
+		return
+	case "variance", "var_pop":
 		return
 
+	// Mathematical functions
+	case "abs":
+		return
+	case "round", "floor", "ceiling", "ceil":
+		return
+	case "sqrt", "pow", "power":
+		return
+	case "mod", "log", "log10", "exp":
+		return
+	case "sign":
+		return
+
+	// String functions
+	case "concat", "length", "char_length":
+		return
+	case "lower", "upper":
+		return
+	case "substring", "trim":
+		return
+
+	// Date functions
 	case "str_to_date":
+		return
+	case "date_format", "now", "curdate", "curtime":
+		return
+	case "date_add", "date_sub":
+		return
+	case "year", "month", "day", "weekday":
+		return
+	case "datediff":
+		return
+	case "unix_timestamp", "from_unixtime":
+		return
+
+	// Type conversion
+	case "cast", "convert":
 		return
 
 	default:


### PR DESCRIPTION
I used Cursor and Claude 3.7 thinking to expand the list of functions
we allow. Specifically I needed `abs`.

TODO before merging:
- [x] Check each of these in the official MySQL docs to ensure they
are all safe:
eg. this doc: https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#operator_case

## Newly Added Functions (42 total):

### Conditional Functions
- [x] ifnull
- [x] nullif

### Aggregation Functions
- [x] stddev
- [x] std
- [x] stddev_pop
- [x] variance
- [x] var_pop

### Mathematical Functions
- [x] abs
- [x] round
- [x] floor
- [x] ceiling
- [x] ceil
- [x] sqrt
- [x] pow
- [x] power
- [x] mod
- [x] log
- [x] log10
- [x] exp
- [x] sign

### String Functions
- [x] concat
- [x] length
- [x] char_length
- [x] lower
- [x] upper
- [x] substring
- [x] trim

### Date Functions
- [x] date_format
- [x] now
- [x] curdate
- [x] curtime
- [x] date_add
- [x] date_sub
- [x] year
- [x] month
- [x] day
- [x] weekday
- [x] datediff
- [x] unix_timestamp
- [x] from_unixtime

### Type Conversion
- [x] cast
- [x] convert

TODO (After this PR):
- Expand the list to ALL functions that are safe, from the docs? At least make sure `CASE` is supported
