### PR TITLE
Feature: Add releasefinder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -316,6 +316,7 @@
 /Makefile @grafana/grafana-developer-enablement-squad
 /scripts/build/ @grafana/grafana-developer-enablement-squad
 /scripts/list-release-artifacts.sh @grafana/grafana-developer-enablement-squad
+/scripts/releasefinder.sh @baldm0mma
 /.trivyignore @grafana/grafana-backend-services-squad
 
 # OSS Plugin Partnerships backend code

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -72,20 +72,20 @@ for tag in $(git tag | sort -V); do
         # Check if there's a matching release branch in origin
         release_branch="release-${tag#v}"
         if git show-ref --verify --quiet "refs/remotes/origin/$release_branch" 2>/dev/null; then
-            release_branches+=("${tag#v}")
+            release_branches+=("$release_branch")
         fi
         
         # If this is the first tag containing the commit, it's the initial release tag
         if [ ${#direct_tags[@]} -eq 0 ]; then
-            direct_tags+=("${tag#v}")
+            direct_tags+=("$tag")
         else
-            included_tags+=("${tag#v}")
+            included_tags+=("$tag")
         fi
     fi
 done
 
 # Print release branches
-echo "Included in release branches:"
+echo "Present in the following release branches:"
 if [ ${#release_branches[@]} -eq 0 ]; then
     echo "  None"
 else
@@ -103,7 +103,7 @@ fi
 echo
 
 # Print included tags
-echo "Included in these release tags:"
+echo "Present also in the following release tags:"
 if [ ${#included_tags[@]} -eq 0 ]; then
     echo "  None"
 else
@@ -112,8 +112,8 @@ fi
 echo
 
 # Find first release
-if [ ${#release_branches[@]} -gt 0 ]; then
-    first_release=$(printf "%s\n" "${release_branches[@]}" | sort -V | head -n1)
+if [ ${#direct_tags[@]} -gt 0 ]; then
+    first_release=$(printf "%s\n" "${direct_tags[@]}" | sort -V | head -n1)
     echo "First included in release: $first_release"
 else
     echo "Not included in any releases"

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -8,6 +8,10 @@
 # 4. The first release that included the commit
 #
 # Usage: ./scripts/releasefinder.sh <commit-hash>
+# The commit hash can be either:
+# - Full hash (e.g., 1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t)
+# - Short hash (e.g., 1a2b3c4d)
+#
 # Example: ./scripts/releasefinder.sh a1b2c3d4e5f6
 #
 # If you get a "Permission denied" error, make the script executable with:
@@ -24,6 +28,9 @@ fi
 # Check if a commit hash was provided
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <commit-hash>"
+    echo "The commit hash can be either:"
+    echo "  - Full hash (e.g., 1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t)"
+    echo "  - Short hash (e.g., 1a2b3c4d)"
     echo "Example: $0 a1b2c3d4e5f6"
     exit 1
 fi
@@ -33,6 +40,7 @@ COMMIT_HASH=$1
 # Validate that the commit exists
 if ! git cat-file -t "$COMMIT_HASH" >/dev/null 2>&1; then
     echo "Error: Commit $COMMIT_HASH not found in repository"
+    echo "Make sure you've provided a valid commit hash (full or short)"
     exit 1
 fi
 

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# This script finds which Grafana releases include a specific commit.
+# It checks both release branches and tags to determine:
+# 1. Which release branches contain the commit
+# 2. If the commit is directly tagged with a release version
+# 3. Which release tags include the commit
+# 4. The first release that included the commit
+#
+# Usage: ./scripts/releasefinder.sh <commit-hash>
+# Example: ./scripts/releasefinder.sh a1b2c3d4e5f6
+#
+# If you get a "Permission denied" error, make the script executable with:
+#   chmod +x scripts/releasefinder.sh
+
+# Check if script is executable
+if [ ! -x "$0" ]; then
+    echo "Error: This script is not executable."
+    echo "To fix this, run: chmod +x $0"
+    echo "Then try running the script again."
+    exit 1
+fi
+
 # Check if a commit hash was provided
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <commit-hash>"

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -3,7 +3,7 @@
 # This script finds which Grafana releases include a specific commit.
 # It checks both release branches and tags to determine:
 # 1. Which release branches contain the commit
-# 2. If the commit is directly tagged with a release version
+# 2. The first release tag that included the commit
 # 3. Which release tags include the commit
 # 4. The first release that included the commit
 #
@@ -61,7 +61,7 @@ declare -a direct_tags=()
 declare -a included_tags=()
 
 # Get all version tags that contain the commit
-for tag in $(git tag); do
+for tag in $(git tag | sort -V); do
     # Skip non-version tags
     if ! [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         continue
@@ -75,9 +75,8 @@ for tag in $(git tag); do
             release_branches+=("${tag#v}")
         fi
         
-        # Check if this is a direct tag on the commit
-        tag_commit=$(git rev-parse "$tag")
-        if [ "$tag_commit" = "$COMMIT_HASH" ]; then
+        # If this is the first tag containing the commit, it's the initial release tag
+        if [ ${#direct_tags[@]} -eq 0 ]; then
             direct_tags+=("${tag#v}")
         else
             included_tags+=("${tag#v}")
@@ -94,8 +93,8 @@ else
 fi
 echo
 
-# Print direct tags
-echo "Directly tagged with:"
+# Print initial release tag
+echo "Initial release tag:"
 if [ ${#direct_tags[@]} -eq 0 ]; then
     echo "  None"
 else

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -45,7 +45,7 @@ if ! git cat-file -t "$COMMIT_HASH" >/dev/null 2>&1; then
 fi
 
 echo "Fetching latest remote information..."
-git fetch --all --tags --prune
+git fetch --all --tags --prune 2>/dev/null
 
 echo "Finding release branches containing the commit..."
 echo "Finding tags associated with the commit..."
@@ -76,7 +76,8 @@ for tag in $(git tag); do
         fi
         
         # Check if this is a direct tag on the commit
-        if git rev-parse "$tag" == "$COMMIT_HASH" 2>/dev/null; then
+        tag_commit=$(git rev-parse "$tag")
+        if [ "$tag_commit" = "$COMMIT_HASH" ]; then
             direct_tags+=("${tag#v}")
         else
             included_tags+=("${tag#v}")

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -18,11 +18,20 @@ fi
 echo "Fetching latest remote information..."
 git fetch --all --tags --prune
 
-echo "Finding releases for commit $COMMIT_HASH..."
+echo "Finding release branches containing the commit..."
+echo "Finding tags associated with the commit..."
 echo
 
+echo "Results for commit: $COMMIT_HASH"
+echo "============================================="
+echo
+
+# Arrays to store results
+declare -a release_branches=()
+declare -a direct_tags=()
+declare -a included_tags=()
+
 # Get all version tags that contain the commit
-echo "Checking version tags..."
 for tag in $(git tag); do
     # Skip non-version tags
     if ! [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -34,15 +43,49 @@ for tag in $(git tag); do
         # Check if there's a matching release branch in origin
         release_branch="release-${tag#v}"
         if git show-ref --verify --quiet "refs/remotes/origin/$release_branch" 2>/dev/null; then
-            echo "Found in release:"
-            echo "  Tag:   $tag"
-            echo "  Branch: $release_branch"
-            echo
+            release_branches+=("${tag#v}")
+        fi
+        
+        # Check if this is a direct tag on the commit
+        if git rev-parse "$tag" == "$COMMIT_HASH" 2>/dev/null; then
+            direct_tags+=("${tag#v}")
+        else
+            included_tags+=("${tag#v}")
         fi
     fi
 done
 
-# If no releases were found
-if [ $? -ne 0 ]; then
-    echo "No releases found containing the specified commit"
+# Print release branches
+echo "Included in release branches:"
+if [ ${#release_branches[@]} -eq 0 ]; then
+    echo "  None"
+else
+    printf "  - %s\n" "${release_branches[@]}" | sort -V
+fi
+echo
+
+# Print direct tags
+echo "Directly tagged with:"
+if [ ${#direct_tags[@]} -eq 0 ]; then
+    echo "  None"
+else
+    printf "  - %s\n" "${direct_tags[@]}" | sort -V
+fi
+echo
+
+# Print included tags
+echo "Included in these release tags:"
+if [ ${#included_tags[@]} -eq 0 ]; then
+    echo "  None"
+else
+    printf "  - %s\n" "${included_tags[@]}" | sort -V
+fi
+echo
+
+# Find first release
+if [ ${#release_branches[@]} -gt 0 ]; then
+    first_release=$(printf "%s\n" "${release_branches[@]}" | sort -V | head -n1)
+    echo "First included in release: $first_release"
+else
+    echo "Not included in any releases"
 fi 

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -55,6 +55,14 @@ echo "Results for commit: $COMMIT_HASH"
 echo "============================================="
 echo
 
+# Get commit details
+echo "Commit details:"
+echo "  Author: $(git log -1 --format="%an <%ae>" "$COMMIT_HASH")"
+echo "  Date: $(git log -1 --format="%ad" --date=iso "$COMMIT_HASH")"
+echo "  Message:"
+git log -1 --format="  %B" "$COMMIT_HASH" | sed 's/^/    /'
+echo
+
 # Arrays to store results
 declare -a release_branches=()
 declare -a direct_tags=()

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -47,8 +47,8 @@ fi
 echo "Fetching latest remote information..."
 git fetch --all --tags --prune 2>/dev/null
 
-echo "Finding release branches containing the commit..."
-echo "Finding tags associated with the commit..."
+echo "Finding release branches containing the commit"
+echo "Finding tags associated with the commit"
 echo
 
 echo "Results for commit: $COMMIT_HASH"
@@ -110,12 +110,21 @@ echo "Included in release branches:"
 if [ ${#release_branches[@]} -eq 0 ]; then
     echo "  None"
 else
-    printf "  - %s\n" "${release_branches[@]}" | sort -V
+    for branch in "${release_branches[@]}"; do
+        # Convert branch name to tag format (e.g., release-11.5.0 -> v11.5.0)
+        tag_version="v${branch#release-}"
+        # Check if tag exists
+        if git tag | grep -q "^$tag_version$"; then
+            echo "  - $branch"
+        else
+            echo "  - $branch (release for this branch upcoming)"
+        fi
+    done | sort -V
 fi
 echo
 
 # Print initial release tag
-echo "Initial release tag:"
+echo "Initial release tag (the first release in which this commit was included):"
 if [ ${#direct_tags[@]} -eq 0 ]; then
     echo "  None"
 else
@@ -124,7 +133,7 @@ fi
 echo
 
 # Print included tags
-echo "Included in these release tags:"
+echo "Included in these release tags (the subsequent releases that included this commit):"
 if [ ${#included_tags[@]} -eq 0 ]; then
     echo "  None"
 else

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -15,6 +15,9 @@ if ! git cat-file -t "$COMMIT_HASH" >/dev/null 2>&1; then
     exit 1
 fi
 
+echo "Fetching latest remote information..."
+git fetch --all --tags --prune
+
 echo "Finding releases for commit $COMMIT_HASH..."
 echo
 
@@ -28,9 +31,9 @@ for tag in $(git tag); do
     
     # Check if the commit is in this tag
     if git merge-base --is-ancestor "$COMMIT_HASH" "$tag" 2>/dev/null; then
-        # Check if there's a matching release branch
+        # Check if there's a matching release branch in origin
         release_branch="release-${tag#v}"
-        if git show-ref --verify --quiet "refs/heads/$release_branch" 2>/dev/null; then
+        if git show-ref --verify --quiet "refs/remotes/origin/$release_branch" 2>/dev/null; then
             echo "Found in release:"
             echo "  Tag:   $tag"
             echo "  Branch: $release_branch"

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -59,8 +59,6 @@ echo
 echo "Commit details:"
 echo "  Author: $(git log -1 --format="%an <%ae>" "$COMMIT_HASH")"
 echo "  Date: $(git log -1 --format="%ad" --date=iso "$COMMIT_HASH")"
-echo "  Message:"
-git log -1 --format="  %B" "$COMMIT_HASH" | sed 's/^/    /'
 echo
 
 # Arrays to store results

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -60,18 +60,18 @@ declare -a release_branches=()
 declare -a direct_tags=()
 declare -a included_tags=()
 
-# First check all release branches
-for branch in $(git branch -r | grep 'origin/release-' | sed 's/origin\///'); do
+# First check all release branches (including security releases)
+for branch in $(git branch -r | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/origin\///'); do
     # Check if the commit is in this branch's history
     if git merge-base --is-ancestor "$COMMIT_HASH" "origin/$branch" 2>/dev/null; then
         release_branches+=("$branch")
     fi
 done
 
-# Then check all version tags
+# Then check all version tags (including security releases)
 for tag in $(git tag | sort -V); do
     # Skip non-version tags
-    if ! [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if ! [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$ ]]; then
         continue
     fi
     

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -47,8 +47,8 @@ fi
 echo "Fetching latest remote information..."
 git fetch --all --tags --prune 2>/dev/null
 
-echo "Finding release branches containing the commit"
-echo "Finding tags associated with the commit"
+echo "Finding release branches containing the commit..."
+echo "Finding tags associated with the commit..."
 echo
 
 echo "Results for commit: $COMMIT_HASH"

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Check if a commit hash was provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <commit-hash>"
+    echo "Example: $0 a1b2c3d4e5f6"
+    exit 1
+fi
+
+COMMIT_HASH=$1
+
+# Validate that the commit exists
+if ! git cat-file -t "$COMMIT_HASH" >/dev/null 2>&1; then
+    echo "Error: Commit $COMMIT_HASH not found in repository"
+    exit 1
+fi
+
+echo "Finding releases for commit $COMMIT_HASH..."
+echo
+
+# Get all version tags that contain the commit
+echo "Checking version tags..."
+for tag in $(git tag); do
+    # Skip non-version tags
+    if ! [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        continue
+    fi
+    
+    # Check if the commit is in this tag
+    if git merge-base --is-ancestor "$COMMIT_HASH" "$tag" 2>/dev/null; then
+        # Check if there's a matching release branch
+        release_branch="release-${tag#v}"
+        if git show-ref --verify --quiet "refs/heads/$release_branch" 2>/dev/null; then
+            echo "Found in release:"
+            echo "  Tag:   $tag"
+            echo "  Branch: $release_branch"
+            echo
+        fi
+    fi
+done
+
+# If no releases were found
+if [ $? -ne 0 ]; then
+    echo "No releases found containing the specified commit"
+fi 

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -61,6 +61,19 @@ echo "  Author: $(git log -1 --format="%an <%ae>" "$COMMIT_HASH")"
 echo "  Date: $(git log -1 --format="%ad" --date=iso "$COMMIT_HASH")"
 echo
 
+# Check for backport information
+echo "Backport information:"
+if git log -1 --pretty=format:"%B" "$COMMIT_HASH" | grep -q "cherry picked from commit"; then
+    ORIGINAL_COMMIT=$(git log -1 --pretty=format:"%B" "$COMMIT_HASH" | grep "cherry picked from commit" | sed 's/.*cherry picked from commit \([a-f0-9]*\).*/\1/')
+    echo "  This is a backport from commit: $ORIGINAL_COMMIT"
+    echo "  Original commit details:"
+    echo "    Author: $(git log -1 --format="%an <%ae>" "$ORIGINAL_COMMIT")"
+    echo "    Date: $(git log -1 --format="%ad" --date=iso "$ORIGINAL_COMMIT")"
+else
+    echo "  Not a backport"
+fi
+echo
+
 # Arrays to store results
 declare -a release_branches=()
 declare -a direct_tags=()


### PR DESCRIPTION
This adds the ability to check in which releases a certain commit is included. This should help reduce the reliance on milestones, which are often incorrect. This script taps into the actual source of truth (release tags) to find release data. This also handles backport info.

Usage: ./scripts/releasefinder.sh <commit-hash>
The commit hash can be either:
- Full hash (e.g., `ae9460b863cff926823de3a374bbae77e6a8c0e4`)
- Short hash (e.g., `ae9460b`)

Example: `./scripts/releasefinder.sh ae9460b863cff926823de3a374bbae77e6a8c0e4`

Output:
```
Fetching latest remote information...
Finding release branches containing the commit...
Finding tags associated with the commit...

Results for commit: ae9460b
=============================================

Commit details:
  Author: Jev Forsberg <46619047+baldm0mma@users.noreply.github.com>
  Date: 2024-12-05 16:09:38 -0700

Backport information:
  Not a backport

Included in release branches:
  - release-11.5.0
  - release-11.5.1
  - release-11.5.2
  - release-11.5.3
  - release-11.6.0

Initial release tag:
  - v11.5.0

Included in these release tags:
  - v11.5.1
  - v11.5.2

First included in release: v11.5.0
```