### PR TITLE
K8s/Dashboard: DeepCopy should deep copy

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_object_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_object_gen.go
@@ -219,7 +219,7 @@ func (o *Dashboard) Copy() resource.Object {
 }
 
 func (o *Dashboard) DeepCopyObject() runtime.Object {
-	return o.Copy()
+	return o.DeepCopy()
 }
 
 // Interface compliance compile-time check

--- a/apps/dashboard/pkg/apis/dashboard/v1alpha1/dashboard_object_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1alpha1/dashboard_object_gen.go
@@ -219,7 +219,7 @@ func (o *Dashboard) Copy() resource.Object {
 }
 
 func (o *Dashboard) DeepCopyObject() runtime.Object {
-	return o.Copy()
+	return o.DeepCopy()
 }
 
 // Interface compliance compile-time check

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_object_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_object_gen.go
@@ -219,7 +219,7 @@ func (o *Dashboard) Copy() resource.Object {
 }
 
 func (o *Dashboard) DeepCopyObject() runtime.Object {
-	return o.Copy()
+	return o.DeepCopy()
 }
 
 // Interface compliance compile-time check

--- a/apps/dashboard/pkg/migration/conversion/conversion_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_test.go
@@ -45,3 +45,20 @@ func TestConversionMatrixExist(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepCopyValid(t *testing.T) {
+	dash1 := &v0alpha1.Dashboard{}
+	meta1, err := utils.MetaAccessor(dash1)
+	require.NoError(t, err)
+	meta1.SetFolder("f1")
+	require.Equal(t, "f1", dash1.Annotations[utils.AnnoKeyFolder])
+
+	dash1Copy := dash1.DeepCopyObject()
+	metaCopy, err := utils.MetaAccessor(dash1Copy)
+	require.NoError(t, err)
+	require.Equal(t, "f1", metaCopy.GetFolder())
+
+	// Changing copy does not effect the original!
+	metaCopy.SetFolder("XYZ")
+	require.Equal(t, "f1", meta1.GetFolder())
+}

--- a/apps/dashboard/pkg/migration/conversion/conversion_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_test.go
@@ -58,7 +58,7 @@ func TestDeepCopyValid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "f1", metaCopy.GetFolder())
 
-	// Changing copy does not effect the original!
+	// Changing a property on the copy should not effect the original
 	metaCopy.SetFolder("XYZ")
-	require.Equal(t, "f1", meta1.GetFolder())
+	require.Equal(t, "f1", meta1.GetFolder()) // 💣💣💣
 }


### PR DESCRIPTION
The current SDK codegen generates a `DeepCopyObject()` function that calls a shallow copy.

This PR manually replaces the generated values so they are a deep copy.  This is temporary because the next round of codegen would wipe it out