### PR TITLE
TableNG: Image cell hover fix

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -616,6 +616,7 @@ export function mapFrameToDataGrid({
       cellClass: styles.cell,
       renderCell: (props: RenderCellProps<TableRow, TableSummaryRow>): JSX.Element => {
         const { row, rowIdx } = props;
+        const cellType = field.config?.custom?.cellOptions.type;
         const value = row[key];
         // Cell level rendering here
         return (
@@ -640,7 +641,8 @@ export function mapFrameToDataGrid({
                 defaultRowHeight,
                 TABLE.CELL_PADDING,
                 textWrap,
-                cellInspect
+                cellInspect,
+                cellType
               )
             }
             setIsInspecting={setIsInspecting}

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -168,23 +168,20 @@ export function shouldTextOverflow(
   defaultRowHeight: number,
   padding: number,
   textWrap: boolean,
-  cellInspect: boolean
+  cellInspect: boolean,
+  cellType: TableCellDisplayMode
 ): boolean {
-  if (textWrap || cellInspect) {
+  // Tech debt: Technically image cells are of type string, which is misleading (kinda?)
+  // so we need to ensure we don't apply overflow hover states fo type image
+  if (textWrap || cellInspect || cellType === TableCellDisplayMode.Image || !isTextCell(key, columnTypes)) {
     return false;
   }
 
-  if (isTextCell(key, columnTypes)) {
-    const cellWidth = headerCellRefs.current[key].offsetWidth;
-    const cellText = String(row[key] ?? '');
-    const newCellHeight = getCellHeight(cellText, cellWidth, osContext, lineHeight, defaultRowHeight, padding);
+  const cellWidth = headerCellRefs.current[key].offsetWidth;
+  const cellText = String(row[key] ?? '');
+  const newCellHeight = getCellHeight(cellText, cellWidth, osContext, lineHeight, defaultRowHeight, padding);
 
-    if (newCellHeight > defaultRowHeight) {
-      return true;
-    }
-  }
-
-  return false;
+  return newCellHeight > defaultRowHeight;
 }
 
 export function getColumnWidth(field: Field, fieldConfig: TableNGProps['fieldConfig'], key: string): number {


### PR DESCRIPTION
## What does this PR do? 📓 

I noticed weird hover behavior for image cells. After investigating, the root of the issue is that image cells are being treated as a `string` type, which means it's implementing `shouldOverflow`, causing style issues. 

When we build `columnTypes`, technically image cells are of type `string`, which is kind of interesting. The old logic within `shouldTextOverflow()` treats image cells therefore as string, adding certain styles. We don't want that ⛔ 

So let's add a check to the `shouldTextOverflow()` function checking for type image, and bail if it's `true`. 

#### Before

![Kapture 2025-02-25 at 11 57 56](https://github.com/user-attachments/assets/b7b75d1f-e6c8-4a44-8633-1a618c38e8d5)

#### After

![Kapture 2025-02-25 at 11 56 31](https://github.com/user-attachments/assets/c91c5ac9-def3-4489-8364-97231cbacfbb)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
