### PR TITLE
CloudMigrations: Remove public preview banner

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2089,8 +2089,6 @@ delete_access_policy_timeout = 5s
 domain = grafana.net
 # Folder used to store snapshot files. Defaults to the home dir
 snapshot_folder = ""
-# Link to form to give feedback on the feature
-feedback_url = https://docs.google.com/forms/d/e/1FAIpQLSeEE33vhbSpR8A8S1A1ocZ1ByVRRwiRl1GZr2FSrEer_tSa8w/viewform?usp=sf_link
 # How frequently should the frontend UI poll for changes while resources are migrating
 frontend_poll_interval = 2s
 # Controls how the Alert Rules are migrated. Available choices: "paused" and "unchanged". Default: "paused".

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1987,8 +1987,6 @@ default_datasource_uid =
 ;domain = grafana-dev.net
 # Folder used to store snapshot files. Defaults to the home dir
 ;snapshot_folder = ""
-# Link to form to give feedback on the feature
-;feedback_url = ""
 # How frequently should the frontend UI poll for changes while resources are migrating
 ;frontend_poll_interval = 2s
 # Controls how the Alert Rules are migrated. Available choices: "paused" and "unchanged". Default: "paused".

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -198,7 +198,6 @@ export class GrafanaBootConfig implements GrafanaConfig {
   rootFolderUID: string | undefined;
   localFileSystemAvailable: boolean | undefined;
   cloudMigrationIsTarget: boolean | undefined;
-  cloudMigrationFeedbackURL = '';
   cloudMigrationPollIntervalMs = 2000;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset = '1h';

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -269,9 +269,8 @@ type FrontendSettingsDTO struct {
 	PublicDashboardAccessToken string `json:"publicDashboardAccessToken"`
 	PublicDashboardsEnabled    bool   `json:"publicDashboardsEnabled"`
 
-	CloudMigrationIsTarget       bool   `json:"cloudMigrationIsTarget"`
-	CloudMigrationFeedbackURL    string `json:"cloudMigrationFeedbackURL"`
-	CloudMigrationPollIntervalMs int    `json:"cloudMigrationPollIntervalMs"`
+	CloudMigrationIsTarget       bool `json:"cloudMigrationIsTarget"`
+	CloudMigrationPollIntervalMs int  `json:"cloudMigrationPollIntervalMs"`
 
 	DateFormats setting.DateFormats `json:"dateFormats,omitempty"`
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -240,7 +240,6 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		PublicDashboardAccessToken:       c.PublicDashboardAccessToken,
 		PublicDashboardsEnabled:          hs.Cfg.PublicDashboardsEnabled,
 		CloudMigrationIsTarget:           isCloudMigrationTarget,
-		CloudMigrationFeedbackURL:        hs.Cfg.CloudMigration.FeedbackURL,
 		CloudMigrationPollIntervalMs:     int(hs.Cfg.CloudMigration.FrontendPollInterval.Milliseconds()),
 		SharedWithMeFolderUID:            folder.SharedWithMeFolderUID,
 		RootFolderUID:                    accesscontrol.GeneralFolderUID,

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -32,7 +32,6 @@ type CloudMigrationSettings struct {
 	CreateTokenTimeout          time.Duration
 	DeleteTokenTimeout          time.Duration
 	TokenExpiresAfter           time.Duration
-	FeedbackURL                 string
 	FrontendPollInterval        time.Duration
 	AlertRulesState             string
 
@@ -60,7 +59,6 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.DeleteTokenTimeout = cloudMigration.Key("delete_token_timeout").MustDuration(5 * time.Second)
 	cfg.CloudMigration.TokenExpiresAfter = cloudMigration.Key("token_expires_after").MustDuration(7 * 24 * time.Hour)
 	cfg.CloudMigration.IsDeveloperMode = cloudMigration.Key("developer_mode").MustBool(false)
-	cfg.CloudMigration.FeedbackURL = cloudMigration.Key("feedback_url").MustString("")
 	cfg.CloudMigration.FrontendPollInterval = cloudMigration.Key("frontend_poll_interval").MustDuration(2 * time.Second)
 	cfg.CloudMigration.AlertRulesState = cloudMigration.Key("alert_rules_state").In(GMSAlertRulesPaused, []string{GMSAlertRulesPaused, GMSAlertRulesUnchanged})
 

--- a/public/app/features/migrate-to-cloud/MigrateToCloud.tsx
+++ b/public/app/features/migrate-to-cloud/MigrateToCloud.tsx
@@ -1,48 +1,9 @@
 import { config } from '@grafana/runtime';
-import { Alert, TextLink } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
-
-import { Trans, t } from '../../core/internationalization';
 
 import { Page as CloudPage } from './cloud/Page';
 import { Page as OnPremPage } from './onprem/Page';
 
 export default function MigrateToCloud() {
-  const feedbackURL = config.cloudMigrationFeedbackURL;
-  return (
-    <Page navId="migrate-to-cloud">
-      <Alert
-        title={t('migrate-to-cloud.public-preview.title', 'Migrate to Grafana Cloud is in public preview')}
-        buttonContent={t('migrate-to-cloud.public-preview.button-text', 'Give feedback')}
-        severity={'info'}
-        onRemove={
-          feedbackURL
-            ? () => {
-                window.open(feedbackURL, '_blank');
-              }
-            : undefined
-        }
-      >
-        <Trans i18nKey="migrate-to-cloud.public-preview.message">
-          <TextLink
-            href="https://grafana.com/docs/grafana-cloud/account-management/migration-guide/cloud-migration-assistant/"
-            external
-          >
-            Visit our docs
-          </TextLink>{' '}
-          to learn more about this feature!
-        </Trans>
-        {config.cloudMigrationIsTarget && (
-          <>
-            &nbsp;
-            <Trans i18nKey="migrate-to-cloud.public-preview.message-cloud">
-              Your self-managed instance of Grafana requires version 11.5+, or 11.2+ with the onPremToCloudMigrations
-              feature flag enabled.
-            </Trans>
-          </>
-        )}
-      </Alert>
-      {config.cloudMigrationIsTarget ? <CloudPage /> : <OnPremPage />}
-    </Page>
-  );
+  return <Page navId="migrate-to-cloud">{config.cloudMigrationIsTarget ? <CloudPage /> : <OnPremPage />}</Page>;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2635,12 +2635,6 @@
       "link-title": "Grafana Cloud pricing",
       "title": "How much does it cost?"
     },
-    "public-preview": {
-      "button-text": "Give feedback",
-      "message": "<0>Visit our docs</0> to learn more about this feature!",
-      "message-cloud": "Your self-managed instance of Grafana requires version 11.5+, or 11.2+ with the onPremToCloudMigrations feature flag enabled.",
-      "title": "Migrate to Grafana Cloud is in public preview"
-    },
     "resource-details": {
       "dismiss-button": "OK",
       "error-messages": {


### PR DESCRIPTION
**What is this feature?**

Removes the following banner:

![Screenshot 2025-03-18 at 12 12 20](https://github.com/user-attachments/assets/28255053-0e60-4ddd-b515-26ab85691163)

**Why do we need this feature?**

The feedback form hasn't been used much, and since we're GAing the feature, we can remove the banner altogether.

**Who is this feature for?**

Cloud Migration Assistant users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1265

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
