### PR TITLE
fix(unified-storage): reduce lock contention when pruning

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -88,6 +88,7 @@ type pruningKey struct {
 	namespace string
 	group     string
 	resource  string
+	name      string
 }
 
 // Small abstraction to allow for different pruner implementations.
@@ -215,6 +216,7 @@ func (b *backend) initPruner(ctx context.Context) error {
 						Namespace: key.namespace,
 						Group:     key.group,
 						Resource:  key.resource,
+						Name:      key.name,
 					},
 				})
 				if err != nil {
@@ -228,6 +230,7 @@ func (b *backend) initPruner(ctx context.Context) error {
 					"namespace", key.namespace,
 					"group", key.group,
 					"resource", key.resource,
+					"name", key.name,
 					"rows", rows)
 				return nil
 			})
@@ -237,6 +240,7 @@ func (b *backend) initPruner(ctx context.Context) error {
 				"namespace", key.namespace,
 				"group", key.group,
 				"resource", key.resource,
+				"name", key.name,
 				"error", err)
 		},
 		Reg: b.reg,

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -351,7 +351,12 @@ func (b *backend) create(ctx context.Context, event resource.WriteEvent) (int64,
 		}); err != nil {
 			return guid, fmt.Errorf("insert into resource history: %w", err)
 		}
-		_ = b.historyPruner.Add(pruningKey{namespace: event.Key.Namespace, group: event.Key.Group, resource: event.Key.Resource})
+		_ = b.historyPruner.Add(pruningKey{
+			namespace: event.Key.Namespace,
+			group:     event.Key.Group,
+			resource:  event.Key.Resource,
+			name:      event.Key.Name,
+		})
 		if b.simulatedNetworkLatency > 0 {
 			time.Sleep(b.simulatedNetworkLatency)
 		}
@@ -405,7 +410,12 @@ func (b *backend) update(ctx context.Context, event resource.WriteEvent) (int64,
 		}); err != nil {
 			return guid, fmt.Errorf("insert into resource history: %w", err)
 		}
-		_ = b.historyPruner.Add(pruningKey{namespace: event.Key.Namespace, group: event.Key.Group, resource: event.Key.Resource})
+		_ = b.historyPruner.Add(pruningKey{
+			namespace: event.Key.Namespace,
+			group:     event.Key.Group,
+			resource:  event.Key.Resource,
+			name:      event.Key.Name,
+		})
 		return guid, nil
 	})
 
@@ -453,7 +463,12 @@ func (b *backend) delete(ctx context.Context, event resource.WriteEvent) (int64,
 		}); err != nil {
 			return guid, fmt.Errorf("insert into resource history: %w", err)
 		}
-		_ = b.historyPruner.Add(pruningKey{namespace: event.Key.Namespace, group: event.Key.Group, resource: event.Key.Resource})
+		_ = b.historyPruner.Add(pruningKey{
+			namespace: event.Key.Namespace,
+			group:     event.Key.Group,
+			resource:  event.Key.Resource,
+			name:      event.Key.Name,
+		})
 		return guid, nil
 	})
 
@@ -502,7 +517,12 @@ func (b *backend) restore(ctx context.Context, event resource.WriteEvent) (int64
 		}); err != nil {
 			return guid, fmt.Errorf("insert into resource history: %w", err)
 		}
-		_ = b.historyPruner.Add(pruningKey{namespace: event.Key.Namespace, group: event.Key.Group, resource: event.Key.Resource})
+		_ = b.historyPruner.Add(pruningKey{
+			namespace: event.Key.Namespace,
+			group:     event.Key.Group,
+			resource:  event.Key.Resource,
+			name:      event.Key.Name,
+		})
 
 		// 3. Update all resource history entries with the new UID
 		// Note: we do not update any history entries that have a deletion timestamp included. This will become

--- a/pkg/storage/unified/sql/data/resource_history_prune.sql
+++ b/pkg/storage/unified/sql/data/resource_history_prune.sql
@@ -17,6 +17,7 @@ WHERE {{ .Ident "guid" }} IN (
     {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
     AND {{ .Ident "group" }} = {{ .Arg .Key.Group }}
     AND {{ .Ident "resource" }} = {{ .Arg .Key.Resource }}
+    AND {{ .Ident "name" }} = {{ .Arg .Key.Name }}
   ) AS {{ .Ident "ranked" }}
   WHERE {{ .Ident "rn" }} > {{ .Arg .HistoryLimit }}
 );

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -264,6 +264,7 @@ func TestUnifiedStorageQueries(t *testing.T) {
 							Namespace: "nn",
 							Group:     "gg",
 							Resource:  "rr",
+							Name:      "na",
 						},
 						HistoryLimit: 100,
 					},

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_prune-simple.sql
@@ -17,7 +17,7 @@ WHERE `guid` IN (
     `namespace` = 'nn'
     AND `group` = 'gg'
     AND `resource` = 'rr'
-    AND `name` = ''
+    AND `name` = 'na'
   ) AS `ranked`
   WHERE `rn` > 100
 );

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_prune-simple.sql
@@ -17,6 +17,7 @@ WHERE `guid` IN (
     `namespace` = 'nn'
     AND `group` = 'gg'
     AND `resource` = 'rr'
+    AND `name` = ''
   ) AS `ranked`
   WHERE `rn` > 100
 );

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_prune-simple.sql
@@ -17,7 +17,7 @@ WHERE "guid" IN (
     "namespace" = 'nn'
     AND "group" = 'gg'
     AND "resource" = 'rr'
-    AND "name" = ''
+    AND "name" = 'na'
   ) AS "ranked"
   WHERE "rn" > 100
 );

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_prune-simple.sql
@@ -17,6 +17,7 @@ WHERE "guid" IN (
     "namespace" = 'nn'
     AND "group" = 'gg'
     AND "resource" = 'rr'
+    AND "name" = ''
   ) AS "ranked"
   WHERE "rn" > 100
 );

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_prune-simple.sql
@@ -17,7 +17,7 @@ WHERE "guid" IN (
     "namespace" = 'nn'
     AND "group" = 'gg'
     AND "resource" = 'rr'
-    AND "name" = ''
+    AND "name" = 'na'
   ) AS "ranked"
   WHERE "rn" > 100
 );

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_prune-simple.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_prune-simple.sql
@@ -17,6 +17,7 @@ WHERE "guid" IN (
     "namespace" = 'nn'
     AND "group" = 'gg'
     AND "resource" = 'rr'
+    AND "name" = ''
   ) AS "ranked"
   WHERE "rn" > 100
 );


### PR DESCRIPTION
This PR reduces the write latency when running the pruner. Instead of pruning all resources of a specific type, we only prune the resources by exact name. This makes the query much more effective, as the subset of rows to consider is much smaller and the full index can be used. It also reduces the lock contention by tenant, as we only lock the specific resource for a very short amount of time.

The fix was tested in cloud, applied at around 10:15
![image](https://github.com/user-attachments/assets/bbd0e280-f89c-40e7-8836-e61dcead6a85)
