### PR TITLE
Folders: Fix user setting in api

### DIFF
--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -2,10 +2,12 @@ package folders
 
 import (
 	"fmt"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
@@ -70,11 +72,11 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	// We're going to have to align with that. For now we do need the user ID because the folder type stores it
 	// as the only user identifier
 
-	if v.CreatedByUID != "" {
-		meta.SetCreatedBy(v.UpdatedByUID)
+	if v.CreatedBy != 0 {
+		meta.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(v.CreatedBy, 10)))
 	}
-	if v.UpdatedByUID != "" {
-		meta.SetUpdatedBy(v.UpdatedByUID)
+	if v.UpdatedBy != 0 {
+		meta.SetUpdatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(v.UpdatedBy, 10)))
 	}
 	if v.ParentUID != "" {
 		meta.SetFolder(v.ParentUID)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -366,6 +366,9 @@ func (s *Service) GetLegacy(ctx context.Context, q *folder.GetFolderQuery) (*fol
 		f.FullpathUIDs = f.UID // set full path to the folder UID
 	}
 
+	f.CreatedBy = dashFolder.CreatedBy
+	f.UpdatedBy = dashFolder.UpdatedBy
+
 	return f, err
 }
 

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -1998,6 +1998,8 @@ func TestFolderServiceGetFolder(t *testing.T) {
 			fldr, err := tc.svc.Get(context.Background(), &q)
 			require.NoError(t, err)
 			require.Equal(t, f.UID, fldr.UID)
+			require.Equal(t, f.CreatedBy, fldr.CreatedBy)
+			require.Equal(t, f.UpdatedBy, fldr.CreatedBy)
 
 			require.Equal(t, tc.expectedFullpath, fldr.Fullpath)
 		})


### PR DESCRIPTION
**What is this feature?**

This PR fixes setting the created by user & updated by user, both in the current flow on main & in the k8s flow. 

Before:
<img width="630" alt="Screenshot 2025-03-17 at 4 40 29 PM" src="https://github.com/user-attachments/assets/47283f09-4849-46a3-a8e6-6d9f88df8946" />

After:
<img width="651" alt="Screenshot 2025-03-17 at 4 39 10 PM" src="https://github.com/user-attachments/assets/f0f4e6f0-f3e4-48b1-a893-bca87e1550f1" />


K8s flow:
<img width="931" alt="Screenshot 2025-03-17 at 4 55 16 PM" src="https://github.com/user-attachments/assets/bdcee81d-44c6-4988-9440-04b1aad1973b" />


Closes https://github.com/grafana/app-platform-wg/issues/239