### PR TITLE
Alerting: Prometheus mode template function

### DIFF
--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -196,7 +196,7 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				if promRule.Record != "" {
 					require.Equal(t, fmt.Sprintf("[%s] %s", tc.promGroup.Name, promRule.Record), grafanaRule.Title)
 					require.NotNil(t, grafanaRule.Record)
-					require.Equal(t, grafanaRule.Record.From, queryRefID)
+					require.Equal(t, grafanaRule.Record.From, QueryRefID)
 					require.Equal(t, promRule.Record, grafanaRule.Record.Metric)
 					require.Equal(t, tc.config.DatasourceUID, grafanaRule.Record.TargetDatasourceUID)
 				} else {
@@ -209,16 +209,23 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				}
 				require.Equal(t, expectedFor, grafanaRule.For, tc.name)
 
-				expectedLabels := make(map[string]string, len(promRule.Labels)+len(tc.promGroup.Labels))
-				maps.Copy(expectedLabels, tc.promGroup.Labels)
-				maps.Copy(expectedLabels, promRule.Labels)
-
 				uidData := fmt.Sprintf("%d|%s|%s|%d", tc.orgID, tc.namespace, tc.promGroup.Name, j)
 				u := uuid.NewSHA1(uuid.NameSpaceOID, []byte(uidData))
 				require.Equal(t, u.String(), grafanaRule.UID, tc.name)
 
+				expectedLabels := make(map[string]string, len(promRule.Labels)+len(tc.promGroup.Labels))
+				maps.Copy(expectedLabels, tc.promGroup.Labels)
+				maps.Copy(expectedLabels, promRule.Labels)
 				require.Equal(t, expectedLabels, grafanaRule.Labels, tc.name)
-				require.Equal(t, promRule.Annotations, grafanaRule.Annotations, tc.name)
+
+				var expectedAnnotations map[string]string
+				if promRule.Annotations == nil {
+					expectedAnnotations = map[string]string{}
+				} else {
+					expectedAnnotations = promRule.Annotations
+				}
+				require.Equal(t, expectedAnnotations, grafanaRule.Annotations, tc.name)
+
 				require.Equal(t, models.Duration(0*time.Minute), grafanaRule.Data[0].RelativeTimeRange.To)
 				require.Equal(t, models.Duration(10*time.Minute), grafanaRule.Data[0].RelativeTimeRange.From)
 

--- a/pkg/services/ngalert/prom/query.go
+++ b/pkg/services/ngalert/prom/query.go
@@ -25,7 +25,7 @@ func createQueryNode(datasourceUID, datasourceType, expr string, fromTimeRange, 
 		"expr":    expr,
 		"instant": true,
 		"range":   false,
-		"refId":   queryRefID,
+		"refId":   QueryRefID,
 	}
 
 	if datasourceType == datasources.DS_LOKI {
@@ -40,7 +40,7 @@ func createQueryNode(datasourceUID, datasourceType, expr string, fromTimeRange, 
 	return models.AlertQuery{
 		DatasourceUID: datasourceUID,
 		Model:         modelJSON,
-		RefID:         queryRefID,
+		RefID:         QueryRefID,
 		RelativeTimeRange: models.RelativeTimeRange{
 			From: models.Duration(fromTimeRange + evaluationOffset),
 			To:   models.Duration(0 + evaluationOffset),
@@ -66,7 +66,7 @@ func createMathNode() (models.AlertQuery, error) {
 			Type:       expr.QueryTypeMath,
 		},
 		MathQuery: expr.MathQuery{
-			Expression: fmt.Sprintf("is_number($%[1]s) || is_nan($%[1]s) || is_inf($%[1]s)", queryRefID),
+			Expression: fmt.Sprintf("is_number($%[1]s) || is_nan($%[1]s) || is_inf($%[1]s)", QueryRefID),
 		},
 	}
 

--- a/pkg/services/ngalert/prom/template.go
+++ b/pkg/services/ngalert/prom/template.go
@@ -1,0 +1,132 @@
+package prom
+
+import (
+	"reflect"
+	"strings"
+	"text/template/parse"
+)
+
+const (
+	PrometheusModeTemplateCall = "{{- _prometheusMode -}}"
+)
+
+func convertTemplates(m map[string]string) error {
+	for k, v := range m {
+		nv, err := convertTemplate(v)
+		if err != nil {
+			return err
+		}
+		m[k] = nv
+	}
+
+	return nil
+}
+
+// convertTemplate analyzes a template string to determine if it uses Prometheus-style
+// value references ($value or .Value). If it does, it adds a _prometheusMode function call
+// to the beginning of the template to switch the template rendering to Prometheus compatibility mode.
+// This allows templates converted from Prometheus alerting rules to continue working without modification.
+func convertTemplate(tmpl string) (string, error) {
+	searchFor := map[string]struct{}{
+		"$value":  {},
+		".Value":  {},
+		"$.Value": {},
+	}
+
+	// Create a parser with SkipFuncCheck to avoid errors with unknown functions
+	p := parse.New("tmpl")
+	p.Mode = parse.ParseComments | parse.SkipFuncCheck
+
+	// Add temporary prefix with the variables that are expected by the template,
+	// otherwise the parsing fails.
+	tmpPrefix := `{{$value := ""}}{{$labels := ""}}`
+
+	tree, err := p.Parse(tmpPrefix+tmpl, "{{", "}}", map[string]*parse.Tree{})
+	if err != nil {
+		return "", err
+	}
+
+	// Search for the variables in the template
+	found := walkNodes(tree.Root, searchFor)
+	if found {
+		return PrometheusModeTemplateCall + tmpl, nil
+	}
+
+	return tmpl, nil
+}
+
+// walkNodes recursively traverses the AST to find all variable nodes with certain names
+// and returns the boolean indicating whether they are present in the template.
+func walkNodes(node parse.Node, searchFor map[string]struct{}) bool {
+	var found bool
+
+	var walk func(node parse.Node)
+	walk = func(node parse.Node) {
+		if node == nil || reflect.ValueOf(node).IsNil() {
+			return
+		}
+
+		switch n := node.(type) {
+		case *parse.VariableNode:
+			if _, ok := searchFor[strings.Join(n.Ident, ".")]; ok {
+				found = true
+			}
+
+		case *parse.FieldNode:
+			if _, ok := searchFor["."+strings.Join(n.Ident, ".")]; ok {
+				found = true
+			}
+
+		case *parse.ActionNode:
+			walk(n.Pipe)
+
+		case *parse.ChainNode:
+			walk(n.Node)
+
+		case *parse.CommandNode:
+			for _, arg := range n.Args {
+				walk(arg)
+			}
+
+		case *parse.ListNode:
+			for _, child := range n.Nodes {
+				walk(child)
+			}
+
+		case *parse.PipeNode:
+			for _, cmd := range n.Cmds {
+				walk(cmd)
+			}
+
+		case *parse.IfNode:
+			walk(n.Pipe)
+			walk(n.List)
+			if n.ElseList != nil {
+				walk(n.ElseList)
+			}
+
+		case *parse.RangeNode:
+			walk(n.Pipe)
+			walk(n.List)
+			if n.ElseList != nil {
+				walk(n.ElseList)
+			}
+
+		case *parse.WithNode:
+			walk(n.Pipe)
+			walk(n.List)
+			if n.ElseList != nil {
+				walk(n.ElseList)
+			}
+
+		case *parse.TemplateNode:
+			if n.Pipe != nil {
+				walk(n.Pipe)
+			}
+		}
+	}
+
+	walk(node)
+
+	return found
+}

--- a/pkg/services/ngalert/prom/template_test.go
+++ b/pkg/services/ngalert/prom/template_test.go
@@ -1,0 +1,180 @@
+package prom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertTemplates(t *testing.T) {
+	testCases := []struct {
+		name       string
+		templates  map[string]string
+		expected   map[string]string
+		shouldFail bool
+	}{
+		{
+			name: "simple template with $value",
+			templates: map[string]string{
+				"template": "Value is {{$value}}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}Value is {{$value}}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "simple template with .Value",
+			templates: map[string]string{
+				"template": "Value is {{.Value}}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}Value is {{.Value}}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template with $.Value",
+			templates: map[string]string{
+				"template": `
+					{{- range .Items}}
+					Value: {{.Value}}
+					Global Value: {{$.Value}}
+					{{- end}}
+				`,
+			},
+			expected: map[string]string{
+				"template": `{{- _prometheusMode -}}
+					{{- range .Items}}
+					Value: {{.Value}}
+					Global Value: {{$.Value}}
+					{{- end}}
+				`,
+			},
+			shouldFail: false,
+		},
+		{
+			name: "complex template with $value in if statement",
+			templates: map[string]string{
+				"template": "{{if gt $value 100.0}}Too high{{else}}Good{{end}}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}{{if gt $value 100.0}}Too high{{else}}Good{{end}}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "complex template with .Value in if statement",
+			templates: map[string]string{
+				"template": "{{if gt .Value 100.0}}Too high{{else}}Good{{end}}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}{{if gt .Value 100.0}}Too high{{else}}Good{{end}}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template with $value in nested structures",
+			templates: map[string]string{
+				"template": "{{range .Values}}{{if eq . $value}}Match{{end}}{{end}}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}{{range .Values}}{{if eq . $value}}Match{{end}}{{end}}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template without $value or .Value",
+			templates: map[string]string{
+				"template": "This template does not use the values",
+			},
+			expected: map[string]string{
+				"template": "This template does not use the values",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template with $labels",
+			templates: map[string]string{
+				"template": "Instance: {{ $labels.instance }}",
+			},
+			expected: map[string]string{
+				"template": "Instance: {{ $labels.instance }}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template with both $value and $labels",
+			templates: map[string]string{
+				"template": "{{ $labels.instance }} has value {{ $value }}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}{{ $labels.instance }} has value {{ $value }}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "template with multiple $value occurrences",
+			templates: map[string]string{
+				"template": "First: {{ $value }}, Second: {{ $value }}",
+			},
+			expected: map[string]string{
+				"template": "{{- _prometheusMode -}}First: {{ $value }}, Second: {{ $value }}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "multiple templates with mixed patterns",
+			templates: map[string]string{
+				"summary":     "Instance {{ $labels.instance }} has high CPU usage",
+				"description": "{{ $labels.instance }} has value {{ $value }}",
+			},
+			expected: map[string]string{
+				"summary":     "Instance {{ $labels.instance }} has high CPU usage",
+				"description": "{{- _prometheusMode -}}{{ $labels.instance }} has value {{ $value }}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "all templates with values",
+			templates: map[string]string{
+				"summary":     "Value is {{ $value }}",
+				"description": "Detailed value is {{ .Value }}",
+			},
+			expected: map[string]string{
+				"summary":     "{{- _prometheusMode -}}Value is {{ $value }}",
+				"description": "{{- _prometheusMode -}}Detailed value is {{ .Value }}",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "no templates with values",
+			templates: map[string]string{
+				"summary":     "Instance {{ $labels.instance }} is down",
+				"description": "Instance {{ $labels.instance }} has been down for more than 5 minutes",
+			},
+			expected: map[string]string{
+				"summary":     "Instance {{ $labels.instance }} is down",
+				"description": "Instance {{ $labels.instance }} has been down for more than 5 minutes",
+			},
+			shouldFail: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := make(map[string]string)
+			for k, v := range tc.templates {
+				input[k] = v
+			}
+
+			err := convertTemplates(input)
+			if tc.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adds `{{ _prometheusMode }}` function to the templates of the alert rules that were converted from Prometheus rule definitions.

**Why do we need this feature?**

In Prometheus templating both `$value` and `.Value` return the value of the query. In Grafana the syntax is different: `.Values.<refID>.Value`, and `.Value`/`$value` return the string like

```
[ var='A' labels={foo=bar} value=10 ], [ var='B' labels={bar=baz, foo=bar} value=1 ]
```

To make the templating work after the Prometheus -> Grafana conversion in the same way, we add `{{ _prometheusMode }}` function to the beginning of the template and when it's called we switch the rendering mode to return the values just like in Prometheus.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
