### PR TITLE
Fix format of timestamps sent to Spanner.

### DIFF
--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -36,9 +36,10 @@ type Engine struct {
 	showSQL      bool
 	showExecTime bool
 
-	logger     core.ILogger
-	TZLocation *time.Location // The timezone of the application
-	DatabaseTZ *time.Location // The timezone of the database
+	logger          core.ILogger
+	TZLocation      *time.Location // The timezone of the application
+	DatabaseTZ      *time.Location // The timezone of the database
+	timestampFormat string         // Format applied to time.Time before passing it to database in Timestamp and DateTime columns.
 
 	tagHandlers map[string]tagHandler
 
@@ -748,7 +749,9 @@ func (engine *Engine) formatTime(sqlTypeName string, t time.Time) (v any) {
 		v = s[11:19]
 	case core.Date:
 		v = t.Format("2006-01-02")
-	case core.DateTime, core.TimeStamp, core.Varchar: // !DarthPestilane! format time when sqlTypeName is core.Varchar.
+	case core.DateTime, core.TimeStamp:
+		v = t.Format(engine.timestampFormat)
+	case core.Varchar: // !DarthPestilane! format time when sqlTypeName is core.Varchar.
 		v = t.Format("2006-01-02 15:04:05")
 	case core.TimeStampz:
 		v = t.Format(time.RFC3339Nano)

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -83,19 +83,27 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 	}
 
 	engine := &Engine{
-		db:             db,
-		dialect:        dialect,
-		Tables:         make(map[reflect.Type]*core.Table),
-		mutex:          &sync.RWMutex{},
-		TagIdentifier:  "xorm",
-		TZLocation:     time.Local,
-		tagHandlers:    defaultTagHandlers,
-		defaultContext: context.Background(),
+		db:              db,
+		dialect:         dialect,
+		Tables:          make(map[reflect.Type]*core.Table),
+		mutex:           &sync.RWMutex{},
+		TagIdentifier:   "xorm",
+		TZLocation:      time.Local,
+		tagHandlers:     defaultTagHandlers,
+		defaultContext:  context.Background(),
+		timestampFormat: "2006-01-02 15:04:05",
 	}
 
-	if uri.DbType == core.SQLITE {
+	switch uri.DbType {
+	case core.SQLITE:
 		engine.DatabaseTZ = time.UTC
-	} else {
+	case "spanner":
+		engine.DatabaseTZ = time.UTC
+		// We need to specify "Z" to indicate that timestamp is in UTC.
+		// Otherwise Spanner uses default America/Los_Angeles timezone.
+		// https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#time_zones
+		engine.timestampFormat = "2006-01-02 15:04:05Z"
+	default:
 		engine.DatabaseTZ = time.Local
 	}
 


### PR DESCRIPTION
This PR fixes format of timestamps sent to Spanner in TIMESTAMP columns, so that Spanner doesn't consider them to be in `America/Los_Angeles` ([link](https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#time_zones)).

This fixes tests that expect returned timestamps to be recent (eg. `TestIntegrationDashboardDataAccess/Should_be_able_to_update_dashboard_by_id_and_remove_folderId` test that previously failed with `Max difference between 2025-03-14 23:34:59 +0000 UTC and 2025-03-14 17:34:56.325769 +0100 CET m=+13.181816418 allowed is 3s, but difference was 7h0m2.674231s` error when running on Spanner), but also timestamps stored in `migration_log`.

```sql
SELECT TIMESTAMP '2025-03-14 16:30:00'; -- returns "2025-03-14T23:30:00Z"
SELECT TIMESTAMP '2025-03-14 16:30:00Z'; -- returns "2025-03-14T16:30:00Z"
```