### PR TITLE
[Provisioning] Add in-code TODOs in API Server area

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -113,7 +113,7 @@ type ExportJobOptions struct {
 
 type MigrateJobOptions struct {
 	// Target file prefix
-	// TODO: rename to path
+	// TODO: remove as we know have path in the repository
 	Prefix string `json:"prefix,omitempty"`
 
 	// Preserve history (if possible)

--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -104,6 +104,7 @@ type ExportJobOptions struct {
 	Branch string `json:"branch,omitempty"`
 
 	// Prefix in target file system
+	// TODO: rename to Path
 	Prefix string `json:"prefix,omitempty"`
 
 	// Include the identifier in the exported metadata
@@ -112,6 +113,7 @@ type ExportJobOptions struct {
 
 type MigrateJobOptions struct {
 	// Target file prefix
+	// TODO: rename to path
 	Prefix string `json:"prefix,omitempty"`
 
 	// Preserve history (if possible)

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -51,6 +51,7 @@ func (*filesConnector) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 // TODO: document the synchronous write and delete on the API Spec
+// TODO: Move dual write logic to `resources` package and keep this connector simple
 func (s *filesConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	logger := logging.FromContext(ctx).With("logger", "files-connector", "repository_name", name)
 	ctx = logging.Context(ctx, logger)

--- a/pkg/registry/apis/provisioning/history.go
+++ b/pkg/registry/apis/provisioning/history.go
@@ -79,6 +79,7 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 		logger := logger.With("ref", ref, "path", filePath)
 		ctx := logging.Context(r.Context(), logger)
 
+		// TODO: Add history pagination
 		commits, err := versioned.History(ctx, filePath, ref)
 		if err != nil {
 			logger.Debug("failed to get history", "error", err)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -96,6 +96,8 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 
 	isFromLegacy := dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, w.storageStatus)
 	progress.SetTotal(ctx, 10) // will show a progress bar
+
+	// TODO: we should fail fast if migration is not possible and not always clone the repository.
 	if repo.Config().Spec.GitHub != nil {
 		progress.SetMessage(ctx, "clone "+repo.Config().Spec.GitHub.URL)
 		reader, writer := io.Pipe()
@@ -197,7 +199,6 @@ func (w *MigrationWorker) migrateFromLegacy(ctx context.Context, rw repository.R
 			},
 		},
 	}, progress)
-
 	if err != nil { // this will have an error when too many errors exist
 		progress.SetMessage(ctx, "error importing resources, reverting")
 		if e2 := stopReadingUnifiedStorage(ctx, w.storageStatus); e2 != nil {

--- a/pkg/registry/apis/provisioning/list.go
+++ b/pkg/registry/apis/provisioning/list.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -46,21 +44,6 @@ func (s *listConnector) Connect(ctx context.Context, name string, opts runtime.O
 	ns, ok := request.NamespaceFrom(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing namespace")
-	}
-
-	if s == nil {
-		return nil, &apierrors.StatusError{ErrStatus: metav1.Status{
-			Status:  metav1.StatusFailure,
-			Code:    http.StatusInternalServerError,
-			Message: "listConnector is null??",
-		}}
-	}
-	if s.lister == nil {
-		return nil, &apierrors.StatusError{ErrStatus: metav1.Status{
-			Status:  metav1.StatusFailure,
-			Code:    http.StatusInternalServerError,
-			Message: "lister is null??",
-		}}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/registry/apis/provisioning/list.go
+++ b/pkg/registry/apis/provisioning/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
+// TODO: Rename to resources as it's not clear that we are returning here is repository resources
 type listConnector struct {
 	getter RepoGetter
 	lister resources.ResourceLister

--- a/pkg/registry/apis/provisioning/list.go
+++ b/pkg/registry/apis/provisioning/list.go
@@ -47,6 +47,7 @@ func (s *listConnector) Connect(ctx context.Context, name string, opts runtime.O
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO: Add pagination to resource lister
 		rsp, err := s.lister.List(ctx, ns, name)
 		if err != nil {
 			responder.Error(err)

--- a/pkg/registry/apis/provisioning/migrate.go
+++ b/pkg/registry/apis/provisioning/migrate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 )
 
+// TODO: should we have merge migrate and sync connectors and have a single repository job connector?
 type migrateConnector struct {
 	dual       dualwrite.Service
 	repoGetter RepoGetter

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -174,6 +174,8 @@ func RegisterAPIService(
 	return builder, nil
 }
 
+// TODO: Move specific endpoint authorization together with the rest of the logic.
+// so that things are not spread out all over the place.
 func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return authorizer.AuthorizerFunc(
 		func(ctx context.Context, a authorizer.Attributes) (decision authorizer.Decision, reason string, err error) {
@@ -318,6 +320,8 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	repositoryStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, repositoryStorage)
 
 	storage := map[string]rest.Storage{}
+
+	// TODO: Add some logic so that the connectors can registered themselves and we don't have logic all over the place
 	storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
 	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
 	storage[provisioning.RepositoryResourceInfo.StoragePath("status")] = repositoryStatusStorage
@@ -362,6 +366,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	return nil
 }
 
+// TODO: Move this to a more appropriate place. Probably controller/mutation.go
 func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	obj := a.GetObject()
 
@@ -386,6 +391,7 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 		r.Spec.Sync.IntervalSeconds = 60
 	}
 
+	// TODO: move this logic into github repository concrete implementation.
 	if r.Spec.Type == provisioning.GitHubRepositoryType {
 		if r.Spec.GitHub == nil {
 			return fmt.Errorf("github configuration is required")
@@ -408,6 +414,7 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 	return nil
 }
 
+// TODO: move logic to a more appropriate place. Probably controller/validation.go
 func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
 	obj := a.GetObject()
 	if obj == nil || a.GetOperation() == admission.Connect || a.GetOperation() == admission.Delete {
@@ -478,6 +485,7 @@ func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o adm
 	return nil
 }
 
+// TODO: move this to a more appropriate place. Probably controller/validation.go
 func (b *APIBuilder) verifySingleInstanceTarget(cfg *provisioning.Repository) *field.Error {
 	if cfg.Spec.Sync.Target == provisioning.SyncTargetTypeInstance {
 		all, err := b.repositoryLister.Repositories(cfg.Namespace).List(labels.Everything())
@@ -582,6 +590,7 @@ func (b *APIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return provisioning.GetOpenAPIDefinitions
 }
 
+// TODO: move endpoint specific logic to the connector so that we don't have things spread out all over the place.
 func (b *APIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	oas.Info.Description = "Provisioning"
 
@@ -915,6 +924,7 @@ spec:
 	return oas, nil
 }
 
+// TODO: move this to a more appropriate place
 func (b *APIBuilder) encryptSecrets(ctx context.Context, repo *provisioning.Repository) error {
 	var err error
 	if repo.Spec.GitHub != nil &&
@@ -996,6 +1006,7 @@ func (b *APIBuilder) tryRunningOnlyUnifiedStorage() error {
 }
 
 // Helpers for fetching valid Repository objects
+// TODO: where should the helpers live?
 
 func (b *APIBuilder) GetRepository(ctx context.Context, name string) (repository.Repository, error) {
 	obj, err := b.getter.Get(ctx, name, &metav1.GetOptions{})

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -321,6 +321,8 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
 	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
 	storage[provisioning.RepositoryResourceInfo.StoragePath("status")] = repositoryStatusStorage
+
+	// TODO: Do not set private fields directly, use factory methods.
 	storage[provisioning.RepositoryResourceInfo.StoragePath("webhook")] = &webhookConnector{
 		getter:          b,
 		jobs:            b.jobs,

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/util/errhttp"
 )
 
+// TODO: Move the specific logic to the connector so that we don't have logic all over the place.
 // GetAPIRoutes implements the direct HTTP handlers that bypass k8s
 func (b *APIBuilder) GetAPIRoutes() *builder.APIRoutes {
 	return &builder.APIRoutes{
@@ -26,7 +27,7 @@ func (b *APIBuilder) GetAPIRoutes() *builder.APIRoutes {
 					Get: &spec3.Operation{
 						OperationProps: spec3.OperationProps{
 							OperationId: "getResourceStats",                     // used for RTK client
-							Tags:        []string{"Provisioning", "Repository"}, //includes stats for repositores and provisiong in general
+							Tags:        []string{"Provisioning", "Repository"}, // includes stats for repositores and provisiong in general
 							Description: "Get resource stats for this namespace",
 							Parameters: []*spec3.Parameter{
 								{
@@ -72,7 +73,7 @@ func (b *APIBuilder) GetAPIRoutes() *builder.APIRoutes {
 					Get: &spec3.Operation{
 						OperationProps: spec3.OperationProps{
 							OperationId: "getFrontendSettings", // used for RTK client
-							//includes stats for repositores and provisiong in general
+							// includes stats for repositores and provisiong in general
 							// This must include "Repository" so that the RTK client will invalidate when things are deleted
 							Tags:        []string{"Provisioning", "Repository"},
 							Description: "Get the frontend settings for this namespace",
@@ -118,6 +119,7 @@ func (b *APIBuilder) GetAPIRoutes() *builder.APIRoutes {
 	}
 }
 
+// TODO: why didn't we create a connector as we did before or have a separate file?
 func (b *APIBuilder) handleStats(w http.ResponseWriter, r *http.Request) {
 	u, ok := authlib.AuthInfoFrom(r.Context())
 	if !ok {
@@ -134,6 +136,8 @@ func (b *APIBuilder) handleStats(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(stats)
 }
 
+// TODO: why didn't we create a connector as we did before or have a separate file?
+// TODO: is there a better way to provide a filtered view of the repositories to the frontend?
 func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	u, ok := authlib.AuthInfoFrom(ctx)
@@ -149,7 +153,8 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	settings := provisioning.RepositoryViewList{
-		Items:         make([]provisioning.RepositoryView, len(all)),
+		Items: make([]provisioning.RepositoryView, len(all)),
+		// FIXME: this shouldn't be here in provisioning but at the dual writer or something about the storage
 		LegacyStorage: dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, b.storageStatus),
 	}
 	for i, val := range all {

--- a/pkg/registry/apis/provisioning/sync.go
+++ b/pkg/registry/apis/provisioning/sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 )
 
+// TODO: should we have merge migrate and sync connectors and have a single repository job connector?
 type syncConnector struct {
 	repoGetter RepoGetter
 	jobs       jobs.JobQueue

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -70,7 +70,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, opts runtime.O
 					return
 				}
 
-				// TODO: remove this hack and it's not needed needed anymore as we validate OnCreate
+				// TODO: Explore how to better support synchronous validation for the UI (and likely remove this hack)
 				if name != "new" {
 					repo, err = s.getter.AsRepository(ctx, &cfg)
 					if err != nil {

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -70,6 +70,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, opts runtime.O
 					return
 				}
 
+				// TODO: remove this hack and it's not needed needed anymore as we validate OnCreate
 				if name != "new" {
 					repo, err = s.getter.AsRepository(ctx, &cfg)
 					if err != nil {
@@ -105,6 +106,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, opts runtime.O
 	}), nil
 }
 
+// TODO: Move tester to a more suitable location out of the connector.
 type RepositoryTester struct {
 	// Across Grafana (currently used to get a folder client)
 	clientFactory *resources.ClientFactory


### PR DESCRIPTION
- Add TODOs for files endpoint
- Add TODO history endpoint
- Add TODO to move files logic to resource package
- Add TODO to not use private fields directly
- Remove unnecessary checks in list connector
- Add pagination TODO in lister
- Add TODO to rename resources
- Add todo about cloning too early
- Add TODO to propose to merge sync and migrate endpoints
- Add TODOs in register
- Add more TODOs in connectors & routes
- Add TODOs about prefix
