### PR TITLE
SQL Expressions: Add syntax highlighting and autocomplete

### DIFF
--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -2,13 +2,23 @@ import { css } from '@emotion/css';
 import { useMemo, useRef, useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { SQLEditor } from '@grafana/plugin-ui';
+import { SQLEditor, LanguageDefinition } from '@grafana/plugin-ui';
 import { useStyles2 } from '@grafana/ui';
 
 import { ExpressionQuery } from '../types';
 
 // Account for Monaco editor's border to prevent clipping
 const EDITOR_BORDER_ADJUSTMENT = 2; // 1px border on top and bottom
+
+// Define the language definition for MySQL syntax highlighting and autocomplete
+const EDITOR_LANGUAGE_DEFINITION: LanguageDefinition = {
+  id: 'mysql',
+  // Additional properties could be added here in the future if needed
+  // eg:
+  // completionProvider: to autocomplete field (ie column) names when given
+  // a table name (dataframe reference)
+  // formatter: to format the SQL query and dashboard variables
+};
 
 interface Props {
   refIds: Array<SelectableValue<string>>;
@@ -45,17 +55,13 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
     return () => resizeObserver.disconnect();
   }, []);
 
-  const editorLanguageDefinition = {
-    id: 'mysql',
-  };
-
   return (
     <div ref={containerRef} className={styles.editorContainer}>
       <SQLEditor
         query={query.expression || initialQuery}
         onChange={onEditorChange}
         height={dimensions.height - EDITOR_BORDER_ADJUSTMENT}
-        language={editorLanguageDefinition}
+        language={EDITOR_LANGUAGE_DEFINITION}
       />
     </div>
   );

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -45,12 +45,17 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
     return () => resizeObserver.disconnect();
   }, []);
 
+  const editorLanguageDefinition = {
+    id: 'mysql',
+  };
+
   return (
     <div ref={containerRef} className={styles.editorContainer}>
       <SQLEditor
         query={query.expression || initialQuery}
         onChange={onEditorChange}
         height={dimensions.height - EDITOR_BORDER_ADJUSTMENT}
+        language={editorLanguageDefinition}
       />
     </div>
   );


### PR DESCRIPTION
Here we **add syntax highlighting and autocomplete** for MySQL dialect of
SQL. We don't yet have the full functionality that other SQL monaco
editors have, namely
- No autocomplete of table or column names
- No autoformatting yet (meaning no formatting of template variables)

But this is a vast improvement already. The above improvements can come
later - they are slightly harder to do.

Looks like this right now:

![Screenshot 2025-03-12 at 10 48 41](https://github.com/user-attachments/assets/348396c5-6813-459e-9b89-3e758bb965c2)
