### PR TITLE
Docs: update terraform documentation to assign basic_roles

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
@@ -93,6 +93,78 @@ provider "grafana" {
 }
 ```
 
+
+## Provision basic roles
+
+The following example shows how to assign basic roles to users, teams, and service accounts. Basic roles are predefined in Grafana and provide a set of permissions for common use cases.
+
+| Basic role      | UID                   |
+| --------------- | --------------------- |
+| `None`          | `basic_none`          |
+| `Viewer`        | `basic_viewer`        |
+| `Editor`        | `basic_editor`        |
+| `Admin`         | `basic_admin`         |
+| `Grafana Admin` | `basic_grafana_admin` |
+
+You can use any of the basic role UIDs from the table above in your role assignments. For example, to assign the "None" role, use `basic_none` as the `role_uid`.
+
+```terraform
+resource "grafana_team" "viewer_team" {
+  name = "terraform_viewer_team"
+}
+
+resource "grafana_user" "editor_user" {
+  email    = "terraform_editor@example.com"
+  login    = "terraform_editor_user"
+  password = <TEST_PASSWORD>
+}
+
+resource "grafana_service_account" "admin_sa" {
+  name = "terraform_admin_sa"
+}
+
+# Assign Viewer role to a team
+resource "grafana_role_assignment" "viewer_role_assignment" {
+  role_uid = "basic_viewer"
+  teams    = [grafana_team.viewer_team.id]
+}
+
+# Assign Editor role to a user
+resource "grafana_role_assignment" "editor_role_assignment" {
+  role_uid = "basic_editor"
+  users    = [grafana_user.editor_user.id]
+}
+
+
+
+# Assign Admin role to a service account
+resource "grafana_role_assignment" "admin_role_assignment" {
+  role_uid = "basic_admin"
+  service_accounts = [grafana_service_account.admin_sa.id]
+}
+```
+
+### Provision basic role to multiple users
+
+```terraform
+resource "grafana_user" "editor_user_2" {
+  email    = "terraform_editor_2@example.com"
+  login    = "terraform_editor_2_user"
+  password = <TEST_PASSWORD>
+}
+resource "grafana_user" "editor_user_3" {
+  email    = "terraform_editor_3@example.com"
+  login    = "terraform_editor_3_user"
+  password = <TEST_PASSWORD>
+}
+
+# Assign Editor role to multiply users
+resource "grafana_role_assignment" "editor_role_assignment" {
+  role_uid = "basic_editor"
+  users    = [grafana_user.editor_user_2.id, grafana_user.editor_user_3.id]
+}
+```
+
 ## Provision custom roles
 
 The following example shows how to provision a custom role with some permissions.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
@@ -93,7 +93,6 @@ provider "grafana" {
 }
 ```
 
-
 ## Provision basic roles
 
 The following example shows how to assign basic roles to users, teams, and service accounts. Basic roles are predefined in Grafana and provide a set of permissions for common use cases.
@@ -134,8 +133,6 @@ resource "grafana_role_assignment" "editor_role_assignment" {
   role_uid = "basic_editor"
   users    = [grafana_user.editor_user.id]
 }
-
-
 
 # Assign Admin role to a service account
 resource "grafana_role_assignment" "admin_role_assignment" {


### PR DESCRIPTION
The current documentation fails to explain how to assign basic roles (Admin, Editor, Viewer) via Terraform. This leads to the misconception that basic roles cannot be assigned after initial Okta SSO setup 🌾 

This adds multiple examples of how to provision basic roles using terraform