### PR TITLE
fix(unified-storage): Improve test coverage on legacy searcher and parse result helper

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -257,6 +257,8 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 			})
 		}
 
+		list.TotalHits = int64(len(list.Results.Rows))
+
 		return list, nil
 	}
 

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -115,6 +115,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			},
 		}, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Sorting should be properly parsed into legacy sorting options (asc), and results added", func(t *testing.T) {
@@ -181,6 +184,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			},
 		}, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Sorting should be properly parsed into legacy sorting options (desc)", func(t *testing.T) {
@@ -247,6 +253,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			},
 		}, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Query for tags should return facet properly", func(t *testing.T) {
@@ -287,6 +296,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			},
 		}, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Query should be set as the title, and * should be removed", func(t *testing.T) {
@@ -309,6 +321,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Should read labels for the dashboard ids", func(t *testing.T) {
@@ -337,6 +352,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Should modify fields to legacy compatible queries", func(t *testing.T) {
@@ -377,6 +395,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
 	})
 
 	t.Run("Should retrieve dashboards by plugin through a different function", func(t *testing.T) {
@@ -409,6 +430,10 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
+		require.Equal(t, resp.TotalHits, int64(1))
 	})
 
 	t.Run("Should retrieve dashboards by provisioner name through a different function", func(t *testing.T) {
@@ -438,6 +463,10 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
+		require.Equal(t, resp.TotalHits, int64(1))
 	})
 
 	t.Run("Should retrieve orphaned dashboards if provisioner not in is specified", func(t *testing.T) {
@@ -467,5 +496,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		mockStore.AssertExpectations(t)
+		for _, row := range resp.Results.Rows {
+			require.Equal(t, len(row.Cells), len(resp.Results.Columns))
+		}
+		require.Equal(t, resp.TotalHits, int64(1))
 	})
 }

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -76,6 +76,12 @@ func ParseResults(result *resource.ResourceSearchResponse, offset int64) (v0alph
 	}
 
 	for i, row := range result.Results.Rows {
+		if len(row.Cells) != len(result.Results.Columns) {
+			// there should never be mismatch len between # Columns and # Cells in a row. This indicates a bug in our
+			// code
+			return v0alpha1.SearchResults{}, fmt.Errorf("error parsing Search Response: mismatch number of columns and cells")
+		}
+
 		fields := &common.Unstructured{}
 		for colIndex, col := range result.Results.Columns {
 			if _, ok := excludedFields[col.Name]; !ok {

--- a/pkg/services/dashboards/service/search/search_test.go
+++ b/pkg/services/dashboards/service/search/search_test.go
@@ -10,44 +10,93 @@ import (
 
 // regression test - parsing int32 values from search results was causing a panic
 func TestParseResults(t *testing.T) {
-	resSearchResp := &resource.ResourceSearchResponse{
-		Results: &resource.ResourceTable{
-			Columns: []*resource.ResourceTableColumnDefinition{
-				{
-					Name: "title",
-					Type: resource.ResourceTableColumnDefinition_STRING,
-				},
-				{
-					Name: "folder",
-					Type: resource.ResourceTableColumnDefinition_STRING,
-				},
-				{
-					Name: search.DASHBOARD_ERRORS_LAST_1_DAYS,
-					Type: resource.ResourceTableColumnDefinition_INT64,
-				},
-				{
-					Name: search.DASHBOARD_LINK_COUNT,
-					Type: resource.ResourceTableColumnDefinition_INT32,
-				},
-			},
-			Rows: []*resource.ResourceTableRow{
-				{
-					Key: &resource.ResourceKey{
-						Name:     "uid",
-						Resource: "dashboard",
+	t.Run("should parse results", func(t *testing.T) {
+		resSearchResp := &resource.ResourceSearchResponse{
+			Results: &resource.ResourceTable{
+				Columns: []*resource.ResourceTableColumnDefinition{
+					{
+						Name: "title",
+						Type: resource.ResourceTableColumnDefinition_STRING,
 					},
-					Cells: [][]byte{
-						[]byte("Dashboard 1"),
-						[]byte("folder1"),
-						[]byte("100"),
-						[]byte("25"),
+					{
+						Name: "folder",
+						Type: resource.ResourceTableColumnDefinition_STRING,
+					},
+					{
+						Name: search.DASHBOARD_ERRORS_LAST_1_DAYS,
+						Type: resource.ResourceTableColumnDefinition_INT64,
+					},
+					{
+						Name: search.DASHBOARD_LINK_COUNT,
+						Type: resource.ResourceTableColumnDefinition_INT32,
 					},
 				},
+				Rows: []*resource.ResourceTableRow{
+					{
+						Key: &resource.ResourceKey{
+							Name:     "uid",
+							Resource: "dashboard",
+						},
+						Cells: [][]byte{
+							[]byte("Dashboard 1"),
+							[]byte("folder1"),
+							[]byte("100"),
+							[]byte("25"),
+						},
+					},
+				},
 			},
-		},
-		TotalHits: 1,
-	}
+			TotalHits: 1,
+		}
 
-	_, err := ParseResults(resSearchResp, 0)
-	require.NoError(t, err)
+		_, err := ParseResults(resSearchResp, 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("should return error when trying to parse results with mismatch length between Columns and row Cells", func(t *testing.T) {
+		resSearchResp := &resource.ResourceSearchResponse{
+			Results: &resource.ResourceTable{
+				Columns: []*resource.ResourceTableColumnDefinition{
+					{
+						Name: "title",
+						Type: resource.ResourceTableColumnDefinition_STRING,
+					},
+					{
+						Name: "folder",
+						Type: resource.ResourceTableColumnDefinition_STRING,
+					},
+					{
+						Name: search.DASHBOARD_ERRORS_LAST_1_DAYS,
+						Type: resource.ResourceTableColumnDefinition_INT64,
+					},
+					{
+						Name: search.DASHBOARD_LINK_COUNT,
+						Type: resource.ResourceTableColumnDefinition_INT32,
+					},
+					{
+						Name: search.DASHBOARD_LEGACY_ID,
+						Type: resource.ResourceTableColumnDefinition_INT32,
+					},
+				},
+				Rows: []*resource.ResourceTableRow{
+					{
+						Key: &resource.ResourceKey{
+							Name:     "uid",
+							Resource: "dashboard",
+						},
+						Cells: [][]byte{
+							[]byte("Dashboard 1"),
+							[]byte("folder1"),
+							[]byte("100"),
+							[]byte("25"),
+						},
+					},
+				},
+			},
+			TotalHits: 1,
+		}
+
+		_, err := ParseResults(resSearchResp, 0)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Follow up for https://github.com/grafana/grafana/pull/102044

* Make `ParseResults` return an error when it finds a row with mismatched number of Columns and Cells
* Update the code path in the legacy searcher that was missing `TotalHits`
* Improve legacy searcher tests to check for Cell and Column length count, to prevent this from happening again if we add/remove columns from the search response