### PR TITLE
Prometheus: Enable prometheusRunQueriesInParallel feature toggle by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -32,6 +32,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `logsContextDatasourceUi`              | Allow datasource to provide custom UI for context view                                                                              | Yes                |
 | `lokiQuerySplitting`                   | Split large interval queries into subqueries with smaller time intervals                                                            | Yes                |
 | `influxdbBackendMigration`             | Query InfluxDB InfluxQL without the proxy                                                                                           | Yes                |
+| `prometheusRunQueriesInParallel`       | Enables running Prometheus queries in parallel                                                                                      | Yes                |
 | `dataplaneFrontendFallback`            | Support dataplane contract field name change for transformations and field name matchers where the name is different                | Yes                |
 | `unifiedRequestLog`                    | Writes error logs to the request logger                                                                                             | Yes                |
 | `recordedQueriesMulti`                 | Enables writing multiple items from a single query within Recorded Queries                                                          | Yes                |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -273,9 +273,10 @@ var (
 		{
 			Name:         "prometheusRunQueriesInParallel",
 			Description:  "Enables running Prometheus queries in parallel",
-			Stage:        FeatureStagePrivatePreview,
+			Stage:        FeatureStageGeneralAvailability,
 			FrontendOnly: false,
 			Owner:        grafanaOSSBigTent,
+			Expression:   "true", // enabled by default
 		},
 		{
 			Name:        "lokiLogsDataplane",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -34,7 +34,7 @@ individualCookiePreferences,experimental,@grafana/grafana-backend-group,false,fa
 influxdbBackendMigration,GA,@grafana/partner-datasources,false,false,true
 influxqlStreamingParser,experimental,@grafana/partner-datasources,false,false,false
 influxdbRunQueriesInParallel,privatePreview,@grafana/partner-datasources,false,false,false
-prometheusRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
+prometheusRunQueriesInParallel,GA,@grafana/oss-big-tent,false,false,false
 lokiLogsDataplane,experimental,@grafana/observability-logs,false,false,false
 dataplaneFrontendFallback,GA,@grafana/observability-metrics,false,false,true
 disableSSEDataplane,experimental,@grafana/observability-metrics,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3400,16 +3400,17 @@
     {
       "metadata": {
         "name": "prometheusRunQueriesInParallel",
-        "resourceVersion": "1735845919509",
+        "resourceVersion": "1741880974067",
         "creationTimestamp": "2024-08-12T12:31:39Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-01-02 19:25:19.509884 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-13 15:49:34.067699 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables running Prometheus queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/oss-big-tent"
+        "stage": "GA",
+        "codeowner": "@grafana/oss-big-tent",
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
**What is this feature?**

Enable `prometheusRunQueriesInParallel` feature toggle by default. That feature toggle enables running Prometheus queries concurrently.

Concurrent query number can be configured via grafana config: 

```
[datasources]
concurrent_query_count = <desired number. Default is 10>
```

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
