### PR TITLE
Repository link should point to configured branch

### DIFF
--- a/public/app/features/provisioning/JobStatus.tsx
+++ b/public/app/features/provisioning/JobStatus.tsx
@@ -112,7 +112,10 @@ function RepositoryLink({ name }: RepositoryLinkProps) {
     return null;
   }
 
-  const repoHref = repo.spec?.github?.url;
+  const repoHref =
+    repo.spec?.github?.url && repo.spec?.github?.branch
+      ? `${repo.spec.github.url}/tree/${repo.spec.github.branch}`
+      : repo.spec?.github?.url;
   const folderHref = repo.spec?.sync.target === 'folder' ? `/dashboards/f/${repo.metadata?.name}` : '/dashboards';
 
   if (!repoHref) {

--- a/public/app/features/provisioning/RepositoryActions.tsx
+++ b/public/app/features/provisioning/RepositoryActions.tsx
@@ -20,7 +20,9 @@ export function RepositoryActions({
   onMigrateClick,
 }: RepositoryActionsProps) {
   const name = repository.metadata?.name ?? '';
-  const remoteURL = repository.spec?.github?.url ?? '';
+  const remoteURL = repository.spec?.github?.branch
+    ? `${repository.spec?.github?.url}/tree/${repository.spec?.github?.branch}`
+    : (repository.spec?.github?.url ?? '');
 
   return (
     <Stack>


### PR DESCRIPTION
I don't know when this was lost but we must point to the branch so that we see what has been migrated or what we are really connected to.
