### PR TITLE
Dashboards: Fix inconsistent variable quoting for repeated panels

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
@@ -59,7 +59,7 @@ describe('PanelRepeaterGridItem', () => {
   });
 
   it('Should pass isMulti/includeAll values if variable is multi variable and has them set', async () => {
-    const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 1, includeAll: true });
+    const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 1 });
 
     activateFullSceneTree(scene);
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
@@ -58,6 +58,27 @@ describe('PanelRepeaterGridItem', () => {
     expect(repeater.state.repeatedPanels?.length).toBe(5);
   });
 
+  it('Should pass isMulti/includeAll values if variable is multi variable and has them set', async () => {
+    const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 1, includeAll: true });
+
+    activateFullSceneTree(scene);
+
+    expect(repeater.state.repeatedPanels?.length).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(repeater.state.repeatedPanels?.length).toBe(5);
+
+    // LocalValueVariableState is not exposed, so we build this type casting
+    const variableState = repeater.state.repeatedPanels![0].state.$variables?.state.variables[0].state as {
+      isMulti?: boolean;
+      includeAll?: boolean;
+    };
+
+    expect(variableState.isMulti).toBe(true);
+    expect(variableState.includeAll).toBe(true);
+  });
+
   it('Should display a panel when there are no options', async () => {
     const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 1, numberOfOptions: 0 });
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -157,6 +157,8 @@ export class DashboardGridItem
               name: variable.state.name,
               value: variableValues[index],
               text: String(variableTexts[index]),
+              isMulti: variable.state.isMulti,
+              includeAll: variable.state.includeAll,
             }),
           ],
         }),

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -127,8 +127,6 @@ interface SceneOptions {
   useRowRepeater?: boolean;
   throwError?: string;
   variableRefresh?: VariableRefresh;
-  isMulti?: boolean;
-  includeAll?: boolean;
 }
 
 export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel) {
@@ -172,8 +170,8 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
     query: 'A.*',
     value: ALL_VARIABLE_VALUE,
     text: ALL_VARIABLE_TEXT,
-    isMulti: options.isMulti ?? true,
-    includeAll: options.includeAll ?? true,
+    isMulti: true,
+    includeAll: true,
     delayMs: options.variableQueryTime,
     optionsToReturn: [
       { label: 'A', value: '1' },

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -127,6 +127,8 @@ interface SceneOptions {
   useRowRepeater?: boolean;
   throwError?: string;
   variableRefresh?: VariableRefresh;
+  isMulti?: boolean;
+  includeAll?: boolean;
 }
 
 export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel) {
@@ -170,8 +172,8 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
     query: 'A.*',
     value: ALL_VARIABLE_VALUE,
     text: ALL_VARIABLE_TEXT,
-    isMulti: true,
-    includeAll: true,
+    isMulti: options.isMulti ?? true,
+    includeAll: options.includeAll ?? true,
     delayMs: options.variableQueryTime,
     optionsToReturn: [
       { label: 'A', value: '1' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue where repeated panels would end up with bad queries (at least in sql datasources), because of improper interpolation on the sql datasource side. This was caused from the dashboard though, where a multi value variable used for a repeated panel would, when performing the repeat, turn that multi value variable into a repeated panels local value variable. When performing said repeat, the newly created local value variable would be unaware that this is actually sourced from a multi value var which follows special interpolation rules in sql datasources, and further down the line, the sql datasource would also be unaware and not apply the correct interpolation.

**Why do we need this feature?**

Fixes the issue

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

**This was observed in sql datasources so use a devenv one for testing, I've tested on mssql**

Repro steps:

1. In a dashboard create a custom multi-value variable, add some test values
2. Leave one value selected
3. Create a panel which uses some SQL datasource (I've used MSSQL)
4. Write a query with that var, I tested with `SELECT ($test)` in a table panel
5. Examine the query in the query inspector. The variable value is quoted.
6. Activate "Repeat by variable"
7. Go "Back to dashboard" and then edit the panel again
8. Examining the query will result in the var value not quoted thus breaking the query.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
