### PR TITLE
unistore: use the same connection string as grafana

### DIFF
--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -203,37 +203,6 @@ then run:
 kubectl --kubeconfig=./grafana.kubeconfig create -f folder-generate.yaml
 ```
 
-### Use a separate database
-
-By default Unified Storage uses the Grafana database. To run against a separate database, update `custom.ini` by adding the following section to it:
-
-```
-[resource_api]
-db_type = mysql
-db_host = localhost:3306
-db_name = grafana
-db_user = <username>
-db_pass = <password>
-```
-
-MySQL and Postgres are both supported. The `<username>` and `<password>` values can be found in the following devenv docker compose files: [MySQL](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/mysql/docker-compose.yaml#L6-L7) and [Postgres](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/postgres/docker-compose.yaml#L4-L5).
-
-Then, run
-```sh
-make devenv sources=<source>
-```
-where source is either `mysql` or `postgres`.
-
-Finally, run the Grafana backend with
-
-```sh
-bra run
-```
-or
-```sh
-make run
-```
-
 ### Run as a GRPC service
 
 #### Start GRPC storage-server

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -23,6 +23,7 @@ import (
 const (
 	dbTypeMySQL    = "mysql"
 	dbTypePostgres = "postgres"
+	dbTypeSQLite   = "sqlite3"
 )
 
 const grafanaDBInstrumentQueriesKey = "instrument_queries"
@@ -88,8 +89,7 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 	dbType := getter.String("type")
 	grafanaDBType := fallbackGetter.String("type")
 	switch {
-	// First try with the config in the "resource_api" section, which is
-	// specific to Unified Storage
+	// Deprecated: First try with the config in the "resource_api" section, which is specific to Unified Storage
 	case dbType == dbTypePostgres:
 		p.registerMetrics = true
 		p.engine, err = getEnginePostgres(getter)
@@ -100,37 +100,23 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		p.engine, err = getEngineMySQL(getter)
 		return p, err
 
-		// TODO: add support for SQLite
-
 	case dbType != "":
 		return p, fmt.Errorf("invalid db type specified: %s", dbType)
 
-	// If we have an empty Resource API db config, try with the core Grafana
-	// database config
-
-	case grafanaDBType == dbTypePostgres:
+	// If we have an empty Resource API db config, try with the core Grafana database config
+	case grafanaDBType != "":
 		p.registerMetrics = true
-		p.engine, err = getEnginePostgres(fallbackGetter)
+		p.engine, err = getEngine(cfg)
 		return p, err
-
-	case grafanaDBType == dbTypeMySQL:
-		p.registerMetrics = true
-		p.engine, err = getEngineMySQL(fallbackGetter)
-		return p, err
-
-	// TODO: add support for SQLite
-
 	case grafanaDB != nil:
-		// try to use the grafana db connection
-
+		// try to use the grafana db connection (should only happen in tests)
 		if fallbackGetter.Bool(grafanaDBInstrumentQueriesKey) {
 			return nil, errGrafanaDBInstrumentedNotSupported
 		}
 		p.engine = grafanaDB.GetEngine()
 		return p, nil
-
 	default:
-		return p, fmt.Errorf("no db connection provided")
+		return p, fmt.Errorf("no database type specified")
 	}
 }
 

--- a/pkg/storage/unified/sql/db/dbimpl/regression_incident_2144_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/regression_incident_2144_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -104,7 +105,8 @@ func TestReproIncident2144UsingGrafanaDB(t *testing.T) {
 
 			t.Run("Resource API provides a reasonable error for this case", func(t *testing.T) {
 				t.Parallel()
-				cfg := newCfgFromIniMap(t, cfgMap)
+				cfg := setting.NewCfg()
+				cfg.SectionWithEnvOverrides("database").Key(grafanaDBInstrumentQueriesKey).SetValue("true")
 				resourceDB, err := ProvideResourceDB(grafanaDB, cfg, nil)
 				require.Nil(t, resourceDB)
 				require.Error(t, err)


### PR DESCRIPTION
Deprecate the resouce_api custom database configuration in favore of using the same connection string as grafana. 
Use the same setup for sqlite.

I will remove the code for resouce_api in another PR