### PR TITLE
Sql Expressions: State when error is from GMS

### DIFF
--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -193,6 +193,18 @@ func TestQueryFramesDateTimeSelect(t *testing.T) {
 	}
 }
 
+func TestErrorsFromGoMySQLServerAreFlagged(t *testing.T) {
+	const GmsNotImplemented = "STDDEV" // not implemented in go-mysql-server as of 2025-03-18
+
+	db := DB{}
+
+	query := `SELECT ` + GmsNotImplemented + `(1);`
+
+	_, err := db.QueryFrames(context.Background(), "sqlExpressionRefId", query, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error in go-mysql-server")
+}
+
 // p is a utility for pointers from constants
 func p[T any](v T) *T {
 	return &v

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -129,7 +129,17 @@ var example_case_statement = `SELECT
   END AS category
 FROM metrics`
 
-var example_all_allowed_functions = `SELECT
+var example_all_allowed_functions = `WITH sample_data AS (
+  SELECT 
+    100 AS value,
+    'example' AS name,
+    NOW() AS created_at
+  UNION ALL SELECT 
+    50 AS value,
+    'test' AS name,
+    DATE_SUB(NOW(), INTERVAL 1 DAY) AS created_at
+)
+SELECT
   -- Conditional functions
   IF(value > 100, 'High', 'Low') AS conditional_if,
   COALESCE(value, 0) AS conditional_coalesce,
@@ -191,6 +201,6 @@ var example_all_allowed_functions = `SELECT
   -- Type conversion
   CAST(value AS CHAR) AS type_cast,
   CONVERT(value, CHAR) AS type_convert
-FROM metrics
+FROM sample_data
 GROUP BY name, value, created_at
 LIMIT 10`


### PR DESCRIPTION
We're at the point where users can start hitting errors where SQL
SQL functions they want to use haven't yet been implemented in Go MySQL
Server (GMS). I wanted to try this out, in order to show us and our
users where the error is coming from if/when this happens, so it's
faster for us to figure out what's wrong, and so that users have the
option to engage with the GMS project (or team) directly.

![image](https://github.com/user-attachments/assets/27b86960-51c8-471b-b067-6b3f4aaa0619)


GMS hasn't implemented `STDDEV()` nor `VARIANCE()` (or their aliases)
yet, so I hit this today.

I also updated the SQL query used in the test case for the allow-list of
functions, to remove any reference to any existing database-table, such
that the query can be copy-pasted straight into a SQL editor (such as
the one for SQL Expressions) and run. That way we can close the loop,
and make sure the test-case is actually considered valid and can be
executed by GMS (and we don't start allowing functions that are nonsense).

**Question for the reviewer:**

Do you want to see tests for the new error-handling?
