### PR TITLE
Live: allow publishing over Centrifuge subscription

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -42,6 +42,20 @@ export interface LiveQueryDataOptions {
 /**
  * @alpha -- experimental
  */
+export interface LivePublishOptions {
+  /**
+   * Publish the data over the websocket instead of the HTTP API.
+   *
+   * This is not recommended for most use cases.
+   *
+   * @experimental
+   */
+  useSocket?: boolean;
+}
+
+/**
+ * @alpha -- experimental
+ */
 export interface GrafanaLiveSrv {
   /**
    * Listen for changes to the main service
@@ -79,7 +93,7 @@ export interface GrafanaLiveSrv {
    *
    * @alpha -- experimental
    */
-  publish(address: LiveChannelAddress, data: unknown): Promise<unknown>;
+  publish(address: LiveChannelAddress, data: unknown, options?: LivePublishOptions): Promise<unknown>;
 }
 
 let singletonInstance: GrafanaLiveSrv;

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -175,6 +175,13 @@ export class CentrifugeLiveChannel<T = any> {
     });
   }
 
+  publish = (data: unknown) => {
+    if (!this.subscription) {
+      return;
+    }
+    return this.subscription.publish(data);
+  };
+
   /**
    * This will close and terminate all streams for this channel
    */

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -175,12 +175,7 @@ export class CentrifugeLiveChannel<T = any> {
     });
   }
 
-  publish = (data: unknown) => {
-    if (!this.subscription) {
-      return;
-    }
-    return this.subscription.publish(data);
-  };
+  publish = (data: unknown) => this.subscription?.publish(data);
 
   /**
    * This will close and terminate all streams for this channel

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -20,6 +20,7 @@ import { FetchResponse } from '@grafana/runtime/src/services/backendSrv';
 import {
   GrafanaLiveSrv,
   LiveDataStreamOptions,
+  LivePublishOptions,
   LiveQueryDataOptions,
   StreamingFrameAction,
   StreamingFrameOptions,
@@ -42,7 +43,7 @@ export type CentrifugeSrvDeps = {
 
 export type StreamingDataQueryResponse = Omit<DataQueryResponse, 'data'> & { data: [StreamingResponseData] };
 
-export type CentrifugeSrv = Omit<GrafanaLiveSrv, 'publish' | 'getDataStream' | 'getQueryData'> & {
+export type CentrifugeSrv = Omit<GrafanaLiveSrv, 'getDataStream' | 'getQueryData'> & {
   getDataStream: (options: LiveDataStreamOptions) => Observable<StreamingDataQueryResponse>;
   getQueryData: (
     options: LiveQueryDataOptions
@@ -243,6 +244,13 @@ export class CentrifugeService implements CentrifugeSrv {
    */
   getPresence: CentrifugeSrv['getPresence'] = (address) => {
     return this.getChannel(address).getPresence();
+  };
+
+  /**
+   * Publish into a channel.
+   */
+  publish = async (address: LiveChannelAddress, data: unknown, options?: LivePublishOptions) => {
+    return this.getChannel(address).publish(data);
   };
 }
 

--- a/public/app/features/live/centrifuge/service.worker.ts
+++ b/public/app/features/live/centrifuge/service.worker.ts
@@ -3,7 +3,7 @@ import './transferHandlers';
 import * as comlink from 'comlink';
 
 import { LiveChannelAddress } from '@grafana/data';
-import { LiveDataStreamOptions, LiveQueryDataOptions } from '@grafana/runtime';
+import { LiveDataStreamOptions, LivePublishOptions, LiveQueryDataOptions } from '@grafana/runtime';
 
 import { remoteObservableAsObservable } from './remoteObservable';
 import { CentrifugeService, CentrifugeSrvDeps } from './service';
@@ -42,6 +42,10 @@ const getPresence = async (address: LiveChannelAddress) => {
   return await centrifuge.getPresence(address);
 };
 
+const publish = async (address: LiveChannelAddress, data: unknown, options?: LivePublishOptions) => {
+  return await centrifuge.publish(address, data, options);
+};
+
 const workObj = {
   initialize,
   getConnectionState,
@@ -49,6 +53,7 @@ const workObj = {
   getStream,
   getQueryData,
   getPresence,
+  publish,
 };
 
 export type RemoteCentrifugeService = typeof workObj;

--- a/public/app/features/live/centrifuge/service.worker.ts
+++ b/public/app/features/live/centrifuge/service.worker.ts
@@ -42,9 +42,8 @@ const getPresence = async (address: LiveChannelAddress) => {
   return await centrifuge.getPresence(address);
 };
 
-const publish = async (address: LiveChannelAddress, data: unknown, options?: LivePublishOptions) => {
-  return await centrifuge.publish(address, data, options);
-};
+const publish = (address: LiveChannelAddress, data: unknown, options?: LivePublishOptions) =>
+  centrifuge.publish(address, data, options);
 
 const workObj = {
   initialize,

--- a/public/app/features/live/centrifuge/serviceWorkerProxy.ts
+++ b/public/app/features/live/centrifuge/serviceWorkerProxy.ts
@@ -47,4 +47,8 @@ export class CentrifugeServiceWorkerProxy implements CentrifugeSrv {
       this.centrifugeWorker.getStream(address) as Promise<comlink.Remote<Observable<LiveChannelEvent<T>>>>
     );
   };
+
+  publish: CentrifugeSrv['publish'] = (address, data, options) => {
+    return this.centrifugeWorker.publish(address, data, options);
+  };
 }

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -97,6 +97,7 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     if (options?.useSocket) {
       return this.deps.centrifugeSrv.publish(address, data);
     }
+
     return this.deps.backendSrv.post(`api/live/publish`, {
       channel: toLiveChannelId(address), // orgId is from user
       data,

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -93,7 +93,10 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
    *
    * @alpha -- experimental
    */
-  publish: GrafanaLiveSrv['publish'] = async (address, data) => {
+  publish: GrafanaLiveSrv['publish'] = async (address, data, options) => {
+    if (options?.useSocket) {
+      return this.deps.centrifugeSrv.publish(address, data);
+    }
     return this.deps.backendSrv.post(`api/live/publish`, {
       channel: toLiveChannelId(address), // orgId is from user
       data,


### PR DESCRIPTION
**What is this feature?**

This commit adds a new option to the `GrafanaLiveSrv` interface that allows the user to publish data over the Centrifuge subscription instead of the HTTP API. This is not the default and should rarely be used, but is required to fulfil certain use cases.

**Why do we need this feature?**

Currently when publishing over a Grafana Live channel, the data is sent over the HTTP API. This works fine when there is only a single Grafana instance running, but when there are multiple instances, the data will only hit one instance, which is often not desired: sometimes you need to guarantee that the data appears on the same instance that the frontend is connected to.

An example of this is in the Grafana LLM app when running the MCP server. The MCP protocol is stateful; users subscribe to a channel to get a long-lived stream of server-sent events, then send subsequent requests to the server to get further results. If there are multiple Grafana instances running then the requests are likely to land on an instance other than the one that the user is connected to.

**Who is this feature for?**

Plugin developers adding advanced streaming capabilities using Grafana Live.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

https://github.com/grafana/grafana-llm-app/pull/599 is a draft PR of a plugin which would use this.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
