### PR TITLE
Search: Set query type for fetching starred dashboards to improve access control filtering

### DIFF
--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -88,6 +88,10 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) (model.
 	if query.IsStarred && len(query.DashboardIds) == 0 && len(query.DashboardUIDs) == 0 {
 		for uid := range staredDashIDs.UserStars {
 			query.DashboardUIDs = append(query.DashboardUIDs, uid)
+			// set the query type if searching for starred dashboards
+			// to limit access control filter
+			// to check access only for dashboards
+			query.Type = "dash-db"
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The access control filter used for legacy searching and listing dashboards and folders,
if the type query parameter (`dash-db` for fetching only dashboards or `dash-folder` for fetching only folders) is not provided, [defaults](https://github.com/grafana/grafana/blob/9264431c81a7297aae9a214d4d60ed6a9a6af47f/pkg/services/sqlstore/permissions/dashboard.go#L88-L98) to search for both accessible dashboards and folders.
However, when searching for starred dashboards we can skip querying for accessible folders.
This change sets the query type for the above cases.

Example query for fetching starred dashboards:

<details><summary>before</summary>
<p>

```
SELECT
			dashboard.id,
			dashboard.org_id,
			dashboard.uid,
			dashboard.title,
			dashboard.slug,
			dashboard_tag.term,
			dashboard.is_folder,
			dashboard.folder_id,
			dashboard.deleted,
			folder.uid AS folder_uid,
			folder.slug AS folder_slug,
			folder.title AS folder_title  
FROM ( 
	-- Subquery to get accessible dashboard IDs to the user
	SELECT dashboard.id 
	FROM dashboard 
	WHERE dashboard.org_id=? 
		AND dashboard.uid IN (?,?,?) -- Filter specific dashboard UIDs
		AND dashboard.uid != ? -- Exclude a specific dashboard
		AND (dashboard.folder_uid != ? OR dashboard.folder_uid IS NULL) -- Filter by folder
		AND (
			-- Check dashboard-level permissions
			(dashboard.uid IN (
				SELECT identifier 
				FROM permission 
				WHERE kind = 'dashboards' 
					AND attribute = 'uid' 
					AND role_id IN(
						-- Get all roles for the user (both direct and builtin)
						SELECT id 
						FROM role 
						INNER JOIN (
							-- User's direct role assignments
							SELECT ur.role_id
							FROM user_role AS ur
							WHERE ur.user_id = ?
								AND (ur.org_id = ? OR ur.org_id = ?)
						UNION
							-- User's builtin role assignments
							SELECT br.role_id 
							FROM builtin_role AS br
							WHERE br.role IN (?)
								AND (br.org_id = ? OR br.org_id = ?)
						) as all_role ON role.id = all_role.role_id
					)  
					AND action IN (?, ?, ?, ?) -- Check for specific permissions
				) 
				AND NOT dashboard.is_folder
			) 
			-- Check folder-level permissions for dashboards within folders
			OR (dashboard.folder_id IN (
				SELECT d.id 
				FROM dashboard as d 
				WHERE d.org_id = ? 
					AND d.uid IN (
						SELECT identifier 
						FROM permission 
						WHERE kind = 'folders' 
							AND attribute = 'uid' 
							AND role_id IN(
								-- Get all roles for the user (both direct and builtin)
								SELECT id 
								FROM role 
								INNER JOIN (
									-- User's direct role assignments
									SELECT ur.role_id
									FROM user_role AS ur
									WHERE ur.user_id = ?
										AND (ur.org_id = ? OR ur.org_id = ?)
								UNION
									-- User's builtin role assignments
									SELECT br.role_id 
									FROM builtin_role AS br
									WHERE br.role IN (?)
										AND (br.org_id = ? OR br.org_id = ?)
								) as all_role ON role.id = all_role.role_id
							)  
							AND action IN (?, ?, ?, ?) -- Check for specific folder permissions
					)
				) 
				AND NOT dashboard.is_folder
			) 
			-- Check permissions for folders themselves
			OR (dashboard.uid IN (
				SELECT identifier 
				FROM permission 
				WHERE kind = 'folders' 
					AND attribute = 'uid' 
					AND role_id IN(
						-- Get all roles for the user (both direct and builtin)
						SELECT id 
						FROM role 
						INNER JOIN (
							-- User's direct role assignments
							SELECT ur.role_id
							FROM user_role AS ur
							WHERE ur.user_id = ?
								AND (ur.org_id = ? OR ur.org_id = ?)
						UNION
							-- User's builtin role assignments
							SELECT br.role_id 
							FROM builtin_role AS br
							WHERE br.role IN (?)
								AND (br.org_id = ? OR br.org_id = ?)
						) as all_role ON role.id = all_role.role_id
					)  
					AND action IN (?, ?, ?, ?) -- Check for specific folder permissions
				) 
				AND dashboard.is_folder
			)
		) 
		AND dashboard.deleted IS NULL -- Only include non-deleted dashboards
	ORDER BY dashboard.title ASC 
	LIMIT 1000 OFFSET 0
) AS ids
-- Join back to get full dashboard details
INNER JOIN dashboard ON ids.id = dashboard.id
-- Get folder information if dashboard is in a folder
LEFT OUTER JOIN dashboard AS folder ON folder.id = dashboard.folder_id
-- Get dashboard tags
LEFT OUTER JOIN dashboard_tag ON dashboard.id = dashboard_tag.dashboard_id
ORDER BY dashboard.title ASC
```

</p>
</details> 

<details><summary>after</summary>
<p>

```
SELECT
			dashboard.id,
			dashboard.org_id,
			dashboard.uid,
			dashboard.title,
			dashboard.slug,
			dashboard_tag.term,
			dashboard.is_folder,
			dashboard.folder_id,
			dashboard.deleted,
			folder.uid AS folder_uid,
			folder.slug AS folder_slug,
			folder.title AS folder_title  
FROM ( 
	-- Subquery to get accessible dashboard IDs to the user
	SELECT dashboard.id 
	FROM dashboard 
	WHERE dashboard.org_id=? 
		AND dashboard.uid IN (?,?,?) -- Filter specific dashboard UIDs
		AND dashboard.is_folder = 0 -- Only include non-folder items
		AND dashboard.uid != ? -- Exclude a specific dashboard
		AND (dashboard.folder_uid != ? OR dashboard.folder_uid IS NULL) -- Filter by folder
		AND ((dashboard.uid IN (
			-- Check dashboard-level permissions
			SELECT identifier 
			FROM permission 
			WHERE kind = 'dashboards' 
				AND attribute = 'uid' 
				AND role_id IN(
					-- Get all roles for the user (both direct and builtin)
					SELECT id 
					FROM role 
					INNER JOIN (
						-- User's direct role assignments
						SELECT ur.role_id
						FROM user_role AS ur
						WHERE ur.user_id = ?
							AND (ur.org_id = ? OR ur.org_id = ?)
					UNION
						-- User's builtin role assignments
						SELECT br.role_id 
						FROM builtin_role AS br
						WHERE br.role IN (?)
							AND (br.org_id = ? OR br.org_id = ?)
					) as all_role ON role.id = all_role.role_id
				)  
				AND action IN (?, ?, ?, ?) -- Check for specific permissions
			) 
			AND NOT dashboard.is_folder
		) 
		OR (dashboard.folder_id IN (
			-- Check folder-level permissions for dashboards within folders
			SELECT d.id 
			FROM dashboard as d 
			WHERE d.org_id = ? 
				AND d.uid IN (
					SELECT identifier 
					FROM permission 
					WHERE kind = 'folders' 
						AND attribute = 'uid' 
						AND role_id IN(
							-- Get all roles for the user (both direct and builtin)
							SELECT id 
							FROM role 
							INNER JOIN (
								-- User's direct role assignments
								SELECT ur.role_id
								FROM user_role AS ur
								WHERE ur.user_id = ?
									AND (ur.org_id = ? OR ur.org_id = ?)
							UNION
								-- User's builtin role assignments
								SELECT br.role_id 
								FROM builtin_role AS br
								WHERE br.role IN (?)
									AND (br.org_id = ? OR br.org_id = ?)
							) as all_role ON role.id = all_role.role_id
						)  
						AND action IN (?, ?, ?, ?) -- Check for specific folder permissions
				)
			) 
			AND NOT dashboard.is_folder
		)) 
		AND dashboard.deleted IS NULL -- Only include non-deleted dashboards
	ORDER BY dashboard.title ASC 
	LIMIT 1000 OFFSET 0
) AS ids
-- Join back to get full dashboard details
INNER JOIN dashboard ON ids.id = dashboard.id
-- Get folder information if dashboard is in a folder
LEFT OUTER JOIN dashboard AS folder ON folder.id = dashboard.folder_id
-- Get dashboard tags
LEFT OUTER JOIN dashboard_tag ON dashboard.id = dashboard_tag.dashboard_id
ORDER BY dashboard.title ASC
```

</p>
</details> 

**Why do we need this feature?**

This will make the search for starred dashboards non admin users more efficient

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
