### PR TITLE
aws-cloudwatch: add explanation of grafana cloudwatch only logs integration

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -259,6 +259,21 @@ Log queries don't keep a single request open, and instead periodically poll for 
 Therefore, they don't recognize the standard Grafana query timeout.
 Because of limits on concurrently running queries in CloudWatch, they can also take longer to finish.
 
+
+### Find logs and troubleshoot errors in Grafana
+
+To locate CloudWatch logs and troubleshoot issues in the Grafana UI:
+
+1. Access CloudWatch Logs in Grafana:
+   - Open the Explore view or create a new dashboard panel
+   - Select your CloudWatch data source
+   - Choose "CloudWatch Logs" from the query type dropdown
+   - Use the "Select Log Groups" button to select your log groups (based on the prefix when selecting)
+
+2. Common Grafana CloudWatch plugin errors and solutions:
+   if you are getting `CloudWatch metrics query failed: AccessDenied: User: arn:aws:sts::<AWS_ACCOUNT_ID>:assumed-role/<ROLE_NAME>/<SESSION_ID> is not authorized to perform: cloudwatch:ListMetrics because no identity-based policy allows the cloudwatch:ListMetrics action status code: 403, request id: <REQUEST_ID> 2. Successfully queried the CloudWatch logs API.`
+   this might be due to grafana UI checking if cloudwatch metrics are passed alongside the log permissions (maybe a bug)
+
 #### X-Ray trace links
 
 To automatically add links in your logs when the log contains the `@xrayTraceId` field, link an X-Ray data source in the "X-Ray trace link" section of the data source configuration.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Gives people who are using cloudwatch only to transfer logs to understand how to see the logs in grafana

**Why do we need this feature?**

to shorten the time it takes from adding the plugin to getting the value out of it.

**Who is this feature for?**

anyone who wants to have the cloudwatch logs but doesn't want cloudwatch metrics.

**Which issue(s) does this PR fix?**:

<N/A>

**Special notes for your reviewer:**
if you read the documentation change, you will see a few next steps that can be features of their own:
1. Add a dashboard only for logs with no metrics needed
2. Fix the issue where you add the plugin, and will get a credentails error even though it works
3. A documentation on how to retrieve the logs (pushing currently here as it's the easiest thing to do

Please check that:
- [V] It works as expected from a user's perspective.
- [V] If this is a pre-GA feature, it is behind a feature toggle.
- [V] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
