### PR TITLE
Alerting: Add an index to alert_rule_version table on (rule_org_id, rule_uid)

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -149,4 +149,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddAlertRuleGuidMigration(mg)
 
 	ualert.AddAlertRuleMissingSeriesEvalsToResolve(mg)
+
+	ualert.AddAlertRuleVersionUIDIndex(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_uid_index.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_uid_index.go
@@ -1,0 +1,15 @@
+package ualert
+
+import (
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+// AddAlertRuleVersionUIDIndex adds an index to the alert_rule_version table on (rule_org_id, rule_uid) columns.
+func AddAlertRuleVersionUIDIndex(mg *migrator.Migrator) {
+	mg.AddMigration("add index to alert_rule_version table on (rule_org_id, rule_uid)",
+		migrator.NewAddIndexMigration(
+			migrator.Table{Name: "alert_rule_version"},
+			&migrator.Index{Cols: []string{"rule_org_id", "rule_uid"}, Type: migrator.IndexType},
+		),
+	)
+}


### PR DESCRIPTION
**What is this feature?**

Adds a migration that adds an index to the `alert_rule_version` table on `(rule_org_id, rule_uid)`.

**Why do we need this feature?**

The index was removed in https://github.com/grafana/grafana/pull/101321, but it makes DELETE operations (such as [this](https://github.com/grafana/grafana/blob/1d0a86252ea6b76727487e96081560984070cbf1/pkg/services/ngalert/store/alert_rule.go#L63)) scan the whole `alert_rule_version` table. In case when it's big, it can lead to timeouts.

Without the index:

```
explain delete from alert_rule_version where rule_org_id = 1 and rule_uid = '123';
+----+-------------+--------------------+------------+------+------------------------------------------------------------------+--------+---------+--------+-------+----------+-------------+
| id | select_type | table              | partitions | type | possible_keys                                                    | key    | key_len | ref    | rows  | filtered | Extra       |
+----+-------------+--------------------+------------+------+------------------------------------------------------------------+--------+---------+--------+-------+----------+-------------+
| 1  | DELETE      | alert_rule_version | <null>     | ALL  | IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_group | <null> | <null>  | <null> | 11691 | 100.0    | Using where |
+----+-------------+--------------------+------------+------+------------------------------------------------------------------+--------+---------+--------+-------+----------+-------------+

```

With the index:

```
 explain delete from alert_rule_version where rule_org_id = 1 and rule_uid = '123';
+----+-------------+--------------------+------------+-------+--------------------------------------------------------------------------------------------------------------+---------------------------------------------+---------+-------------+------+----------+-------------+
| id | select_type | table              | partitions | type  | possible_keys                                                                                                | key                                         | key_len | ref         | rows | filtered | Extra       |
+----+-------------+--------------------+------------+-------+--------------------------------------------------------------------------------------------------------------+---------------------------------------------+---------+-------------+------+----------+-------------+
| 1  | DELETE      | alert_rule_version | <null>     | range | IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_group,IDX_alert_rule_version_rule_org_id_rule_uid | IDX_alert_rule_version_rule_org_id_rule_uid | 170     | const,const | 1    | 100.0    | Using where |
+----+-------------+--------------------+------------+-------+--------------------------------------------------------------------------------------------------------------+---------------------------------------------+---------+-------------+------+----------+-------------+

```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
