### PR TITLE
fix(unified-storage): use new context for background operations

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -3,6 +3,7 @@ package dualwrite
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -43,7 +44,9 @@ func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOp
 	// If we allow the unified read to fail, we can do it in the background.
 	if d.errorIsOK {
 		go func() {
-			if _, err := d.unified.Get(ctx, name, options); err != nil {
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := d.unified.Get(ctxBg, name, options); err != nil {
 				d.log.Error("failed background GET to unified", "err", err)
 			}
 		}()
@@ -71,7 +74,9 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	// If we allow the unified list to fail, we can do it in the background and return.
 	if d.errorIsOK {
 		go func() {
-			if _, err := d.unified.List(ctx, options); err != nil {
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := d.unified.List(ctxBg, options); err != nil {
 				d.log.Error("failed background LIST to unified", "err", err)
 			}
 		}()
@@ -133,7 +138,9 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 	} else if d.errorIsOK {
 		// If we don't use unified as the primary store and errors are okay, let's create it in the background.
 		go func() {
-			if _, err := d.unified.Create(ctx, createdCopy, createValidation, options); err != nil {
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := d.unified.Create(ctxBg, createdCopy, createValidation, options); err != nil {
 				log.Error("unable to create object in unified storage", "err", err)
 			}
 		}()
@@ -177,7 +184,9 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	} else if d.errorIsOK {
 		// If errors are okay and unified is not primary, we can just run it as background operation.
 		go func() {
-			_, _, err := d.unified.Delete(ctx, name, deleteValidation, options)
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, _, err := d.unified.Delete(ctxBg, name, deleteValidation, options)
 			if err != nil && !apierrors.IsNotFound(err) && !d.errorIsOK {
 				d.log.Error("failed background DELETE in unified storage", "err", err)
 			}
@@ -216,7 +225,9 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 	} else if d.errorIsOK {
 		// If unified is not primary, but errors are okay, we can just run in the background.
 		go func() {
-			if _, _, err := d.unified.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options); err != nil {
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, _, err := d.unified.Update(ctxBg, name, objInfo, createValidation, updateValidation, forceAllowCreate, options); err != nil {
 				log.Error("failed background UPDATE to unified storage", "err", err)
 			}
 		}()
@@ -251,7 +262,9 @@ func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest
 	} else if d.errorIsOK {
 		// If unified storage is not the primary store and errors are okay, we can just run it in the background.
 		go func() {
-			if _, err := d.unified.DeleteCollection(ctx, deleteValidation, options, listOptions); err != nil {
+			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := d.unified.DeleteCollection(ctxBg, deleteValidation, options, listOptions); err != nil {
 				log.Error("failed background DELETE collection to unified storage", "err", err)
 			}
 		}()

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -21,6 +21,8 @@ var (
 	_ grafanarest.Storage = (*dualWriter)(nil)
 )
 
+const backgroundReqTimeout = 5 * time.Second
+
 // dualWriter will write first to legacy, then to unified keeping the same internal ID
 type dualWriter struct {
 	legacy      grafanarest.Storage
@@ -44,7 +46,7 @@ func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOp
 	// If we allow the unified read to fail, we can do it in the background.
 	if d.errorIsOK {
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			if _, err := d.unified.Get(ctxBg, name, options); err != nil {
 				d.log.Error("failed background GET to unified", "err", err)
@@ -74,7 +76,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	// If we allow the unified list to fail, we can do it in the background and return.
 	if d.errorIsOK {
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			if _, err := d.unified.List(ctxBg, options); err != nil {
 				d.log.Error("failed background LIST to unified", "err", err)
@@ -138,7 +140,7 @@ func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValida
 	} else if d.errorIsOK {
 		// If we don't use unified as the primary store and errors are okay, let's create it in the background.
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			if _, err := d.unified.Create(ctxBg, createdCopy, createValidation, options); err != nil {
 				log.Error("unable to create object in unified storage", "err", err)
@@ -184,7 +186,7 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	} else if d.errorIsOK {
 		// If errors are okay and unified is not primary, we can just run it as background operation.
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			_, _, err := d.unified.Delete(ctxBg, name, deleteValidation, options)
 			if err != nil && !apierrors.IsNotFound(err) && !d.errorIsOK {
@@ -225,7 +227,7 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 	} else if d.errorIsOK {
 		// If unified is not primary, but errors are okay, we can just run in the background.
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			if _, _, err := d.unified.Update(ctxBg, name, objInfo, createValidation, updateValidation, forceAllowCreate, options); err != nil {
 				log.Error("failed background UPDATE to unified storage", "err", err)
@@ -262,7 +264,7 @@ func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest
 	} else if d.errorIsOK {
 		// If unified storage is not the primary store and errors are okay, we can just run it in the background.
 		go func() {
-			ctxBg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctxBg, cancel := context.WithTimeout(context.Background(), backgroundReqTimeout)
 			defer cancel()
 			if _, err := d.unified.DeleteCollection(ctxBg, deleteValidation, options, listOptions); err != nil {
 				log.Error("failed background DELETE collection to unified storage", "err", err)


### PR DESCRIPTION
This PR adds a new context for background operations, as the original context is closed as soon as the request returns to the client. The timeout for background requests will be 5 seconds, which should be enough.