### PR TITLE
Fix job summary stats issue

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5640,7 +5640,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
     ],
     "public/app/features/provisioning/RepositoryActions.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],

--- a/public/app/features/provisioning/JobStatus.tsx
+++ b/public/app/features/provisioning/JobStatus.tsx
@@ -1,8 +1,9 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 
-import { Alert, ControlledCollapse, InteractiveTable, LinkButton, Spinner, Stack, Text } from '@grafana/ui';
+import { Alert, ControlledCollapse, LinkButton, Spinner, Stack, Text } from '@grafana/ui';
 
+import { JobSummary } from './JobSummary';
 import ProgressBar from './ProgressBar';
 import { useGetRepositoryQuery, useListJobQuery } from './api';
 
@@ -80,8 +81,12 @@ export function JobStatus({ name, onStatusChange, onRunningChange, onErrorChange
             <ProgressBar progress={job.status.progress} />
           </Stack>
 
-          {job.status.summary && <SummaryTable summary={job.status.summary} />}
-
+          {job.status.summary && (
+            <Stack direction="column" gap={2}>
+              <Text variant="h3">Summary</Text>
+              <JobSummary summary={job.status.summary} />
+            </Stack>
+          )}
           {job.status.state === 'success' ? (
             <RepositoryLink name={job.metadata?.labels?.repository} />
           ) : (
@@ -91,56 +96,6 @@ export function JobStatus({ name, onStatusChange, onRunningChange, onErrorChange
           )}
         </Stack>
       )}
-    </Stack>
-  );
-}
-
-interface SummaryRow {
-  resource: string;
-  group: string;
-  created: number;
-  updated: number;
-  unchanged: number;
-  total: number;
-}
-
-interface SummaryTableProps {
-  summary: Array<{
-    resource?: string;
-    group?: string;
-    create?: number;
-    write?: number;
-    noop?: number;
-  }>;
-}
-
-function SummaryTable({ summary }: SummaryTableProps) {
-  const summaryData = useMemo(() => {
-    return summary.map((item) => ({
-      resource: item.resource || '',
-      group: item.group || '',
-      created: item.create || 0,
-      updated: item.write || 0,
-      unchanged: item.noop || 0,
-      total: (item.create || 0) + (item.write || 0) + (item.noop || 0),
-    }));
-  }, [summary]);
-
-  const columns = useMemo(
-    () => [
-      { id: 'resource', header: 'Resource Type' },
-      { id: 'created', header: 'Created' },
-      { id: 'updated', header: 'Updated' },
-      { id: 'unchanged', header: 'Unchanged' },
-      { id: 'total', header: 'Total' },
-    ],
-    []
-  );
-
-  return (
-    <Stack direction="column" gap={2}>
-      <Text variant="h6">Summary</Text>
-      <InteractiveTable columns={columns} data={summaryData} getRowId={(row: SummaryRow) => row.resource} />
     </Stack>
   );
 }

--- a/public/app/features/provisioning/JobSummary.tsx
+++ b/public/app/features/provisioning/JobSummary.tsx
@@ -1,0 +1,67 @@
+import { InteractiveTable, Stack } from '@grafana/ui';
+
+import { JobResourceSummary } from './api';
+
+type SummaryCell<T extends keyof JobResourceSummary = keyof JobResourceSummary> = {
+  row: {
+    original: JobResourceSummary;
+  };
+};
+
+const getSummaryColumns = () => [
+  {
+    id: 'resource',
+    header: 'Resource',
+    cell: ({ row: { original: item } }: SummaryCell) => item.resource,
+  },
+  {
+    id: 'created',
+    header: 'Created',
+    cell: ({ row: { original: item } }: SummaryCell) => item.create?.toString() || '-',
+  },
+  {
+    id: 'deleted',
+    header: 'Deleted',
+    cell: ({ row: { original: item } }: SummaryCell) => item.delete?.toString() || '-',
+  },
+  {
+    id: 'updated',
+    header: 'Updated',
+    cell: ({ row: { original: item } }: SummaryCell) => item.update?.toString() || '-',
+  },
+  {
+    id: 'unchanged',
+    header: 'Unchanged',
+    cell: ({ row: { original: item } }: SummaryCell) => item.noop?.toString() || '-',
+  },
+  {
+    id: 'errors',
+    header: 'Errors',
+    cell: ({ row: { original: item } }: SummaryCell) => item.error?.toString() || '-',
+  },
+  {
+    id: 'total',
+    header: 'Total',
+    cell: ({ row: { original: item } }: SummaryCell) => {
+      const total = (item.create || 0) + (item.delete || 0) + (item.update || 0) + (item.noop || 0) + (item.error || 0);
+      return total.toString();
+    },
+  },
+];
+
+interface Props {
+  summary: JobResourceSummary[];
+}
+
+export function JobSummary({ summary }: Props) {
+  return (
+    <Stack direction="column" gap={2}>
+      <InteractiveTable
+        data={summary}
+        columns={getSummaryColumns()}
+        getRowId={(item) => item.resource || ''}
+        pageSize={10}
+      />
+    </Stack>
+  );
+}

--- a/public/app/features/provisioning/RecentJobs.tsx
+++ b/public/app/features/provisioning/RecentJobs.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 
 import { intervalToAbbreviatedDurationString, TraceKeyValuePair } from '@grafana/data';
-import { Spinner, Alert, Badge, InteractiveTable, Card, Box, Stack, Icon, Text } from '@grafana/ui';
+import { Alert, Badge, Box, Card, Icon, InteractiveTable, Spinner, Stack, Text } from '@grafana/ui';
 
 import KeyValuesTable from '../explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable';
 
-import { Repository, JobResourceSummary, Job, SyncStatus } from './api';
+import { JobSummary } from './JobSummary';
+import { Job, Repository, SyncStatus } from './api';
 import { useRepositoryJobs } from './hooks';
 import { formatTimestamp } from './utils/time';
 
@@ -16,12 +17,6 @@ interface Props {
 type JobCell<T extends keyof Job = keyof Job> = {
   row: {
     original: Job;
-  };
-};
-
-type SummaryCell<T extends keyof JobResourceSummary = keyof JobResourceSummary> = {
-  row: {
-    original: JobResourceSummary;
   };
 };
 
@@ -86,49 +81,6 @@ const getJobColumns = () => [
   },
 ];
 
-const getSummaryColumns = () => [
-  {
-    id: 'group',
-    header: 'Group',
-    cell: ({ row: { original: item } }: SummaryCell) => item.group || '-',
-  },
-  {
-    id: 'resource',
-    header: 'Resource',
-    cell: ({ row: { original: item } }: SummaryCell) => item.resource,
-  },
-  {
-    id: 'write',
-    header: 'Write',
-    cell: ({ row: { original: item } }: SummaryCell) => item.write?.toString() || '-',
-  },
-  {
-    id: 'created',
-    header: 'Created',
-    cell: ({ row: { original: item } }: SummaryCell) => item.create?.toString() || '-',
-  },
-  {
-    id: 'deleted',
-    header: 'Deleted',
-    cell: ({ row: { original: item } }: SummaryCell) => item.delete?.toString() || '-',
-  },
-  {
-    id: 'updated',
-    header: 'Updated',
-    cell: ({ row: { original: item } }: SummaryCell) => item.update?.toString() || '-',
-  },
-  {
-    id: 'unchanged',
-    header: 'Unchanged',
-    cell: ({ row: { original: item } }: SummaryCell) => item.noop?.toString() || '-',
-  },
-  {
-    id: 'errors',
-    header: 'Errors',
-    cell: ({ row: { original: item } }: SummaryCell) => item.error?.toString() || '-',
-  },
-];
-
 interface ExpandedRowProps {
   row: Job;
 }
@@ -165,7 +117,7 @@ function ExpandedRow({ row }: ExpandedRowProps) {
       <Stack direction="column" gap={2}>
         {hasSpec && (
           <Stack direction="column">
-            <Text variant="bodySmall" color="secondary">
+            <Text variant="body" color="secondary">
               Job Specification
             </Text>
             <KeyValuesTable data={data} />
@@ -187,12 +139,12 @@ function ExpandedRow({ row }: ExpandedRowProps) {
           </Stack>
         )}
         {hasSummary && (
-          <InteractiveTable
-            data={row.status!.summary!}
-            columns={getSummaryColumns()}
-            getRowId={(item) => item.resource || ''}
-            pageSize={10}
-          />
+          <Stack direction="column" gap={2}>
+            <Text variant="body" color="secondary">
+              Summary
+            </Text>
+            <JobSummary summary={row.status!.summary!} />
+          </Stack>
         )}
       </Stack>
     </Box>


### PR DESCRIPTION
- Use the same component for both `RecentJobs`.
- Do not use write as it counts update + create.

This is in our main branch when only having a single one: 
![Screenshot 2025-03-13 at 08 59 22](https://github.com/user-attachments/assets/c5cebc20-035a-4e42-9d2a-e29d8a130057)

