### PR TITLE
Team: Add user_uid in TeamMemberDTO

### DIFF
--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -177,6 +177,7 @@ type TeamMemberDTO struct {
 	TeamID     int64          `json:"teamId" xorm:"team_id"`
 	TeamUID    string         `json:"teamUID" xorm:"uid"`
 	UserID     int64          `json:"userId" xorm:"user_id"`
+	UserUID    string         `json:"userUID" xorm:"user_uid"`
 	External   bool           `json:"-"`
 	AuthModule string         `json:"auth_module"`
 	Email      string         `json:"email"`

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -551,17 +551,17 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 		if query.External {
 			sess.Where("team_member.external=?", ss.db.GetDialect().BooleanValue(true))
 		}
-		sess.Select("team_member.org_id," +
-			"team_member.team_id," +
-			"team_member.user_id," +
-			ss.db.GetDialect().Quote("user") + ".email," +
-			ss.db.GetDialect().Quote("user") + ".name," +
-			ss.db.GetDialect().Quote("user") + ".login," +
-			ss.db.GetDialect().Quote("user") + ".uid as user_uid," +
-			"team_member.external," +
-			"team_member.permission," +
-			"user_auth.auth_module," +
-			"team.uid")
+		sess.Select(fmt.Sprintf(`team_member.org_id,
+			team_member.team_id,
+			team_member.user_id,
+			%[1]s.email,
+			%[1]s.name,
+			%[1]s.login,
+			%[1]s.uid as user_uid,
+			team_member.external,
+			team_member.permission,
+			user_auth.auth_module,
+			team.uid`, ss.db.GetDialect().Quote("user")))
 		sess.Asc("user.login", "user.email")
 
 		err := sess.Find(&queryResult)

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -551,18 +551,17 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 		if query.External {
 			sess.Where("team_member.external=?", ss.db.GetDialect().BooleanValue(true))
 		}
-		sess.Cols(
-			"team_member.org_id",
-			"team_member.team_id",
-			"team_member.user_id",
-			"user.email",
-			"user.name",
-			"user.login",
-			"team_member.external",
-			"team_member.permission",
-			"user_auth.auth_module",
-			"team.uid",
-		)
+		sess.Select("team_member.org_id," +
+			"team_member.team_id," +
+			"team_member.user_id," +
+			ss.db.GetDialect().Quote("user") + ".email," +
+			ss.db.GetDialect().Quote("user") + ".name," +
+			ss.db.GetDialect().Quote("user") + ".login," +
+			ss.db.GetDialect().Quote("user") + ".uid as user_uid," +
+			"team_member.external," +
+			"team_member.permission," +
+			"user_auth.auth_module," +
+			"team.uid")
 		sess.Asc("user.login", "user.email")
 
 		err := sess.Find(&queryResult)

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -58,6 +58,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 
 		t.Run("Given saved users and two teams", func(t *testing.T) {
 			var userIds []int64
+			var userUIDs []string
 			const testOrgID int64 = 1
 			var team1, team2 team.Team
 			var usr *user.User
@@ -74,6 +75,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 					usr, err = userSvc.Create(context.Background(), &userCmd)
 					require.NoError(t, err)
 					userIds = append(userIds, usr.ID)
+					userUIDs = append(userUIDs, usr.UID)
 				}
 				team1, err = teamSvc.CreateTeam(context.Background(), "group1 name", "test1@test.com", testOrgID)
 				require.NoError(t, err)
@@ -108,9 +110,13 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, 2, len(q1Result))
 				require.Equal(t, q1Result[0].TeamID, team1.ID)
+				require.Contains(t, userIds[:2], q1Result[0].UserID)
+				require.Contains(t, userUIDs[:2], q1Result[0].UserUID)
 				require.Equal(t, q1Result[0].Login, "loginuser0")
 				require.Equal(t, q1Result[0].OrgID, testOrgID)
 				require.Equal(t, q1Result[1].TeamID, team1.ID)
+				require.Contains(t, userIds[:2], q1Result[1].UserID)
+				require.Contains(t, userUIDs[:2], q1Result[1].UserUID)
 				require.Equal(t, q1Result[1].Login, "loginuser1")
 				require.Equal(t, q1Result[1].OrgID, testOrgID)
 				require.Equal(t, q1Result[1].External, true)

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -21220,6 +21220,9 @@
         "userId": {
           "type": "integer",
           "format": "int64"
+        },
+        "userUID": {
+          "type": "string"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -11281,6 +11281,9 @@
           "userId": {
             "format": "int64",
             "type": "integer"
+          },
+          "userUID": {
+            "type": "string"
           }
         },
         "type": "object"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds the `user_uid` field in `TeamMemberDTO` and includes it in GetTeamMembers() output.

This has been previously attempted in https://github.com/grafana/grafana/pull/102373 but reverted in https://github.com/grafana/grafana/pull/102519 as part of #incident-2025-03-20-grafana-teams-api-failing-to-get-team-members. The issue was the double quotes used for `user` in the SQL select syntax. MySQL supports double quotes only if the mysql server starts with sql_mode=ANSI_QUOTES otherwise only backtick char ` can be used for quoting. Apparently mysql server runs with ANSI_QUOTES in CI pipelines and without it in cloud.

**Why do we need this feature?**

This is needed for the GET /Groups/id endpoint from the SCIM service: https://github.com/grafana/grafana-enterprise/pull/8165.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
