### PR TITLE
Grafana-UI: Support theme color in TagsInput

### DIFF
--- a/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
@@ -12,20 +12,20 @@ interface Props {
   name: string;
   disabled?: boolean;
   onRemove: (tag: string) => void;
-  useThemeColors?: boolean;
+  disableColoredTags?: boolean;
 }
 
 /**
  * @internal
  * Only used internally by TagsInput
  * */
-export const TagItem = ({ name, disabled, onRemove, useThemeColors }: Props) => {
+export const TagItem = ({ name, disabled, onRemove, disableColoredTags }: Props) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
 
   // Use theme colors or random colors based on name
   const tagStyle = useMemo(() => {
-    if (useThemeColors) {
+    if (disableColoredTags) {
       return {
         backgroundColor: theme.colors.background.secondary,
         borderColor: theme.components.input.borderColor,
@@ -35,7 +35,7 @@ export const TagItem = ({ name, disabled, onRemove, useThemeColors }: Props) => 
 
     const { color, borderColor } = getTagColorsFromName(name);
     return { backgroundColor: color, borderColor };
-  }, [name, useThemeColors, theme]);
+  }, [name, disableColoredTags, theme]);
 
   return (
     <li className={styles.itemStyle} style={tagStyle}>

--- a/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
@@ -1,9 +1,9 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { useStyles2, useTheme2 } from '../../themes';
+import { useStyles2 } from '../../themes';
 import { getTagColorsFromName } from '../../utils';
 import { t } from '../../utils/i18n';
 import { IconButton } from '../IconButton/IconButton';
@@ -12,33 +12,29 @@ interface Props {
   name: string;
   disabled?: boolean;
   onRemove: (tag: string) => void;
-  disableColoredTags?: boolean;
+
+  /** Colours the tags 'randomly' based on the name. Defaults to true */
+  autoColors?: boolean;
 }
 
 /**
  * @internal
  * Only used internally by TagsInput
  * */
-export const TagItem = ({ name, disabled, onRemove, disableColoredTags }: Props) => {
-  const theme = useTheme2();
+export const TagItem = ({ name, disabled, onRemove, autoColors = true }: Props) => {
   const styles = useStyles2(getStyles);
 
   // Use theme colors or random colors based on name
   const tagStyle = useMemo(() => {
-    if (disableColoredTags) {
-      return {
-        backgroundColor: theme.colors.background.secondary,
-        borderColor: theme.components.input.borderColor,
-        color: theme.colors.text.primary,
-      };
+    if (autoColors) {
+      const { color, borderColor } = getTagColorsFromName(name);
+      return { backgroundColor: color, borderColor };
     }
-
-    const { color, borderColor } = getTagColorsFromName(name);
-    return { backgroundColor: color, borderColor };
-  }, [name, disableColoredTags, theme]);
+    return undefined;
+  }, [name, autoColors]);
 
   return (
-    <li className={styles.itemStyle} style={tagStyle}>
+    <li className={cx(styles.itemStyle, !tagStyle && styles.defaultTagColor)} style={tagStyle}>
       <span className={styles.nameStyle}>{name}</span>
       <IconButton
         name="times"
@@ -62,7 +58,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       height: `${height}px`,
       lineHeight: `${height - 2}px`,
-      color: '#fff',
       borderWidth: '1px',
       borderStyle: 'solid',
       borderRadius: theme.shape.radius.default,
@@ -71,6 +66,12 @@ const getStyles = (theme: GrafanaTheme2) => {
       textShadow: 'none',
       fontWeight: 500,
       fontSize: theme.typography.size.sm,
+      color: '#fff',
+    }),
+    defaultTagColor: css({
+      backgroundColor: theme.colors.background.secondary,
+      borderColor: theme.components.input.borderColor,
+      color: theme.colors.text.primary,
     }),
     nameStyle: css({
       maxWidth: '25ch',

--- a/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { useStyles2 } from '../../themes';
+import { useStyles2, useTheme2 } from '../../themes';
 import { getTagColorsFromName } from '../../utils';
 import { t } from '../../utils/i18n';
 import { IconButton } from '../IconButton/IconButton';
@@ -12,18 +12,33 @@ interface Props {
   name: string;
   disabled?: boolean;
   onRemove: (tag: string) => void;
+  useThemeColors?: boolean;
 }
 
 /**
  * @internal
  * Only used internally by TagsInput
  * */
-export const TagItem = ({ name, disabled, onRemove }: Props) => {
-  const { color, borderColor } = useMemo(() => getTagColorsFromName(name), [name]);
+export const TagItem = ({ name, disabled, onRemove, useThemeColors }: Props) => {
+  const theme = useTheme2();
   const styles = useStyles2(getStyles);
 
+  // Use theme colors or random colors based on name
+  const tagStyle = useMemo(() => {
+    if (useThemeColors) {
+      return {
+        backgroundColor: theme.colors.background.secondary,
+        borderColor: theme.components.input.borderColor,
+        color: theme.colors.text.primary,
+      };
+    }
+
+    const { color, borderColor } = getTagColorsFromName(name);
+    return { backgroundColor: color, borderColor };
+  }, [name, useThemeColors, theme]);
+
   return (
-    <li className={styles.itemStyle} style={{ backgroundColor: color, borderColor }}>
+    <li className={styles.itemStyle} style={tagStyle}>
       <span className={styles.nameStyle}>{name}</span>
       <IconButton
         name="times"

--- a/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagItem.tsx
@@ -24,7 +24,8 @@ interface Props {
 export const TagItem = ({ name, disabled, onRemove, autoColors = true }: Props) => {
   const styles = useStyles2(getStyles);
 
-  // Use theme colors or random colors based on name
+  // If configured, use random colors based on name.
+  // Otherwise, a default class name will be applied to the tag.
   const tagStyle = useMemo(() => {
     if (autoColors) {
       const { color, borderColor } = getTagColorsFromName(name);

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -25,6 +25,8 @@ export interface Props {
   addOnBlur?: boolean;
   /** Toggle invalid state */
   invalid?: boolean;
+  /** Use theme colors instead of random colors for tags */
+  useThemeColors?: boolean;
 }
 
 export const TagsInput = ({
@@ -37,6 +39,7 @@ export const TagsInput = ({
   addOnBlur,
   invalid,
   id,
+  useThemeColors,
 }: Props) => {
   const [newTagName, setNewTagName] = useState('');
   const styles = useStyles2(getStyles);
@@ -96,7 +99,7 @@ export const TagsInput = ({
       {tags?.length > 0 && (
         <ul className={styles.tags}>
           {tags.map((tag) => (
-            <TagItem key={tag} name={tag} onRemove={onRemove} disabled={disabled} />
+            <TagItem key={tag} name={tag} onRemove={onRemove} disabled={disabled} useThemeColors={useThemeColors} />
           ))}
         </ul>
       )}

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -25,8 +25,8 @@ export interface Props {
   addOnBlur?: boolean;
   /** Toggle invalid state */
   invalid?: boolean;
-  /** Disable colored tags and use theme colors instead */
-  disableColoredTags?: boolean;
+  /** Colours the tags 'randomly' based on the name. Defaults to true */
+  autoColors?: boolean;
 }
 
 export const TagsInput = ({
@@ -39,7 +39,7 @@ export const TagsInput = ({
   addOnBlur,
   invalid,
   id,
-  disableColoredTags,
+  autoColors = true,
 }: Props) => {
   const [newTagName, setNewTagName] = useState('');
   const styles = useStyles2(getStyles);
@@ -99,13 +99,7 @@ export const TagsInput = ({
       {tags?.length > 0 && (
         <ul className={styles.tags}>
           {tags.map((tag) => (
-            <TagItem
-              key={tag}
-              name={tag}
-              onRemove={onRemove}
-              disabled={disabled}
-              disableColoredTags={disableColoredTags}
-            />
+            <TagItem key={tag} name={tag} onRemove={onRemove} disabled={disabled} autoColors={autoColors} />
           ))}
         </ul>
       )}

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -25,8 +25,8 @@ export interface Props {
   addOnBlur?: boolean;
   /** Toggle invalid state */
   invalid?: boolean;
-  /** Use theme colors instead of random colors for tags */
-  useThemeColors?: boolean;
+  /** Disable colored tags and use theme colors instead */
+  disableColoredTags?: boolean;
 }
 
 export const TagsInput = ({
@@ -39,7 +39,7 @@ export const TagsInput = ({
   addOnBlur,
   invalid,
   id,
-  useThemeColors,
+  disableColoredTags,
 }: Props) => {
   const [newTagName, setNewTagName] = useState('');
   const styles = useStyles2(getStyles);
@@ -99,7 +99,13 @@ export const TagsInput = ({
       {tags?.length > 0 && (
         <ul className={styles.tags}>
           {tags.map((tag) => (
-            <TagItem key={tag} name={tag} onRemove={onRemove} disabled={disabled} useThemeColors={useThemeColors} />
+            <TagItem
+              key={tag}
+              name={tag}
+              onRemove={onRemove}
+              disabled={disabled}
+              disableColoredTags={disableColoredTags}
+            />
           ))}
         </ul>
       )}


### PR DESCRIPTION
**What is this feature?**

We need to use the tags component without the random color feature.
This PR supports using the same color in all tags depending on Grafana theme colors.

Currently only possibility
![image](https://github.com/user-attachments/assets/88959740-843e-462d-9324-cbd45b5f7a9a)

New options
![image](https://github.com/user-attachments/assets/2c9fa9ef-1dee-4d5e-8728-ca9a33ae8904)
![image](https://github.com/user-attachments/assets/1a7bdd47-d09f-4350-8fe1-28033bcab0f6)

**Why do we need this feature?**

We want to use the component without the need to override CSS styles using `!important`


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
