### PR TITLE
Alerting: Fix plugin not found error during condition validation

### DIFF
--- a/pkg/services/ngalert/eval/validate.go
+++ b/pkg/services/ngalert/eval/validate.go
@@ -37,7 +37,7 @@ func (e *ConditionValidator) Validate(ctx EvaluationContext, condition models.Co
 		case expr.TypeDatasourceNode:
 			p, found := e.pluginsStore.Plugin(ctx.Ctx, query.DataSource.Type)
 			if !found { // technically this should fail earlier during datasource resolution phase.
-				return fmt.Errorf("datasource refID %s could not be found: %w", query.RefID, plugins.ErrPluginUnavailable)
+				return fmt.Errorf("plugin %s could not be found for datasource query refID %s: %w", query.DataSource.Type, query.RefID, plugins.ErrPluginNotRegistered)
 			}
 			if !p.Backend {
 				return fmt.Errorf("datasource refID %s is not a backend datasource", query.RefID)
@@ -45,7 +45,7 @@ func (e *ConditionValidator) Validate(ctx EvaluationContext, condition models.Co
 		case expr.TypeMLNode:
 			_, found := e.pluginsStore.Plugin(ctx.Ctx, query.DataSource.Type)
 			if !found {
-				return fmt.Errorf("datasource refID %s could not be found: %w", query.RefID, plugins.ErrPluginUnavailable)
+				return fmt.Errorf("plugin %s could not be found for datasource query refID %s: %w", query.DataSource.Type, query.RefID, plugins.ErrPluginNotRegistered)
 			}
 		case expr.TypeCMDNode:
 		}


### PR DESCRIPTION
**What is this feature?**

We're currently returning `ErrPluginUnavailable` which is incorrect as that is reserved for cases where the plugin exists, but connection to the backend plugin is currently unavailable.
