### PR TITLE
Alerting: Fix wrong assumption that threshold id is always c in simple condition

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -442,17 +442,17 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   const switchMode =
     isGrafanaAlertingType && isSwitchModeEnabled
       ? {
-        isAdvancedMode: !simplifiedQueryStep,
-        setAdvancedMode: (isAdvanced: boolean) => {
-          if (!getValues('editorSettings.simplifiedQueryEditor')) {
-            if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
-              setShowResetModal(true);
-              return;
+          isAdvancedMode: !simplifiedQueryStep,
+          setAdvancedMode: (isAdvanced: boolean) => {
+            if (!getValues('editorSettings.simplifiedQueryEditor')) {
+              if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
+                setShowResetModal(true);
+                return;
+              }
             }
-          }
-          setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
-        },
-      }
+            setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
+          },
+        }
       : undefined;
 
   return (

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -160,9 +160,11 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
       }
       // we need to be sure the condition is set once we switch to simple mode
       if (simplifiedQueryStep) {
-        const thresholdId = expressionQueries[expressionQueries.length - 1].refId;
-        setValue('condition', thresholdId); // we set the condition to the last expression,as threshold is the last expression in case of simple mode
-        runQueries(getValues('queries'), thresholdId);
+        const thresholdId = expressionQueries.at(-1)?.refId;
+        if (thresholdId) {
+          setValue('condition', thresholdId); // we set the condition to the last expression,as threshold is the last expression in case of simple mode
+          runQueries(getValues('queries'), thresholdId);
+        }
       } else {
         runQueries(getValues('queries'), condition || (getValues('condition') ?? ''));
       }
@@ -442,17 +444,17 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   const switchMode =
     isGrafanaAlertingType && isSwitchModeEnabled
       ? {
-          isAdvancedMode: !simplifiedQueryStep,
-          setAdvancedMode: (isAdvanced: boolean) => {
-            if (!getValues('editorSettings.simplifiedQueryEditor')) {
-              if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
-                setShowResetModal(true);
-                return;
-              }
+        isAdvancedMode: !simplifiedQueryStep,
+        setAdvancedMode: (isAdvanced: boolean) => {
+          if (!getValues('editorSettings.simplifiedQueryEditor')) {
+            if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
+              setShowResetModal(true);
+              return;
             }
-            setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
-          },
-        }
+          }
+          setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
+        },
+      }
       : undefined;
 
   return (

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -50,7 +50,7 @@ import { RuleEditorSection } from '../RuleEditorSection';
 import { errorFromCurrentCondition, errorFromPreviewData, findRenamedDataQueryReferences, refIdExists } from '../util';
 
 import { CloudDataSourceSelector } from './CloudDataSourceSelector';
-import { SimpleConditionEditor, SimpleConditionIdentifier, getSimpleConditionFromExpressions } from './SimpleCondition';
+import { SimpleConditionEditor, getSimpleConditionFromExpressions } from './SimpleCondition';
 import { SmartAlertTypeDetector } from './SmartAlertTypeDetector';
 import { DESCRIPTIONS } from './descriptions';
 import {
@@ -160,13 +160,14 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
       }
       // we need to be sure the condition is set once we switch to simple mode
       if (simplifiedQueryStep) {
-        setValue('condition', SimpleConditionIdentifier.thresholdId);
-        runQueries(getValues('queries'), SimpleConditionIdentifier.thresholdId);
+        const thresholdId = expressionQueries[expressionQueries.length - 1].refId;
+        setValue('condition', thresholdId); // we set the condition to the last expression,as threshold is the last expression in case of simple mode
+        runQueries(getValues('queries'), thresholdId);
       } else {
         runQueries(getValues('queries'), condition || (getValues('condition') ?? ''));
       }
     },
-    [isCloudAlertRuleType, runQueries, getValues, simplifiedQueryStep, setValue]
+    [isCloudAlertRuleType, runQueries, getValues, simplifiedQueryStep, setValue, expressionQueries]
   );
 
   // whenever we update the queries we have to update the form too
@@ -441,17 +442,17 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   const switchMode =
     isGrafanaAlertingType && isSwitchModeEnabled
       ? {
-          isAdvancedMode: !simplifiedQueryStep,
-          setAdvancedMode: (isAdvanced: boolean) => {
-            if (!getValues('editorSettings.simplifiedQueryEditor')) {
-              if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
-                setShowResetModal(true);
-                return;
-              }
+        isAdvancedMode: !simplifiedQueryStep,
+        setAdvancedMode: (isAdvanced: boolean) => {
+          if (!getValues('editorSettings.simplifiedQueryEditor')) {
+            if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
+              setShowResetModal(true);
+              return;
             }
-            setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
-          },
-        }
+          }
+          setValue('editorSettings.simplifiedQueryEditor', !isAdvanced);
+        },
+      }
       : undefined;
 
   return (

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -164,11 +164,11 @@ function updateReduceExpression(
 
   const newReduceExpression = reduceExpression
     ? produce(reduceExpression?.model, (draft) => {
-        if (draft && draft.conditions) {
-          draft.reducer = reducer;
-          draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
-        }
-      })
+      if (draft && draft.conditions) {
+        draft.reducer = reducer;
+        draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
+      }
+    })
     : undefined;
   newReduceExpression && dispatch(updateExpression(newReduceExpression));
 }
@@ -178,7 +178,7 @@ function updateThresholdFunction(
   expressionQueriesList: Array<AlertQuery<ExpressionQuery>>,
   dispatch: Dispatch<UnknownAction>
 ) {
-  const thresholdExpression = expressionQueriesList[expressionQueriesList.length - 1];
+  const thresholdExpression = expressionQueriesList.at(-1);
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
     if (draft && draft.model.conditions) {
       draft.model.conditions[0].evaluator.type = evaluator;
@@ -194,7 +194,7 @@ function updateThresholdValue(
   dispatch: Dispatch<UnknownAction>
 ) {
   //thresholdExpression is always the last element in the expressionQueriesList
-  const thresholdExpression = expressionQueriesList[expressionQueriesList.length - 1];
+  const thresholdExpression = expressionQueriesList.at(-1);
 
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
     if (draft && draft.model.conditions) {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -20,7 +20,6 @@ import { updateExpression } from './reducer';
 export const SimpleConditionIdentifier = {
   queryId: 'A',
   reducerId: 'B',
-  thresholdId: 'C',
 } as const;
 export interface SimpleCondition {
   whenField?: string;
@@ -165,11 +164,11 @@ function updateReduceExpression(
 
   const newReduceExpression = reduceExpression
     ? produce(reduceExpression?.model, (draft) => {
-        if (draft && draft.conditions) {
-          draft.reducer = reducer;
-          draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
-        }
-      })
+      if (draft && draft.conditions) {
+        draft.reducer = reducer;
+        draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
+      }
+    })
     : undefined;
   newReduceExpression && dispatch(updateExpression(newReduceExpression));
 }
@@ -179,11 +178,7 @@ function updateThresholdFunction(
   expressionQueriesList: Array<AlertQuery<ExpressionQuery>>,
   dispatch: Dispatch<UnknownAction>
 ) {
-  const thresholdExpression = expressionQueriesList.find(
-    (query) =>
-      query.model.type === ExpressionQueryType.threshold && query.model.refId === SimpleConditionIdentifier.thresholdId
-  );
-
+  const thresholdExpression = expressionQueriesList[expressionQueriesList.length - 1];
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
     if (draft && draft.model.conditions) {
       draft.model.conditions[0].evaluator.type = evaluator;
@@ -198,10 +193,8 @@ function updateThresholdValue(
   expressionQueriesList: Array<AlertQuery<ExpressionQuery>>,
   dispatch: Dispatch<UnknownAction>
 ) {
-  const thresholdExpression = expressionQueriesList.find(
-    (query) =>
-      query.model.type === ExpressionQueryType.threshold && query.model.refId === SimpleConditionIdentifier.thresholdId
-  );
+  //thresholdExpression is always the last element in the expressionQueriesList
+  const thresholdExpression = expressionQueriesList[expressionQueriesList.length - 1];
 
   const newThresholdExpression = produce(thresholdExpression, (draft) => {
     if (draft && draft.model.conditions) {
@@ -215,10 +208,7 @@ export function getSimpleConditionFromExpressions(expressions: Array<AlertQuery<
   const reduceExpression = expressions.find(
     (query) => query.model.type === ExpressionQueryType.reduce && query.refId === SimpleConditionIdentifier.reducerId
   );
-  const thresholdExpression = expressions.find(
-    (query) =>
-      query.model.type === ExpressionQueryType.threshold && query.refId === SimpleConditionIdentifier.thresholdId
-  );
+  const thresholdExpression = expressions[expressions.length - 1];
   const conditionsFromThreshold = thresholdExpression?.model.conditions ?? [];
   const whenField = reduceExpression?.model.reducer;
   const params = conditionsFromThreshold[0]?.evaluator?.params

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -164,11 +164,11 @@ function updateReduceExpression(
 
   const newReduceExpression = reduceExpression
     ? produce(reduceExpression?.model, (draft) => {
-      if (draft && draft.conditions) {
-        draft.reducer = reducer;
-        draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
-      }
-    })
+        if (draft && draft.conditions) {
+          draft.reducer = reducer;
+          draft.conditions[0].reducer.type = getReducerType(reducer) ?? ReducerID.last;
+        }
+      })
     : undefined;
   newReduceExpression && dispatch(updateExpression(newReduceExpression));
 }

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
@@ -37,13 +37,13 @@ describe('areQueriesTransformableToSimpleCondition', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if no threshold expression is found with correct type and refId', () => {
+  it('should return true if threshold expression is found with correct type and any refId', () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [dataQuery];
     const result = areQueriesTransformableToSimpleCondition(dataQueries, [
       reduceExpression,
       { ...thresholdExpression, refId: 'hello' },
     ]);
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it('should return false if reduceExpression settings mode is not ReducerMode.Strict', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -38,12 +38,12 @@ const reduceExpression: AlertQuery<ExpressionQuery> = {
   },
 };
 const thresholdExpression: AlertQuery<ExpressionQuery> = {
-  refId: SimpleConditionIdentifier.thresholdId,
+  refId: 'C',
   queryType: 'expression',
   datasourceUid: '__expr__',
   model: {
     type: ExpressionQueryType.threshold,
-    refId: SimpleConditionIdentifier.thresholdId,
+    refId: 'C',
   },
 };
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -791,11 +791,11 @@ export const reduceExpression: AlertQuery<ExpressionQuery> = {
   },
 };
 export const thresholdExpression: AlertQuery<ExpressionQuery> = {
-  refId: SimpleConditionIdentifier.thresholdId,
+  refId: 'C',
   queryType: 'expression',
   datasourceUid: '__expr__',
   model: {
     type: ExpressionQueryType.threshold,
-    refId: SimpleConditionIdentifier.thresholdId,
+    refId: 'C',
   },
 };

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -96,7 +96,7 @@ export function areQueriesTransformableToSimpleCondition(
 
   const thresholdExpressionIndex = expressionQueries.findIndex(
     (query) =>
-      query.model.type === ExpressionQueryType.threshold && query.refId === SimpleConditionIdentifier.thresholdId
+      query.model.type === ExpressionQueryType.threshold 
   );
   const thresholdExpression = expressionQueries.at(thresholdExpressionIndex);
   const conditions = thresholdExpression?.model.conditions ?? [];

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -95,8 +95,7 @@ export function areQueriesTransformableToSimpleCondition(
       reduceExpression.model.settings?.mode === undefined);
 
   const thresholdExpressionIndex = expressionQueries.findIndex(
-    (query) =>
-      query.model.type === ExpressionQueryType.threshold 
+    (query) => query.model.type === ExpressionQueryType.threshold
   );
   const thresholdExpression = expressionQueries.at(thresholdExpressionIndex);
   const conditions = thresholdExpression?.model.conditions ?? [];


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug when using simple condition with no reducer and using a refid for the threshold different than 'C'.

When we use a simple condition we only have the requirement that the threshold is the last expression, but in the rest of the code we were relying on the 'C' refId 

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:


Related to this [escalation](https://github.com/grafana/support-escalations/issues/15163)

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
