### PR TITLE
Feature toggle: Introduce infinityRunQueriesInParallel feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -255,6 +255,7 @@ export interface FeatureToggles {
   assetSriChecks?: boolean;
   alertRuleRestore?: boolean;
   grafanaManagedRecordingRulesDatasources?: boolean;
+  infinityRunQueriesInParallel?: boolean;
   inviteUserExperimental?: boolean;
   extraLanguages?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1790,6 +1790,13 @@ var (
 			HideFromDocs:      true,
 		},
 		{
+			Name:         "infinityRunQueriesInParallel",
+			Description:  "Enables running Infinity queries in parallel",
+			Stage:        FeatureStagePrivatePreview,
+			FrontendOnly: false,
+			Owner:        grafanaOSSBigTent,
+		},
+		{
 			Name:              "inviteUserExperimental",
 			Description:       "Renders invite user button along the app",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -236,5 +236,6 @@ rendererDisableAppPluginsPreload,experimental,@grafana/sharing-squad,false,false
 assetSriChecks,experimental,@grafana/frontend-ops,false,false,true
 alertRuleRestore,preview,@grafana/alerting-squad,false,false,false
 grafanaManagedRecordingRulesDatasources,experimental,@grafana/alerting-squad,false,false,false
+infinityRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 inviteUserExperimental,experimental,@grafana/sharing-squad,false,false,true
 extraLanguages,experimental,@grafana/grafana-frontend-platform,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -955,6 +955,10 @@ const (
 	// Enables writing to data sources for Grafana-managed recording rules.
 	FlagGrafanaManagedRecordingRulesDatasources = "grafanaManagedRecordingRulesDatasources"
 
+	// FlagInfinityRunQueriesInParallel
+	// Enables running Infinity queries in parallel
+	FlagInfinityRunQueriesInParallel = "infinityRunQueriesInParallel"
+
 	// FlagInviteUserExperimental
 	// Renders invite user button along the app
 	FlagInviteUserExperimental = "inviteUserExperimental"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2145,6 +2145,18 @@
     },
     {
       "metadata": {
+        "name": "infinityRunQueriesInParallel",
+        "resourceVersion": "1741881350055",
+        "creationTimestamp": "2025-03-13T15:55:50Z"
+      },
+      "spec": {
+        "description": "Enables running Infinity queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/oss-big-tent"
+      }
+    },
+    {
+      "metadata": {
         "name": "influxdbBackendMigration",
         "resourceVersion": "1735845919509",
         "creationTimestamp": "2022-02-09T18:26:16Z",


### PR DESCRIPTION
**What is this feature?**

This feature toggle enables queries executed in parallel for infinity plugin. See: https://github.com/grafana/grafana-infinity-datasource/pull/1181

It allows the queries coming from the same panel running parallel.

**Why do we need this feature?**

Parallel query execution in Infinity plugin backend.

**Who is this feature for?**

Infinity plugin users.
