### PR TITLE
Update recommended-practices.md to fix 109's header

### DIFF
--- a/contribute/backend/recommended-practices.md
+++ b/contribute/backend/recommended-practices.md
@@ -119,7 +119,7 @@ For example:
 
 Today it's only possible to provision data sources and dashboards, but we want to support it throughout Grafana in the future.
 
-### 109 - Use `context.Context`
+## 109 - Use `context.Context`
 
 **State:** Completed.
 


### PR DESCRIPTION
Minor PR, just to use a `h2` (`##`) header for item 109 in `recommended-practices.md`, as for all other items.