### PR TITLE
[Provisioning] Limit max number of repositories to 10

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5170,7 +5170,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/provisioning/Shared/FolderRepositoryList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5069,8 +5069,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/provisioning/GettingStarted/GettingStarted.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5170,10 +5169,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
+    "public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
     "public/app/features/provisioning/Shared/FolderRepositoryList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/provisioning/Shared/TokenPermissionsInfo.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -502,7 +502,7 @@ func (b *APIBuilder) verifyAgaintsExistingRepositories(cfg *provisioning.Reposit
 
 	if len(all) >= 10 {
 		return field.Forbidden(field.NewPath("spec"),
-			"Only 10 repositories are allowed to target a single instance")
+			"Maximum number of 10 repositories reached")
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -453,8 +453,7 @@ func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o adm
 		}
 	}
 
-	// Make sure there is only one
-	targetError := b.verifySingleInstanceTarget(cfg)
+	targetError := b.verifyAgaintsExistingRepositories(cfg)
 	if targetError != nil {
 		list = append(list, targetError)
 	}
@@ -485,13 +484,14 @@ func (b *APIBuilder) Validate(ctx context.Context, a admission.Attributes, o adm
 }
 
 // TODO: move this to a more appropriate place. Probably controller/validation.go
-func (b *APIBuilder) verifySingleInstanceTarget(cfg *provisioning.Repository) *field.Error {
+func (b *APIBuilder) verifyAgaintsExistingRepositories(cfg *provisioning.Repository) *field.Error {
+	all, err := b.repositoryLister.Repositories(cfg.Namespace).List(labels.Everything())
+	if err != nil {
+		return field.Forbidden(field.NewPath("spec"),
+			"Unable to verify root target: "+err.Error())
+	}
+
 	if cfg.Spec.Sync.Target == provisioning.SyncTargetTypeInstance {
-		all, err := b.repositoryLister.Repositories(cfg.Namespace).List(labels.Everything())
-		if err != nil {
-			return field.Forbidden(field.NewPath("spec", "sync", "target"),
-				"Unable to verify root target // "+err.Error())
-		}
 		for _, v := range all {
 			if v.Name != cfg.Name && v.Spec.Sync.Target == provisioning.SyncTargetTypeInstance {
 				return field.Forbidden(field.NewPath("spec", "sync", "target"),
@@ -499,6 +499,12 @@ func (b *APIBuilder) verifySingleInstanceTarget(cfg *provisioning.Repository) *f
 			}
 		}
 	}
+
+	if len(all) >= 10 {
+		return field.Forbidden(field.NewPath("spec"),
+			"Only 10 repositories are allowed to target a single instance")
+	}
+
 	return nil
 }
 

--- a/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
+++ b/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
@@ -1,8 +1,7 @@
 import { Stack, Text, Box, LinkButton, Icon } from '@grafana/ui';
 import { RepositoryViewList } from 'app/api/clients/provisioning';
 
-import { CONNECT_URL } from '../constants';
-import { checkSyncSettings } from '../utils/checkSyncSettings';
+import { ConnectRepositoryButton } from '../Shared/ConnectRepositoryButton';
 
 interface FeatureItemProps {
   children: React.ReactNode;
@@ -40,16 +39,9 @@ export const FeaturesList = ({
       );
     }
 
-    const [instanceConnected, maxReposReached] = checkSyncSettings(settings);
-    if (instanceConnected || maxReposReached) {
-      return null;
-    }
-
     return (
       <Stack direction="row" alignItems="center" gap={2}>
-        <LinkButton size="md" icon="plus" href={CONNECT_URL}>
-          Connect Grafana to repository
-        </LinkButton>
+        <ConnectRepositoryButton settings={settings} />
       </Stack>
     );
   };

--- a/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
+++ b/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
@@ -2,6 +2,7 @@ import { Stack, Text, Box, LinkButton, Icon } from '@grafana/ui';
 import { RepositoryViewList } from 'app/api/clients/provisioning';
 
 import { CONNECT_URL } from '../constants';
+import { checkSyncSettings } from '../utils/checkSyncSettings';
 
 interface FeatureItemProps {
   children: React.ReactNode;
@@ -37,6 +38,11 @@ export const FeaturesList = ({
           </LinkButton>
         </Box>
       );
+    }
+
+    const [instanceConnected, maxReposReached] = checkSyncSettings(settings);
+    if (instanceConnected || maxReposReached) {
+      return null;
     }
 
     return (

--- a/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
+++ b/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
@@ -1,5 +1,5 @@
 import { Stack, Text, Box, LinkButton, Icon } from '@grafana/ui';
-import { RepositoryViewList } from 'app/api/clients/provisioning';
+import { Repository } from 'app/api/clients/provisioning';
 
 import { ConnectRepositoryButton } from '../Shared/ConnectRepositoryButton';
 
@@ -14,7 +14,7 @@ const FeatureItem = ({ children }: FeatureItemProps) => (
 );
 
 interface FeaturesListProps {
-  settings?: RepositoryViewList;
+  repos?: Repository[];
   hasPublicAccess: boolean;
   hasImageRenderer: boolean;
   hasRequiredFeatures: boolean;
@@ -22,7 +22,7 @@ interface FeaturesListProps {
 }
 
 export const FeaturesList = ({
-  settings,
+  repos,
   hasPublicAccess,
   hasImageRenderer,
   hasRequiredFeatures,
@@ -41,7 +41,7 @@ export const FeaturesList = ({
 
     return (
       <Stack direction="row" alignItems="center" gap={2}>
-        <ConnectRepositoryButton settings={settings} />
+        <ConnectRepositoryButton items={repos} />
       </Stack>
     );
   };

--- a/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 
 import { Alert, Stack, Text, Box } from '@grafana/ui';
-import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning';
+import { useGetFrontendSettingsQuery, Repository } from 'app/api/clients/provisioning';
 
 import { EnhancedFeatures } from './EnhancedFeatures';
 import { FeaturesList } from './FeaturesList';
@@ -47,7 +47,11 @@ HTTP Requests
 const rootUrlExample = `[server]
 root_url = https://d60d-83-33-235-27.ngrok-free.app`;
 
-export default function GettingStarted() {
+interface Props {
+  items: Repository[];
+}
+
+export default function GettingStarted({ items }: Props) {
   const settingsQuery = useGetFrontendSettingsQuery();
   const legacyStorage = settingsQuery.data?.legacyStorage;
 
@@ -112,7 +116,7 @@ export default function GettingStarted() {
       <Stack direction="row" gap={2}>
         <Box width="50%" marginTop={2} paddingTop={2} paddingBottom={2}>
           <FeaturesList
-            settings={settingsQuery.data}
+            repos={items}
             hasPublicAccess={hasPublicAccess}
             hasImageRenderer={hasImageRenderer}
             hasRequiredFeatures={hasRequiredFeatures}

--- a/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
@@ -1,8 +1,12 @@
+import { Repository } from 'app/api/clients/provisioning';
 import { Page } from 'app/core/components/Page/Page';
 
 import GettingStarted from './GettingStarted';
+interface Props {
+  items: Repository[];
+}
 
-export default function GettingStartedPage() {
+export default function GettingStartedPage({ items }: Props) {
   return (
     <Page
       navId="provisioning"
@@ -13,7 +17,7 @@ export default function GettingStartedPage() {
       }}
     >
       <Page.Contents>
-        <GettingStarted />
+        <GettingStarted items={items} />
       </Page.Contents>
     </Page>
   );

--- a/public/app/features/provisioning/HomePage.tsx
+++ b/public/app/features/provisioning/HomePage.tsx
@@ -43,7 +43,7 @@ export default function HomePage() {
   const settings = useGetFrontendSettingsQuery();
   const [deleteAll, deleteAllResult] = useDeletecollectionRepositoryMutation();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [instanceConnected] = checkSyncSettings(settings.data);
+  const { instanceConnected } = checkSyncSettings(items);
   const [activeTab, setActiveTab] = useState<TabSelection>(
     instanceConnected ? TabSelection.Overview : TabSelection.Repositories
   );
@@ -63,7 +63,7 @@ export default function HomePage() {
 
   // Early return for onboarding
   if (!items?.length && !isLoading) {
-    return <GettingStartedPage />;
+    return <GettingStartedPage items={items ?? []} />;
   }
 
   const onConfirmDelete = () => {
@@ -75,9 +75,9 @@ export default function HomePage() {
     if (!instanceConnected) {
       switch (activeTab) {
         case TabSelection.Repositories:
-          return <FolderRepositoryList items={items ?? []} settings={settings.data} />;
+          return <FolderRepositoryList items={items ?? []} />;
         case TabSelection.GettingStarted:
-          return <GettingStarted />;
+          return <GettingStarted items={items ?? []} />;
         default:
           return null;
       }
@@ -96,7 +96,7 @@ export default function HomePage() {
       case TabSelection.Files:
         return <FilesView repo={repo} />;
       case TabSelection.GettingStarted:
-        return <GettingStarted />;
+        return <GettingStarted items={items ?? []} />;
       default:
         return null;
     }

--- a/public/app/features/provisioning/HomePage.tsx
+++ b/public/app/features/provisioning/HomePage.tsx
@@ -75,7 +75,7 @@ export default function HomePage() {
     if (!instanceConnected) {
       switch (activeTab) {
         case TabSelection.Repositories:
-          return <FolderRepositoryList items={items ?? []} />;
+          return <FolderRepositoryList items={items ?? []} settings={settings.data} />;
         case TabSelection.GettingStarted:
           return <GettingStarted />;
         default:

--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
 import { useLocation } from 'react-router';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { SelectableValue, urlUtil } from '@grafana/data';
-import { Alert, EmptyState, Modal, Spinner, Tab, TabContent, TabsBar, Text, TextLink } from '@grafana/ui';
+import { Alert, EmptyState, Spinner, Tab, TabContent, TabsBar, Text, TextLink } from '@grafana/ui';
 import { useGetFrontendSettingsQuery, useListRepositoryQuery } from 'app/api/clients/provisioning';
 import { Page } from 'app/core/components/Page/Page';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';

--- a/public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx
+++ b/public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx
@@ -1,18 +1,32 @@
 import { LinkButton } from '@grafana/ui';
-import { RepositoryViewList } from 'app/api/clients/provisioning';
+import { Repository } from 'app/api/clients/provisioning';
 
 import { CONNECT_URL } from '../constants';
 import { checkSyncSettings } from '../utils/checkSyncSettings';
 
 interface Props {
-  settings?: RepositoryViewList;
+  items?: Repository[];
 }
 
-export function ConnectRepositoryButton({ settings }: Props) {
-  const [instanceConnected, maxReposReached] = checkSyncSettings(settings);
+export function ConnectRepositoryButton({ items }: Props) {
+  const state = checkSyncSettings(items);
 
-  if (instanceConnected || maxReposReached) {
+  if (state.instanceConnected) {
     return null;
+  }
+
+  if (state.maxReposReached) {
+    return (
+      <LinkButton
+        href={CONNECT_URL}
+        variant="primary"
+        icon="plus"
+        disabled={true}
+        tooltip={`Max repositories already created (${state.repoCount})`}
+      >
+        Maximum repos exist ({state.repoCount})
+      </LinkButton>
+    );
   }
 
   return (

--- a/public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx
+++ b/public/app/features/provisioning/Shared/ConnectRepositoryButton.tsx
@@ -1,0 +1,23 @@
+import { LinkButton } from '@grafana/ui';
+import { RepositoryViewList } from 'app/api/clients/provisioning';
+
+import { CONNECT_URL } from '../constants';
+import { checkSyncSettings } from '../utils/checkSyncSettings';
+
+interface Props {
+  settings?: RepositoryViewList;
+}
+
+export function ConnectRepositoryButton({ settings }: Props) {
+  const [instanceConnected, maxReposReached] = checkSyncSettings(settings);
+
+  if (instanceConnected || maxReposReached) {
+    return null;
+  }
+
+  return (
+    <LinkButton href={CONNECT_URL} variant="primary" icon="plus">
+      Connect to repository
+    </LinkButton>
+  );
+}

--- a/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
@@ -11,13 +11,13 @@ export function FolderRepositoryList({ items }: { items: Repository[] }) {
   const [query, setQuery] = useState('');
   const filteredItems = items.filter((item) => item.metadata?.name?.includes(query));
   const settings = useGetFrontendSettingsQuery();
-  const [instanceConnected] = checkSyncSettings(settings.data);
+  const [instanceConnected, maxReposReached] = checkSyncSettings(settings.data);
 
   return (
     <Stack direction={'column'} gap={3}>
       <Stack gap={2}>
         <FilterInput placeholder="Search" value={query} onChange={setQuery} />
-        {!instanceConnected && (
+        {!instanceConnected && !maxReposReached && (
           <LinkButton href={CONNECT_URL} variant="primary" icon={'plus'}>
             Connect to repository
           </LinkButton>

--- a/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
@@ -1,27 +1,26 @@
 import { useState } from 'react';
 
-import { EmptySearchResult, FilterInput, LinkButton, Stack } from '@grafana/ui';
-import { Repository, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning';
+import { EmptySearchResult, FilterInput, Stack } from '@grafana/ui';
+import { Repository, RepositoryViewList } from 'app/api/clients/provisioning';
 
 import { RepositoryCard } from '../Repository/RepositoryCard';
-import { CONNECT_URL } from '../constants';
-import { checkSyncSettings } from '../utils/checkSyncSettings';
 
-export function FolderRepositoryList({ items }: { items: Repository[] }) {
+import { ConnectRepositoryButton } from './ConnectRepositoryButton';
+
+interface Props {
+  items: Repository[];
+  settings?: RepositoryViewList;
+}
+
+export function FolderRepositoryList({ items, settings }: Props) {
   const [query, setQuery] = useState('');
   const filteredItems = items.filter((item) => item.metadata?.name?.includes(query));
-  const settings = useGetFrontendSettingsQuery();
-  const [instanceConnected, maxReposReached] = checkSyncSettings(settings.data);
 
   return (
     <Stack direction={'column'} gap={3}>
       <Stack gap={2}>
         <FilterInput placeholder="Search" value={query} onChange={setQuery} />
-        {!instanceConnected && !maxReposReached && (
-          <LinkButton href={CONNECT_URL} variant="primary" icon={'plus'}>
-            Connect to repository
-          </LinkButton>
-        )}
+        <ConnectRepositoryButton settings={settings} />
       </Stack>
       <Stack direction={'column'}>
         {!!filteredItems.length ? (

--- a/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/FolderRepositoryList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { EmptySearchResult, FilterInput, Stack } from '@grafana/ui';
-import { Repository, RepositoryViewList } from 'app/api/clients/provisioning';
+import { Repository } from 'app/api/clients/provisioning';
 
 import { RepositoryCard } from '../Repository/RepositoryCard';
 
@@ -9,10 +9,9 @@ import { ConnectRepositoryButton } from './ConnectRepositoryButton';
 
 interface Props {
   items: Repository[];
-  settings?: RepositoryViewList;
 }
 
-export function FolderRepositoryList({ items, settings }: Props) {
+export function FolderRepositoryList({ items }: Props) {
   const [query, setQuery] = useState('');
   const filteredItems = items.filter((item) => item.metadata?.name?.includes(query));
 
@@ -20,10 +19,10 @@ export function FolderRepositoryList({ items, settings }: Props) {
     <Stack direction={'column'} gap={3}>
       <Stack gap={2}>
         <FilterInput placeholder="Search" value={query} onChange={setQuery} />
-        <ConnectRepositoryButton settings={settings} />
+        <ConnectRepositoryButton items={items} />
       </Stack>
       <Stack direction={'column'}>
-        {!!filteredItems.length ? (
+        {filteredItems.length ? (
           filteredItems.map((item) => <RepositoryCard key={item.metadata?.name} repository={item} />)
         ) : (
           <EmptySearchResult>No results matching your query </EmptySearchResult>

--- a/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
@@ -2,10 +2,10 @@ import { skipToken } from '@reduxjs/toolkit/query';
 
 import { RepositoryViewList, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning';
 
-import { checkSyncSettings } from '../utils/checkSyncSettings';
-
 export function useIsProvisionedInstance(settings?: RepositoryViewList) {
   const settingsQuery = useGetFrontendSettingsQuery(settings ? skipToken : undefined);
-  const [instanceConnected] = checkSyncSettings(settings || settingsQuery.data);
-  return instanceConnected;
+  if (!settings) {
+    settings = settingsQuery.data;
+  }
+  return settings?.items?.some((item) => item.target === 'instance');
 }

--- a/public/app/features/provisioning/utils/checkSyncSettings.ts
+++ b/public/app/features/provisioning/utils/checkSyncSettings.ts
@@ -1,12 +1,25 @@
-import { RepositoryViewList } from 'app/api/clients/provisioning';
+import { Repository } from 'app/api/clients/provisioning';
 
-export function checkSyncSettings(settings?: RepositoryViewList): [boolean, boolean, boolean] {
-  if (!settings?.items?.length) {
-    return [false, false, false];
+type syncState = {
+  instanceConnected: boolean;
+  folderConnected: boolean;
+  repoCount: number;
+  maxReposReached: boolean;
+};
+
+export function checkSyncSettings(repos?: Repository[]): syncState {
+  if (!repos?.length) {
+    return {
+      instanceConnected: false,
+      folderConnected: false,
+      repoCount: 0,
+      maxReposReached: false,
+    };
   }
-  const instanceConnected = settings.items.some((item) => item.target === 'instance');
-  const folderConnected = settings.items.some((item) => item.target === 'folder');
-  const maxReposReached = Boolean((settings.items ?? []).length >= 10);
-
-  return [instanceConnected, folderConnected, maxReposReached];
+  return {
+    instanceConnected: repos.some((item) => item.spec?.sync.target === 'instance'),
+    folderConnected: repos.some((item) => item.spec?.sync.target === 'folder'),
+    maxReposReached: Boolean((repos ?? []).length >= 10),
+    repoCount: repos.length,
+  };
 }

--- a/public/app/features/provisioning/utils/checkSyncSettings.ts
+++ b/public/app/features/provisioning/utils/checkSyncSettings.ts
@@ -1,10 +1,12 @@
 import { RepositoryViewList } from 'app/api/clients/provisioning';
 
-export function checkSyncSettings(settings?: RepositoryViewList): [boolean, boolean] {
+export function checkSyncSettings(settings?: RepositoryViewList): [boolean, boolean, boolean] {
   if (!settings?.items?.length) {
-    return [false, false];
+    return [false, false, false];
   }
   const instanceConnected = settings.items.some((item) => item.target === 'instance');
   const folderConnected = settings.items.some((item) => item.target === 'folder');
-  return [instanceConnected, folderConnected];
+  const maxReposReached = Boolean((settings.items ?? []).length >= 10);
+
+  return [instanceConnected, folderConnected, maxReposReached];
 }


### PR DESCRIPTION
## Why?

To avoid certain situations in which we have many expensive operations at once and reduce surface for attacks.

See https://github.com/grafana/grafana/pull/102458#discussion_r2003545103 

## How

- Limit to maximum 10 repositories in backend
- Do not display connect button if more than 10 or already connected to instance.
- Only fetch settings once.
- Create a reusable component for the button.
