### PR TITLE
Authz: Fix namespace authorization when calling a cluster resource

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/namespace.go
+++ b/pkg/services/apiserver/auth/authorizer/namespace.go
@@ -40,6 +40,11 @@ func (auth namespaceAuthorizer) Authorize(ctx context.Context, a authorizer.Attr
 		return authorizer.DecisionDeny, "invalid namespace", err
 	}
 
+	// If we call a cluster resource we delegate to the next authorizer
+	if ns.Value == "" {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
 	if ns.OrgID != ident.GetOrgID() {
 		return authorizer.DecisionDeny, "invalid org", nil
 	}


### PR DESCRIPTION
**What is this feature?**
When I did https://github.com/grafana/grafana/pull/101449 Missed that we had this check if both stack and org authorizers. 

For more context see https://raintank-corp.slack.com/archives/C06PNGH5H28/p1741867397802029

**Why do we need this feature?**

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
