### PR TITLE
Chore: Remove print from fake service account svc

### DIFF
--- a/pkg/services/serviceaccounts/tests/fakes.go
+++ b/pkg/services/serviceaccounts/tests/fakes.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
@@ -58,7 +57,6 @@ func (f *FakeServiceAccountService) MigrateApiKey(ctx context.Context, orgID, ke
 }
 
 func (f *FakeServiceAccountService) MigrateApiKeysToServiceAccounts(ctx context.Context, orgID int64) (*serviceaccounts.MigrationResult, error) {
-	fmt.Printf("fake migration result: %v", f.ExpectedMigrationResult)
 	return f.ExpectedMigrationResult, f.ExpectedErr
 }
 


### PR DESCRIPTION
I noticed that grafana-bench was failing to parse the go test coverage output: https://github.com/grafana/grafana/actions/runs/13924224327/job/38964427935

```ini
time=2025-03-18T13:30:10.136Z
level=ERROR
msg="parsing go-json input invalid format missing start for test \"github.com/grafana/grafana/pkg/services/serviceaccounts/api\""
service=bench
```

Turns out the output becomes quite different when there are print statements in a test, and it breaks `grafana-bench`.

Perhaps the parser needs to cover these scenarios, but for now it makes sense as well to remove these debug prints.