### PR TITLE
K8s: Add sorting by more than titles

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -34,11 +34,33 @@ func NewDashboardSearchClient(dashboardStore dashboards.Store, sorter sort.Servi
 }
 
 var sortByMapping = map[string]string{
-	unisearch.DASHBOARD_VIEWS_LAST_30_DAYS:  "viewed-recently-",
-	unisearch.DASHBOARD_VIEWS_TOTAL:         "viewed-",
-	unisearch.DASHBOARD_ERRORS_LAST_30_DAYS: "errors-recently-",
-	unisearch.DASHBOARD_ERRORS_TOTAL:        "errors-",
-	"title":                                 "alpha-",
+	unisearch.DASHBOARD_VIEWS_LAST_30_DAYS:  "viewed-recently",
+	unisearch.DASHBOARD_VIEWS_TOTAL:         "viewed",
+	unisearch.DASHBOARD_ERRORS_LAST_30_DAYS: "errors-recently",
+	unisearch.DASHBOARD_ERRORS_TOTAL:        "errors",
+	"title":                                 "alpha",
+}
+
+func ParseSortName(sortName string) (string, bool, error) {
+	if sortName == "" {
+		return "", false, nil
+	}
+
+	isDesc := strings.HasSuffix(sortName, "-desc")
+	isAsc := strings.HasSuffix(sortName, "-asc")
+	// default to desc if no suffix is provided
+	if !isDesc && !isAsc {
+		isDesc = true
+	}
+
+	prefix := strings.TrimSuffix(strings.TrimSuffix(sortName, "-desc"), "-asc")
+	for key, mappedPrefix := range sortByMapping {
+		if prefix == mappedPrefix {
+			return key, isDesc, nil
+		}
+	}
+
+	return "", false, fmt.Errorf("no matching sort field found for: %s", sortName)
 }
 
 // nolint:gocyclo
@@ -99,9 +121,9 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 		sorterName := sortByMapping[sortByField]
 
 		if sort.Desc {
-			sorterName += "desc"
+			sorterName += "-desc"
 		} else {
-			sorterName += "asc"
+			sorterName += "-asc"
 		}
 
 		if sorter, ok := c.sorter.GetSortOption(sorterName); ok {
@@ -207,22 +229,27 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 		}
 	}
 	searchFields := resource.StandardSearchFields()
+	columns := []*resource.ResourceTableColumnDefinition{
+		searchFields.Field(resource.SEARCH_FIELD_TITLE),
+		searchFields.Field(resource.SEARCH_FIELD_FOLDER),
+		searchFields.Field(resource.SEARCH_FIELD_TAGS),
+		{
+			Name:        unisearch.DASHBOARD_LEGACY_ID,
+			Type:        resource.ResourceTableColumnDefinition_INT64,
+			Description: "Deprecated legacy id of the dashboard",
+		},
+	}
+
+	if sortByField != "" {
+		columns = append(columns, &resource.ResourceTableColumnDefinition{
+			Name: sortByField,
+			Type: resource.ResourceTableColumnDefinition_INT64,
+		})
+	}
+
 	list := &resource.ResourceSearchResponse{
 		Results: &resource.ResourceTable{
-			Columns: []*resource.ResourceTableColumnDefinition{
-				searchFields.Field(resource.SEARCH_FIELD_TITLE),
-				searchFields.Field(resource.SEARCH_FIELD_FOLDER),
-				searchFields.Field(resource.SEARCH_FIELD_TAGS),
-				{
-					Name:        unisearch.DASHBOARD_LEGACY_ID,
-					Type:        resource.ResourceTableColumnDefinition_INT64,
-					Description: "Deprecated legacy id of the dashboard",
-				},
-				{
-					Name: sortByField,
-					Type: resource.ResourceTableColumnDefinition_INT64,
-				},
-			},
+			Columns: columns,
 		},
 	}
 
@@ -249,11 +276,22 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 		}
 
 		for _, dashboard := range dashes {
+			cells := [][]byte{
+				[]byte(dashboard.Title),
+				[]byte(dashboard.FolderUID),
+				[]byte("[]"), // no tags retrieved for provisioned dashboards
+				[]byte(strconv.FormatInt(dashboard.ID, 10)),
+			}
+
+			if sortByField != "" {
+				cells = append(cells, []byte("0"))
+			}
+
 			list.Results.Rows = append(list.Results.Rows, &resource.ResourceTableRow{
 				Key: getResourceKey(&dashboards.DashboardSearchProjection{
 					UID: dashboard.UID,
 				}, req.Options.Key.Namespace),
-				Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), []byte(strconv.FormatInt(dashboard.ID, 10)), {}, {}},
+				Cells: cells,
 			})
 		}
 
@@ -275,9 +313,20 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resource.Resour
 			return nil, err
 		}
 
+		cells := [][]byte{
+			[]byte(dashboard.Title),
+			[]byte(dashboard.FolderUID),
+			tags,
+			[]byte(strconv.FormatInt(dashboard.ID, 10)),
+		}
+
+		if sortByField != "" {
+			cells = append(cells, []byte(strconv.FormatInt(dashboard.SortMeta, 10)))
+		}
+
 		list.Results.Rows = append(list.Results.Rows, &resource.ResourceTableRow{
 			Key:   getResourceKey(dashboard, req.Options.Key.Namespace),
-			Cells: [][]byte{[]byte(dashboard.Title), []byte(dashboard.FolderUID), tags, []byte(strconv.FormatInt(dashboard.ID, 10)), []byte(strconv.FormatInt(dashboard.SortMeta, 10))},
+			Cells: cells,
 		})
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1301,7 +1301,7 @@ func (dr *DashboardServiceImpl) FindDashboards(ctx context.Context, query *dashb
 				if err != nil {
 					return nil, err
 				}
-				result.SortMeta = int64(hit.Field.GetNestedInt64(fieldName))
+				result.SortMeta = hit.Field.GetNestedInt64(fieldName)
 			}
 
 			if hit.Resource == folderv0alpha1.RESOURCE {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacysearcher"
 	"github.com/grafana/grafana/pkg/util/retryer"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
@@ -1295,6 +1296,14 @@ func (dr *DashboardServiceImpl) FindDashboards(ctx context.Context, query *dashb
 				Tags:        hit.Tags,
 			}
 
+			if hit.Field != nil && query.Sort.Name != "" {
+				fieldName, _, err := legacysearcher.ParseSortName(query.Sort.Name)
+				if err != nil {
+					return nil, err
+				}
+				result.SortMeta = int64(hit.Field.GetNestedInt64(fieldName))
+			}
+
 			if hit.Resource == folderv0alpha1.RESOURCE {
 				result.IsFolder = true
 			}
@@ -1840,12 +1849,12 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 		request.Federated = []*resource.ResourceKey{federate}
 	}
 
-	// technically, there exists the ability to register multiple ways of sorting using the legacy database
-	// see RegisterSortOption in pkg/services/search/sorting.go
-	// however, it doesn't look like we are taking advantage of that. And since by default the legacy
-	// sql will sort by title ascending, we only really need to handle the "alpha-desc" case
-	if query.Sort.Name == "alpha-desc" {
-		request.SortBy = append(request.SortBy, &resource.ResourceSearchRequest_Sort{Field: resource.SEARCH_FIELD_TITLE, Desc: true})
+	if query.Sort.Name != "" {
+		sortName, isDesc, err := legacysearcher.ParseSortName(query.Sort.Name)
+		if err != nil {
+			return dashboardv0alpha1.SearchResults{}, err
+		}
+		request.SortBy = append(request.SortBy, &resource.ResourceSearchRequest_Sort{Field: sortName, Desc: isDesc})
 	}
 
 	res, err := dr.k8sclient.Search(ctx, query.OrgId, request)

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/search/model"
+	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -2132,9 +2133,15 @@ func TestSearchDashboardsThroughK8sRaw(t *testing.T) {
 	service := &DashboardServiceImpl{k8sclient: k8sCliMock}
 	query := &dashboards.FindPersistedDashboardsQuery{
 		OrgId: 1,
+		Sort:  sort.SortAlphaAsc,
 	}
 	k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
-	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.Anything).Return(&resource.ResourceSearchResponse{
+	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.MatchedBy(func(req *resource.ResourceSearchRequest) bool {
+		return len(req.SortBy) == 1 &&
+			// should be converted to "title" due to ParseSortName
+			req.SortBy[0].Field == "title" &&
+			!req.SortBy[0].Desc
+	})).Return(&resource.ResourceSearchResponse{
 		Results: &resource.ResourceTable{
 			Columns: []*resource.ResourceTableColumnDefinition{
 				{


### PR DESCRIPTION
**What is this feature?**

This PR adds support for sorting by all the available sorting methods (either in oss or enterprise) when:
- Sending a request to k8s (needed for all modes)
- Falling back to the legacy search in modes 0-2

This is with solely `kubernetesClientDashboardsFolders` enabled

Mode0:
<img width="1182" alt="Screenshot 2025-03-18 at 4 10 43 PM" src="https://github.com/user-attachments/assets/e1436559-ef9c-4bf2-8a99-80d2fa7cb2c5" />

Mode4:
<img width="877" alt="Screenshot 2025-03-18 at 4 05 04 PM" src="https://github.com/user-attachments/assets/46a742d3-ee06-46fe-9cf9-94edfffec9bf" />

**Why do we need this feature?**

We want to enable kubernetesClientDashboardsFolders by default, so we need to be able to support all search methods in the dashboard/folder list page.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/250
