### PR TITLE
I18n: Add useT hook for plugin translation API

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -887,7 +887,8 @@ exports[`better eslint`] = {
     "public/app/app.ts:5381": [
       [0, 0, 0, "\'@grafana/runtime/src/components/PanelDataErrorView\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'@grafana/runtime/src/components/PanelRenderer\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/runtime/src/components/PluginPage\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
+      [0, 0, 0, "\'@grafana/runtime/src/components/PluginPage\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/runtime/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "3"]
     ],
     "public/app/core/TableModel.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -2882,6 +2883,9 @@ exports[`better eslint`] = {
     ],
     "public/app/features/auth-config/utils/data.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
+    "public/app/features/bookmarks/BookmarksPage.tsx:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/browse-dashboards/api/browseDashboardsAPI.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`@reduxjs/toolkit/query/react\`)", "0"]

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -9,5 +9,7 @@
  * and be subject to the standard policies
  */
 
+export { useT, setUseTHook } from './utils/i18n';
+
 // Dummy export to make it a valid module. Remove when we have real exports.
-export const unstable = {};
+// export const unstable = {};

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -10,6 +10,3 @@
  */
 
 export { useTranslate as useT, setUseTranslateHook } from './utils/i18n';
-
-// Dummy export to make it a valid module. Remove when we have real exports.
-// export const unstable = {};

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -9,7 +9,7 @@
  * and be subject to the standard policies
  */
 
-export { useT, setUseTHook } from './utils/i18n';
+export { useTranslate as useT, setUseTranslateHook as setUseTHook } from './utils/i18n';
 
 // Dummy export to make it a valid module. Remove when we have real exports.
 // export const unstable = {};

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -9,7 +9,7 @@
  * and be subject to the standard policies
  */
 
-export { useTranslate as useT, setUseTranslateHook as setUseTHook } from './utils/i18n';
+export { useTranslate as useT, setUseTranslateHook } from './utils/i18n';
 
 // Dummy export to make it a valid module. Remove when we have real exports.
 // export const unstable = {};

--- a/packages/grafana-runtime/src/utils/i18n.ts
+++ b/packages/grafana-runtime/src/utils/i18n.ts
@@ -13,6 +13,6 @@ export let useT: UseTHook = () => {
   };
 };
 
-export function setUseTHook(useT: UseTHook) {
-  useT = useT;
+export function setUseTHook(useTParam: UseTHook) {
+  useT = useTParam;
 }

--- a/packages/grafana-runtime/src/utils/i18n.ts
+++ b/packages/grafana-runtime/src/utils/i18n.ts
@@ -1,0 +1,18 @@
+type UseTHook = () => (id: string, defaultMessage: string, values?: Record<string, unknown>) => string;
+
+// Fallback implementation that should be overridden by setUseT
+export let useT: UseTHook = () => {
+  const errorMessage = 'useT is not set. useT must not be called before Grafana is initialized.';
+  if (process.env.NODE_ENV === 'development') {
+    throw new Error(errorMessage);
+  }
+
+  console.error(errorMessage);
+  return (id: string, defaultMessage: string) => {
+    return defaultMessage;
+  };
+};
+
+export function setUseTHook(useT: UseTHook) {
+  useT = useT;
+}

--- a/packages/grafana-runtime/src/utils/i18n.ts
+++ b/packages/grafana-runtime/src/utils/i18n.ts
@@ -1,7 +1,10 @@
-type UseTHook = () => (id: string, defaultMessage: string, values?: Record<string, unknown>) => string;
+type UseTranslateHook = () => (id: string, defaultMessage: string, values?: Record<string, unknown>) => string;
 
-// Fallback implementation that should be overridden by setUseT
-export let useT: UseTHook = () => {
+/**
+ * Provides a i18next-compatible translation function.
+ */
+export let useTranslate: UseTranslateHook = () => {
+  // Fallback implementation that should be overridden by setUseT
   const errorMessage = 'useT is not set. useT must not be called before Grafana is initialized.';
   if (process.env.NODE_ENV === 'development') {
     throw new Error(errorMessage);
@@ -13,6 +16,6 @@ export let useT: UseTHook = () => {
   };
 };
 
-export function setUseTHook(useTParam: UseTHook) {
-  useT = useTParam;
+export function setUseTranslateHook(useTParam: UseTranslateHook) {
+  useTranslate = useTParam;
 }

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -45,6 +45,7 @@ import {
 import { setPanelDataErrorView } from '@grafana/runtime/src/components/PanelDataErrorView';
 import { setPanelRenderer } from '@grafana/runtime/src/components/PanelRenderer';
 import { setPluginPage } from '@grafana/runtime/src/components/PluginPage';
+import { setUseTHook } from '@grafana/runtime/src/unstable';
 import config, { updateConfig } from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -58,7 +59,7 @@ import { getAllOptionEditors, getAllStandardFieldConfigs } from './core/componen
 import { PluginPage } from './core/components/Page/PluginPage';
 import { GrafanaContextType, useChromeHeaderHeight, useReturnToPreviousInternal } from './core/context/GrafanaContext';
 import { initializeCrashDetection } from './core/crash';
-import { initializeI18n } from './core/internationalization';
+import { initializeI18n, useTInternal } from './core/internationalization';
 import { setMonacoEnv } from './core/monacoEnv';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
 import { CorrelationsService } from './core/services/CorrelationsService';
@@ -253,6 +254,7 @@ export class GrafanaApp {
 
       setReturnToPreviousHook(useReturnToPreviousInternal);
       setChromeHeaderHeightHook(useChromeHeaderHeight);
+      setUseTHook(useTInternal);
 
       if (config.featureToggles.crashDetection) {
         initializeCrashDetection();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -59,7 +59,7 @@ import { getAllOptionEditors, getAllStandardFieldConfigs } from './core/componen
 import { PluginPage } from './core/components/Page/PluginPage';
 import { GrafanaContextType, useChromeHeaderHeight, useReturnToPreviousInternal } from './core/context/GrafanaContext';
 import { initializeCrashDetection } from './core/crash';
-import { initializeI18n, useTInternal } from './core/internationalization';
+import { initializeI18n, useTranslateInternal } from './core/internationalization';
 import { setMonacoEnv } from './core/monacoEnv';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
 import { CorrelationsService } from './core/services/CorrelationsService';
@@ -254,7 +254,7 @@ export class GrafanaApp {
 
       setReturnToPreviousHook(useReturnToPreviousInternal);
       setChromeHeaderHeightHook(useChromeHeaderHeight);
-      setUseTHook(useTInternal);
+      setUseTHook(useTranslateInternal);
 
       if (config.featureToggles.crashDetection) {
         initializeCrashDetection();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -45,7 +45,7 @@ import {
 import { setPanelDataErrorView } from '@grafana/runtime/src/components/PanelDataErrorView';
 import { setPanelRenderer } from '@grafana/runtime/src/components/PanelRenderer';
 import { setPluginPage } from '@grafana/runtime/src/components/PluginPage';
-import { setUseTHook } from '@grafana/runtime/src/unstable';
+import { setUseTranslateHook } from '@grafana/runtime/src/unstable';
 import config, { updateConfig } from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -254,7 +254,7 @@ export class GrafanaApp {
 
       setReturnToPreviousHook(useReturnToPreviousInternal);
       setChromeHeaderHeightHook(useChromeHeaderHeight);
-      setUseTHook(useTranslateInternal);
+      setUseTranslateHook(useTranslateInternal);
 
       if (config.featureToggles.crashDetection) {
         initializeCrashDetection();

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -118,6 +118,6 @@ export function getI18next() {
 // This hook doesn't do much now, but we want it to define the API for plugins.
 // Perhaps in the future this will use useTranslation from react-i18next or something else
 // from context
-export function useTInternal() {
+export function useTranslateInternal() {
   return t;
 }

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -72,6 +72,8 @@ export const Trans = (props: TransProps): ReactElement => {
  * This is a simple wrapper over i18n.t() to provide default namespaces and enforce a consistent API.
  * Note: Don't use this in the top level module scope. This wrapper needs initialization, which is done during Grafana
  * startup, and it will throw if used before.
+ *
+ * This will soon be deprecated in favor of useT()
  * @param id ID of the translation string
  * @param defaultMessage Default message to use if the translation is missing
  * @param values Values to be interpolated into the string
@@ -110,4 +112,12 @@ export function getI18next() {
   }
 
   return i18nInstance || i18n;
+}
+
+// We want to move to a react-only API for translations.
+// This hook doesn't do much now, but we want it to define the API for plugins.
+// Perhaps in the future this will use useTranslation from react-i18next or something else
+// from context
+export function useTInternal() {
+  return t;
 }

--- a/public/app/features/bookmarks/BookmarksPage.tsx
+++ b/public/app/features/bookmarks/BookmarksPage.tsx
@@ -1,15 +1,17 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { useT } from '@grafana/runtime/src/unstable';
 import { EmptyState, useStyles2 } from '@grafana/ui';
 import { usePinnedItems } from 'app/core/components/AppChrome/MegaMenu/hooks';
 import { findByUrl } from 'app/core/components/AppChrome/MegaMenu/utils';
 import { NavLandingPageCard } from 'app/core/components/NavLandingPage/NavLandingPageCard';
 import { Page } from 'app/core/components/Page/Page';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans } from 'app/core/internationalization';
 import { useSelector } from 'app/types';
 
 export function BookmarksPage() {
+  const t = useT();
   const styles = useStyles2(getStyles);
   const pinnedItems = usePinnedItems();
   const navTree = useSelector((state) => state.navBarTree);


### PR DESCRIPTION
This PR adds a new `useT()` hook in `@grafana/runtime` to serve as the public react-only API for translating plugins.

At the moment all the hook does is return the statically defined `t` function, but in the future this may get `t` from react context or form react-i18next's `useTranslation`. The point of this now is to establish the API.

Part of https://github.com/grafana/grafana/issues/102028 