### PR TITLE
Reset summary between export and pull

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -219,8 +219,11 @@ func (w *MigrationWorker) migrateFromUnifiedStorage(ctx context.Context, repo re
 			},
 		},
 	}, progress); err != nil {
-		return err
+		return fmt.Errorf("export resources: %w", err)
 	}
+
+	// Reset the results after the export as pull will operate on the same resources
+	progress.ResetResults()
 
 	progress.SetMessage(ctx, "pulling resources")
 	err := w.syncWorker.Process(ctx, repo, provisioning.Job{
@@ -231,11 +234,11 @@ func (w *MigrationWorker) migrateFromUnifiedStorage(ctx context.Context, repo re
 		},
 	}, progress)
 	if err != nil {
-		return err
+		return fmt.Errorf("pull resources: %w", err)
 	}
 	dynamicClient, _, err := w.clients.New(repo.Config().Namespace)
 	if err != nil {
-		return fmt.Errorf("error getting client: %w", err)
+		return fmt.Errorf("getting client: %w", err)
 	}
 
 	progress.SetMessage(ctx, "removing unprovisioned folders")

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -190,6 +190,9 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 		}
 	}
 
+	// Reset the results after the export as pull will operate on the same resources
+	progress.ResetResults()
+
 	// Delegate the import to a sync (from the already checked out go-git repository!)
 	progress.SetMessage(ctx, "pulling resources")
 	err = w.syncWorker.Process(ctx, rw, provisioning.Job{

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -77,6 +77,14 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	r.maybeNotify(ctx)
 }
 
+// ResetResults will reset the results of the job
+func (r *jobProgressRecorder) ResetResults() {
+	r.resultCount = 0
+	r.errorCount = 0
+	r.errors = nil
+	r.summaries = make(map[string]*provisioning.JobResourceSummary)
+}
+
 func (r *jobProgressRecorder) SetMessage(ctx context.Context, msg string) {
 	r.message = msg
 	logging.FromContext(ctx).Info("job progress message", "message", msg)

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -29,6 +29,7 @@ type JobQueue interface {
 
 type JobProgressRecorder interface {
 	Record(ctx context.Context, result JobResourceResult)
+	ResetResults()
 	SetFinalMessage(ctx context.Context, msg string)
 	SetMessage(ctx context.Context, msg string)
 	SetRef(ref string)


### PR DESCRIPTION
Running export and sync results in duplicate results as we count as "created" to the repository on the export and then created in Grafana when we pull.

This solution is not final but at least it gives more accurate counts for dashboards


![Screenshot 2025-03-13 at 13 24 53](https://github.com/user-attachments/assets/378f1a15-fbd2-4b5e-a157-2701ac2c2770)
![Screenshot 2025-03-13 at 13 24 42](https://github.com/user-attachments/assets/90b530a7-a453-4ea8-8f9a-e26d84f9d06b)

