### PR TITLE
[Provisioning] Remove unused checkout method in go-git

### DIFF
--- a/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
+++ b/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -21,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/safepath"
@@ -155,51 +153,6 @@ func mkdirTempClone(root string, config *provisioning.Repository) (string, error
 		return "", fmt.Errorf("config is missing name")
 	}
 	return os.MkdirTemp(root, fmt.Sprintf("clone-%s-%s-", config.Namespace, config.Name))
-}
-
-// Remove everything from the tree
-func (g *GoGitRepo) Checkout(ctx context.Context, branch string, createIfNotFound bool) error {
-	if branch == "" {
-		return fmt.Errorf("expecting branch name")
-	}
-
-	branchCoOpts := git.CheckoutOptions{
-		Branch: plumbing.NewBranchReferenceName(branch),
-		Force:  true, // removes any local changes
-	}
-	err := g.tree.Checkout(&branchCoOpts)
-	if err == nil {
-		return nil // success
-	}
-
-	logger := logging.FromContext(ctx)
-	logger.Info("local checkout failed, will attempt to fetch remote branch of same name.", "branch", branch)
-
-	remote, err := g.repo.Remote("origin")
-	if err != nil {
-		return err
-	}
-	err = remote.Fetch(&git.FetchOptions{
-		RefSpecs: []config.RefSpec{config.RefSpec(
-			fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch),
-		)},
-		Auth: &githttp.BasicAuth{ // reuse logic from clone?
-			Username: "grafana",
-			Password: g.decryptedPassword,
-		},
-	})
-	if err != nil {
-		logger.Info("origin fetch failed.", "branch", branch, "err", err)
-	}
-
-	// Try again, this time create
-	err = g.tree.Checkout(&branchCoOpts)
-	if err != nil && createIfNotFound {
-		// It did not exist, so lets create it
-		branchCoOpts.Create = true
-		return g.tree.Checkout(&branchCoOpts)
-	}
-	return err
 }
 
 // Affer making changes to the worktree, push changes

--- a/pkg/registry/apis/provisioning/repository/go-git/wrapper_test.go
+++ b/pkg/registry/apis/provisioning/repository/go-git/wrapper_test.go
@@ -73,10 +73,6 @@ func TestGoGitWrapper(t *testing.T) {
 
 	fmt.Printf("TREE:%s\n", string(jj))
 
-	branch := fmt.Sprintf("unit-test-%s", time.Now().Format("20060102-150405")) // the branch name to create
-	err = wrap.Checkout(ctx, branch, true)
-	require.NoError(t, err)
-
 	ctx = repository.WithAuthorSignature(ctx, repository.CommitSignature{
 		Name:  "xxxxx",
 		Email: "rrr@yyyy.zzz",


### PR DESCRIPTION
It's not used anymore as we don't want to remove files from the repository anymore.
