### PR TITLE
Alerting: Remove uniqueness checks from the Prometheus conversion

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -123,15 +122,13 @@ func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 		expectedRules := make(map[string]string)
 		for _, rule := range simpleGroup.Rules {
 			if rule.Alert != "" {
-				title := fmt.Sprintf("[%s] %s", simpleGroup.Name, rule.Alert)
 				promRuleYAML, err := yaml.Marshal(rule)
 				require.NoError(t, err)
-				expectedRules[title] = string(promRuleYAML)
+				expectedRules[rule.Alert] = string(promRuleYAML)
 			} else if rule.Record != "" {
-				title := fmt.Sprintf("[%s] %s", simpleGroup.Name, rule.Record)
 				promRuleYAML, err := yaml.Marshal(rule)
 				require.NoError(t, err)
-				expectedRules[title] = string(promRuleYAML)
+				expectedRules[rule.Record] = string(promRuleYAML)
 			}
 		}
 

--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -119,7 +119,6 @@ func (p *Converter) PrometheusRulesToGrafana(orgID int64, namespaceUID string, g
 }
 
 func (p *Converter) convertRuleGroup(orgID int64, namespaceUID string, promGroup PrometheusRuleGroup) (*models.AlertRuleGroup, error) {
-	uniqueNames := map[string]int{}
 	rules := make([]models.AlertRule, 0, len(promGroup.Rules))
 
 	interval := time.Duration(promGroup.Interval)
@@ -134,12 +133,6 @@ func (p *Converter) convertRuleGroup(orgID int64, namespaceUID string, promGroup
 		}
 		gr.RuleGroupIndex = i + 1
 		gr.IntervalSeconds = int64(interval.Seconds())
-
-		// Check rule title uniqueness within the group.
-		uniqueNames[gr.Title]++
-		if val := uniqueNames[gr.Title]; val > 1 {
-			gr.Title = fmt.Sprintf("%s (%d)", gr.Title, val)
-		}
 
 		uid, err := getUID(orgID, namespaceUID, promGroup.Name, i, rule)
 		if err != nil {
@@ -209,13 +202,6 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 		isPaused = p.cfg.AlertRules.IsPaused
 		title = rule.Alert
 	}
-
-	// Temporary workaround for avoiding the uniqueness check for the rule title.
-	// In Grafana alert rule titles must be unique within the same org and folder,
-	// but Prometheus allows multiple rules with the same name. By adding the group name
-	// to the title we ensure that the title is unique within the group.
-	// TODO: Remove this workaround when we have a proper solution for handling rule title uniqueness.
-	title = fmt.Sprintf("[%s] %s", promGroup.Name, title)
 
 	labels := make(map[string]string, len(rule.Labels)+len(promGroup.Labels))
 	maps.Copy(labels, promGroup.Labels)

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -194,13 +194,13 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				grafanaRule := grafanaGroup.Rules[j]
 
 				if promRule.Record != "" {
-					require.Equal(t, fmt.Sprintf("[%s] %s", tc.promGroup.Name, promRule.Record), grafanaRule.Title)
+					require.Equal(t, promRule.Record, grafanaRule.Title)
 					require.NotNil(t, grafanaRule.Record)
 					require.Equal(t, grafanaRule.Record.From, queryRefID)
 					require.Equal(t, promRule.Record, grafanaRule.Record.Metric)
 					require.Equal(t, tc.config.DatasourceUID, grafanaRule.Record.TargetDatasourceUID)
 				} else {
-					require.Equal(t, fmt.Sprintf("[%s] %s", tc.promGroup.Name, promRule.Alert), grafanaRule.Title)
+					require.Equal(t, promRule.Alert, grafanaRule.Title)
 				}
 
 				var expectedFor time.Duration
@@ -267,10 +267,10 @@ func TestPrometheusRulesToGrafanaWithDuplicateRuleNames(t *testing.T) {
 
 	require.Equal(t, "test-group-1", group.Title)
 	require.Len(t, group.Rules, 4)
-	require.Equal(t, "[test-group-1] alert", group.Rules[0].Title)
-	require.Equal(t, "[test-group-1] alert (2)", group.Rules[1].Title)
-	require.Equal(t, "[test-group-1] another alert", group.Rules[2].Title)
-	require.Equal(t, "[test-group-1] alert (3)", group.Rules[3].Title)
+	require.Equal(t, "alert", group.Rules[0].Title)
+	require.Equal(t, "alert", group.Rules[1].Title)
+	require.Equal(t, "another alert", group.Rules[2].Title)
+	require.Equal(t, "alert", group.Rules[3].Title)
 }
 
 func TestCreateMathNode(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Removes the temporary workarounds that were in the Prometheus to Grafana conversion code. Now that alert rule titles don't have any uniqueness constraints (https://github.com/grafana/grafana/pull/102067), these workarounds are no longer needed.