### PR TITLE
Secrets: remove unneeded cfg dependency on storages

### DIFF
--- a/pkg/registry/apis/secret/encryption/manager/manager_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager_test.go
@@ -90,19 +90,8 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 	// Initialize data key storage with a fake db
 	testDB := db.InitTestDB(t)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
-	defaultKey := "SdlklWklckeLS"
-	cfg := &setting.Cfg{
-		SecretsManagement: setting.SecretsManagerSettings{
-			SecretKey:          defaultKey,
-			EncryptionProvider: "secretKey.v1",
-			Encryption: setting.EncryptionSettings{
-				DataKeysCacheTTL:        5 * time.Minute,
-				DataKeysCleanupInterval: 1 * time.Nanosecond,
-				Algorithm:               "aes-cfb",
-			},
-		},
-	}
-	store, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+
+	store, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -210,7 +199,7 @@ func TestEncryptionService_UseCurrentProvider(t *testing.T) {
 
 		features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 		testDB := db.InitTestDB(t)
-		encryptionStore, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, &setting.Cfg{}, features)
+		encryptionStore, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 		require.NoError(t, err)
 
 		encryptionManager, err := ProvideEncryptionManager(
@@ -497,7 +486,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 					},
 				},
 			}
-			store, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+			store, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 			require.NoError(t, err)
 
 			usageStats := &usagestats.UsageStatsMock{T: t}

--- a/pkg/registry/apis/secret/encryption/manager/test_helpers.go
+++ b/pkg/registry/apis/secret/encryption/manager/test_helpers.go
@@ -33,7 +33,7 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 			},
 		},
 	}
-	store, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+	store, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 	require.NoError(tb, err)
 
 	usageStats := &usagestats.UsageStatsMock{T: tb}

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
@@ -53,10 +53,10 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (OSSKeeperService, error) 
 	testDB := db.InitTestDB(t)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 	require.NoError(t, err)
 
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, cfg, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, features)
 	require.NoError(t, err)
 
 	encryptionManager, err := manager.ProvideEncryptionManager(tracing.InitializeTracerForTest(), dataKeyStore, cfg, &usagestats.UsageStatsMock{T: t}, nil)

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
@@ -158,7 +158,7 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*SQLKeeper, error) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	// Initialize the encryption manager
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 	require.NoError(t, err)
 
 	usageStats := &usagestats.UsageStatsMock{T: t}
@@ -173,7 +173,7 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*SQLKeeper, error) {
 	require.NoError(t, err)
 
 	// Initialize encrypted value storage with a fake db
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, cfg, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, features)
 	require.NoError(t, err)
 
 	// Initialize the SQLKeeper

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -410,7 +410,7 @@ var wireBasicSet = wire.NewSet(
 	secretmetadata.ProvideKeeperMetadataStorage,
 	secretmetadata.ProvideDecryptStorage,
 	secretdecrypt.ProvideDecryptAllowList,
-	secretencryption.ProvideDataKeyStorageStorage,
+	secretencryption.ProvideDataKeyStorage,
 	secretencryption.ProvideEncryptedValueStorage,
 	encryptionManager.ProvideEncryptionManager,
 	gsmEncryption.ProvideThirdPartyProviderMap,

--- a/pkg/storage/secret/encryption/data_key_store_test.go
+++ b/pkg/storage/secret/encryption/data_key_store_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/stretchr/testify/require"
 )
@@ -26,8 +25,7 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	// Initialize data key storage with a fake db
 	testDB := db.InitTestDB(t)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
-	cfg := &setting.Cfg{}
-	store, err := ProvideDataKeyStorageStorage(testDB, cfg, features)
+	store, err := ProvideDataKeyStorage(testDB, features)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/storage/secret/encryption/encrypted_value_store.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -24,7 +23,7 @@ type EncryptedValueStorage interface {
 	Delete(ctx context.Context, namespace string, uid string) error
 }
 
-func ProvideEncryptedValueStorage(db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles) (EncryptedValueStorage, error) {
+func ProvideEncryptedValueStorage(db db.DB, features featuremgmt.FeatureToggles) (EncryptedValueStorage, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
 		!features.IsEnabledGlobally(featuremgmt.FlagSecretsManagementAppPlatform) {
 		return &encryptedValStorage{}, nil

--- a/pkg/storage/secret/encryption/encrypted_value_store_test.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,10 +13,9 @@ func TestEncryptedValueStoreImpl(t *testing.T) {
 	// Initialize data key storage with a fake db
 	testDB := db.InitTestDB(t)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
-	cfg := &setting.Cfg{}
 	ctx := context.Background()
 
-	store, err := ProvideEncryptedValueStorage(testDB, cfg, features)
+	store, err := ProvideEncryptedValueStorage(testDB, features)
 	require.NoError(t, err)
 
 	t.Run("creating an encrypted value returns it", func(t *testing.T) {

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -14,13 +14,11 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // TODO: this should be a "decrypt" service rather, so that other services can wire and call it.
 func ProvideDecryptStorage(
 	db db.DB,
-	cfg *setting.Cfg,
 	features featuremgmt.FeatureToggles,
 	keeperService secretkeeper.Service,
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage,

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -284,10 +284,10 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	tracer := tracing.InitializeTracerForTest()
 
 	// Initialize encryption manager and storage
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorageStorage(db, cfg, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(db, features)
 	require.NoError(t, err)
 
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(db, cfg, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(db, features)
 	require.NoError(t, err)
 
 	encryptionManager, err := encryptionmanager.ProvideEncryptionManager(
@@ -308,11 +308,11 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	require.NoError(t, err)
 
 	// Initialize the secure value storage
-	svStorage, err := ProvideSecureValueMetadataStorage(db, cfg, features, accessClient, keeperService)
+	svStorage, err := ProvideSecureValueMetadataStorage(db, features, accessClient, keeperService)
 	require.NoError(t, err)
 
 	// Initialize the decrypt storage
-	decryptSvc, err := ProvideDecryptStorage(db, cfg, features, keeperService, svStorage, allowList)
+	decryptSvc, err := ProvideDecryptStorage(db, features, keeperService, svStorage, allowList)
 	require.NoError(t, err)
 
 	return decryptSvc.(*decryptStorage), svStorage

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -12,12 +12,11 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func ProvideKeeperMetadataStorage(db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, accessClient claims.AccessClient) (contracts.KeeperMetadataStorage, error) {
+func ProvideKeeperMetadataStorage(db db.DB, features featuremgmt.FeatureToggles, accessClient claims.AccessClient) (contracts.KeeperMetadataStorage, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
 		!features.IsEnabledGlobally(featuremgmt.FlagSecretsManagementAppPlatform) {
 		return &keeperMetadataStorage{}, nil

--- a/pkg/storage/secret/metadata/secret_mgmt_test.go
+++ b/pkg/storage/secret/metadata/secret_mgmt_test.go
@@ -204,10 +204,10 @@ func setupTestService(t *testing.T) contracts.SecureValueMetadataStorage {
 
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorageStorage(testDB, cfg, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(testDB, features)
 	require.NoError(t, err)
 
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, cfg, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(testDB, features)
 	require.NoError(t, err)
 
 	// Initialize the encryption manager
@@ -229,7 +229,7 @@ func setupTestService(t *testing.T) contracts.SecureValueMetadataStorage {
 	accessClient := accesscontrol.NewLegacyAccessClient(accessControl)
 
 	// Initialize the keeper storage and add a test keeper
-	keeperStorage, err := ProvideKeeperMetadataStorage(testDB, cfg, features, accessClient)
+	keeperStorage, err := ProvideKeeperMetadataStorage(testDB, features, accessClient)
 	require.NoError(t, err)
 	testKeeper := &secretv0alpha1.Keeper{
 		Spec: secretv0alpha1.KeeperSpec{
@@ -243,7 +243,7 @@ func setupTestService(t *testing.T) contracts.SecureValueMetadataStorage {
 	require.NoError(t, err)
 
 	// Initialize the secure value storage
-	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(testDB, cfg, features, accessClient, keeperService)
+	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(testDB, features, accessClient, keeperService)
 	require.NoError(t, err)
 
 	return secureValueMetadataStorage

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -14,20 +14,21 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func ProvideSecureValueMetadataStorage(db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, accessClient claims.AccessClient, keeperService secretkeeper.Service) (contracts.SecureValueMetadataStorage, error) {
+func ProvideSecureValueMetadataStorage(db db.DB, features featuremgmt.FeatureToggles, accessClient claims.AccessClient, keeperService secretkeeper.Service) (contracts.SecureValueMetadataStorage, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
 		!features.IsEnabledGlobally(featuremgmt.FlagSecretsManagementAppPlatform) {
 		return &secureValueMetadataStorage{}, nil
 	}
 
-	if err := migrator.MigrateSecretSQL(db.GetEngine(), cfg); err != nil {
+	// Pass `cfg` as `nil` because it is not used. If it ends up being used, it will panic.
+	// This is intended, as we shouldn't need any configuration settings here for secrets migrations.
+	if err := migrator.MigrateSecretSQL(db.GetEngine(), nil); err != nil {
 		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 


### PR DESCRIPTION
Clean up removing of `setting.Cfg` dependency on our DB storages, since it's not really needed, not even to run migrations.

Also fix a small typo on `ProvideDataKeyStorageStorage` -> `ProvideDataKeyStorage`

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1191