### PR TITLE
Responsive Grid: Minor fixes

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2992,19 +2992,6 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/scene/UnlinkModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
-    "public/app/features/dashboard-scene/scene/layout-manager/LayoutOrchestrator.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
-    "public/app/features/dashboard-scene/scene/layout-manager/utils.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
-    ],
-    "public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/dashboard-scene/serialization/angularMigration.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from '@emotion/css';
-import classNames from 'classnames';
 import { CSSProperties, ReactElement, ReactNode, useId, useRef, useState } from 'react';
 import * as React from 'react';
 import { useMeasure, useToggle } from 'react-use';
@@ -348,7 +347,7 @@ export function PanelChrome({
 
       {hasHeader && (
         <div
-          className={classNames(styles.headerContainer, dragClass)}
+          className={cx(styles.headerContainer, dragClass)}
           style={headerStyles}
           data-testid="header-container"
           onPointerMove={() => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -70,7 +70,7 @@ import { isUsingAngularDatasourcePlugin, isUsingAngularPanelPlugin } from './ang
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-import { DropZonePlaceholder } from './layout-default/DropZonePlaceholder';
+import { DropZonePlaceholder } from './layout-manager/DropZonePlaceholder';
 import { LayoutOrchestrator } from './layout-manager/LayoutOrchestrator';
 import { LayoutRestorer } from './layouts-shared/LayoutRestorer';
 import { addNewRowTo, addNewTabTo } from './layouts-shared/addNew';

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { createRef, RefObject } from 'react';
+import { createRef } from 'react';
 import { Unsubscribable } from 'rxjs';
 
 import {
@@ -53,6 +53,8 @@ export class DashboardGridItem
   private _prevRepeatValues?: VariableValueSingle[];
 
   private _gridSizeSub: Unsubscribable | undefined;
+
+  public containerRef = createRef<HTMLElement>();
 
   public constructor(state: DashboardGridItemState) {
     super(state);
@@ -248,17 +250,15 @@ export class DashboardGridItem
     return this.state.variableName !== undefined;
   }
 
-  toIntermediate(): IntermediateLayoutItem {
+  public toIntermediate(): IntermediateLayoutItem {
     throw new Error('Method not implemented.');
   }
 
-  // Drag and drop
-  public containerRef: RefObject<HTMLElement> = createRef<HTMLElement>();
   public distanceToPoint?(point: Point): number {
     throw new Error('Method not implemented.');
   }
 
-  boundingBox?(): Rect | undefined {
+  public boundingBox?(): Rect | undefined {
     throw new Error('Method not implemented.');
   }
 }

--- a/public/app/features/dashboard-scene/scene/layout-manager/DropZonePlaceholder.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-manager/DropZonePlaceholder.tsx
@@ -1,5 +1,4 @@
-import { css } from '@emotion/css';
-import classNames from 'classnames';
+import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
@@ -20,11 +19,11 @@ export class DropZonePlaceholder extends SceneObjectBase<DropZonePlaceholderStat
     return (
       <Portal>
         <div
-          className={classNames(styles.placeholder, {
+          className={cx(styles.placeholder, {
             [styles.visible]: width > 0 && height > 0,
           })}
           style={{ width, height, transform: `translate(${left}px, ${top}px)` }}
-        ></div>
+        />
       </Portal>
     );
   };

--- a/public/app/features/dashboard-scene/scene/layout-manager/LayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-manager/LayoutOrchestrator.tsx
@@ -1,8 +1,8 @@
 import { SceneObjectState, SceneObjectBase, SceneObjectRef, sceneGraph, VizPanel } from '@grafana/scenes';
 
-import { DropZonePlaceholder } from '../layout-default/DropZonePlaceholder';
 import { DashboardLayoutItem, isDashboardLayoutItem } from '../types/DashboardLayoutItem';
 
+import { DropZonePlaceholder } from './DropZonePlaceholder';
 import { closestOfType, DropZone, isSceneLayoutWithDragAndDrop, Point, SceneLayoutWithDragAndDrop } from './utils';
 
 interface LayoutOrchestratorState extends SceneObjectState {
@@ -22,8 +22,13 @@ export class LayoutOrchestrator extends SceneObjectBase<LayoutOrchestratorState>
       return;
     }
 
+    if (!(e.target instanceof HTMLElement)) {
+      console.warn('Target is not a HTML element.');
+      return;
+    }
+
     document.body.setPointerCapture(e.pointerId);
-    const targetRect = (e.target as HTMLElement).getBoundingClientRect();
+    const targetRect = e.target.getBoundingClientRect();
     this.dragOffset = { top: e.y - targetRect.top, left: e.x - targetRect.left };
     this.setState({ activeLayoutItemRef: closestLayoutItem.getRef() });
     document.addEventListener('pointermove', this.onDrag);
@@ -111,10 +116,9 @@ export class LayoutOrchestrator extends SceneObjectBase<LayoutOrchestratorState>
   }
 
   public findClosestDropZone(p: Point) {
-    const sceneLayouts = sceneGraph.findAllObjects(
-      this.getRoot(),
-      isSceneLayoutWithDragAndDrop
-    ) as SceneLayoutWithDragAndDrop[];
+    const sceneLayouts = sceneGraph
+      .findAllObjects(this.getRoot(), isSceneLayoutWithDragAndDrop)
+      .filter(isSceneLayoutWithDragAndDrop);
     let closestDropZone: (DropZone & { layout: SceneObjectRef<SceneLayoutWithDragAndDrop> }) | undefined = undefined;
     let closestDistance = Number.MAX_VALUE;
     for (const layout of sceneLayouts) {

--- a/public/app/features/dashboard-scene/scene/layout-manager/utils.ts
+++ b/public/app/features/dashboard-scene/scene/layout-manager/utils.ts
@@ -27,7 +27,12 @@ export interface SceneLayoutWithDragAndDrop extends SceneLayout {
 
 // todo@kay: Not the most robust interface check, should make more robust.
 export function isSceneLayoutWithDragAndDrop(o: SceneObject): o is SceneLayoutWithDragAndDrop {
-  return typeof (o as any).isDraggable === 'function' && typeof (o as any).closestDropZone === 'function';
+  return (
+    'isDraggable' in o &&
+    'closestDropZone' in o &&
+    typeof o.isDraggable === 'function' &&
+    typeof o.closestDropZone === 'function'
+  );
 }
 
 /** Walks up the scene graph, returning the first non-undefined result of `extract` */

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
@@ -1,8 +1,7 @@
 import { isEqual } from 'lodash';
-import React from 'react';
+import { createRef } from 'react';
 
 import {
-  SceneObject,
   CustomVariable,
   LocalValueVariable,
   MultiValueVariable,
@@ -44,13 +43,13 @@ export class ResponsiveGridItem extends SceneObjectBase<ResponsiveGridItemState>
     onVariableUpdateCompleted: () => this.performRepeat(),
   });
   public readonly isDashboardLayoutItem = true;
+  public containerRef = createRef<HTMLDivElement>();
+  public cachedBoundingBox: Rect | undefined;
 
   public constructor(state: ResponsiveGridItemState) {
     super({ ...state, conditionalRendering: state?.conditionalRendering ?? ConditionalRendering.createEmpty() });
     this.addActivationHandler(() => this._activationHandler());
   }
-
-  public containerRef = React.createRef<HTMLDivElement>();
 
   private _activationHandler() {
     if (this.state.variableName) {
@@ -68,20 +67,6 @@ export class ResponsiveGridItem extends SceneObjectBase<ResponsiveGridItemState>
 
   public getOptions(): OptionsPaneCategoryDescriptor {
     return getOptions(this);
-  }
-
-  public toggleHideWhenNoData() {
-    this.setState({ hideWhenNoData: !this.state.hideWhenNoData });
-  }
-
-  public setBody(body: SceneObject): void {
-    if (body instanceof VizPanel) {
-      this.setState({ body });
-    }
-  }
-
-  public getVizPanel() {
-    return this.state.body;
   }
 
   public performRepeat() {
@@ -158,7 +143,6 @@ export class ResponsiveGridItem extends SceneObjectBase<ResponsiveGridItemState>
     this.performRepeat();
   }
 
-  public cachedBoundingBox: Rect | undefined;
   public computeBoundingBox() {
     const itemContainer = this.containerRef.current;
     if (!itemContainer || this.state.isHidden) {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemRenderer.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { cx } from '@emotion/css';
 
 import { SceneComponentProps } from '@grafana/scenes';
 
@@ -10,7 +10,6 @@ export interface ResponsiveGridItemProps extends SceneComponentProps<ResponsiveG
 
 export function ResponsiveGridItemRenderer({ model }: ResponsiveGridItemProps) {
   const { body } = model.useState();
-  // const style = useStyles2(getStyles);
   const { showHiddenElements } = useDashboardState(model);
   const isConditionallyHidden = useIsConditionallyHidden(model);
 
@@ -22,16 +21,13 @@ export function ResponsiveGridItemRenderer({ model }: ResponsiveGridItemProps) {
   return model.state.repeatedPanels ? (
     <>
       {model.state.repeatedPanels.map((item) => (
-        <div
-          className={classNames({ 'dashboard-visible-hidden-element': isHiddenButVisibleElement })}
-          key={item.state.key}
-        >
+        <div className={cx({ 'dashboard-visible-hidden-element': isHiddenButVisibleElement })} key={item.state.key}>
           <item.Component model={item} />
         </div>
       ))}
     </>
   ) : (
-    <div className={classNames({ 'dashboard-visible-hidden-element': isHiddenButVisibleElement })}>
+    <div className={cx({ 'dashboard-visible-hidden-element': isHiddenButVisibleElement })}>
       <body.Component model={body} />
     </div>
   );

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { RefObject } from 'react';
 
 import { SceneObject, VizPanel } from '@grafana/scenes';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -23,6 +23,11 @@ export interface DashboardLayoutItem extends SceneObject {
   isDashboardLayoutItem: true;
 
   /**
+   * Reference to the container DOM element.
+   */
+  containerRef: RefObject<HTMLElement>;
+
+  /**
    * Return layout item options (like repeat, repeat direction, etc. for the default DashboardGridItem)
    */
   getOptions?(): OptionsPaneCategoryDescriptor;
@@ -37,11 +42,19 @@ export interface DashboardLayoutItem extends SceneObject {
    */
   editingCompleted?(withChanges: boolean): void;
 
+  /**
+   * Converts the current layout item into an intermediate format.
+   */
   toIntermediate(): IntermediateLayoutItem;
 
-  containerRef: React.RefObject<HTMLElement>;
-
+  /**
+   * Calculates the distance from the current object to a specified point.
+   */
   distanceToPoint?(point: Point): number;
+
+  /**
+   * Retrieves the bounding box of an element or object.
+   */
   boundingBox?(): Rect | undefined;
 }
 


### PR DESCRIPTION
- moved DropZonePlaceholder.tsx  from layout-default to layout-manager
- replaced classnames with cx
- replaced various methods of getting the DashboardScene with getDashboardSceneFor helper method
- set accessors and return values to class methods
- reordered the class members a little bit (moved vars and constants before the constructor)
- removed unused methods and types
- added some comments to the members of DashboardLayoutItem
- removed type assertions