### PR TITLE
Alerting: Remove rule type switch for modified export mode

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -320,7 +320,7 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
             {/* Step 1 */}
             <AlertRuleNameAndMetric />
             {/* Step 2 */}
-            <QueryAndExpressionsStep editingExistingRule={!!existing} onDataChange={checkAlertCondition} />
+            <QueryAndExpressionsStep editingExistingRule={!!existing} onDataChange={checkAlertCondition} mode="edit" />
             {/* Step 3-4-5 */}
             {showDataSourceDependantStep && (
               <>

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
@@ -100,7 +100,7 @@ export function ModifyExportRuleForm({ ruleForm, alertUid }: ModifyExportRuleFor
             {/* Step 1 */}
             <AlertRuleNameAndMetric />
             {/* Step 2 */}
-            <QueryAndExpressionsStep editingExistingRule={existing} onDataChange={checkAlertCondition} />
+            <QueryAndExpressionsStep editingExistingRule={existing} onDataChange={checkAlertCondition} mode="draft" />
             {/* Step 3-4-5 */}
             <GrafanaFolderAndLabelsStep />
 

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -77,9 +77,15 @@ import { useAlertQueryRunner } from './useAlertQueryRunner';
 interface Props {
   editingExistingRule: boolean;
   onDataChange: (error: string) => void;
+  /**
+   * The mode of the rule editor.
+   * - 'edit' standard rule editor mode
+   * - 'draft' non-saveable form mode used for exporting to provisioning formats
+   */
+  mode: 'edit' | 'draft';
 }
 
-export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: Props) => {
+export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mode }: Props) => {
   const {
     setValue,
     getValues,
@@ -515,12 +521,14 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
                 }}
               />
             </Field>
-            <SmartAlertTypeDetector
-              editingExistingRule={editingExistingRule}
-              queries={queries}
-              rulesSourcesWithRuler={rulesSourcesWithRuler}
-              onClickSwitch={onClickSwitch}
-            />
+            {mode === 'edit' && (
+              <SmartAlertTypeDetector
+                editingExistingRule={editingExistingRule}
+                queries={queries}
+                rulesSourcesWithRuler={rulesSourcesWithRuler}
+                onClickSwitch={onClickSwitch}
+              />
+            )}
           </Stack>
         )}
 
@@ -555,7 +563,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
               </Tooltip>
             )}
             {/* We only show Switch for Grafana managed alerts */}
-            {isGrafanaAlertingType && !simplifiedQueryStep && (
+            {isGrafanaAlertingType && !simplifiedQueryStep && mode === 'edit' && (
               <SmartAlertTypeDetector
                 editingExistingRule={editingExistingRule}
                 rulesSourcesWithRuler={rulesSourcesWithRuler}


### PR DESCRIPTION
**What is this feature?**
This PR removes the rule type switch component when using the form in the modified export mode

**Why do we need this feature?**
Modified export mode is only available for GMA. 
When exporting existing rule it's not an issue (although clutters the interface) but when creating a new rule in the export mode, the user can switch the rule type, and the form throws errors when the user switches to Data-source managed

<img width="447" alt="image" src="https://github.com/user-attachments/assets/81c51c23-7eed-4746-9bf7-d726963ebee1" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
