### PR TITLE
FeatureToggles: Make the api namespaced

### DIFF
--- a/pkg/registry/apis/featuretoggle/README.md
+++ b/pkg/registry/apis/featuretoggle/README.md
@@ -1,5 +1,3 @@
 This package supports the [Feature toggle admin page](https://grafana.com/docs/grafana/latest/administration/feature-toggles/) feature. 
 
 In order to update feature toggles through the app, the PATCH handler calls a webhook that should update Grafana's configuration and restarts the instance. 
-
-For local development, set the app mode to `development` by adding `app_mode = development` to the top level of your Grafana .ini file.

--- a/pkg/registry/apis/featuretoggle/features.go
+++ b/pkg/registry/apis/featuretoggle/features.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/apis/featuretoggle/v0alpha1"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/apis/featuretoggle/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 var (
@@ -46,7 +47,7 @@ func (s *featuresStorage) New() runtime.Object {
 func (s *featuresStorage) Destroy() {}
 
 func (s *featuresStorage) NamespaceScoped() bool {
-	return false
+	return true
 }
 
 func (s *featuresStorage) GetSingularName() string {

--- a/pkg/registry/apis/featuretoggle/register.go
+++ b/pkg/registry/apis/featuretoggle/register.go
@@ -106,7 +106,7 @@ func (b *FeatureFlagAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
 
 	tags := []string{"Editor"}
 	return &builder.APIRoutes{
-		Root: []builder.APIRouteHandler{
+		Namespace: []builder.APIRouteHandler{
 			{
 				Path: "current",
 				Spec: &spec3.PathProps{
@@ -115,6 +115,18 @@ func (b *FeatureFlagAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
 							Tags:        tags,
 							Summary:     "Current configuration with details",
 							Description: "Show details about the current flags and where they come from",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+							},
 							Responses: &spec3.Responses{
 								ResponsesProps: spec3.ResponsesProps{
 									StatusCodeResponses: map[int]*spec3.Response{
@@ -140,6 +152,18 @@ func (b *FeatureFlagAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
 							Tags:        tags,
 							Summary:     "Update individual toggles",
 							Description: "Patch some of the toggles (keyed by the toggle name)",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+							},
 							RequestBody: &spec3.RequestBody{
 								RequestBodyProps: spec3.RequestBodyProps{
 									Required:    true,


### PR DESCRIPTION
The feature toggles apis is currently cluster scoped -- this is conceptually accurate, but becomes a problem in cloud with our token verification and how this would ever run as a multi-tenant service.

This PR updates the API so it is namespaced... then it falls into all the patterns a bit nicer.

<img width="993" alt="image" src="https://github.com/user-attachments/assets/d5359448-1c4a-4dbb-b92e-a8848053d603" />



TODO:
- [ ] Update the UI that calls this API