### PR TITLE
Folders: Add pagination to list

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -90,14 +90,22 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		return nil, err
 	}
 
-	// List must return all folders
-	hits, err := s.service.GetFoldersLegacy(ctx, folder.GetFoldersQuery{
+	query := folder.GetFoldersQuery{
 		SignedInUser: user,
 		OrgID:        orgId,
-		// TODO: enable pagination
-		// Limit:        paging.page,
-		// Page:         paging.limit,
-	})
+	}
+	if options.Continue != "" {
+		query.Page = paging.page
+		query.Limit = paging.limit
+	} else if options.Limit > 0 {
+		query.Limit = options.Limit
+		query.Page = 1
+		// also need to update the paging token so the continue token is correct
+		paging.limit = options.Limit
+		paging.page = 1
+	}
+
+	hits, err := s.service.GetFoldersLegacy(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -498,7 +498,11 @@ func (ss *FolderStoreImpl) GetFolders(ctx context.Context, q folder.GetFoldersFr
 			}
 
 			if len(q.AncestorUIDs) == 0 {
-				if q.OrderByTitle {
+				if q.Limit > 0 {
+					s.WriteString(` ORDER BY f0.title ASC`)
+					s.WriteString(` LIMIT ? OFFSET ?`)
+					args = append(args, q.Limit, (q.Page-1)*q.Limit)
+				} else if q.OrderByTitle {
 					s.WriteString(` ORDER BY f0.title ASC`)
 				}
 

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -878,7 +878,7 @@ func TestIntegrationGetFolders(t *testing.T) {
 	for i := 0; i < foldersNum; i++ {
 		uid := util.GenerateShortUID()
 		f, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{
-			Title:       folderTitle,
+			Title:       folderTitle + fmt.Sprintf("-%d", i),
 			Description: folderDsc,
 			OrgID:       orgID,
 			UID:         uid,
@@ -981,6 +981,23 @@ func TestIntegrationGetFolders(t *testing.T) {
 		assert.NotEmpty(t, actualFolder.Created)
 		assert.NotEmpty(t, actualFolder.Updated)
 		assert.NotEmpty(t, actualFolder.URL)
+	})
+
+	t.Run("get folders with limit and page should work as expected", func(t *testing.T) {
+		q := folder.NewGetFoldersQuery(folder.GetFoldersQuery{
+			OrgID: orgID,
+			UIDs:  uids,
+			Limit: 3,
+			Page:  2,
+		})
+
+		actualFolders, err := folderStore.GetFolders(context.Background(), q)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(actualFolders))
+
+		for i, actualFolder := range actualFolders {
+			assert.Equal(t, fmt.Sprintf("folder1-%d", i+3), actualFolder.Title)
+		}
 	})
 }
 

--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -13,6 +13,7 @@ type FakeService struct {
 	ExpectedHitList          model.HitList
 	ExpectedError            error
 	ExpectedDescendantCounts map[string]int64
+	LastQuery                folder.GetFoldersQuery
 }
 
 func NewFakeService() *FakeService {
@@ -90,5 +91,6 @@ func (s *FakeService) SearchFolders(ctx context.Context, q folder.SearchFoldersQ
 }
 
 func (s *FakeService) GetFoldersLegacy(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
+	s.LastQuery = q
 	return s.ExpectedFolders, s.ExpectedError
 }

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -175,6 +175,10 @@ type GetFoldersQuery struct {
 	WithFullpathUIDs bool
 	BatchSize        uint64
 
+	// Pagination options
+	Limit int64
+	Page  int64
+
 	// OrderByTitle is used to sort the folders by title
 	// Set to true when ordering is meaningful (used for listing folders)
 	// otherwise better to keep it false since ordering can have a performance impact


### PR DESCRIPTION
**What is this feature?**

This PR adds pagination to /api/folders, which then allows us to also have pagination on /apis/folder.grafana.app/v0alpha1/namespaces/default/folders in modes 0-2, since we fallback to `GetFoldersLegacy` in those modes.

**Why do we need this feature?**

We need to support pagination in k8s list

**Examples:**
/api flow:
![Screenshot 2025-03-17 at 6 36 20 PM](https://github.com/user-attachments/assets/10bd11b8-48d2-4986-ac33-7ecf70e7bfb9)
![Screenshot 2025-03-17 at 6 36 30 PM](https://github.com/user-attachments/assets/745730e7-fcb6-42eb-a187-ffc2b0a4aa63)
![Screenshot 2025-03-17 at 6 36 40 PM](https://github.com/user-attachments/assets/3e6f7693-329c-4cb6-aa9d-845ae9803a77)
![Screenshot 2025-03-17 at 6 36 47 PM](https://github.com/user-attachments/assets/93990be4-b8e4-414d-86be-10c94163020c)


/apis flow:
![Screenshot 2025-03-17 at 6 35 22 PM](https://github.com/user-attachments/assets/23aa7d17-a6de-40a3-b239-e6150db7815e)
![Screenshot 2025-03-17 at 6 35 32 PM](https://github.com/user-attachments/assets/bdee02a2-4eeb-4e8f-a0bd-1116e9b66048)
![Screenshot 2025-03-17 at 6 35 42 PM](https://github.com/user-attachments/assets/c01cadfc-fee9-43bd-a97c-95532f8adeac)
![Screenshot 2025-03-17 at 6 36 03 PM](https://github.com/user-attachments/assets/c72fa45f-b40c-40c1-83e6-965207f4e922)


**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/238
