### PR TITLE
Dynamic Dashboards: Add repeat responsive items

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -71,19 +71,12 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
         );
     }, [panel]);
 
-    const layoutCategory = useMemo(() => {
-      if (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions) {
-        return layoutElement.getOptions();
-      }
-      return undefined;
-    }, [layoutElement]);
+    const layoutCategories = useMemo(
+      () => (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions ? layoutElement.getOptions() : []),
+      [layoutElement]
+    );
 
-    const categories = [panelOptions];
-    if (layoutCategory) {
-      categories.push(layoutCategory);
-    }
-
-    return categories;
+    return [panelOptions, ...layoutCategories];
   }
 
   public onDelete() {

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -84,8 +84,8 @@ export function getPanelFrameOptions(panel: VizPanel): OptionsPaneCategoryDescri
       )
     );
 
-  if (isDashboardLayoutItem(layoutElement) && layoutElement.getOptions) {
-    descriptor.addCategory(layoutElement.getOptions());
+  if (isDashboardLayoutItem(layoutElement)) {
+    layoutElement.getOptions?.().forEach(descriptor.addCategory);
   }
 
   return descriptor;

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -85,7 +85,7 @@ export function getPanelFrameOptions(panel: VizPanel): OptionsPaneCategoryDescri
     );
 
   if (isDashboardLayoutItem(layoutElement)) {
-    layoutElement.getOptions?.().forEach(descriptor.addCategory);
+    layoutElement.getOptions?.().forEach((category) => descriptor.addCategory(category));
   }
 
   return descriptor;

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -82,7 +82,7 @@ export class DashboardGridItem
     return this.state.variableName ? 'panel-repeater-grid-item' : '';
   }
 
-  public getOptions(): OptionsPaneCategoryDescriptor {
+  public getOptions(): OptionsPaneCategoryDescriptor[] {
     return getDashboardGridItemOptions(this);
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { SelectableValue } from '@grafana/data';
 import { sceneGraph, SceneGridLayout } from '@grafana/scenes';
 import { RadioButtonGroup, Select } from '@grafana/ui';
@@ -11,45 +9,41 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 import { DashboardGridItem } from './DashboardGridItem';
 
 export function getDashboardGridItemOptions(gridItem: DashboardGridItem): OptionsPaneCategoryDescriptor[] {
-  const repeatCategory = useMemo(
-    () =>
-      new OptionsPaneCategoryDescriptor({
-        title: t('dashboard.default-layout.item-options.repeat.title', 'Repeat options'),
-        id: 'Repeat options',
-        isOpenDefault: false,
-      })
-        .addItem(
-          new OptionsPaneItemDescriptor({
-            title: t('dashboard.default-layout.item-options.repeat.variable.title', 'Repeat by variable'),
-            description: t(
-              'dashboard.default-layout.item-options.repeat.variable.description',
-              'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
-            ),
-            render: () => <RepeatByOption gridItem={gridItem} />,
-          })
-        )
-        .addItem(
-          new OptionsPaneItemDescriptor({
-            title: t('dashboard.default-layout.item-options.repeat.direction.title', 'Repeat direction'),
-            useShowIf: () => {
-              const { variableName } = gridItem.useState();
-              return Boolean(variableName);
-            },
-            render: () => <RepeatDirectionOption gridItem={gridItem} />,
-          })
-        )
-        .addItem(
-          new OptionsPaneItemDescriptor({
-            title: t('dashboard.default-layout.item-options.repeat.max', 'Max per row'),
-            useShowIf: () => {
-              const { variableName, repeatDirection } = gridItem.useState();
-              return Boolean(variableName) && repeatDirection === 'h';
-            },
-            render: () => <MaxPerRowOption gridItem={gridItem} />,
-          })
+  const repeatCategory = new OptionsPaneCategoryDescriptor({
+    title: t('dashboard.default-layout.item-options.repeat.title', 'Repeat options'),
+    id: 'Repeat options',
+    isOpenDefault: false,
+  })
+    .addItem(
+      new OptionsPaneItemDescriptor({
+        title: t('dashboard.default-layout.item-options.repeat.variable.title', 'Repeat by variable'),
+        description: t(
+          'dashboard.default-layout.item-options.repeat.variable.description',
+          'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
         ),
-    [gridItem]
-  );
+        render: () => <RepeatByOption gridItem={gridItem} />,
+      })
+    )
+    .addItem(
+      new OptionsPaneItemDescriptor({
+        title: t('dashboard.default-layout.item-options.repeat.direction.title', 'Repeat direction'),
+        useShowIf: () => {
+          const { variableName } = gridItem.useState();
+          return Boolean(variableName);
+        },
+        render: () => <RepeatDirectionOption gridItem={gridItem} />,
+      })
+    )
+    .addItem(
+      new OptionsPaneItemDescriptor({
+        title: t('dashboard.default-layout.item-options.repeat.max', 'Max per row'),
+        useShowIf: () => {
+          const { variableName, repeatDirection } = gridItem.useState();
+          return Boolean(variableName) && repeatDirection === 'h';
+        },
+        render: () => <MaxPerRowOption gridItem={gridItem} />,
+      })
+    );
 
   return [repeatCategory];
 }

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { SelectableValue } from '@grafana/data';
 import { sceneGraph, SceneGridLayout } from '@grafana/scenes';
 import { RadioButtonGroup, Select } from '@grafana/ui';
@@ -8,47 +10,48 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 
 import { DashboardGridItem } from './DashboardGridItem';
 
-export function getDashboardGridItemOptions(gridItem: DashboardGridItem): OptionsPaneCategoryDescriptor {
-  const category = new OptionsPaneCategoryDescriptor({
-    title: t('dashboard.default-layout.item-options.repeat.title', 'Repeat options'),
-    id: 'Repeat options',
-    isOpenDefault: false,
-  });
-
-  category.addItem(
-    new OptionsPaneItemDescriptor({
-      title: t('dashboard.default-layout.item-options.repeat.variable.title', 'Repeat by variable'),
-      description: t(
-        'dashboard.default-layout.item-options.repeat.variable.description',
-        'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
-      ),
-      render: () => <RepeatByOption gridItem={gridItem} />,
-    })
+export function getDashboardGridItemOptions(gridItem: DashboardGridItem): OptionsPaneCategoryDescriptor[] {
+  const repeatCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({
+        title: t('dashboard.default-layout.item-options.repeat.title', 'Repeat options'),
+        id: 'Repeat options',
+        isOpenDefault: false,
+      })
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.default-layout.item-options.repeat.variable.title', 'Repeat by variable'),
+            description: t(
+              'dashboard.default-layout.item-options.repeat.variable.description',
+              'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
+            ),
+            render: () => <RepeatByOption gridItem={gridItem} />,
+          })
+        )
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.default-layout.item-options.repeat.direction.title', 'Repeat direction'),
+            useShowIf: () => {
+              const { variableName } = gridItem.useState();
+              return Boolean(variableName);
+            },
+            render: () => <RepeatDirectionOption gridItem={gridItem} />,
+          })
+        )
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.default-layout.item-options.repeat.max', 'Max per row'),
+            useShowIf: () => {
+              const { variableName, repeatDirection } = gridItem.useState();
+              return Boolean(variableName) && repeatDirection === 'h';
+            },
+            render: () => <MaxPerRowOption gridItem={gridItem} />,
+          })
+        ),
+    [gridItem]
   );
 
-  category.addItem(
-    new OptionsPaneItemDescriptor({
-      title: t('dashboard.default-layout.item-options.repeat.direction.title', 'Repeat direction'),
-      useShowIf: () => {
-        const { variableName } = gridItem.useState();
-        return Boolean(variableName);
-      },
-      render: () => <RepeatDirectionOption gridItem={gridItem} />,
-    })
-  );
-
-  category.addItem(
-    new OptionsPaneItemDescriptor({
-      title: t('dashboard.default-layout.item-options.repeat.max', 'Max per row'),
-      useShowIf: () => {
-        const { variableName, repeatDirection } = gridItem.useState();
-        return Boolean(variableName) && repeatDirection === 'h';
-      },
-      render: () => <MaxPerRowOption gridItem={gridItem} />,
-    })
-  );
-
-  return category;
+  return [repeatCategory];
 }
 
 interface OptionComponentProps {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
@@ -60,7 +60,7 @@ export class ResponsiveGridItem extends SceneObjectBase<ResponsiveGridItemState>
     };
   }
 
-  public getOptions(): OptionsPaneCategoryDescriptor {
+  public getOptions(): OptionsPaneCategoryDescriptor[] {
     return getOptions(this);
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemEditor.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { t } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -10,23 +8,19 @@ import { useConditionalRenderingEditor } from '../../conditional-rendering/Condi
 import { ResponsiveGridItem } from './ResponsiveGridItem';
 
 export function getOptions(model: ResponsiveGridItem): OptionsPaneCategoryDescriptor[] {
-  const repeatCategory = useMemo(
-    () =>
-      new OptionsPaneCategoryDescriptor({
-        title: t('dashboard.responsive-layout.item-options.repeat.title', 'Repeat options'),
-        id: 'repeat-options',
-        isOpenDefault: false,
-      }).addItem(
-        new OptionsPaneItemDescriptor({
-          title: t('dashboard.responsive-layout.item-options.repeat.variable.title', 'Repeat by variable'),
-          description: t(
-            'dashboard.responsive-layout.item-options.repeat.variable.description',
-            'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
-          ),
-          render: () => <RepeatByOption item={model} />,
-        })
+  const repeatCategory = new OptionsPaneCategoryDescriptor({
+    title: t('dashboard.responsive-layout.item-options.repeat.title', 'Repeat options'),
+    id: 'repeat-options',
+    isOpenDefault: false,
+  }).addItem(
+    new OptionsPaneItemDescriptor({
+      title: t('dashboard.responsive-layout.item-options.repeat.variable.title', 'Repeat by variable'),
+      description: t(
+        'dashboard.responsive-layout.item-options.repeat.variable.description',
+        'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
       ),
-    [model]
+      render: () => <RepeatByOption item={model} />,
+    })
   );
 
   const conditionalRenderingCategory = useConditionalRenderingEditor(model.state.conditionalRendering)!;

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItemEditor.tsx
@@ -1,9 +1,48 @@
+import { useMemo } from 'react';
+
+import { t } from 'app/core/internationalization';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect';
 
 import { useConditionalRenderingEditor } from '../../conditional-rendering/ConditionalRenderingEditor';
 
 import { ResponsiveGridItem } from './ResponsiveGridItem';
 
-export function getOptions(model: ResponsiveGridItem): OptionsPaneCategoryDescriptor {
-  return useConditionalRenderingEditor(model.state.conditionalRendering)!;
+export function getOptions(model: ResponsiveGridItem): OptionsPaneCategoryDescriptor[] {
+  const repeatCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({
+        title: t('dashboard.responsive-layout.item-options.repeat.title', 'Repeat options'),
+        id: 'repeat-options',
+        isOpenDefault: false,
+      }).addItem(
+        new OptionsPaneItemDescriptor({
+          title: t('dashboard.responsive-layout.item-options.repeat.variable.title', 'Repeat by variable'),
+          description: t(
+            'dashboard.responsive-layout.item-options.repeat.variable.description',
+            'Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.'
+          ),
+          render: () => <RepeatByOption item={model} />,
+        })
+      ),
+    [model]
+  );
+
+  const conditionalRenderingCategory = useConditionalRenderingEditor(model.state.conditionalRendering)!;
+
+  return [repeatCategory, conditionalRenderingCategory];
+}
+
+function RepeatByOption({ item }: { item: ResponsiveGridItem }) {
+  const { variableName } = item.useState();
+
+  return (
+    <RepeatRowSelect2
+      id="repeat-by-variable-select"
+      sceneContext={item}
+      repeat={variableName}
+      onChange={(value?: string) => item.setRepeatByVariable(value)}
+    />
+  );
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
@@ -19,48 +19,61 @@ import { RowItem } from './RowItem';
 
 export function getEditOptions(model: RowItem): OptionsPaneCategoryDescriptor[] {
   const { layout } = model.useState();
-  const rowOptions = useMemo(() => {
-    const editPaneHeaderOptions = new OptionsPaneCategoryDescriptor({ title: '', id: 'row-options' })
-      .addItem(
-        new OptionsPaneItemDescriptor({
-          title: t('dashboard.rows-layout.option.title', 'Title'),
-          render: () => <RowTitleInput row={model} />,
-        })
-      )
-      .addItem(
-        new OptionsPaneItemDescriptor({
-          title: t('dashboard.rows-layout.option.height', 'Height'),
-          render: () => <RowHeightSelect row={model} />,
-        })
-      );
 
-    editPaneHeaderOptions
-      .addItem(
+  const rowCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({ title: '', id: 'row-options' })
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.rows-layout.row-options.row.title', 'Title'),
+            render: () => <RowTitleInput row={model} />,
+          })
+        )
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.rows-layout.row-options.row.height', 'Height'),
+            render: () => <RowHeightSelect row={model} />,
+          })
+        )
+        .addItem(
+          new OptionsPaneItemDescriptor({
+            title: t('dashboard.rows-layout.row-options.row.hide-header', 'Hide row header'),
+            render: () => <RowHeaderSwitch row={model} />,
+          })
+        ),
+    [model]
+  );
+
+  const repeatCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({
+        title: t('dashboard.rows-layout.row-options.repeat.title', 'Repeat options'),
+        id: 'repeat-options',
+        isOpenDefault: false,
+      }).addItem(
         new OptionsPaneItemDescriptor({
-          title: t('dashboard.rows-layout.option.repeat', 'Repeat for'),
+          title: t('dashboard.rows-layout.row-options.repeat.variable.title', 'Repeat by variable'),
+          description: t(
+            'dashboard.rows-layout.row-options.repeat.variable.description',
+            'Repeat this row for each value in the selected variable.'
+          ),
           render: () => <RowRepeatSelect row={model} />,
         })
-      )
-      .addItem(
-        new OptionsPaneItemDescriptor({
-          title: t('dashboard.rows-layout.option.hide-header', 'Hide row header'),
-          render: () => <RowHeaderSwitch row={model} />,
-        })
-      );
-
-    return editPaneHeaderOptions;
-  }, [model]);
+      ),
+    [model]
+  );
 
   const layoutCategory = useLayoutCategory(layout);
 
-  const conditionalRenderingOptions = useMemo(() => {
-    return useConditionalRenderingEditor(model.state.conditionalRendering);
-  }, [model]);
+  const editOptions = [rowCategory, layoutCategory, repeatCategory];
 
-  const editOptions = [rowOptions, layoutCategory];
+  const conditionalRenderingCategory = useMemo(
+    () => useConditionalRenderingEditor(model.state.conditionalRendering),
+    [model]
+  );
 
-  if (conditionalRenderingOptions) {
-    editOptions.push(conditionalRenderingOptions);
+  if (conditionalRenderingCategory) {
+    editOptions.push(conditionalRenderingCategory);
   }
 
   return editOptions;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -11,19 +11,22 @@ import { useEditPaneInputAutoFocus } from '../layouts-shared/utils';
 import { TabItem } from './TabItem';
 
 export function getEditOptions(model: TabItem): OptionsPaneCategoryDescriptor[] {
-  const tabOptions = useMemo(() => {
-    return new OptionsPaneCategoryDescriptor({ title: '', id: 'tab-item-options' }).addItem(
-      new OptionsPaneItemDescriptor({
-        title: t('dashboard.tabs-layout.tab-options.title-option', 'Title'),
-        render: () => <TabTitleInput tab={model} />,
-      })
-    );
-  }, [model]);
-
   const { layout } = model.useState();
-  const layoutOptions = useLayoutCategory(layout);
 
-  return [tabOptions, layoutOptions];
+  const tabCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({ title: '', id: 'tab-item-options' }).addItem(
+        new OptionsPaneItemDescriptor({
+          title: t('dashboard.tabs-layout.tab-options.title-option', 'Title'),
+          render: () => <TabTitleInput tab={model} />,
+        })
+      ),
+    [model]
+  );
+
+  const layoutCategory = useLayoutCategory(layout);
+
+  return [tabCategory, layoutCategory];
 }
 
 function TabTitleInput({ tab }: { tab: TabItem }) {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
@@ -14,7 +14,7 @@ export interface DashboardLayoutItem extends SceneObject {
   /**
    * Return layout item options (like repeat, repeat direction, etc. for the default DashboardGridItem)
    */
-  getOptions?(): OptionsPaneCategoryDescriptor;
+  getOptions?(): OptionsPaneCategoryDescriptor[];
 
   /**
    * When going into panel edit

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1333,12 +1333,12 @@
       "description": "Panels resize to fit and form uniform grids",
       "item-options": {
         "repeat": {
+          "title": "Repeat options",
           "variable": {
             "description": "Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.",
             "title": "Repeat by variable"
           }
-        },
-        "title": "Repeat options"
+        }
       },
       "name": "Auto grid",
       "options": {
@@ -1354,12 +1354,6 @@
     "rows-layout": {
       "description": "Collapsable panel groups with headings",
       "name": "Rows",
-      "option": {
-        "height": "Height",
-        "hide-header": "Hide row header",
-        "repeat": "Repeat for",
-        "title": "Title"
-      },
       "options": {
         "height-expand": "Expand",
         "height-min": "Min"
@@ -1383,6 +1377,18 @@
         }
       },
       "row-options": {
+        "repeat": {
+          "title": "Repeat options",
+          "variable": {
+            "description": "Repeat this row for each value in the selected variable.",
+            "title": "Repeat by variable"
+          }
+        },
+        "row": {
+          "height": "Height",
+          "hide-header": "Hide row header",
+          "title": "Title"
+        },
         "title-option": "Title"
       }
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1331,6 +1331,15 @@
     },
     "responsive-layout": {
       "description": "Panels resize to fit and form uniform grids",
+      "item-options": {
+        "repeat": {
+          "variable": {
+            "description": "Repeat this panel for each value in the selected variable. This is not visible while in edit mode. You need to go back to dashboard and then update the variable or reload the dashboard.",
+            "title": "Repeat by variable"
+          }
+        },
+        "title": "Repeat options"
+      },
       "name": "Auto grid",
       "options": {
         "columns": "Columns",


### PR DESCRIPTION
**What is this feature?**

Repeat options for responsive items were removed when we introduced conditional rendering. This PR brings them back as well as aligning these options between item types.

**Why do we need this feature?**

Consistency and bug fixing

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
