### PR TITLE
CI: Test pro and enterprise + unit and integration tests for CodeCov

### DIFF
--- a/.github/actions/test-coverage-processor/action.yml
+++ b/.github/actions/test-coverage-processor/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: 'Token for CodeCov (required for CodeCov reporting)'
     required: false
     default: ''
-  codecov-flags:
-    description: 'Flags to categorize the upload to CodeCov (comma-separated)'
-    required: false
-    default: ''
   codecov-name:
     description: 'Custom name for the upload to CodeCov'
     required: false
@@ -36,7 +32,7 @@ runs:
       if: inputs.codecov-token != ''
       with:
         files: ${{ inputs.coverage-file }}
-        flags: ${{ inputs.codecov-flags }}
+        flags: ${{ inputs.codecov-name }}
         name: ${{ inputs.codecov-name }}
         slug: grafana/grafana
         # This URL doesn't use the Google auth, but is much more locked down. As such, it requires OIDC or a CodeCov-provided token to do anything.

--- a/.github/actions/test-coverage-processor/action.yml
+++ b/.github/actions/test-coverage-processor/action.yml
@@ -2,10 +2,6 @@ name: 'Go Coverage Processor'
 description: 'Process Go test coverage files and generate reports'
 
 inputs:
-  test-type:
-    description: 'Type of test (e.g., be-unit, be-integration)'
-    required: true
-    type: string
   coverage-file:
     description: 'Path to the Go coverage file (.cov)'
     required: true
@@ -14,8 +10,8 @@ inputs:
     description: 'Token for CodeCov (required for CodeCov reporting)'
     required: false
     default: ''
-  codecov-flag:
-    description: 'Flag to categorize the upload to CodeCov'
+  codecov-flags:
+    description: 'Flags to categorize the upload to CodeCov (comma-separated)'
     required: false
     default: ''
   codecov-name:
@@ -40,8 +36,8 @@ runs:
       if: inputs.codecov-token != ''
       with:
         files: ${{ inputs.coverage-file }}
-        flags: ${{ inputs.codecov-flag || inputs.test-type }}
-        name: ${{ inputs.codecov-name || inputs.test-type }}
+        flags: ${{ inputs.codecov-flags }}
+        name: ${{ inputs.codecov-name }}
         slug: grafana/grafana
         # This URL doesn't use the Google auth, but is much more locked down. As such, it requires OIDC or a CodeCov-provided token to do anything.
         url: https://codecov-webhook.grafana-dev.net

--- a/.github/workflows/pr-backend-coverage.yml
+++ b/.github/workflows/pr-backend-coverage.yml
@@ -13,14 +13,19 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  EDITION: 'oss'
-  WIRE_TAGS: 'oss'
-
 jobs:
   main:
-    name: Backend Unit Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        edition: ['oss', 'pro', 'enterprise']
+        test-type: ['unit', 'integration']
+
+    name: Backend ${{ matrix.test-type }} tests (${{ matrix.edition }})
     runs-on: ubuntu-latest-8-cores
+    env:
+      EDITION: ${{ matrix.edition }}
+      WIRE_TAGS: ${{ matrix.edition }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,19 +39,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential shared-mime-info
           go install github.com/mfridman/tparse@c1754a1f484ac5cd422697b0fec635177ddc8507 # v0.17.0
+      - name: Setup Enterprise
+        if: ${{ matrix.edition != 'oss' }}
+        uses: ./.github/actions/setup-enterprise
+        with:
+          github-app-name: 'grafana-ci-bot'
       - name: Generate Go code
         run: make gen-go
-      - name: Run unit tests
-        run: COVER_OPTS="-coverprofile=be-unit.cov -coverpkg=github.com/grafana/grafana/..." GO_TEST_OUTPUT="/tmp/unit.log" make test-go-unit-cov
+      - name: Run ${{ matrix.test-type }} tests
+        run: COVER_OPTS="-coverprofile=grafana.cov -coverpkg=github.com/grafana/grafana/..." GO_TEST_OUTPUT="/tmp/tests.log" make test-go-${{ matrix.test-type }}-cov
       - name: Process and upload coverage
         uses: ./.github/actions/test-coverage-processor
         with:
-          test-type: 'be-unit'
-          # Needs to be named 'unit.cov' based on the Makefile command `make test-go-unit`
-          coverage-file: 'unit.cov'
+          # Needs to be named 'grafana.cov' based on the Makefile command's inputs
+          coverage-file: 'grafana.cov'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          codecov-flag: 'be-unit'
-          codecov-name: 'be-unit'
+          codecov-flags: 'be-${{ matrix.test-type }},${{ matrix.edition }}'
+          codecov-name: 'be-${{ matrix.test-type }}-${{ matrix.edition }}'
 
       - name: Install Grafana Bench
         # We can't allow forks here, as we need secret access.
@@ -57,12 +66,12 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           grafana-bench report \
-            --trigger pr-backend-unit-tests-oss \
+            --trigger pr-backend-${{ matrix.test-type }}-tests-${{ matrix.edition }} \
             --report-input go \
             --report-output log \
             --grafana-version "$(git rev-parse HEAD)" \
-            --suite-name grafana-oss-unit-tests \
-            /tmp/unit.log
+            --suite-name grafana-${{ matrix.edition }}-${{ matrix.test-type }}-tests \
+            /tmp/tests.log
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-backend-coverage.yml
+++ b/.github/workflows/pr-backend-coverage.yml
@@ -54,7 +54,6 @@ jobs:
           # Needs to be named 'grafana.cov' based on the Makefile command's inputs
           coverage-file: 'grafana.cov'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          codecov-flags: 'be-${{ matrix.test-type }},${{ matrix.edition }}'
           codecov-name: 'be-${{ matrix.test-type }}-${{ matrix.edition }}'
 
       - name: Install Grafana Bench

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,12 @@ test-go-unit-pretty: check-tparse
 .PHONY: test-go-integration
 test-go-integration: ## Run integration tests for backend with flags.
 	@echo "test backend integration tests"
-	$(GO) test $(GO_RACE_FLAG) -count=1 -run "^TestIntegration" -covermode=atomic -coverprofile=$(GO_INTEGRATION_COVER_PROFILE)  -timeout=5m $(GO_INTEGRATION_TESTS) $(GO_TEST_OUTPUT)
+	$(GO) test $(GO_RACE_FLAG) -count=1 -run "^TestIntegration" -timeout=5m $(GO_INTEGRATION_TESTS) $(GO_TEST_OUTPUT)
+
+.PHONY: test-go-integration-cov
+test-go-integration-cov: ## Run integration tests for backend with flags and coverage
+	@echo "backend integration tests with coverage"
+	$(GO) test $(GO_RACE_FLAG) -count=1 -run "^TestIntegration" $(if $(filter true,$(GO_UNIT_COVERAGE)),-covermode=atomic -coverprofile=$(GO_UNIT_COVER_PROFILE) $(if $(GO_UNIT_TEST_COVERPKG),-coverpkg=$(GO_UNIT_TEST_COVERPKG)),) -timeout=5m $(GO_INTEGRATION_TESTS) $(GO_TEST_OUTPUT)
 
 .PHONY: test-go-integration-alertmanager
 test-go-integration-alertmanager: ## Run integration tests for the remote alertmanager (config taken from the mimir_backend block).


### PR DESCRIPTION
This will make us start testing everything for OSS, Pro, and Enterprise in both unit and integration tests and report it all to CodeCov.