### PR TITLE
fix(prom): return label keys from prometheus language providers

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -470,6 +470,34 @@ describe('Language completion provider', () => {
           )
         );
       });
+
+      it('should set `labelKeys` on language provider', async () => {
+        const mockQueries: PromQuery[] = [
+          {
+            refId: 'C',
+            expr: 'go_gc_pauses_seconds_bucket',
+          },
+        ];
+        const fetchLabel = languageProvider.fetchLabels;
+        const requestSpy = jest.spyOn(languageProvider, 'request').mockResolvedValue(['foo', 'bar']);
+        await fetchLabel(tr, mockQueries);
+        expect(requestSpy).toHaveBeenCalled();
+        expect(languageProvider.labelKeys).toEqual(['bar', 'foo']);
+      });
+
+      it('should return labelKeys from request', async () => {
+        const mockQueries: PromQuery[] = [
+          {
+            refId: 'C',
+            expr: 'go_gc_pauses_seconds_bucket',
+          },
+        ];
+        const fetchLabel = languageProvider.fetchLabels;
+        const requestSpy = jest.spyOn(languageProvider, 'request').mockResolvedValue(['foo', 'bar']);
+        const keys = await fetchLabel(tr, mockQueries);
+        expect(requestSpy).toHaveBeenCalled();
+        expect(keys).toEqual(['bar', 'foo']);
+      });
     });
 
     describe('with GET', () => {

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -251,6 +251,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const res = await this.request(url, [], searchParams, this.getDefaultCacheHeaders());
     if (Array.isArray(res)) {
       this.labelKeys = res.slice().sort();
+      return res.slice().sort();
     }
 
     return [];


### PR DESCRIPTION
**What is this feature?**

The return type of `fetchLabels` is `Promise<string[]>` but in fact it would always only return an empty array. This PR is fixing this behavior by returning the label keys from the API.