### PR TITLE
Spanner: Fix query for limiting query history.

### DIFF
--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -2,7 +2,6 @@ package queryhistory
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -401,7 +400,7 @@ func (s QueryHistoryService) enforceQueryHistoryRowLimit(ctx context.Context, li
 				sqlLimit = 10000
 			}
 
-			res, err := session.Exec(sql, strconv.FormatInt(sqlLimit, 10))
+			res, err := session.Exec(sql, sqlLimit)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR fixes query for limiting query history when running on Spanner. (Similar to https://github.com/grafana/grafana/pull/102125)

```
spanner: code = "InvalidArgument", desc = "LIMIT expects an integer literal or parameter [at 10:63]\n                                                        LIMIT @p1\n                                                              ^", requestID = "1.bc7f4e69b2c99b2d.1.1.704.1"
```

Covered by `TestIntegrationEnforceRowLimitInQueryHistory`.