### PR TITLE
Alerting: Add ability to delete rules permanently from the UI

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1069,4 +1069,9 @@ export interface FeatureToggles {
   * @default true
   */
   alertingRuleRecoverDeleted?: boolean;
+  /**
+  * Enables the UI functionality to delete permanently alert rules
+  * @default true
+  */
+  alertingDeletePermanently?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1846,6 +1846,16 @@ var (
 			HideFromDocs:      true,
 			Expression:        "true", // enabled by default
 		},
+		{
+			Name:              "alertingDeletePermanently",
+			Description:       "Enables the UI functionality to delete permanently alert rules",
+			FrontendOnly:      true,
+			Stage:             FeatureStageGeneralAvailability,
+			Owner:             grafanaAlertingSquad,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+			Expression:        "true", // enabled by default
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -243,3 +243,4 @@ noBackdropBlur,experimental,@grafana/grafana-frontend-platform,false,false,true
 alertingMigrationUI,experimental,@grafana/alerting-squad,false,false,true
 unifiedStorageHistoryPruner,experimental,@grafana/search-and-storage,false,false,false
 alertingRuleRecoverDeleted,GA,@grafana/alerting-squad,false,false,true
+alertingDeletePermanently,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -982,4 +982,8 @@ const (
 	// FlagAlertingRuleRecoverDeleted
 	// Enables the UI functionality to recover and view deleted alert rules
 	FlagAlertingRuleRecoverDeleted = "alertingRuleRecoverDeleted"
+
+	// FlagAlertingDeletePermanently
+	// Enables the UI functionality to delete permanently alert rules
+	FlagAlertingDeletePermanently = "alertingDeletePermanently"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -249,6 +249,22 @@
     },
     {
       "metadata": {
+        "name": "alertingDeletePermanently",
+        "resourceVersion": "1742483070313",
+        "creationTimestamp": "2025-03-20T15:04:30Z"
+      },
+      "spec": {
+        "description": "Enables the UI functionality to delete permanently alert rules",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true,
+        "hideFromDocs": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingDisableSendAlertsExternal",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2024-05-23T12:29:19Z"

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -315,16 +315,17 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         rulerConfig: RulerDataSourceConfig;
         namespace: string;
         payload: PostableRulerRuleGroupDTO;
+        deletePermanently?: boolean;
       }>
     >({
-      query: ({ payload, namespace, rulerConfig, notificationOptions }) => {
+      query: ({ payload, namespace, rulerConfig, notificationOptions, deletePermanently }) => {
         const { path, params } = rulerUrlBuilder(rulerConfig).namespace(namespace);
 
         const successMessage = t('alerting.rule-groups.update.success', 'Successfully updated rule group');
 
         return {
           url: path,
-          params,
+          params: { ...params, deletePermanently: deletePermanently ? 'true' : undefined },
           data: payload,
           method: 'POST',
           notificationOptions: {

--- a/public/app/features/alerting/unified/components/rule-editor/DeletePermanentlyModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DeletePermanentlyModal.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { locationService } from '@grafana/runtime';
+import { ConfirmModal } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+import { dispatch } from 'app/store/store';
+import { EditableRuleIdentifier, RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+
+import { shouldUsePrometheusRulesPrimary } from '../../featureToggles';
+import { useDeleteRuleFromGroup } from '../../hooks/ruleGroup/useDeleteRuleFromGroup';
+import { usePrometheusConsistencyCheck } from '../../hooks/usePrometheusConsistencyCheck';
+import { fetchPromAndRulerRulesAction, fetchRulerRulesAction } from '../../state/actions';
+import { ruleGroupIdentifierV2toV1 } from '../../utils/groupIdentifier';
+import { isCloudRuleIdentifier } from '../../utils/rules';
+
+type DeletePermanentlyModalHook = [
+  JSX.Element,
+  (ruleIdentifier: EditableRuleIdentifier, groupIdentifier: RuleGroupIdentifierV2) => void,
+  () => void,
+];
+type DeleteRuleInfo = { ruleIdentifier: EditableRuleIdentifier; groupIdentifier: RuleGroupIdentifierV2 } | undefined;
+
+const prometheusRulesPrimary = shouldUsePrometheusRulesPrimary();
+
+export const useDeletePermanentlyModal = (redirectToListView = false): DeletePermanentlyModalHook => {
+  const [ruleToDelete, setRuleToDelete] = useState<DeleteRuleInfo>();
+  const [deleteRulePermanentlyFromGroup] = useDeleteRuleFromGroup(true); // delete permanently
+  const { waitForRemoval } = usePrometheusConsistencyCheck();
+
+  const dismissModal = useCallback(() => {
+    setRuleToDelete(undefined);
+  }, []);
+
+  const showModal = useCallback(
+    (ruleIdentifier: EditableRuleIdentifier, groupIdentifier: RuleGroupIdentifierV2, deletePermanently = false) => {
+      setRuleToDelete({ ruleIdentifier, groupIdentifier });
+    },
+    []
+  );
+
+  const deleteRule = useCallback(async () => {
+    if (!ruleToDelete) {
+      return;
+    }
+
+    const { ruleIdentifier, groupIdentifier } = ruleToDelete;
+
+    const groupIdentifierV1 = ruleGroupIdentifierV2toV1(groupIdentifier);
+    const rulesSourceName = groupIdentifierV1.dataSourceName;
+
+    await deleteRulePermanentlyFromGroup.execute(groupIdentifierV1, ruleIdentifier);
+    // refetch rules for this rules source
+    // @TODO remove this when we moved everything to RTKQ – then the endpoint will simply invalidate the tags
+    dispatch(fetchPromAndRulerRulesAction({ rulesSourceName }));
+
+    if (prometheusRulesPrimary && isCloudRuleIdentifier(ruleIdentifier)) {
+      await waitForRemoval(ruleIdentifier);
+    } else {
+      // Without this the delete popup will close and the user will still see the deleted rule
+      await dispatch(fetchRulerRulesAction({ rulesSourceName }));
+    }
+
+    dismissModal();
+
+    if (redirectToListView) {
+      locationService.replace('/alerting/list');
+    }
+  }, [deleteRulePermanentlyFromGroup, dismissModal, ruleToDelete, redirectToListView, waitForRemoval]);
+
+  const modal = useMemo(
+    () => (
+      <ConfirmModal
+        isOpen={Boolean(ruleToDelete)}
+        title={t('alerting.delete-permanently-modal-title', 'Delete rule')}
+        body={t(
+          'alerting.delete-permanently-modal-body',
+          'Deleting this rule will permanently remove it from your alert rule list. This rule will not be recoverable.Are you sure you want to delete permanently this rule?'
+        )}
+        confirmText={t('alerting.delete-permanently-modal-confirm-text', 'Yes, delete permanently')}
+        icon="exclamation-triangle"
+        onConfirm={() => deleteRule()}
+        onDismiss={dismissModal}
+      />
+    ),
+    [ruleToDelete, deleteRule, dismissModal]
+  );
+
+  return [modal, showModal, dismissModal];
+};

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
@@ -1,4 +1,5 @@
 import { AppEvents } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { ComponentSize, Dropdown, Menu } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
@@ -24,6 +25,7 @@ interface Props {
   handleDelete: (rule: RulerRuleDTO, groupIdentifier: RuleGroupIdentifierV2) => void;
   handleDuplicateRule: (identifier: RuleIdentifier) => void;
   onPauseChange?: () => void;
+  handleDeletePermanently: (rule: RulerRuleDTO, groupIdentifier: RuleGroupIdentifierV2) => void;
   buttonSize?: ComponentSize;
 }
 
@@ -40,6 +42,7 @@ const AlertRuleMenu = ({
   handleDelete,
   handleDuplicateRule,
   onPauseChange,
+  handleDeletePermanently,
   buttonSize,
 }: Props) => {
   // check all abilities and permissions
@@ -48,6 +51,17 @@ const AlertRuleMenu = ({
 
   const [deleteSupported, deleteAllowed] = useRulerRuleAbility(rulerRule, groupIdentifier, AlertRuleAction.Delete);
   const canDelete = deleteSupported && deleteAllowed;
+
+  const [deletePermanentlySupported, deletePermanentlyAllowed] = useRulerRuleAbility(
+    rulerRule,
+    groupIdentifier,
+    AlertRuleAction.DeletePermanently
+  );
+  const canDeletePermanently =
+    deletePermanentlySupported &&
+    deletePermanentlyAllowed &&
+    config.featureToggles.alertingRuleRecoverDeleted &&
+    config.featureToggles.alertRuleRestore;
 
   const [duplicateSupported, duplicateAllowed] = useRulerRuleAbility(
     rulerRule,
@@ -139,6 +153,14 @@ const AlertRuleMenu = ({
             onClick={() => handleDelete(rulerRule, groupIdentifier)}
           />
         </>
+      )}
+      {canDeletePermanently && rulerRule && (
+        <Menu.Item
+          label={t('alerting.alert-menu.delete-permanently', 'Delete Permanently')}
+          icon="exclamation-triangle"
+          destructive
+          onClick={() => handleDeletePermanently(rulerRule, groupIdentifier)}
+        />
       )}
     </>
   );

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
@@ -58,10 +58,8 @@ const AlertRuleMenu = ({
     AlertRuleAction.DeletePermanently
   );
   const canDeletePermanently =
-    deletePermanentlySupported &&
-    deletePermanentlyAllowed &&
-    config.featureToggles.alertingRuleRecoverDeleted &&
-    config.featureToggles.alertRuleRestore;
+    deletePermanentlySupported && deletePermanentlyAllowed && config.featureToggles.alertRuleRestore; // soft delete is only available if the feature toggle is enabled
+  config.featureToggles.alertingDeletePermanently;
 
   const [duplicateSupported, duplicateAllowed] = useRulerRuleAbility(
     rulerRule,

--- a/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
@@ -18,6 +18,7 @@ import { createViewLink } from '../../utils/misc';
 import * as ruleId from '../../utils/rule-id';
 import { rulerRuleType } from '../../utils/rules';
 import { createRelativeUrl } from '../../utils/url';
+import { useDeletePermanentlyModal } from '../rule-editor/DeletePermanentlyModal';
 
 import { RedirectToCloneRule } from './CloneRule';
 
@@ -42,6 +43,7 @@ export const RuleActionsButtons = ({ compact, showViewButton, rule, rulesSource 
 
   const redirectToListView = compact ? false : true;
   const [deleteModal, showDeleteModal] = useDeleteModal(redirectToListView);
+  const [deletePermanentlyModal, showDeletePermanentlyModal] = useDeletePermanentlyModal(redirectToListView);
 
   const [showSilenceDrawer, setShowSilenceDrawer] = useState<boolean>(false);
 
@@ -111,6 +113,12 @@ export const RuleActionsButtons = ({ compact, showViewButton, rule, rulesSource 
             showDeleteModal(editableRuleIdentifier, groupId);
           }
         }}
+        handleDeletePermanently={() => {
+          if (rule.rulerRule) {
+            const editableRuleIdentifier = ruleId.fromRulerRuleAndGroupIdentifierV2(groupId, rule.rulerRule);
+            showDeletePermanentlyModal(editableRuleIdentifier, groupId);
+          }
+        }}
         handleSilence={() => setShowSilenceDrawer(true)}
         handleDuplicateRule={() => setRedirectToClone({ identifier, isProvisioned })}
         onPauseChange={() => {
@@ -125,6 +133,7 @@ export const RuleActionsButtons = ({ compact, showViewButton, rule, rulesSource 
         buttonSize={buttonSize}
       />
       {deleteModal}
+      {deletePermanentlyModal}
       {rulerRuleType.grafana.alertingRule(rule.rulerRule) && showSilenceDrawer && (
         <SilenceGrafanaRuleDrawer rulerRule={rule.rulerRule} onClose={() => setShowSilenceDrawer(false)} />
       )}

--- a/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
@@ -6,6 +6,10 @@ exports[`AlertRule abilities should report no permissions while we are loading d
     false,
     false,
   ],
+  "delete-alert-rule-permanently": [
+    false,
+    false,
+  ],
   "duplicate-alert-rule": [
     false,
     false,
@@ -44,6 +48,10 @@ exports[`AlertRule abilities should report no permissions while we are loading d
 exports[`AlertRule abilities should report that all actions are supported for a Grafana Managed alert rule 1`] = `
 {
   "delete-alert-rule": [
+    true,
+    false,
+  ],
+  "delete-alert-rule-permanently": [
     true,
     false,
   ],

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.ts
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.ts
@@ -13,7 +13,7 @@ import { useProduceNewRuleGroup } from './useProduceNewRuleGroup';
  *
  * If no more rules are left in the group it will remove the entire group instead of updating.
  */
-export function useDeleteRuleFromGroup() {
+export function useDeleteRuleFromGroup(deletePermanently?: boolean) {
   const [produceNewRuleGroup] = useProduceNewRuleGroup();
   const [upsertRuleGroup] = alertRuleApi.endpoints.upsertRuleGroupForNamespace.useMutation();
   const [deleteRuleGroup] = alertRuleApi.endpoints.deleteRuleGroupFromNamespace.useMutation();
@@ -42,6 +42,7 @@ export function useDeleteRuleFromGroup() {
       namespace: namespaceName,
       payload: newRuleGroupDefinition,
       notificationOptions: { successMessage },
+      deletePermanently,
     }).unwrap();
   });
 }

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -88,6 +88,7 @@ export enum AlertRuleAction {
   ModifyExport = 'modify-export-rule',
   Pause = 'pause-alert-rule',
   Restore = 'restore-alert-rule',
+  DeletePermanently = 'delete-alert-rule-permanently',
 }
 
 // this enum lists all of the actions we can perform within alerting in general, not linked to a specific
@@ -234,6 +235,10 @@ export function useAllAlertRuleAbilities(rule: CombinedRule): Abilities<AlertRul
       [AlertRuleAction.ModifyExport]: [isGrafanaManagedAlertRule, exportAllowed],
       [AlertRuleAction.Pause]: [MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule, isEditable ?? false],
       [AlertRuleAction.Restore]: [MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule, isEditable ?? false],
+      [AlertRuleAction.DeletePermanently]: [
+        MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule,
+        (isRemovable && isAdmin()) ?? false,
+      ],
     };
 
     return abilities;
@@ -281,6 +286,10 @@ export function useAllRulerRuleAbilities(
       [AlertRuleAction.ModifyExport]: [isGrafanaManagedAlertRule, exportAllowed],
       [AlertRuleAction.Pause]: [MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule, isEditable ?? false],
       [AlertRuleAction.Restore]: [MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule, isEditable ?? false],
+      [AlertRuleAction.DeletePermanently]: [
+        MaybeSupportedUnlessImmutable && isGrafanaManagedAlertRule,
+        (isRemovable && isAdmin()) ?? false,
+      ],
     };
 
     return abilities;

--- a/public/app/features/alerting/unified/rule-list/components/RuleActionsButtons.V2.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleActionsButtons.V2.tsx
@@ -9,6 +9,7 @@ import SilenceGrafanaRuleDrawer from 'app/features/alerting/unified/components/s
 import { Rule, RuleGroupIdentifierV2, RuleIdentifier } from 'app/types/unified-alerting';
 import { RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
+import { useDeletePermanentlyModal } from '../../components/rule-editor/DeletePermanentlyModal';
 import { AlertRuleAction, useRulerRuleAbility } from '../../hooks/useAbilities';
 import * as ruleId from '../../utils/rule-id';
 import { isProvisionedRule, rulerRuleType } from '../../utils/rules';
@@ -32,6 +33,8 @@ export function RuleActionsButtons({ compact, rule, promRule, groupIdentifier }:
   const [deleteModal, showDeleteModal] = useDeleteModal(redirectToListView);
 
   const [showSilenceDrawer, setShowSilenceDrawer] = useState<boolean>(false);
+
+  const [deletePermanentlyModal, showDeletePermanentlyModal] = useDeletePermanentlyModal(redirectToListView);
 
   const [redirectToClone, setRedirectToClone] = useState<
     { identifier: RuleIdentifier; isProvisioned: boolean } | undefined
@@ -70,8 +73,10 @@ export function RuleActionsButtons({ compact, rule, promRule, groupIdentifier }:
         handleDelete={() => showDeleteModal(identifier, groupIdentifier)}
         handleSilence={() => setShowSilenceDrawer(true)}
         handleDuplicateRule={() => setRedirectToClone({ identifier, isProvisioned })}
+        handleDeletePermanently={() => showDeletePermanentlyModal(identifier, groupIdentifier)}
       />
       {deleteModal}
+      {deletePermanentlyModal}
       {rulerRuleType.grafana.alertingRule(rule) && showSilenceDrawer && (
         <SilenceGrafanaRuleDrawer rulerRule={rule} onClose={() => setShowSilenceDrawer(false)} />
       )}


### PR DESCRIPTION
**What is this feature?**

This PR adds the ability to remove rules permanently from the UI when soft delete is enabled.
This is only enabled for Admin users.
The feature is enabled by default but protected by `alertingDeletePermanently` ff.

**Why do we need this feature?**

When enabling soft delete in alert rules, we need to allow users to delete permanently rules form the UI.

**Who is this feature for?**

Admins.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<img width="1587" alt="Screenshot 2025-03-20 at 16 21 44" src="https://github.com/user-attachments/assets/20b4b5e3-9ddb-4024-a5f0-c21cd4068dc4" />


<img width="1245" alt="Screenshot 2025-03-20 at 16 22 24" src="https://github.com/user-attachments/assets/e748d421-e78c-4a0b-b2d3-b5d87cab5a96" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
