### PR TITLE
alerting(ui): add external links to read more about labels and annotations

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -106,18 +106,18 @@ const AnnotationsStep = () => {
             <>
               <p>
                 {t(
-                  'alerting.rule-form.labels.annotations-description1',
+                  'alerting.rule-form.annotations.description1',
                   'Annotations add additional information to alerts, helping alert responders identify and address potential issues.'
                 )}
               </p>
               <p>
                 {t(
-                  'alerting.rule-form.labels.annotations-description2',
+                  'alerting.rule-form.annotations.description2',
                   'For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.'
                 )}
               </p>
               {t(
-                'alerting.rule-form.labels.annotations-description3',
+                'alerting.rule-form.annotations.description3',
                 'Annotations can contain a combination of text and template code, which is used to include data from queries.'
               )}
             </>

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -98,9 +98,30 @@ const AnnotationsStep = () => {
           <Trans i18nKey="alerting.annotations.description">Add more context to your alert notifications.</Trans>
         </Text>
         <NeedHelpInfo
-          contentText={`Annotations add metadata to provide more information on the alert in your alert notification messages.
-          For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.
-          Annotations can contain a combination of text and template code.`}
+          externalLink={
+            'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/#annotations'
+          }
+          linkText={`Read about annotations`}
+          contentText={
+            <>
+              <p>
+                {t(
+                  'alerting.rule-form.labels.annotations-description1',
+                  'Annotations add additional information to alerts, helping alert responders identify and address potential issues.'
+                )}
+              </p>
+              <p>
+                {t(
+                  'alerting.rule-form.labels.annotations-description2',
+                  'For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.'
+                )}
+              </p>
+              {t(
+                'alerting.rule-form.labels.annotations-description3',
+                'Annotations can contain a combination of text and template code, which is used to include data from queries.'
+              )}
+            </>
+          }
           title="Annotations"
         />
       </Stack>

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -404,6 +404,8 @@ function LabelsField() {
             {getLabelText(type)}
           </Text>
           <NeedHelpInfo
+            externalLink={'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/'}
+            linkText={`Read about labels`}
             contentText="The dropdown only displays labels that you have previously used for alerts.
             Select a label from the options below or type in a new one."
             title="Labels"

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInForm.tsx
@@ -37,6 +37,8 @@ export function LabelsFieldInForm({ onEditClick }: LabelsFieldInFormProps) {
             {text}
           </Text>
           <NeedHelpInfo
+            externalLink={'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/'}
+            linkText={`Read about labels`}
             contentText="The dropdown only displays labels that you have previously used for alerts.
               Select a label from the options below or type in a new one."
             title="Labels"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -544,6 +544,9 @@
         "error-parsing": "Failed to parse duration",
         "validation": "Pending period must be greater than or equal to the evaluation interval."
       },
+      "annotations-description1": "Evaluation groups are containers for evaluating alert and recording rules.",
+      "annotations-description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
+      "annotations-description3": "Annotations can contain a combination of text and template code, which is used to include data from queries.",
       "folder": {
         "cancel": "Cancel",
         "create": "Create",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -544,9 +544,6 @@
         "error-parsing": "Failed to parse duration",
         "validation": "Pending period must be greater than or equal to the evaluation interval."
       },
-      "annotations-description1": "Evaluation groups are containers for evaluating alert and recording rules.",
-      "annotations-description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
-      "annotations-description3": "Annotations can contain a combination of text and template code, which is used to include data from queries.",
       "folder": {
         "cancel": "Cancel",
         "create": "Create",
@@ -566,6 +563,11 @@
       },
       "pause": {
         "label": "Pause evaluation"
+      },
+      "annotations": {
+        "description1": "Evaluation groups are containers for evaluating alert and recording rules.",
+        "description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
+        "description3": "Annotations can contain a combination of text and template code, which is used to include data from queries.",
       },
       "threshold": {
         "recovery": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -512,6 +512,11 @@
       "label-target-data-source": "Target data source"
     },
     "rule-form": {
+      "annotations": {
+        "description1": "Annotations add additional information to alerts, helping alert responders identify and address potential issues.",
+        "description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
+        "description3": "Annotations can contain a combination of text and template code, which is used to include data from queries."
+      },
       "evaluation": {
         "evaluation-group-and-interval": "Evaluation group and interval",
         "group": {
@@ -563,11 +568,6 @@
       },
       "pause": {
         "label": "Pause evaluation"
-      },
-      "annotations": {
-        "description1": "Annotations add additional information to alerts, helping alert responders identify and address potential issues.",
-        "description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
-        "description3": "Annotations can contain a combination of text and template code, which is used to include data from queries."
       },
       "threshold": {
         "recovery": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -565,9 +565,9 @@
         "label": "Pause evaluation"
       },
       "annotations": {
-        "description1": "Evaluation groups are containers for evaluating alert and recording rules.",
+        "description1": "Annotations add additional information to alerts, helping alert responders identify and address potential issues.",
         "description2": "For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.",
-        "description3": "Annotations can contain a combination of text and template code, which is used to include data from queries.",
+        "description3": "Annotations can contain a combination of text and template code, which is used to include data from queries."
       },
       "threshold": {
         "recovery": {


### PR DESCRIPTION

Add external doc links in help UIs for labels and annotations.

![Screenshot 2025-03-14 at 11 59 04](https://github.com/user-attachments/assets/7b6d75d7-15fe-4ad4-9088-9391e2492fdb)

![Screenshot 2025-03-14 at 11 58 55](https://github.com/user-attachments/assets/c55a321e-e220-439b-bc69-82532fe2fe11)
