### PR TITLE
Advisor: Avoid returning an error when creating initial resources

### DIFF
--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
@@ -76,6 +76,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	lastCreated, err := r.checkLastCreated(ctx)
 	if err != nil {
 		r.log.Error("Error getting last check creation time", "error", err)
+		// Wait for interval to create the next scheduled check
+		lastCreated = time.Now()
 	} else {
 		// do an initial creation if necessary
 		if lastCreated.IsZero() {

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
@@ -14,6 +14,7 @@ import (
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checkregistry"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/infra/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
@@ -30,6 +31,7 @@ type Runner struct {
 	evaluationInterval time.Duration
 	maxHistory         int
 	namespace          string
+	log                log.Logger
 }
 
 // NewRunner creates a new Runner.
@@ -66,22 +68,23 @@ func New(cfg app.Config) (app.Runnable, error) {
 		evaluationInterval: evalInterval,
 		maxHistory:         maxHistory,
 		namespace:          namespace,
+		log:                log.New("advisor.checkscheduler"),
 	}, nil
 }
 
 func (r *Runner) Run(ctx context.Context) error {
 	lastCreated, err := r.checkLastCreated(ctx)
 	if err != nil {
-		return err
-	}
-
-	// do an initial creation if necessary
-	if lastCreated.IsZero() {
-		err = r.createChecks(ctx)
-		if err != nil {
-			klog.Error("Error creating new check reports", "error", err)
-		} else {
-			lastCreated = time.Now()
+		r.log.Error("Error getting last check creation time", "error", err)
+	} else {
+		// do an initial creation if necessary
+		if lastCreated.IsZero() {
+			err = r.createChecks(ctx)
+			if err != nil {
+				klog.Error("Error creating new check reports", "error", err)
+			} else {
+				lastCreated = time.Now()
+			}
 		}
 	}
 

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -30,7 +30,7 @@ func TestRunner_Run_NoErrorOnList(t *testing.T) {
 	runner := &Runner{
 		checkRegistry:      mockCheckService,
 		client:             mockClient,
-		log:                log.New("test"),
+		log:                log.NewNopLogger(),
 		evaluationInterval: 1 * time.Hour,
 	}
 
@@ -49,7 +49,7 @@ func TestRunner_checkLastCreated_ErrorOnList(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
-		log:    log.New("test"),
+		log:    log.NewNopLogger(),
 	}
 
 	lastCreated, err := runner.checkLastCreated(context.Background())
@@ -74,7 +74,7 @@ func TestRunner_createChecks_ErrorOnCreate(t *testing.T) {
 	runner := &Runner{
 		checkRegistry: mockCheckService,
 		client:        mockClient,
-		log:           log.New("test"),
+		log:           log.NewNopLogger(),
 	}
 
 	err := runner.createChecks(context.Background())
@@ -98,7 +98,7 @@ func TestRunner_createChecks_Success(t *testing.T) {
 	runner := &Runner{
 		checkRegistry: mockCheckService,
 		client:        mockClient,
-		log:           log.New("test"),
+		log:           log.NewNopLogger(),
 	}
 
 	err := runner.createChecks(context.Background())
@@ -114,7 +114,7 @@ func TestRunner_cleanupChecks_ErrorOnList(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
-		log:    log.New("test"),
+		log:    log.NewNopLogger(),
 	}
 
 	err := runner.cleanupChecks(context.Background())
@@ -135,7 +135,7 @@ func TestRunner_cleanupChecks_WithinMax(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
-		log:    log.New("test"),
+		log:    log.NewNopLogger(),
 	}
 
 	err := runner.cleanupChecks(context.Background())
@@ -165,7 +165,7 @@ func TestRunner_cleanupChecks_ErrorOnDelete(t *testing.T) {
 	runner := &Runner{
 		client:     mockClient,
 		maxHistory: defaultMaxHistory,
-		log:        log.New("test"),
+		log:        log.NewNopLogger(),
 	}
 	err := runner.cleanupChecks(context.Background())
 	assert.ErrorContains(t, err, "delete error")
@@ -201,7 +201,7 @@ func TestRunner_cleanupChecks_Success(t *testing.T) {
 	runner := &Runner{
 		client:     mockClient,
 		maxHistory: defaultMaxHistory,
-		log:        log.New("test"),
+		log:        log.NewNopLogger(),
 	}
 	err := runner.cleanupChecks(context.Background())
 	assert.NoError(t, err)

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -16,28 +16,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestRunner_Run_NoErrorOnList(t *testing.T) {
-	mockCheckService := &MockCheckService{}
-	mockClient := &MockClient{
-		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
-			return nil, errors.New("list error")
-		},
-		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
-			return &advisorv0alpha1.Check{}, nil
-		},
-	}
+func TestRunner_Run(t *testing.T) {
+	t.Run("does not crash when error on list", func(t *testing.T) {
+		mockCheckService := &MockCheckService{}
+		mockClient := &MockClient{
+			listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+				return nil, errors.New("list error")
+			},
+			createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+				return &advisorv0alpha1.Check{}, nil
+			},
+		}
 
-	runner := &Runner{
-		checkRegistry:      mockCheckService,
-		client:             mockClient,
-		log:                log.NewNopLogger(),
-		evaluationInterval: 1 * time.Hour,
-	}
+		runner := &Runner{
+			checkRegistry:      mockCheckService,
+			client:             mockClient,
+			log:                log.NewNopLogger(),
+			evaluationInterval: 1 * time.Hour,
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	err := runner.Run(ctx)
-	assert.ErrorAs(t, err, &context.Canceled)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := runner.Run(ctx)
+		assert.ErrorAs(t, err, &context.Canceled)
+	})
 }
 
 func TestRunner_checkLastCreated_ErrorOnList(t *testing.T) {

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,6 +30,7 @@ func TestRunner_Run_ErrorOnList(t *testing.T) {
 	runner := &Runner{
 		checkRegistry: mockCheckService,
 		client:        mockClient,
+		log:           log.New("test"),
 	}
 
 	err := runner.Run(context.Background())
@@ -44,6 +46,7 @@ func TestRunner_checkLastCreated_ErrorOnList(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
+		log:    log.New("test"),
 	}
 
 	lastCreated, err := runner.checkLastCreated(context.Background())
@@ -68,6 +71,7 @@ func TestRunner_createChecks_ErrorOnCreate(t *testing.T) {
 	runner := &Runner{
 		checkRegistry: mockCheckService,
 		client:        mockClient,
+		log:           log.New("test"),
 	}
 
 	err := runner.createChecks(context.Background())
@@ -91,6 +95,7 @@ func TestRunner_createChecks_Success(t *testing.T) {
 	runner := &Runner{
 		checkRegistry: mockCheckService,
 		client:        mockClient,
+		log:           log.New("test"),
 	}
 
 	err := runner.createChecks(context.Background())
@@ -106,6 +111,7 @@ func TestRunner_cleanupChecks_ErrorOnList(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
+		log:    log.New("test"),
 	}
 
 	err := runner.cleanupChecks(context.Background())
@@ -126,6 +132,7 @@ func TestRunner_cleanupChecks_WithinMax(t *testing.T) {
 
 	runner := &Runner{
 		client: mockClient,
+		log:    log.New("test"),
 	}
 
 	err := runner.cleanupChecks(context.Background())
@@ -155,6 +162,7 @@ func TestRunner_cleanupChecks_ErrorOnDelete(t *testing.T) {
 	runner := &Runner{
 		client:     mockClient,
 		maxHistory: defaultMaxHistory,
+		log:        log.New("test"),
 	}
 	err := runner.cleanupChecks(context.Background())
 	assert.ErrorContains(t, err, "delete error")
@@ -190,6 +198,7 @@ func TestRunner_cleanupChecks_Success(t *testing.T) {
 	runner := &Runner{
 		client:     mockClient,
 		maxHistory: defaultMaxHistory,
+		log:        log.New("test"),
 	}
 	err := runner.cleanupChecks(context.Background())
 	assert.NoError(t, err)

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -28,20 +28,16 @@ func TestRunner_Run_NoErrorOnList(t *testing.T) {
 	}
 
 	runner := &Runner{
-		checkRegistry: mockCheckService,
-		client:        mockClient,
-		log:           log.New("test"),
+		checkRegistry:      mockCheckService,
+		client:             mockClient,
+		log:                log.New("test"),
+		evaluationInterval: 1 * time.Hour,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	var err error
-	go func() {
-		err = runner.Run(ctx)
-	}()
-
-	time.Sleep(1 * time.Second)
 	cancel()
-	assert.NoError(t, err)
+	err := runner.Run(ctx)
+	assert.ErrorAs(t, err, &context.Canceled)
 }
 
 func TestRunner_checkLastCreated_ErrorOnList(t *testing.T) {

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestRunner_Run_ErrorOnList(t *testing.T) {
+func TestRunner_Run_NoErrorOnList(t *testing.T) {
 	mockCheckService := &MockCheckService{}
 	mockClient := &MockClient{
 		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
@@ -33,8 +33,15 @@ func TestRunner_Run_ErrorOnList(t *testing.T) {
 		log:           log.New("test"),
 	}
 
-	err := runner.Run(context.Background())
-	assert.Error(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	var err error
+	go func() {
+		err = runner.Run(ctx)
+	}()
+
+	time.Sleep(1 * time.Second)
+	cancel()
+	assert.NoError(t, err)
 }
 
 func TestRunner_checkLastCreated_ErrorOnList(t *testing.T) {

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -90,16 +90,18 @@ func (r *Runner) Run(ctx context.Context) error {
 					if err != nil {
 						// Ignore the error, it's probably due to a race condition
 						r.log.Error("Error updating check type", "error", err)
-					} else {
-						continue
 					}
+					return nil
 				}
 				r.log.Error("Error creating check type, retrying", "error", err, "attempt", i+1)
-				time.Sleep(r.retryDelay)
 				if i == r.retryAttempts-1 {
 					r.log.Error("Unable to register check type")
 				}
+				time.Sleep(r.retryDelay)
+				continue
 			}
+			r.log.Debug("Check type registered successfully", "check_type", t.ID())
+			return nil
 		}
 	}
 	return nil

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -96,8 +96,9 @@ func (r *Runner) Run(ctx context.Context) error {
 				r.log.Error("Error creating check type, retrying", "error", err, "attempt", i+1)
 				if i == r.retryAttempts-1 {
 					r.log.Error("Unable to register check type")
+				} else {
+					time.Sleep(r.retryDelay)
 				}
-				time.Sleep(r.retryDelay)
 				continue
 			}
 			r.log.Debug("Check type registered successfully", "check_type", t.ID())

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -3,6 +3,7 @@ package checktyperegisterer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/k8s"
@@ -10,6 +11,7 @@ import (
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checkregistry"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,6 +23,9 @@ type Runner struct {
 	checkRegistry checkregistry.CheckService
 	client        resource.Client
 	namespace     string
+	log           log.Logger
+	retryAttempts int
+	retryDelay    time.Duration
 }
 
 // NewRunner creates a new Runner.
@@ -47,6 +52,9 @@ func New(cfg app.Config) (app.Runnable, error) {
 		checkRegistry: checkRegistry,
 		client:        client,
 		namespace:     namespace,
+		log:           log.New("advisor.checktyperegisterer"),
+		retryAttempts: 3,
+		retryDelay:    time.Second * 5,
 	}, nil
 }
 
@@ -73,18 +81,25 @@ func (r *Runner) Run(ctx context.Context) error {
 			},
 		}
 		id := obj.GetStaticMetadata().Identifier()
-		_, err := r.client.Create(ctx, id, obj, resource.CreateOptions{})
-		if err != nil {
-			if errors.IsAlreadyExists(err) {
-				// Already exists, update
-				_, err = r.client.Update(ctx, id, obj, resource.UpdateOptions{})
-				if err != nil {
-					return err
-				} else {
-					continue
+		for i := 0; i < r.retryAttempts; i++ {
+			_, err := r.client.Create(ctx, id, obj, resource.CreateOptions{})
+			if err != nil {
+				if errors.IsAlreadyExists(err) {
+					// Already exists, update
+					_, err = r.client.Update(ctx, id, obj, resource.UpdateOptions{})
+					if err != nil {
+						// Ignore the error, it's probably due to a race condition
+						r.log.Error("Error updating check type", "error", err)
+					} else {
+						continue
+					}
+				}
+				r.log.Error("Error creating check type, retrying", "error", err, "attempt", i+1)
+				time.Sleep(r.retryDelay)
+				if i == r.retryAttempts-1 {
+					r.log.Error("Unable to register check type")
 				}
 			}
-			return err
 		}
 	}
 	return nil

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer_test.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/infra/log"
 	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -117,7 +118,10 @@ func TestCheckTypesRegisterer_Run(t *testing.T) {
 					createFunc: tt.createFunc,
 					updateFunc: tt.updateFunc,
 				},
-				namespace: "custom-namespace",
+				namespace:     "custom-namespace",
+				log:           log.New("test"),
+				retryAttempts: 1,
+				retryDelay:    0,
 			}
 			err := r.Run(context.Background())
 			if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We have found some errors when getting / creating resources at startup. This may be caused because the storage backend is not ready to receive requests or any other reason. Before this PR, if this initial requests failed, the server crashed. To avoid that we:

 - Skip the first check generation if it's not possible to check when the last one was created. Log the error in this case. This is not critical since the check will be automatically generated after the configured interval (24h) or if the user manually uses the app.
 - Retries up to 3 times the check type generation. This is necessary for the frontend to work properly but it's not a long term solution since the goal is to use [CustomRoutes](https://github.com/grafana/grafana/pull/102145) for this so it's not necessary to store check types as resources. If after 3 retries the resources are not yet generated, the error is logged and it will require for the instance to be restarted in order to try again.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
