### PR TITLE
fix(unified-storage): update instrumentation_server metric gatherer

### DIFF
--- a/pkg/server/instrumentation_service.go
+++ b/pkg/server/instrumentation_service.go
@@ -9,19 +9,21 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type instrumentationService struct {
 	*services.BasicService
-	cfg      *setting.Cfg
-	httpServ *http.Server
-	log      log.Logger
-	errChan  chan error
+	cfg          *setting.Cfg
+	httpServ     *http.Server
+	log          log.Logger
+	errChan      chan error
+	promGatherer prometheus.Gatherer
 }
 
-func NewInstrumentationService(log log.Logger, cfg *setting.Cfg) (*instrumentationService, error) {
-	s := &instrumentationService{log: log, cfg: cfg}
+func NewInstrumentationService(log log.Logger, cfg *setting.Cfg, promGatherer prometheus.Gatherer) (*instrumentationService, error) {
+	s := &instrumentationService{log: log, cfg: cfg, promGatherer: promGatherer}
 	s.BasicService = services.NewBasicService(s.start, s.running, s.stop)
 	return s, nil
 }
@@ -56,7 +58,7 @@ func (s *instrumentationService) stop(failureReason error) error {
 
 func (s *instrumentationService) newInstrumentationServer(ctx context.Context) *http.Server {
 	router := http.NewServeMux()
-	router.Handle("/metrics", promhttp.Handler())
+	router.Handle("/metrics", promhttp.HandlerFor(s.promGatherer, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 
 	srv := &http.Server{
 		// 5s timeout for header reads to avoid Slowloris attacks (https://thetooth.io/blog/slowloris-attack/)

--- a/pkg/server/instrumentation_service_test.go
+++ b/pkg/server/instrumentation_service_test.go
@@ -18,7 +18,7 @@ import (
 func TestRunInstrumentationService(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.HTTPPort = "3001"
-	s, err := NewInstrumentationService(log.New("test-logger"), cfg)
+	s, err := NewInstrumentationService(log.New("test-logger"), cfg, prometheus.DefaultGatherer)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/101825 moved some metrics out of the global scope. These metrics disappeared from the unified storage pods after deployment.

This is because the `/metrics` endpoint exposed in the instrumentation server uses `prometheus.DefaultRegisterer` if you use `promhttp.Handler`: https://github.com/prometheus/client_golang/blob/main/prometheus/promhttp/http.go#L96

This PR changes the metrics handler to use the gatherer we get from wire instead. This is what Grafana does if you run it normally: https://github.com/grafana/grafana/blob/main/pkg/api/http_server.go#L680