### PR TITLE
[release-11.5.3] Dashboards: Fix missing `v/e/i` keybindings to return back to dashboard

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -43,7 +43,13 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   keybindings.addBinding({
     key: 'v',
     onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
-      if (!scene.state.viewPanelScene) {
+      if (scene.state.viewPanelScene) {
+        locationService.push(
+          locationUtil.getUrlForPartial(locationService.getLocation(), {
+            viewPanel: undefined,
+          })
+        );
+      } else {
         const url = locationUtil.stripBaseFromUrl(getViewPanelUrl(vizPanel));
         locationService.push(url);
       }
@@ -178,7 +184,13 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
         const sceneRoot = vizPanel.getRoot();
         if (sceneRoot instanceof DashboardScene) {
           const panelId = getPanelIdForVizPanel(vizPanel);
-          if (!scene.state.editPanel) {
+          if (scene.state.editPanel) {
+            locationService.push(
+              locationUtil.getUrlForPartial(locationService.getLocation(), {
+                editPanel: undefined,
+              })
+            );
+          } else {
             const url = locationUtil.stripBaseFromUrl(getEditPanelUrl(panelId));
             locationService.push(url);
           }


### PR DESCRIPTION
Backport 3e7626cc96c91af4b168514a778f4fbab5b3281d from #101876

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the old architecture you could use `v` and `e` to go into view and edit mode but also, on a second press, go back to the dashboard. This PR brings these keybindings back for parity. Also adds the functionality for the inspect tab as well as cause it makes sense to have it there as well.

**Why do we need this feature?**

To bring back this feature lost after the scenes migration.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
