### PR TITLE
Table: Add refID to frame list

### DIFF
--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -79,7 +79,7 @@ export function TablePanel(props: Props) {
 
   const names = frames.map((frame, index) => {
     return {
-      label: getFrameDisplayName(frame),
+      label: `${frame.refId}: ${getFrameDisplayName(frame)}`,
       value: index,
     };
   });


### PR DESCRIPTION
**What is this feature?**

There is logic that will select a name for a frame, to appear in a list when there are multiple frames. In some scenarios, there may be multiple frames that have the same name, with no way of knowing which is which. 

This adds the query ref ID to prefix the frame name, so if the frames are from different queries, they can be made distinct that way. I did not check for uniqueness to only add the prefix when it needs it, as I think the refID is always required and unique, so it will be a good addition even if the generated names are different.

![Screenshot 2025-03-13 at 3 42 01 PM](https://github.com/user-attachments/assets/47b81a35-1a95-4093-8a45-5927911ed26b)

**Special notes for your reviewer:**

<details><summary>Example dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 312,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "datasource",
        "uid": "-- Mixed --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green"
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "frameIndex": 1,
        "showHeader": true
      },
      "pluginVersion": "11.6.0-pre",
      "targets": [
        {
          "csvContent": "value,NotValue\na,23",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "value,NotValue\nb,34",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "MultiFrame same fields",
  "uid": "fefq0mhlb20w0e",
  "version": 7
}

```
</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
