### PR TITLE
TimeSeries: Support tooltip series customization

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, ReactNode } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -34,21 +34,25 @@ export const VizTooltipContent = ({
 
   return (
     <div className={styles.wrapper} style={scrollableStyle}>
-      {items.map(({ label, value, color, colorIndicator, colorPlacement, isActive, lineStyle }, i) => (
-        <VizTooltipRow
-          key={i}
-          label={label}
-          value={value}
-          color={color}
-          colorIndicator={colorIndicator}
-          colorPlacement={colorPlacement}
-          isActive={isActive}
-          justify={'space-between'}
-          isPinned={isPinned}
-          lineStyle={lineStyle}
-          showValueScroll={!scrollable}
-        />
-      ))}
+      {items.map(({ label, value, color, colorIndicator, colorPlacement, isActive, lineStyle, customizer }, i) => {
+        const defaultRow = (
+          <VizTooltipRow
+            key={i}
+            label={label}
+            value={value}
+            color={color}
+            colorIndicator={colorIndicator}
+            colorPlacement={colorPlacement}
+            isActive={isActive}
+            justify={'space-between'}
+            isPinned={isPinned}
+            lineStyle={lineStyle}
+            showValueScroll={!scrollable}
+          />
+        );
+
+        return customizer ? React.createElement(customizer.component, { ...customizer.props, defaultRow }) : defaultRow;
+      })}
       {children}
     </div>
   );

--- a/packages/grafana-ui/src/components/VizTooltip/types.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/types.ts
@@ -1,3 +1,6 @@
+import React from 'react';
+
+import { Field } from '@grafana/data';
 import { LineStyle } from '@grafana/schema';
 
 export enum ColorIndicator {
@@ -19,6 +22,14 @@ export enum ColorPlacement {
   trailing = 'trailing',
 }
 
+export interface VizTooltipItemCustomComponentProps {
+  field: Field;
+  allFields: Field[];
+  dataIdx: number;
+  isActive?: boolean;
+  defaultRow: React.ReactNode;
+}
+
 export interface VizTooltipItem {
   label: string;
   value: string;
@@ -27,6 +38,10 @@ export interface VizTooltipItem {
   colorPlacement?: ColorPlacement;
   isActive?: boolean;
   lineStyle?: LineStyle;
+  customizer?: {
+    props: VizTooltipItemCustomComponentProps;
+    component: React.ComponentType<VizTooltipItemCustomComponentProps>;
+  };
 
   // internal/tmp for sorting
   numeric?: number;

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -88,13 +88,14 @@ export const getContentItems = (
 
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i];
+    const graphFieldConfig = field.config.custom;
 
     if (
       field === xField ||
       field.type === FieldType.time ||
       !fieldFilter(field) ||
-      field.config.custom?.hideFrom?.tooltip ||
-      field.config.custom?.hideFrom?.viz
+      graphFieldConfig?.hideFrom?.tooltip ||
+      graphFieldConfig?.hideFrom?.viz
     ) {
       continue;
     }
@@ -140,15 +141,24 @@ export const getContentItems = (
       colorPlacement = ColorPlacement.trailing;
     }
 
+    const isActive = mode === TooltipDisplayMode.Multi && seriesIdx === i;
+
     rows.push({
       label: field.state?.displayName ?? field.name,
       value: formattedValueToString(display),
       color: display.color ?? FALLBACK_COLOR,
       colorIndicator,
       colorPlacement,
-      isActive: mode === TooltipDisplayMode.Multi && seriesIdx === i,
+      isActive,
       numeric,
-      lineStyle: field.config.custom?.lineStyle,
+      lineStyle: graphFieldConfig?.lineStyle,
+      // Customizer needs access to other fields and dataIdx
+      customizer: graphFieldConfig?.tooltipSeriesComponent
+        ? {
+            props: { field, allFields: fields, dataIdx, isActive, defaultRow: null },
+            component: graphFieldConfig.tooltipSeriesComponent,
+          }
+        : undefined,
     });
   }
 

--- a/public/app/plugins/panel/timeseries/config.ts
+++ b/public/app/plugins/panel/timeseries/config.ts
@@ -204,6 +204,14 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig, isTime = true): SetFi
           },
           showIf: (config) => config.drawStyle !== GraphDrawStyle.Points,
         })
+        .addRadio({
+          path: 'tooltipSeriesComponent',
+          name: 'Custom tooltip series component',
+          category: categoryStyles,
+          defaultValue: undefined,
+          hideFromDefaults: true,
+          hideFromOverrides: true,
+        })
         .addSliderInput({
           path: 'pointSize',
           name: 'Point size',


### PR DESCRIPTION
Explores an alternative to https://github.com/grafana/grafana/pull/101090

Problem:

Plugins want to extend time series tooltip to show series differently or show content from other fields. Example:

![image](https://github.com/user-attachments/assets/87c6c413-04e0-4319-9f7e-b0fb9ae1d4ac)


This PR

* Make it possible via field config to add a new `tooltipSeriesComponent` option. 

This is a react component with these props

```ts
export interface VizTooltipItemCustomComponentProps {
  field: Field;
  allFields: Field[];
  dataIdx: number;
  isActive?: boolean;
  defaultRow: React.ReactNode;
}
```

You get passed the default series row and the custom component can choose to render it plus additional info or replace it. This way we do not need to re-implement anything unless strictly needed. 

Demo that takes advantage of this new extensibility https://github.com/grafana/scenes/pull/1075

<img width="383" alt="Screenshot 2025-03-18 at 07 48 57" src="https://github.com/user-attachments/assets/6667f47e-c4a0-4e17-b840-ff37d1eac4ce" />
