### PR TITLE
Alerting: Add migration to clean up rule versions table

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
@@ -157,8 +157,6 @@ func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migr
 		toKeep = maxRetention
 	}
 
-	mg.Logger.Debug("Cleaning up rule versions", "batchSize", batchSize)
-
 	var rules []alertRule
 	err := sess.Table(alertRule{}).Select("uid, version").Find(&rules)
 	if err != nil {
@@ -169,7 +167,8 @@ func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migr
 	if len(rules)%batchSize != 0 {
 		batches++
 	}
-	mg.Logger.Debug("Processing in batches", "batchSize", batchSize, "batches", batches)
+
+	mg.Logger.Info("Cleaning up table `alert_rule_version`", "batchSize", batchSize, "batches", batches, "keepVersions", toKeep)
 
 	for i := 0; i < batches; i++ {
 		end := i*batchSize + batchSize
@@ -196,6 +195,7 @@ func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migr
 		if err != nil {
 			return err
 		}
+
 		mg.Logger.Debug(fmt.Sprintf("Batch %d of %d processed", i+1, batches))
 	}
 	return nil

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
@@ -2,6 +2,8 @@ package ualert
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -29,9 +31,12 @@ func AddAlertRuleGuidMigration(mg *migrator.Migrator) {
 		Nullable: false,
 		Default:  "''",
 	}))
-	mg.AddMigration("drop index in alert_rule_version table on rule_org_id, rule_uid and version columns", migrator.NewDropIndexMigration(alertRuleVersion, alertRuleVersionUDX_OrgIdRuleUIDVersion))
+
+	mg.AddMigration("cleanup alert_rule_version table", &cleanUpRuleVersionsMigration{})
 
 	mg.AddMigration("populate rule guid in alert rule table", &setRuleGuidMigration{})
+
+	mg.AddMigration("drop index in alert_rule_version table on rule_org_id, rule_uid and version columns", migrator.NewDropIndexMigration(alertRuleVersion, alertRuleVersionUDX_OrgIdRuleUIDVersion))
 
 	mg.AddMigration("add index in alert_rule_version table on rule_org_id, rule_uid, rule_guid and version columns",
 		migrator.NewAddIndexMigration(alertRuleVersion,
@@ -115,6 +120,83 @@ func (c setRuleGuidMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) er
 	if err != nil {
 		mg.Logger.Error("Failed to update alert_rule_version table with GUIDs from alert_rule table", "error", err)
 		return err
+	}
+	return nil
+}
+
+type cleanUpRuleVersionsMigration struct {
+	migrator.MigrationBase
+}
+
+var _ migrator.CodeMigration = (*cleanUpRuleVersionsMigration)(nil)
+
+func (c cleanUpRuleVersionsMigration) SQL(migrator.Dialect) string {
+	return codeMigration
+}
+
+func getBatchSize() int {
+	const defaultBatchSize = 50
+	envvar := os.Getenv("ALERT_RULE_VERSION_CLEANUP_MIGRATION_BATCH_SIZE")
+	if envvar == "" {
+		return defaultBatchSize
+	}
+	batchSize, err := strconv.Atoi(envvar)
+	if err != nil {
+		return defaultBatchSize
+	}
+	return batchSize
+}
+
+func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	var batchSize = getBatchSize()
+
+	const maxRetention = 100
+	toKeep := mg.Cfg.UnifiedAlerting.RuleVersionRecordLimit
+	if toKeep <= 0 {
+		mg.Logger.Info("Rule version record limit is not set, fallback to 100", "limit", toKeep)
+		toKeep = maxRetention
+	}
+
+	mg.Logger.Debug("Cleaning up rule versions", "batchSize", batchSize)
+
+	var rules []alertRule
+	err := sess.Table(alertRule{}).Select("uid, version").Find(&rules)
+	if err != nil {
+		return err
+	}
+	mg.Logger.Debug("Got alert rule UIDs", "count", len(rules))
+	batches := len(rules) / batchSize
+	if len(rules)%batchSize != 0 {
+		batches++
+	}
+	mg.Logger.Debug("Processing in batches", "batchSize", batchSize, "batches", batches)
+
+	for i := 0; i < batches; i++ {
+		end := i*batchSize + batchSize
+		if end > len(rules) {
+			end = len(rules)
+		}
+		bd := strings.Builder{}
+		for idx, r := range rules[i*batchSize : end] {
+			if idx == 0 {
+				bd.WriteString(fmt.Sprintf("SELECT '%s' as uid, %d as version", r.UID, r.Version))
+				continue
+			}
+			bd.WriteString(fmt.Sprintf(" UNION ALL SELECT '%s', %d ", r.UID, r.Version))
+		}
+		_, err = sess.Exec(fmt.Sprintf(`
+			DELETE FROM alert_rule_version
+			WHERE EXISTS (
+			    SELECT 1
+			    FROM (%s) AR
+			    WHERE AR.uid = alert_rule_version.rule_uid 
+			    AND alert_rule_version.version < AR.version - %d
+			)`, bd.String(), toKeep),
+		)
+		if err != nil {
+			return err
+		}
+		mg.Logger.Debug(fmt.Sprintf("Batch %d of %d processed", i+1, batches))
 	}
 	return nil
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
@@ -158,11 +158,11 @@ func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migr
 	}
 
 	var rules []alertRule
-	err := sess.Table(alertRule{}).Select("uid, version").Find(&rules)
+	err := sess.Table(alertRule{}).Select("uid, version").Where("version > ?", toKeep).Find(&rules)
 	if err != nil {
 		return err
 	}
-	mg.Logger.Debug("Got alert rule UIDs", "count", len(rules))
+	mg.Logger.Debug("Got alert rule UIDs with versions greater than retention", "count", len(rules))
 	batches := len(rules) / batchSize
 	if len(rules)%batchSize != 0 {
 		batches++


### PR DESCRIPTION
**What is this feature?**
Adds a migration to clean-up table `alert_rule_version` before setting GUIDs and updating indices
The migration honors the setting `rule_version_record_limit` from the configuration file. If it is default (i.e. 0) then it falls back to hard coded number of 100, i.e. keep 100 most recent versions of the rule.
The migration runs queries in batches, default is 50 rule UIDs per batch. It can be adjusted via environment variable `ALERT_RULE_VERSION_CLEANUP_MIGRATION_BATCH_SIZE`


**Why do we need this feature?**
The table `alert_rule_version` has not been maintained and turned off by default. This may cause the table to grow to millions of the records, for example when used provisioning or updating rules in big groups (when a rule is updated in such group, all rules are updated with version increase).

This change is critical to speed up later migrations and reduce a chance of timeout.