### PR TITLE
Alerting: Support query_offset in the Prometheus conversion

### DIFF
--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -208,6 +208,9 @@
     "isPaused": {
      "type": "boolean"
     },
+    "keepFiringFor": {
+     "$ref": "#/definitions/Duration"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
@@ -467,6 +470,10 @@
     },
     "health": {
      "type": "string"
+    },
+    "keepFiringFor": {
+     "format": "double",
+     "type": "number"
     },
     "labels": {
      "$ref": "#/definitions/Labels"
@@ -3012,7 +3019,20 @@
     "Interval": {
      "$ref": "#/definitions/Duration"
     },
+    "Labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "Limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "Name": {
+     "type": "string"
+    },
+    "QueryOffset": {
      "type": "string"
     },
     "Rules": {
@@ -3116,6 +3136,10 @@
     "isPaused": {
      "example": false,
      "type": "boolean"
+    },
+    "keep_firing_for": {
+     "format": "duration",
+     "type": "string"
     },
     "labels": {
      "additionalProperties": {
@@ -4952,7 +4976,6 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert",
     "type": "object"

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -192,9 +192,12 @@ type PrometheusNamespace struct {
 
 // swagger:model
 type PrometheusRuleGroup struct {
-	Name     string           `yaml:"name"`
-	Interval model.Duration   `yaml:"interval"`
-	Rules    []PrometheusRule `yaml:"rules"`
+	Name        string            `yaml:"name"`
+	Interval    model.Duration    `yaml:"interval"`
+	QueryOffset *model.Duration   `yaml:"query_offset,omitempty"`
+	Limit       int               `yaml:"limit,omitempty"`
+	Rules       []PrometheusRule  `yaml:"rules"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -208,6 +208,9 @@
     "isPaused": {
      "type": "boolean"
     },
+    "keepFiringFor": {
+     "$ref": "#/definitions/Duration"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
@@ -467,6 +470,10 @@
     },
     "health": {
      "type": "string"
+    },
+    "keepFiringFor": {
+     "format": "double",
+     "type": "number"
     },
     "labels": {
      "$ref": "#/definitions/Labels"
@@ -3012,7 +3019,20 @@
     "Interval": {
      "$ref": "#/definitions/Duration"
     },
+    "Labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "Limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "Name": {
+     "type": "string"
+    },
+    "QueryOffset": {
      "type": "string"
     },
     "Rules": {
@@ -3116,6 +3136,10 @@
     "isPaused": {
      "example": false,
      "type": "boolean"
+    },
+    "keep_firing_for": {
+     "format": "duration",
+     "type": "string"
     },
     "labels": {
      "additionalProperties": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4433,6 +4433,9 @@
         "isPaused": {
           "type": "boolean"
         },
+        "keepFiringFor": {
+          "$ref": "#/definitions/Duration"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -4702,6 +4705,10 @@
         },
         "health": {
           "type": "string"
+        },
+        "keepFiringFor": {
+          "type": "number",
+          "format": "double"
         },
         "labels": {
           "$ref": "#/definitions/Labels"
@@ -7238,7 +7245,20 @@
         "Interval": {
           "$ref": "#/definitions/Duration"
         },
+        "Labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "Limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "Name": {
+          "type": "string"
+        },
+        "QueryOffset": {
           "type": "string"
         },
         "Rules": {
@@ -7353,6 +7373,10 @@
         "isPaused": {
           "type": "boolean",
           "example": false
+        },
+        "keep_firing_for": {
+          "type": "string",
+          "format": "duration"
         },
         "labels": {
           "type": "object",

--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -199,7 +199,7 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	var err error
 
 	isRecordingRule := rule.Record != ""
-	query, err = p.createQuery(rule.Expr, isRecordingRule)
+	query, err = p.createQuery(rule.Expr, isRecordingRule, promGroup)
 	if err != nil {
 		return models.AlertRule{}, err
 	}
@@ -265,8 +265,16 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 //
 // This is needed to ensure that we keep the Prometheus behaviour, where any returned result
 // is considered alerting, and only when the query returns no data is the alert treated as normal.
-func (p *Converter) createQuery(expr string, isRecordingRule bool) ([]models.AlertQuery, error) {
-	queryNode, err := createQueryNode(p.cfg.DatasourceUID, p.cfg.DatasourceType, expr, *p.cfg.FromTimeRange, *p.cfg.EvaluationOffset)
+func (p *Converter) createQuery(expr string, isRecordingRule bool, promGroup PrometheusRuleGroup) ([]models.AlertQuery, error) {
+	// If evaluation offset is set on the group level, use that, otherwise use the global evaluation offset.
+	var evaluationOffset time.Duration
+	if promGroup.QueryOffset != nil {
+		evaluationOffset = time.Duration(*promGroup.QueryOffset)
+	} else {
+		evaluationOffset = *p.cfg.EvaluationOffset
+	}
+
+	queryNode, err := createQueryNode(p.cfg.DatasourceUID, p.cfg.DatasourceType, expr, *p.cfg.FromTimeRange, evaluationOffset)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -36,8 +36,9 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 			orgID:     1,
 			namespace: "some-namespace-uid",
 			promGroup: PrometheusRuleGroup{
-				Name:     "test-group-1",
-				Interval: prommodel.Duration(10 * time.Second),
+				Name:        "test-group-1",
+				Interval:    prommodel.Duration(10 * time.Second),
+				QueryOffset: util.Pointer(prommodel.Duration(1 * time.Minute)),
 				Rules: []PrometheusRule{
 					{
 						Alert: "alert-1",
@@ -124,16 +125,13 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:      "rule group with query_offset is not supported",
+			name:      "query_offset must be >= 0",
 			orgID:     1,
 			namespace: "namespaceUID",
 			promGroup: PrometheusRuleGroup{
-				Name:     "test-group-1",
-				Interval: prommodel.Duration(10 * time.Second),
-				QueryOffset: func() *prommodel.Duration {
-					d := prommodel.Duration(30 * time.Second)
-					return &d
-				}(),
+				Name:        "test-group-1",
+				Interval:    prommodel.Duration(10 * time.Second),
+				QueryOffset: util.Pointer(prommodel.Duration(-1)),
 				Rules: []PrometheusRule{
 					{
 						Alert: "alert-1",
@@ -142,7 +140,7 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "query_offset is not supported",
+			errorMsg:    "query_offset must be >= 0",
 		},
 		{
 			name:      "rule group with limit is not supported",
@@ -275,8 +273,13 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				if tc.config.EvaluationOffset != nil {
 					evalOffset = *tc.config.EvaluationOffset
 				}
+				if tc.promGroup.QueryOffset != nil {
+					// group-level offset takes precedence
+					evalOffset = time.Duration(*tc.promGroup.QueryOffset)
+				}
+
 				require.Equal(t, models.Duration(evalOffset), grafanaRule.Data[0].RelativeTimeRange.To)
-				require.Equal(t, models.Duration(evalOffset+10*time.Minute), grafanaRule.Data[0].RelativeTimeRange.From)
+				require.Equal(t, models.Duration(10*time.Minute+evalOffset), grafanaRule.Data[0].RelativeTimeRange.From)
 
 				originalRuleDefinition, err := yaml.Marshal(promRule)
 				require.NoError(t, err)

--- a/pkg/services/ngalert/prom/models.go
+++ b/pkg/services/ngalert/prom/models.go
@@ -25,12 +25,12 @@ type PrometheusRuleGroup struct {
 }
 
 func (g *PrometheusRuleGroup) Validate() error {
-	if g.QueryOffset != nil {
-		return ErrPrometheusRuleGroupValidationFailed.Errorf("query_offset is not supported")
-	}
-
 	if g.Limit != 0 {
 		return ErrPrometheusRuleGroupValidationFailed.Errorf("limit is not supported")
+	}
+
+	if g.QueryOffset != nil && *g.QueryOffset < prommodel.Duration(0) {
+		return ErrPrometheusRuleGroupValidationFailed.Errorf("query_offset must be >= 0")
 	}
 
 	for _, rule := range g.Rules {

--- a/pkg/services/ngalert/prom/models_test.go
+++ b/pkg/services/ngalert/prom/models_test.go
@@ -26,6 +26,7 @@ func TestPrometheusRuleGroup_Validate(t *testing.T) {
 				Labels: map[string]string{
 					"label-1": "value-1",
 				},
+				QueryOffset: util.Pointer(prommodel.Duration(time.Duration(1) * time.Second)),
 				Rules: []PrometheusRule{
 					{
 						Alert: "test_alert",
@@ -36,14 +37,14 @@ func TestPrometheusRuleGroup_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "invalid group with query_offset",
+			name: "invalid group with negative query_offset",
 			group: PrometheusRuleGroup{
 				Name:        "test_group",
 				Interval:    prommodel.Duration(60),
-				QueryOffset: util.Pointer(prommodel.Duration(10)),
+				QueryOffset: util.Pointer(prommodel.Duration(-1)),
 			},
 			expectError: true,
-			errorMsg:    "query_offset is not supported",
+			errorMsg:    "query_offset must be >= 0",
 		},
 		{
 			name: "invalid group with limit",

--- a/pkg/services/ngalert/prom/query.go
+++ b/pkg/services/ngalert/prom/query.go
@@ -43,7 +43,7 @@ func createQueryNode(datasourceUID, datasourceType, expr string, fromTimeRange, 
 		RefID:         queryRefID,
 		RelativeTimeRange: models.RelativeTimeRange{
 			From: models.Duration(fromTimeRange + evaluationOffset),
-			To:   models.Duration(0 + evaluationOffset),
+			To:   models.Duration(evaluationOffset),
 		},
 	}, nil
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12654,6 +12654,9 @@
         "isPaused": {
           "type": "boolean"
         },
+        "keepFiringFor": {
+          "$ref": "#/definitions/Duration"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -12923,6 +12926,10 @@
         },
         "health": {
           "type": "string"
+        },
+        "keepFiringFor": {
+          "type": "number",
+          "format": "double"
         },
         "labels": {
           "$ref": "#/definitions/Labels"
@@ -18688,7 +18695,20 @@
         "Interval": {
           "$ref": "#/definitions/Duration"
         },
+        "Labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "Limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "Name": {
+          "type": "string"
+        },
+        "QueryOffset": {
           "type": "string"
         },
         "Rules": {
@@ -18803,6 +18823,10 @@
         "isPaused": {
           "type": "boolean",
           "example": false
+        },
+        "keep_firing_for": {
+          "type": "string",
+          "format": "duration"
         },
         "labels": {
           "type": "object",
@@ -22869,7 +22893,6 @@
       }
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2715,6 +2715,9 @@
           "isPaused": {
             "type": "boolean"
           },
+          "keepFiringFor": {
+            "$ref": "#/components/schemas/Duration"
+          },
           "labels": {
             "additionalProperties": {
               "type": "string"
@@ -2974,6 +2977,10 @@
           },
           "health": {
             "type": "string"
+          },
+          "keepFiringFor": {
+            "format": "double",
+            "type": "number"
           },
           "labels": {
             "$ref": "#/components/schemas/Labels"
@@ -8750,7 +8757,20 @@
           "Interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "Labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "Limit": {
+            "format": "int64",
+            "type": "integer"
+          },
           "Name": {
+            "type": "string"
+          },
+          "QueryOffset": {
             "type": "string"
           },
           "Rules": {
@@ -8854,6 +8874,10 @@
           "isPaused": {
             "example": false,
             "type": "boolean"
+          },
+          "keep_firing_for": {
+            "format": "duration",
+            "type": "string"
           },
           "labels": {
             "additionalProperties": {
@@ -12930,7 +12954,6 @@
         "type": "object"
       },
       "gettableAlerts": {
-        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },


### PR DESCRIPTION
**What is this feature?**

Adds support for rule group-level `query_offset` in Prometheus to Grafana rule conversion. It allows specifying a time offset for rule evaluation, which gets applied and saved during the conversion.

**Why do we need this feature?**

To support [query_offset](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group).

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/1061

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
