### PR TITLE
GeoMap: Add a MapLibre style base layer

### DIFF
--- a/devenv/dev-dashboards/panel-geomap/geomap-vector.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-vector.json
@@ -1,0 +1,168 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 62,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "maplibre"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "color": {
+                "field": "Price",
+                "fixed": "dark-green"
+              },
+              "fillOpacity": 0.4,
+              "shape": "circle",
+              "showLegend": true,
+              "size": {
+                "field": "Count",
+                "fixed": 5,
+                "max": 15,
+                "min": 2
+              },
+              "style": {
+                "opacity": 0.7
+              }
+            },
+            "location": {
+              "gazetteer": "public/gazetteer/usa-states.json",
+              "lookup": "State",
+              "mode": "auto"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "coords",
+          "lat": 38.297683,
+          "lon": -99.228359,
+          "shared": false,
+          "zoom": 3.98
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "csvFileName": "flight_info_by_state.csv",
+          "refId": "A",
+          "scenarioId": "csv_file"
+        }
+      ],
+      "title": "Vector Map Example",
+      "type": "geomap"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [
+    "gdev",
+    "panel-tests",
+    "geomap"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Panel Tests - Geomap Vector",
+  "uid": "c6e693ba-0d8b-47b4-84d6-2e9ace8b9f33",
+  "version": 3
+}

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -42,6 +42,7 @@
     "geomap-route-layer": (import '../dev-dashboards/panel-geomap/geomap-route-layer.json'),
     "geomap-spatial-operations-transformer": (import '../dev-dashboards/panel-geomap/geomap-spatial-operations-transformer.json'),
     "geomap-v91": (import '../dev-dashboards/panel-geomap/geomap-v91.json'),
+    "geomap-vector": (import '../dev-dashboards/panel-geomap/geomap-vector.json'),
     "geomap_multi-layers": (import '../dev-dashboards/panel-geomap/geomap_multi-layers.json'),
     "global-variables-and-interpolation": (import '../dev-dashboards/feature-templating/global-variables-and-interpolation.json'),
     "graph-gradient-area-fills": (import '../dev-dashboards/panel-graph/graph-gradient-area-fills.json'),

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -207,7 +207,7 @@ You can add multiple layers of data to a single geomap in order to create rich, 
 
 #### Layer type
 
-There are seven map layer types to choose from in a geomap.
+There are eight map layer types to choose from in a geomap.
 
 - [Markers](#markers-layer) renders a marker at each data point.
 - [Heatmap](#heatmap-layer) visualizes a heatmap of the data.
@@ -220,6 +220,7 @@ There are seven map layer types to choose from in a geomap.
 - [CARTO basemap](#carto-basemap-layer) adds a layer from CARTO Raster basemaps.
 - [ArcGIS MapServer](#arcgis-mapserver-layer) adds a layer from an ESRI ArcGIS MapServer.
 - [XYZ Tile layer](#xyz-tile-layer) adds a map from a generic tile layer.
+- [MapLibre Style layer](#maplibre-style-layer) adds a map from a MapLibre / Mapbox style URL.
 
 {{< admonition type="note" >}}
 Beta is equivalent to the [public preview](/docs/release-life-cycle/) release stage.
@@ -529,6 +530,13 @@ The XYZ Tile layer is a map from a generic tile layer.
 - [Tiled Web Map Wikipedia](https://en.wikipedia.org/wiki/Tiled_web_map)
 - [List of Open Street Map Tile Servers](https://wiki.openstreetmap.org/wiki/Tile_servers)
 
+#### MapLibre Style Layer
+
+The MapLibre Style Layer is a map defined via a MapLibre / Mapbox `style.json` URL. The style contains the URL to the tiles, layer definitions and more. Most often, they are based on vector tiles as opposed to raster tiles.
+
+- **URL template** - Set a valid style url, for example: https://demotiles.maplibre.org/style.json
+- **Access Token** - An API token for mapbox maps. Only works for `mapbox://` URLs. In other cases, you might have to include the token in the URL, for example: https://example.com/map/style.json?key=XXX
+
 ### Basemap layer options
 
 A basemap layer provides the visual foundation for a mapping application. It typically contains data with global coverage. Several base layer options
@@ -536,12 +544,13 @@ are available each with specific configuration options to style the base map.
 
 Basemap layer types can also be added as layers. You can specify an opacity.
 
-There are four basemap layer types to choose from in a geomap.
+There are five basemap layer types to choose from in a geomap.
 
 - [Open Street Map](#open-street-map-layer) adds a map from a collaborative free geographic world database.
 - [CARTO basemap](#carto-basemap-layer) adds a layer from CARTO Raster basemaps.
 - [ArcGIS MapServer](#arcgis-mapserver-layer) adds a layer from an ESRI ArcGIS MapServer.
 - [XYZ Tile layer](#xyz-tile-layer) adds a map from a generic tile layer.
+- [MapLibre Style layer](#maplibre-style-layer) adds a map from a MapLibre / Mapbox style URL.
 
 The default basemap layer uses the CARTO map. You can define custom default base layers in the `.ini` configuration file.
 
@@ -551,7 +560,7 @@ The default basemap layer uses the CARTO map. You can define custom default base
 
 You can configure the default base map using config files with Grafana’s provisioning system. For more information on all the settings, refer to the [provisioning docs page](ref:provisioning-docs-page).
 
-Use the JSON configuration option `default_baselayer_config` to define the default base map. There are currently four base map options to choose from: `carto`, `esri-xyz`, `osm-standard`, `xyz`. Here are some provisioning examples for each base map option.
+Use the JSON configuration option `default_baselayer_config` to define the default base map. There are currently five base map options to choose from: `carto`, `esri-xyz`, `osm-standard`, `xyz`, `maplibre`. Here are some provisioning examples for each base map option.
 
 - **carto** loads the CartoDB tile server. You can choose from `auto`, `dark`, and `light` theme for the base map and can be set as shown below. The `showLabels` tag determines whether or not Grafana shows the Country details on top of the map. Here is an example:
 
@@ -613,6 +622,17 @@ default_baselayer_config = `{
   "config": {
     "attribution": "Open street map",
     "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+  }
+}`
+```
+
+- **maplibre** loads a custom tile server defined by the user. Set a valid style `url` for this option in order to properly load a default base map. Here is an example:
+
+```ini
+default_baselayer_config = `{
+  "type": "maplibre",
+  "config": {
+    "url": "https://demotiles.maplibre.org/style.json"
   }
 }`
 ```

--- a/package.json
+++ b/package.json
@@ -374,6 +374,7 @@
     "node-forge": "^1.3.1",
     "ol": "10.6.1",
     "ol-ext": "4.0.33",
+    "ol-mapbox-style": "^13.0.1",
     "pluralize": "^8.0.0",
     "prismjs": "1.30.0",
     "rc-slider": "11.1.8",

--- a/public/app/plugins/panel/geomap/layers/basemaps/index.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/index.ts
@@ -1,6 +1,7 @@
 import { cartoLayers } from './carto';
 import { esriLayers } from './esri';
 import { genericLayers } from './generic';
+import { maplibreLayers } from './maplibre';
 import { osmLayers } from './osm';
 
 /**
@@ -11,4 +12,5 @@ export const basemapLayers = [
   ...cartoLayers,
   ...esriLayers, // keep formatting
   ...genericLayers,
+  ...maplibreLayers,
 ];

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,0 +1,58 @@
+import Map from 'ol/Map';
+import LayerGroup from 'ol/layer/Group';
+import { apply } from 'ol-mapbox-style';
+
+import { MapLayerRegistryItem, MapLayerOptions, GrafanaTheme2, EventBus } from '@grafana/data';
+
+export interface MaplibreConfig {
+  url: string;
+  accessToken?: string;
+}
+
+const sampleURL = 'https://tiles.stadiamaps.com/styles/alidade_smooth.json';
+
+export const defaultMaplibreConfig: MaplibreConfig = {
+  url: sampleURL,
+};
+
+export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
+  id: 'maplibre',
+  name: 'MapLibre Style layer',
+  description: 'Add a map using Mapbox / MapLibre style.json URL',
+  isBaseMap: true,
+
+  create: async (map: Map, options: MapLayerOptions<MaplibreConfig>, eventBus: EventBus, theme: GrafanaTheme2) => ({
+    init: () => {
+      const cfg = { ...options.config };
+      if (!cfg.url) {
+        cfg.url = defaultMaplibreConfig.url;
+      }
+
+      const layer = new LayerGroup();
+      apply(layer, cfg.url, { accessToken: cfg.accessToken });
+
+      return layer;
+    },
+    registerOptionsUI: (builder) => {
+      builder
+        .addTextInput({
+          path: 'config.url',
+          name: 'URL template',
+          description: 'URL to the styles.json file.',
+          settings: {
+            placeholder: defaultMaplibreConfig.url,
+          },
+        })
+        .addTextInput({
+          path: 'config.accessToken',
+          name: 'Access Token',
+          description: 'Token for mapbox:// urls',
+          settings: {
+            placeholder: '',
+          },
+        });
+    },
+  }),
+};
+
+export const maplibreLayers = [maplibreLayer];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,6 +5122,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mapbox/jsonlint-lines-primitives@github:mapbox/jsonlint#commit=e31b7289baedf3e1000d7ae7edd42268212c9954":
+  version: 2.0.2
+  resolution: "@mapbox/jsonlint-lines-primitives@https://github.com/mapbox/jsonlint.git#commit=e31b7289baedf3e1000d7ae7edd42268212c9954"
+  checksum: 10/660bd93beac97f0f4bdcfbbded3282efaf2ab4debb99da55f7fb7b27250e0dfa7dd572a9040802fdc008c71d0bb5ff7e565a7426177fda6c3d17e9bf1598bbaf
+  languageName: node
+  linkType: hard
+
+"@mapbox/unitbezier@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@mapbox/unitbezier@npm:0.0.1"
+  checksum: 10/bf104c85dbff37bf47d3217d9457a3abbf23714f78fefadea64e56bdc7c538491b626166809ef28db134f09baccd6ca3df6988a6422df90d8d0c9a23b0686043
+  languageName: node
+  linkType: hard
+
+"@maplibre/maplibre-gl-style-spec@npm:^23.1.0":
+  version: 23.3.0
+  resolution: "@maplibre/maplibre-gl-style-spec@npm:23.3.0"
+  dependencies:
+    "@mapbox/jsonlint-lines-primitives": "npm:~2.0.2"
+    "@mapbox/unitbezier": "npm:^0.0.1"
+    json-stringify-pretty-compact: "npm:^4.0.0"
+    minimist: "npm:^1.2.8"
+    quickselect: "npm:^3.0.0"
+    rw: "npm:^1.3.3"
+    tinyqueue: "npm:^3.0.0"
+  bin:
+    gl-style-format: dist/gl-style-format.mjs
+    gl-style-migrate: dist/gl-style-migrate.mjs
+    gl-style-validate: dist/gl-style-validate.mjs
+  checksum: 10/72493afafdde916704494f4ecbecb7e8c16f515393e5a2304d898b2884cd03540806eabd809ce2229d5bc89bbdbe480f4e3802be040fd1ca910e7c9abdcbe3da
+  languageName: node
+  linkType: hard
+
 "@mdx-js/react@npm:^3.0.0":
   version: 3.0.1
   resolution: "@mdx-js/react@npm:3.0.1"
@@ -18396,6 +18429,7 @@ __metadata:
     nx: "npm:20.7.1"
     ol: "npm:10.6.1"
     ol-ext: "npm:4.0.33"
+    ol-mapbox-style: "npm:^13.0.1"
     openapi-types: "npm:^12.1.3"
     pa11y-ci: "npm:^3.1.0"
     pdf-parse: "npm:^1.1.1"
@@ -21406,6 +21440,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-pretty-compact@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "json-stringify-pretty-compact@npm:4.0.0"
+  checksum: 10/a10d5c423e467872994a49c5c1b56b073f277ce02d899cf567fc625f3783b89406bee6408bfb3b4bdeeff509b6a562f5259227e26754a6186f721809ca895f0c
+  languageName: node
+  linkType: hard
+
 "json-stringify-safe@npm:^5.0.1, json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
@@ -22473,6 +22514,13 @@ __metadata:
   version: 1.5.0
   resolution: "map-or-similar@npm:1.5.0"
   checksum: 10/3cf43bcd0e7af41d7bade5f8b5be6bb9d021cc47e6008ad545d071cf3a709ba782884002f9eec6ccd51f572fc17841e07bf74628e0bc3694c33f4622b03e4b4c
+  languageName: node
+  linkType: hard
+
+"mapbox-to-css-font@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "mapbox-to-css-font@npm:3.2.0"
+  checksum: 10/3be43671c674e7e988be054ae3b263c8c34d5ba79d07f3b0dfaee7109842e12841dfeefe6a380a625e76582af2ce701c386d18d29e30c3ac45acb18eba250c79
   languageName: node
   linkType: hard
 
@@ -24214,6 +24262,18 @@ __metadata:
   peerDependencies:
     ol: ">= 5.3.0"
   checksum: 10/20eb7f08e824db2bdf3837bc654230409c207336c52c67b259a6eb6e5f56645d45c0f5eea1cfa87b19cebb4e8cee383ef1d04c06a5647896927f574849c59c49
+  languageName: node
+  linkType: hard
+
+"ol-mapbox-style@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "ol-mapbox-style@npm:13.0.1"
+  dependencies:
+    "@maplibre/maplibre-gl-style-spec": "npm:^23.1.0"
+    mapbox-to-css-font: "npm:^3.2.0"
+  peerDependencies:
+    ol: "*"
+  checksum: 10/ff4a3d39fadc058da53cebb5d215ebb7f7bfa99885adc34334392e24179775efc7efd9f9d55f578167f035a3073b68cd53ab9dee36b1ce2360d55e086dd14485
   languageName: node
   linkType: hard
 
@@ -28368,7 +28428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rw@npm:1":
+"rw@npm:1, rw@npm:^1.3.3":
   version: 1.3.3
   resolution: "rw@npm:1.3.3"
   checksum: 10/e90985d64777a00f4ab5f8c0bfea2fb5645c6bda5238840afa339c8a4f86f776e8ce83731155643a7425a0b27ce89077dab27b2f57519996ba4d2fe54cac1941
@@ -30588,6 +30648,13 @@ __metadata:
     fdir: "npm:^6.4.3"
     picomatch: "npm:^4.0.2"
   checksum: 10/4ad28701fa9118b32ef0e27f409e0a6c5741e8b02286d50425c1f6f71e6d6c6ded9dd5bbbbb714784b08623c4ec4d150151f1d3d996cfabe0495f908ab4f7002
+  languageName: node
+  linkType: hard
+
+"tinyqueue@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "tinyqueue@npm:3.0.0"
+  checksum: 10/44195ae628e98f4de49acefac1fafa63a7f2b5d8a5c23ace6f49917109db3435db8ec9854f87c0d50f8a8c6a73f1526f3941921618a071e4ee1d246afacf69bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds a new base layer to the GeoMap plugin. This layer allows displaying MapLibre (or Mapbox) style vectorized maps that are defined in a style.json. The URL for said style definition is configurable.

**Why do we need this feature?**

The current layers only allow for two layers which have configurable URLs: ArcGIS and XYZ. It is my understanding that both of those only support rasterized tiles, not vector tiles. The latter can look much nicer, which is why we want them in my opinion :)

As an example, here is the CARTO light mode map in one of the dev dashboards compared with [this style](https://docs.stadiamaps.com/map-styles/alidade-smooth-dark/) that uses vector tiles:
<img width="1159" alt="Screenshot 2025-03-19 at 00 48 27" src="https://github.com/user-attachments/assets/2b52c93c-b3e5-47af-adf9-daec5332317b" />

The text looks much sharper and more readable to me.

**Who is this feature for?**

Potentially everyone who displays maps in Grafana. It will especially benefit people who would like to use self-hosted, openly available or commercial vector maps as a base. See also linked issue for more examples.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #102409

**Special notes for your reviewer:**
- Uses the [ol-mapbox-style](https://github.com/openlayers/ol-mapbox-style) library for compatibility with the other layers.
- I recently made two upstream contributions in that library to make this work with FLOSS [versatiles](https://versatiles.org/) tiles.
- I'm a bit hesitant regarding the "Access Token" config. Since it only works for 'mapbox://' URLs ([doc](https://openlayers.org/ol-mapbox-style/interfaces/_internal_.Options.html#accesstoken)) I think it might be more confusing to  users than being helpful... What do you think?

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

I don't know whether or not this feature, if accepted, is pre-GA :eyes: