### PR TITLE
Dashboard Provisioning: Retry once if dashboard not found when using unified storage

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -245,6 +245,9 @@ func (dr *DashboardServiceImpl) GetProvisionedDashboardData(ctx context.Context,
 							ManagerIdentity: name,
 							OrgId:           orgID,
 						})
+						if lastErr == nil {
+							break
+						}
 						// If the dashboard is not found, its probably because were looking for a deleted dashboard.
 						// This can be caused by the indexer lag, so we wait briefly then retry one more time.
 						var statusErr *apierrors.StatusError
@@ -254,10 +257,7 @@ func (dr *DashboardServiceImpl) GetProvisionedDashboardData(ctx context.Context,
 								continue
 							}
 						}
-
-						if lastErr != nil {
-							return lastErr
-						}
+						return lastErr
 					}
 
 					mu.Lock()

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -249,7 +249,7 @@ func (dr *DashboardServiceImpl) GetProvisionedDashboardData(ctx context.Context,
 						// This can be caused by the indexer lag, so we wait briefly then retry one more time.
 						var statusErr *apierrors.StatusError
 						if errors.As(lastErr, &statusErr) {
-							if statusErr.Status().Reason == v1.StatusReasonNotFound {
+							if statusErr.Status().Reason == v1.StatusReasonNotFound && attempt < maxRetries {
 								time.Sleep(1 * time.Second)
 								continue
 							}

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -713,7 +713,6 @@ func TestGetProvisionedDashboardData(t *testing.T) {
 		require.NoError(t, err)
 		k8sCliMock.AssertExpectations(t)
 	})
-
 }
 
 func TestGetProvisionedDashboardDataByDashboardID(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/grafana/search-and-storage-team/issues/222

**Problem**
When we provision dashboards, we sometimes delete orphaned dashboards then search US for all dashboards to provision. Because of indexer lag, sometimes the deleted dashboards show up in the search results. This causes dashboard not found errors when trying to Get the dashboard from US, and in cloud will cause pods to fail to start.

**Changes**
If we encounter a dashboard not found error, sleep for a second (indexer latency SLO is 95% in less than 1s) and then retry one more time.

**Notes for reviewers**
An easier possible solution would be to ignore dashboard not found errors entirely, but I didn't want to mask other legitimate issues that might cause that.