### PR TITLE
Chore: Remove dataplane as option from prom converter

### DIFF
--- a/pkg/promlib/converter/prom_bench_test.go
+++ b/pkg/promlib/converter/prom_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkReadPrometheusStyleResult_FromFile(b *testing.B) {
 		"prom-matrix-histogram-partitioned.json",
 	}
 
-	opt := Options{Dataplane: true}
+	opt := Options{}
 
 	for _, tf := range testFiles {
 		testData := readTestData(b, tf)

--- a/pkg/promlib/converter/testdata/prom-infos-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-infos-frame.jsonc
@@ -1,10 +1,10 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
 //  Frame[0] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -33,10 +33,10 @@
 //  
 //  
 //  Frame[1] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -65,10 +65,10 @@
 //  
 //  
 //  Frame[2] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -97,10 +97,10 @@
 //  
 //  
 //  Frame[3] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -129,10 +129,10 @@
 //  
 //  
 //  Frame[4] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -166,10 +166,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -221,10 +221,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -276,10 +276,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -338,10 +338,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -400,10 +400,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"

--- a/pkg/promlib/converter/testdata/prom-matrix-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-matrix-frame.jsonc
@@ -4,7 +4,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -28,7 +28,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -57,7 +57,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -106,7 +106,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"

--- a/pkg/promlib/converter/testdata/prom-matrix-with-nans-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-matrix-with-nans-frame.jsonc
@@ -4,7 +4,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -33,7 +33,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"

--- a/pkg/promlib/converter/testdata/prom-query-range-big-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-query-range-big-frame.jsonc
@@ -4,7 +4,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -35,7 +35,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -66,7 +66,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -97,7 +97,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -128,7 +128,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -159,7 +159,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -190,7 +190,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -221,7 +221,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -252,7 +252,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -283,7 +283,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -314,7 +314,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -345,7 +345,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -376,7 +376,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -407,7 +407,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -438,7 +438,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -469,7 +469,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -500,7 +500,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -531,7 +531,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -562,7 +562,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -593,7 +593,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -624,7 +624,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -655,7 +655,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -686,7 +686,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -717,7 +717,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -748,7 +748,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -779,7 +779,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -810,7 +810,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -841,7 +841,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -872,7 +872,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -903,7 +903,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -934,7 +934,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -965,7 +965,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -996,7 +996,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1027,7 +1027,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1058,7 +1058,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1089,7 +1089,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1120,7 +1120,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1151,7 +1151,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1182,7 +1182,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1213,7 +1213,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1244,7 +1244,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1275,7 +1275,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1306,7 +1306,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1337,7 +1337,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1368,7 +1368,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1399,7 +1399,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1430,7 +1430,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1461,7 +1461,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1492,7 +1492,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1523,7 +1523,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1554,7 +1554,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1585,7 +1585,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1616,7 +1616,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1647,7 +1647,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1678,7 +1678,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1709,7 +1709,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1740,7 +1740,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1771,7 +1771,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1802,7 +1802,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1833,7 +1833,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -1869,7 +1869,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -2428,7 +2428,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -2987,7 +2987,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -3546,7 +3546,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -4105,7 +4105,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -4664,7 +4664,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -5223,7 +5223,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -5782,7 +5782,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -6341,7 +6341,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -6900,7 +6900,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -7459,7 +7459,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -8018,7 +8018,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -8577,7 +8577,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -9136,7 +9136,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -9695,7 +9695,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -10254,7 +10254,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -10813,7 +10813,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -11372,7 +11372,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -11931,7 +11931,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -12490,7 +12490,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -13049,7 +13049,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -13608,7 +13608,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -14167,7 +14167,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -14726,7 +14726,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -15285,7 +15285,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -15844,7 +15844,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -16403,7 +16403,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -16962,7 +16962,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -17521,7 +17521,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -18080,7 +18080,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -18639,7 +18639,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -19198,7 +19198,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -19757,7 +19757,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -20316,7 +20316,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -20875,7 +20875,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -21434,7 +21434,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -21993,7 +21993,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -22552,7 +22552,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -23111,7 +23111,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -23670,7 +23670,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -24229,7 +24229,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -24788,7 +24788,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -25347,7 +25347,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -25906,7 +25906,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -26465,7 +26465,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -27024,7 +27024,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -27583,7 +27583,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -28142,7 +28142,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -28701,7 +28701,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -29260,7 +29260,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -29819,7 +29819,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -30378,7 +30378,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -30937,7 +30937,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -31496,7 +31496,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -32055,7 +32055,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -32614,7 +32614,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -33173,7 +33173,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -33732,7 +33732,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -34291,7 +34291,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -34850,7 +34850,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"

--- a/pkg/promlib/converter/testdata/prom-query-range-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-query-range-frame.jsonc
@@ -4,7 +4,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -35,7 +35,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -66,7 +66,7 @@
 //      "type": "timeseries-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
@@ -102,7 +102,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -661,7 +661,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"
@@ -1220,7 +1220,7 @@
           "type": "timeseries-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "matrix"

--- a/pkg/promlib/converter/testdata/prom-scalar-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-scalar-frame.jsonc
@@ -4,7 +4,7 @@
 //      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "scalar"
@@ -31,7 +31,7 @@
           "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "scalar"

--- a/pkg/promlib/converter/testdata/prom-vector-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-vector-frame.jsonc
@@ -1,10 +1,10 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
 //  Frame[0] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -23,10 +23,10 @@
 //  
 //  
 //  Frame[1] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -45,10 +45,10 @@
 //  
 //  
 //  Frame[2] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -67,10 +67,10 @@
 //  
 //  
 //  Frame[3] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -89,10 +89,10 @@
 //  
 //  
 //  Frame[4] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -116,10 +116,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -161,10 +161,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -206,10 +206,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -258,10 +258,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -310,10 +310,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"

--- a/pkg/promlib/converter/testdata/prom-warnings-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-warnings-frame.jsonc
@@ -1,10 +1,10 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
 //  Frame[0] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -33,10 +33,10 @@
 //  
 //  
 //  Frame[1] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -65,10 +65,10 @@
 //  
 //  
 //  Frame[2] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -97,10 +97,10 @@
 //  
 //  
 //  Frame[3] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -129,10 +129,10 @@
 //  
 //  
 //  Frame[4] {
-//      "type": "timeseries-multi",
+//      "type": "numeric-multi",
 //      "typeVersion": [
 //          0,
-//          0
+//          1
 //      ],
 //      "custom": {
 //          "resultType": "vector"
@@ -166,10 +166,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -221,10 +221,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -276,10 +276,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -338,10 +338,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"
@@ -400,10 +400,10 @@
     {
       "schema": {
         "meta": {
-          "type": "timeseries-multi",
+          "type": "numeric-multi",
           "typeVersion": [
             0,
-            0
+            1
           ],
           "custom": {
             "resultType": "vector"

--- a/pkg/promlib/querydata/response.go
+++ b/pkg/promlib/querydata/response.go
@@ -41,7 +41,7 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		statusCode == http.StatusServiceUnavailable:
 
 		iter := jsoniter.Parse(jsoniter.ConfigDefault, res.Body, 1024)
-		r := converter.ReadPrometheusStyleResult(iter, converter.Options{Dataplane: true})
+		r := converter.ReadPrometheusStyleResult(iter, converter.Options{})
 		r.Status = backend.Status(res.StatusCode)
 
 		// Add frame to attach metadata

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/promlib/converter"
 	"github.com/grafana/grafana/pkg/tsdb/loki/instrumentation"
@@ -219,7 +220,7 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 	defer span.End()
 
 	iter := jsoniter.Parse(jsoniter.ConfigDefault, resp.Body, 1024)
-	res := converter.ReadPrometheusStyleResult(iter, converter.Options{Dataplane: true})
+	res := converter.ReadPrometheusStyleResult(iter, converter.Options{})
 
 	if res.Error != nil {
 		span.RecordError(res.Error)


### PR DESCRIPTION
**What is this feature?**
Since dataplane was defaulted for a long time ago via https://github.com/grafana/grafana/pull/92218 we don't need the dataplane as option since it is `true` everywhere. 


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
