### PR TITLE
Preferences: Make org settings strings translatable

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4896,11 +4896,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
-    "public/app/features/org/OrgProfile.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
-    ],
     "public/app/features/org/SelectOrgPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],

--- a/public/app/features/org/OrgDetailsPage.tsx
+++ b/public/app/features/org/OrgDetailsPage.tsx
@@ -5,6 +5,7 @@ import { Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
 import { appEvents, contextSrv } from 'app/core/core';
+import { t } from 'app/core/internationalization';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { AccessControlAction, StoreState } from 'app/types';
 import { ShowConfirmModalEvent } from 'app/types/events';
@@ -29,9 +30,12 @@ export class OrgDetailsPage extends PureComponent<Props> {
     return new Promise<boolean>((resolve) => {
       appEvents.publish(
         new ShowConfirmModalEvent({
-          title: 'Confirm preferences update',
-          text: 'This will update the preferences for the whole organization. Are you sure you want to update the preferences?',
-          yesText: 'Save',
+          title: t('org-profile.confirm-preferences-update-title', 'Confirm preferences update'),
+          text: t(
+            'org-profile.confirm-preferences-update-text',
+            'This will update the preferences for the whole organization. Are you sure you want to update the preferences?'
+          ),
+          yesText: t('org-profile.confirm-preferences-update-yes-text', 'Save'),
           yesButtonVariant: 'primary',
           onConfirm: async () => resolve(true),
           onDismiss: async () => resolve(false),

--- a/public/app/features/org/OrgProfile.tsx
+++ b/public/app/features/org/OrgProfile.tsx
@@ -1,6 +1,7 @@
 import { Input, Field, FieldSet, Button } from '@grafana/ui';
 import { Form } from 'app/core/components/Form/Form';
 import { contextSrv } from 'app/core/core';
+import { t } from 'app/core/internationalization';
 import { AccessControlAction } from 'app/types';
 
 export interface Props {
@@ -18,12 +19,12 @@ const OrgProfile = ({ onSubmit, orgName }: Props) => {
   return (
     <Form defaultValues={{ orgName }} onSubmit={({ orgName }: FormDTO) => onSubmit(orgName)}>
       {({ register }) => (
-        <FieldSet label="Organization profile" disabled={!canWriteOrg}>
-          <Field label="Organization name">
+        <FieldSet label={t('org-profile.title', 'Organization profile')} disabled={!canWriteOrg}>
+          <Field label={t('org-profile.name', 'Organization name')}>
             <Input id="org-name-input" type="text" {...register('orgName', { required: true })} />
           </Field>
 
-          <Button type="submit">Update organization name</Button>
+          <Button type="submit">{t('org-profile.update-name-button', 'Update organization name')}</Button>
         </FieldSet>
       )}
     </Form>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2993,6 +2993,14 @@
       "error": "Login provider denied login request"
     }
   },
+  "org-profile": {
+    "confirm-preferences-update-text": "This will update the preferences for the whole organization. Are you sure you want to update the preferences?",
+    "confirm-preferences-update-title": "Confirm preferences update",
+    "confirm-preferences-update-yes-text": "Save",
+    "name": "Organization name",
+    "title": "Organization profile",
+    "update-name-button": "Update organization name"
+  },
   "panel": {
     "header-menu": {
       "copy": "Copy",


### PR DESCRIPTION
**What is this feature?**

Makes some (I think the remaining ones) strings in the `/org` page translatable.

**Why do we need this feature?**

Localization!

**Who is this feature for?**

Non-english users of Grafana.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
