### PR TITLE
K8s: Dashboards: Fix multi-org provisioning flow

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -240,9 +240,9 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 				OrgID:    user.GetOrgID(),
 			})
 		} else if query.ManagerIdentity != "" {
-			dashes, err = c.dashboardStore.GetProvisionedDashboardsByName(ctx, query.ManagerIdentity)
+			dashes, err = c.dashboardStore.GetProvisionedDashboardsByName(ctx, query.ManagerIdentity, user.GetOrgID())
 		} else if len(query.ManagerIdentityNotIn) > 0 {
-			dashes, err = c.dashboardStore.GetOrphanedProvisionedDashboards(ctx, query.ManagerIdentityNotIn)
+			dashes, err = c.dashboardStore.GetOrphanedProvisionedDashboards(ctx, query.ManagerIdentityNotIn, user.GetOrgID())
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -437,7 +437,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 	})
 
 	t.Run("Should retrieve dashboards by provisioner name through a different function", func(t *testing.T) {
-		mockStore.On("GetProvisionedDashboardsByName", mock.Anything, "test").Return([]*dashboards.Dashboard{
+		mockStore.On("GetProvisionedDashboardsByName", mock.Anything, "test", mock.Anything).Return([]*dashboards.Dashboard{
 			{UID: "uid", Title: "Test Dashboard", FolderUID: "folder1"},
 		}, nil).Once()
 
@@ -470,7 +470,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 	})
 
 	t.Run("Should retrieve orphaned dashboards if provisioner not in is specified", func(t *testing.T) {
-		mockStore.On("GetOrphanedProvisionedDashboards", mock.Anything, []string{"test", "test2"}).Return([]*dashboards.Dashboard{
+		mockStore.On("GetOrphanedProvisionedDashboards", mock.Anything, []string{"test", "test2"}, mock.Anything).Return([]*dashboards.Dashboard{
 			{UID: "uid", Title: "Test Dashboard", FolderUID: "folder1"},
 		}, nil).Once()
 

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -81,8 +81,8 @@ type Store interface {
 	GetProvisionedDashboardData(ctx context.Context, name string) ([]*DashboardProvisioning, error)
 	GetProvisionedDataByDashboardID(ctx context.Context, dashboardID int64) (*DashboardProvisioning, error)
 	GetProvisionedDataByDashboardUID(ctx context.Context, orgID int64, dashboardUID string) (*DashboardProvisioning, error)
-	GetProvisionedDashboardsByName(ctx context.Context, name string) ([]*Dashboard, error)
-	GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string) ([]*Dashboard, error)
+	GetProvisionedDashboardsByName(ctx context.Context, name string, orgID int64) ([]*Dashboard, error)
+	GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string, orgID int64) ([]*Dashboard, error)
 	SaveDashboard(ctx context.Context, cmd SaveDashboardCommand) (*Dashboard, error)
 	SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error)
 	UnprovisionDashboard(ctx context.Context, id int64) error

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -146,7 +146,7 @@ func (d *dashboardStore) GetProvisionedDashboardData(ctx context.Context, name s
 	return result, err
 }
 
-func (d *dashboardStore) GetProvisionedDashboardsByName(ctx context.Context, name string) ([]*dashboards.Dashboard, error) {
+func (d *dashboardStore) GetProvisionedDashboardsByName(ctx context.Context, name string, orgID int64) ([]*dashboards.Dashboard, error) {
 	ctx, span := tracer.Start(ctx, "dashboards.database.GetProvisionedDashboardsByName")
 	defer span.End()
 
@@ -154,7 +154,7 @@ func (d *dashboardStore) GetProvisionedDashboardsByName(ctx context.Context, nam
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
-			Where(`dashboard_provisioning.name = ?`, name).Find(&dashes)
+			Where(`dashboard_provisioning.name = ? AND dashboard.org_id = ?`, name, orgID).Find(&dashes)
 	})
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (d *dashboardStore) GetProvisionedDashboardsByName(ctx context.Context, nam
 	return dashes, nil
 }
 
-func (d *dashboardStore) GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string) ([]*dashboards.Dashboard, error) {
+func (d *dashboardStore) GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string, orgID int64) ([]*dashboards.Dashboard, error) {
 	ctx, span := tracer.Start(ctx, "dashboards.database.GetOrphanedProvisionedDashboards")
 	defer span.End()
 
@@ -170,6 +170,7 @@ func (d *dashboardStore) GetOrphanedProvisionedDashboards(ctx context.Context, n
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
+			Where(`dashboard.org_id = ?`, orgID).
 			NotIn(`dashboard_provisioning.name`, notIn).Find(&dashes)
 	})
 	if err != nil {

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -293,16 +293,23 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		require.Equal(t, res[0], provisioningData)
 
 		// get dashboards within the provisioner
-		dashs, err := dashboardStore.GetProvisionedDashboardsByName(context.Background(), "test")
+		dashs, err := dashboardStore.GetProvisionedDashboardsByName(context.Background(), "test", 1)
 		require.NoError(t, err)
 		require.Len(t, dashs, 1)
+		dashs, err = dashboardStore.GetProvisionedDashboardsByName(context.Background(), "test", 2)
+		require.NoError(t, err)
+		require.Len(t, dashs, 0)
 
 		// find dashboards not within that provisioner
-		dashs, err = dashboardStore.GetOrphanedProvisionedDashboards(context.Background(), []string{"test"})
+		dashs, err = dashboardStore.GetOrphanedProvisionedDashboards(context.Background(), []string{"test"}, 1)
 		require.NoError(t, err)
 		require.Len(t, dashs, 1)
+		dashs, err = dashboardStore.GetOrphanedProvisionedDashboards(context.Background(), []string{"test"}, 2)
+		require.NoError(t, err)
+		require.Len(t, dashs, 0)
+
 		// if both are provided, nothing should be returned
-		dashs, err = dashboardStore.GetOrphanedProvisionedDashboards(context.Background(), []string{"test", "orphaned"})
+		dashs, err = dashboardStore.GetOrphanedProvisionedDashboards(context.Background(), []string{"test", "orphaned"}, 1)
 		require.NoError(t, err)
 		require.Len(t, dashs, 0)
 

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -437,8 +437,8 @@ func (_m *FakeDashboardStore) GetDashboardsByPluginID(ctx context.Context, query
 }
 
 // GetOrphanedProvisionedDashboards provides a mock function with given fields: ctx, notIn
-func (_m *FakeDashboardStore) GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string) ([]*Dashboard, error) {
-	ret := _m.Called(ctx, notIn)
+func (_m *FakeDashboardStore) GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string, orgID int64) ([]*Dashboard, error) {
+	ret := _m.Called(ctx, notIn, orgID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrphanedProvisionedDashboards")
@@ -446,19 +446,19 @@ func (_m *FakeDashboardStore) GetOrphanedProvisionedDashboards(ctx context.Conte
 
 	var r0 []*Dashboard
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]*Dashboard, error)); ok {
-		return rf(ctx, notIn)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, int64) ([]*Dashboard, error)); ok {
+		return rf(ctx, notIn, orgID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []string) []*Dashboard); ok {
-		r0 = rf(ctx, notIn)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, int64) []*Dashboard); ok {
+		r0 = rf(ctx, notIn, orgID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*Dashboard)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(ctx, notIn)
+	if rf, ok := ret.Get(1).(func(context.Context, []string, int64) error); ok {
+		r1 = rf(ctx, notIn, orgID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -497,8 +497,8 @@ func (_m *FakeDashboardStore) GetProvisionedDashboardData(ctx context.Context, n
 }
 
 // GetProvisionedDashboardsByName provides a mock function with given fields: ctx, name
-func (_m *FakeDashboardStore) GetProvisionedDashboardsByName(ctx context.Context, name string) ([]*Dashboard, error) {
-	ret := _m.Called(ctx, name)
+func (_m *FakeDashboardStore) GetProvisionedDashboardsByName(ctx context.Context, name string, orgID int64) ([]*Dashboard, error) {
+	ret := _m.Called(ctx, name, orgID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProvisionedDashboardsByName")
@@ -506,19 +506,19 @@ func (_m *FakeDashboardStore) GetProvisionedDashboardsByName(ctx context.Context
 
 	var r0 []*Dashboard
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]*Dashboard, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) ([]*Dashboard, error)); ok {
+		return rf(ctx, name, orgID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []*Dashboard); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) []*Dashboard); ok {
+		r0 = rf(ctx, name, orgID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*Dashboard)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
+		r1 = rf(ctx, name, orgID)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This PR fixes provisioning in the k8s flow for multi-org, which broke when we introduced the legacy search fallback. At first it was always reaching out to unistore, which is namespaced, so this did not fail. But now, if you have provisioned dashboards and multiple orgs, grafana will not start up because the search function will return data for all orgs, and then it will fail here: https://github.com/grafana/grafana/blob/main/pkg/services/dashboards/service/dashboard_service.go#L1862 with not found.

Fixes https://github.com/grafana/app-platform-wg/issues/251