### PR TITLE
Use in-memory sequence number generator when running integration tests against Spanner emulator.

### DIFF
--- a/pkg/services/sqlstore/migrator/spanner_dialect.go
+++ b/pkg/services/sqlstore/migrator/spanner_dialect.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -15,12 +14,10 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	spannerdriver "github.com/googleapis/go-sql-spanner"
 	"github.com/grafana/dskit/concurrency"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"xorm.io/core"
 
+	spannerext "github.com/grafana/grafana/pkg/extensions/spanner"
 	"xorm.io/xorm"
 
 	_ "embed"
@@ -294,7 +291,7 @@ func (s *SpannerDialect) executeDDLStatements(ctx context.Context, engine *xorm.
 		return err
 	}
 
-	opts := SpannerConnectorConfigToClientOptions(cfg)
+	opts := spannerext.SpannerConnectorConfigToClientOptions(cfg)
 
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx, opts...)
 	if err != nil {
@@ -317,28 +314,6 @@ func (s *SpannerDialect) executeDDLStatements(ctx context.Context, engine *xorm.
 		return fmt.Errorf("failed to apply database DDL update: %v", err)
 	}
 	return nil
-}
-
-// SpannerConnectorConfigToClientOptions is adapted from https://github.com/googleapis/go-sql-spanner/blob/main/driver.go#L341-L477, from version 1.11.1.
-func SpannerConnectorConfigToClientOptions(connectorConfig spannerdriver.ConnectorConfig) []option.ClientOption {
-	var opts []option.ClientOption
-	if connectorConfig.Host != "" {
-		opts = append(opts, option.WithEndpoint(connectorConfig.Host))
-	}
-	if strval, ok := connectorConfig.Params["credentials"]; ok {
-		opts = append(opts, option.WithCredentialsFile(strval))
-	}
-	if strval, ok := connectorConfig.Params["credentialsjson"]; ok {
-		opts = append(opts, option.WithCredentialsJSON([]byte(strval)))
-	}
-	if strval, ok := connectorConfig.Params["useplaintext"]; ok {
-		if val, err := strconv.ParseBool(strval); err == nil && val {
-			opts = append(opts,
-				option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
-				option.WithoutAuthentication())
-		}
-	}
-	return opts
 }
 
 func (s *SpannerDialect) UnionDistinct() string {

--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -44,7 +44,7 @@ type Engine struct {
 	tagHandlers map[string]tagHandler
 
 	defaultContext    context.Context
-	sequenceGenerator *sequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
+	sequenceGenerator SequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
 }
 
 // CondDeleted returns the conditions whether a record is soft deleted.
@@ -239,9 +239,6 @@ func (engine *Engine) NewSession() *Session {
 
 // Close the engine
 func (engine *Engine) Close() error {
-	if engine.sequenceGenerator != nil {
-		engine.sequenceGenerator.close()
-	}
 	return engine.db.Close()
 }
 

--- a/pkg/util/xorm/sequence_inmem.go
+++ b/pkg/util/xorm/sequence_inmem.go
@@ -1,0 +1,39 @@
+package xorm
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync"
+)
+
+type inMemSequenceGenerator struct {
+	sequencesMu sync.Mutex
+	nextValues  map[string]int
+}
+
+func newInMemSequenceGenerator() *inMemSequenceGenerator {
+	return &inMemSequenceGenerator{
+		nextValues: make(map[string]int),
+	}
+}
+
+func (g *inMemSequenceGenerator) Next(_ context.Context, table, column string) (int64, error) {
+	if table == "migration_log" {
+		// Don't use sequential IDs for migration log entries, as we don't clean up migration_log table between tests,
+		// so restarting the sequence can lead to conflicting IDs.
+		return rand.Int64(), nil
+	}
+
+	key := fmt.Sprintf("%s:%s", table, column)
+
+	g.sequencesMu.Lock()
+	defer g.sequencesMu.Unlock()
+
+	seq, ok := g.nextValues[key]
+	if !ok {
+		seq = 1
+	}
+	g.nextValues[key] = seq + 1
+	return int64(seq), nil
+}


### PR DESCRIPTION
This PR introduces "in-memory" sequence number generator which is used when running integration tests against Spanner emulator (detected by checking for "plain-text" connection).

We do this because Spanner emulator only supports one transaction at a time. Our previous generator always started new transaction to get next ID, but that only worked if there was no previous transaction running.

This fixes some of the integration tests that previously failed with `rpc error: code = Aborted desc = Transaction was aborted due to a concurrent modification` error, eg. `TestIntegrationQueryLibrary` or `TestIntegrationProvisioning/Creating_and_getting_repositories`.