### PR TITLE
Docs: Add auth for metrics to hardening page

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-security-hardening/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-security-hardening/index.md
@@ -118,6 +118,18 @@ Example:
 hide_version = true
 ```
 
+### Enable auth for metrics
+
+By default, metrics from Grafana itself can be accessed without authentication. This can lead to inadvertent information leakage.
+
+To enable basic authentication for the metrics endpoint:
+
+```toml
+# If both are set, basic auth will be required for the metrics endpoints
+basic_auth_username =
+basic_auth_password =
+```
+
 ### Enforce domain verification
 
 If set to `true`, the Grafana server redirects requests that have a Host-header value that is mismatched to the actual domain. This might help to mitigate some DNS rebinding attacks.


### PR DESCRIPTION
**What is this feature?**

Adds instructions to enable authentication for metrics from Grafana itself to the security hardening docs.

**Why do we need this feature?**

Putting metrics behind authentication appears to fit in line with other hardening measures, such as hiding the version number.

**Who is this feature for?**

Anyone following the instructions from the hardening page.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
