### PR TITLE
Alerting: Sanitize labels in ExternalAlertmanager before sending

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	alertingClusterPB "github.com/grafana/alerting/cluster/clusterpb"
-	alertingModels "github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
 
 	"gopkg.in/yaml.v3"
@@ -486,16 +485,6 @@ func (am *Alertmanager) GetAlertGroups(ctx context.Context, active, silenced, in
 }
 
 func (am *Alertmanager) PutAlerts(ctx context.Context, alerts apimodels.PostableAlerts) error {
-	for _, a := range alerts.PostableAlerts {
-		for k, v := range a.Labels {
-			// The Grafana Alertmanager skips empty and namespace UID labels.
-			// To get the same alert fingerprint we need to remove these labels too.
-			// https://github.com/grafana/alerting/blob/2dda1c67ec02625ac9fc8607157b3d5825d47919/notify/grafana_alertmanager.go#L722-L724
-			if len(v) == 0 || k == alertingModels.NamespaceUIDLabel {
-				delete(a.Labels, k)
-			}
-		}
-	}
 	am.log.Debug("Sending alerts to a remote alertmanager", "url", am.url, "alerts", len(alerts.PostableAlerts))
 	am.sender.SendAlerts(alerts)
 	return nil


### PR DESCRIPTION
**What is this feature?**

We remove empty and the namespace uid label before sending them to an external alertmanager (https://github.com/grafana/grafana/pull/90284). This PR moves this logic to the ExternalAlertmanager so that it can be reused.
