### PR TITLE
FieldState: Add frame name to header rename logic

### DIFF
--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -197,6 +197,8 @@ export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFr
     displayName = parts.join(' ');
   } else if (field.name) {
     displayName = field.name;
+  } else if (frame?.name) {
+    displayName = frame?.name;
   } else {
     displayName = TIME_SERIES_VALUE_FIELD_NAME;
   }


### PR DESCRIPTION
**What is this feature?**

Users may have the scenario where a variable selection can return one or multiple series worth of data. They desire to have consistency on how the data is displayed.

There is logic in place where if multiple series are returned, the names used will be the name of that series, but if there is only one frame, and one series in that frame, the name will be simply "Value". This means in the table visualization, we will have metrics names sometimes, and "Value" others.

This changes logic in a central location - if it gets to this point without a name, it will use the name of the frame before using "Value". If needed, I can isolate this for only the table panel, or make it an optional setting.. It didn't break any tests, so I was curious what others thought about this as a more centralized change.

**Which issue(s) does this PR fix?**:

This is a potential solution to https://github.com/grafana/support-escalations/issues/13604 - please see the escalation for more information on the use case. 

**Special notes for your reviewer:**

Before
<img width="1193" alt="Screenshot 2025-03-14 at 8 03 53 PM" src="https://github.com/user-attachments/assets/f00114cc-b969-4f1d-8c93-93084af5db6f" />

After
<img width="1198" alt="Screenshot 2025-03-14 at 8 04 46 PM" src="https://github.com/user-attachments/assets/35662046-a27c-4bf0-a55d-5acad8985b3f" />

<details><summary>Example dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 316,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green"
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "11.6.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"executedQueryString\": \"redacted\",\n        \"typeVersion\": [\n          0,\n          0\n        ]\n      },\n      \"name\": \"frame name\",\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {},\n          \"labels\": {},\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1729123200000,\n          1729728000000,\n          1730332800000,\n          1730937600000,\n          1731542400000\n        ],\n        [\n          3925212689.0915337,\n          3847485705.1491184,\n          3925212689.0915337,\n          3925212689.0915337,\n          3771297869.403597\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Frame name test",
  "uid": "aefunterrdkhsd",
  "version": 1
}
```
</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
