### PR TITLE
GrafanaUI: Fix Combobox throwing error with too many items

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
@@ -1,0 +1,103 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { useOptions } from './useOptions';
+
+describe('useOptions', () => {
+  it('should handle a large number of synchronous options without throwing an error', () => {
+    const largeOptions = Array.from({ length: 1_000_000 }, (_, i) => ({
+      label: `Option ${i + 1}`,
+      value: `${i + 1}`,
+    }));
+    const { result } = renderHook(() => useOptions(largeOptions, false));
+
+    act(() => {
+      result.current.updateOptions('Option 999999');
+    });
+
+    expect(result.current.options).toEqual([{ label: 'Option 999999', value: '999999' }]);
+  });
+
+  it('should return filtered options for synchronous options', () => {
+    const options = [
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+    ];
+    const { result } = renderHook(() => useOptions(options, false));
+
+    act(() => {
+      result.current.updateOptions('Option 1');
+    });
+
+    expect(result.current.options).toEqual([{ label: 'Option 1', value: '1' }]);
+  });
+
+  it('should handle asynchronous options', async () => {
+    const asyncOptions = jest.fn().mockResolvedValue([
+      { label: 'Async Option 1', value: '1' },
+      { label: 'Async Option 2', value: '2' },
+    ]);
+    const { result } = renderHook(() => useOptions(asyncOptions, false));
+
+    act(() => {
+      result.current.updateOptions('Async');
+    });
+
+    expect(result.current.asyncLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.asyncLoading).toBe(false));
+
+    expect(result.current.options).toEqual([
+      { label: 'Async Option 1', value: '1' },
+      { label: 'Async Option 2', value: '2' },
+    ]);
+  });
+
+  it('should add a custom value if enabled', () => {
+    const options = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Carrot', value: 'carrot' },
+    ];
+    const { result } = renderHook(() => useOptions(options, true));
+
+    act(() => {
+      result.current.updateOptions('car');
+    });
+
+    expect(result.current.options).toEqual([
+      { label: 'car', value: 'car', description: 'Use custom value' },
+      { label: 'Carrot', value: 'carrot' },
+    ]);
+  });
+
+  it('should not add a custom value if it already exists', () => {
+    const options = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Carrot', value: 'carrot' },
+    ];
+    const { result } = renderHook(() => useOptions(options, true));
+
+    act(() => {
+      result.current.updateOptions('carrot');
+    });
+
+    expect(result.current.options).toEqual([{ label: 'Carrot', value: 'carrot' }]);
+  });
+
+  it('should handle errors in asynchronous options', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const asyncOptions = jest.fn().mockRejectedValue(new Error('Async error'));
+    const { result } = renderHook(() => useOptions(asyncOptions, false));
+
+    act(() => {
+      result.current.updateOptions('Async');
+    });
+
+    expect(result.current.asyncLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.asyncLoading).toBe(false));
+
+    expect(result.current.asyncLoading).toBe(false);
+    expect(result.current.asyncError).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes an regression introduced in https://github.com/grafana/grafana/issues/100603 where Combobox will crash the page if passed too many items.

Calling `anyFunction(...options)` - spreading an unbound array of options as function arguments - will crash browsers when options is 'too large'. It appears Chrome has a lower limit than Firefox, but both will crash with 1m options.

This PR fixes the issue by using `arr = arr.concat(options)` instead which avoids the problem. It also adds some basic unit tests for `useOptions` (previously it was tested only as a part of Combobox), including a sanity check for this case.

Also added a lint rule for just `useOptions` to prevent the use of spread at all. Options should never be spread as function arguments, and other array methods tend to be faster than spreading large arrays.


Fixes https://github.com/grafana/grafana/issues/102428