### PR TITLE
Alerting: Rename variables in the rule template during Prometheus-conversion

### DIFF
--- a/pkg/services/ngalert/prom/template.go
+++ b/pkg/services/ngalert/prom/template.go
@@ -1,0 +1,198 @@
+// Package prom contains utilities for working with Prometheus and alert templates.
+package prom
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"text/template/parse"
+)
+
+// VariableReplacer is responsible for replacing template variables with specified values.
+//
+// Examples:
+//
+//	// Initialize a replacer that transforms template variables
+//	replacer := NewVariableReplacer(map[string]string{
+//	    "Value": ".Values.query.Value",
+//	    "Name":  ".Values.query.Name",
+//	})
+//
+//	// Example 1: Simple variable replacement
+//	templates := map[string]string{
+//	    "greeting": "Hello {{ .Name }}",
+//	}
+//	replacer.Replace(templates)
+//	// templates now contains:
+//		{"greeting": "Hello {{ .Values.query.Name }}"}
+//
+//
+//	// Example 2: Multiple variables and control structures
+//	templates := map[string]string{
+//	    "message": "{{ if eq .Value 10 }}High value{{ else }}Low value{{ end }}",
+//	}
+//	replacer.Replace(templates)
+//	// templates now contains:
+//		{"message": "{{ if eq .Values.query.Value 10 }}High value{{ else }}Low value{{ end }}"}
+type VariableReplacer struct {
+	replacements map[string]string
+}
+
+func NewVariableReplacer(replacements map[string]string) *VariableReplacer {
+	return &VariableReplacer{
+		replacements: replacements,
+	}
+}
+
+// Replace processes a map of template strings, replacing variables according to the
+// replacer's configuration and updating the map in place.
+func (r *VariableReplacer) Replace(m map[string]string) error {
+	if m == nil {
+		return nil
+	}
+
+	for k, v := range m {
+		nv, err := r.replaceVariables(v)
+		if err != nil {
+			return err
+		}
+		m[k] = nv
+	}
+	return nil
+}
+
+// replaceVariables processes a single template string, replacing all variables
+// according to the replacer's configuration.
+func (r *VariableReplacer) replaceVariables(tmpl string) (string, error) {
+	// Create a parser with SkipFuncCheck to avoid errors with unknown functions
+	p := parse.New("tmpl")
+	p.Mode = parse.ParseComments | parse.SkipFuncCheck
+
+	// Add temporary prefix with the variables that are expected by the template,
+	// otherwise the parsing fails.
+	tmpPrefix := `{{- $value := "" -}}{{- $labels := "" -}}`
+	tmpl = tmpPrefix + tmpl
+
+	tree, err := p.Parse(tmpl, "{{", "}}", map[string]*parse.Tree{})
+	if err != nil {
+		return "", err
+	}
+
+	// Find all variable nodes
+	nodes, err := r.walkNodes(tree.Root)
+	if err != nil {
+		return "", err
+	}
+
+	// Sort nodes by position in the template string
+	// to process them in order
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Pos < nodes[j].Pos
+	})
+
+	// Construct the new template string by replacing variables
+	var result strings.Builder
+	pos := 0
+	for _, n := range nodes {
+		if new, ok := r.replacements[n.Ident]; ok {
+			// Add text up to this variable
+			result.WriteString(tmpl[pos:n.Pos])
+			// Add the replacement
+			result.WriteString(new)
+			// Update position in the original template to the end of the variable
+			pos = n.Pos + len(n.Ident)
+		}
+	}
+
+	// Add any remaining text after the last processed variable
+	if pos < len(tmpl) {
+		result.WriteString(tmpl[pos:])
+	}
+
+	resultTmpl := result.String()[len(tmpPrefix):]
+
+	return resultTmpl, nil
+}
+
+// variableNode represents a variable in a template with its position.
+type variableNode struct {
+	Pos   int    // Position in the template string
+	Ident string // Name of the variable
+}
+
+// walkNodes recursively traverses the AST to find all variable nodes.
+// It returns a slice of variable nodes found in the tree.
+func (r *VariableReplacer) walkNodes(root parse.Node) ([]*variableNode, error) {
+	var err error
+	result := []*variableNode{}
+
+	var walk func(node parse.Node)
+	walk = func(node parse.Node) {
+		if node == nil || reflect.ValueOf(node).IsNil() {
+			return
+		}
+
+		switch n := node.(type) {
+		// Variable nodes
+		case *parse.VariableNode:
+			if len(n.Ident) > 0 {
+				v := &variableNode{
+					Pos:   int(n.Pos),
+					Ident: strings.Join(n.Ident, "."),
+				}
+				result = append(result, v)
+			}
+		case *parse.FieldNode:
+			if len(n.Ident) > 0 {
+				v := &variableNode{
+					Pos: int(n.Pos),
+					// Preprend the dot to the variable name if it's a field variable
+					// to match it with the template.
+					Ident: "." + strings.Join(n.Ident, "."),
+				}
+				result = append(result, v)
+			}
+
+		// Nodes with args
+		case *parse.ActionNode:
+			walk(n.Pipe)
+		case *parse.ChainNode:
+			walk(n.Node)
+		case *parse.CommandNode:
+			for _, arg := range n.Args {
+				walk(arg)
+			}
+		case *parse.ListNode:
+			for _, node := range n.Nodes {
+				walk(node)
+			}
+		case *parse.PipeNode:
+			for _, cmd := range n.Cmds {
+				walk(cmd)
+			}
+
+		// Control structure nodes
+		case *parse.IfNode:
+			walk(n.Pipe)
+			walk(n.List)
+			walk(n.ElseList)
+		case *parse.RangeNode:
+			walk(n.Pipe)
+			walk(n.List)
+			walk(n.ElseList)
+		case *parse.WithNode:
+			walk(n.Pipe)
+			walk(n.List)
+			walk(n.ElseList)
+		case *parse.BranchNode:
+			walk(n.Pipe)
+			walk(n.List)
+			walk(n.ElseList)
+		case *parse.TemplateNode:
+			walk(n.Pipe)
+		}
+	}
+
+	walk(root)
+	return result, err
+}

--- a/pkg/services/ngalert/prom/template_test.go
+++ b/pkg/services/ngalert/prom/template_test.go
@@ -1,0 +1,305 @@
+package prom
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceVariablesInMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputMap    map[string]string
+		replaceMap  map[string]string
+		expectedMap map[string]string
+		expectError bool
+	}{
+		{
+			name:        "nil map",
+			inputMap:    nil,
+			replaceMap:  map[string]string{".Value": ".Values.query.Value"},
+			expectedMap: nil,
+			expectError: false,
+		},
+		{
+			name:        "empty map",
+			inputMap:    map[string]string{},
+			replaceMap:  map[string]string{".Value": ".Values.query.Value"},
+			expectedMap: map[string]string{},
+			expectError: false,
+		},
+		{
+			name: "no template delimiters at all",
+			inputMap: map[string]string{
+				"key1": "Just some plain text with no template expressions and string .Value",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "Just some plain text with no template expressions and string .Value",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty template",
+			inputMap: map[string]string{
+				"key1": "",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "",
+			},
+			expectError: false,
+		},
+		{
+			name: "simple replacement",
+			inputMap: map[string]string{
+				"key1": "Hello {{- $labels -}} {{ .Value }}",
+				// "key2": "Hello {{ .Long.Value.With.Dots.And.Fields }}! This is a test when the replacement is shorter.",
+			},
+			replaceMap: map[string]string{
+				".Value":                           ".Values.query.Value",
+				".Long.Value.With.Dots.And.Fields": ".NewVal",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{- $labels -}} {{ .Values.query.Value }}",
+				// "key2": "Hello {{ .NewVal }}! This is a test when the replacement is shorter.",
+			},
+			expectError: false,
+		},
+		{
+			name: "multiline template",
+			inputMap: map[string]string{
+				"key1": `Line1: {{ .Value }}
+                         Line2: {{ .Name }}`,
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+				".Name":  ".Values.query.Name",
+			},
+			expectedMap: map[string]string{
+				"key1": `Line1: {{ .Values.query.Value }}
+                         Line2: {{ .Values.query.Name }}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "nested function calls in the template",
+			inputMap: map[string]string{
+				"key1": `{{ printf "%s" (trimSpace .Name) }}`,
+			},
+			replaceMap: map[string]string{
+				".Name": ".Values.query.Name",
+			},
+			expectedMap: map[string]string{
+				"key1": `{{ printf "%s" (trimSpace .Values.query.Name) }}`,
+			},
+			expectError: false,
+		},
+		// {
+		// 	name: "nested fields .Foo.Bar",
+		// 	inputMap: map[string]string{
+		// 		"key1": "Hello {{ .Foo.Bar }}",
+		// 	},
+		// 	replaceMap: map[string]string{
+		// 		".Foo.Bar": ".Values.foo.bar",
+		// 	},
+		// 	expectedMap: map[string]string{
+		// 		"key1": "Hello {{ .Values.foo.bar }}",
+		// 	},
+		// 	expectError: false,
+		// },
+		{
+			name: "braces that are not template delimeters",
+			inputMap: map[string]string{
+				"key1": "String with braces \\{\\{ notATemplate \\}\\}, so no replacement",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "String with braces \\{\\{ notATemplate \\}\\}, so no replacement",
+			},
+			expectError: false,
+		},
+		{
+			name: "template with range usage",
+			inputMap: map[string]string{
+				"key1": `{{ range .Items }}Item: {{ . }}{{ end }}`,
+			},
+			replaceMap: map[string]string{
+				".Items": ".Values.itemList",
+			},
+			expectedMap: map[string]string{
+				"key1": `{{ range .Values.itemList }}Item: {{ . }}{{ end }}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "template with nested pipeline and multiple arguments",
+			inputMap: map[string]string{
+				"key1": `{{ if (eq (printf "%s" .Value) "hello") }}Yes{{ else }}No{{ end }}`,
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": `{{ if (eq (printf "%s" .Values.query.Value) "hello") }}Yes{{ else }}No{{ end }}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "single map variable replacement",
+			inputMap: map[string]string{
+				"key1": "Hello {{ .Value }}",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{ .Values.query.Value }}",
+			},
+			expectError: false,
+		},
+		{
+			name: "variable replacement",
+			inputMap: map[string]string{
+				"key1": "Hello {{ $value }}",
+				"key2": "Hi {{ $value.and.some.field }}",
+			},
+			replaceMap: map[string]string{
+				"$value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{ .Values.query.Value }}",
+				"key2": "Hi {{ $value.and.some.field }}",
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple occurrences of same variable",
+			inputMap: map[string]string{
+				"key1": "{{ .Value }} and {{ .Value }} again",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "{{ .Values.query.Value }} and {{ .Values.query.Value }} again",
+			},
+			expectError: false,
+		},
+		{
+			name: "no replacement needed",
+			inputMap: map[string]string{
+				"key1": "Hello {{ .OtherValue }}",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{ .OtherValue }}",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid template syntax",
+			inputMap: map[string]string{
+				"key1": "Hello {{ .Value",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: nil, // We don't care about the state after error
+			expectError: true,
+		},
+		{
+			name: "multiple different variables",
+			inputMap: map[string]string{
+				"key1": "Hello {{ .Name }} and {{ .Value }}",
+			},
+			replaceMap: map[string]string{
+				".Name":  ".Values.query.Name",
+				".Value": ".Values.query.Value",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{ .Values.query.Name }} and {{ .Values.query.Value }}",
+			},
+			expectError: false,
+		},
+		{
+			name: "complex template with control structures",
+			inputMap: map[string]string{
+				"key1": "{{ if eq .Value 10 }}{{ .Name }}{{ else }}{{ .Fallback }}{{ end }}",
+			},
+			replaceMap: map[string]string{
+				".Name":     ".Values.query.Name",
+				".Value":    ".Values.query.Value",
+				".Fallback": ".Values.query.Fallback",
+			},
+			expectedMap: map[string]string{
+				"key1": "{{ if eq .Values.query.Value 10 }}{{ .Values.query.Name }}{{ else }}{{ .Values.query.Fallback }}{{ end }}",
+			},
+			expectError: false,
+		},
+		{
+			name: ",ixed template types with pipes",
+			inputMap: map[string]string{
+				"key1": "{{ .Item | printf \"%.2f\" }}",
+				"key2": "{{ .Count }} items",
+			},
+			replaceMap: map[string]string{
+				".Item":  ".Values.query.Item",
+				".Count": ".Values.query.Count",
+			},
+			expectedMap: map[string]string{
+				"key1": "{{ .Values.query.Item | printf \"%.2f\" }}",
+				"key2": "{{ .Values.query.Count }} items",
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple entries with mixed templates",
+			inputMap: map[string]string{
+				"key1": "Hello {{ .Value }}",
+				"key2": "World {{ .Value }}",
+				"key3": "{{ .Name }} says hi",
+			},
+			replaceMap: map[string]string{
+				".Value": ".Values.query.Value",
+				".Name":  ".Values.query.Name",
+			},
+			expectedMap: map[string]string{
+				"key1": "Hello {{ .Values.query.Value }}",
+				"key2": "World {{ .Values.query.Value }}",
+				"key3": "{{ .Values.query.Name }} says hi",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var testMap map[string]string
+			if tc.inputMap != nil {
+				testMap = make(map[string]string)
+				maps.Copy(testMap, tc.inputMap)
+			}
+
+			r := NewVariableReplacer(tc.replaceMap)
+			err := r.Replace(testMap)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedMap, testMap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

This PR adds functionality to rename variables in Prometheus alert rule templates when converting them to Grafana alert rules. It renames `.Value` and `$value` variables to `.Values.<refID>.Value`.

**Why do we need this feature?**

In Prometheus templating both `$value` and `.Value` return the value of the query. In Grafana the syntax is different: `.Values.<refID>.Value`, and `.Value`/`$value` return the string like 

`[ var='A' labels={foo=bar} value=10 ], [ var='B' labels={bar=baz, foo=bar} value=1 ]`

To make the templating work after the Prometheus -> Grafana conversion in the same way, we rename `$value` and `.Value` to `.Values.query.Value`.

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
