### PR TITLE
Chore: Add pushes to `main` in the `storybook-verification` workflow

### DIFF
--- a/.github/workflows/storybook-verification.yml
+++ b/.github/workflows/storybook-verification.yml
@@ -4,7 +4,13 @@ on:
   pull_request:
     paths:
       - 'packages/grafana-ui/**'
-      - '.github/workflows/storybook-verification.yml'
+      - '!docs/**'
+      - '!*.md'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/grafana-ui/**'
       - '!docs/**'
       - '!*.md'
 


### PR DESCRIPTION
Really what we're doing is simply adding a "push to `main`" trigger to the already-built GHA, since the 2 drone pipelines for `pr` and `main` pipeline are already identical.