### PR TITLE
Grafana Data: Use package.json exports for internal code

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -392,8 +392,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
-    "packages/grafana-data/test/__mocks__/pluginMocks.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    "packages/grafana-data/test/helpers/pluginMocks.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-e2e-selectors/src/resolver.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -970,11 +971,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
-    "public/app/core/components/GraphNG/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToUndefThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
-    ],
     "public/app/core/components/Layers/LayerDragDropList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -996,9 +992,6 @@ exports[`better eslint`] = {
     ],
     "public/app/core/components/OptionsUI/fieldColor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
-    ],
-    "public/app/core/components/OptionsUI/registry.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/overrides/processors\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/OptionsUI/units.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1081,14 +1074,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
-    "public/app/core/components/TimelineChart/timeline.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/core/components/TimelineChart/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToValue\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
-    ],
     "public/app/core/config.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`Settings\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "1"]
@@ -1131,12 +1116,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/core/services/theme.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/registry\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/core/specs/backend_srv.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -1176,9 +1155,6 @@ exports[`better eslint`] = {
     "public/app/core/utils/deferred.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/core/utils/explore.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/core/utils/fetch.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -1200,10 +1176,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/utils/richHistory.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySearchFilters\`)", "1"],
-      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySettings\`)", "2"],
-      [0, 0, 0, "Do not re-export imported variable (\`SortOrder\`)", "3"]
+      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySearchFilters\`)", "0"],
+      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySettings\`)", "1"],
+      [0, 0, 0, "Do not re-export imported variable (\`SortOrder\`)", "2"]
     ],
     "public/app/core/utils/ticks.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -1390,9 +1365,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
@@ -1405,8 +1380,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"]
     ],
     "public/app/features/alerting/unified/NotificationPoliciesPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2052,11 +2026,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -2426,9 +2399,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "22"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "23"]
     ],
-    "public/app/features/alerting/unified/components/rules/central-state-history/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/fieldComparers\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
@@ -2449,9 +2419,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
-    ],
-    "public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/fieldComparers\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/settings/AlertmanagerCard.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2674,9 +2641,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
-    "public/app/features/alerting/unified/utils/misc.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/alerting/unified/utils/receiver-form.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -2693,9 +2657,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
-    "public/app/features/alerting/unified/utils/routeTree.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/arrayUtils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/alerting/unified/utils/rule-form.ts:5381": [
       [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
@@ -2704,9 +2665,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
-    ],
-    "public/app/features/alerting/unified/utils/time.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/annotations/components/AnnotationResultMapper.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -2773,9 +2731,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
     ],
     "public/app/features/auth-config/AuthProvidersListPage.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/auth-config/ProviderConfigForm.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2829,9 +2786,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "2"]
-    ],
-    "public/app/features/canvas/element.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/canvas/elements/notFound.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
@@ -3082,9 +3036,6 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/saving/shared.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
-    ],
-    "public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard-scene/scene/PanelLinks.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -3566,10 +3517,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/dashboard/components/PanelEditor/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -3681,20 +3630,13 @@ exports[`better eslint`] = {
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
-    "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/query\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/dashboard/components/ShareModal/ViewJsonModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
-    "public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/features/dashboard/components/SubMenu/SubMenu.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -3807,12 +3749,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/labelsToFields\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/merge\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
@@ -3834,9 +3776,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "24"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "25"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "26"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "27"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "29"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "27"]
     ],
     "public/app/features/dashboard/state/DashboardModel.repeat.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -3949,10 +3889,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/datasources/components/CloudInfoBox.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/datasources/components/DashboardsTable.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4133,8 +4072,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "7"]
     ],
     "public/app/features/dimensions/scale.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/scale\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/dimensions/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -4212,9 +4150,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
-    "public/app/features/explore/Logs/Logs.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/explore/Logs/Logs.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -4238,9 +4173,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
-    "public/app/features/explore/Logs/LogsMetaRow.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/explore/Logs/LogsMetaRow.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -4254,9 +4186,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
-    ],
-    "public/app/features/explore/Logs/LogsTable.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/Logs/LogsTableAvailableFields.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4272,9 +4201,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
-    ],
-    "public/app/features/explore/Logs/LogsTableWrap.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/Logs/LogsTableWrap.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4556,9 +4482,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "public/app/features/explore/state/main.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/explore/state/time.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -4748,10 +4671,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/live/centrifuge/LiveDataStream.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/dataframe/StreamingDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/runtime/src/services/live\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/runtime/src/utils/toDataQueryError\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "\'@grafana/runtime/src/services/live\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/toDataQueryError\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/live/centrifuge/channel.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -4773,12 +4695,8 @@ exports[`better eslint`] = {
     "public/app/features/live/live.ts:5381": [
       [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
-    "public/app/features/logs/components/InfiniteScroll.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/logs/components/InfiniteScroll.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/logs/components/LogDetails.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4825,9 +4743,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
-    ],
-    "public/app/features/logs/logsModel.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/valueFormats/symbolFormatters\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/logs/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5168,23 +5083,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/plugins/extensions/usePluginComponents.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/plugins/extensions/usePluginFunctions.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/plugins/extensions/validators.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "public/app/features/plugins/pluginPreloader.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/plugins/sandbox/distortion_map.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5570,8 +5476,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/trails/DataTrailsHistory.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5605,21 +5510,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueFilterEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
-    ],
-    "public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5655,13 +5555,9 @@ exports[`better eslint`] = {
     "public/app/features/transformers/calculateHeatmap/editor/helper.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/transformers/calculateHeatmap/heatmap.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/transformers/calculateHeatmap/heatmap.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5669,66 +5565,58 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/BinaryOperationOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
-    ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/UnaryOperationEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+    ],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx:5381": [
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/UnaryOperationEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CalculateFieldTransformerEditor\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`calculateFieldTransformRegistryItem\`)", "1"]
     ],
     "public/app/features/transformers/editors/ConcatenateTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/concat\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
@@ -5743,15 +5631,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "13"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "14"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "15"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "16"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "17"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "16"]
     ],
     "public/app/features/transformers/editors/EnumMappingEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
+      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/transformers/editors/EnumMappingRow.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
@@ -5759,48 +5645,39 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByName\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/runtime/src/services\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"]
-    ],
-    "public/app/features/transformers/editors/FilterByRefIdTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByRefId\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/features/transformers/editors/FormatStringTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/formatString\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/services\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/formatTime\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
-    ],
-    "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
-    ],
-    "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupToNestedTable\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
+    ],
+    "public/app/features/transformers/editors/FormatStringTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+    ],
+    "public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+    ],
+    "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5809,73 +5686,59 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/HistogramTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinByField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+    ],
+    "public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/transformers/editors/LimitTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+    ],
+    "public/app/features/transformers/editors/MergeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
+    "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+    ],
+    "public/app/features/transformers/editors/ReduceTransformerEditor.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+    ],
+    "public/app/features/transformers/editors/RenameByRegexTransformer.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
-    "public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/labelsToFields\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
-    ],
-    "public/app/features/transformers/editors/LimitTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/limit\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
-    ],
-    "public/app/features/transformers/editors/MergeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/merge\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
-    ],
-    "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/order\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
-    ],
-    "public/app/features/transformers/editors/ReduceTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/reduce\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
-    ],
-    "public/app/features/transformers/editors/RenameByRegexTransformer.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/renameByRegex\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
-    ],
-    "public/app/features/transformers/editors/SeriesToRowsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/seriesToRows\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/transformers/editors/SortByTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/sortBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/TransposeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/transpose\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5901,11 +5764,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
-    ],
-    "public/app/features/transformers/extractFields/extractFields.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/sortBy\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/data/src/utils/tests/mockTransformationsRegistry\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/features/transformers/extractFields/extractFields.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5949,10 +5807,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/ids\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
-    ],
     "public/app/features/transformers/lookupGazetteer/fieldLookup.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -5965,10 +5819,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
-    ],
-    "public/app/features/transformers/partitionByValues/partitionByValues.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByName\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/noop\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/transformers/prepareTimeSeries/PrepareTimeSeriesEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6004,18 +5854,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
     ],
     "public/app/features/transformers/spatial/optionsHelper.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
-    ],
-    "public/app/features/transformers/spatial/spatialTransformer.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/ids\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -6298,9 +6142,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/plugins/datasource/azuremonitor/__mocks__/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/data\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/datasource/azuremonitor/azureMetadata/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"]
@@ -6471,9 +6312,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
-    "public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/moment_wrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/datasource/cloudwatch/types.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
@@ -6496,9 +6334,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/datasource/elasticsearch/ElasticResponse.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
@@ -6527,8 +6365,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "29"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "30"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "31"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "32"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "31"]
     ],
     "public/app/plugins/datasource/elasticsearch/LanguageProvider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -6903,21 +6740,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/bars.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/barchart/quadtree.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/panel/barchart/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/fieldState\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/candlestick/CandlestickPanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
-    "public/app/plugins/panel/candlestick/fields.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/candlestick/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CandleStyle\`)", "0"],
@@ -6928,28 +6758,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`Options\`)", "5"],
       [0, 0, 0, "Do not re-export imported variable (\`VizDisplayMode\`)", "6"],
       [0, 0, 0, "Do not re-export imported variable (\`defaultCandlestickColors\`)", "7"]
-    ],
-    "public/app/plugins/panel/canvas/components/CanvasTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/types/action\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/canvas/editor/connectionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/canvas/editor/element/elementEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
-    ],
-    "public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/canvas/editor/options.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/datagrid/components/DatagridContextMenu.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/debug/CursorView.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -6963,10 +6771,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/geomap/components/MarkersLegend.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/scale\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/panel/geomap/editor/GeomapStyleRulesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -6992,9 +6799,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/plugins/panel/geomap/editor/layerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/geomap/layers/basemaps/esri.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -7002,8 +6806,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/geomap/layers/data/routeLayer.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/geomap/layers/registry.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -7015,9 +6818,6 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/panel/geomap/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
-    ],
-    "public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/matchers/compareValues\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/geomap/utils/layers.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7059,26 +6859,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "15"],
       [0, 0, 0, "Do not use any type assertions.", "16"]
     ],
-    "public/app/plugins/panel/histogram/Histogram.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/histogram/HistogramPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/histogram/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/histogram/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/live/LivePanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/logs/LogsPanel.test.tsx:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "public/app/plugins/panel/logs/LogsPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/logs/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
@@ -7113,9 +6898,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/stat/StatMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/panel/stat/StatPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/fieldOverrides\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/state-timeline/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
@@ -7124,11 +6906,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/panel/table/migrations.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/reduce\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/plugins/panel/text/textPanelMigrationHandler.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7167,31 +6948,17 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/plugins/panel/timeseries/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToValue\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
-    ],
-    "public/app/plugins/panel/trend/TrendPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/xychart/SeriesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"]
     ],
-    "public/app/plugins/panel/xychart/XYChartPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/panel/xychart/XYChartTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/plugins/panel/xychart/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/xychart/scatter.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
@@ -7205,14 +6972,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "11"],
       [0, 0, 0, "Do not use any type assertions.", "12"],
       [0, 0, 0, "Do not use any type assertions.", "13"],
-      [0, 0, 0, "Do not use any type assertions.", "14"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
-    ],
-    "public/app/plugins/panel/xychart/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/data/src/field/fieldState\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "17"]
     ],
     "public/app/plugins/sdk.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`loadPluginCss\`)", "0"]

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -29,6 +29,10 @@
     "./unstable": {
       "import": "./src/unstable.ts",
       "require": "./src/unstable.ts"
+    },
+    "./test": {
+      "import": "./test/index.ts",
+      "require": "./test/index.ts"
     }
   },
   "publishConfig": {

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -15,6 +15,22 @@
   },
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "module": "src/index.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    },
+    "./internal": {
+      "import": "./src/internal/index.ts",
+      "require": "./src/internal/index.ts"
+    },
+    "./unstable": {
+      "import": "./src/unstable.ts",
+      "require": "./src/unstable.ts"
+    }
+  },
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -1,0 +1,104 @@
+/**
+ * This file is used to share internal grafana/ui code with Grafana core.
+ * Note that these exports are also used within Enterprise.
+ *
+ * Through the exports declared in package.json we can import this code in core Grafana and the grafana/ui
+ * package will continue to be able to access all code when it's published to npm as it's private to the package.
+ *
+ * During the yarn pack lifecycle the exports[./internal] property is deleted from the package.json
+ * preventing the code from being importable by plugins or other npm packages making it truly "internal".
+ *
+ */
+
+export { actionsOverrideProcessor } from '../field/overrides/processors';
+export { nullToUndefThreshold } from '../transformations/transformers/nulls/nullToUndefThreshold';
+export { applyNullInsertThreshold } from '../transformations/transformers/nulls/nullInsertThreshold';
+export {
+  NULL_EXPAND,
+  NULL_REMOVE,
+  NULL_RETAIN,
+  isLikelyAscendingVector,
+  maybeSortFrame,
+} from '../transformations/transformers/joinDataFrames';
+export { ConcatenateFrameNameMode, type ConcatenateTransformerOptions } from '../transformations/transformers/concat';
+export {
+  type ConvertFieldTypeOptions,
+  type ConvertFieldTypeTransformerOptions,
+  convertFieldType,
+} from '../transformations/transformers/convertFieldType';
+export { type FilterFieldsByNameTransformerOptions } from '../transformations/transformers/filterByName';
+export { type FilterFramesByRefIdTransformerOptions } from '../transformations/transformers/filterByRefId';
+export { FormatStringOutput, type FormatStringTransformerOptions } from '../transformations/transformers/formatString';
+export { organizeFieldsTransformer } from '../transformations/transformers/organize';
+export { labelsToFieldsTransformer } from '../transformations/transformers/labelsToFields';
+export { type FormatTimeTransformerOptions } from '../transformations/transformers/formatTime';
+export {
+  type GroupByFieldOptions,
+  GroupByOperationID,
+  type GroupByTransformerOptions,
+} from '../transformations/transformers/groupBy';
+export {
+  type GroupToNestedTableTransformerOptions,
+  SHOW_NESTED_HEADERS_DEFAULT,
+} from '../transformations/transformers/groupToNestedTable';
+export {
+  type BinaryValue,
+  type BinaryOptions,
+  CalculateFieldMode,
+  type CalculateFieldTransformerOptions,
+  getNameFromOptions,
+  defaultWindowOptions,
+  checkBinaryValueType,
+  type CumulativeOptions,
+  type ReduceOptions,
+  type UnaryOptions,
+  WindowAlignment,
+  type WindowOptions,
+  WindowSizeMode,
+} from '../transformations/transformers/calculateField';
+export { type SeriesToRowsTransformerOptions } from '../transformations/transformers/seriesToRows';
+export { histogramFieldInfo, type HistogramTransformerInputs } from '../transformations/transformers/histogram';
+export { type JoinByFieldOptions, JoinMode } from '../transformations/transformers/joinByField';
+export { LabelsToFieldsMode, type LabelsToFieldsOptions } from '../transformations/transformers/labelsToFields';
+export { type LimitTransformerOptions } from '../transformations/transformers/limit';
+export { type MergeTransformerOptions } from '../transformations/transformers/merge';
+export { ReduceTransformerMode, type ReduceTransformerOptions } from '../transformations/transformers/reduce';
+export { createOrderFieldsComparer } from '../transformations/transformers/order';
+export { type RenameByRegexTransformerOptions } from '../transformations/transformers/renameByRegex';
+export { type OrganizeFieldsTransformerOptions } from '../transformations/transformers/organize';
+export { compareValues } from '../transformations/matchers/compareValues';
+export {
+  type SortByField,
+  type SortByTransformerOptions,
+  sortByTransformer,
+} from '../transformations/transformers/sortBy';
+export { type TransposeTransformerOptions } from '../transformations/transformers/transpose';
+export {
+  type FilterByValueTransformerOptions,
+  FilterByValueMatch,
+  FilterByValueType,
+  type FilterByValueFilter,
+} from '../transformations/transformers/filterByValue';
+export { getMatcherConfig } from '../transformations/transformers/filterByName';
+export { mockTransformationsRegistry } from '../utils/tests/mockTransformationsRegistry';
+export { noopTransformer } from '../transformations/transformers/noop';
+export { DataTransformerID } from '../transformations/transformers/ids';
+
+export { mergeTransformer } from '../transformations/transformers/merge';
+export { getThemeById } from '../themes/registry';
+export { GrafanaEdition } from '../types/config';
+export { SIPrefix } from '../valueFormats/symbolFormatters';
+export { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '../datetime/rangeutil';
+
+export { type PluginAddedLinksConfigureFunc, type PluginExtensionEventHelpers } from '../types/pluginExtensions';
+
+export { getStreamingFrameOptions } from '../dataframe/StreamingDataFrame';
+export { secondsToHms, relativeToTimeRange } from '../datetime/rangeutil';
+export { describeInterval } from '../datetime/rangeutil';
+export { fieldIndexComparer } from '../field/fieldComparers';
+export { decoupleHideFromState } from '../field/fieldState';
+export { findNumericFieldMinMax } from '../field/fieldOverrides';
+export { insertAfterImmutably, insertBeforeImmutably } from '../utils/arrayUtils';
+export { type PanelOptionsSupplier } from '../panel/PanelPlugin';
+export { sanitize, sanitizeUrl } from '../text/sanitize';
+export { type NestedValueAccess, type NestedPanelOptions, isNestedPanelOptions } from '../utils/OptionsUIBuilders';

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -88,17 +88,13 @@ export { mergeTransformer } from '../transformations/transformers/merge';
 export { getThemeById } from '../themes/registry';
 export { GrafanaEdition } from '../types/config';
 export { SIPrefix } from '../valueFormats/symbolFormatters';
-export { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '../datetime/rangeutil';
 
 export { type PluginAddedLinksConfigureFunc, type PluginExtensionEventHelpers } from '../types/pluginExtensions';
 
 export { getStreamingFrameOptions } from '../dataframe/StreamingDataFrame';
-export { secondsToHms, relativeToTimeRange } from '../datetime/rangeutil';
-export { describeInterval } from '../datetime/rangeutil';
 export { fieldIndexComparer } from '../field/fieldComparers';
 export { decoupleHideFromState } from '../field/fieldState';
 export { findNumericFieldMinMax } from '../field/fieldOverrides';
-export { insertAfterImmutably, insertBeforeImmutably } from '../utils/arrayUtils';
 export { type PanelOptionsSupplier } from '../panel/PanelPlugin';
 export { sanitize, sanitizeUrl } from '../text/sanitize';
 export { type NestedValueAccess, type NestedPanelOptions, isNestedPanelOptions } from '../utils/OptionsUIBuilders';

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -1,8 +1,8 @@
 /**
- * This file is used to share internal grafana/ui code with Grafana core.
+ * This file is used to share internal grafana/data code with Grafana core.
  * Note that these exports are also used within Enterprise.
  *
- * Through the exports declared in package.json we can import this code in core Grafana and the grafana/ui
+ * Through the exports declared in package.json we can import this code in core Grafana and the grafana/data
  * package will continue to be able to access all code when it's published to npm as it's private to the package.
  *
  * During the yarn pack lifecycle the exports[./internal] property is deleted from the package.json

--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
@@ -11,8 +11,7 @@ import {
   ThresholdsMode,
 } from '@grafana/data';
 
-import { getPanelPlugin } from '../../test/__mocks__/pluginMocks';
-import { mockStandardFieldConfigOptions } from '../../test/helpers/fieldConfig';
+import { getPanelPlugin, mockStandardFieldConfigOptions } from '../../test';
 
 import { getPanelOptionsWithDefaults, restoreCustomOverrideRules } from './getPanelOptionsWithDefaults';
 

--- a/packages/grafana-data/test/helpers/pluginMocks.ts
+++ b/packages/grafana-data/test/helpers/pluginMocks.ts
@@ -1,7 +1,7 @@
 import { defaultsDeep } from 'lodash';
 import { ComponentType } from 'react';
 
-import { PanelPluginMeta, PluginMeta, PluginType, PanelPlugin, PanelProps } from '../../src';
+import { PanelPluginMeta, PluginMeta, PluginType, PanelPlugin, PanelProps } from '../../';
 
 export const getMockPlugins = (amount: number): PluginMeta[] => {
   const plugins: PluginMeta[] = [];

--- a/packages/grafana-data/test/index.ts
+++ b/packages/grafana-data/test/index.ts
@@ -1,0 +1,2 @@
+export { getMockPlugin, getMockPlugins, getPanelPlugin } from './helpers/pluginMocks';
+export { mockStandardFieldConfigOptions } from './helpers/fieldConfig';

--- a/packages/grafana-prometheus/src/querybuilder/operationUtils.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operationUtils.ts
@@ -2,7 +2,7 @@
 import { capitalize } from 'lodash';
 import pluralize from 'pluralize';
 
-import { SelectableValue } from '@grafana/data/src';
+import { SelectableValue } from '@grafana/data';
 
 import { LabelParamEditor } from './components/LabelParamEditor';
 import {

--- a/public/app/core/components/GraphNG/utils.ts
+++ b/public/app/core/components/GraphNG/utils.ts
@@ -1,7 +1,5 @@
-import { DataFrame, Field, FieldType, outerJoinDataFrames, TimeRange } from '@grafana/data';
-import { NULL_EXPAND, NULL_REMOVE, NULL_RETAIN } from '@grafana/data/src/transformations/transformers/joinDataFrames';
-import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
-import { nullToUndefThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullToUndefThreshold';
+import { DataFrame, Field, FieldType, outerJoinDataFrames, TimeRange, applyNullInsertThreshold } from '@grafana/data';
+import { NULL_EXPAND, NULL_REMOVE, NULL_RETAIN, nullToUndefThreshold } from '@grafana/data/internal';
 import { GraphDrawStyle } from '@grafana/schema';
 
 import { XYFieldMatchers } from './types';

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -29,7 +29,7 @@ import {
   Action,
   DataLinksFieldConfigSettings,
 } from '@grafana/data';
-import { actionsOverrideProcessor } from '@grafana/data/src/field/overrides/processors';
+import { actionsOverrideProcessor } from '@grafana/data/internal';
 import { FieldConfig } from '@grafana/schema';
 import { RadioButtonGroup, TimeZonePicker, Switch } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -1,7 +1,6 @@
 import uPlot, { Series } from 'uplot';
 
-import { GrafanaTheme2, TimeRange } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
+import { GrafanaTheme2, TimeRange, colorManipulator } from '@grafana/data';
 import { TimelineValueAlignment, VisibilityMode } from '@grafana/schema';
 import { FIXED_UNIT } from '@grafana/ui';
 import { distribute, SPACE_BETWEEN } from 'app/plugins/panel/barchart/distribute';
@@ -533,5 +532,5 @@ function getFillColor(fieldConfig: { fillOpacity?: number; lineWidth?: number },
   }
 
   const opacityPercent = (fieldConfig.fillOpacity ?? 100) / 100;
-  return alpha(color, opacityPercent);
+  return colorManipulator.alpha(color, opacityPercent);
 }

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -18,10 +18,10 @@ import {
   outerJoinDataFrames,
   ValueMapping,
   ThresholdsConfig,
+  applyNullInsertThreshold,
+  nullToValue,
 } from '@grafana/data';
-import { maybeSortFrame, NULL_RETAIN } from '@grafana/data/src/transformations/transformers/joinDataFrames';
-import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
-import { nullToValue } from '@grafana/data/src/transformations/transformers/nulls/nullToValue';
+import { maybeSortFrame, NULL_RETAIN } from '@grafana/data/internal';
 import {
   VizLegendOptions,
   AxisPlacement,

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -1,5 +1,5 @@
 import { BuildInfo } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/src/types/config';
+import { GrafanaEdition } from '@grafana/data/internal';
 import { Faro, Instrumentation } from '@grafana/faro-core';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import { BrowserConfig, FetchTransport } from '@grafana/faro-web-sdk';

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -1,4 +1,4 @@
-import { getThemeById } from '@grafana/data/src/themes/registry';
+import { getThemeById } from '@grafana/data/internal';
 import { ThemeChangedEvent } from '@grafana/runtime';
 
 import appEvents from '../app_events';

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -1,5 +1,12 @@
-import { DataSourceApi, dateTime, ExploreUrlState, GrafanaConfig, locationUtil, LogsSortOrder } from '@grafana/data';
-import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
+import {
+  DataSourceApi,
+  dateTime,
+  ExploreUrlState,
+  GrafanaConfig,
+  locationUtil,
+  LogsSortOrder,
+  serializeStateToUrlParam,
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { RefreshPicker } from '@grafana/ui';

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -1,7 +1,13 @@
 import { omit } from 'lodash';
 
-import { DataQuery, DataSourceApi, dateTimeFormat, ExploreUrlState, urlUtil } from '@grafana/data';
-import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
+import {
+  DataQuery,
+  DataSourceApi,
+  dateTimeFormat,
+  ExploreUrlState,
+  urlUtil,
+  serializeStateToUrlParam,
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification, createWarningNotification } from 'app/core/copy/appNotification';

--- a/public/app/features/admin/UserListPublicDashboardPage/DashboardsListModalButton.tsx
+++ b/public/app/features/admin/UserListPublicDashboardPage/DashboardsListModalButton.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { config } from '@grafana/runtime';
 import { Button, LoadingPlaceholder, Modal, ModalsController, useStyles2 } from '@grafana/ui';

--- a/public/app/features/admin/UserListPublicDashboardPage/DeleteUserModalButton.tsx
+++ b/public/app/features/admin/UserListPublicDashboardPage/DeleteUserModalButton.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Button, Modal, ModalsController, useStyles2 } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -2,8 +2,7 @@ import { css, cx } from '@emotion/css';
 import { keyBy, startCase, uniqueId } from 'lodash';
 import * as React from 'react';
 
-import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, urlUtil } from '@grafana/data';
-import { secondsToHms } from '@grafana/data/internal';
+import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, rangeUtil, urlUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { Preview } from '@grafana/sql/src/components/visual-query-builder/Preview';
@@ -123,7 +122,7 @@ export function QueryPreview({
   if (relativeTimeRange) {
     headerItems.push(
       <Text color="secondary" key="timerange">
-        {secondsToHms(relativeTimeRange.from)} to now
+        {rangeUtil.secondsToHms(relativeTimeRange.from)} to now
       </Text>
     );
   }

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -3,7 +3,7 @@ import { keyBy, startCase, uniqueId } from 'lodash';
 import * as React from 'react';
 
 import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, urlUtil } from '@grafana/data';
-import { secondsToHms } from '@grafana/data/src/datetime/rangeutil';
+import { secondsToHms } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { Preview } from '@grafana/sql/src/components/visual-query-builder/Preview';

--- a/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.tsx
+++ b/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, useStyles2 } from '@grafana/ui';
 
 import { AlertmanagerChoice } from '../../../../plugins/datasource/alertmanager/types';

--- a/public/app/features/alerting/unified/components/rule-editor/CloudAlertPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudAlertPreview.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { DataFrame, GrafanaTheme2 } from '@grafana/data/src';
+import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { Icon, TagList, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { labelsToTags } from '../../utils/labels';

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -5,7 +5,7 @@ import { useDebounce } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList } from 'react-window';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import {
   Alert,
   Button,

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { GrafanaTheme2, RelativeTimeRange, dateTime, getDefaultRelativeTimeRange } from '@grafana/data';
-import { relativeToTimeRange } from '@grafana/data/internal';
+import { GrafanaTheme2, RelativeTimeRange, dateTime, getDefaultRelativeTimeRange, rangeUtil } from '@grafana/data';
 import { Icon, InlineField, RelativeTimeRangePicker, Toggletip, clearButtonStyles, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -27,7 +26,7 @@ export const QueryOptions = ({
 
   const [showOptions, setShowOptions] = useState(false);
 
-  const timeRange = query.relativeTimeRange ? relativeToTimeRange(query.relativeTimeRange) : undefined;
+  const timeRange = query.relativeTimeRange ? rangeUtil.relativeToTimeRange(query.relativeTimeRange) : undefined;
 
   return (
     <>

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 
 import { GrafanaTheme2, RelativeTimeRange, dateTime, getDefaultRelativeTimeRange } from '@grafana/data';
-import { relativeToTimeRange } from '@grafana/data/src/datetime/rangeutil';
+import { relativeToTimeRange } from '@grafana/data/internal';
 import { Icon, InlineField, RelativeTimeRangePicker, Toggletip, clearButtonStyles, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleTypePicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleTypePicker.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { isEmpty } from 'lodash';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Stack, useStyles2 } from '@grafana/ui';
 
 import { useRulesSourcesWithRuler } from '../../../hooks/useRuleSourcesWithRuler';

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { capitalize } from 'lodash';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Label, RadioButtonGroup, Tag, useStyles2 } from '@grafana/ui';
 import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime/src';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -11,7 +11,7 @@ import {
   ThresholdsMode,
   getDisplayProcessor,
 } from '@grafana/data';
-import { fieldIndexComparer } from '@grafana/data/src/field/fieldComparers';
+import { fieldIndexComparer } from '@grafana/data/internal';
 import { mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 import { labelsMatchMatchers } from '../../../utils/alertmanager';

--- a/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
@@ -9,7 +9,7 @@ import {
   GrafanaTheme2,
   getDisplayProcessor,
 } from '@grafana/data';
-import { fieldIndexComparer } from '@grafana/data/src/field/fieldComparers';
+import { fieldIndexComparer } from '@grafana/data/internal';
 import { MappingType, ThresholdsMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/home/PluginIntegrations.tsx
+++ b/public/app/features/alerting/unified/home/PluginIntegrations.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { useAlertingHomePageExtensions } from '../plugins/useAlertingHomePageExtensions';

--- a/public/app/features/alerting/unified/styles/pagination.ts
+++ b/public/app/features/alerting/unified/styles/pagination.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 
 export const getPaginationStyles = (theme: GrafanaTheme2) => {
   return css({

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash';
 
 import { Labels, UrlQueryMap } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/src/types/config';
+import { GrafanaEdition } from '@grafana/data/internal';
 import { config, isFetchError } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/alerting/unified/utils/routeTree.ts
+++ b/public/app/features/alerting/unified/utils/routeTree.ts
@@ -5,7 +5,7 @@
 import { produce } from 'immer';
 import { omit } from 'lodash';
 
-import { insertAfterImmutably, insertBeforeImmutably } from '@grafana/data/internal';
+import { arrayUtils } from '@grafana/data';
 import { ROUTES_META_SYMBOL, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import {
@@ -109,12 +109,12 @@ export const addRouteToReferenceRoute = (
 
     // insert new policy before / above the referenceRoute
     if (position === 'above') {
-      parentRoute.routes = insertBeforeImmutably(parentRoute.routes ?? [], newRoute, positionInParent);
+      parentRoute.routes = arrayUtils.insertBeforeImmutably(parentRoute.routes ?? [], newRoute, positionInParent);
     }
 
     // insert new policy after / below the referenceRoute
     if (position === 'below') {
-      parentRoute.routes = insertAfterImmutably(parentRoute.routes ?? [], newRoute, positionInParent);
+      parentRoute.routes = arrayUtils.insertAfterImmutably(parentRoute.routes ?? [], newRoute, positionInParent);
     }
   });
 };

--- a/public/app/features/alerting/unified/utils/routeTree.ts
+++ b/public/app/features/alerting/unified/utils/routeTree.ts
@@ -5,7 +5,7 @@
 import { produce } from 'immer';
 import { omit } from 'lodash';
 
-import { insertAfterImmutably, insertBeforeImmutably } from '@grafana/data/src/utils/arrayUtils';
+import { insertAfterImmutably, insertBeforeImmutably } from '@grafana/data/internal';
 import { ROUTES_META_SYMBOL, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import {

--- a/public/app/features/alerting/unified/utils/time.ts
+++ b/public/app/features/alerting/unified/utils/time.ts
@@ -1,4 +1,4 @@
-import { describeInterval } from '@grafana/data/src/datetime/rangeutil';
+import { describeInterval } from '@grafana/data/internal';
 
 import { TimeOptions } from '../types/time';
 

--- a/public/app/features/alerting/unified/utils/time.ts
+++ b/public/app/features/alerting/unified/utils/time.ts
@@ -1,4 +1,4 @@
-import { describeInterval } from '@grafana/data/internal';
+import { rangeUtil } from '@grafana/data';
 
 import { TimeOptions } from '../types/time';
 
@@ -18,7 +18,7 @@ export function parseInterval(value: string): [number, string] {
 }
 
 export function intervalToSeconds(interval: string): number {
-  const { sec, count } = describeInterval(interval);
+  const { sec, count } = rangeUtil.describeInterval(interval);
   return sec * count;
 }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.test.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-import { AnnotationQuery, DataSourceApi, DataSourceInstanceSettings } from '@grafana/data/src';
+import { AnnotationQuery, DataSourceApi, DataSourceInstanceSettings } from '@grafana/data';
 
 import StandardAnnotationQueryEditor, { Props as EditorProps } from './StandardAnnotationQueryEditor';
 

--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -1,7 +1,7 @@
 import { JSX, useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { GrafanaEdition } from '@grafana/data/src/types/config';
+import { GrafanaEdition } from '@grafana/data/internal';
 import { reportInteraction } from '@grafana/runtime';
 import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';

--- a/public/app/features/canvas/element.ts
+++ b/public/app/features/canvas/element.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react';
 
 import { DataLink, RegistryItem, Action } from '@grafana/data';
-import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
+import { PanelOptionsSupplier } from '@grafana/data/internal';
 import { ColorDimensionConfig, ScaleDimensionConfig } from '@grafana/schema';
 import { config } from 'app/core/config';
 import { BackgroundConfig, Constraint, LineConfig, Placement } from 'app/plugins/panel/canvas/panelcfg.gen';

--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { PluginState } from '@grafana/data';
+import { GrafanaTheme2, PluginState } from '@grafana/data';
 import { TextDimensionMode } from '@grafana/schema';
 import { Button, Spinner, useStyles2 } from '@grafana/ui';
 import { DimensionContext } from 'app/features/dimensions/context';

--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { PluginState } from '@grafana/data/src';
+import { PluginState } from '@grafana/data';
 import { TextDimensionMode } from '@grafana/schema';
 import { Button, Spinner, useStyles2 } from '@grafana/ui';
 import { DimensionContext } from 'app/features/dimensions/context';

--- a/public/app/features/canvas/types.ts
+++ b/public/app/features/canvas/types.ts
@@ -1,4 +1,4 @@
-import { LinkModel } from '@grafana/data/src';
+import { LinkModel } from '@grafana/data';
 import { ColorDimensionConfig, ResourceDimensionConfig, TextDimensionConfig } from '@grafana/schema';
 import { BackgroundImageSize } from 'app/plugins/panel/canvas/panelcfg.gen';
 

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.test.tsx
@@ -2,7 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from 'test/test-utils';
 
 import { FieldType, getDefaultTimeRange, LoadingState, toDataFrame } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { config } from '@grafana/runtime';
 import { SceneQueryRunner, SceneTimeRange, VizPanel, VizPanelMenu } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -10,7 +10,7 @@ import {
   standardTransformersRegistry,
   toDataFrame,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { SceneCanvasText, SceneDataTransformer, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import * as libpanels from 'app/features/library-panels/state/api';

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
@@ -6,7 +6,7 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { PanelProps } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import {
   LocationServiceProvider,

--- a/public/app/features/dashboard-scene/pages/PublicDashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/PublicDashboardScenePage.test.tsx
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 import { render } from 'test/test-utils';
 
 import { getDefaultTimeRange, LoadingState, PanelData, PanelProps } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { config, getPluginLinkExtensions, setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -15,7 +15,7 @@ import {
   TimeRange,
   toDataFrame,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService, setPluginExtensionsHook } from '@grafana/runtime';
 import { PANEL_EDIT_LAST_USED_DATASOURCE } from 'app/features/dashboard/utils/dashboard';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import { DataQueryRequest, DataSourceApi, LoadingState, PanelPlugin } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import {
   CancelActivationHandler,
   CustomVariable,

--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
 import { standardEditorsRegistry, standardFieldConfigEditorRegistry } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { VizPanel } from '@grafana/scenes';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/components/OptionsUI/registry';

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -10,7 +10,7 @@ import {
   LoadingState,
   PanelData,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneDataTransformer, SceneFlexLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { SHARED_DASHBOARD_QUERY, DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/constants';

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
@@ -1,4 +1,4 @@
-import { sanitizeUrl } from '@grafana/data/src/text/sanitize';
+import { sanitizeUrl } from '@grafana/data/internal';
 import { selectors } from '@grafana/e2e-selectors';
 import { sceneGraph } from '@grafana/scenes';
 import { DashboardLink } from '@grafana/schema';

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { config, setPluginImportUtils } from '@grafana/runtime';
 
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import { FieldType, LoadingState, PanelData, getDefaultTimeRange, toDataFrame } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { SceneCanvasText, sceneGraph, SceneGridLayout, VizPanel } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -8,7 +8,7 @@ import {
   toDataFrame,
   urlUtil,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { config, getPluginLinkExtensions, locationService } from '@grafana/runtime';
 import {
   LocalValueVariable,

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
@@ -1,4 +1,4 @@
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneGridLayout, SceneVariableSet, TestVariable, VizPanel } from '@grafana/scenes';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.test.tsx
@@ -1,5 +1,5 @@
 import { VariableRefresh } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SceneCanvasText,

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeaterBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeaterBehavior.test.tsx
@@ -1,5 +1,5 @@
 import { VariableRefresh } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SceneGridRow,

--- a/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
@@ -1,5 +1,5 @@
 import { PanelTypeChangedHandler } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 import { getAngularPanelMigrationHandler } from './angularMigration';

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -1,5 +1,5 @@
 import { LoadingState } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { config } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -13,7 +13,7 @@ import {
   toDataFrame,
   VariableSupportType,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { getPluginLinkExtensions, setPluginImportUtils } from '@grafana/runtime';
 import { MultiValueVariable, sceneGraph, SceneGridRow, VizPanel } from '@grafana/scenes';
 import { Dashboard, LoadingState, Panel, RowPanel, VariableRefresh } from '@grafana/schema';

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -8,7 +8,7 @@ import {
   getDefaultTimeRange,
   toDataFrame,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import {
   SceneVariableSet,

--- a/public/app/features/dashboard-scene/sharing/ShareButton/share-externally/ShareExternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/share-externally/ShareExternally.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
 import { getDefaultTimeRange, LoadingState } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { config, setPluginImportUtils } from '@grafana/runtime';
 import {

--- a/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { locationService, setPluginImportUtils } from '@grafana/runtime';
 import { SceneTimeRange, UrlSyncContextProvider } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { advanceTo, clear } from 'jest-date-mock';
 
 import { dateTime } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService, setPluginImportUtils } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { config, setPluginImportUtils } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -1,4 +1,4 @@
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 
 import { ContextSrv, setContextSrv } from '../../../../core/services/context_srv';
 import { PanelModel } from '../../state/PanelModel';

--- a/public/app/features/dashboard/components/HelpWizard/HelpWizard.test.tsx
+++ b/public/app/features/dashboard/components/HelpWizard/HelpWizard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { FieldType, getDefaultTimeRange, LoadingState, toDataFrame } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 
 import { PanelModel } from '../../state/PanelModel';
 

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -13,7 +13,7 @@ import {
   TimeRange,
   toDataFrame,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/components/OptionsUI/registry';
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelHeaderCorner.tsx
@@ -1,8 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { Component } from 'react';
 
-import { renderMarkdown, LinkModelSupplier, ScopedVars, IconName } from '@grafana/data';
-import { GrafanaTheme2 } from '@grafana/data/';
+import { GrafanaTheme2, renderMarkdown, LinkModelSupplier, ScopedVars, IconName } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { locationService, getTemplateSrv } from '@grafana/runtime';
 import { Tooltip, PopoverContent, Icon, Themeable2, withTheme2, useStyles2 } from '@grafana/ui';

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -7,13 +7,9 @@ import {
   PanelPlugin,
   StandardEditorContext,
   VariableSuggestionsScope,
-} from '@grafana/data';
-import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
-import {
-  NestedValueAccess,
   PanelOptionsEditorBuilder,
-  isNestedPanelOptions,
-} from '@grafana/data/src/utils/OptionsUIBuilders';
+} from '@grafana/data';
+import { NestedValueAccess, isNestedPanelOptions, PanelOptionsSupplier } from '@grafana/data/internal';
 import { VizPanel } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 import { LibraryVizPanelInfo } from 'app/features/dashboard-scene/panel-edit/LibraryVizPanelInfo';

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -1,5 +1,5 @@
 import { PanelPlugin } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { LibraryElementDTOMeta } from '@grafana/schema';
 import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { panelModelAndPluginReady, removePanel } from 'app/features/panel/state/reducers';

--- a/public/app/features/dashboard/components/PublicDashboardNotAvailable/PublicDashboardNotAvailable.tsx
+++ b/public/app/features/dashboard/components/PublicDashboardNotAvailable/PublicDashboardNotAvailable.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useForm } from 'react-hook-form';
 
-import { GrafanaTheme2, TimeRange } from '@grafana/data/src';
+import { GrafanaTheme2, TimeRange } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import {
   Button,

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/Configuration.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/Configuration.tsx
@@ -1,6 +1,6 @@
 import { UseFormRegister } from 'react-hook-form';
 
-import { TimeRange } from '@grafana/data/src';
+import { TimeRange } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { FieldSet, Label, Switch, TimeRangeInput, Stack, VerticalGroup } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/CreatePublicDashboard/AcknowledgeCheckboxes.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/CreatePublicDashboard/AcknowledgeCheckboxes.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { UseFormRegister } from 'react-hook-form';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { Checkbox, FieldSet, HorizontalGroup, LinkButton, useStyles2, VerticalGroup } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ModalAlerts/UnsupportedDataSourcesAlert.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ModalAlerts/UnsupportedDataSourcesAlert.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import cx from 'classnames';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { config } from '@grafana/runtime';
 import { Alert, useStyles2 } from '@grafana/ui';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
-import { BootData, DataQuery } from '@grafana/data/src';
+import { BootData, DataQuery } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { reportInteraction, setEchoSrv } from '@grafana/runtime';
 import { Panel } from '@grafana/schema';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Spinner, useStyles2 } from '@grafana/ui';
 import { useGetPublicDashboardQuery } from 'app/features/dashboard/api/publicDashboardApi';
 import { publicDashboardPersisted } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx
@@ -1,5 +1,4 @@
-import { TypedVariableModel } from '@grafana/data';
-import { DataSourceRef, DataQuery } from '@grafana/data/src/types/query';
+import { DataSourceRef, DataQuery, TypedVariableModel } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { updateConfig } from 'app/core/config';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -1,6 +1,6 @@
 import { useEffectOnce } from 'react-use';
 
-import { sanitizeUrl } from '@grafana/data/src/text/sanitize';
+import { sanitizeUrl } from '@grafana/data/internal';
 import { selectors } from '@grafana/e2e-selectors';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { DashboardLink } from '@grafana/schema';

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import { useAsync } from 'react-use';
 
 import { GrafanaTheme2, ScopedVars } from '@grafana/data';
-import { sanitize, sanitizeUrl } from '@grafana/data/src/text/sanitize';
+import { sanitize, sanitizeUrl } from '@grafana/data/internal';
 import { selectors } from '@grafana/e2e-selectors';
 import { DashboardLink } from '@grafana/schema';
 import { Dropdown, Icon, LinkButton, Button, Menu, ScrollContainer, useStyles2 } from '@grafana/ui';

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1,7 +1,7 @@
 import { each, map } from 'lodash';
 
 import { DataLinkBuiltInVars, MappingType, VariableHide } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { FieldConfigSource } from '@grafana/schema';
 import { config } from 'app/core/config';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from 'app/core/constants';

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -27,8 +27,7 @@ import {
   ValueMapping,
   VariableHide,
 } from '@grafana/data';
-import { labelsToFieldsTransformer } from '@grafana/data/src/transformations/transformers/labelsToFields';
-import { mergeTransformer } from '@grafana/data/src/transformations/transformers/merge';
+import { labelsToFieldsTransformer, mergeTransformer } from '@grafana/data/internal';
 import { getDataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
 import { DataTransformerConfig } from '@grafana/schema';
 import { AxisPlacement, GraphFieldConfig } from '@grafana/ui';

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -11,8 +11,7 @@ import {
   PanelMigrationHandler,
   PanelTypeChangedHandler,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
-import { mockStandardFieldConfigOptions } from '@grafana/data/test/helpers/fieldConfig';
+import { getPanelPlugin, mockStandardFieldConfigOptions } from '@grafana/data/test';
 import { setTemplateSrv } from '@grafana/runtime';
 import { queryBuilder } from 'app/features/variables/shared/testing/builders';
 

--- a/public/app/features/dashboard/utils/panel.test.ts
+++ b/public/app/features/dashboard/utils/panel.test.ts
@@ -2,7 +2,7 @@ import { advanceTo, clear } from 'jest-date-mock';
 import { ComponentClass } from 'react';
 
 import { dateTime, DateTime, PanelProps, TimeRange } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { applyPanelTimeOverrides, calculateInnerPanelHeight } from 'app/features/dashboard/utils/panel';
 
 import { PanelModel } from '../state/PanelModel';

--- a/public/app/features/dashboard/utils/timeRange.ts
+++ b/public/app/features/dashboard/utils/timeRange.ts
@@ -1,5 +1,4 @@
-import { DateTime, TimeRange } from '@grafana/data';
-import { dateMath, dateTime, isDateTime } from '@grafana/data';
+import { dateMath, dateTime, isDateTime, DateTime, TimeRange } from '@grafana/data';
 import { TimeModel } from 'app/features/dashboard/state/TimeModel';
 
 export const getTimeRange = (

--- a/public/app/features/dashboard/utils/timeRange.ts
+++ b/public/app/features/dashboard/utils/timeRange.ts
@@ -1,5 +1,5 @@
 import { DateTime, TimeRange } from '@grafana/data';
-import { dateMath, dateTime, isDateTime } from '@grafana/data/src';
+import { dateMath, dateTime, isDateTime } from '@grafana/data';
 import { TimeModel } from 'app/features/dashboard/state/TimeModel';
 
 export const getTimeRange = (

--- a/public/app/features/datasources/components/CloudInfoBox.tsx
+++ b/public/app/features/datasources/components/CloudInfoBox.tsx
@@ -1,5 +1,5 @@
 import { DataSourceSettings } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/src/types/config';
+import { GrafanaEdition } from '@grafana/data/internal';
 import { Alert } from '@grafana/ui';
 import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValueProvider';
 import { config } from 'app/core/config';

--- a/public/app/features/datasources/state/buildCategories.test.ts
+++ b/public/app/features/datasources/state/buildCategories.test.ts
@@ -1,5 +1,5 @@
 import { DataSourcePluginMeta } from '@grafana/data';
-import { getMockPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getMockPlugin } from '@grafana/data/test';
 
 import { buildCategories } from './buildCategories';
 

--- a/public/app/features/dimensions/context.ts
+++ b/public/app/features/dimensions/context.ts
@@ -1,4 +1,4 @@
-import { PanelData } from '@grafana/data/src';
+import { PanelData } from '@grafana/data';
 import {
   ColorDimensionConfig,
   ResourceDimensionConfig,

--- a/public/app/features/dimensions/scale.ts
+++ b/public/app/features/dimensions/scale.ts
@@ -1,5 +1,4 @@
-import { DataFrame, Field } from '@grafana/data';
-import { getMinMaxAndDelta } from '@grafana/data/src/field/scale';
+import { getMinMaxAndDelta, DataFrame, Field } from '@grafana/data';
 import { ScaleDimensionConfig, ScaleDimensionMode } from '@grafana/schema';
 
 import { DimensionSupplier, ScaleDimensionOptions } from './types';

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -16,7 +16,7 @@ import {
   ExploreLogsPanelState,
   DataQuery,
 } from '@grafana/data';
-import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
+import { organizeFieldsTransformer } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { LokiQueryDirection } from 'app/plugins/datasource/loki/dataquery.gen';

--- a/public/app/features/explore/Logs/LogsColumnSearch.tsx
+++ b/public/app/features/explore/Logs/LogsColumnSearch.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Input, useTheme2 } from '@grafana/ui';
 
 function getStyles(theme: GrafanaTheme2) {

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -4,7 +4,7 @@ import saveAs from 'file-saver';
 import { ComponentProps } from 'react';
 
 import { FieldType, LogLevel, LogsDedupStrategy, standardTransformersRegistry, toDataFrame } from '@grafana/data';
-import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
+import { organizeFieldsTransformer } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -14,8 +14,8 @@ import {
   DataTransformerConfig,
   CustomTransformOperator,
   Labels,
+  DataFrame,
 } from '@grafana/data';
-import { DataFrame } from '@grafana/data/';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/explore/Logs/LogsTable.test.tsx
+++ b/public/app/features/explore/Logs/LogsTable.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { ComponentProps } from 'react';
 
 import { DataFrame, FieldType, LogsSortOrder, standardTransformersRegistry, toUtc } from '@grafana/data';
-import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
+import { organizeFieldsTransformer } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 

--- a/public/app/features/explore/Logs/LogsTableActiveFields.tsx
+++ b/public/app/features/explore/Logs/LogsTableActiveFields.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { DragDropContext, Draggable, DraggableProvided, Droppable, DropResult } from '@hello-pangea/dnd';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 
 import { LogsTableEmptyFields } from './LogsTableEmptyFields';

--- a/public/app/features/explore/Logs/LogsTableMultiSelect.tsx
+++ b/public/app/features/explore/Logs/LogsTableMultiSelect.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 
 import { LogsTableActiveFields } from './LogsTableActiveFields';

--- a/public/app/features/explore/Logs/LogsTableWrap.test.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.test.tsx
@@ -1,13 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ComponentProps } from 'react';
 
-import {
-  createTheme,
-  ExploreLogsPanelState,
-  LogsSortOrder,
-  standardTransformersRegistry,
-  toUtc,
-} from '@grafana/data/src';
+import { createTheme, ExploreLogsPanelState, LogsSortOrder, standardTransformersRegistry, toUtc } from '@grafana/data';
 import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
 import { config } from '@grafana/runtime';
 

--- a/public/app/features/explore/Logs/LogsTableWrap.test.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ComponentProps } from 'react';
 
 import { createTheme, ExploreLogsPanelState, LogsSortOrder, standardTransformersRegistry, toUtc } from '@grafana/data';
-import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
+import { organizeFieldsTransformer } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 
 import { extractFieldsTransformer } from '../../transformers/extractFields/extractFields';

--- a/public/app/features/explore/Logs/utils/testMocks.test.ts
+++ b/public/app/features/explore/Logs/utils/testMocks.test.ts
@@ -1,4 +1,4 @@
-import { DataFrame, Field, FieldType } from '@grafana/data/src';
+import { DataFrame, Field, FieldType } from '@grafana/data';
 
 import { DataFrameType } from '../../../../../../packages/grafana-data';
 

--- a/public/app/features/explore/NoData.tsx
+++ b/public/app/features/explore/NoData.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, PanelContainer } from '@grafana/ui';
 
 export const NoData = () => {

--- a/public/app/features/explore/PrometheusListView/ItemLabels.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemLabels.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { Field, GrafanaTheme2 } from '@grafana/data/';
+import { Field, GrafanaTheme2 } from '@grafana/data';
 import { InstantQueryRefIdIndex } from '@grafana/prometheus';
 import { useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/explore/PrometheusListView/ItemValues.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemValues.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import { rawListItemColumnWidth, rawListPaddingToHoldSpaceForCopyIcon, RawListValue } from './RawListItem';

--- a/public/app/features/explore/PrometheusListView/RawListContainer.test.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 
-import { FieldType, FormattedValue, toDataFrame } from '@grafana/data/src';
+import { FieldType, FormattedValue, toDataFrame } from '@grafana/data';
 
 import RawListContainer, { RawListContainerProps } from './RawListContainer';
 

--- a/public/app/features/explore/PrometheusListView/RawListContainer.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { useWindowSize } from 'react-use';
 import { VariableSizeList as List } from 'react-window';
 
-import { DataFrame, Field as DataFrameField } from '@grafana/data/';
+import { DataFrame, Field as DataFrameField } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime/src';
 import { Field, Switch } from '@grafana/ui';
 

--- a/public/app/features/explore/PrometheusListView/RawListItem.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useCopyToClipboard } from 'react-use';
 
-import { Field, GrafanaTheme2 } from '@grafana/data/';
+import { Field, GrafanaTheme2 } from '@grafana/data';
 import { isValidLegacyName, utf8Support } from '@grafana/prometheus/src/utf8_support';
 import { reportInteraction } from '@grafana/runtime/src';
 import { IconButton, useStyles2 } from '@grafana/ui';

--- a/public/app/features/explore/PrometheusListView/RawListItemAttributes.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItemAttributes.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import { RawListValue } from './RawListItem';

--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -1,7 +1,6 @@
 import { thunkTester } from 'test/core/thunk/thunkTester';
 
-import { dateTime, ExploreUrlState } from '@grafana/data';
-import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
+import { dateTime, ExploreUrlState, serializeStateToUrlParam } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -12,7 +12,7 @@ import {
   LoadingState,
   StreamingDataFrame,
 } from '@grafana/data';
-import { getStreamingFrameOptions } from '@grafana/data/src/dataframe/StreamingDataFrame';
+import { getStreamingFrameOptions } from '@grafana/data/internal';
 import { LiveDataStreamOptions, StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
 import { toDataQueryError } from '@grafana/runtime/src/utils/toDataQueryError';
 

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -2,8 +2,7 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useEffect, useRef, useState } from 'react';
 
-import { CoreApp, LogRowModel, dateTimeForTimeZone } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/internal';
+import { CoreApp, LogRowModel, dateTimeForTimeZone, rangeUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { LogsSortOrder } from '@grafana/schema';
 
@@ -16,7 +15,7 @@ const absoluteRange = {
   from: 1702578600000,
   to: 1702578900000,
 };
-const defaultRange = convertRawToRange({
+const defaultRange = rangeUtil.convertRawToRange({
   from: dateTimeForTimeZone(defaultTz, absoluteRange.from),
   to: dateTimeForTimeZone(defaultTz, absoluteRange.to),
 });

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { useEffect, useRef, useState } from 'react';
 
 import { CoreApp, LogRowModel, dateTimeForTimeZone } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
+import { convertRawToRange } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { LogsSortOrder } from '@grafana/schema';
 

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { ReactNode, MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 import { AbsoluteTimeRange, CoreApp, LogRowModel, TimeRange } from '@grafana/data';
-import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/src/datetime/rangeutil';
+import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/internal';
 import { config, reportInteraction } from '@grafana/runtime';
 import { LogsSortOrder, TimeZone } from '@grafana/schema';
 import { Button, Icon } from '@grafana/ui';

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
 import { ReactNode, MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 
-import { AbsoluteTimeRange, CoreApp, LogRowModel, TimeRange } from '@grafana/data';
-import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/internal';
+import { AbsoluteTimeRange, CoreApp, LogRowModel, TimeRange, rangeUtil } from '@grafana/data';
+// import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/internal';
 import { config, reportInteraction } from '@grafana/runtime';
 import { LogsSortOrder, TimeZone } from '@grafana/schema';
 import { Button, Icon } from '@grafana/ui';
@@ -140,8 +140,8 @@ export const InfiniteScroll = ({
   }, [loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone, topScrollEnabled]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
-  const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);
-  const hideBottomMessage = sortOrder === LogsSortOrder.Ascending && isRelativeTime(range.raw.to);
+  const hideTopMessage = sortOrder === LogsSortOrder.Descending && rangeUtil.isRelativeTime(range.raw.to);
+  const hideBottomMessage = sortOrder === LogsSortOrder.Ascending && rangeUtil.isRelativeTime(range.raw.to);
 
   const loadOlderLogs = useCallback(() => {
     //If we are not on the last page, use next page's range
@@ -344,5 +344,7 @@ export function canScrollBottom(
 
 // Given a TimeRange, returns a new instance if using relative time, or else the same.
 function updateCurrentRange(timeRange: TimeRange, timeZone: TimeZone) {
-  return isRelativeTimeRange(timeRange.raw) ? convertRawToRange(timeRange.raw, timeZone) : timeRange;
+  return rangeUtil.isRelativeTimeRange(timeRange.raw)
+    ? rangeUtil.convertRawToRange(timeRange.raw, timeZone)
+    : timeRange;
 }

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ComponentProps } from 'react';
 
-import { CoreApp, FieldType, LinkModel } from '@grafana/data';
-import { Field } from '@grafana/data/';
+import { Field, CoreApp, FieldType, LinkModel } from '@grafana/data';
 
 import { LogDetailsRow } from './LogDetailsRow';
 import { createLogRow } from './__mocks__/logRow';

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -39,7 +39,7 @@ import {
   toDataFrame,
   toUtc,
 } from '@grafana/data';
-import { SIPrefix } from '@grafana/data/src/valueFormats/symbolFormatters';
+import { SIPrefix } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { BarAlignment, GraphDrawStyle, StackingMode } from '@grafana/schema';
 import { colors } from '@grafana/ui';

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardModal.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardModal.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { ConfirmModal, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';

--- a/public/app/features/panel/state/actions.test.ts
+++ b/public/app/features/panel/state/actions.test.ts
@@ -1,6 +1,5 @@
 import { standardEditorsRegistry, standardFieldConfigEditorRegistry } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
-import { mockStandardFieldConfigOptions } from '@grafana/data/test/helpers/fieldConfig';
+import { getPanelPlugin, mockStandardFieldConfigOptions } from '@grafana/data/test';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { panelPluginLoaded } from 'app/features/plugins/admin/state/actions';
 

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -4,7 +4,7 @@ import { Routes, Route, Link } from 'react-router-dom-v5-compat';
 import { render } from 'test/test-utils';
 
 import { AppPlugin, PluginType, AppRootProps, NavModelItem, PluginIncludeType, OrgRole } from '@grafana/data';
-import { getMockPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getMockPlugin } from '@grafana/data/test';
 import { setEchoSrv } from '@grafana/runtime';
 import { GrafanaRouteWrapper } from 'app/core/navigation/GrafanaRoute';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -1,7 +1,7 @@
 import { ReplaySubject } from 'rxjs';
 
 import { IconName, PluginExtensionAddedLinkConfig } from '@grafana/data';
-import { PluginAddedLinksConfigureFunc, PluginExtensionEventHelpers } from '@grafana/data/src/types/pluginExtensions';
+import { PluginAddedLinksConfigureFunc, PluginExtensionEventHelpers } from '@grafana/data/internal';
 
 import * as errors from '../errors';
 import { isGrafanaDevMode } from '../utils';

--- a/public/app/features/plugins/extensions/validators.ts
+++ b/public/app/features/plugins/extensions/validators.ts
@@ -1,13 +1,14 @@
-import type {
-  PluginExtensionAddedLinkConfig,
-  PluginExtension,
-  PluginExtensionLink,
-  PluginContextType,
-  PluginExtensionAddedComponentConfig,
-  PluginExtensionExposedComponentConfig,
-  PluginExtensionAddedFunctionConfig,
+import {
+  type PluginExtensionAddedLinkConfig,
+  type PluginExtension,
+  type PluginExtensionLink,
+  type PluginContextType,
+  type PluginExtensionAddedComponentConfig,
+  type PluginExtensionExposedComponentConfig,
+  type PluginExtensionAddedFunctionConfig,
+  PluginExtensionPoints,
 } from '@grafana/data';
-import { PluginAddedLinksConfigureFunc, PluginExtensionPoints } from '@grafana/data/src/types/pluginExtensions';
+import { PluginAddedLinksConfigureFunc } from '@grafana/data/internal';
 import { config, isPluginExtensionLink } from '@grafana/runtime';
 
 import * as errors from './errors';

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -49,7 +49,7 @@ export const sharedDependenciesMap = {
   '@emotion/css': () => import('@emotion/css'),
   '@emotion/react': () => import('@emotion/react'),
   '@grafana/data': grafanaData,
-  '@grafana/data/unstable': () => import('@grafana/data/src/unstable'),
+  '@grafana/data/unstable': () => import('@grafana/data/unstable'),
   '@grafana/runtime': grafanaRuntime,
   '@grafana/runtime/unstable': () => import('@grafana/runtime/src/unstable'),
   '@grafana/slate-react': () => import('slate-react'),

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,5 +1,8 @@
-import type { PluginExtensionAddedLinkConfig, PluginExtensionExposedComponentConfig } from '@grafana/data';
-import { PluginExtensionAddedComponentConfig } from '@grafana/data/src/types/pluginExtensions';
+import type {
+  PluginExtensionAddedLinkConfig,
+  PluginExtensionExposedComponentConfig,
+  PluginExtensionAddedComponentConfig,
+} from '@grafana/data';
 import type { AppPluginConfig } from '@grafana/runtime';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 

--- a/public/app/features/scopes/tests/utils/render.tsx
+++ b/public/app/features/scopes/tests/utils/render.tsx
@@ -2,7 +2,7 @@ import { cleanup, waitFor } from '@testing-library/react';
 import { KBarProvider } from 'kbar';
 import { render } from 'test/test-utils';
 
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { config, setPluginImportUtils } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
 import { defaultDashboard } from '@grafana/schema';

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { getTimeZoneInfo, GrafanaTheme2, InternalTimeZones, TIME_FORMAT } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
+import { convertRawToRange } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import {
   SceneComponentProps,

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -1,8 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { getTimeZoneInfo, GrafanaTheme2, InternalTimeZones, TIME_FORMAT } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/internal';
+import { getTimeZoneInfo, GrafanaTheme2, InternalTimeZones, TIME_FORMAT, rangeUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   SceneComponentProps,
@@ -349,7 +348,7 @@ export function parseTimeTooltip(urlValues: SceneObjectUrlValues): string {
     return '';
   }
 
-  const range = convertRawToRange({
+  const range = rangeUtil.convertRawToRange({
     from: urlValues.from,
     to: urlValues.to,
   });

--- a/public/app/features/trails/Integrations/logs/lokiRecordingRules.test.ts
+++ b/public/app/features/trails/Integrations/logs/lokiRecordingRules.test.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import type { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
-import { getMockPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getMockPlugin } from '@grafana/data/test';
 import * as runtime from '@grafana/runtime';
 
 import { MetricsLogsConnector } from './base';

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueFilterEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueFilterEditor.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { Field, SelectableValue, valueMatchers } from '@grafana/data';
-import { FilterByValueFilter } from '@grafana/data/src/transformations/transformers/filterByValue';
+import { FilterByValueFilter } from '@grafana/data/internal';
 import { Button, Select, InlineField, InlineFieldRow, Box } from '@grafana/ui';
 
 import { valueMatchersUI } from './ValueMatchers/valueMatchersUI';

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -1,7 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
 
 import { DataFrame, FieldType, ValueMatcherID, valueMatchers } from '@grafana/data';
-import { FilterByValueMatch, FilterByValueType } from '@grafana/data/src/transformations/transformers/filterByValue';
+import { FilterByValueMatch, FilterByValueType } from '@grafana/data/internal';
 
 import { FilterByValueTransformerEditor } from './FilterByValueTransformerEditor';
 

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -19,7 +19,7 @@ import {
   FilterByValueMatch,
   FilterByValueTransformerOptions,
   FilterByValueType,
-} from '@grafana/data/src/transformations/transformers/filterByValue';
+} from '@grafana/data/internal';
 import { Button, RadioButtonGroup, InlineField, Box } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/calculateHeatmap/heatmap.test.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.test.ts
@@ -1,5 +1,4 @@
-import { FieldType } from '@grafana/data';
-import { toDataFrame } from '@grafana/data/src/dataframe/processDataFrame';
+import { FieldType, toDataFrame } from '@grafana/data';
 import { HeatmapCalculationOptions } from '@grafana/schema';
 
 import { rowsToCellsHeatmap, calculateHeatmapFromData } from './heatmap';

--- a/public/app/features/transformers/calculateHeatmap/heatmap.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.ts
@@ -15,7 +15,7 @@ import {
   TransformationApplicabilityLevels,
   TimeRange,
 } from '@grafana/data';
-import { isLikelyAscendingVector } from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import { isLikelyAscendingVector } from '@grafana/data/internal';
 import {
   ScaleDistribution,
   HeatmapCellLayout,

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/BinaryOperationOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/BinaryOperationOptionsEditor.tsx
@@ -5,7 +5,7 @@ import {
   CalculateFieldMode,
   CalculateFieldTransformerOptions,
   checkBinaryValueType,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+} from '@grafana/data/internal';
 import { getFieldTypeIconName, InlineField, InlineFieldRow, Select } from '@grafana/ui';
 
 import { LABEL_WIDTH } from './constants';

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx
@@ -21,7 +21,7 @@ import {
   CalculateFieldTransformerOptions,
   getNameFromOptions,
   defaultWindowOptions,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+} from '@grafana/data/internal';
 import { getTemplateSrv, config as cfg } from '@grafana/runtime';
 import { InlineField, InlineSwitch, Input, Select } from '@grafana/ui';
 

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx
@@ -1,9 +1,5 @@
 import { ReducerID, SelectableValue } from '@grafana/data';
-import {
-  CalculateFieldMode,
-  CalculateFieldTransformerOptions,
-  CumulativeOptions,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+import { CalculateFieldMode, CalculateFieldTransformerOptions, CumulativeOptions } from '@grafana/data/internal';
 import { InlineField, Select, StatsPicker } from '@grafana/ui';
 
 import { LABEL_WIDTH } from './constants';

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CalculateFieldTransformerOptions } from '@grafana/data/src/transformations/transformers/calculateField';
+import { CalculateFieldTransformerOptions } from '@grafana/data/internal';
 import { InlineField, InlineSwitch } from '@grafana/ui';
 
 import { LABEL_WIDTH } from './constants';

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx
@@ -1,8 +1,5 @@
 import { ReducerID } from '@grafana/data';
-import {
-  CalculateFieldTransformerOptions,
-  ReduceOptions,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+import { CalculateFieldTransformerOptions, ReduceOptions } from '@grafana/data/internal';
 import { FilterPill, HorizontalGroup, InlineField, StatsPicker } from '@grafana/ui';
 
 import { LABEL_WIDTH } from './constants';

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/UnaryOperationEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/UnaryOperationEditor.tsx
@@ -1,9 +1,5 @@
 import { unaryOperators, SelectableValue, UnaryOperationID } from '@grafana/data';
-import {
-  UnaryOptions,
-  CalculateFieldMode,
-  CalculateFieldTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+import { UnaryOptions, CalculateFieldMode, CalculateFieldTransformerOptions } from '@grafana/data/internal';
 import { InlineField, InlineFieldRow, InlineLabel, Select } from '@grafana/ui';
 
 import { LABEL_WIDTH } from './constants';

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
@@ -5,7 +5,7 @@ import {
   CalculateFieldTransformerOptions,
   WindowOptions,
   WindowSizeMode,
-} from '@grafana/data/src/transformations/transformers/calculateField';
+} from '@grafana/data/internal';
 import { InlineField, RadioButtonGroup, Select, StatsPicker } from '@grafana/ui';
 import { NumberInput } from 'app/core/components/OptionsUI/NumberInput';
 

--- a/public/app/features/transformers/editors/ConcatenateTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConcatenateTransformerEditor.tsx
@@ -8,10 +8,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import {
-  ConcatenateFrameNameMode,
-  ConcatenateTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/concat';
+import { ConcatenateFrameNameMode, ConcatenateTransformerOptions } from '@grafana/data/internal';
 import { InlineField, Input, Select } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -12,10 +12,7 @@ import {
   TransformerCategory,
   getTimeZones,
 } from '@grafana/data';
-import {
-  ConvertFieldTypeOptions,
-  ConvertFieldTypeTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/convertFieldType';
+import { ConvertFieldTypeOptions, ConvertFieldTypeTransformerOptions } from '@grafana/data/internal';
 import { Button, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 import { allFieldTypeIconOptions, FieldNamePicker } from '@grafana/ui/internal';
 import { findField } from 'app/features/dimensions';

--- a/public/app/features/transformers/editors/EnumMappingEditor.tsx
+++ b/public/app/features/transformers/editors/EnumMappingEditor.tsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import { DataFrame, EnumFieldConfig, GrafanaTheme2 } from '@grafana/data';
-import { ConvertFieldTypeTransformerOptions } from '@grafana/data/src/transformations/transformers/convertFieldType';
+import { ConvertFieldTypeTransformerOptions } from '@grafana/data/internal';
 import { Button, HorizontalGroup, InlineFieldRow, useStyles2, VerticalGroup } from '@grafana/ui';
 
 import EnumMappingRow from './EnumMappingRow';

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -11,7 +11,7 @@ import {
   TransformerCategory,
   SelectableValue,
 } from '@grafana/data';
-import { FilterFieldsByNameTransformerOptions } from '@grafana/data/src/transformations/transformers/filterByName';
+import { FilterFieldsByNameTransformerOptions } from '@grafana/data/internal';
 import { getTemplateSrv } from '@grafana/runtime/src/services';
 import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
 

--- a/public/app/features/transformers/editors/FilterByRefIdTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByRefIdTransformerEditor.tsx
@@ -6,7 +6,7 @@ import {
   TransformerCategory,
   FrameMatcherID,
 } from '@grafana/data';
-import { FilterFramesByRefIdTransformerOptions } from '@grafana/data/src/transformations/transformers/filterByRefId';
+import { FilterFramesByRefIdTransformerOptions } from '@grafana/data/internal';
 import { FrameMultiSelectionEditor } from 'app/plugins/panel/geomap/editor/FrameSelectionEditor';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/FormatStringTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatStringTransformerEditor.tsx
@@ -12,10 +12,7 @@ import {
   FieldNamePickerConfigSettings,
   TransformerCategory,
 } from '@grafana/data';
-import {
-  FormatStringOutput,
-  FormatStringTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/formatString';
+import { FormatStringOutput, FormatStringTransformerOptions } from '@grafana/data/internal';
 import { Select, InlineFieldRow, InlineField } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';
 import { NumberInput } from 'app/core/components/OptionsUI/NumberInput';

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -9,7 +9,7 @@ import {
   getFieldDisplayName,
   PluginState,
 } from '@grafana/data';
-import { FormatTimeTransformerOptions } from '@grafana/data/src/transformations/transformers/formatTime';
+import { FormatTimeTransformerOptions } from '@grafana/data/internal';
 import { Select, InlineFieldRow, InlineField, Input } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
@@ -11,11 +11,7 @@ import {
   TransformerCategory,
   GrafanaTheme2,
 } from '@grafana/data';
-import {
-  GroupByFieldOptions,
-  GroupByOperationID,
-  GroupByTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/groupBy';
+import { GroupByFieldOptions, GroupByOperationID, GroupByTransformerOptions } from '@grafana/data/internal';
 import { useTheme2, Select, StatsPicker, InlineField, Stack, Alert } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
@@ -16,11 +16,9 @@ import {
   GroupByFieldOptions,
   GroupByOperationID,
   GroupByTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/groupBy';
-import {
   GroupToNestedTableTransformerOptions,
   SHOW_NESTED_HEADERS_DEFAULT,
-} from '@grafana/data/src/transformations/transformers/groupToNestedTable';
+} from '@grafana/data/internal';
 import { useTheme2, Select, StatsPicker, InlineField, Field, Switch, Alert, Stack } from '@grafana/ui';
 
 import { useAllFieldNamesFromDataFrames } from '../utils';

--- a/public/app/features/transformers/editors/HistogramTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/HistogramTransformerEditor.tsx
@@ -7,10 +7,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import {
-  histogramFieldInfo,
-  HistogramTransformerInputs,
-} from '@grafana/data/src/transformations/transformers/histogram';
+import { histogramFieldInfo, HistogramTransformerInputs } from '@grafana/data/internal';
 import { InlineField, InlineFieldRow, InlineSwitch } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -8,7 +8,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { JoinByFieldOptions, JoinMode } from '@grafana/data/src/transformations/transformers/joinByField';
+import { JoinByFieldOptions, JoinMode } from '@grafana/data/internal';
 import { getTemplateSrv } from '@grafana/runtime';
 import { Select, InlineFieldRow, InlineField } from '@grafana/ui';
 import { useFieldDisplayNames, useSelectOptions } from '@grafana/ui/internal';

--- a/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
@@ -8,10 +8,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import {
-  LabelsToFieldsMode,
-  LabelsToFieldsOptions,
-} from '@grafana/data/src/transformations/transformers/labelsToFields';
+import { LabelsToFieldsMode, LabelsToFieldsOptions } from '@grafana/data/internal';
 import { InlineField, InlineFieldRow, RadioButtonGroup, Select, FilterPill, Stack } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/LimitTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/LimitTransformerEditor.tsx
@@ -7,7 +7,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { LimitTransformerOptions } from '@grafana/data/src/transformations/transformers/limit';
+import { LimitTransformerOptions } from '@grafana/data/internal';
 import { InlineFieldRow } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/MergeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/MergeTransformerEditor.tsx
@@ -5,7 +5,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { MergeTransformerOptions } from '@grafana/data/src/transformations/transformers/merge';
+import { MergeTransformerOptions } from '@grafana/data/internal';
 import { FieldValidationMessage } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
@@ -10,8 +10,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { createOrderFieldsComparer } from '@grafana/data/src/transformations/transformers/order';
-import { OrganizeFieldsTransformerOptions } from '@grafana/data/src/transformations/transformers/organize';
+import { createOrderFieldsComparer, OrganizeFieldsTransformerOptions } from '@grafana/data/internal';
 import {
   Input,
   IconButton,

--- a/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
@@ -9,7 +9,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { ReduceTransformerMode, ReduceTransformerOptions } from '@grafana/data/src/transformations/transformers/reduce';
+import { ReduceTransformerMode, ReduceTransformerOptions } from '@grafana/data/internal';
 import { selectors } from '@grafana/e2e-selectors';
 import { InlineField, Select, StatsPicker, InlineSwitch } from '@grafana/ui';
 

--- a/public/app/features/transformers/editors/RenameByRegexTransformer.tsx
+++ b/public/app/features/transformers/editors/RenameByRegexTransformer.tsx
@@ -8,7 +8,7 @@ import {
   stringToJsRegex,
   TransformerCategory,
 } from '@grafana/data';
-import { RenameByRegexTransformerOptions } from '@grafana/data/src/transformations/transformers/renameByRegex';
+import { RenameByRegexTransformerOptions } from '@grafana/data/internal';
 import { InlineField, Input } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';

--- a/public/app/features/transformers/editors/SeriesToRowsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/SeriesToRowsTransformerEditor.tsx
@@ -5,7 +5,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { SeriesToRowsTransformerOptions } from '@grafana/data/src/transformations/transformers/seriesToRows';
+import { SeriesToRowsTransformerOptions } from '@grafana/data/internal';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
 

--- a/public/app/features/transformers/editors/SortByTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/SortByTransformerEditor.tsx
@@ -7,7 +7,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { SortByField, SortByTransformerOptions } from '@grafana/data/src/transformations/transformers/sortBy';
+import { SortByField, SortByTransformerOptions } from '@grafana/data/internal';
 import { getTemplateSrv } from '@grafana/runtime';
 import { InlineField, InlineSwitch, InlineFieldRow, Select } from '@grafana/ui';
 

--- a/public/app/features/transformers/editors/TransposeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/TransposeTransformerEditor.tsx
@@ -5,7 +5,7 @@ import {
   TransformerUIProps,
   TransformerCategory,
 } from '@grafana/data';
-import { TransposeTransformerOptions } from '@grafana/data/src/transformations/transformers/transpose';
+import { TransposeTransformerOptions } from '@grafana/data/internal';
 import { InlineField, InlineFieldRow, Input } from '@grafana/ui';
 
 export const TransposeTransfomerEditor = ({ options, onChange }: TransformerUIProps<TransposeTransformerOptions>) => {

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -5,10 +5,9 @@ import {
   Field,
   FieldType,
   transformDataFrame,
+  toDataFrame,
 } from '@grafana/data';
-import { toDataFrame } from '@grafana/data/src/dataframe/processDataFrame';
-import { SortByTransformerOptions, sortByTransformer } from '@grafana/data/src/transformations/transformers/sortBy';
-import { mockTransformationsRegistry } from '@grafana/data/src/utils/tests/mockTransformationsRegistry';
+import { mockTransformationsRegistry, SortByTransformerOptions, sortByTransformer } from '@grafana/data/internal';
 
 import { extractFieldsTransformer } from './extractFields';
 import { ExtractFieldsOptions, FieldExtractorID } from './types';

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -1,6 +1,4 @@
-import { FieldMatcherID, fieldMatchers, FieldType } from '@grafana/data';
-import { toDataFrame } from '@grafana/data/src/dataframe/processDataFrame';
-import { DataTransformerID } from '@grafana/data/src/transformations/transformers/ids';
+import { DataTransformerID, toDataFrame, FieldMatcherID, fieldMatchers, FieldType } from '@grafana/data';
 import { frameAsGazetter } from 'app/features/geo/gazetteer/gazetteer';
 
 import { addFieldsFromGazetteer } from './fieldLookup';

--- a/public/app/features/transformers/partitionByValues/partitionByValues.ts
+++ b/public/app/features/transformers/partitionByValues/partitionByValues.ts
@@ -8,8 +8,7 @@ import {
   DataTransformContext,
   FieldMatcher,
 } from '@grafana/data';
-import { getMatcherConfig } from '@grafana/data/src/transformations/transformers/filterByName';
-import { noopTransformer } from '@grafana/data/src/transformations/transformers/noop';
+import { getMatcherConfig, noopTransformer } from '@grafana/data/internal';
 
 import { partition } from './partition';
 

--- a/public/app/features/transformers/spatial/optionsHelper.tsx
+++ b/public/app/features/transformers/spatial/optionsHelper.tsx
@@ -1,8 +1,7 @@
 import { set, get as lodashGet } from 'lodash';
 
 import { StandardEditorContext, TransformerUIProps, PanelOptionsEditorBuilder } from '@grafana/data';
-import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
-import { NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedValueAccess, PanelOptionsSupplier } from '@grafana/data/internal';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { fillOptionsPaneItems } from 'app/features/dashboard/components/PanelEditor/getVisualizationOptions';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';

--- a/public/app/features/transformers/spatial/spatialTransformer.test.ts
+++ b/public/app/features/transformers/spatial/spatialTransformer.test.ts
@@ -1,6 +1,5 @@
-import { FieldMatcherID, fieldMatchers, FieldType } from '@grafana/data';
-import { toDataFrame } from '@grafana/data/src/dataframe/processDataFrame';
-import { DataTransformerID } from '@grafana/data/src/transformations/transformers/ids';
+import { toDataFrame, FieldMatcherID, fieldMatchers, FieldType } from '@grafana/data';
+import { DataTransformerID } from '@grafana/data/internal';
 import { frameAsGazetter } from 'app/features/geo/gazetteer/gazetteer';
 
 describe('spatial transformer', () => {

--- a/public/app/features/variables/datasource/actions.test.ts
+++ b/public/app/features/variables/datasource/actions.test.ts
@@ -1,5 +1,5 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { getMockPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getMockPlugin } from '@grafana/data/test';
 
 import { reduxTester } from '../../../../test/core/redux/reduxTester';
 import { variableAdapters } from '../adapters';

--- a/public/app/features/variables/datasource/reducer.test.ts
+++ b/public/app/features/variables/datasource/reducer.test.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 
 import { DataSourceInstanceSettings, DataSourceVariableModel } from '@grafana/data';
-import { getMockPlugins } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getMockPlugins } from '@grafana/data/test';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import { getDataSourceInstanceSetting } from '../shared/testing/helpers';

--- a/public/app/features/variables/state/initVariableTransaction.test.ts
+++ b/public/app/features/variables/state/initVariableTransaction.test.ts
@@ -1,4 +1,4 @@
-import { DataSourceRef, LoadingState } from '@grafana/data/src';
+import { DataSourceRef, LoadingState } from '@grafana/data';
 import { setDataSourceSrv } from '@grafana/runtime/src';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 

--- a/public/app/features/variables/state/migrateVariablesDatasourceNameToRef.test.ts
+++ b/public/app/features/variables/state/migrateVariablesDatasourceNameToRef.test.ts
@@ -1,4 +1,4 @@
-import { DataSourceRef } from '@grafana/data/src';
+import { DataSourceRef } from '@grafana/data';
 
 import { adHocBuilder, queryBuilder } from '../shared/testing/builders';
 import { toVariablePayload } from '../utils';

--- a/public/app/plugins/datasource/azuremonitor/__mocks__/utils.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/utils.ts
@@ -1,5 +1,4 @@
-import { VariableType, VariableWithOptions } from '@grafana/data';
-import { LoadingState } from '@grafana/data/src/types/data';
+import { LoadingState, VariableType, VariableWithOptions } from '@grafana/data';
 
 interface TemplateableValue {
   variableName: string;

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/RawQuery.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/RawQuery.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import Prism, { Grammar } from 'prismjs';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 
 export interface Props {

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -1,7 +1,6 @@
 import { of } from 'rxjs';
 
-import { CustomVariableModel, getFrameDisplayName, VariableHide } from '@grafana/data';
-import { dateTime } from '@grafana/data/src/datetime/moment_wrapper';
+import { dateTime, CustomVariableModel, getFrameDisplayName, VariableHide } from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 
 import {

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -8,7 +8,7 @@ import {
   LoadingState,
   standardTransformersRegistry,
 } from '@grafana/data';
-import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
+import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
@@ -8,7 +8,7 @@ import {
   MutableDataFrame,
   PreferredVisualisationType,
 } from '@grafana/data';
-import { convertFieldType } from '@grafana/data/src/transformations/transformers/convertFieldType';
+import { convertFieldType } from '@grafana/data/internal';
 import TableModel from 'app/core/TableModel';
 
 import { isMetricAggregationWithField } from './components/QueryEditor/MetricAggregationsEditor/aggregations';

--- a/public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { QueryEditorProps } from '@grafana/data/src';
+import { QueryEditorProps } from '@grafana/data';
 import { InlineFormLabel, Input, Stack } from '@grafana/ui';
 
 import InfluxDatasource from '../../../datasource';

--- a/public/app/plugins/datasource/influxdb/components/editor/constants.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/constants.ts
@@ -1,4 +1,4 @@
-import { SelectableValue } from '@grafana/data/src';
+import { SelectableValue } from '@grafana/data';
 
 import { ResultFormat } from '../../types';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/QueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { QueryEditorProps } from '@grafana/data/src';
+import { QueryEditorProps } from '@grafana/data';
 
 import InfluxDatasource from '../../../datasource';
 import { buildRawQuery } from '../../../queryUtils';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { PureComponent } from 'react';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data/src';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime/src';
 import {
   CodeEditor,

--- a/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { PureComponent } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { SQLQuery, SqlQueryEditorLazy, applyQueryDefaults } from '@grafana/sql';
 import { InlineFormLabel, LinkButton, Themeable2, withTheme2 } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/getTemplateVariableOptions.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/getTemplateVariableOptions.ts
@@ -1,4 +1,4 @@
-import { TypedVariableModel } from '@grafana/data/src';
+import { TypedVariableModel } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime/src';
 
 export function getTemplateVariableOptions(wrapper: (v: TypedVariableModel) => string) {

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/withTemplateVariableOptions.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/withTemplateVariableOptions.ts
@@ -1,5 +1,5 @@
 // helper function to make it easy to call this from the widget-render-code
-import { TypedVariableModel } from '@grafana/data/src';
+import { TypedVariableModel } from '@grafana/data';
 
 import { getTemplateVariableOptions } from './getTemplateVariableOptions';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/wrapper.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/utils/wrapper.ts
@@ -1,4 +1,4 @@
-import { TypedVariableModel } from '@grafana/data/src';
+import { TypedVariableModel } from '@grafana/data';
 
 export function wrapRegex(v: TypedVariableModel): string {
   return `/^$${v.name}$/`;

--- a/public/app/plugins/datasource/influxdb/influxql_metadata_query.ts
+++ b/public/app/plugins/datasource/influxdb/influxql_metadata_query.ts
@@ -1,4 +1,4 @@
-import { ScopedVars } from '@grafana/data/src';
+import { ScopedVars } from '@grafana/data';
 import config from 'app/core/config';
 
 import InfluxDatasource from './datasource';

--- a/public/app/plugins/datasource/tempo/_importedDependencies/datasources/prometheus/RawQuery.tsx
+++ b/public/app/plugins/datasource/tempo/_importedDependencies/datasources/prometheus/RawQuery.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import Prism, { Grammar } from 'prismjs';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 
 export interface Props {

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -1,4 +1,4 @@
-import { DataSourceJsonData } from '@grafana/data/src';
+import { DataSourceJsonData } from '@grafana/data';
 import { NodeGraphOptions, TraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 
 import { TempoQuery as TempoBase, TempoQueryType, TraceqlFilter } from './dataquery.gen';

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -1,7 +1,6 @@
 import uPlot, { Axis, AlignedData, Scale } from 'uplot';
 
-import { DataFrame, dateTimeFormat, GrafanaTheme2, systemDateFormats, TimeZone } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
+import { colorManipulator, DataFrame, dateTimeFormat, GrafanaTheme2, systemDateFormats, TimeZone } from '@grafana/data';
 import {
   StackingMode,
   VisibilityMode,
@@ -545,7 +544,8 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
         });
 
         barsColors.push({
-          fill: fillOpacity < 1 ? colors.map((c) => (c != null ? alpha(c, fillOpacity) : null)) : colors,
+          fill:
+            fillOpacity < 1 ? colors.map((c) => (c != null ? colorManipulator.alpha(c, fillOpacity) : null)) : colors,
           stroke: colors,
         });
       }

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -13,7 +13,7 @@ import {
   getFieldSeriesColor,
   outerJoinDataFrames,
 } from '@grafana/data';
-import { decoupleHideFromState } from '@grafana/data/src/field/fieldState';
+import { decoupleHideFromState } from '@grafana/data/internal';
 import {
   AxisColorMode,
   AxisPlacement,

--- a/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react';
 
-import { cacheFieldDisplayNames, DataFrame, FieldType, getFieldSeriesColor } from '@grafana/data';
-import { Field } from '@grafana/data/';
+import { Field, cacheFieldDisplayNames, DataFrame, FieldType, getFieldSeriesColor } from '@grafana/data';
 import { AxisPlacement, VizLegendOptions } from '@grafana/schema';
 import { useTheme2, VizLayout, VizLayoutLegendProps, VizLegend, VizLegendItem } from '@grafana/ui';
 import { getDisplayValuesForCalcs } from '@grafana/ui/internal';

--- a/public/app/plugins/panel/candlestick/fields.ts
+++ b/public/app/plugins/panel/candlestick/fields.ts
@@ -7,7 +7,7 @@ import {
   outerJoinDataFrames,
   TimeRange,
 } from '@grafana/data';
-import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import { maybeSortFrame } from '@grafana/data/internal';
 import { findField } from 'app/features/dimensions';
 
 import { prepareGraphableFields } from '../timeseries/utils';

--- a/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
@@ -12,7 +12,7 @@ import {
   getFieldDisplayName,
   ScopedVars,
   ValueLinkConfig,
-} from '@grafana/data/src';
+} from '@grafana/data';
 import { ActionModel } from '@grafana/data/src/types/action';
 import { Portal, useStyles2, VizTooltipContainer } from '@grafana/ui';
 import {

--- a/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
@@ -12,8 +12,8 @@ import {
   getFieldDisplayName,
   ScopedVars,
   ValueLinkConfig,
+  ActionModel,
 } from '@grafana/data';
-import { ActionModel } from '@grafana/data/src/types/action';
 import { Portal, useStyles2, VizTooltipContainer } from '@grafana/ui';
 import {
   VizTooltipContent,

--- a/public/app/plugins/panel/canvas/editor/connectionEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/connectionEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
 import { Scene } from 'app/features/canvas/runtime/scene';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 

--- a/public/app/plugins/panel/canvas/editor/element/QuickPositioning.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/QuickPositioning.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data/src';
+import { GrafanaTheme2 } from '@grafana/data';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { QuickPlacement } from 'app/features/canvas/types';

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
 import { CanvasElementOptions } from 'app/features/canvas/element';
 import {
   canvasElementRegistry,

--- a/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
@@ -4,8 +4,7 @@ import { useMemo, useState } from 'react';
 import { useObservable } from 'react-use';
 
 import { DataFrame, GrafanaTheme2, PanelOptionsEditorBuilder, StandardEditorContext } from '@grafana/data';
-import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
-import { NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedValueAccess, PanelOptionsSupplier } from '@grafana/data/internal';
 import { useStyles2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { FrameState } from 'app/features/canvas/runtime/frame';

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 import { Scene } from 'app/features/canvas/runtime/scene';

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -1,7 +1,7 @@
 import { capitalize } from 'lodash';
 
 import { FieldType } from '@grafana/data';
-import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
+import { PanelOptionsSupplier } from '@grafana/data/internal';
 import { ConnectionDirection } from 'app/features/canvas/element';
 import { SVGElements } from 'app/features/canvas/runtime/element';
 import { ColorDimensionEditor, ResourceDimensionEditor, ScaleDimensionEditor } from 'app/features/dimensions/editors';

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -1,7 +1,6 @@
 import { isNumber, isString } from 'lodash';
 
-import { AppEvents, getFieldDisplayName, PluginState, SelectableValue } from '@grafana/data';
-import { DataFrame, Field } from '@grafana/data/';
+import { DataFrame, Field, AppEvents, getFieldDisplayName, PluginState, SelectableValue } from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { hasAlphaPanels, config } from 'app/core/config';
 import {

--- a/public/app/plugins/panel/datagrid/components/DatagridContextMenu.tsx
+++ b/public/app/plugins/panel/datagrid/components/DatagridContextMenu.tsx
@@ -3,7 +3,7 @@ import { capitalize } from 'lodash';
 import * as React from 'react';
 
 import { DataFrame, FieldType } from '@grafana/data';
-import { convertFieldType } from '@grafana/data/src/transformations/transformers/convertFieldType';
+import { convertFieldType } from '@grafana/data/internal';
 import { reportInteraction } from '@grafana/runtime';
 import { ContextMenu, MenuGroup, MenuItem } from '@grafana/ui';
 import { MenuDivider } from '@grafana/ui/internal';

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -4,8 +4,13 @@ import { useMemo } from 'react';
 import { useObservable } from 'react-use';
 import { of } from 'rxjs';
 
-import { DataFrame, formattedValueToString, getFieldColorModeForField, GrafanaTheme2 } from '@grafana/data';
-import { getMinMaxAndDelta } from '@grafana/data/src/field/scale';
+import {
+  getMinMaxAndDelta,
+  DataFrame,
+  formattedValueToString,
+  getFieldColorModeForField,
+  GrafanaTheme2,
+} from '@grafana/data';
 import { useStyles2, VizLegendItem } from '@grafana/ui';
 import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -1,7 +1,7 @@
 import { get as lodashGet, isEqual } from 'lodash';
 
 import { FrameGeometrySourceMode, getFrameMatchers, MapLayerOptions } from '@grafana/data';
-import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/internal';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';
 

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -20,8 +20,8 @@ import {
   DataHoverClearEvent,
   DataFrame,
   FieldType,
+  colorManipulator
 } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
 import { MapLayerOptions, FrameGeometrySourceMode } from '@grafana/schema';
 import { FrameVectorSource } from 'app/features/geo/utils/frameVectorSource';
 import { getGeometryField, getLocationMatchers } from 'app/features/geo/utils/location';
@@ -207,10 +207,10 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
       image: new Circle({
         radius: crosshairRadius,
         stroke: new Stroke({
-          color: alpha(crosshairColor, 1),
+          color: colorManipulator.alpha(crosshairColor, 1),
           width: 1,
         }),
-        fill: new Fill({ color: alpha(crosshairColor, 0.4) }),
+        fill: new Fill({ color: colorManipulator.alpha(crosshairColor, 0.4) }),
       }),
     });
     const lineStyle = new Style({

--- a/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts
+++ b/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts
@@ -1,6 +1,6 @@
 import { FeatureLike } from 'ol/Feature';
 
-import { compareValues } from '@grafana/data/src/transformations/matchers/compareValues';
+import { compareValues } from '@grafana/data/internal';
 
 import { FeatureRuleConfig } from '../types';
 

--- a/public/app/plugins/panel/geomap/utils/tooltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.ts
@@ -2,7 +2,7 @@ import { debounce } from 'lodash';
 import { MapBrowserEvent } from 'ol';
 import { toLonLat } from 'ol/proj';
 
-import { DataFrame, DataHoverClearEvent } from '@grafana/data/src';
+import { DataFrame, DataHoverClearEvent } from '@grafana/data';
 
 import { GeomapPanel } from '../GeomapPanel';
 import { GeomapHoverPayload, GeomapLayerHover } from '../event';

--- a/public/app/plugins/panel/geomap/utils/utils.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.ts
@@ -2,7 +2,7 @@ import { Map as OpenLayersMap } from 'ol';
 import { defaults as interactionDefaults } from 'ol/interaction';
 
 import { SelectableValue } from '@grafana/data';
-import { DataFrame, GrafanaTheme2 } from '@grafana/data/src';
+import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { getColorDimension, getScalarDimension, getScaledDimension, getTextDimension } from 'app/features/dimensions';
 import { getGrafanaDatasource } from 'app/plugins/datasource/grafana/datasource';
 

--- a/public/app/plugins/panel/geomap/utils/utils.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.ts
@@ -1,8 +1,7 @@
 import { Map as OpenLayersMap } from 'ol';
 import { defaults as interactionDefaults } from 'ol/interaction';
 
-import { SelectableValue } from '@grafana/data';
-import { DataFrame, GrafanaTheme2 } from '@grafana/data';
+import { DataFrame, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { getColorDimension, getScalarDimension, getScaledDimension, getTextDimension } from 'app/features/dimensions';
 import { getGrafanaDatasource } from 'app/plugins/datasource/grafana/datasource';
 

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -1,7 +1,7 @@
 import { find } from 'lodash';
 
 import { DataFrame, dateTime, Field, FieldType, getFieldDisplayName, getTimeField, TimeRange } from '@grafana/data';
-import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
+import { applyNullInsertThreshold } from '@grafana/data/internal';
 import { colors } from '@grafana/ui';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -9,11 +9,9 @@ import {
   getFieldSeriesColor,
   GrafanaTheme2,
   roundDecimals,
-} from '@grafana/data';
-import {
   histogramBucketSizes,
   histogramFrameBucketMaxFieldName,
-} from '@grafana/data/src/transformations/transformers/histogram';
+} from '@grafana/data';
 import { VizLegendOptions, ScaleDistribution, AxisPlacement, ScaleDirection, ScaleOrientation } from '@grafana/schema';
 import {
   Themeable2,

--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from 'react';
 
-import { DataFrameType, PanelProps, buildHistogram, cacheFieldDisplayNames, getHistogramFields } from '@grafana/data';
-import { histogramFieldsToFrame, joinHistograms } from '@grafana/data/src/transformations/transformers/histogram';
+import {
+  histogramFieldsToFrame,
+  joinHistograms,
+  DataFrameType,
+  PanelProps,
+  buildHistogram,
+  cacheFieldDisplayNames,
+  getHistogramFields,
+} from '@grafana/data';
 import { TooltipDisplayMode, TooltipPlugin2, useTheme2 } from '@grafana/ui';
 import { TooltipHoverMode } from '@grafana/ui/internal';
 

--- a/public/app/plugins/panel/histogram/module.tsx
+++ b/public/app/plugins/panel/histogram/module.tsx
@@ -4,8 +4,8 @@ import {
   FieldType,
   identityOverrideProcessor,
   PanelPlugin,
+  histogramFieldInfo,
 } from '@grafana/data';
-import { histogramFieldInfo } from '@grafana/data/src/transformations/transformers/histogram';
 import { commonOptionsBuilder, graphFieldOptions } from '@grafana/ui';
 import { StackingEditor } from '@grafana/ui/internal';
 

--- a/public/app/plugins/panel/histogram/utils.ts
+++ b/public/app/plugins/panel/histogram/utils.ts
@@ -1,8 +1,9 @@
-import { DataFrame, FieldType } from '@grafana/data';
 import {
   isHistogramFrameBucketMinFieldName,
   isHistogramFrameBucketMaxFieldName,
-} from '@grafana/data/src/transformations/transformers/histogram';
+  DataFrame,
+  FieldType,
+} from '@grafana/data';
 
 export function originalDataHasHistogram(frames?: DataFrame[]): boolean {
   if (frames?.length !== 1) {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -30,7 +30,7 @@ import {
   LogSortOrderChangeEvent,
   LoadingState,
 } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
+import { convertRawToRange } from '@grafana/data/internal';
 import { config, getAppEvents } from '@grafana/runtime';
 import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -29,8 +29,8 @@ import {
   urlUtil,
   LogSortOrderChangeEvent,
   LoadingState,
+  rangeUtil,
 } from '@grafana/data';
-import { convertRawToRange } from '@grafana/data/internal';
 import { config, getAppEvents } from '@grafana/runtime';
 import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
@@ -574,7 +574,7 @@ export async function requestMoreLogs(
     return [];
   }
 
-  const range: TimeRange = convertRawToRange({
+  const range: TimeRange = rangeUtil.convertRawToRange({
     from: dateTimeForTimeZone(timeZone, timeRange.from),
     to: dateTimeForTimeZone(timeZone, timeRange.to),
   });

--- a/public/app/plugins/panel/nodeGraph/Node.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { FieldType } from '@grafana/data/src';
+import { FieldType } from '@grafana/data';
 
 import { Node } from './Node';
 

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -10,7 +10,7 @@ import {
   NumericRange,
   PanelProps,
 } from '@grafana/data';
-import { findNumericFieldMinMax } from '@grafana/data/src/field/fieldOverrides';
+import { findNumericFieldMinMax } from '@grafana/data/internal';
 import { BigValueTextMode, BigValueGraphMode } from '@grafana/schema';
 import { BigValue, DataLinksContextMenu, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi } from '@grafana/ui/internal';

--- a/public/app/plugins/panel/status-history/utils.ts
+++ b/public/app/plugins/panel/status-history/utils.ts
@@ -1,5 +1,4 @@
-import { ActionModel, Field, InterpolateFunction, LinkModel } from '@grafana/data';
-import { DataFrame } from '@grafana/data/';
+import { DataFrame, ActionModel, Field, InterpolateFunction, LinkModel } from '@grafana/data';
 import { getActions } from 'app/features/actions/utils';
 
 export const getDataLinks = (field: Field, rowIdx: number) => {

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -10,7 +10,7 @@ import {
   DataFrame,
   FieldType,
 } from '@grafana/data';
-import { ReduceTransformerOptions } from '@grafana/data/src/transformations/transformers/reduce';
+import { ReduceTransformerOptions } from '@grafana/data/internal';
 
 import { Options } from './panelcfg.gen';
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -7,10 +7,10 @@ import {
   isBooleanUnit,
   TimeRange,
   cacheFieldDisplayNames,
+  applyNullInsertThreshold,
+  nullToValue,
 } from '@grafana/data';
-import { convertFieldType } from '@grafana/data/src/transformations/transformers/convertFieldType';
-import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
-import { nullToValue } from '@grafana/data/src/transformations/transformers/nulls/nullToValue';
+import { convertFieldType } from '@grafana/data/internal';
 import { GraphFieldConfig, LineInterpolation, TooltipDisplayMode, VizTooltipOptions } from '@grafana/schema';
 import { buildScaleKey } from '@grafana/ui/internal';
 

--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from 'react';
 
-import { DataFrame, FieldMatcherID, fieldMatchers, FieldType, PanelProps, TimeRange } from '@grafana/data';
-import { isLikelyAscendingVector } from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import {
+  isLikelyAscendingVector,
+  DataFrame,
+  FieldMatcherID,
+  fieldMatchers,
+  FieldType,
+  PanelProps,
+  TimeRange,
+} from '@grafana/data';
 import { config, PanelDataErrorView } from '@grafana/runtime';
 import { KeyboardPlugin, TooltipDisplayMode, usePanelContext, TooltipPlugin2 } from '@grafana/ui';
 import { TooltipHoverMode } from '@grafana/ui/internal';

--- a/public/app/plugins/panel/xychart/XYChartPanel.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { FALLBACK_COLOR, PanelProps } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
+import { colorManipulator, FALLBACK_COLOR, PanelProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   TooltipDisplayMode,
@@ -72,7 +71,7 @@ export const XYChartPanel2 = (props: Props2) => {
         items.push({
           yAxis: 1, // TODO: pull from y field
           label: s.name.value,
-          color: alpha(s.color.fixed ?? FALLBACK_COLOR, 1),
+          color: colorManipulator.alpha(s.color.fixed ?? FALLBACK_COLOR, 1),
           getItemKey: () => `${idx}-${s.name.value}`,
           fieldName: yField.state?.displayName ?? yField.name,
           disabled: yField.state?.hideFrom?.viz ?? false,

--- a/public/app/plugins/panel/xychart/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
-import { DataFrame, InterpolateFunction, LinkModel } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
+import { colorManipulator, DataFrame, InterpolateFunction, LinkModel } from '@grafana/data';
 import {
   VizTooltipContent,
   VizTooltipFooter,
@@ -67,7 +66,7 @@ export const XYChartTooltip = ({
   const headerItem: VizTooltipItem = {
     label,
     value: '',
-    color: alpha(seriesColor ?? '#fff', 0.5),
+    color: colorManipulator.alpha(seriesColor ?? '#fff', 0.5),
     colorIndicator: ColorIndicator.marker_md,
   };
 

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -11,8 +11,8 @@ import {
   MappingType,
   SpecialValueMatch,
   ThresholdsMode,
+  colorManipulator,
 } from '@grafana/data';
-import { alpha } from '@grafana/data/src/themes/colorManipulator';
 import { AxisPlacement, FieldColorModeId, ScaleDirection, ScaleOrientation, VisibilityMode } from '@grafana/schema';
 import { UPlotConfigBuilder } from '@grafana/ui';
 import { FacetedData, FacetSeries } from '@grafana/ui/internal';
@@ -86,8 +86,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
 
           let pointAlpha = scatterInfo.fillOpacity / 100;
 
-          u.ctx.fillStyle = alpha((series.fill as any)(), pointAlpha);
-          u.ctx.strokeStyle = alpha((series.stroke as any)(), 1);
+          u.ctx.fillStyle = colorManipulator.alpha((series.fill as any)(), pointAlpha);
+          u.ctx.strokeStyle = colorManipulator.alpha((series.stroke as any)(), 1);
           u.ctx.lineWidth = strokeWidth;
 
           let deg360 = 2 * Math.PI;
@@ -138,8 +138,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
                   if (pointColors[i] !== curColorIdx) {
                     curColorIdx = pointColors[i];
                     let c = curColorIdx === -1 ? FALLBACK_COLOR : pointPalette[curColorIdx];
-                    u.ctx.fillStyle = paletteHasAlpha ? c : alpha(c as string, pointAlpha);
-                    u.ctx.strokeStyle = alpha(c as string, 1);
+                    u.ctx.fillStyle = paletteHasAlpha ? c : colorManipulator.alpha(c as string, pointAlpha);
+                    u.ctx.strokeStyle = colorManipulator.alpha(c as string, 1);
                   }
                 }
 
@@ -421,8 +421,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
       pathBuilder: drawBubbles, // drawBubbles({disp: {size: {values: () => }}})
       theme,
       scaleKey: '', // facets' scales used (above)
-      lineColor: alpha(lineColor ?? '#ffff', 1),
-      fillColor: alpha(pointColor ?? '#ffff', 0.5),
+      lineColor: colorManipulator.alpha(lineColor ?? '#ffff', 1),
+      fillColor: colorManipulator.alpha(pointColor ?? '#ffff', 0.5),
       show: !field.state?.hideFrom?.viz,
     });
   });

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -12,7 +12,7 @@ import {
   FieldMatcherID,
   FieldConfigSource,
 } from '@grafana/data';
-import { decoupleHideFromState } from '@grafana/data/src/field/fieldState';
+import { decoupleHideFromState } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 import { VisibilityMode } from '@grafana/schema';
 

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -4,7 +4,7 @@ import { ComponentType, ReactNode } from 'react';
 import { Router } from 'react-router-dom';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 
-import { GrafanaTheme2 } from '@grafana/data/';
+import { GrafanaTheme2 } from '@grafana/data';
 import {
   config,
   locationService,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Following on from PR #101815 ...

This PR uses exports in package.json to limit the public API of the @grafana/data NPM package. Right now it creates a single file that re-exports all the current "internal" code that is used throughout Grafana core/enterprise and updates usage throughout the projects to point to the grafana/data/internal and grafana/data/test exports.

**Why do we need this feature?**

We've been marking code in our NPM packages with an @internal docBlock to highlight it's not actually part of the public API. As far as I can tell this is done to share code from the package within Grafana core but it's not supposed to be used by plugins.

This PR gives us the ability to build an "internal api" convention around package.json exports. The grafana-data/src/internal directory can be used as the place to export code (or possibly put code) we want to use both within the package and in Grafana core but not expose it to plugins.

Additionally by using exports in both development and published NPM packages we align the import paths to the unstable entry-points across Grafana core code and plugins. The also opens the door to solving the issue we have with scenes and schema (which imports from @grafana/schema/dist/esm/) needing us to rewrite these paths in [core webpack config](https://github.com/grafana/grafana/blob/main/scripts/webpack/webpack.common.js#L64-L66) and [jest config](https://github.com/grafana/grafana/blob/main/jest.config.js#L55).

**Who is this feature for?**

Grafana Maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related https://github.com/grafana/grafana-community-team/issues/327

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
