### PR TITLE
K8s/Storage: Refactor Upsert (create from update)

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -143,9 +143,13 @@ type grafanaMetaAccessor struct {
 // required fields are missing. Fields that are not required return the default
 // value and are a no-op if set.
 func MetaAccessor(raw interface{}) (GrafanaMetaAccessor, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("unable to read metadata from nil object")
+	}
+
 	obj, err := meta.Accessor(raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read metadata from: %T, %s", raw, err)
 	}
 
 	// reflection to find title and other non object properties

--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -6,13 +6,11 @@
 package apistore
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/storage"
 
@@ -111,13 +109,4 @@ func toListRequest(k *resource.ResourceKey, opts storage.ListOptions) (*resource
 	}
 
 	return req, predicate, nil
-}
-
-func isUnchanged(codec runtime.Codec, buf []byte, newObj runtime.Object) (bool, error) {
-	newBuf := new(bytes.Buffer)
-	if err := codec.Encode(newObj, newBuf); err != nil {
-		return false, err
-	}
-
-	return bytes.Equal(buf, newBuf.Bytes()), nil
 }

--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -113,16 +113,11 @@ func toListRequest(k *resource.ResourceKey, opts storage.ListOptions) (*resource
 	return req, predicate, nil
 }
 
-func isUnchanged(codec runtime.Codec, obj runtime.Object, newObj runtime.Object) (bool, error) {
-	buf := new(bytes.Buffer)
-	if err := codec.Encode(obj, buf); err != nil {
-		return false, err
-	}
-
+func isUnchanged(codec runtime.Codec, buf []byte, newObj runtime.Object) (bool, error) {
 	newBuf := new(bytes.Buffer)
 	if err := codec.Encode(newObj, newBuf); err != nil {
 		return false, err
 	}
 
-	return bytes.Equal(buf.Bytes(), newBuf.Bytes()), nil
+	return bytes.Equal(buf, newBuf.Bytes()), nil
 }


### PR DESCRIPTION
While looking at https://github.com/grafana/grafana/pull/102527 I noticed that the "create" logic in Update duplicates what we do in Create.

This PR refactors things so that the upsert command delegates to the same Create function.

NOTE: the k8s watch and storage test this path