### PR TITLE
Config: Removes setting `viewers_can_edit`

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -71,11 +71,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(org.RoleEditor)},
 	}
 
-	//nolint:staticcheck // ViewersCanEdit is deprecated but still used for backward compatibility
-	if hs.Cfg.ViewersCanEdit {
-		datasourcesExplorerRole.Grants = append(datasourcesExplorerRole.Grants, string(org.RoleViewer))
-	}
-
 	datasourcesReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Name:        "fixed:datasources:reader",

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -221,11 +221,6 @@ func (a *accessControlDashboardGuardian) CanEdit() (bool, error) {
 		return false, ErrGuardianDashboardNotFound.Errorf("failed to check edit permissions for dashboard")
 	}
 
-	//nolint:staticcheck // ViewersCanEdit is deprecated but still used for backward compatibility
-	if a.cfg.ViewersCanEdit {
-		return a.CanView()
-	}
-
 	return a.evaluate(
 		accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(a.dashboard.UID)),
 	)
@@ -234,11 +229,6 @@ func (a *accessControlDashboardGuardian) CanEdit() (bool, error) {
 func (a *accessControlFolderGuardian) CanEdit() (bool, error) {
 	if a.folder == nil {
 		return false, ErrGuardianFolderNotFound.Errorf("failed to check edit permissions for folder")
-	}
-
-	//nolint:staticcheck // ViewersCanEdit is deprecated but still used for backward compatibility
-	if a.cfg.ViewersCanEdit {
-		return a.CanView()
 	}
 
 	return a.evaluate(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(a.folder.UID)))

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -36,11 +36,10 @@ var (
 )
 
 type accessControlGuardianTestCase struct {
-	desc           string
-	dashboard      *dashboards.Dashboard
-	permissions    []accesscontrol.Permission
-	viewersCanEdit bool
-	expected       bool
+	desc        string
+	dashboard   *dashboards.Dashboard
+	permissions []accesscontrol.Permission
+	expected    bool
 }
 
 func TestAccessControlDashboardGuardian_CanSave(t *testing.T) {
@@ -258,18 +257,6 @@ func TestAccessControlDashboardGuardian_CanEdit(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc:      "should be able to edit dashboard with read action when viewer_can_edit is true",
-			dashboard: dashboard,
-			permissions: []accesscontrol.Permission{
-				{
-					Action: dashboards.ActionDashboardsRead,
-					Scope:  "dashboards:uid:1",
-				},
-			},
-			viewersCanEdit: true,
-			expected:       true,
-		},
-		{
 			desc:      "should not be able to edit folder with folder write and dashboard wildcard scope",
 			dashboard: fldr,
 			permissions: []accesscontrol.Permission{
@@ -324,25 +311,11 @@ func TestAccessControlDashboardGuardian_CanEdit(t *testing.T) {
 			},
 			expected: false,
 		},
-		{
-			desc:      "should be able to edit folder with folder read action when viewer_can_edit is true",
-			dashboard: fldr,
-			permissions: []accesscontrol.Permission{
-				{
-					Action: dashboards.ActionFoldersRead,
-					Scope:  folderUIDScope,
-				},
-			},
-			viewersCanEdit: true,
-			expected:       true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			//nolint:staticcheck
-			cfg.ViewersCanEdit = tt.viewersCanEdit
 			guardian := setupAccessControlGuardianTest(t, tt.dashboard, tt.permissions, cfg)
 
 			can, err := guardian.CanEdit()

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -30,9 +30,7 @@ type CallbackHandler func(c *contextmodel.ReqContext) response.Response
 func (s *QueryHistoryService) permissionsMiddleware(handler CallbackHandler, errorMessage string) CallbackHandler {
 	return func(c *contextmodel.ReqContext) response.Response {
 		hasAccess := ac.HasAccess(s.accessControl, c)
-		// ViewersCanEdit is deprecated but still used for backward compatibility
-		//nolint:staticcheck
-		if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
+		if c.GetOrgRole() == org.RoleViewer && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
 			return response.Error(http.StatusUnauthorized, errorMessage, nil)
 		}
 		return handler(c)

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -20,6 +20,7 @@ import {
 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
+import grafanaConfig from 'app/core/config';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 import { contextSrv } from 'app/core/core';
 import { Trans, t } from 'app/core/internationalization';
@@ -77,6 +78,11 @@ export function ToolbarActions({ dashboard }: Props) {
   const isEditingAndShowingDashboard = isEditing && isShowingDashboard;
   const dashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
   const isManaged = Boolean(dashboard.isManaged());
+
+  // Internal only;
+  // allows viewer editing without ability to save
+  // used for grafana play
+  const canEdit = grafanaConfig.viewersCanEdit;
 
   if (!isEditingPanel) {
     // This adds the presence indicators in enterprise
@@ -364,7 +370,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'main-buttons',
-    condition: !isEditing && dashboard.canEditDashboard() && !isViewingPanel && !isPlaying && editable,
+    condition: !isEditing && (dashboard.canEditDashboard() || canEdit) && !isViewingPanel && !isPlaying && editable,
     render: () => (
       <Button
         onClick={() => {


### PR DESCRIPTION
Reapplying the changes to introduce it to v12.0.x.
This reverts commit 56c896fa72529b86260f560ab14a906282a233fc.

We are removing the setting for `viewers_can_edit` as we are conslidating our settings/options into having a more opinonated view of how to run grafana. We opt of keeping the check `viewers_can_edit` setting only from the frontend. 

Fixes: https://github.com/grafana/identity-access-team/issues/1164

✅  Tested on ephemeral instance to edit a dashboard panel.

# Release notice breaking change
We're removing the `viewers_can_edit` setting in this version of Grafana. While this might require a small adjustment for some workflows, this change simplifies Grafana's configuration and strengthens security by centralizing Explore access management through roles. This ensures a more consistent and secure experience for everyone. 

- If `viewers_can_edit` is enabled for your Grafana, Viewers will no longer be able to access the Explore feature

The recommended way to give viewers access to Explore is to upgrade them to the Editor role or utilize an access control role assignment.