### PR TITLE
Update User API doc to include Cloud info/link

### DIFF
--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -36,6 +36,8 @@ To use these API endpoints you have to use Basic authentication and the Grafana 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
 {{< /admonition >}}
 
+For Grafana Cloud customers, refer to [Organization HTTP API](/docs/grafana/latest/developers/http_api/org/) for finding users.
+
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
 ## Search Users

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -36,7 +36,7 @@ To use these API endpoints you have to use Basic authentication and the Grafana 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
 {{< /admonition >}}
 
-For Grafana Cloud customers, refer to [Organization HTTP API](/docs/grafana/latest/developers/http_api/org/) for finding users.
+For Grafana Cloud customers, refer to [Organization HTTP API](/docs/grafana/latest/developers/http_api/org/) for finding users with the org Admin role.
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 


### PR DESCRIPTION
Per [support request](https://github.com/orgs/grafana/projects/795/views/2?pane=issue&itemId=100715003&issue=grafana%7Csupport-escalations%7C6213), Grafana Cloud admins are confused about Grafana server admins vs their capabilities in cloud. 
Added clarification and link for where cloud admins can go to find users.