### PR TITLE
Dashboards: Fix crashing dashboards after save

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -67,8 +67,10 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
     containerStyle.overflow = 'unset';
   }
 
-  const onBodyRef = (ref: HTMLDivElement) => {
-    dashboard.onSetScrollRef(new DivScrollElement(ref));
+  const onBodyRef = (ref: HTMLDivElement | null) => {
+    if (ref) {
+      dashboard.onSetScrollRef(new DivScrollElement(ref));
+    }
   };
 
   return (

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -70,7 +70,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       getDashboardUrl({
         uid: v.metadata.name,
         currentQueryParams: '',
-        slug: kbn.slugifyForUrl(v.spec.title),
+        slug: kbn.slugifyForUrl(v.spec.title.trim()),
       })
     );
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -143,7 +143,7 @@ export class K8sDashboardV2API
       getDashboardUrl({
         uid: v.metadata.name,
         currentQueryParams: '',
-        slug: kbn.slugifyForUrl(v.spec.title),
+        slug: kbn.slugifyForUrl(v.spec.title.trim()),
       })
     );
 


### PR DESCRIPTION
**What is this feature?**

This PR brings two changes:
- only create a `DivScrollElement` if the `ref` is not `null`. This avoids potential issues with trying to access HTML props on null refs.
- when creating a slug for a dashboard after we save the said dashboard, trim the white spaces on edges. This was causing issues with dashboards that had empty spaces at the end of the title.

For example, having a dashboard with the following title: "Test " (notice the space at the end), whenever the user was trying to save the dashboard from the edit panel page, the dashboard was saved but the page was then crashing.

The cause was that because of the mismatch of URL, there was a quick navigation happening which caused the body scroll ref to be null.

**Why do we need this feature?**

Fix crashing dashboards on save.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
