### PR TITLE
[IAM] Clear user's permission cache after login

### DIFF
--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -142,6 +142,7 @@ func ProvideRegistration(
 
 	authnSvc.RegisterPostAuthHook(rbacSync.SyncPermissionsHook, 120)
 	authnSvc.RegisterPostLoginHook(orgSync.SetDefaultOrgHook, 140)
+	authnSvc.RegisterPostLoginHook(rbacSync.ClearUserPermissionCacheHook, 170)
 
 	nsSync := sync.ProvideNamespaceSync(cfg)
 	authnSvc.RegisterPostAuthHook(nsSync.SyncNamespace, 150)

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -199,7 +199,6 @@ func (s *RBACSync) ClearUserPermissionCacheHook(ctx context.Context, ident *auth
 
 	ctxLogger := s.log.FromContext(ctx)
 	if !ident.IsIdentityType(claims.TypeUser) {
-
 		ctxLogger.Debug("Skipping user permission cache clear, not a user", "type", ident.GetIdentityType())
 		return
 	}

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -186,3 +186,23 @@ func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r 
 		RolesToRemove: rolesToRemove,
 	})
 }
+
+// ClearUserPermissionCacheHook clears a user's permission cache if user Login succeeded. Necessary so that if a user logs in
+// through different SSO providers with different roles assigned in each, they do not get the wrong permissions.
+func (s *RBACSync) ClearUserPermissionCacheHook(ctx context.Context, ident *authn.Identity, r *authn.Request, err error) {
+	ctx, span := s.tracer.Start(ctx, "rbac.sync.ClearUserPermissionCacheHook")
+	defer span.End()
+
+	if err != nil {
+		return
+	}
+
+	ctxLogger := s.log.FromContext(ctx)
+	if !ident.IsIdentityType(claims.TypeUser) {
+
+		ctxLogger.Debug("Skipping user permission cache clear, not a user", "type", ident.GetIdentityType())
+		return
+	}
+
+	s.ac.ClearUserPermissionCache(ident)
+}


### PR DESCRIPTION
Since the permission cache shares the same entry for a user regardless of the SSO provider they used to log in, we should clear their cache entry after logging in to make sure that the user does not get a cached set of permissions that does not match the permissions they should have with the SSO provider they just used to log in.

As an alternative, we could maybe use different cache keys for a user depending on the SSO provider they used to log in, but that seems much more risky and complex.

Please let me know if anyone thinks a PostLoginHook is not the right place to clear the permission cache from, or if you have any other ideas to fix this.