### PR TITLE
Geomap: Group by field option in routes layer

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,34 @@
+name: Build and Push Grafana Docker Image
+
+on:
+  push:
+    branches: [ '**' ]
+  workflow_dispatch:  # Permette di eseguire manualmente il workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/grafana-rm:latest
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/grafana-rm:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/grafana-rm:buildcache,mode=max

--- a/public/app/features/geo/utils/frameVectorSource.ts
+++ b/public/app/features/geo/utils/frameVectorSource.ts
@@ -6,10 +6,17 @@ import { DataFrame, Field } from '@grafana/data';
 
 import { getGeometryField, LocationFieldMatchers } from './location';
 
+export interface FrameVectorSourceOptions {
+  groupBy?: string; // Campo per il raggruppamento
+}
+
 export interface FrameVectorSourceOptions {}
 
 export class FrameVectorSource<T extends Geometry = Geometry> extends VectorSource<T> {
-  constructor(public location: LocationFieldMatchers) {
+  constructor(
+    public location: LocationFieldMatchers,
+    options: FrameVectorSourceOptions = {}
+  ) {
     super({});
   }
 
@@ -55,6 +62,61 @@ export class FrameVectorSource<T extends Geometry = Geometry> extends VectorSour
     );
 
     // only call this at the end
+    this.changed();
+  }
+
+  updateLineStringGrouped(frame: DataFrame, groupByField: string) {
+    this.clear(true);
+
+    const info = getGeometryField(frame, this.location);
+    if (!info.field) {
+      this.changed();
+      return;
+    }
+
+    const groupField = frame.fields.find((f) => f.name === groupByField);
+    if (!groupField) {
+      this.updateLineString(frame);
+      return;
+    }
+
+    const field = info.field as unknown as Field<Point>;
+
+    const groups: Record<string, Point[]> = {};
+    const values = field.values;
+    const groupValues = groupField.values;
+
+    for (let i = 0; i < values.length; i++) {
+      const p = values[i];
+      if (p instanceof Point) {
+        const groupValue = groupValues[i];
+        if (groupValue !== null && groupValue !== undefined) {
+          const key = String(groupValue);
+          if (!groups[key]) {
+            groups[key] = [];
+          }
+          groups[key].push(p);
+        }
+      }
+    }
+
+    let featureIndex = 0;
+    Object.entries(groups).forEach(([groupValue, points]) => {
+      if (points.length > 1) {
+        const coords = points.map((p) => p.getCoordinates());
+        const lineGeometry: Geometry = new LineString(coords);
+
+        this.addFeatureInternal(
+          new Feature({
+            frame,
+            rowIndex: featureIndex++,
+            [groupByField]: groupValue,
+            geometry: lineGeometry as T,
+          })
+        );
+      }
+    });
+
     this.changed();
   }
 }


### PR DESCRIPTION
This feature aim is to create multiple routes grouping location data by field in geomap panel under route layer. 

For further details see https://community.grafana.com/t/show-multiple-routes-in-a-single-geomap-panel/112045.

closes https://github.com/grafana/grafana/issues/102245

need help to add "add to changelog" label