### PR TITLE
[Provisioning] Improve progress recording and updates

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -18,12 +18,12 @@ import (
 // FIXME: revise logging in this method
 func (r *exportJob) loadFolders(ctx context.Context) error {
 	logger := r.logger
-	r.progress.SetMessage("reading folder tree")
+	r.progress.SetMessage(ctx, "reading folder tree")
 
 	repoName := r.target.Config().Name
 
 	// TODO: should this be logging or message or both?
-	r.progress.SetMessage("read folder tree from unified storage")
+	r.progress.SetMessage(ctx, "read folder tree from unified storage")
 	client := r.client.Resource(schema.GroupVersionResource{
 		Group:    folders.GROUP,
 		Version:  folders.VERSION,
@@ -51,7 +51,7 @@ func (r *exportJob) loadFolders(ctx context.Context) error {
 	}
 
 	// create folders first is required so that empty folders exist when finished
-	r.progress.SetMessage("write folders")
+	r.progress.SetMessage(ctx, "write folders")
 
 	err = r.folderTree.Walk(ctx, func(ctx context.Context, folder resources.Folder) error {
 		p := folder.Path + "/"

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -26,7 +26,7 @@ func (r *exportJob) loadResources(ctx context.Context) error {
 	}}
 
 	for _, kind := range kinds {
-		r.progress.SetMessage(fmt.Sprintf("reading %s resource", kind.Resource))
+		r.progress.SetMessage(ctx, fmt.Sprintf("reading %s resource", kind.Resource))
 		if err := r.loadResourcesFromAPIServer(ctx, kind); err != nil {
 			return fmt.Errorf("error loading %s %w", kind.Resource, err)
 		}

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -64,7 +64,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	)
 
 	if repo.Config().Spec.GitHub != nil {
-		progress.SetMessage("clone target")
+		progress.SetMessage(ctx, "clone target")
 		buffered, err = gogit.Clone(ctx, repo.Config(), gogit.GoGitCloneOptions{
 			Root:                   r.clonedir,
 			SingleCommitBeforePush: true,
@@ -90,20 +90,20 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	worker := newExportJob(ctx, rw, *options, dynamicClient, progress)
 
 	// Load and write all folders
-	progress.SetMessage("start folder export")
+	progress.SetMessage(ctx, "start folder export")
 	err = worker.loadFolders(ctx)
 	if err != nil {
 		return err
 	}
 
-	progress.SetMessage("start resource export")
+	progress.SetMessage(ctx, "start resource export")
 	err = worker.loadResources(ctx)
 	if err != nil {
 		return err
 	}
 
 	if buffered != nil {
-		progress.SetMessage("push changes")
+		progress.SetMessage(ctx, "push changes")
 		if err := buffered.Push(ctx, os.Stdout); err != nil {
 			return fmt.Errorf("error pushing changes: %w", err)
 		}

--- a/pkg/registry/apis/provisioning/jobs/migrate/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/folders.go
@@ -106,7 +106,6 @@ func (j *migrationJob) loadFolders(ctx context.Context) error {
 			return result.Error
 		}
 
-		j.progress.Record(ctx, result)
 		return nil
 	})
 	if err != nil {

--- a/pkg/registry/apis/provisioning/jobs/migrate/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/folders.go
@@ -48,11 +48,11 @@ func (f *folderReader) Write(ctx context.Context, key *resource.ResourceKey, val
 
 func (j *migrationJob) loadFolders(ctx context.Context) error {
 	logger := j.logger
-	j.progress.SetMessage("reading folder tree")
+	j.progress.SetMessage(ctx, "reading folder tree")
 
 	repoName := j.target.Config().Name
 
-	j.progress.SetMessage("migrate folder tree from legacy")
+	j.progress.SetMessage(ctx, "migrate folder tree from legacy")
 	reader := &folderReader{
 		tree:           j.folderTree,
 		targetRepoName: repoName,
@@ -70,7 +70,7 @@ func (j *migrationJob) loadFolders(ctx context.Context) error {
 	}
 
 	// create folders first is required so that empty folders exist when finished
-	j.progress.SetMessage("write folders")
+	j.progress.SetMessage(ctx, "write folders")
 
 	err = j.folderTree.Walk(ctx, func(ctx context.Context, folder resources.Folder) error {
 		p := folder.Path + "/"

--- a/pkg/registry/apis/provisioning/jobs/migrate/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/resources.go
@@ -70,7 +70,7 @@ func (j *migrationJob) loadResources(ctx context.Context) error {
 	}}
 
 	for _, kind := range kinds {
-		j.progress.SetMessage(fmt.Sprintf("migrate %s resource", kind.Resource))
+		j.progress.SetMessage(ctx, fmt.Sprintf("migrate %s resource", kind.Resource))
 		gr := kind.GroupResource()
 		opts := legacy.MigrateOptions{
 			Namespace:   j.namespace,

--- a/pkg/registry/apis/provisioning/jobs/migrate/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/resources.go
@@ -91,7 +91,7 @@ func (j *migrationJob) loadResources(ctx context.Context) error {
 			if history > count {
 				count = history // the number of items we will process
 			}
-			j.progress.SetTotal(int(count))
+			j.progress.SetTotal(ctx, int(count))
 		}
 
 		opts.OnlyCount = false // this time actually write

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -94,12 +94,12 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	isFromLegacy := dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, w.storageStatus)
 	progress.SetTotal(10) // will show a progress bar
 	if repo.Config().Spec.GitHub != nil {
-		progress.SetMessage("clone " + repo.Config().Spec.GitHub.URL)
+		progress.SetMessage(ctx, "clone "+repo.Config().Spec.GitHub.URL)
 		reader, writer := io.Pipe()
 		go func() {
 			scanner := bufio.NewScanner(reader)
 			for scanner.Scan() {
-				progress.SetMessage(scanner.Text())
+				progress.SetMessage(ctx, scanner.Text())
 			}
 		}()
 
@@ -134,7 +134,7 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	}
 
 	if options.History {
-		progress.SetMessage("loading users")
+		progress.SetMessage(ctx, "loading users")
 		err = worker.loadUsers(ctx)
 		if err != nil {
 			return fmt.Errorf("error loading users: %w", err)
@@ -142,13 +142,13 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	}
 
 	if isFromLegacy {
-		progress.SetMessage("exporting folders")
+		progress.SetMessage(ctx, "exporting folders")
 		err = worker.loadFolders(ctx)
 		if err != nil {
 			return err
 		}
 
-		progress.SetMessage("exporting resources")
+		progress.SetMessage(ctx, "exporting resources")
 		err = worker.loadResources(ctx)
 		if err != nil {
 			return err
@@ -167,12 +167,12 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	}
 
 	if buffered != nil {
-		progress.SetMessage("pushing changes")
+		progress.SetMessage(ctx, "pushing changes")
 		reader, writer := io.Pipe()
 		go func() {
 			scanner := bufio.NewScanner(reader)
 			for scanner.Scan() {
-				progress.SetMessage(scanner.Text())
+				progress.SetMessage(ctx, scanner.Text())
 			}
 		}()
 

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -92,7 +92,7 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	)
 
 	isFromLegacy := dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, w.storageStatus)
-	progress.SetTotal(10) // will show a progress bar
+	progress.SetTotal(ctx, 10) // will show a progress bar
 	if repo.Config().Spec.GitHub != nil {
 		progress.SetMessage(ctx, "clone "+repo.Config().Spec.GitHub.URL)
 		reader, writer := io.Pipe()

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -142,18 +142,19 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	}
 
 	if isFromLegacy {
-		progress.SetMessage(ctx, "exporting folders")
+		progress.SetMessage(ctx, "exporting legacy folders")
 		err = worker.loadFolders(ctx)
 		if err != nil {
 			return err
 		}
 
-		progress.SetMessage(ctx, "exporting resources")
+		progress.SetMessage(ctx, "exporting legacy resources")
 		err = worker.loadResources(ctx)
 		if err != nil {
 			return err
 		}
 	} else {
+		progress.SetMessage(ctx, "exporting resources")
 		err = w.exportWorker.Process(ctx, rw, provisioning.Job{
 			Spec: provisioning.JobSpec{
 				Push: &provisioning.ExportJobOptions{

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -166,13 +166,14 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 		}
 	}
 
+	logger := logging.FromContext(ctx)
 	if buffered != nil {
 		progress.SetMessage(ctx, "pushing changes")
 		reader, writer := io.Pipe()
 		go func() {
 			scanner := bufio.NewScanner(reader)
 			for scanner.Scan() {
-				progress.SetMessage(ctx, scanner.Text())
+				logger.Info("push output", "text", scanner.Text())
 			}
 		}()
 
@@ -204,6 +205,7 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 			logger.Warn("error trying to revert dual write settings after an error", "err", err)
 		}
 	}
+
 	return err
 }
 

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -188,9 +188,6 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 		}
 	}
 
-	// enable sync (won't be saved)
-	rw.Config().Spec.Sync.Enabled = true
-
 	// Delegate the import to a sync (from the already checked out go-git repository!)
 	progress.SetMessage(ctx, "pulling resources")
 	err = w.syncWorker.Process(ctx, rw, provisioning.Job{

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -36,15 +36,16 @@ type JobResourceResult struct {
 }
 
 type jobProgressRecorder struct {
-	started     time.Time
-	total       int
-	ref         string
-	message     string
-	resultCount int
-	errorCount  int
-	errors      []string
-	progressFn  ProgressFn
-	summaries   map[string]*provisioning.JobResourceSummary
+	started      time.Time
+	total        int
+	ref          string
+	message      string
+	finalMessage string
+	resultCount  int
+	errorCount   int
+	errors       []string
+	progressFn   ProgressFn
+	summaries    map[string]*provisioning.JobResourceSummary
 }
 
 func newJobProgressRecorder(ProgressFn ProgressFn) JobProgressRecorder {
@@ -78,8 +79,9 @@ func (r *jobProgressRecorder) SetMessage(ctx context.Context, msg string) {
 	logging.FromContext(ctx).Info("job progress message", "message", msg)
 }
 
-func (r *jobProgressRecorder) GetMessage() string {
-	return r.message
+func (r *jobProgressRecorder) SetFinalMessage(ctx context.Context, msg string) {
+	r.finalMessage = msg
+	logging.FromContext(ctx).Info("job final message", "message", msg)
 }
 
 func (r *jobProgressRecorder) SetRef(ref string) {
@@ -198,8 +200,8 @@ func (r *jobProgressRecorder) Complete(ctx context.Context, err error) provision
 	}
 
 	// Override message if progress have a more explicit message
-	if r.message != "" && jobStatus.State != provisioning.JobStateError {
-		jobStatus.Message = r.message
+	if r.finalMessage != "" && jobStatus.State != provisioning.JobStateError {
+		jobStatus.Message = r.finalMessage
 	}
 
 	return jobStatus

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -51,7 +51,7 @@ type jobProgressRecorder struct {
 func newJobProgressRecorder(ProgressFn ProgressFn) JobProgressRecorder {
 	return &jobProgressRecorder{
 		started:    time.Now(),
-		progressFn: maybeNotifyProgress(5*time.Second, ProgressFn),
+		progressFn: maybeNotifyProgress(2*time.Second, ProgressFn),
 		summaries:  make(map[string]*provisioning.JobResourceSummary),
 	}
 }
@@ -77,6 +77,7 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 func (r *jobProgressRecorder) SetMessage(ctx context.Context, msg string) {
 	r.message = msg
 	logging.FromContext(ctx).Info("job progress message", "message", msg)
+	r.notify(ctx)
 }
 
 func (r *jobProgressRecorder) SetFinalMessage(ctx context.Context, msg string) {

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -90,8 +90,10 @@ func (r *jobProgressRecorder) GetRef() string {
 	return r.ref
 }
 
-func (r *jobProgressRecorder) SetTotal(total int) {
+func (r *jobProgressRecorder) SetTotal(ctx context.Context, total int) {
 	r.total = total
+
+	r.notify(ctx)
 }
 
 func (r *jobProgressRecorder) TooManyErrors() error {

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -73,8 +73,9 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	r.notify(ctx)
 }
 
-func (r *jobProgressRecorder) SetMessage(msg string) {
+func (r *jobProgressRecorder) SetMessage(ctx context.Context, msg string) {
 	r.message = msg
+	logging.FromContext(ctx).Info("job progress message", "message", msg)
 }
 
 func (r *jobProgressRecorder) GetMessage() string {

--- a/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
@@ -73,7 +73,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	logger.Info("process pull request")
 	defer logger.Info("pull request processed")
 
-	progress.SetMessage("listing pull request files")
+	progress.SetMessage(ctx, "listing pull request files")
 	base := cfg.GitHub.Branch
 	ref := options.Hash
 	files, err := prRepo.CompareFiles(ctx, base, ref)
@@ -81,17 +81,17 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 		return fmt.Errorf("failed to list pull request files: %s", err.Error())
 	}
 
-	progress.SetMessage("clearing pull request comments")
+	progress.SetMessage(ctx, "clearing pull request comments")
 	if err := prRepo.ClearAllPullRequestFileComments(ctx, options.PR); err != nil {
 		return fmt.Errorf("failed to clear pull request comments: %+v", err)
 	}
 
 	if len(files) == 0 {
-		progress.SetMessage("no files to process")
+		progress.SetMessage(ctx, "no files to process")
 		return nil
 	}
 
-	progress.SetMessage("processing pull request files")
+	progress.SetMessage(ctx, "processing pull request files")
 	previews := make([]resourcePreview, 0, len(files))
 	for _, f := range files {
 		result := jobs.JobResourceResult{
@@ -139,11 +139,11 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	}
 
 	if len(previews) == 0 {
-		progress.SetMessage("no previews to add")
+		progress.SetMessage(ctx, "no previews to add")
 		return nil
 	}
 
-	progress.SetMessage("generating previews comment")
+	progress.SetMessage(ctx, "generating previews comment")
 	comment, err := c.previewer.GenerateComment(previews)
 	if err != nil {
 		return fmt.Errorf("generate comment: %w", err)

--- a/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest/worker.go
@@ -87,7 +87,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	}
 
 	if len(files) == 0 {
-		progress.SetMessage(ctx, "no files to process")
+		progress.SetFinalMessage(ctx, "no files to process")
 		return nil
 	}
 
@@ -139,7 +139,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	}
 
 	if len(previews) == 0 {
-		progress.SetMessage(ctx, "no previews to add")
+		progress.SetFinalMessage(ctx, "no previews to add")
 		return nil
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -29,7 +29,7 @@ type JobQueue interface {
 
 type JobProgressRecorder interface {
 	Record(ctx context.Context, result JobResourceResult)
-	SetMessage(msg string)
+	SetMessage(ctx context.Context, msg string)
 	GetMessage() string
 	SetRef(ref string)
 	GetRef() string

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -33,7 +33,7 @@ type JobProgressRecorder interface {
 	GetMessage() string
 	SetRef(ref string)
 	GetRef() string
-	SetTotal(total int)
+	SetTotal(ctx context.Context, total int)
 	TooManyErrors() error
 	Complete(ctx context.Context, err error) provisioning.JobStatus
 }

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -29,8 +29,8 @@ type JobQueue interface {
 
 type JobProgressRecorder interface {
 	Record(ctx context.Context, result JobResourceResult)
+	SetFinalMessage(ctx context.Context, msg string)
 	SetMessage(ctx context.Context, msg string)
-	GetMessage() string
 	SetRef(ref string)
 	GetRef() string
 	SetTotal(ctx context.Context, total int)

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -84,12 +84,12 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		},
 	}
 
-	progress.SetMessage("update sync status at start")
+	progress.SetMessage(ctx, "update sync status at start")
 	if err := r.patchStatus(ctx, cfg, patchOperations); err != nil {
 		return fmt.Errorf("update repo with job status at start: %w", err)
 	}
 
-	progress.SetMessage("execute sync job")
+	progress.SetMessage(ctx, "execute sync job")
 	syncJob, err := r.createJob(ctx, rw, progress)
 	if err != nil {
 		return fmt.Errorf("failed to create sync job: %w", err)
@@ -105,7 +105,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 	}
 
 	// Update final status using JSON patch
-	progress.SetMessage("update status and stats")
+	progress.SetMessage(ctx, "update status and stats")
 	patchOperations = []map[string]interface{}{
 		{
 			"op":    "replace",
@@ -131,7 +131,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 	}
 
 	if syncError == nil {
-		progress.SetMessage("job completed successfully")
+		progress.SetMessage(ctx, "job completed successfully")
 	}
 
 	return syncError
@@ -230,7 +230,7 @@ func (r *syncJob) run(ctx context.Context, options provisioning.SyncJobOptions) 
 
 		if cfg.Status.Sync.LastRef != "" && options.Incremental {
 			if currentRef == cfg.Status.Sync.LastRef {
-				r.progress.SetMessage("same commit as last sync")
+				r.progress.SetMessage(ctx, "same commit as last sync")
 				return nil
 			}
 
@@ -253,7 +253,7 @@ func (r *syncJob) run(ctx context.Context, options provisioning.SyncJobOptions) 
 	}
 
 	if len(changes) == 0 {
-		r.progress.SetMessage("no changes to sync")
+		r.progress.SetMessage(ctx, "no changes to sync")
 		return nil
 	}
 
@@ -275,7 +275,7 @@ func (r *syncJob) applyChanges(ctx context.Context, changes []ResourceFileChange
 	})
 
 	r.progress.SetTotal(len(changes))
-	r.progress.SetMessage("replicating changes")
+	r.progress.SetMessage(ctx, "replicating changes")
 
 	// Create folder structure first
 	for _, change := range changes {
@@ -314,7 +314,7 @@ func (r *syncJob) applyChanges(ctx context.Context, changes []ResourceFileChange
 		r.progress.Record(ctx, r.writeResourceFromFile(ctx, change.Path, "", change.Action))
 	}
 
-	r.progress.SetMessage("changes replicated")
+	r.progress.SetMessage(ctx, "changes replicated")
 
 	return nil
 }
@@ -327,12 +327,12 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 	}
 
 	if len(diff) < 1 {
-		r.progress.SetMessage("no changes detected between commits")
+		r.progress.SetMessage(ctx, "no changes detected between commits")
 		return nil
 	}
 
 	r.progress.SetTotal(len(diff))
-	r.progress.SetMessage("replicating versioned changes")
+	r.progress.SetMessage(ctx, "replicating versioned changes")
 
 	for _, change := range diff {
 		if err := r.progress.TooManyErrors(); err != nil {
@@ -362,7 +362,7 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 		}
 	}
 
-	r.progress.SetMessage("versioned changes replicated")
+	r.progress.SetMessage(ctx, "versioned changes replicated")
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -274,7 +274,7 @@ func (r *syncJob) applyChanges(ctx context.Context, changes []ResourceFileChange
 		return len(changes[i].Path) > len(changes[j].Path)
 	})
 
-	r.progress.SetTotal(len(changes))
+	r.progress.SetTotal(ctx, len(changes))
 	r.progress.SetMessage(ctx, "replicating changes")
 
 	// Create folder structure first
@@ -331,7 +331,7 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 		return nil
 	}
 
-	r.progress.SetTotal(len(diff))
+	r.progress.SetTotal(ctx, len(diff))
 	r.progress.SetMessage(ctx, "replicating versioned changes")
 
 	for _, change := range diff {

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -130,10 +130,6 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		return fmt.Errorf("update repo with job final status: %w", err)
 	}
 
-	if syncError == nil {
-		progress.SetMessage(ctx, "job completed successfully")
-	}
-
 	return syncError
 }
 
@@ -230,7 +226,7 @@ func (r *syncJob) run(ctx context.Context, options provisioning.SyncJobOptions) 
 
 		if cfg.Status.Sync.LastRef != "" && options.Incremental {
 			if currentRef == cfg.Status.Sync.LastRef {
-				r.progress.SetMessage(ctx, "same commit as last sync")
+				r.progress.SetFinalMessage(ctx, "same commit as last sync")
 				return nil
 			}
 
@@ -253,7 +249,7 @@ func (r *syncJob) run(ctx context.Context, options provisioning.SyncJobOptions) 
 	}
 
 	if len(changes) == 0 {
-		r.progress.SetMessage(ctx, "no changes to sync")
+		r.progress.SetFinalMessage(ctx, "no changes to sync")
 		return nil
 	}
 
@@ -327,7 +323,7 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 	}
 
 	if len(diff) < 1 {
-		r.progress.SetMessage(ctx, "no changes detected between commits")
+		r.progress.SetFinalMessage(ctx, "no changes detected between commits")
 		return nil
 	}
 


### PR DESCRIPTION
- Log job progress message.
- Notify Progress when setting total.
- Add SetFinalMessage to record the messages in early returns.
- Remove unnecessary hack to allow the sync as now it's not blocked by sync job itself.
