### PR TITLE
[WIP] IAM: Setup script for running the iam.grafana.app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,10 @@ pkg/services/quota/quotaimpl/storage/storage.json
 /devenv/datasources_bulk.yaml
 
 /scripts/build/release_publisher/release_publisher
+# iam-access-dev
+/scripts/iam/.env
+/scripts/iam/custom.ini
+!/scripts/iam/custom-iam-template.ini
 *.patch
 !.yarn/patches/*.patch
 

--- a/scripts/iam/.env.example
+++ b/scripts/iam/.env.example
@@ -1,0 +1,6 @@
+# .env.example
+GRPC_SERVER_AUTH_SIGNING_KEYS_URL=http://localhost:6481/jwks
+GRPC_SERVER_KEY_FILE=path/to/authz.key
+GRPC_SERVER_CERT_FILE=path/to/authz.crt
+DB_DEFAULT_CONNECTION="user:password@tcp(localhost:13306)/stacks_info"
+DB_HG_CONNECTION="user:password@tcp(localhost:13306)/"

--- a/scripts/iam/README.md
+++ b/scripts/iam/README.md
@@ -1,0 +1,27 @@
+## Configuration
+
+To run the IAM API server, you'll need to set up your configuration:
+
+1. Copy the template files:
+   ```bash
+   cp custom.ini.template custom.ini
+   cp .env.example .env
+   ```
+
+2. Update the `.env` file with your actual configuration values:
+   - Replace placeholder values with your actual database credentials
+   - Update paths to your key and certificate files
+   - Set your actual signing keys URL
+
+3. Run the server:
+   ```bash
+   ./bin/grafana server --config=custom.ini
+   ```
+
+Full setup for certificate generations
+
+```bash
+openssl ecparam -genkey -name prime256v1 -out PATH_TO/authz.key
+openssl req -new -key PATH_TO/authz.key -out PATH_TO/authz.csr -config PATH_TO/openssl.cnf
+openssl x509 -req -days 365 -in PATH_TO/authz.csr -signkey PATH_TO/authz.key -out PATH_TO/authz.crt -extensions v3_req -extfile PATH_TO/openssl.cnf
+```

--- a/scripts/iam/custom-iam-template.ini
+++ b/scripts/iam/custom-iam-template.ini
@@ -1,0 +1,15 @@
+# custom.ini.template
+[grpc_server_authentication]
+signing_keys_url = ${GRPC_SERVER_AUTH_SIGNING_KEYS_URL}
+
+[grpc_server]
+enabled = true
+key_file = ${GRPC_SERVER_KEY_FILE}
+cert_file = ${GRPC_SERVER_CERT_FILE}
+use_tls = true
+
+[database]
+servers = default=${DB_DEFAULT_CONNECTION},hg_db=${DB_HG_CONNECTION}
+
+[feature_toggles]
+GrafanaAPIServerWithExperimentalAPIs = true

--- a/scripts/iam/launch.sh
+++ b/scripts/iam/launch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Load environment variables
+if [ -f scripts/iam/.env ]; then
+    export $(cat scripts/iam/.env | xargs)
+fi
+
+# Generate config from template
+envsubst < scripts/iam/custom-iam-template.ini > scripts/iam/custom.ini
+
+# Launch the service
+./bin/grafana server \
+    --config=scripts/iam/custom.ini \
+    --target=iam.grafana.app


### PR DESCRIPTION
We have a bunch of flags/env and configurations in order to run the `iam.grafana.app`. This is one step to make it easier to know what to setup and how to run the `iam.grafana.app` with a single script.

It's not perfect, but we have something at least.

**proposals:**

1. we would just keep a command circling around and then have a .env file set for them to be applied.

2. custom.inis for iam, to be then populated with .env files that are updated (this proposal)