### PR TITLE
fix(unified-storage): Fix legacysearch returning mismatched cell/column count in response

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -253,7 +253,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 				Key: getResourceKey(&dashboards.DashboardSearchProjection{
 					UID: dashboard.UID,
 				}, req.Options.Key.Namespace),
-				Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), {}, {}},
+				Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), []byte(strconv.FormatInt(dashboard.ID, 10)), {}, {}},
 			})
 		}
 


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/101944 introduced a new column field to store the legacy dashboard ID, but I forgot to include it in the response in this block. This is causing a panic when that code path hits.