### PR TITLE
Create metric to measure success/failures of datasources within ds querier

### DIFF
--- a/pkg/registry/apis/query/metrics.go
+++ b/pkg/registry/apis/query/metrics.go
@@ -10,7 +10,8 @@ const (
 )
 
 type queryMetrics struct {
-	dsRequests *prometheus.CounterVec
+	dsRequests  *prometheus.CounterVec
+	dsResponses *prometheus.CounterVec
 
 	// older metric
 	expressionsQuerySummary *prometheus.SummaryVec
@@ -24,6 +25,12 @@ func newQueryMetrics(reg prometheus.Registerer) *queryMetrics {
 			Name:      "ds_queries_total",
 			Help:      "Number of datasource queries made from the query service",
 		}, []string{"error", "dataplane", "datasource_type"}),
+
+		dsResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "plugin_request_total",
+			Help:      "The total amount of plugin requests",
+		}, []string{"plugin_id", "status", "status_source"}),
 
 		expressionsQuerySummary: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{

--- a/pkg/registry/apis/query/metrics.go
+++ b/pkg/registry/apis/query/metrics.go
@@ -27,7 +27,8 @@ func newQueryMetrics(reg prometheus.Registerer) *queryMetrics {
 		}, []string{"error", "dataplane", "datasource_type"}),
 
 		dsResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "grafana",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
 			Name:      "plugin_request_total",
 			Help:      "The total amount of plugin requests",
 		}, []string{"plugin_id", "status", "status_source"}),


### PR DESCRIPTION
Marked as draft for now as it needs tests and such

**What is this feature?**

Creates a new prom metric for us to measure the health of individual datasources by their responses from within the ds querier. We already do this in single tenant grafana, but any queries that do not get forwarded to single tenant grafana will be missed in our metrics without something like this.

**Why do we need this feature?**

To better measure the health of our individual datasources.

We currently measure the health of datasources from within grafana with this metric: https://github.com/grafana/grafana/blob/89882749124f6d6e1ffb521bd89378e525756e13/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go#L34

however if we want the ds querier to ping datasources directly we may skip over this metric and lose insight into the health of our datasources. 

We've done some work to capture this in the datasources themselves here: https://github.com/grafana/grafana-plugin-sdk-go/commit/501b8365f31d6b021d71e317a4049ad5690d42e7

but if all our metrics are within the datasources itself it can be difficult to determine if a datasource is down entirely or just not getting much traffic. So it makes sense to put the metric in the client of the datasource, in this case the ds-querier. 

**Who is this feature for?**

grafana devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/8015

**Special notes for your reviewer:**

Open questions for reviewer: 
- I removed target should I keep it? I wasn't sure what to put there... are all of these remote?
- I removed endpoint... I would love to keep it but my guess is that this is data we do not have in the ds querier

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

