### PR TITLE
test(unified-storage): Create initial e2e test scenario for unified storage

### DIFF
--- a/pkg/storage/unified/e2e/grafana.go
+++ b/pkg/storage/unified/e2e/grafana.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	_ "embed"
+
+	"github.com/grafana/e2e"
+	gapi "github.com/grafana/grafana-api-golang-client"
+)
+
+const (
+	defaultGrafanaImage = "grafana/grafana:main"
+	grafanaBinary       = "/run.sh"
+	grafanaHTTPPort     = 3000
+	grafanaGRPCPort     = 10000
+)
+
+// GetDefaultImage returns the Docker image to use to run the Grafana..
+func GetGrafanaImage() string {
+	if img := os.Getenv("GRAFANA_IMAGE"); img != "" {
+		return img
+	}
+
+	return defaultGrafanaImage
+}
+
+type GrafanaService struct {
+	*e2e.HTTPService
+}
+
+func NewGrafanaService(name string, flags, envVars map[string]string) *GrafanaService {
+	svc := &GrafanaService{
+		HTTPService: e2e.NewHTTPService(
+			name,
+			GetGrafanaImage(),
+			e2e.NewCommandWithoutEntrypoint(grafanaBinary, e2e.BuildArgs(flags)...),
+			e2e.NewHTTPReadinessProbe(grafanaHTTPPort, "/ready", 200, 299),
+			grafanaHTTPPort,
+			grafanaGRPCPort),
+	}
+
+	svc.ConcreteService.SetEnvVars(envVars)
+
+	return svc
+}
+
+func (g *GrafanaService) GRPCEndpoint() string {
+	return g.HTTPService.NetworkEndpoint(grafanaGRPCPort)
+}
+
+type GrafanaClient struct {
+	*gapi.Client
+}
+
+func NewGrafanaClient(host string, orgID int64) (*GrafanaClient, error) {
+	cfg := gapi.Config{
+		BasicAuth: url.UserPassword("admin", "admin"),
+		OrgID:     orgID,
+		HTTPHeaders: map[string]string{
+			"X-Disable-Provenance": "true",
+		},
+	}
+
+	client, err := gapi.New(fmt.Sprintf("http://%s/", host), cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GrafanaClient{
+		Client: client,
+	}, nil
+}

--- a/pkg/storage/unified/e2e/grafana.go
+++ b/pkg/storage/unified/e2e/grafana.go
@@ -10,20 +10,25 @@ import (
 )
 
 const (
+	grafanaINI = `
+app_mode = development
+target = all
+
+[grafana-apiserver]
+address = 0.0.0.0:10000
+storage_type = unified-grpc
+
+[unified_storage.dashboards.dashboard.grafana.app]
+dualWriterMode = 5
+
+[unified_storage.folders.folder.grafana.app]
+dualWriterMode = 5
+`
 	defaultGrafanaImage = "grafana/grafana:main"
 	grafanaBinary       = "/run.sh"
 	grafanaHTTPPort     = 3000
 	grafanaGRPCPort     = 10000
 )
-
-// GetDefaultImage returns the Docker image to use to run the Grafana..
-func GetGrafanaImage() string {
-	if img := os.Getenv("GRAFANA_IMAGE"); img != "" {
-		return img
-	}
-
-	return defaultGrafanaImage
-}
 
 type GrafanaService struct {
 	*e2e.HTTPService
@@ -70,4 +75,13 @@ func NewGrafanaClient(host string, orgID int64) (*GrafanaClient, error) {
 	return &GrafanaClient{
 		Client: client,
 	}, nil
+}
+
+// GetDefaultImage returns the Docker image to use to run the Grafana..
+func GetGrafanaImage() string {
+	if img := os.Getenv("GRAFANA_IMAGE"); img != "" {
+		return img
+	}
+
+	return defaultGrafanaImage
 }

--- a/pkg/storage/unified/e2e/grafana.go
+++ b/pkg/storage/unified/e2e/grafana.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"os"
 
-	_ "embed"
-
 	"github.com/grafana/e2e"
 	gapi "github.com/grafana/grafana-api-golang-client"
 )

--- a/pkg/storage/unified/e2e/postgres.go
+++ b/pkg/storage/unified/e2e/postgres.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"os"
+
+	"github.com/grafana/e2e"
+)
+
+const (
+	defaultPostgresImage = "postgres:16.4"
+	postgresHTTPPort     = 5432
+)
+
+// GetDefaultImage returns the Docker image to use to run the Postgres..
+func GetPostgresImage() string {
+	if img := os.Getenv("POSTGRES_IMAGE"); img != "" {
+		return img
+	}
+
+	return defaultPostgresImage
+}
+
+type PostgresService struct {
+	*e2e.HTTPService
+}
+
+func NewPostgresService(name string, envVars map[string]string) *PostgresService {
+	svc := &PostgresService{
+		HTTPService: e2e.NewHTTPService(
+			name,
+			GetPostgresImage(),
+			nil,
+			nil,
+			postgresHTTPPort,
+		),
+	}
+
+	svc.SetEnvVars(envVars)
+
+	return svc
+}

--- a/pkg/storage/unified/e2e/storage.go
+++ b/pkg/storage/unified/e2e/storage.go
@@ -44,10 +44,11 @@ func NewStorageService(name string, flags, envVars map[string]string) *StorageSe
 	return svc
 }
 
-// TODO: remove this method when the storage-server module has a graceful shutdown
-// the following method is implemented because the storage-server module does not have a graceful shutdown
+// TODO: remove this method when the storage-server module has a graceful shutdown on docker stop
+// the following method is implemented because the storage-server module is not shutting down gracefully
+// https://github.com/grafana/search-and-storage-team/issues/228
 func (s *StorageService) Stop() error {
-	s.ConcreteService.Stop()
+	_ = s.ConcreteService.Stop()
 	return nil
 }
 

--- a/pkg/storage/unified/e2e/storage.go
+++ b/pkg/storage/unified/e2e/storage.go
@@ -1,0 +1,34 @@
+package e2e
+
+import (
+	"github.com/grafana/e2e"
+)
+
+const (
+	storageServerCmd = "grafana-server target"
+)
+
+type StorageService struct {
+	*e2e.ConcreteService
+}
+
+func NewStorageService(name string, flags, envVars map[string]string) *StorageService {
+	svc := &StorageService{
+		ConcreteService: e2e.NewConcreteService(
+			name,
+			GetGrafanaImage(),
+			e2e.NewCommand(storageServerCmd,
+				e2e.BuildArgs(flags)...),
+			e2e.NewTCPReadinessProbe(10000),
+			10000,
+		),
+	}
+
+	svc.SetEnvVars(envVars)
+
+	return svc
+}
+
+func (g *StorageService) GRPCEndpoint() string {
+	return g.NetworkEndpoint(grafanaGRPCPort)
+}

--- a/pkg/storage/unified/e2e/unified_scenario.go
+++ b/pkg/storage/unified/e2e/unified_scenario.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/grafana/e2e"
@@ -113,7 +114,7 @@ func (s *UnifiedScenario) NewPostgresService(name string) *PostgresService {
 
 func (s *UnifiedScenario) loadCfg(svc, content string) error {
 	dst := fmt.Sprintf("%s/%s.ini", s.SharedDir(), svc)
-	destination, err := os.Create(dst)
+	destination, err := os.Create(filepath.Clean(dst))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/e2e/unified_scenario.go
+++ b/pkg/storage/unified/e2e/unified_scenario.go
@@ -56,8 +56,7 @@ func (s *UnifiedScenario) NewGrafanaService(name string, grpcEndpoint string) (*
 		"GF_DATABASE_SSL_MODE":              "disable",
 	}
 
-	err := s.loadCfg(name, grafanaINI)
-	if err != nil {
+	if err := s.loadCfg(name, grafanaINI); err != nil {
 		return nil, err
 	}
 	g := NewGrafanaService(name, flags, envVars)
@@ -92,8 +91,7 @@ func (s *UnifiedScenario) NewStorageService(name string) (*StorageService, error
 		"GF_DATABASE_SSL_MODE":      "disable",
 	}
 
-	err := s.loadCfg(name, storageINI)
-	if err != nil {
+	if err := s.loadCfg(name, storageINI); err != nil {
 		return nil, err
 	}
 	us := NewStorageService(name, flags, envVars)

--- a/pkg/storage/unified/e2e/unified_scenario.go
+++ b/pkg/storage/unified/e2e/unified_scenario.go
@@ -1,0 +1,89 @@
+package e2e
+
+import (
+	"os"
+
+	"github.com/grafana/e2e"
+)
+
+type UnifiedScenario struct {
+	*e2e.Scenario
+
+	Grafana        *GrafanaService
+	UnifiedStorage *StorageService
+	Postgres       *PostgresService
+}
+
+func NewUnifiedScenario() (*UnifiedScenario, error) {
+	s, err := e2e.NewScenario(GetNetworkName())
+	if err != nil {
+		return nil, err
+	}
+
+	return &UnifiedScenario{
+		Scenario: s,
+	}, nil
+}
+
+func (s *UnifiedScenario) NewGrafanaService(name string, grpcEndpoint string) *GrafanaService {
+	flags := map[string]string{}
+	envVars := map[string]string{
+		"GF_FEATURE_TOGGLES_ENABLE":         "grafanaAPIServerWithExperimentalAPIs, kubernetesClientDashboardsFolders, unifiedStorageSearch",
+		"GF_GRAFANA_APISERVER_ADDRESS":      grpcEndpoint,
+		"GF_GRAFANA_APISERVER_STORAGE_TYPE": "unified-grpc",
+	}
+
+	g := NewGrafanaService(name, flags, envVars)
+	s.Grafana = g
+	return g
+}
+
+func (s *UnifiedScenario) NewGrafanaClient(grafanaName string, orgID int64) (*GrafanaClient, error) {
+	g := s.Grafana
+	return NewGrafanaClient(g.HTTPEndpoint(), orgID)
+}
+
+func (s *UnifiedScenario) NewUnifiedStorageService(name string) *StorageService {
+	flags := map[string]string{}
+	envVars := map[string]string{
+		"GF_DEFAULT_TARGET":                 "storage-server",
+		"GF_GRPC_SERVER_ADDRESS":            "0.0.0.0:10000",
+		"GF_FEATURE_TOGGLES_ENABLE":         "grpcServer,unifiedStorage",
+		"GF_GRAFANA_APISERVER_STORAGE_TYPE": "unified",
+		"GF_RESOURCE_API_DB_TYPE":           "postgres",
+		"GF_RESOURCE_API_DB_HOST":           "postgres:5432",
+		"GF_RESOURCE_API_DB_NAME":           "grafana",
+		"GF_RESOURCE_API_DB_USER":           "admin",
+		"GF_RESOURCE_API_DB_PASS":           "admin",
+	}
+
+	us := NewStorageService(name, flags, envVars)
+	s.UnifiedStorage = us
+	return us
+}
+
+func (s *UnifiedScenario) NewPostgresService(name string) *PostgresService {
+	ps := NewPostgresService(name, map[string]string{
+		"POSTGRES_USER":     "admin",
+		"POSTGRES_PASSWORD": "admin",
+		"POSTGRES_DB":       "grafana",
+	})
+	s.Postgres = ps
+
+	return ps
+}
+
+const (
+	defaultNetworkName = "e2e-grafana-unified"
+)
+
+// GetNetworkName returns the docker network name to run tests within.
+func GetNetworkName() string {
+	// If the E2E_NETWORK_NAME is set, use that for the network name.
+	// Otherwise, return the default network name.
+	if os.Getenv("E2E_NETWORK_NAME") != "" {
+		return os.Getenv("E2E_NETWORK_NAME")
+	}
+
+	return defaultNetworkName
+}

--- a/pkg/storage/unified/e2e/unified_test.go
+++ b/pkg/storage/unified/e2e/unified_test.go
@@ -19,10 +19,12 @@ func TestUnifiedStorage(t *testing.T) {
 		postgres := s.NewPostgresService("postgres")
 		require.NoError(t, s.Scenario.StartAndWaitReady(postgres))
 
-		storage := s.NewUnifiedStorageService("storage")
+		storage, err := s.NewStorageService("storage")
+		require.NoError(t, err)
 		require.NoError(t, s.Scenario.StartAndWaitReady(storage))
 
-		grafana := s.NewGrafanaService("grafana", storage.GRPCEndpoint())
+		grafana, err := s.NewGrafanaService("grafana", storage.GRPCEndpoint())
+		require.NoError(t, err)
 		require.NoError(t, s.Scenario.StartAndWaitReady(grafana))
 
 		const org1 = 1
@@ -38,7 +40,10 @@ func TestUnifiedStorage(t *testing.T) {
 				"uid":   uid,
 				"title": "Test Dashboard 1",
 			},
-			FolderID: folderOrg1.ID,
+			FolderID:  folderOrg1.ID,
+			FolderUID: folderOrg1.UID,
+			Overwrite: false,
+			Message:   "Test Dashboard 1",
 		}
 
 		dashboardOrg1, err := gorg1.NewDashboard(dashboard)
@@ -52,6 +57,6 @@ func TestUnifiedStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, folderOrg1.UID, newFolder.UID)
 
-		require.NoError(t, s.Scenario.Stop(postgres, storage, grafana))
+		require.NoError(t, s.Scenario.Stop(grafana, storage, postgres))
 	})
 }

--- a/pkg/storage/unified/e2e/unified_test.go
+++ b/pkg/storage/unified/e2e/unified_test.go
@@ -8,9 +8,8 @@ import (
 )
 
 func TestUnifiedStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping e2e test")
-	}
+	// TODO: remove this line when ci pipeline is ready
+	t.Skip("skipping e2e test")
 
 	t.Run("Create folder and dashboard", func(t *testing.T) {
 		s, err := NewUnifiedScenario()

--- a/pkg/storage/unified/e2e/unified_test.go
+++ b/pkg/storage/unified/e2e/unified_test.go
@@ -1,0 +1,57 @@
+package e2e
+
+import (
+	"testing"
+
+	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnifiedStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+
+	t.Run("Create folder and dashboard", func(t *testing.T) {
+		s, err := NewUnifiedScenario()
+		require.NoError(t, err)
+
+		postgres := s.NewPostgresService("postgres")
+		require.NoError(t, s.Scenario.StartAndWaitReady(postgres))
+
+		storage := s.NewUnifiedStorageService("storage")
+		require.NoError(t, s.Scenario.StartAndWaitReady(storage))
+
+		grafana := s.NewGrafanaService("grafana", storage.GRPCEndpoint())
+		require.NoError(t, s.Scenario.StartAndWaitReady(grafana))
+
+		const org1 = 1
+		gorg1, err := s.NewGrafanaClient("grafana", org1)
+		require.NoError(t, err)
+
+		folderOrg1, err := gorg1.NewFolder("test-folder-1")
+		require.NoError(t, err)
+
+		const uid = "test-dashboard-1"
+		dashboard := gapi.Dashboard{
+			Model: map[string]interface{}{
+				"uid":   uid,
+				"title": "Test Dashboard 1",
+			},
+			FolderID: folderOrg1.ID,
+		}
+
+		dashboardOrg1, err := gorg1.NewDashboard(dashboard)
+		require.NoError(t, err)
+
+		newDashboard, err := gorg1.DashboardByUID(uid)
+		require.NoError(t, err)
+		require.Equal(t, dashboardOrg1.UID, newDashboard.Model["uid"])
+
+		newFolder, err := gorg1.Folder(folderOrg1.ID)
+		require.NoError(t, err)
+		require.Equal(t, folderOrg1.UID, newFolder.UID)
+
+		require.NoError(t, s.Scenario.Stop(postgres, storage, grafana))
+	})
+}


### PR DESCRIPTION
Fixes: https://github.com/grafana/search-and-storage-team/issues/183

Add initial version of a e2e test scenario.
Goes through the folder and dashboard creation using the unified storage grpc api.
The test is disabled for now. It will be enabled in subsequent PRs once the CI pipeline for it is completed.

Follow-up regarding `storage-server` target graceful termination: https://github.com/grafana/search-and-storage-team/issues/228