### PR TITLE
Snapshots: Disable external snapshots config by default

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -440,9 +440,14 @@ data_keys_cache_cleanup_interval = 1m
 # set to false to remove snapshot functionality
 enabled = true
 
-# snapshot sharing options
+# external snapshot sharing options
+# Set to `true` to enable external snapshot publish endpoint (default `false`).
 external_enabled = false
+
+# Set root URL to a Grafana instance where you want to publish external snapshots.
 external_snapshot_url =
+
+# Set name for external snapshot button.
 external_snapshot_name =
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -441,9 +441,9 @@ data_keys_cache_cleanup_interval = 1m
 enabled = true
 
 # snapshot sharing options
-external_enabled = true
-external_snapshot_url = https://snapshots.raintank.io
-external_snapshot_name = Publish to snapshots.raintank.io
+external_enabled = false
+external_snapshot_url =
+external_snapshot_name =
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -446,9 +446,9 @@
 ;enabled = true
 
 # snapshot sharing options
-;external_enabled = true
-;external_snapshot_url = https://snapshots.raintank.io
-;external_snapshot_name = Publish to snapshots.raintank.io
+;external_enabled = false
+;external_snapshot_url =
+;external_snapshot_name =
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -447,13 +447,13 @@
 
 # external snapshot sharing options
 # Set to `true` to enable external snapshot publish endpoint (default `false`).
-external_enabled = false
+;external_enabled = false
 
 # Set root URL to a Grafana instance where you want to publish external snapshots.
-external_snapshot_url =
+;external_snapshot_url =
 
 # Set name for external snapshot button.
-external_snapshot_name =
+;external_snapshot_name =
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -445,10 +445,15 @@
 # set to false to remove snapshot functionality
 ;enabled = true
 
-# snapshot sharing options
-;external_enabled = false
-;external_snapshot_url =
-;external_snapshot_name =
+# external snapshot sharing options
+# Set to `true` to enable external snapshot publish endpoint (default `false`).
+external_enabled = false
+
+# Set root URL to a Grafana instance where you want to publish external snapshots.
+external_snapshot_url =
+
+# Set name for external snapshot button.
+external_snapshot_name =
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/docs/sources/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/_index.md
@@ -160,7 +160,7 @@ A dashboard snapshot publicly shares a dashboard while removing sensitive data s
 You can publish snapshots to your local instance or to an external instance and anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 
 {{< admonition type=note >}}
-Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots Raintank instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
+Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots `Raintank` instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
 {{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.
@@ -332,7 +332,7 @@ A panel snapshot shares an interactive panel publicly while removing sensitive d
 
 You can publish snapshots to your local instance or to an external instance and anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 {{< admonition type=note >}}
-Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots Raintank instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
+Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots `Raintank` instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
 {{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.

--- a/docs/sources/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/_index.md
@@ -157,11 +157,10 @@ To manage your reports, navigate to **Dashboards > Reporting > Reports**.
 
 A dashboard snapshot publicly shares a dashboard while removing sensitive data such as queries and panel links, leaving only visible metrics and series names. Anyone with the link can access the snapshot.
 
-You can publish snapshots to your local instance or to [snapshots.raintank.io](http://snapshots.raintank.io). The latter is a free service provided by Grafana Labs that enables you to publish dashboard snapshots to an external Grafana instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
+You can publish snapshots to your local instance or to an external instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 
 {{< admonition type=note >}}
-The snapshots.raintank.io option is disabled by default in Grafana Cloud. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
-{{< /admonition >}}
+Publishing to the external instance snapshots.raintank.io is disabled by default. Snapshots raintank instance will be turned off in Grafana 13. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.{{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.
 
@@ -176,9 +175,9 @@ To share your dashboard with anyone as a snapshot, follow these steps:
    - **1 Day**
    - **1 Week**
    - **Never**
-1. Click **Publish snapshot** or **Publish to snapshots.raintank.io**.
+1. Click **Publish snapshot**.
 
-   Grafana generates the link of the snapshot. Note that you can't publish dashboard snapshots containing custom panels to snapshot.raintank.io.
+   Grafana generates the link of the snapshot.
 
 1. Click **Copy link**, and share it either within your organization or publicly on the web.
 1. Click the **X** at the top-right corner to close the share drawer.
@@ -330,10 +329,9 @@ The result is an interactive Grafana visualization embedded in an iframe.
 
 A panel snapshot shares an interactive panel publicly while removing sensitive data such as queries and panel links, leaving only visible metrics and series names. Anyone with the link can access the snapshot.
 
-You can publish snapshots to your local instance or to [snapshots.raintank.io](http://snapshots.raintank.io). The latter is a free service provided by Grafana Labs that enables you to publish dashboard snapshots to an external Grafana instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
-
+You can publish snapshots to your local instance or to an external instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 {{< admonition type=note >}}
-The snapshots.raintank.io option is disabled by default in Grafana Cloud. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
+Publishing to the external instance snapshots.raintank.io is disabled by default. Snapshots raintank instance will be turned off in Grafana 13. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
 {{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.
@@ -348,9 +346,9 @@ To share your panel with anyone as a snapshot, follow these steps:
    - **1 Day**
    - **1 Week**
    - **Never**
-1. Click **Publish snapshot** or **Publish to snapshots.raintank.io**.
+1. Click **Publish snapshot**.
 
-   Grafana generates the link of the snapshot. Note that you can't publish snapshots that include custom panels to snapshot.raintank.io.
+   Grafana generates the link of the snapshot.
 
 1. Click **Copy link**, and share it either within your organization or publicly on the web.
 1. Click the **X** at the top-right corner to close the share drawer.

--- a/docs/sources/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/_index.md
@@ -157,10 +157,11 @@ To manage your reports, navigate to **Dashboards > Reporting > Reports**.
 
 A dashboard snapshot publicly shares a dashboard while removing sensitive data such as queries and panel links, leaving only visible metrics and series names. Anyone with the link can access the snapshot.
 
-You can publish snapshots to your local instance or to an external instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
+You can publish snapshots to your local instance or to an external instance and anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 
 {{< admonition type=note >}}
-Publishing to the external instance snapshots.raintank.io is disabled by default. Snapshots raintank instance will be turned off in Grafana 13. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.{{< /admonition >}}
+Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots Raintank instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
+{{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.
 
@@ -329,9 +330,9 @@ The result is an interactive Grafana visualization embedded in an iframe.
 
 A panel snapshot shares an interactive panel publicly while removing sensitive data such as queries and panel links, leaving only visible metrics and series names. Anyone with the link can access the snapshot.
 
-You can publish snapshots to your local instance or to an external instance. Anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
+You can publish snapshots to your local instance or to an external instance and anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 {{< admonition type=note >}}
-Publishing to the external instance snapshots.raintank.io is disabled by default. Snapshots raintank instance will be turned off in Grafana 13. You can update [your config file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
+Publishing to the external instance snapshots.raintank.io is disabled by default. The snapshots Raintank instance will be turned off in Grafana 13. You can update [your `config` file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#external_enabled) to enable this functionality.
 {{< /admonition >}}
 
 To see the other snapshots shared from your organization, navigate to **Dashboards > Snapshots** in the main menu.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -818,15 +818,15 @@ Set to `false` to disable the snapshot feature (default `true`).
 
 #### `external_enabled`
 
-Set to `false` to disable external snapshot publish endpoint (default `true`).
+Set to `true` to enable external snapshot publish endpoint (default `false`).
 
 #### `external_snapshot_url`
 
-Set root URL to a Grafana instance where you want to publish external snapshots (defaults to https://snapshots.raintank.io).
+Set root URL to a Grafana instance where you want to publish external snapshots.
 
 #### `external_snapshot_name`
 
-Set name for external snapshot button. Defaults to `Publish to snapshots.raintank.io`.
+Set name for external snapshot button.
 
 #### `public_mode`
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -351,7 +351,7 @@ type Cfg struct {
 	ExternalSnapshotName string
 	ExternalEnabled      bool
 
-	// Only used in https://snapshots.raintank.io/
+	// Only used in external snapshot instances
 	SnapshotPublicMode bool
 
 	ErrTemplateName string


### PR DESCRIPTION
**What is this feature?**

Update `defaults.ini` to disable external snapshots by default.

**Why do we need this feature?**

We are deprecating the [snapshots raintank external instance](https://docs.google.com/document/d/1U0qoFXM5tGWYNgvzbayZADUnl2BScrk0PgW7KyUd0lc/edit?tab=t.jyk95bmw1dko#heading=h.ecic4sx2up8q) in Grafana 12 and planning to turn it off in Grafana 13.
This change only removes this configuration by default but it will still available until Grafana 13.
The external snapshots feature won't be removed but a custom external instance (managed by users) will be needed.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
