### PR TITLE
GrafanaUI: Prevent ToolbarButton from submitting form

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -86,6 +86,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
         className={buttonStyles}
         aria-label={getButtonAriaLabel(ariaLabel, tooltip)}
         aria-expanded={isOpen}
+        type="button"
         {...rest}
       >
         {renderIcon(icon, iconSize)}


### PR DESCRIPTION
I bumped into a bug developing a plugin where a ToolbarButton from the scenes panel inside a form will submit the form.

Since the buttons inside ToolbarButton don't specify their type, they will submit any form that wraps the component. I don't think that should be the case, so I went ahead and gave them type='button'.