### PR TITLE
Alerting: Move summary position above paused rule indicator

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -99,9 +99,9 @@ const RuleViewer = () => {
       info={createMetadata(rule)}
       subTitle={
         <Stack direction="column">
-          {isPaused && <InfoPausedRule />}
           {summary}
           {/* alerts and notifications and stuff */}
+          {isPaused && <InfoPausedRule />}
           {isFederatedRule && <FederatedRuleWarning />}
           {/* indicator for rules in a provisioned group */}
           {isProvisioned && (


### PR DESCRIPTION
Moves the position of the paused rule indicator; screenshot below is the _before_.


**Before**

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/1781b1fc-70f8-40dd-b8dc-1f8a09b342d5" />
