### PR TITLE
Dashboards: Fix duplicate provisioning when errors occur on title-only based provisioning

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -11,6 +11,7 @@ import (
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
@@ -25,6 +26,36 @@ func getDashboardFromEvent(event resource.WriteEvent) (*dashboard.Dashboard, err
 	dash := &dashboard.Dashboard{}
 	err := json.Unmarshal(event.Value, dash)
 	return dash, err
+}
+
+func getProvisioningDataFromEvent(event resource.WriteEvent) (*dashboards.DashboardProvisioning, error) {
+	obj, ok := event.Object.GetRuntimeObject()
+	if !ok {
+		return nil, fmt.Errorf("object is not a runtime object")
+	}
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	provisioningData, ok := meta.GetManagerProperties()
+	if !ok || (provisioningData.Kind != utils.ManagerKindClassicFP) { //nolint:staticcheck
+		return nil, nil
+	}
+	source, ok := meta.GetSourceProperties()
+	if !ok {
+		return nil, nil
+	}
+	provisioning := &dashboards.DashboardProvisioning{
+		Name:       provisioningData.Identity,
+		ExternalID: source.Path,
+		CheckSum:   source.Checksum,
+	}
+	if source.TimestampMillis > 0 {
+		provisioning.Updated = time.UnixMilli(source.TimestampMillis).Unix()
+	}
+
+	return provisioning, nil
 }
 
 func isDashboardKey(key *resource.ResourceKey, requireName bool) error {
@@ -63,19 +94,43 @@ func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.Writ
 			if err != nil {
 				return 0, err
 			}
-
-			after, _, err := a.SaveDashboard(ctx, info.OrgID, dash)
+			// In unistore, provisioning data is stored as annotations on the dashboard object. In legacy, it is stored in a separate
+			// database table. For the legacy fallback, we need to save the provisioning data in the same transaction - so we need to handle these separately.
+			// Without this, we can end up having dashboards created in legacy, unistore timing out, and then never saving the provisioning data, which
+			// results in duplicated dashboards on next startup.
+			provisioning, err := getProvisioningDataFromEvent(event)
 			if err != nil {
 				return 0, err
 			}
-			if after != nil {
-				meta, err := utils.MetaAccessor(after)
+			if provisioning != nil {
+				cmd, _, err := a.buildSaveDashboardCommand(ctx, info.OrgID, dash)
 				if err != nil {
 					return 0, err
 				}
-				rv, err = meta.GetResourceVersionInt64()
+
+				after, err := a.dashStore.SaveProvisionedDashboard(ctx, *cmd, provisioning)
 				if err != nil {
 					return 0, err
+				}
+
+				// dashboard version is the RV in legacy storage
+				if after != nil {
+					rv = int64(after.Version)
+				}
+			} else {
+				after, _, err := a.SaveDashboard(ctx, info.OrgID, dash)
+				if err != nil {
+					return 0, err
+				}
+				if after != nil {
+					meta, err := utils.MetaAccessor(after)
+					if err != nil {
+						return 0, err
+					}
+					rv, err = meta.GetResourceVersionInt64()
+					if err != nil {
+						return 0, err
+					}
 				}
 			}
 		}

--- a/pkg/registry/apis/dashboard/legacy/storage_test.go
+++ b/pkg/registry/apis/dashboard/legacy/storage_test.go
@@ -1,0 +1,129 @@
+package legacy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+func TestGetProvisioningDataFromEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		manager utils.ManagerProperties
+		source  utils.SourceProperties
+		want    *dashboards.DashboardProvisioning
+	}{
+		{
+			name: "valid provisioning data",
+			manager: utils.ManagerProperties{
+				Kind:     utils.ManagerKindClassicFP, //nolint:staticcheck
+				Identity: "test-name",
+			},
+			source: utils.SourceProperties{
+				Path:            "test-path",
+				Checksum:        "test-checksum",
+				TimestampMillis: 1000,
+			},
+			want: &dashboards.DashboardProvisioning{
+				Name:       "test-name",
+				ExternalID: "test-path",
+				CheckSum:   "test-checksum",
+				Updated:    1,
+			},
+		},
+		{
+			name: "non-provisioned dashboard",
+			manager: utils.ManagerProperties{
+				Kind: "different-kind",
+			},
+			source: utils.SourceProperties{},
+			want:   nil,
+		},
+		{
+			name:    "missing runtime object",
+			manager: utils.ManagerProperties{},
+			source:  utils.SourceProperties{},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &unstructured.Unstructured{
+				Object: map[string]any{},
+			}
+			meta, err := utils.MetaAccessor(res)
+			require.NoError(t, err)
+			meta.SetManagerProperties(tt.manager)
+			meta.SetSourceProperties(tt.source)
+			got, err := getProvisioningDataFromEvent(resource.WriteEvent{
+				Object: meta,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// test that we use the save provisioning function if the file based provisioning is set
+func TestWriteProvisioningEvent(t *testing.T) {
+	dashData := &dashboards.Dashboard{
+		Title:   "Test Dashboard",
+		Version: 2,
+	}
+	dashBytes, err := json.Marshal(dashData)
+	require.NoError(t, err)
+
+	key := &resource.ResourceKey{
+		Group:     dashboard.DashboardResourceInfo.GroupResource().Group,
+		Resource:  dashboard.DashboardResourceInfo.GroupResource().Resource,
+		Name:      "test-dashboard",
+		Namespace: "stacks-1",
+	}
+
+	res := &unstructured.Unstructured{
+		Object: map[string]any{},
+	}
+	meta, err := utils.MetaAccessor(res)
+	require.NoError(t, err)
+	meta.SetManagerProperties(utils.ManagerProperties{
+		Kind:     utils.ManagerKindClassicFP, //nolint:staticcheck
+		Identity: "test-name",
+	})
+	meta.SetSourceProperties(utils.SourceProperties{
+		Path:            "test-path",
+		Checksum:        "test-checksum",
+		TimestampMillis: 1000,
+	})
+
+	event := resource.WriteEvent{
+		Type:   resource.WatchEvent_ADDED,
+		Key:    key,
+		Object: meta,
+		Value:  dashBytes,
+	}
+
+	mockStore := dashboards.NewFakeDashboardStore(t)
+	mockStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashData, nil)
+
+	access := &dashboardSqlAccess{
+		dashStore: mockStore,
+	}
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+	rv, err := access.WriteEvent(ctx, event)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), rv)
+	mockStore.AssertExpectations(t)
+}

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -84,7 +84,7 @@ type Store interface {
 	GetProvisionedDashboardsByName(ctx context.Context, name string) ([]*Dashboard, error)
 	GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string) ([]*Dashboard, error)
 	SaveDashboard(ctx context.Context, cmd SaveDashboardCommand) (*Dashboard, error)
-	SaveProvisionedDashboard(ctx context.Context, dash *Dashboard, provisioning *DashboardProvisioning) error
+	SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error)
 	UnprovisionDashboard(ctx context.Context, id int64) error
 	// ValidateDashboardBeforeSave validates a dashboard before save.
 	ValidateDashboardBeforeSave(ctx context.Context, dashboard *Dashboard, overwrite bool) (bool, error)

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -52,14 +52,12 @@ func TestIntegrationDashboardProvisioningTest(t *testing.T) {
 			ExternalID: "/var/grafana.json",
 			Updated:    now.Unix(),
 		}
-		dash, err := dashboardStore.SaveDashboard(context.Background(), saveDashboardCmd)
-		require.NoError(t, err)
+
+		dash, err := dashboardStore.SaveProvisionedDashboard(context.Background(), saveDashboardCmd, provisioning)
+		require.Nil(t, err)
 		require.NotNil(t, dash)
 		require.NotEqual(t, 0, dash.ID)
 		dashId := dash.ID
-
-		err = dashboardStore.SaveProvisionedDashboard(context.Background(), dash, provisioning)
-		require.Nil(t, err)
 
 		t.Run("Deleting orphaned provisioned dashboards", func(t *testing.T) {
 			saveCmd := dashboards.SaveDashboardCommand{
@@ -71,8 +69,6 @@ func TestIntegrationDashboardProvisioningTest(t *testing.T) {
 					"title": "another_dashboard",
 				}),
 			}
-			anotherDash, err := dashboardStore.SaveDashboard(context.Background(), saveCmd)
-			require.NoError(t, err)
 
 			provisioning := &dashboards.DashboardProvisioning{
 				Name:       "another_reader",
@@ -80,7 +76,7 @@ func TestIntegrationDashboardProvisioningTest(t *testing.T) {
 				Updated:    now.Unix(),
 			}
 
-			err = dashboardStore.SaveProvisionedDashboard(context.Background(), anotherDash, provisioning)
+			anotherDash, err := dashboardStore.SaveProvisionedDashboard(context.Background(), saveCmd, provisioning)
 			require.Nil(t, err)
 
 			query := &dashboards.GetDashboardsQuery{DashboardIDs: []int64{anotherDash.ID}}

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -253,27 +253,37 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 
 	t.Run("Should delete associated provisioning info, even without the dashboard existing in the db", func(t *testing.T) {
 		setup()
-		dash1 := insertTestDashboard(t, dashboardStore, "provisioned", 1, 0, "", false, "provisioned")
-		dash2 := insertTestDashboard(t, dashboardStore, "orphaned", 1, 0, "", false, "orphaned")
 		provisioningData := &dashboards.DashboardProvisioning{
-			ID:          1,
-			DashboardID: dash1.ID,
-			Name:        "test",
-			CheckSum:    "123",
-			Updated:     54321,
-			ExternalID:  "/path/to/dashboard",
+			ID:         1,
+			Name:       "test",
+			CheckSum:   "123",
+			Updated:    54321,
+			ExternalID: "/path/to/dashboard",
 		}
-		err := dashboardStore.SaveProvisionedDashboard(context.Background(), dash1, provisioningData)
+		dash1, err := dashboardStore.SaveProvisionedDashboard(context.Background(), dashboards.SaveDashboardCommand{
+			OrgID:    1,
+			IsFolder: false,
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"id":    nil,
+				"title": "provisioned",
+			}),
+		}, provisioningData)
 		require.NoError(t, err)
 		provisioningData2 := &dashboards.DashboardProvisioning{
-			ID:          1,
-			DashboardID: dash2.ID,
-			Name:        "orphaned",
-			CheckSum:    "123",
-			Updated:     54321,
-			ExternalID:  "/path/to/dashboard",
+			ID:         1,
+			Name:       "orphaned",
+			CheckSum:   "123",
+			Updated:    54321,
+			ExternalID: "/path/to/dashboard",
 		}
-		err = dashboardStore.SaveProvisionedDashboard(context.Background(), dash2, provisioningData2)
+		_, err = dashboardStore.SaveProvisionedDashboard(context.Background(), dashboards.SaveDashboardCommand{
+			OrgID:    1,
+			IsFolder: false,
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"id":    nil,
+				"title": "orphaned",
+			}),
+		}, provisioningData2)
 		require.NoError(t, err)
 
 		// get provisioning data

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -677,24 +677,17 @@ func (dr *DashboardServiceImpl) SaveProvisionedDashboard(ctx context.Context, dt
 	if err != nil {
 		return nil, err
 	}
+	if cmd == nil {
+		return nil, fmt.Errorf("failed to build save dashboard command. cmd is nil")
+	}
 
 	var dash *dashboards.Dashboard
 	if dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesClientDashboardsFolders) {
-		// save the dashboard but then do NOT return
-		// we want to save the provisioning data to the dashboard_provisioning table still
-		// to ensure we can safely rollback to mode2 if needed
 		dash, err = dr.saveProvisionedDashboardThroughK8s(ctx, cmd, provisioning, false)
-		if err != nil {
-			return nil, err
-		}
 	} else {
-		dash, err = dr.saveDashboard(ctx, cmd)
-		if err != nil {
-			return nil, err
-		}
+		dash, err = dr.dashboardStore.SaveProvisionedDashboard(ctx, *cmd, provisioning)
 	}
 
-	err = dr.dashboardStore.SaveProvisionedDashboard(ctx, dash, provisioning)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -159,9 +159,7 @@ func TestDashboardService(t *testing.T) {
 			dto := &dashboards.SaveDashboardDTO{}
 
 			t.Run("Should not return validation error if dashboard is provisioned", func(t *testing.T) {
-				fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("*dashboards.DashboardProvisioning")).Return(nil).Once()
-				fakeStore.On("SaveDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand")).Return(&dashboards.Dashboard{Data: simplejson.New()}, nil).Once()
-
+				fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand"), mock.AnythingOfType("*dashboards.DashboardProvisioning")).Return(&dashboards.Dashboard{Data: simplejson.New()}, nil).Once()
 				dto.Dashboard = dashboards.NewDashboard("Dash")
 				dto.Dashboard.SetID(3)
 				dto.User = &user.SignedInUser{UserID: 1}
@@ -170,9 +168,7 @@ func TestDashboardService(t *testing.T) {
 			})
 
 			t.Run("Should override invalid refresh interval if dashboard is provisioned", func(t *testing.T) {
-				fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("*dashboards.DashboardProvisioning")).Return(nil).Once()
-				fakeStore.On("SaveDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand")).Return(&dashboards.Dashboard{Data: simplejson.New()}, nil).Once()
-
+				fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand"), mock.AnythingOfType("*dashboards.DashboardProvisioning")).Return(&dashboards.Dashboard{Data: simplejson.New()}, nil).Once()
 				oldRefreshInterval := service.cfg.MinRefreshInterval
 				service.cfg.MinRefreshInterval = "5m"
 				defer func() { service.cfg.MinRefreshInterval = oldRefreshInterval }()
@@ -1216,8 +1212,7 @@ func TestSaveProvisionedDashboard(t *testing.T) {
 	t.Run("Should fallback to dashboard store if Kubernetes feature flags are not enabled", func(t *testing.T) {
 		service.features = featuremgmt.WithFeatures()
 		fakeStore.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
-		fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		fakeStore.On("SaveDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
+		fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 		dashboard, err := service.SaveProvisionedDashboard(context.Background(), query, &dashboards.DashboardProvisioning{})
 		require.NoError(t, err)
 		require.NotNil(t, dashboard)
@@ -1237,7 +1232,7 @@ func TestSaveProvisionedDashboard(t *testing.T) {
 
 	t.Run("Should use Kubernetes create if feature flags are enabled", func(t *testing.T) {
 		ctx, k8sCliMock := setupK8sDashboardTests(service)
-		fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		fakeStore.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 		k8sCliMock.On("GetUserFromMeta", mock.Anything, mock.Anything).Return(&user.User{}, nil)
 		k8sCliMock.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&dashboardUnstructured, nil)

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -694,22 +694,34 @@ func (_m *FakeDashboardStore) SaveDashboard(ctx context.Context, cmd SaveDashboa
 	return r0, r1
 }
 
-// SaveProvisionedDashboard provides a mock function with given fields: ctx, dash, provisioning
-func (_m *FakeDashboardStore) SaveProvisionedDashboard(ctx context.Context, dash *Dashboard, provisioning *DashboardProvisioning) error {
-	ret := _m.Called(ctx, dash, provisioning)
+// SaveProvisionedDashboard provides a mock function with given fields: ctx, cmd, provisioning
+func (_m *FakeDashboardStore) SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error) {
+	ret := _m.Called(ctx, cmd, provisioning)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveProvisionedDashboard")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *Dashboard, *DashboardProvisioning) error); ok {
-		r0 = rf(ctx, dash, provisioning)
+	var r0 *Dashboard
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, SaveDashboardCommand, *DashboardProvisioning) (*Dashboard, error)); ok {
+		return rf(ctx, cmd, provisioning)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, SaveDashboardCommand, *DashboardProvisioning) *Dashboard); ok {
+		r0 = rf(ctx, cmd, provisioning)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Dashboard)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, SaveDashboardCommand, *DashboardProvisioning) error); ok {
+		r1 = rf(ctx, cmd, provisioning)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SoftDeleteDashboard provides a mock function with given fields: ctx, orgID, dashboardUid


### PR DESCRIPTION
This PR fixes an issue where file based provisioned dashboards could be provisioned twice, on initial save**, if only the title (not the uid nor the id) was specified in the json. This specifically would happen when the request timed out, or if grafana crashed / restarted, between creating the dashboard & saving the provisioned dashboard data in the `SaveProvisionedDashboard` function. This would then end up with the dashboard created in the dashboard table, but no record of it being created in the dashboard provisioning table.

This PR instead changes it to be completed in one transaction instead.

Note: This did not impact dashboards provisioned by uid or id because the save dashboard flow checks to see if a dashboard already exists by that uid or id before deciding if it is a create or an update. So it would update those dashboards instead on the next start up. That check used to include titles, but since those are no longer unique, it can no longer do that.

** For the k8s flow, this would happen anytime an issue occurred, not just on initial save, because there was another bug that was setting the returned dashboard with the relative path [here](https://github.com/grafana/grafana/pull/102249/files#diff-4f5edb016b217f9469f603a9d7908131001db5fdaab3a0a103cbda413f9bebd6R323), so it was deleting & recreating all provisioned dashboards on every restart. This PR also fixes that bug. Thanks to @toddtreece for finding / fixing that! Pulled in the changes from https://github.com/grafana/grafana/pull/102248 so we could test all the changes e2e