### PR TITLE
[release-11.5.3] docs(alerting): alert instance state resets when rule changes

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
@@ -52,13 +52,15 @@ An alert instance can be in either of the following states:
 | **No Data<sup>\*</sup>** | The state of an alert whose query returns no data or all values are null. <br/> An alert in this state generates a new [DatasourceNoData alert](#no-data-and-error-alerts). You can [modify the default behavior of the no data state](#modify-the-no-data-or-error-state).       |
 | **Error<sup>\*</sup>**   | The state of an alert when an error or timeout occurred evaluating the alert rule. <br/> An alert in this state generates a new [DatasourceError alert](#no-data-and-error-alerts). You can [modify the default behavior of the error state](#modify-the-no-data-or-error-state). |
 
+If an alert rule changes (except for updates to annotations, the evaluation interval, or other internal fields), its alert instances reset to the `Normal` state. The alert instance state then updates accordingly during the next evaluation.
+
+{{< figure src="/media/docs/alerting/alert-instance-states-v3.png" caption="Alert instance state diagram" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
+
 {{< admonition type="note" >}}
 
 `No Data` and `Error` states are supported only for Grafana-managed alert rules.
 
 {{< /admonition >}}
-
-{{< figure src="/media/docs/alerting/alert-instance-states-v3.png" caption="Alert instance state diagram" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
 
 ### Notification routing
 


### PR DESCRIPTION
Backport 3e1513a6df3945cd573beb19480791904184256f from #102038\n\n---\n\nminor addition: document what happens to alert instances when the alert rule changes.

> If an alert rule changes, its alert instances reset to the `Normal` state. During the next evaluation, the alert instance state updates accordingly.


@yuri-tceretian, I read this from you. Are we missing anything else?
