### PR TITLE
MetricsDrilldown: Advance `exploreMetricsUseExternalAppPlugin` feature toggle stage

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -115,6 +115,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `improvedExternalSessionHandling`     | Enables improved support for OAuth external sessions. After enabling this feature, users might need to re-authenticate themselves.                                                           |
 | `elasticsearchCrossClusterSearch`     | Enables cross cluster search in the Elasticsearch datasource                                                                                                                                 |
 | `improvedExternalSessionHandlingSAML` | Enables improved support for SAML external sessions. Ensure the NameID format is correctly configured in Grafana for SAML Single Logout to function properly.                                |
+| `exploreMetricsUseExternalAppPlugin`  | Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin                                                                                                |
 | `alertRuleRestore`                    | Enables the alert rule restore feature                                                                                                                                                       |
 
 ## Experimental feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1660,8 +1660,8 @@ var (
 		},
 		{
 			Name:            "exploreMetricsUseExternalAppPlugin",
-			Description:     "Use the externalized Metrics Drilldown (formerly known as Explore Metrics) app plugin",
-			Stage:           FeatureStageExperimental,
+			Description:     "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
+			Stage:           FeatureStagePublicPreview,
 			Owner:           grafanaObservabilityMetricsSquad,
 			FrontendOnly:    true,
 			RequiresRestart: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1665,7 +1665,6 @@ var (
 			Owner:           grafanaObservabilityMetricsSquad,
 			FrontendOnly:    true,
 			RequiresRestart: true,
-			HideFromDocs:    true,
 		},
 		{
 			Name:            "datasourceConnectionsTab",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -220,7 +220,7 @@ templateVariablesUsesCombobox,experimental,@grafana/grafana-frontend-platform,fa
 ABTestFeatureToggleB,experimental,@grafana/sharing-squad,false,false,false
 grafanaAdvisor,experimental,@grafana/plugins-platform-backend,false,false,false
 elasticsearchImprovedParsing,experimental,@grafana/aws-datasources,false,false,false
-exploreMetricsUseExternalAppPlugin,experimental,@grafana/observability-metrics,false,true,true
+exploreMetricsUseExternalAppPlugin,preview,@grafana/observability-metrics,false,true,true
 datasourceConnectionsTab,experimental,@grafana/plugins-platform-backend,false,false,true
 fetchRulesUsingPost,experimental,@grafana/alerting-squad,false,false,false
 alertingConversionAPI,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -892,7 +892,7 @@ const (
 	FlagElasticsearchImprovedParsing = "elasticsearchImprovedParsing"
 
 	// FlagExploreMetricsUseExternalAppPlugin
-	// Use the externalized Metrics Drilldown (formerly known as Explore Metrics) app plugin
+	// Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin
 	FlagExploreMetricsUseExternalAppPlugin = "exploreMetricsUseExternalAppPlugin"
 
 	// FlagDatasourceConnectionsTab

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1661,15 +1661,15 @@
     {
       "metadata": {
         "name": "exploreMetricsUseExternalAppPlugin",
-        "resourceVersion": "1738596266973",
+        "resourceVersion": "1741882290104",
         "creationTimestamp": "2025-01-21T23:24:50Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-02-03 15:24:26.973231 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-13 16:11:30.104067 +0000 UTC"
         }
       },
       "spec": {
-        "description": "Use the externalized Metrics Drilldown (formerly known as Explore Metrics) app plugin",
-        "stage": "experimental",
+        "description": "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
+        "stage": "preview",
         "codeowner": "@grafana/observability-metrics",
         "frontend": true,
         "requiresRestart": true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1661,10 +1661,10 @@
     {
       "metadata": {
         "name": "exploreMetricsUseExternalAppPlugin",
-        "resourceVersion": "1741882290104",
+        "resourceVersion": "1741883352541",
         "creationTimestamp": "2025-01-21T23:24:50Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-03-13 16:11:30.104067 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-13 16:29:12.541156 +0000 UTC"
         }
       },
       "spec": {
@@ -1672,8 +1672,7 @@
         "stage": "preview",
         "codeowner": "@grafana/observability-metrics",
         "frontend": true,
-        "requiresRestart": true,
-        "hideFromDocs": true
+        "requiresRestart": true
       }
     },
     {


### PR DESCRIPTION
## Related issue

This PR supports #98990.

## What is this change?

This PR advances the `exploreMetricsUseExternalAppPlugin` feature toggle stage from Experimental to Public Preview, and un-hides it from the [feature toggle docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/#public-preview-feature-toggles). This is safe to do now that `grafana-metricsdrilldown-app` is in the [Grafana Plugins Catalog](https://grafana.com/grafana/plugins/grafana-metricsdrilldown-app).

This change brings us one step closer to enabling `exploreMetricsUseExternalAppPlugin` by default.

## What to expect when enabling the feature toggle

When enabling the `exploreMetricsUseExternalAppPlugin` feature toggle, the `grafana-metricsdrilldown-app` will be preinstalled. Clicking on **Drilldown** > **Metrics** will take you to `/a/grafana-metricsdrilldown-app` instead of `/explore/metrics`. The experience is mostly the same, and better in some ways.