### PR TITLE
Spanner: Fix queries for deleting query history.

### DIFF
--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -327,12 +327,12 @@ func (s QueryHistoryService) deleteStaleQueries(ctx context.Context, olderThan i
 			FROM query_history
 			WHERE uid IN (` + uids_sql + `)`
 
-		_, err := session.Exec(details_sql, strconv.FormatInt(olderThan, 10))
+		_, err := session.Exec(details_sql, olderThan)
 		if err != nil {
 			return err
 		}
 
-		res, err := session.Exec(sql, strconv.FormatInt(olderThan, 10))
+		res, err := session.Exec(sql, olderThan)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes SQL queries when deleting query history when using Spanner.

```
logger=cleanup t=2025-03-13T16:38:15.424117+01:00 level=error msg="Problem deleting stale query history" error="spanner: code = \"InvalidArgument\", desc = \"No matching signature for operator <= for argument types: INT64, STRING\\\\n  Signature: T1 <= T1\\\\n    Unable to find common supertype for templated argument <T1>\\\\n      Input types for <T1>: {INT64, STRING} [at 8:29]\\\\n                        AND query_history.created_at <= @p1\\\\n                            ^\", requestID = \"1.b773a0ada92c3f42.1.1.3023.1\""
```

Covered by integration tests in `TestIntegrationDeleteStaleQueryFromQueryHistory`.