### PR TITLE
Storage: Add resource version matching in unified storage API

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -669,6 +669,19 @@ func (b *backend) getHistory(ctx context.Context, req *resource.ListRequest, cb 
 		listReq.StartRV = continueToken.ResourceVersion
 	}
 
+	// Set ExactRV when using Exact matching
+	if req.VersionMatch == resource.ResourceVersionMatch_Exact {
+		if req.ResourceVersion <= 0 {
+			return 0, fmt.Errorf("expecting an explicit resource version query when using Exact matching")
+		}
+		listReq.ExactRV = req.ResourceVersion
+	}
+
+	// Set MinRV when using NotOlderThan matching to filter at the database level
+	if req.ResourceVersion > 0 && req.VersionMatch == resource.ResourceVersionMatch_NotOlderThan {
+		listReq.MinRV = req.ResourceVersion
+	}
+
 	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
 		var err error
 		iter.listRV, err = fetchLatestRV(ctx, tx, b.dialect, req.Options.Key.Group, req.Options.Key.Resource)

--- a/pkg/storage/unified/sql/data/resource_history_get.sql
+++ b/pkg/storage/unified/sql/data/resource_history_get.sql
@@ -18,4 +18,10 @@ WHERE 1 = 1
   {{ if (gt .StartRV 0) }}
   AND {{ .Ident "resource_version" }} < {{ .Arg .StartRV }}
   {{ end }}
+  {{ if (gt .MinRV 0) }}
+  AND {{ .Ident "resource_version" }} >= {{ .Arg .MinRV }}
+  {{ end }}
+  {{ if (gt .ExactRV 0) }}
+  AND {{ .Ident "resource_version" }} = {{ .Arg .ExactRV }}
+  {{ end }}
 ORDER BY resource_version DESC

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -246,6 +246,8 @@ type sqlGetHistoryRequest struct {
 	Key     *resource.ResourceKey
 	Trash   bool  // only deleted items
 	StartRV int64 // from NextPageToken
+	MinRV   int64 // minimum resource version for NotOlderThan
+	ExactRV int64 // exact resource version for Exact
 }
 
 func (r sqlGetHistoryRequest) Validate() error {


### PR DESCRIPTION
**What is this feature?**
This PR implements proper resource version matching support in Grafana's unified storage API. It adds the ability to filter resources by exact version or minimum version when retrieving history from the database.

**Why do we need this feature?**
Resource version matching allows for more precise queries when retrieving resources from the database. This enhancement ensures the storage layer correctly handles different version matching strategies, improving data consistency and query accuracy.

**Who is this feature for?**
This feature benefits Grafana developers and any features or plugins that rely on the unified storage API for resource management. It provides more reliable and predictable resource retrieval behavior.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
