### PR TITLE
Dashboard Schema V2: Handle diffing issues

### DIFF
--- a/public/app/core/utils/object.ts
+++ b/public/app/core/utils/object.ts
@@ -10,9 +10,9 @@ export function sortedDeepCloneWithoutNulls<T>(value: T): T {
       .sort()
       .reduce((acc: any, key) => {
         const v = (value as any)[key];
-        // Remove null values and also -Infinity which is not a valid JSON value
-        if (v != null && v !== -Infinity) {
-          acc[key] = sortedDeepCloneWithoutNulls(v);
+        // Remove null values and convert -Infinity to 0 because -Infinity is not a valid JSON value
+        if (v != null) {
+          acc[key] = v === -Infinity ? 0 : sortedDeepCloneWithoutNulls(v);
         }
         return acc;
       }, {});

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -189,6 +189,12 @@ function getElements(scene: DashboardScene) {
         }).filter(([_, value]) => value !== undefined)
       );
 
+      // if mappings is empty, we don't want to persist it because backend will return
+      // not persist empty mappings and we'll have an unneeded diff in the save UI
+      if (!vizPanel.state.fieldConfig.defaults.mappings?.length) {
+        defaults.mappings = undefined;
+      }
+
       const vizFieldConfig: FieldConfigSource = {
         ...vizPanel.state.fieldConfig,
         defaults,


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/pull/99966 introduced types generations for both backend and frontend for schema v2. This has caused diffing issues:
- if we pass empty array for `fieldConfig.defaults.mappings` mappings fled won't be persisted in the db. 
- if `color.value` is not passed for an object inside `thresholds.steps` array, the backed will automatically assign 0 to value. This is not necessary because even if we passed multiple colors without values, the runtime will set the first color in the steps array as base. However, the backend requires it https://github.com/grafana/grafana/blob/ea89a68028805fa1ec7d0d810a22b1d6d20bf8f2/pkg/apis/dashboard/v2alpha1/zz_generated.openapi.go#L3849

**Why do we need this feature?**

To keep diffing as clean as possible. 

Please check that:
- [x] It works as expected from a user's perspective.
