### PR TITLE
Transformations: Fix field naming in Add field from calc (Binary mode)

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -185,7 +185,7 @@ export const calculateFieldTransformer: DataTransformerInfo<CalculateFieldTransf
                 }
                 // For each field of type match, apply operator
                 frame.fields.map((field, index) => {
-                  if (!options.replaceFields) {
+                  if (!options.replaceFields && !newFields.includes(field)) {
                     newFields.push(field);
                   }
                   if (field.type === fieldType) {
@@ -210,6 +210,7 @@ export const calculateFieldTransformer: DataTransformerInfo<CalculateFieldTransf
                       name: `${field.name} ${options.binary?.operator ?? ''} ${options.binary?.right.matcher?.options ?? options.binary?.right.fixed}`,
                       values: arr,
                     };
+                    delete newField.state;
                     newFields.push(newField);
                     didAddNewFields = true;
                   }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/102324

- avoids copying original field's `field.state` by reference.
- avoids re-adding time field (or any other field) that has already been added

<details><summary>weird-transform-names.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 472,
  "links": [],
  "panels": [
    {
      "datasource": {
        "default": true,
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green"
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 20,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "11.6.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 2
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "joinByField",
          "options": {
            "byField": "time",
            "mode": "outer"
          }
        },
        {
          "id": "calculateField",
          "options": {
            "binary": {
              "left": {
                "matcher": {
                  "id": "byType",
                  "options": "number"
                }
              },
              "operator": "*",
              "right": {
                "fixed": "-1"
              }
            },
            "mode": "binary",
            "reduce": {
              "reducer": "sum"
            }
          }
        },
        {
          "id": "organize",
          "options": {}
        },
        {
          "id": "filterFieldsByName",
          "options": {}
        }
      ],
      "type": "timeseries"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "weird-transform-names",
  "uid": "ceg5hbtgkz3eob",
  "version": 1
}
```
</details>

before:

![image](https://github.com/user-attachments/assets/ac7376ea-29e9-4d5e-9fab-c94978fb33f9)

after:

![image](https://github.com/user-attachments/assets/af366a01-0578-45af-897f-862e453c1e94)