### PR TITLE
SecureValues: Move authz+filtering of List to reststorage layer

### DIFF
--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -6,7 +6,6 @@ import (
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -20,7 +19,7 @@ type KeeperMetadataStorage interface {
 	Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.Keeper, error)
 	Update(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
-	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
+	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.Keeper, error)
 }
 
 // ErrKeeperInvalidSecureValues is returned when a Keeper references SecureValues that do not exist.

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -6,7 +6,6 @@ import (
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 )
 
 var (
@@ -19,5 +18,5 @@ type SecureValueMetadataStorage interface {
 	Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.SecureValue, error)
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
-	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
+	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.SecureValue, error)
 }

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -143,10 +143,10 @@ func (b *SecretAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	secureRestStorage := map[string]rest.Storage{
 		// Default path for `securevalue`.
 		// The `reststorage.SecureValueRest` struct will implement interfaces for CRUDL operations on `securevalue`.
-		secureValueResource.StoragePath(): reststorage.NewSecureValueRest(b.secureValueMetadataStorage, secureValueResource),
+		secureValueResource.StoragePath(): reststorage.NewSecureValueRest(b.secureValueMetadataStorage, b.accessClient, secureValueResource),
 
 		// The `reststorage.KeeperRest` struct will implement interfaces for CRUDL operations on `keeper`.
-		keeperResource.StoragePath(): reststorage.NewKeeperRest(b.keeperMetadataStorage, keeperResource),
+		keeperResource.StoragePath(): reststorage.NewKeeperRest(b.keeperMetadataStorage, b.accessClient, keeperResource),
 	}
 
 	apiGroupInfo.VersionedResourcesStorageMap[secretv0alpha1.VERSION] = secureRestStorage

--- a/pkg/registry/apis/secret/reststorage/keeper_fake.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_fake.go
@@ -9,7 +9,6 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -89,7 +88,7 @@ func (s *fakeKeeperMetadataStorage) Delete(ctx context.Context, namespace xkube.
 	return nil
 }
 
-func (s *fakeKeeperMetadataStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error) {
+func (s *fakeKeeperMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.Keeper, error) {
 	ns, ok := s.values[namespace.String()]
 	if !ok {
 		s.values[namespace.String()] = ns
@@ -98,7 +97,5 @@ func (s *fakeKeeperMetadataStorage) List(ctx context.Context, namespace xkube.Na
 	for _, v := range ns {
 		l = append(l, v)
 	}
-	return &secretv0alpha1.KeeperList{
-		Items: l,
-	}, nil
+	return l, nil
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_fake.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_fake.go
@@ -9,7 +9,6 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -99,7 +98,7 @@ func (s *fakeSecureValueMetadataStorage) Delete(ctx context.Context, namespace x
 	return nil
 }
 
-func (s *fakeSecureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error) {
+func (s *fakeSecureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.SecureValue, error) {
 	ns, ok := s.values[namespace.String()]
 	if !ok {
 		ns = make(map[string]secretv0alpha1.SecureValue)
@@ -109,7 +108,5 @@ func (s *fakeSecureValueMetadataStorage) List(ctx context.Context, namespace xku
 	for _, v := range ns {
 		l = append(l, v)
 	}
-	return &secretv0alpha1.SecureValueList{
-		Items: l,
-	}, nil
+	return l, nil
 }

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -18,8 +18,6 @@ import (
 	encryptionmanager "github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -299,16 +297,12 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	)
 	require.NoError(t, err)
 
-	// Initialize access control and client
-	accessControl := acimpl.ProvideAccessControl(features)
-	accessClient := accesscontrol.NewLegacyAccessClient(accessControl)
-
 	// Initialize the keeper service
 	keeperService, err := secretkeeper.ProvideService(tracer, encValueStore, encryptionManager)
 	require.NoError(t, err)
 
 	// Initialize the secure value storage
-	svStorage, err := ProvideSecureValueMetadataStorage(db, features, accessClient, keeperService)
+	svStorage, err := ProvideSecureValueMetadataStorage(db, features, keeperService)
 	require.NoError(t, err)
 
 	// Initialize the decrypt storage

--- a/pkg/storage/secret/metadata/secret_mgmt_test.go
+++ b/pkg/storage/secret/metadata/secret_mgmt_test.go
@@ -19,8 +19,6 @@ import (
 	encryptionmanager "github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	encryptionstorage "github.com/grafana/grafana/pkg/storage/secret/encryption"
@@ -224,12 +222,8 @@ func setupTestService(t *testing.T) contracts.SecureValueMetadataStorage {
 	keeperService, err := secretkeeper.ProvideService(tracing.InitializeTracerForTest(), encValueStore, encMgr)
 	require.NoError(t, err)
 
-	// Initialize access client + access control
-	accessControl := &actest.FakeAccessControl{ExpectedEvaluate: true}
-	accessClient := accesscontrol.NewLegacyAccessClient(accessControl)
-
 	// Initialize the keeper storage and add a test keeper
-	keeperStorage, err := ProvideKeeperMetadataStorage(testDB, features, accessClient)
+	keeperStorage, err := ProvideKeeperMetadataStorage(testDB, features)
 	require.NoError(t, err)
 	testKeeper := &secretv0alpha1.Keeper{
 		Spec: secretv0alpha1.KeeperSpec{
@@ -243,7 +237,7 @@ func setupTestService(t *testing.T) contracts.SecureValueMetadataStorage {
 	require.NoError(t, err)
 
 	// Initialize the secure value storage
-	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(testDB, features, accessClient, keeperService)
+	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(testDB, features, keeperService)
 	require.NoError(t, err)
 
 	return secureValueMetadataStorage


### PR DESCRIPTION
Delegates filtering and custom authz (based on resource name) to the `reststorage` layer, and the "DB" layer is unawares.