### PR TITLE
SecretsManagement: update allowed decrypters constant (and default keeper)

### DIFF
--- a/public/app/features/secrets-management/components/SecretForm.tsx
+++ b/public/app/features/secrets-management/components/SecretForm.tsx
@@ -32,7 +32,7 @@ export function SecretForm({
   disableNameField = false,
 }: BaseSecretFormProps) {
   const audiences = [
-    ...ALLOWED_SECRET_DECRYPTERS.map((audience) => ({ label: audience, value: audience })),
+    ...Object.entries(ALLOWED_SECRET_DECRYPTERS).map(([label, value]) => ({ label, value })),
     ...(initialValues?.audiences ?? []),
   ];
 

--- a/public/app/features/secrets-management/constants.ts
+++ b/public/app/features/secrets-management/constants.ts
@@ -1,10 +1,10 @@
 // @see https://github.com/grafana/grafana-enterprise/blob/secret-service/feature-branch/src/pkg/extensions/secret/decrypt/allow_list.go
-export const ALLOWED_SECRET_DECRYPTERS = [
-  'k6.grafana.app/secret-decrypter-thing',
-  'synthetic-monitoring.grafana.app/secret-decrypter-thing',
-];
+export const ALLOWED_SECRET_DECRYPTERS = {
+  'k6': 'actor_k6',
+  'Synthetic Monitoring': 'actor_synthetic-monitoring',
+};
 
-export const MOCKED_SECRET_KEEPER = 'my-keeper-1';
+export const MOCKED_SECRET_KEEPER = 'kp-default-sql';
 
 export const MOCKED_FILTER_OPTIONS = [
   { label: 'All', value: 'all' },


### PR DESCRIPTION
We've defined the initial decrypter values we'll accept on the backend, so I am changing it to reflect that (+ making it nicer by having a label)