### PR TITLE
Advisor: Avoid Watcher

### DIFF
--- a/apps/advisor/pkg/app/app.go
+++ b/apps/advisor/pkg/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checkscheduler"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checktyperegisterer"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -25,11 +26,6 @@ func New(cfg app.Config) (app.App, error) {
 		return nil, fmt.Errorf("invalid config type")
 	}
 	checkRegistry := specificConfig.CheckRegistry
-	stackID := specificConfig.StackID
-	namespace, err := checks.GetNamespace(stackID)
-	if err != nil {
-		return nil, err
-	}
 	log := log.New("advisor.app")
 
 	// Prepare storage client
@@ -59,26 +55,27 @@ func New(cfg app.Config) (app.App, error) {
 				Validator: &simple.Validator{
 					ValidateFunc: func(ctx context.Context, req *app.AdmissionRequest) error {
 						if req.Object != nil {
-							_, err := getCheck(req.Object, checkMap)
-							return err
+							check, err := getCheck(req.Object, checkMap)
+							if err != nil {
+								return err
+							}
+							if req.Action == resource.AdmissionActionCreate {
+								go func() {
+									log.Debug("Processing check", "namespace", req.Object.GetNamespace())
+									requester, err := identity.GetRequester(ctx)
+									if err != nil {
+										log.Error("Error getting requester", "error", err)
+										return
+									}
+									ctx = identity.WithRequester(context.Background(), requester)
+									err = processCheck(ctx, client, req.Object, check)
+									if err != nil {
+										log.Error("Error processing check", "error", err)
+									}
+								}()
+							}
 						}
 						return nil
-					},
-				},
-				Watcher: &simple.Watcher{
-					AddFunc: func(ctx context.Context, obj resource.Object) error {
-						log.Debug("Adding check", "namespace", obj.GetNamespace())
-						if obj.GetNamespace() != namespace {
-							log.Debug("Skipping check in namespace", "namespace", obj.GetNamespace())
-							return nil
-						} else {
-							log.Debug("Processing check in namespace", "namespace", obj.GetNamespace())
-						}
-						check, err := getCheck(obj, checkMap)
-						if err != nil {
-							return err
-						}
-						return processCheck(ctx, client, obj, check)
 					},
 				},
 			},

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -6,13 +6,9 @@ import (
 	"fmt"
 	"sync"
 
-	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/resource"
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func getCheck(obj resource.Object, checkMap map[string]checks.Check) (checks.Check, error) {
@@ -39,6 +35,9 @@ func getStatusAnnotation(obj resource.Object) string {
 
 func setStatusAnnotation(ctx context.Context, client resource.Client, obj resource.Object, status string) error {
 	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
 	annotations[checks.StatusAnnotation] = status
 	return client.PatchInto(ctx, obj.GetStaticMetadata().Identifier(), resource.PatchRequest{
 		Operations: []resource.PatchOperation{{
@@ -59,20 +58,20 @@ func processCheck(ctx context.Context, client resource.Client, obj resource.Obje
 	if !ok {
 		return fmt.Errorf("invalid object type")
 	}
-	// Populate ctx with the user that created the check
-	meta, err := utils.MetaAccessor(obj)
-	if err != nil {
-		return err
-	}
-	createdBy := meta.GetCreatedBy()
-	typ, uid, err := claims.ParseTypeID(createdBy)
-	if err != nil {
-		return err
-	}
-	ctx = identity.WithRequester(ctx, &user.SignedInUser{
-		UserUID:      uid,
-		FallbackType: typ,
-	})
+	// // Populate ctx with the user that created the check
+	// meta, err := utils.MetaAccessor(obj)
+	// if err != nil {
+	// 	return err
+	// }
+	// createdBy := meta.GetCreatedBy()
+	// typ, uid, err := claims.ParseTypeID(createdBy)
+	// if err != nil {
+	// 	return err
+	// }
+	// ctx = identity.WithRequester(ctx, &user.SignedInUser{
+	// 	UserUID:      uid,
+	// 	FallbackType: typ,
+	// })
 	// Get the items to check
 	items, err := check.Items(ctx)
 	if err != nil {

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -58,20 +58,6 @@ func processCheck(ctx context.Context, client resource.Client, obj resource.Obje
 	if !ok {
 		return fmt.Errorf("invalid object type")
 	}
-	// // Populate ctx with the user that created the check
-	// meta, err := utils.MetaAccessor(obj)
-	// if err != nil {
-	// 	return err
-	// }
-	// createdBy := meta.GetCreatedBy()
-	// typ, uid, err := claims.ParseTypeID(createdBy)
-	// if err != nil {
-	// 	return err
-	// }
-	// ctx = identity.WithRequester(ctx, &user.SignedInUser{
-	// 	UserUID:      uid,
-	// 	FallbackType: typ,
-	// })
 	// Get the items to check
 	items, err := check.Items(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The original issue was that the application watcher was listening for changes in all namespaces, which doesn't scale. Even if the watcher behavior is reduced to listen in only one namespace, it's not guaranteed that this will not cause issues when scaling it further.

I thought of replacing the watcher with a loop request (every N seconds) but rather than that I finally chose to reuse the resource validator and trigger there a background population of the check (as the watcher does). This is faster (doesn't have to wait N seconds to receive the changes) and easier to implement. The downside is that if a check is not completely processed (e.g. in case of a server shutdown), it will never be processed. In any case, if we find that a problem, we can scan for unprocessed checks on every start (not included in this PR).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-community-team/issues/358

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
