### PR TITLE
Dashboard: Switch back to prev layout restores state

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -70,6 +70,7 @@ import { isUsingAngularDatasourcePlugin, isUsingAngularPanelPlugin } from './ang
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { LayoutRestorer } from './layouts-shared/LayoutRestorer';
 import { addNewRowTo, addNewTabTo } from './layouts-shared/addNew';
 import { DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { LayoutParent } from './types/LayoutParent';
@@ -173,6 +174,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     Dashboard | DashboardV2Spec,
     DashboardMeta | DashboardWithAccessInfo<DashboardV2Spec>['metadata']
   >;
+
+  private _layoutRestorer = new LayoutRestorer();
 
   public constructor(state: Partial<DashboardSceneState>, serializerVersion: 'v1' | 'v2' = 'v1') {
     super({
@@ -613,8 +616,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public switchLayout(layout: DashboardLayoutManager) {
-    this.setState({ body: layout });
-    layout.activateRepeaters?.();
+    this.setState({ body: this._layoutRestorer.getLayout(layout, this.state.body) });
+    this.state.body.activateRepeaters?.();
   }
 
   public getLayout(): DashboardLayoutManager {

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -404,7 +404,7 @@ export class DefaultGridLayoutManager
 
       currentX += panelWidth;
 
-      if (currentX + panelWidth >= GRID_COLUMN_COUNT) {
+      if (currentX + panelWidth > GRID_COLUMN_COUNT) {
         currentX = 0;
         currentY += panelHeight;
       }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -5,6 +5,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { ConditionalRendering } from '../../conditional-rendering/ConditionalRendering';
 import { getDefaultVizPanel } from '../../utils/utils';
 import { ResponsiveGridLayoutManager } from '../layout-responsive-grid/ResponsiveGridLayoutManager';
+import { LayoutRestorer } from '../layouts-shared/LayoutRestorer';
 import { BulkActionElement } from '../types/BulkActionElement';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../types/EditableDashboardElement';
@@ -36,6 +37,7 @@ export class RowItem
   });
 
   public readonly isEditableDashboardElement = true;
+  private _layoutRestorer = new LayoutRestorer();
 
   public constructor(state?: Partial<RowItemState>) {
     super({
@@ -71,7 +73,7 @@ export class RowItem
   }
 
   public switchLayout(layout: DashboardLayoutManager) {
-    this.setState({ layout });
+    this.setState({ layout: this._layoutRestorer.getLayout(layout, this.state.layout) });
   }
 
   public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -4,6 +4,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 
 import { getDefaultVizPanel } from '../../utils/utils';
 import { ResponsiveGridLayoutManager } from '../layout-responsive-grid/ResponsiveGridLayoutManager';
+import { LayoutRestorer } from '../layouts-shared/LayoutRestorer';
 import { BulkActionElement } from '../types/BulkActionElement';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../types/EditableDashboardElement';
@@ -30,6 +31,7 @@ export class TabItem
   });
 
   public readonly isEditableDashboardElement = true;
+  private _layoutRestorer = new LayoutRestorer();
 
   constructor(state?: Partial<TabItemState>) {
     super({
@@ -52,7 +54,7 @@ export class TabItem
   }
 
   public switchLayout(layout: DashboardLayoutManager) {
-    this.setState({ layout });
+    this.setState({ layout: this._layoutRestorer.getLayout(layout, this.state.layout) });
   }
 
   public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/LayoutRestorer.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/LayoutRestorer.ts
@@ -1,0 +1,25 @@
+import { vizPanelToSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
+import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
+
+export class LayoutRestorer {
+  private layoutMap: Record<string, DashboardLayoutManager> = {};
+
+  public getLayout(
+    newLayout: DashboardLayoutManager,
+    currentLayout: DashboardLayoutManager
+  ): DashboardLayoutManager | undefined {
+    // If we have an old version of this layout and panels are the same we can reuse it
+    const prevLayout = this.layoutMap[newLayout.descriptor.id];
+    if (prevLayout) {
+      const oldPanelSchema = prevLayout.getVizPanels().map(vizPanelToSchemaV2);
+      const newPanelSchema = newLayout.getVizPanels().map(vizPanelToSchemaV2);
+      if (JSON.stringify(oldPanelSchema) === JSON.stringify(newPanelSchema)) {
+        return prevLayout;
+      }
+    }
+
+    this.layoutMap[currentLayout.descriptor.id] = currentLayout;
+
+    return newLayout;
+  }
+}


### PR DESCRIPTION
Was a lot tricker than I thought it would be, was unsure where to maintain this state. Inside DashboardSelector is tricky as it unmounts when selected object changes. 

Ended up needing to remember state per "layout parent".  

The current logic is that if your switching back to a previous layout and the panels are exactly the same we just use the prev layout. The problem with this is that if you make any config change to any panel (or add a panel) after switching layout and want to go back your out of luck. We can extend this with a opt-in way to discard changes and go back to prev layout (or try to merge them) but that is too time consuming / complex a task I feel right now (more high prio issues to work on) 