### PR TITLE
Docs: Update service account doc

### DIFF
--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -63,6 +63,8 @@ refs:
 
 You can use a service account to run automated workloads in Grafana, such as dashboard provisioning, configuration, or report generation. Create service accounts and tokens to authenticate applications, such as Terraform, with the Grafana API.
 
+A service account is not the same as a Grafana [user](/docs/grafana/latest/administration/user-management/). The role of a service account is primarily to automate work using the Grafana API.
+
 {{< admonition type="note" >}}
 Service accounts replace [API keys](ref:migrate-api-keys) as the primary way to authenticate applications that interact with Grafana.
 {{< /admonition >}}


### PR DESCRIPTION
Update the content to include that a service account is not the same as a user account, per [this service request.](https://github.com/grafana/support-escalations/issues/6998)