### PR TITLE
Revert "Unified Storage: Use match all query instead of wildcard for not-in requirement query"

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -803,7 +803,7 @@ func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *r
 		boolQuery.AddMustNot(mustNotQueries...)
 
 		// must still have a value
-		notEmptyQuery := bleve.NewMatchAllQuery()
+		notEmptyQuery := bleve.NewWildcardQuery("*")
 		boolQuery.AddMust(notEmptyQuery)
 
 		return boolQuery, nil


### PR DESCRIPTION
Reverts grafana/grafana#101953

Might be causing dashboard provisioning errors