### PR TITLE
Chore: Revert Disabling fe-unit-tests github action in release branches (#102361)

### DIFF
--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-#      Commenting out to unblock backports to release branches 
-#      - release-*.*.*
+      - release-*.*.*
 
 jobs:
   frontend-unit-tests:


### PR DESCRIPTION
This reverts commit b28e552a9ba851f21432e887d4c3edbd32a16319 introduced by https://github.com/grafana/grafana/pull/102361

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
;tldr; checks were enforced by the branch-protection rules defined in the gh repo settings