### PR TITLE
datasources: querier: single-tenant: explicit permission-check

### DIFF
--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -127,7 +127,7 @@ func RegisterAPIService(features featuremgmt.FeatureToggles,
 	builder, err := NewQueryAPIBuilder(
 		features,
 		&CommonDataSourceClientSupplier{
-			Client: client.NewQueryClientForPluginClient(pluginClient, pCtxProvider),
+			Client: client.NewQueryClientForPluginClient(pluginClient, pCtxProvider, accessControl),
 		},
 		ar,
 		client.NewDataSourceRegistryFromStore(pluginStore, dataSourcesService),


### PR DESCRIPTION
in the single-tenant querier, we need to make sure the user has query-access to the datasources that are mentioned in the request-json.

currently, this happens implicitly:
- we call [GetDataSourceInstanceSettings](https://github.com/grafana/grafana/blob/38151b1ae476ce9d4e1e9a52566ce06d04a27e83/pkg/registry/apis/query/client/plugin.go#L73), which will return the needed info, but also verify that the current-user has the permission needed

i think an explicit permission-check would be better, considering the function's name ( `GetDataSourceInstanceSettings` ) does not indicate that there is a perm-check happening.

this PR does an explicit permission-check at the beginning.

about the deleted code: the old code was looking at the possible errors returned by `GetDataSourceInstanceSettings`, and if it was the permission-failure-error, it made sure it becomes the correct k8s-error. this special-handling is not needed anymore, it should never happen because of our check above. (if it would happen still, we'll get a http500, and we will know we need to fix something in the code)