### PR TITLE
feat(util): add key based debouncer

### DIFF
--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -294,6 +294,7 @@ func (d *debouncer[T]) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-d.resetChan:
+			minTimer.Stop()
 			minTimer.Reset(d.minWait)
 		case <-minTimer.C:
 			d.processFunc(d.key)

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -109,9 +109,13 @@ type Debouncer[T any] struct {
 //	})
 //
 //	// Queue events
-//	debouncer.Add("user-1")
+//	if err := debouncer.Add("user-1"); err != nil {
+//	  // Do something with the error.
+//	}
 //	// Adding the same key resets MinWait but not MaxWait
-//	debouncer.Add("user-1")
+//	if err := debouncer.Add("user-1"); err != nil {
+//	  // Do something with the error.
+//	}
 //
 // The event will be processed when either MinWait expires (after the most recent add)
 // or MaxWait expires (after the first add), whichever comes first.

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -121,7 +121,6 @@ type Group[T comparable] struct {
 //
 //	group := debouncer.NewGroup(DebouncerOpts[string]{
 //		BufferSize:     1000,
-//		KeyFunc:        func(s string) string { return s },
 //		ProcessHandler: func(ctx context.Context, key string) error {
 //		  // This is where you perform the expensive operation
 //		  return doSuperExpensiveCommand(key)

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	ErrBufferFull = errors.New("debouncer buffer full")
+	ErrBufferFull               = errors.New("debouncer buffer full")
+	ErrMinWaitBiggerThanMaxWait = errors.New("")
 )
 
 type KeyFunc[T any] func(T) string
@@ -151,12 +152,17 @@ func NewGroup[T any](opts DebouncerOpts[T]) (*Group[T], error) {
 	if opts.BufferSize <= 0 {
 		opts.BufferSize = 100
 	}
+
 	if opts.MinWait <= 0 {
 		opts.MinWait = time.Minute
 	}
 	if opts.MaxWait <= 0 {
 		opts.MaxWait = 5 * time.Minute
 	}
+	if opts.MinWait > opts.MaxWait {
+		return nil, errors.New("minWait is bigger than maxWait")
+	}
+
 	if opts.KeyFunc == nil {
 		return nil, errors.New("keyFunc is required")
 	}

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -187,13 +187,12 @@ func (d *Debouncer[T]) SetMaxWait(maxWait time.Duration) {
 func (d *Debouncer[T]) processValue(value T, processFunc ProcessFunc[T]) {
 	key := d.opts.KeyFunc(value)
 	d.debouncersMu.Lock()
-	defer d.debouncersMu.Unlock()
-
 	debouncer, ok := d.debouncers[key]
 	if !ok {
 		debouncer = newKeyDebouncer[T](d.opts.MinWait, d.opts.MaxWait)
 		d.debouncers[key] = debouncer
 	}
+	d.debouncersMu.Unlock()
 
 	wrappedProcessFunc := func(v T) {
 		d.processWithMetrics(d.ctx, v, processFunc)

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	ErrBufferFull               = errors.New("debouncer buffer full")
-	ErrMinWaitBiggerThanMaxWait = errors.New("")
+	ErrBufferFull = errors.New("debouncer buffer full")
 )
 
 type ProcessFunc[T comparable] func(context.Context, T) error

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -29,20 +29,32 @@ type metrics struct {
 func newMetrics(reg prometheus.Registerer, name string) *metrics {
 	return &metrics{
 		itemsAddedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: name + "_debouncer_items_added_total",
+			Name: "debouncer_items_added_total",
 			Help: "Total number of items added to the debouncer",
+			ConstLabels: prometheus.Labels{
+				"name": name,
+			},
 		}),
 		itemsDroppedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: name + "_debouncer_items_dropped_total",
+			Name: "debouncer_items_dropped_total",
 			Help: "Total number of items dropped due to a full buffer",
+			ConstLabels: prometheus.Labels{
+				"name": name,
+			},
 		}),
 		itemsProcessedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: name + "_debouncer_items_processed_total",
+			Name: "debouncer_items_processed_total",
 			Help: "Total number of items processed by the debouncer",
+			ConstLabels: prometheus.Labels{
+				"name": name,
+			},
 		}),
 		processingErrorsCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: name + "_debouncer_processing_errors_total",
+			Name: "debouncer_processing_errors_total",
 			Help: "Total number of errors during processing",
+			ConstLabels: prometheus.Labels{
+				"name": name,
+			},
 		}),
 		processingDurationHistogram: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            name + "_debouncer_processing_duration_seconds",
@@ -51,6 +63,9 @@ func newMetrics(reg prometheus.Registerer, name string) *metrics {
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
+			ConstLabels: prometheus.Labels{
+				"name": name,
+			},
 		}),
 	}
 }

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/dskit/instrument"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -44,9 +45,12 @@ func newMetrics(reg prometheus.Registerer, name string) *metrics {
 			Help: "Total number of errors during processing",
 		}),
 		processingDurationHistogram: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    name + "_debouncer_processing_duration_seconds",
-			Help:    "Time taken to process items",
-			Buckets: prometheus.DefBuckets,
+			Name:                            name + "_debouncer_processing_duration_seconds",
+			Help:                            "Time taken to process items",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
 		}),
 	}
 }

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -163,10 +163,6 @@ func NewGroup[T any](opts DebouncerOpts[T]) (*Group[T], error) {
 		opts.ErrorHandler = func(_ T, _ error) {}
 	}
 
-	if opts.Reg == nil {
-		opts.Reg = prometheus.NewRegistry()
-	}
-
 	return &Group[T]{
 		buffer:         make(chan T, opts.BufferSize),
 		debouncers:     make(map[string]*debouncer[T]),

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -237,8 +237,7 @@ func (g *Group[T]) processWithMetrics(ctx context.Context, value T, processFunc 
 	defer timer.ObserveDuration()
 	g.metrics.itemsProcessedCounter.Inc()
 
-	err := processFunc(ctx, value)
-	if err != nil && g.errorHandler != nil {
+	if err := processFunc(ctx, value); err != nil {
 		g.errorHandler(value, err)
 		g.metrics.processingErrorsCounter.Inc()
 	}

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -209,14 +209,6 @@ func (g *Group[T]) Stop() {
 	}
 }
 
-func (g *Group[T]) SetMinWait(minWait time.Duration) {
-	g.opts.MinWait = minWait
-}
-
-func (g *Group[T]) SetMaxWait(maxWait time.Duration) {
-	g.opts.MaxWait = maxWait
-}
-
 func (g *Group[T]) processValue(value T) {
 	key := g.opts.KeyFunc(value)
 	g.debouncersMu.Lock()

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -1,0 +1,245 @@
+package debouncer
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	ErrBufferFull = errors.New("debouncer buffer full")
+)
+
+type KeyFunc[T any] func(T) string
+type ProcessFunc[T any] func(context.Context, T) error
+
+type metrics struct {
+	itemsAddedCounter           prometheus.Counter
+	itemsDroppedCounter         prometheus.Counter
+	itemsProcessedCounter       prometheus.Counter
+	processingErrorsCounter     prometheus.Counter
+	processingDurationHistogram prometheus.Histogram
+}
+
+func newMetrics(reg prometheus.Registerer, name string) *metrics {
+	return &metrics{
+		itemsAddedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: name + "_debouncer_items_added_total",
+			Help: "Total number of items added to the debouncer",
+		}),
+		itemsDroppedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: name + "_debouncer_items_dropped_total",
+			Help: "Total number of items dropped due to a full buffer",
+		}),
+		itemsProcessedCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: name + "_debouncer_items_processed_total",
+			Help: "Total number of items processed by the debouncer",
+		}),
+		processingErrorsCounter: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: name + "_debouncer_processing_errors_total",
+			Help: "Total number of errors during processing",
+		}),
+		processingDurationHistogram: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    name + "_debouncer_processing_duration_seconds",
+			Help:    "Time taken to process items",
+			Buckets: prometheus.DefBuckets,
+		}),
+	}
+}
+
+type DebouncerOpts[T any] struct {
+	BufferSize   int
+	KeyFunc      KeyFunc[T]
+	MinWait      time.Duration
+	MaxWait      time.Duration
+	Reg          prometheus.Registerer
+	Name         string
+	ErrorHandler func(T, error)
+}
+
+type Debouncer[T any] struct {
+	opts   DebouncerOpts[T]
+	buffer chan T
+
+	// mutex protecting the debouncers map.
+	debouncersMu sync.Mutex
+	debouncers   map[string]*keyDebouncer[T]
+
+	wg           sync.WaitGroup
+	ctx          context.Context
+	cancel       context.CancelFunc
+	errorHandler func(T, error)
+	metrics      *metrics
+}
+
+func NewDebouncer[T any](opts DebouncerOpts[T]) *Debouncer[T] {
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = 100
+	}
+	if opts.MinWait <= 0 {
+		opts.MinWait = time.Minute
+	}
+	if opts.MaxWait <= 0 {
+		opts.MaxWait = 5 * time.Minute
+	}
+	if opts.KeyFunc == nil {
+		panic("KeyFunc is required")
+	}
+
+	if opts.Reg == nil {
+		opts.Reg = prometheus.NewRegistry()
+	}
+
+	return &Debouncer[T]{
+		opts:         opts,
+		buffer:       make(chan T, opts.BufferSize),
+		debouncers:   make(map[string]*keyDebouncer[T]),
+		metrics:      newMetrics(opts.Reg, opts.Name),
+		errorHandler: opts.ErrorHandler,
+	}
+}
+
+func (d *Debouncer[T]) Add(value T) error {
+	select {
+	case d.buffer <- value:
+		d.metrics.itemsAddedCounter.Inc()
+		return nil
+	default:
+		d.metrics.itemsDroppedCounter.Inc()
+		return ErrBufferFull
+	}
+}
+
+func (d *Debouncer[T]) Start(ctx context.Context, processFunc ProcessFunc[T]) {
+	d.ctx, d.cancel = context.WithCancel(ctx)
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		for {
+			select {
+			case <-d.ctx.Done():
+				return
+			case value := <-d.buffer:
+				d.processValue(value, processFunc)
+			}
+		}
+	}()
+}
+
+func (d *Debouncer[T]) Stop() {
+	if d.cancel != nil {
+		d.cancel()
+		d.wg.Wait()
+	}
+}
+
+func (d *Debouncer[T]) SetMinWait(minWait time.Duration) {
+	d.opts.MinWait = minWait
+}
+
+func (d *Debouncer[T]) SetMaxWait(maxWait time.Duration) {
+	d.opts.MaxWait = maxWait
+}
+
+func (d *Debouncer[T]) processValue(value T, processFunc ProcessFunc[T]) {
+	key := d.opts.KeyFunc(value)
+	d.debouncersMu.Lock()
+	defer d.debouncersMu.Unlock()
+
+	debouncer, ok := d.debouncers[key]
+	if !ok {
+		debouncer = newKeyDebouncer[T](d.opts.MinWait, d.opts.MaxWait)
+		d.debouncers[key] = debouncer
+	}
+
+	wrappedProcessFunc := func(v T) {
+		d.processWithMetrics(d.ctx, v, key, processFunc)
+
+		d.debouncersMu.Lock()
+		defer d.debouncersMu.Unlock()
+		if current, exists := d.debouncers[key]; exists && current == debouncer {
+			delete(d.debouncers, key)
+		}
+	}
+
+	debouncer.update(value, wrappedProcessFunc)
+}
+
+func (d *Debouncer[T]) processWithMetrics(ctx context.Context, value T, key string, processFunc ProcessFunc[T]) {
+	if d.metrics != nil {
+		timer := prometheus.NewTimer(d.metrics.processingDurationHistogram)
+		defer timer.ObserveDuration()
+		d.metrics.itemsProcessedCounter.Inc()
+	}
+
+	err := processFunc(ctx, value)
+	if err != nil && d.errorHandler != nil {
+		d.errorHandler(value, err)
+		if d.metrics != nil {
+			d.metrics.processingErrorsCounter.Inc()
+		}
+	}
+}
+
+// keyDebouncer handles debouncing for a specific key.
+type keyDebouncer[T any] struct {
+	// mutex that protects the whole debouncer process.
+	mu       sync.Mutex
+	value    T
+	minTimer *time.Timer
+	maxTimer *time.Timer
+	minWait  time.Duration
+	maxWait  time.Duration
+}
+
+// newKeyDebouncer creates a new key debouncer.
+func newKeyDebouncer[T any](minWait, maxWait time.Duration) *keyDebouncer[T] {
+	return &keyDebouncer[T]{
+		minWait: minWait,
+		maxWait: maxWait,
+	}
+}
+
+// update updates the debouncer with a new value.
+func (d *keyDebouncer[T]) update(value T, processFunc func(T)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.value = value
+
+	if d.minTimer != nil {
+		d.minTimer.Stop()
+	}
+	d.minTimer = time.AfterFunc(d.minWait, func() {
+		d.process(processFunc)
+	})
+
+	// Ensure max timer is only set once.
+	if d.maxTimer == nil {
+		d.maxTimer = time.AfterFunc(d.maxWait, func() {
+			d.process(processFunc)
+		})
+	}
+}
+
+// process processes the current value.
+func (d *keyDebouncer[T]) process(processFunc func(T)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Stop timers and clear references.
+	if d.minTimer != nil {
+		d.minTimer.Stop()
+		d.minTimer = nil
+	}
+	if d.maxTimer != nil {
+		d.maxTimer.Stop()
+		d.maxTimer = nil
+	}
+
+	processFunc(d.value)
+}

--- a/pkg/util/debouncer/debouncer_test.go
+++ b/pkg/util/debouncer/debouncer_test.go
@@ -71,22 +71,15 @@ func TestDebouncer(t *testing.T) {
 		group.Start(ctx)
 
 		ticker := time.NewTicker(time.Millisecond * 40)
+		defer ticker.Stop()
+
 		start := time.Now()
-		counter := 0
-	testLoop:
-		for {
-			// Add a safeguard to exit eventually.
-			if counter > 25 {
-				ticker.Stop()
+
+		for counter := 0; counter < 25; counter++ {
+			<-ticker.C
+			_ = group.Add("key1")
+			if processed["key1"] == 1 {
 				break
-			}
-			select {
-			case <-ticker.C:
-				_ = group.Add("key1")
-				if processed["key1"] == 1 {
-					break testLoop
-				}
-				counter++
 			}
 		}
 

--- a/pkg/util/debouncer/debouncer_test.go
+++ b/pkg/util/debouncer/debouncer_test.go
@@ -14,30 +14,32 @@ import (
 
 func TestDebouncer(t *testing.T) {
 	t.Run("should process values after min wait", func(t *testing.T) {
-		debouncer := NewDebouncer(DebouncerOpts[string]{
-			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
-			MinWait:    10 * time.Millisecond,
-			MaxWait:    100 * time.Millisecond,
-		})
-
 		var processedMu sync.Mutex
 		processedValues := make(map[string]int)
+
+		group, err := NewGroup(DebouncerOpts[string]{
+			BufferSize: 10,
+			KeyFunc:    func(s string) string { return s },
+			ProcessHandler: func(ctx context.Context, value string) error {
+				processedMu.Lock()
+				processedValues[value]++
+				processedMu.Unlock()
+				return nil
+			},
+			MinWait: 10 * time.Millisecond,
+			MaxWait: 100 * time.Millisecond,
+		})
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		debouncer.Start(ctx, func(ctx context.Context, value string) error {
-			processedMu.Lock()
-			processedValues[value]++
-			processedMu.Unlock()
-			return nil
-		})
+		group.Start(ctx)
 
-		require.NoError(t, debouncer.Add("key1"))
-		require.NoError(t, debouncer.Add("key2"))
+		require.NoError(t, group.Add("key1"))
+		require.NoError(t, group.Add("key2"))
 		// Should be deduplicated.
-		require.NoError(t, debouncer.Add("key1"))
+		require.NoError(t, group.Add("key1"))
 
 		// Wait for processing.
 		time.Sleep(20 * time.Millisecond)
@@ -50,25 +52,27 @@ func TestDebouncer(t *testing.T) {
 	})
 
 	t.Run("should process values after max wait", func(t *testing.T) {
-		debouncer := NewDebouncer(DebouncerOpts[string]{
+		processed := make(map[string]int, 1)
+
+		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
 			KeyFunc:    func(s string) string { return s },
-			MinWait:    100 * time.Millisecond,
+			ProcessHandler: func(ctx context.Context, value string) error {
+				processed[value]++
+				return nil
+			},
+			MinWait: 100 * time.Millisecond,
 			// Test max wait by setting it lower than min wait.
 			MaxWait: 20 * time.Millisecond,
 		})
-
-		processed := make(map[string]int, 1)
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		debouncer.Start(ctx, func(ctx context.Context, value string) error {
-			processed[value]++
-			return nil
-		})
+		group.Start(ctx)
 
-		require.NoError(t, debouncer.Add("key1"))
+		require.NoError(t, group.Add("key1"))
 		// Wait for max wait to trigger.
 		time.Sleep(30 * time.Millisecond)
 
@@ -76,72 +80,81 @@ func TestDebouncer(t *testing.T) {
 	})
 
 	t.Run("should handle buffer full", func(t *testing.T) {
-		debouncer := NewDebouncer(DebouncerOpts[string]{
-			BufferSize: 1,
-			KeyFunc:    func(s string) string { return s },
-			MinWait:    10 * time.Millisecond,
-			MaxWait:    100 * time.Millisecond,
+		group, err := NewGroup(DebouncerOpts[string]{
+			BufferSize:     1,
+			KeyFunc:        func(s string) string { return s },
+			ProcessHandler: func(ctx context.Context, value string) error { return nil },
+			MinWait:        10 * time.Millisecond,
+			MaxWait:        100 * time.Millisecond,
 		})
+		require.NoError(t, err)
 
-		require.NoError(t, debouncer.Add("key1"))
+		require.NoError(t, group.Add("key1"))
 		// Buffer should be full by now as we are not reading from it yet.
-		require.ErrorIs(t, debouncer.Add("key2"), ErrBufferFull)
+		require.ErrorIs(t, group.Add("key2"), ErrBufferFull)
 	})
 
 	t.Run("should track metrics", func(t *testing.T) {
-		debouncer := NewDebouncer(DebouncerOpts[string]{
+		var wg sync.WaitGroup
+
+		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
 			KeyFunc:    func(s string) string { return s },
-			MinWait:    10 * time.Millisecond,
-			MaxWait:    100 * time.Millisecond,
-			Reg:        prometheus.NewPedanticRegistry(),
-			Name:       "test",
+			ProcessHandler: func(ctx context.Context, value string) error {
+				wg.Done()
+				return nil
+			},
+			MinWait: 10 * time.Millisecond,
+			MaxWait: 100 * time.Millisecond,
+			Reg:     prometheus.NewPedanticRegistry(),
+			Name:    "test",
 		})
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		debouncer.Start(ctx, func(ctx context.Context, value string) error {
-			wg.Done()
-			return nil
-		})
+		group.Start(ctx)
 
-		require.NoError(t, debouncer.Add("key1"))
-		require.NoError(t, debouncer.Add("key1"))
+		wg.Add(1)
+		require.NoError(t, group.Add("key1"))
+		require.NoError(t, group.Add("key1"))
 
 		wg.Wait()
 
-		require.Equal(t, float64(2), testutil.ToFloat64(debouncer.metrics.itemsAddedCounter))
-		require.Equal(t, float64(1), testutil.ToFloat64(debouncer.metrics.itemsProcessedCounter))
+		require.Equal(t, float64(2), testutil.ToFloat64(group.metrics.itemsAddedCounter))
+		require.Equal(t, float64(1), testutil.ToFloat64(group.metrics.itemsProcessedCounter))
 	})
 
 	t.Run("should handle errors", func(t *testing.T) {
-		errs := make(chan error, 10)
+		var (
+			wg          sync.WaitGroup
+			errs        = make(chan error, 10)
+			expectedErr = errors.New("test error")
+		)
 
-		debouncer := NewDebouncer(DebouncerOpts[string]{
-			BufferSize:   10,
-			KeyFunc:      func(s string) string { return s },
+		group, err := NewGroup(DebouncerOpts[string]{
+			BufferSize: 10,
+			KeyFunc:    func(s string) string { return s },
+			ProcessHandler: func(ctx context.Context, value string) error {
+				wg.Done()
+				return expectedErr
+			},
 			MinWait:      10 * time.Millisecond,
 			MaxWait:      100 * time.Millisecond,
 			Reg:          prometheus.NewPedanticRegistry(),
 			Name:         "test_errors",
 			ErrorHandler: func(_ string, err error) { errs <- err },
 		})
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		expectedErr := errors.New("test error")
-		var wg sync.WaitGroup
-		wg.Add(1)
-		debouncer.Start(ctx, func(ctx context.Context, value string) error {
-			wg.Done()
-			return expectedErr
-		})
+		group.Start(ctx)
 
-		require.NoError(t, debouncer.Add("key1"))
+		wg.Add(1)
+		require.NoError(t, group.Add("key1"))
 
 		wg.Wait()
 
@@ -152,48 +165,50 @@ func TestDebouncer(t *testing.T) {
 			t.Fatal("expected error")
 		}
 
-		require.Equal(t, float64(1), testutil.ToFloat64(debouncer.metrics.processingErrorsCounter))
+		require.Equal(t, float64(1), testutil.ToFloat64(group.metrics.processingErrorsCounter))
 	})
 
 	t.Run("should gracefully handle stops", func(t *testing.T) {
-		debouncer := NewDebouncer(DebouncerOpts[string]{
-			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
-			MinWait:    50 * time.Millisecond,
-			MaxWait:    100 * time.Millisecond,
-		})
-
 		// Create a channel to signal when processing is done.
 		done := make(chan struct{})
 
-		// Start the debouncer with a context
+		group, err := NewGroup(DebouncerOpts[string]{
+			BufferSize: 10,
+			KeyFunc:    func(s string) string { return s },
+			ProcessHandler: func(ctx context.Context, item string) error {
+				// Start a goroutine to wait for context cancellation.
+				go func() {
+					<-ctx.Done()
+					close(done)
+				}()
+				return nil
+			},
+			MinWait: 50 * time.Millisecond,
+			MaxWait: 100 * time.Millisecond,
+		})
+		require.NoError(t, err)
+
+		// Start the group with a context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		debouncer.Start(ctx, func(ctx context.Context, item string) error {
-			// Start a goroutine to wait for context cancellation.
-			go func() {
-				<-ctx.Done()
-				close(done)
-			}()
-			return nil
-		})
+		group.Start(ctx)
 
 		// Send an item to trigger processing.
-		require.NoError(t, debouncer.Add("key-1"))
+		require.NoError(t, group.Add("key-1"))
 
-		// Give the debouncer a moment to process the item.
+		// Give the group a moment to process the item.
 		time.Sleep(50 * time.Millisecond)
 
-		// Stop the debouncer, which should cancel the context.
-		debouncer.Stop()
+		// Stop the group, which should cancel the context.
+		group.Stop()
 
 		// Wait for the done signal or timeout.
 		select {
 		case <-done:
-			// Success - the debouncer was stopped and the context was canceled
+			// Success - the group was stopped and the context was canceled
 		case <-time.After(time.Second):
-			t.Fatal("Timed out waiting for debouncer to stop")
+			t.Fatal("Timed out waiting for group to stop")
 		}
 	})
 }

--- a/pkg/util/debouncer/debouncer_test.go
+++ b/pkg/util/debouncer/debouncer_test.go
@@ -84,7 +84,6 @@ func TestDebouncer(t *testing.T) {
 		}
 
 		require.WithinDuration(t, start.Add(time.Millisecond*500), time.Now(), time.Millisecond*100)
-
 	})
 
 	t.Run("should handle buffer full", func(t *testing.T) {

--- a/pkg/util/debouncer/debouncer_test.go
+++ b/pkg/util/debouncer/debouncer_test.go
@@ -19,7 +19,6 @@ func TestDebouncer(t *testing.T) {
 
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, value string) error {
 				processedMu.Lock()
 				processedValues[value]++
@@ -57,7 +56,6 @@ func TestDebouncer(t *testing.T) {
 
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, value string) error {
 				processed[value]++
 				return nil
@@ -99,7 +97,6 @@ func TestDebouncer(t *testing.T) {
 	t.Run("should handle buffer full", func(t *testing.T) {
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize:     1,
-			KeyFunc:        func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, value string) error { return nil },
 			MinWait:        10 * time.Millisecond,
 			MaxWait:        100 * time.Millisecond,
@@ -116,7 +113,6 @@ func TestDebouncer(t *testing.T) {
 
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, value string) error {
 				wg.Done()
 				return nil
@@ -152,7 +148,6 @@ func TestDebouncer(t *testing.T) {
 
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, value string) error {
 				wg.Done()
 				return expectedErr
@@ -191,7 +186,6 @@ func TestDebouncer(t *testing.T) {
 
 		group, err := NewGroup(DebouncerOpts[string]{
 			BufferSize: 10,
-			KeyFunc:    func(s string) string { return s },
 			ProcessHandler: func(ctx context.Context, item string) error {
 				// Start a goroutine to wait for context cancellation.
 				go func() {


### PR DESCRIPTION
This PR adds a key based debouncer the the util package. This was extracted as part of #101970 

A key based debouncer enabled to run an action based on a key and duplicate for a given timeframe.

```golang
// Create a new debouncer group for processing events with string keys.
// This debouncer helps optimize expensive operations by:
// 1. Grouping identical events that occur in rapid succession.
// 2. Processing each unique key only once after waiting periods expire.
group := debouncer.NewGroup(DebouncerOpts[string]{
	// Maximum number of pending events to buffer.
	BufferSize: 10,
	
	// MinWait: Cooldown period after receiving an event.
	// If another event with the same key arrives during this period,
	// the timer resets and we wait another 10 seconds.
	MinWait: time.Second * 10,
	
	// MaxWait: Maximum time any event will wait before processing.
	// Even if new events for the same key keep arriving,
	// we guarantee processing after 60 seconds from the first event.
	MaxWait: time.Minute,

	// This function will be called when an event is ready to be processed.
	ProcessFunc: func(key string) error {
		// This is where you perform the expensive operation.
		// The debouncer ensures this only runs once per key after the waiting periods.
		if err := doSuperExpensiveCommand(key); err != nil {
	  		return err
		}
		return nil
	},
})

// Start evaluation any events that are added to the group.
group.Start(ctx)

// Queue an event for "user-1".
group.Add("user-1")
// At this point:
// - MinWait timer starts (10 seconds)
// - MaxWait timer starts (60 seconds)

// Add another event for the same key during the MinWait period.
group.Add("user-1")
// This resets the MinWait timer back to 10 seconds.
// The MaxWait timer continues running from when the first event was added.

// The event will be processed when either:
// - MinWait expires (10 seconds after the most recent add)
// - MaxWait expires (60 seconds after the first add)
// This ensures we don't process too frequently, but also don't wait forever.

// Eventually cleanup everything.
group.Stop()
```