### PR TITLE
Alerting: Fix rule instances table

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -34,6 +34,8 @@ export const RuleDetails = ({ rule }: Props) => {
   } = rule;
 
   const annotations = useCleanAnnotations(rule.annotations);
+  const isAlertingRule =
+    rulerRuleType.any.alertingRule(rule.rulerRule) || prometheusRuleType.alertingRule(rule.promRule);
 
   return (
     <div>
@@ -53,12 +55,11 @@ export const RuleDetails = ({ rule }: Props) => {
           <RuleDetailsDataSources rulesSource={rulesSource} rule={rule} />
         </div>
       </div>
-      {rulerRuleType.any.alertingRule(rule.rulerRule) ||
-        (prometheusRuleType.alertingRule(rule.promRule) && (
-          <DetailsField label="Instances" horizontal={true}>
-            <RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={INSTANCES_DISPLAY_LIMIT} />
-          </DetailsField>
-        ))}
+      {isAlertingRule && (
+        <DetailsField label="Instances" horizontal={true}>
+          <RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={INSTANCES_DISPLAY_LIMIT} />
+        </DetailsField>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
**What is this feature?**
This PR fixes the condition which control displaying the list of alert instances in the alert list page

This resolves a regression that occurred due to recent refactoring.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
