### PR TITLE
Provisioning: Pick a better default title

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -58,8 +58,8 @@ export function getDefaultValues(repository?: RepositorySpec): RepositoryFormDat
       workflows: ['branch', 'write'],
       path: 'grafana/',
       sync: {
-        enabled: true,
-        target: 'instance',
+        enabled: false,
+        target: 'folder',
         intervalSeconds: 60,
       },
     };

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -68,13 +68,6 @@ export function BootstrapStep({ onOptionSelect, settingsData, repoName }: Props)
         setValue('migrate.history', true);
         setValue('migrate.identifier', true);
       }
-
-      if (option.target === 'instance') {
-        const timestamp = Date.now();
-        setValue('repository.title', `instance-${timestamp}`);
-      } else if (option.target === 'folder') {
-        setValue('repository.title', '');
-      }
       onOptionSelect(option.operation === 'migrate');
     },
     [setValue, onOptionSelect]

--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -3,6 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { Combobox, ComboboxOption, Field, Input, SecretInput, Stack } from '@grafana/ui';
 
+import { getWorkflowOptions } from '../Config/ConfigForm';
 import { TokenPermissionsInfo } from '../Shared/TokenPermissionsInfo';
 
 import { WizardFormData } from './types';
@@ -34,7 +35,10 @@ export function ConnectStep() {
         onChange={(value) => {
           const repoType = value?.value;
           setValue('repository.type', repoType);
-          setValue('repository.workflows', repoType === 'github' ? ['branch', 'write'] : ['write']);
+          setValue(
+            'repository.workflows',
+            getWorkflowOptions(repoType).map((v) => v.value)
+          );
         }}
       />
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -28,11 +28,6 @@ export function ProvisioningWizard() {
   const navigate = useNavigate();
   const values = getDefaultValues();
 
-  // Disable sync at the start of the wizard
-  values.sync.enabled = false;
-  // HACK: Set folder as default for now as instance will block
-  values.sync.target = 'folder';
-
   const methods = useForm<WizardFormData>({
     defaultValues: {
       repository: values,
@@ -78,6 +73,18 @@ export function ProvisioningWizard() {
       const isValid = await methods.trigger('repository');
       if (!isValid) {
         return;
+      }
+
+      // Pick a name nice name based on type+settings
+      const current = methods.getValues();
+      switch (current.repository.type) {
+        case 'github':
+          const name = current.repository.url ?? 'github';
+          methods.setValue('repository.title', name.replace('https://github/', ''));
+          break;
+        case 'local':
+          methods.setValue('repository.title', current.repository.path ?? 'local');
+          break;
       }
     }
 


### PR DESCRIPTION
When creating a repository with the wizard, we currently default to the title "Repository" -- this updates the logic so we use the url or path by default:

![2025-03-20_11-30-12 (1)](https://github.com/user-attachments/assets/fe8081dc-97d0-46d6-8aee-7a914163943f)
