### PR TITLE
Search: fix - title filter returning too many matches

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -873,10 +873,14 @@ func newQuery(key string, value string, prefix string) query.Query {
 		for _, token := range tokens {
 			_, ok := hasTerms(token)
 			if ok {
-				qq.AddQuery(bleve.NewTermQuery(token))
+				tq := bleve.NewTermQuery(token)
+				tq.FieldVal = prefix + key
+				qq.AddQuery(tq)
 				continue
 			}
-			qq.AddQuery(bleve.NewMatchQuery(token))
+			mq := bleve.NewMatchQuery(token)
+			mq.FieldVal = prefix + key
+			qq.AddQuery(mq)
 		}
 
 		cq := bleve.NewDisjunctionQuery(q, qq)

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -858,6 +858,7 @@ func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *r
 	)
 }
 
+// newQuery will create a query that will match the value or the tokens of the value
 func newQuery(key string, value string, prefix string) query.Query {
 	delimiter, ok := hasTerms(value)
 	if termField[key] && ok {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -159,7 +159,7 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 	var index bleve.Index
 
 	build := true
-	mapper, err := getBleveMappings(fields)
+	mapper, err := GetBleveMappings(fields)
 	if err != nil {
 		return nil, err
 	}
@@ -1107,7 +1107,7 @@ func (q *permissionScopedQuery) Searcher(ctx context.Context, i index.IndexReade
 
 // hasTerms - any value that will be split into multiple tokens
 var hasTerms = func(v string) (string, bool) {
-	for _, c := range termCharacters {
+	for _, c := range TermCharacters {
 		if strings.Contains(v, c) {
 			return c, true
 		}
@@ -1116,7 +1116,7 @@ var hasTerms = func(v string) (string, bool) {
 }
 
 // characters that will be used to determine if a value is split into tokens
-var termCharacters = []string{
+var TermCharacters = []string{
 	" ", "-", "_", ".", ",", ":", ";", "?", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "+",
 	"=", "{", "}", "[", "]", "|", "\\", "/", "<", ">", "~", "`",
 	"'", "\"",

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -796,7 +796,6 @@ var termField = map[string]bool{
 
 // Convert a "requirement" into a bleve query
 func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *resource.ErrorResult) {
-	key := req.Key
 	switch selection.Operator(req.Operator) {
 	case selection.Equals, selection.DoubleEquals:
 		if len(req.Values) == 0 {
@@ -804,13 +803,13 @@ func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *r
 		}
 
 		if len(req.Values) == 1 {
-			filter := filterValue(key, req.Values[0])
-			return newQuery(key, filter, prefix), nil
+			filter := filterValue(req.Key, req.Values[0])
+			return newQuery(req.Key, filter, prefix), nil
 		}
 
 		conjuncts := []query.Query{}
 		for _, v := range req.Values {
-			q := newQuery(key, filterValue(key, v), prefix)
+			q := newQuery(req.Key, filterValue(req.Key, v), prefix)
 			conjuncts = append(conjuncts, q)
 		}
 
@@ -826,13 +825,13 @@ func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *r
 			return query.NewMatchAllQuery(), nil
 		}
 		if len(req.Values) == 1 {
-			q := newQuery(key, filterValue(key, req.Values[0]), prefix)
+			q := newQuery(req.Key, filterValue(req.Key, req.Values[0]), prefix)
 			return q, nil
 		}
 
 		disjuncts := []query.Query{}
 		for _, v := range req.Values {
-			q := newQuery(key, filterValue(key, v), prefix)
+			q := newQuery(req.Key, filterValue(req.Key, v), prefix)
 			disjuncts = append(disjuncts, q)
 		}
 
@@ -843,7 +842,7 @@ func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *r
 
 		var mustNotQueries []query.Query
 		for _, value := range req.Values {
-			q := newQuery(key, filterValue(key, value), prefix)
+			q := newQuery(req.Key, filterValue(req.Key, value), prefix)
 			mustNotQueries = append(mustNotQueries, q)
 		}
 		boolQuery.AddMustNot(mustNotQueries...)
@@ -883,8 +882,7 @@ func newQuery(key string, value string, prefix string) query.Query {
 			qq.AddQuery(mq)
 		}
 
-		cq := bleve.NewDisjunctionQuery(q, qq)
-		return cq
+		return bleve.NewDisjunctionQuery(q, qq)
 	}
 	q := bleve.NewMatchQuery(value)
 	q.FieldVal = prefix + key

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -31,22 +31,21 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 	}
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_NAME, nameMapping)
 
+	// for sorting by title full phrase
+	titlePhraseMapping := bleve.NewKeywordFieldMapping()
+	titlePhraseMapping.Store = false // already stored in title
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_PHRASE, titlePhraseMapping)
+
 	// for searching by title - uses an edge ngram token filter
 	titleSearchMapping := bleve.NewTextFieldMapping()
 	titleSearchMapping.Analyzer = TITLE_ANALYZER
 	titleSearchMapping.Store = false // already stored in title
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_NGRAM, titleSearchMapping)
 
 	// mapping for title to search on words/tokens larger than the ngram size
 	titleWordMapping := bleve.NewTextFieldMapping()
 	titleWordMapping.Analyzer = standard.Name
 	titleWordMapping.Store = true
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping)
-
-	// for filtering/sorting by title full phrase
-	titlePhraseMapping := bleve.NewKeywordFieldMapping()
-	titleSearchMapping.Store = false // already stored in title
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_PHRASE, titlePhraseMapping)
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping, titleSearchMapping, titlePhraseMapping)
 
 	descriptionMapping := &mapping.FieldMapping{
 		Name:               resource.SEARCH_FIELD_DESCRIPTION,

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-func getBleveMappings(fields resource.SearchableDocumentFields) (mapping.IndexMapping, error) {
+func GetBleveMappings(fields resource.SearchableDocumentFields) (mapping.IndexMapping, error) {
 	mapper := bleve.NewIndexMapping()
 
 	err := RegisterCustomAnalyzers(mapper)

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -45,6 +45,7 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 	titleWordMapping := bleve.NewTextFieldMapping()
 	titleWordMapping.Analyzer = standard.Name
 	titleWordMapping.Store = true
+	// NOTE: this causes 3 title fields in the response
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping, titleSearchMapping, titlePhraseMapping)
 
 	descriptionMapping := &mapping.FieldMapping{

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -1,4 +1,4 @@
-package search
+package search_test
 
 import (
 	"fmt"
@@ -9,10 +9,11 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 )
 
 func TestDocumentMapping(t *testing.T) {
-	mappings, err := getBleveMappings(nil)
+	mappings, err := search.GetBleveMappings(nil)
 	require.NoError(t, err)
 	data := resource.IndexableDocument{
 		Title:       "title",

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -48,5 +48,5 @@ func TestDocumentMapping(t *testing.T) {
 
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
-	require.Equal(t, 16, len(doc.Fields))
+	require.Equal(t, 17, len(doc.Fields))
 }

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -1,0 +1,125 @@
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIndex() (resource.ResourceIndex, string) {
+	// size := 1000000  // TODO: 200k documents standard size?
+	size := 200000
+	// batchSize := 1000 slower 8s (for 200k documents) - 34s (for 1M documents)
+	// batchSize := 10000 // faster 5s  (for 200k documents) - 27s (for 1M documents)
+	batchSize := 100000 // fasterer 3.5s  (for 200k documents) - 27s  (for 1M documents)
+	writer := newTestWriter(size, batchSize)
+	return newTestDashboardsIndex(nil, 1, int64(size), int64(batchSize), writer)
+}
+
+const maxAllowedTime = 20 * time.Millisecond // Reasonable (can vary per env) performance threshold per query (e.g., 20ms)
+const maxAllowedAllocMB = 1                  // 1MB memory per operation
+const maxAllowedAlloc = maxAllowedAllocMB * 1024 * 1024
+const verbose = false
+
+// BenchmarkBleveQuery measures the time, mem, cpu to execute a search query
+// changes the the indexer settings can cause unforseen performance issues ( for example: using wildcard queries )
+// this will fail if the stats exceed the "normal" thresholds
+func BenchmarkBleveQuery(b *testing.B) {
+	var memStatsStart runtime.MemStats
+	var memStatsAfterIndex runtime.MemStats
+	runtime.ReadMemStats(&memStatsStart)
+
+	testIndex, testIndexDir := setupIndex()
+	defer os.RemoveAll(testIndexDir)
+	runtime.ReadMemStats(&memStatsAfterIndex)
+
+	allocDiff := memStatsAfterIndex.Alloc - memStatsStart.Alloc
+
+	logVerbose(fmt.Sprintf("Memory allocated for index: %d bytes", allocDiff))
+
+	searchRequest := newQueryByTitle("name99999")
+
+	b.ResetTimer()   // Reset timer before benchmarking
+	b.ReportAllocs() // Track memory allocations
+
+	for i := 0; i < b.N; i++ {
+		start := time.Now() // Start timer
+		var memStatsBefore, memStatsAfter runtime.MemStats
+		runtime.ReadMemStats(&memStatsBefore)
+
+		_, err := testIndex.Search(context.Background(), nil, searchRequest, nil)
+
+		elapsed := time.Since(start) // Calculate elapsed time
+		runtime.ReadMemStats(&memStatsAfter)
+		allocDiff := (memStatsAfter.Alloc - memStatsBefore.Alloc)
+		if memStatsAfter.Alloc < memStatsBefore.Alloc {
+			// This can happen due to memory being freed after the search operation
+			allocDiff = 0 // don't care if it goes down
+		}
+
+		logVerbose(fmt.Sprintf("Memory allocated for query: %d bytes", allocDiff))
+
+		require.NoError(b, err)
+
+		// Fail if query takes longer than maxAllowedTime
+		if elapsed > maxAllowedTime {
+			b.Fatalf("Query too slow: %v (limit: %v)", elapsed, maxAllowedTime)
+		}
+		// Check memory allocation limit
+		if allocDiff > maxAllowedAlloc {
+			b.Fatalf("Excessive memory usage: %d mb (limit: %d mb)", allocDiff, maxAllowedAllocMB)
+		}
+	}
+}
+
+func newTestWriter(size int, batchSize int) IndexWriter {
+	key := &resource.ResourceKey{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	return func(index resource.ResourceIndex) (int64, error) {
+		total := time.Now()
+		start := time.Now()
+		for i := range size {
+			name := fmt.Sprintf("name%d", i)
+			err := index.Write(&resource.IndexableDocument{
+				RV:   int64(i),
+				Name: name,
+				Key: &resource.ResourceKey{
+					Name:      name,
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+				},
+				Title: name + "-title",
+			})
+			if err != nil {
+				return 0, err
+			}
+			// show progress for every batch
+			if i%batchSize == 0 && verbose {
+				fmt.Printf("Indexed %d documents\n", i)
+				end := time.Now()
+				fmt.Printf("Time taken for indexing batch: %s\n", end.Sub(start))
+				start = time.Now()
+			}
+		}
+		end := time.Now()
+		logVerbose(fmt.Sprintf("Indexed %d documents in %s", size, end.Sub(total)))
+		return 0, nil
+	}
+}
+
+func logVerbose(msg string) {
+	if verbose {
+		fmt.Println(msg)
+	}
+}

--- a/pkg/storage/unified/search/document_test.go
+++ b/pkg/storage/unified/search/document_test.go
@@ -1,4 +1,4 @@
-package search
+package search_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 )
 
 func doSnapshotTests(t *testing.T, builder resource.DocumentBuilder, kind string, key *resource.ResourceKey, names []string) {
@@ -52,14 +53,14 @@ func TestDashboardDocumentBuilder(t *testing.T) {
 		Resource:  "dashboards",
 	}
 
-	info, err := DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &DashboardDocumentBuilder{
+	info, err := search.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
+		return &search.DashboardDocumentBuilder{
 			Namespace: namespace,
 			Blob:      blob,
 			Stats: map[string]map[string]int64{
 				"aaa": {
-					DASHBOARD_ERRORS_LAST_1_DAYS: 1,
-					DASHBOARD_ERRORS_LAST_7_DAYS: 1,
+					search.DASHBOARD_ERRORS_LAST_1_DAYS: 1,
+					search.DASHBOARD_ERRORS_LAST_7_DAYS: 1,
 				},
 			},
 			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{


### PR DESCRIPTION
we removed wildcard searching as it caused performance issues.  this broke a couple areas that were wrapping the filter with wildcards

removed the wildcards we were using for title search.  title_ngram allows for partial matching now, so we can take the original approach ( filter by title field explicitly )
