### PR TITLE
Dashboards: Fix time range bug when use_browser_locale is enabled

### DIFF
--- a/packages/grafana-data/src/datetime/parser.test.ts
+++ b/packages/grafana-data/src/datetime/parser.test.ts
@@ -23,6 +23,18 @@ describe('dateTimeParse', () => {
     expect(date.format()).toEqual('2020-08-20T10:30:20Z');
   });
 
+  it('should be able to parse ISO 8601 date strings when useBrowserLocale is true', () => {
+    systemDateFormats.update({
+      fullDate: 'YYYY-MM-DD HH:mm:ss.SSS',
+      interval: {} as SystemDateFormatsState['interval'],
+      useBrowserLocale: true,
+    });
+
+    const date = dateTimeParse('2025-03-12T07:09:37.253Z', { timeZone: 'browser' });
+    expect(date.isValid()).toBe(true);
+    expect(date.format()).toEqual('2025-03-12T02:09:37-05:00');
+  });
+
   it('should be able to parse array formats used by calendar', () => {
     const date = dateTimeParse([2020, 5, 10, 10, 30, 20], { timeZone: 'utc' });
     expect(date.format()).toEqual('2020-06-10T10:30:20Z');

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -70,13 +70,15 @@ const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateT
     return dateTimeForTimeZone(zone.name, value, format);
   }
 
+  if (format === systemDateFormats.fullDate) {
+    // We use parsed here to handle case when `use_browser_locale` is true
+    // We need to pass the parsed value to handle case when value is an ISO 8601 date string
+    return dateTime(parsed, format);
+  }
+
   switch (lowerCase(timeZone)) {
     case 'utc':
       return toUtc(value, format);
-    // We used parsed here to handle case when `use_browser_locale` is true
-    // We need to pass the parsed value to handle case when value is an ISO 8601 date string
-    case 'browser':
-      return dateTime(parsed, format);
     default:
       return dateTime(value, format);
   }

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -66,6 +66,11 @@ const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateT
   const zone = moment.tz.zone(timeZone);
   const format = options?.format ?? systemDateFormats.fullDate;
 
+  // Check if value is an ISO 8601 date string
+  if (moment(value, moment.ISO_8601, true).isValid()) {
+    return dateTime(value);
+  }
+
   if (zone && zone.name) {
     return dateTimeForTimeZone(zone.name, value, format);
   }


### PR DESCRIPTION
**What is this feature?**

It fixes a bug where when `use_browser_locale` was enabled, any dashboard with absolute time ranges in the URL would default to `from=now-6h&to=now`. 

**How to reproduce**
**Before fix:**
1. Set the following option in your config file:
```
[date_formats]  
use_browser_locale = true
```
2. Paste link like this into URL bar http://localhost:3000/d/ceeyevtbz0phca/today-dash-1?orgId=1&from=2025-03-12T07:09:37.253Z&to=2025-03-12T13:09:37.253Z&timezone=browser
3. It will evaluate to http://localhost:3000/d/ceeyevtbz0phca/today-dash-1?orgId=1&from=now-6h&to=now&timezone=browser


**After fix:**
1. Paste the link from step 1 above. The URL will not change, and time range picker will look like this:
![Screenshot 2025-03-17 at 10 25 47 PM](https://github.com/user-attachments/assets/6a8c7cdc-4e3e-478f-8ae8-e654b5225878)

The problem was that when evaluating if a time range value is valid, [SceneTimeRange](https://github.com/grafana/scenes/blob/6555df6beb987192f3f6e6ea07d499ab1b5a9214/packages/scenes/src/core/SceneTimeRange.tsx#L19) runs the following:
1. [isValid](https://github.com/grafana/scenes/blob/e9d54b48b11fac51f2938fd164af994302284628/packages/scenes/src/utils/date.ts) function, which calls [dateTimeParse](https://github.com/grafana/grafana/blob/38731f827ad9655d2fa00f17a2d87b8255984051/packages/grafana-data/src/datetime/parser.ts#L43) from `grafana-data`
5.  Since our value is a string, `dateTimeParse` will call [parseString](https://github.com/grafana/grafana/blob/38731f827ad9655d2fa00f17a2d87b8255984051/packages/grafana-data/src/datetime/parser.ts), which will look at https://github.com/grafana/grafana/blob/38731f827ad9655d2fa00f17a2d87b8255984051/packages/grafana-data/src/datetime/parser.ts#L67-L68 Where `systemDateFormats.fullDate` will be configured through [useBroswerLocale](https://github.com/grafana/grafana/blob/9595fd6b6697f7f0e60ddb2f9ead7c43d5affcd0/packages/grafana-data/src/datetime/formats.ts#L40) which will run since `use_browser_locale` is enabled. 
6. Because the `timeZone="browser"`, then `parseString` will run this: https://github.com/grafana/grafana/blob/38731f827ad9655d2fa00f17a2d87b8255984051/packages/grafana-data/src/datetime/parser.ts#L82-L83
7. This `dateTime` function is just a wrapper around moment function: https://github.com/grafana/grafana/blob/e7ab142348e17cfa1cf3800825c071821ab89976/packages/grafana-data/src/datetime/moment_wrapper.ts#L116-L117 And since moment fails to format it properly, `dateTime.isValid()` will return false. 

The solution was to pass the parsed value because parse function will call `toDateTime`, which will handle ISO 8601 dates. 

```ts
config.dateFormats?.useBrowserLocale
```
And try to do some type of formatting.

**Who is this feature for?**

Any Grafana dashboards user.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/15176
Fixes https://github.com/grafana/grafana/issues/95209

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.