### PR TITLE
Alerting: Make $value return the query value in case when a single datasource is used

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/reference.md
+++ b/docs/sources/alerting/alerting-rules/templates/reference.md
@@ -80,10 +80,10 @@ Templates are based on the **Go templating system**. Refer to [Template language
 
 The following variables are available when templating annotations and labels:
 
-| Variables          | Description                                                                                                                                                                                                                                                                          |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                                                                                                                                                               |
-| [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                                                                                                                                                      |
+| Variables          | Description                                                                                                                                                                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                                                                                                                                                           |
+| [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                                                                                                                                                  |
 | [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. When a single data source is used, it returns the value of the query. It is generally recommended to use [$values](#values). |
 
 ### $labels

--- a/docs/sources/alerting/alerting-rules/templates/reference.md
+++ b/docs/sources/alerting/alerting-rules/templates/reference.md
@@ -84,7 +84,7 @@ The following variables are available when templating annotations and labels:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                                                                                                                                                               |
 | [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                                                                                                                                                      |
-| [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. When a single data source is used, it returns the value of the query. Using [$values](#values) instead is generally recommended. |
+| [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. When a single data source is used, it returns the value of the query. It is generally recommended to use [$values](#values). |
 
 ### $labels
 

--- a/docs/sources/alerting/alerting-rules/templates/reference.md
+++ b/docs/sources/alerting/alerting-rules/templates/reference.md
@@ -80,11 +80,11 @@ Templates are based on the **Go templating system**. Refer to [Template language
 
 The following variables are available when templating annotations and labels:
 
-| Variables          | Description                                                                                                                                         |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                              |
-| [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                     |
-| [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. |
+| Variables          | Description                                                                                                                                                                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [$labels](#labels) | Contains all labels from the query, only query labels.                                                                                                                                                                                                                               |
+| [$values](#values) | Contains the labels and floating point values of all instant queries and expressions, indexed by their Ref IDs.                                                                                                                                                                      |
+| [$value](#value)   | A string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule. When a single data source is used, it returns the value of the query. Using [$values](#values) instead is generally recommended. |
 
 ### $labels
 
@@ -145,16 +145,24 @@ Alternatively, you can use the `index()` function to retrieve the query value:
 
 The `$value` variable is a string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule.
 
+When a single data source is used in the alert rule, `$value` will return the query value directly.
+
 This example prints the `$value` variable:
 
 ```
 {{ $value }}: CPU usage has exceeded 80% for the last 5 minutes.
 ```
 
-It would display something like this:
+When using multiple data sources, it would display something like this:
 
 ```
-[ var='A' labels={instance=instance1} value=81.234 ]: CPU usage has exceeded 80% for the last 5 minutes.
+[ var='A' labels={instance=instance1} value=81.234, , [ var='B' labels={instance=instance2} value=1 ] ]: CPU usage has exceeded 80% for the last 5 minutes.
+```
+
+But with a single data source, it would display just the value of the query:
+
+```
+81.234: CPU usage has exceeded 80% for the last 5 minutes.
 ```
 
 Instead, we recommend using [$values](#values), which contains the same information as `$value` but is structured in an easier-to-use table format.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -434,9 +434,9 @@ func getExprRequest(ctx EvaluationContext, condition models.Condition, dsCacheSe
 }
 
 type NumberValueCapture struct {
-	Var    string // RefID
-	Type   expr.NodeType
-	Labels data.Labels
+	Var              string // RefID
+	IsDatasourceNode bool
+	Labels           data.Labels
 
 	Value *float64
 }
@@ -469,10 +469,10 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 		}
 		fp := labels.Fingerprint()
 		m[fp] = NumberValueCapture{
-			Var:    refID,
-			Type:   datasourceType,
-			Value:  value,
-			Labels: labels.Copy(),
+			Var:              refID,
+			IsDatasourceNode: datasourceType == expr.TypeDatasourceNode,
+			Value:            value,
+			Labels:           labels.Copy(),
 		}
 		captures[refID] = m
 	}

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -787,9 +787,9 @@ func TestQueryDataResponseToExecutionResults(t *testing.T) {
 		require.Len(t, evaluatedResults, 1)
 		result := evaluatedResults[0]
 
-		// Validate that datasource types were correctly set
-		require.Equal(t, expr.TypeDatasourceNode, result.Values["A"].Type)
-		require.Equal(t, expr.TypeCMDNode, result.Values["B"].Type)
+		// Validate that IsDatasourceNode were correctly set
+		require.True(t, result.Values["A"].IsDatasourceNode)
+		require.False(t, result.Values["B"].IsDatasourceNode)
 	})
 }
 
@@ -1154,10 +1154,10 @@ func TestEvaluate(t *testing.T) {
 							Meta: &data.FrameMeta{
 								Custom: []NumberValueCapture{
 									{
-										Var:    "B",
-										Type:   expr.TypeCMDNode,
-										Labels: data.Labels{"foo": "bar"},
-										Value:  util.Pointer(15.0),
+										Var:              "B",
+										IsDatasourceNode: false,
+										Labels:           data.Labels{"foo": "bar"},
+										Value:            util.Pointer(15.0),
 									},
 								},
 							},
@@ -1177,16 +1177,16 @@ func TestEvaluate(t *testing.T) {
 							Meta: &data.FrameMeta{
 								Custom: []NumberValueCapture{
 									{
-										Var:    "B",
-										Type:   expr.TypeCMDNode,
-										Labels: data.Labels{"foo": "bar"},
-										Value:  util.Pointer(15.0),
+										Var:              "B",
+										IsDatasourceNode: false,
+										Labels:           data.Labels{"foo": "bar"},
+										Value:            util.Pointer(15.0),
 									},
 									{
-										Var:    "C",
-										Type:   expr.TypeCMDNode,
-										Labels: data.Labels{"foo": "bar"},
-										Value:  util.Pointer(1.0),
+										Var:              "C",
+										IsDatasourceNode: false,
+										Labels:           data.Labels{"foo": "bar"},
+										Value:            util.Pointer(1.0),
 									},
 								},
 							},
@@ -1201,16 +1201,16 @@ func TestEvaluate(t *testing.T) {
 				},
 				Values: map[string]NumberValueCapture{
 					"B": {
-						Var:    "B",
-						Type:   expr.TypeCMDNode,
-						Labels: data.Labels{"foo": "bar"},
-						Value:  util.Pointer(15.0),
+						Var:              "B",
+						IsDatasourceNode: false,
+						Labels:           data.Labels{"foo": "bar"},
+						Value:            util.Pointer(15.0),
 					},
 					"C": {
-						Var:    "C",
-						Type:   expr.TypeCMDNode,
-						Labels: data.Labels{"foo": "bar"},
-						Value:  util.Pointer(1.0),
+						Var:              "C",
+						IsDatasourceNode: false,
+						Labels:           data.Labels{"foo": "bar"},
+						Value:            util.Pointer(1.0),
 					},
 				},
 				// Note the absence of "A" in the EvaluationString.

--- a/pkg/services/ngalert/state/template/template.go
+++ b/pkg/services/ngalert/state/template/template.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/template"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 )
 
@@ -42,8 +43,9 @@ func (l Labels) String() string {
 // Value contains the labels and value of a Reduce, Math or Threshold
 // expression for a series.
 type Value struct {
-	Labels Labels
-	Value  float64
+	Labels   Labels
+	Value    float64
+	nodeType expr.NodeType
 }
 
 func (v Value) String() string {
@@ -63,8 +65,9 @@ func NewValues(captures map[string]eval.NumberValueCapture) map[string]Value {
 			f = math.NaN()
 		}
 		values[refID] = Value{
-			Labels: Labels(capture.Labels),
-			Value:  f,
+			Labels:   Labels(capture.Labels),
+			Value:    f,
+			nodeType: capture.Type,
 		}
 	}
 	return values
@@ -73,14 +76,43 @@ func NewValues(captures map[string]eval.NumberValueCapture) map[string]Value {
 type Data struct {
 	Labels Labels
 	Values map[string]Value
-	Value  string
+
+	// Value is the .Value and $value variables in templates.
+	// For single datasource queries, this will be the numeric value of the query.
+	// For multiple datasource queries, this will be the evaluation string.
+	Value string
 }
 
 func NewData(labels map[string]string, res eval.Result) Data {
+	values := NewValues(res.Values)
+
+	// By default, use the evaluation string as the Value
+	valueStr := res.EvaluationString
+
+	// If there's exactly one datasource node, use its value instead
+	// This makes the $value variable compatible with Prometheus templating
+	// where $value holds the numeric value of the alert query
+	datasourceNodeCount := 0
+	var datasourceNodeValue Value
+	for _, v := range values {
+		if v.nodeType == expr.TypeDatasourceNode {
+			datasourceNodeCount++
+			if datasourceNodeCount > 1 {
+				// Multiple datasource nodes found, we'll use the evaluation string
+				break
+			}
+			datasourceNodeValue = v
+		}
+	}
+
+	if datasourceNodeCount == 1 {
+		valueStr = datasourceNodeValue.String()
+	}
+
 	return Data{
 		Labels: labels,
-		Values: NewValues(res.Values),
-		Value:  res.EvaluationString,
+		Values: values,
+		Value:  valueStr,
 	}
 }
 

--- a/pkg/services/ngalert/state/template/template.go
+++ b/pkg/services/ngalert/state/template/template.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/template"
 
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 )
 
@@ -43,9 +42,9 @@ func (l Labels) String() string {
 // Value contains the labels and value of a Reduce, Math or Threshold
 // expression for a series.
 type Value struct {
-	Labels   Labels
-	Value    float64
-	nodeType expr.NodeType
+	Labels           Labels
+	Value            float64
+	isDatasourceNode bool
 }
 
 func (v Value) String() string {
@@ -65,9 +64,9 @@ func NewValues(captures map[string]eval.NumberValueCapture) map[string]Value {
 			f = math.NaN()
 		}
 		values[refID] = Value{
-			Labels:   Labels(capture.Labels),
-			Value:    f,
-			nodeType: capture.Type,
+			Labels:           Labels(capture.Labels),
+			Value:            f,
+			isDatasourceNode: capture.IsDatasourceNode,
 		}
 	}
 	return values
@@ -95,7 +94,7 @@ func NewData(labels map[string]string, res eval.Result) Data {
 	datasourceNodeCount := 0
 	var datasourceNodeValue Value
 	for _, v := range values {
-		if v.nodeType == expr.TypeDatasourceNode {
+		if v.isDatasourceNode {
 			datasourceNodeCount++
 			if datasourceNodeCount > 1 {
 				// Multiple datasource nodes found, we'll use the evaluation string

--- a/pkg/services/ngalert/state/template/template_test.go
+++ b/pkg/services/ngalert/state/template/template_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -78,10 +77,10 @@ func TestNewData(t *testing.T) {
 			EvaluationString: "[ var='A' labels={instance=foo} value=10 ]",
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeCMDNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
+					Var:              "A",
+					IsDatasourceNode: false,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
 				},
 			},
 		}
@@ -95,16 +94,16 @@ func TestNewData(t *testing.T) {
 			EvaluationString: "[ var='A' labels={instance=foo} value=10 ]",
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
+					Var:              "A",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
 				},
 				"B": {
-					Var:    "B",
-					Type:   expr.TypeCMDNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(20.0),
+					Var:              "B",
+					IsDatasourceNode: false,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(20.0),
 				},
 			},
 		}
@@ -118,16 +117,16 @@ func TestNewData(t *testing.T) {
 			EvaluationString: "[ var='A' labels={instance=foo} value=10 ]",
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
+					Var:              "A",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
 				},
 				"B": {
-					Var:    "B",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "bar"},
-					Value:  util.Pointer(20.0),
+					Var:              "B",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "bar"},
+					Value:            util.Pointer(20.0),
 				},
 			},
 		}
@@ -150,10 +149,10 @@ func TestDatasourceValueInTemplating(t *testing.T) {
 			EvaluationString: "[ var='A' labels={instance=foo} value=no data ]",
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  nil, // nil value
+					Var:              "A",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            nil, // nil value
 				},
 			},
 		}
@@ -168,22 +167,22 @@ func TestDatasourceValueInTemplating(t *testing.T) {
 			EvaluationString: "[ var='A' labels={instance=foo} value=10, var='B' labels={instance=foo} value=20, var='C' labels={instance=foo} value=30 ]",
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
+					Var:              "A",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
 				},
 				"B": {
-					Var:    "B",
-					Type:   expr.TypeCMDNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(20.0),
+					Var:              "B",
+					IsDatasourceNode: false,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(20.0),
 				},
 				"C": {
-					Var:    "C",
-					Type:   expr.TypeCMDNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(30.0),
+					Var:              "C",
+					IsDatasourceNode: false,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(30.0),
 				},
 			},
 		}
@@ -198,22 +197,22 @@ func TestDatasourceValueInTemplating(t *testing.T) {
 			EvaluationString: evalStr,
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
+					Var:              "A",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
 				},
 				"B": {
-					Var:    "B",
-					Type:   expr.TypeDatasourceNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(20.0),
+					Var:              "B",
+					IsDatasourceNode: true,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(20.0),
 				},
 				"C": {
-					Var:    "C",
-					Type:   expr.TypeCMDNode,
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(30.0),
+					Var:              "C",
+					IsDatasourceNode: false,
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(30.0),
 				},
 			},
 		}
@@ -264,10 +263,10 @@ func TestExpandTemplate(t *testing.T) {
 		alertInstance: eval.Result{
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(1.1),
-					Type:   expr.TypeDatasourceNode,
+					Var:              "A",
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(1.1),
+					IsDatasourceNode: true,
 				},
 			},
 		},
@@ -278,10 +277,10 @@ func TestExpandTemplate(t *testing.T) {
 		alertInstance: eval.Result{
 			Values: map[string]eval.NumberValueCapture{
 				"A": {
-					Var:    "A",
-					Labels: data.Labels{},
-					Value:  util.Pointer(1.0),
-					Type:   expr.TypeDatasourceNode,
+					Var:              "A",
+					Labels:           data.Labels{},
+					Value:            util.Pointer(1.0),
+					IsDatasourceNode: true,
 				},
 			},
 		},
@@ -308,16 +307,16 @@ func TestExpandTemplate(t *testing.T) {
 		alertInstance: eval.Result{
 			Values: map[string]eval.NumberValueCapture{
 				"query": {
-					Var:    "query",
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.123),
-					Type:   expr.TypeDatasourceNode,
+					Var:              "query",
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.123),
+					IsDatasourceNode: true,
 				},
 				"math": {
-					Var:    "math",
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.0),
-					Type:   expr.TypeCMDNode,
+					Var:              "math",
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.0),
+					IsDatasourceNode: false,
 				},
 			},
 			EvaluationString: "[ var='query' labels={instance=foo} value=10.123, var='math' labels={instance=foo} value=10 ]",
@@ -334,16 +333,16 @@ func TestExpandTemplate(t *testing.T) {
 		alertInstance: eval.Result{
 			Values: map[string]eval.NumberValueCapture{
 				"query": {
-					Var:    "query",
-					Labels: data.Labels{"instance": "foo"},
-					Value:  util.Pointer(10.123),
-					Type:   expr.TypeDatasourceNode,
+					Var:              "query",
+					Labels:           data.Labels{"instance": "foo"},
+					Value:            util.Pointer(10.123),
+					IsDatasourceNode: true,
 				},
 				"second-query": {
-					Var:    "second-query",
-					Labels: data.Labels{"instance": "bar"},
-					Value:  util.Pointer(20.456),
-					Type:   expr.TypeDatasourceNode,
+					Var:              "second-query",
+					Labels:           data.Labels{"instance": "bar"},
+					Value:            util.Pointer(20.456),
+					IsDatasourceNode: true,
 				},
 			},
 			EvaluationString: "[ var='query' labels={instance=foo} value=10.123, var='second-query' labels={instance=bar} value=20.456 ]",


### PR DESCRIPTION
**What is this feature?**

This PR changes the behavior of the `$value` and `.Value` variables in alerting templating to be more compatible with Prometheus templating. When a single datasource is used in the alerting rule, these variables will now return the numeric value from the query instead of the evaluation string.

**Why do we need this feature?**

It makes Grafana templating more compatible with Prometheus templates. In Prometheus, `$value` returns the numeric value of the query, but in Grafana it's the evaluation string: `[ var='A' labels={instance=instance1} value=81.234 ]`. This is because in Grafana multiple datasources can be used in the alert rule, and it's not always possible to get a single value.

This change makes Grafana's behavior consistent with Prometheus when a single datasource is used, and in case when multiple datasources are used in the query, it keeps the old behaviour.

Both `$value` and `.Value` are **not recommended** to use ([documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules/templates/reference/#value)), and it's better to use `.Values` instead.

<details>

<summary><h4>Screenshots</h4></summary>

Query with 2 series:

```
label_replace(
    vector(time() % 3 + 0.123), "my_label", "query_1", "__name__", ".*"
) or label_replace(
    vector(time() % 2 + 0.456), "my_label", "query_2", "__name__", ".*"
)
```

Template:

```
$value: {{ $value }}
.Values: {{ .Value }}
$values: {{ $values }}
.Values: {{ .Values }}
```

### Before
<img width="934" alt="Screenshot 2025-03-24 at 15 53 32" src="https://github.com/user-attachments/assets/3c2606f4-c8db-4693-8462-4c04e8594453" />


### After
<img width="915" alt="Screenshot 2025-03-24 at 15 55 52" src="https://github.com/user-attachments/assets/e8dc3544-ca57-421d-9db5-b8818b6833c9" />

</details>


**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/1078

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

# Release notice breaking change

The behavior of `$value` and `.Value` variables in alerting templating has been changed. When a single datasource is used in an alerting rule, these variables will now return the numeric value from the query instead of the evaluation string. This changes the previous behavior where these variables would always return the full evaluation string (e.g., `[ var='A' labels={instance=instance1} value=81.234 ]`).

If your alert notifications rely on the previous format when using a single datasource, you may need to update your templates. Note that using multiple datasources in an alert rule will preserve the old behavior.

As noted in the documentation, both `$value` and `.Value` are not recommended for use - it's better to use `.Values` or `$values` instead.