### PR TITLE
Alerting: Add rule_query_offset setting for Prometheus rule conversion

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1515,6 +1515,16 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
+[unified_alerting.prometheus_conversion]
+# Configuration options for converting Prometheus alerting and recording rules to Grafana rules.
+# These settings affect rules created via the Prometheus conversion API.
+
+# Offset the rule evaluation time for imported rules by a specified duration in the past.
+# This offset is applied and saved to the rule query during the conversion process from Prometheus to Grafana format.
+# The setting only affects rules imported after the configuration change is made and does not modify existing rules.
+# Accepts duration formats like: 30s, 1m, 1h.
+rule_query_offset = 1m
+
 [recording_rules]
 # Enable recording rules. You must provide write credentials below.
 enabled = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1496,6 +1496,16 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
+[unified_alerting.prometheus_conversion]
+# Configuration options for converting Prometheus alerting and recording rules to Grafana rules.
+# These settings affect rules created via the Prometheus conversion API.
+
+# Offset the rule evaluation time for imported rules by a specified duration in the past.
+# This offset is applied and saved to the rule query during the conversion process from Prometheus to Grafana format.
+# The setting only affects rules imported after the configuration change is made and does not modify existing rules.
+# Accepts duration formats like: 30s, 1m, 1h.
+rule_query_offset = 1m
+
 #################################### Recording Rules #####################
 [recording_rules]
 # Enable recording rules. You must provide write credentials below.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -463,6 +463,7 @@ func (srv *ConvertPrometheusSrv) convertToGrafanaRuleGroup(
 				IsPaused: pauseAlertRules,
 			},
 			KeepOriginalRuleDefinition: util.Pointer(keepOriginalRuleDefinition),
+			EvaluationOffset:           &srv.cfg.PrometheusConversion.RuleQueryOffset,
 		},
 	)
 	if err != nil {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -112,6 +112,7 @@ type UnifiedAlertingSettings struct {
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	RemoteAlertmanager            RemoteAlertmanagerSettings
 	RecordingRules                RecordingRuleSettings
+	PrometheusConversion          UnifiedAlertingPrometheusConversionSettings
 
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
 	MaxStateSaveConcurrency    int
@@ -163,6 +164,12 @@ type UnifiedAlertingScreenshotSettings struct {
 
 type UnifiedAlertingReservedLabelSettings struct {
 	DisabledLabels map[string]struct{}
+}
+
+// UnifiedAlertingPrometheusConversionSettings contains configuration for converting Prometheus rules to Grafana format
+type UnifiedAlertingPrometheusConversionSettings struct {
+	// RuleQueryOffset defines a time offset to apply to rule queries during conversion from Prometheus to Grafana format
+	RuleQueryOffset time.Duration
 }
 
 type UnifiedAlertingStateHistorySettings struct {
@@ -436,6 +443,11 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		ExternalLabels:        stateHistoryLabels.KeysHash(),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
+
+	prometheusConversion := iniFile.Section("unified_alerting.prometheus_conversion")
+	uaCfg.PrometheusConversion = UnifiedAlertingPrometheusConversionSettings{
+		RuleQueryOffset: prometheusConversion.Key("rule_query_offset").MustDuration(0),
+	}
 
 	rr := iniFile.Section("recording_rules")
 	uaCfgRecordingRules := RecordingRuleSettings{

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -446,7 +446,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	prometheusConversion := iniFile.Section("unified_alerting.prometheus_conversion")
 	uaCfg.PrometheusConversion = UnifiedAlertingPrometheusConversionSettings{
-		RuleQueryOffset: prometheusConversion.Key("rule_query_offset").MustDuration(0),
+		RuleQueryOffset: prometheusConversion.Key("rule_query_offset").MustDuration(time.Minute),
 	}
 
 	rr := iniFile.Section("recording_rules")


### PR DESCRIPTION
**What is this feature?**

Adds a new configuration option to specify a time offset for rule evaluation, which gets applied and saved during the Prometheus -> Grafana conversion. For example:

```
[unified_alerting.prometheus_conversion]
rule_query_offset = 1m
```

Changing this option affects only the rules imported after the change. If `query_offset` is set at the group level, it takes precedence over this setting.

Default is set to `1m`.

**Why do we need this feature?**

To configure the default offset that is applied during the import. The option is similar to [rule_query_offset](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) in Prometheus, but gets applied only during conversion and does not affect already created rules.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/1061

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
