### PR TITLE
fix (unified-storage): always do perm filtering in bleve by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -818,7 +818,6 @@ export interface FeatureToggles {
   unifiedStorageSearchSprinkles?: boolean;
   /**
   * Enable permission filtering on unified storage search
-  * @deprecated
   * @default true
   */
   unifiedStorageSearchPermissionFiltering?: boolean;

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -818,6 +818,7 @@ export interface FeatureToggles {
   unifiedStorageSearchSprinkles?: boolean;
   /**
   * Enable permission filtering on unified storage search
+  * @default true
   */
   unifiedStorageSearchPermissionFiltering?: boolean;
   /**

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -818,6 +818,7 @@ export interface FeatureToggles {
   unifiedStorageSearchSprinkles?: boolean;
   /**
   * Enable permission filtering on unified storage search
+  * @deprecated
   * @default true
   */
   unifiedStorageSearchPermissionFiltering?: boolean;

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -407,6 +407,7 @@ func asResourceKey(ns string, k string) (*resource.ResourceKey, error) {
 
 func (s *SearchHandler) getDashboardsUIDsSharedWithUser(ctx context.Context, user identity.Requester) ([]string, error) {
 	if !s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchPermissionFiltering) {
+		s.log.Warn("Tried to search for 'sharedwithme' dashboards with ", featuremgmt.FlagUnifiedStorageSearchPermissionFiltering, " disabled")
 		return []string{}, nil
 	}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1405,7 +1405,7 @@ var (
 		{
 			Name:              "unifiedStorageSearchPermissionFiltering",
 			Description:       "Enable permission filtering on unified storage search",
-			Stage:             FeatureStageExperimental,
+			Stage:             FeatureStageDeprecated,
 			Owner:             grafanaSearchAndStorageSquad,
 			Expression:        "true",
 			HideFromDocs:      true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1405,7 +1405,7 @@ var (
 		{
 			Name:              "unifiedStorageSearchPermissionFiltering",
 			Description:       "Enable permission filtering on unified storage search",
-			Stage:             FeatureStageDeprecated,
+			Stage:             FeatureStageGeneralAvailability,
 			Owner:             grafanaSearchAndStorageSquad,
 			Expression:        "true",
 			HideFromDocs:      true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1407,6 +1407,7 @@ var (
 			Description:       "Enable permission filtering on unified storage search",
 			Stage:             FeatureStageExperimental,
 			Owner:             grafanaSearchAndStorageSquad,
+			Expression:        "true",
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -184,7 +184,7 @@ useSessionStorageForRedirection,GA,@grafana/identity-access-team,false,false,fal
 rolePickerDrawer,experimental,@grafana/identity-access-team,false,false,false
 unifiedStorageSearch,experimental,@grafana/search-and-storage,false,false,false
 unifiedStorageSearchSprinkles,experimental,@grafana/search-and-storage,false,false,false
-unifiedStorageSearchPermissionFiltering,deprecated,@grafana/search-and-storage,false,false,false
+unifiedStorageSearchPermissionFiltering,GA,@grafana/search-and-storage,false,false,false
 managedDualWriter,experimental,@grafana/search-and-storage,false,false,false
 pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -184,7 +184,7 @@ useSessionStorageForRedirection,GA,@grafana/identity-access-team,false,false,fal
 rolePickerDrawer,experimental,@grafana/identity-access-team,false,false,false
 unifiedStorageSearch,experimental,@grafana/search-and-storage,false,false,false
 unifiedStorageSearchSprinkles,experimental,@grafana/search-and-storage,false,false,false
-unifiedStorageSearchPermissionFiltering,experimental,@grafana/search-and-storage,false,false,false
+unifiedStorageSearchPermissionFiltering,deprecated,@grafana/search-and-storage,false,false,false
 managedDualWriter,experimental,@grafana/search-and-storage,false,false,false
 pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4261,15 +4261,15 @@
     {
       "metadata": {
         "name": "unifiedStorageSearchPermissionFiltering",
-        "resourceVersion": "1742488778432",
+        "resourceVersion": "1742564039800",
         "creationTimestamp": "2025-01-22T11:38:37Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-03-20 16:39:38.432983 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-21 13:33:59.800619 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enable permission filtering on unified storage search",
-        "stage": "deprecated",
+        "stage": "GA",
         "codeowner": "@grafana/search-and-storage",
         "hideFromAdminPage": true,
         "hideFromDocs": true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4261,15 +4261,15 @@
     {
       "metadata": {
         "name": "unifiedStorageSearchPermissionFiltering",
-        "resourceVersion": "1742485648505",
+        "resourceVersion": "1742488778432",
         "creationTimestamp": "2025-01-22T11:38:37Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-03-20 15:47:28.505165 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-20 16:39:38.432983 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enable permission filtering on unified storage search",
-        "stage": "experimental",
+        "stage": "deprecated",
         "codeowner": "@grafana/search-and-storage",
         "hideFromAdminPage": true,
         "hideFromDocs": true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4261,15 +4261,19 @@
     {
       "metadata": {
         "name": "unifiedStorageSearchPermissionFiltering",
-        "resourceVersion": "1737489629408",
-        "creationTimestamp": "2025-01-22T11:38:37Z"
+        "resourceVersion": "1742485648505",
+        "creationTimestamp": "2025-01-22T11:38:37Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-03-20 15:47:28.505165 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable permission filtering on unified storage search",
         "stage": "experimental",
         "codeowner": "@grafana/search-and-storage",
         "hideFromAdminPage": true,
-        "hideFromDocs": true
+        "hideFromDocs": true,
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
Changes `unifiedStorageSearchPermissionFiltering` to default true