### PR TITLE
docs(Configure grafana): add `alerting_rule_group_rules` limit option

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1720,6 +1720,10 @@ Sets a global limit on number of alert rules that can be created. Default is -1 
 
 Sets a global limit on number of correlations that can be created. Default is -1 (unlimited).
 
+#### `alerting_rule_group_rules`
+
+Limit the number of Grafana-managed alert rules allowed per rule group. Default is 100.
+
 #### `alerting_rule_evaluation_results`
 
 Limit the number of query evaluation results per alert rule. If the condition query of an alert rule produces more results than this limit, the evaluation results in an error. Default is -1 (unlimited).


### PR DESCRIPTION
This `alerting_rule_group_rules` option was undocumented. 

This PR documents this option that helps in understanding alerting usage limits across all Grafana editions: OSS, Enterprise, and Cloud.

Previously discussed this with @gillesdemey  and @stevesg.

🌟  [Preview](https://deploy-preview-grafana-102142-zb444pucvq-vp.a.run.app/docs/grafana/latest/setup-grafana/configure-grafana/#alerting_rule_group_rules)