### PR TITLE
Scopes: Fix translation key of `scopes.dashboards.toggle.expand`

### DIFF
--- a/public/app/features/scopes/selector/ScopesSelector.tsx
+++ b/public/app/features/scopes/selector/ScopesSelector.tsx
@@ -40,7 +40,7 @@ export const ScopesSelector = () => {
     ? t('scopes.dashboards.toggle.disabled', 'Suggested dashboards list is disabled due to read only mode')
     : drawerOpened
       ? t('scopes.dashboards.toggle.collapse', 'Collapse suggested dashboards list')
-      : t('scopes.dashboards.toggle..expand', 'Expand suggested dashboards list');
+      : t('scopes.dashboards.toggle.expand', 'Expand suggested dashboards list');
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
**What is this feature?**

Fixes `scopes.dashboards.toggle..expand` to `scopes.dashboards.toggle.expand`