### PR TITLE
feat(datasource/Tempo): Report timerange to Rudderstack

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1643,7 +1643,7 @@ function reportTempoQueryMetrics(
     app: options.app ?? '',
     grafana_version: config.buildInfo.version,
     timeRangeSeconds: options.range ? options.range.to.unix() - options.range.from.unix() : 0,
-    timeRange: options.range.raw.from + ';' + options.range.raw.to,
+    timeRange: options.range ? options.range.raw.from + ';' + options.range.raw.to : '',
     ...metrics,
   });
 }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1642,6 +1642,8 @@ function reportTempoQueryMetrics(
     datasourceType: 'tempo',
     app: options.app ?? '',
     grafana_version: config.buildInfo.version,
+    timeRangeSeconds: options.range.to.unix() - options.range.from.unix(),
+    timeRange: options.range.raw.from + ';' + options.range.raw.to,
     ...metrics,
   });
 }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1642,7 +1642,7 @@ function reportTempoQueryMetrics(
     datasourceType: 'tempo',
     app: options.app ?? '',
     grafana_version: config.buildInfo.version,
-    timeRangeSeconds: options.range.to.unix() - options.range.from.unix(),
+    timeRangeSeconds: options.range ? options.range.to.unix() - options.range.from.unix() : 0,
     timeRange: options.range.raw.from + ';' + options.range.raw.to,
     ...metrics,
   });


### PR DESCRIPTION
**What is this feature?**

This adds another parameter to the Rudderstack instrumentation that reporting the query time range in seconds and raw selection as follows:

![Screenshot 2025-03-14 at 5 08 16 PM](https://github.com/user-attachments/assets/c55b3319-08e1-4a67-8d25-cdcebd5390cf)

**Why do we need this feature?**

Measure the experienced performance of trace queries and to inform improvements
in both the datasource and the backend database.

**Who is this feature for?**

All users of the Tempo datasource.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
