### PR TITLE
Transformations: Correct documentation around prepare time series

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -1189,29 +1189,11 @@ Use this transformation to address issues when a data source returns time series
 
 #### Available options
 
-##### Multi-frame time series
-
-Use this option to transform the time series data frame from the wide format to the long format. This is particularly helpful when your data source delivers time series information in a format that needs to be reshaped for optimal compatibility with your visualization.
-
-**Example: Converting from wide to long format**
-
-| Timestamp           | Value1 | Value2 |
-| ------------------- | ------ | ------ |
-| 2023-01-01 00:00:00 | 10     | 20     |
-| 2023-01-01 01:00:00 | 15     | 25     |
-
-**Transformed to:**
-
-| Timestamp           | Variable | Value |
-| ------------------- | -------- | ----- |
-| 2023-01-01 00:00:00 | Value1   | 10    |
-| 2023-01-01 00:00:00 | Value2   | 20    |
-| 2023-01-01 01:00:00 | Value1   | 15    |
-| 2023-01-01 01:00:00 | Value2   | 25    |
-
 ##### Wide time series
 
-Select this option to transform the time series data frame from the long format to the wide format. If your data source returns time series data in a long format and your visualization requires a wide format, this transformation simplifies the process.
+Select this option to transform the time series data frame from the long format to the wide format.
+
+A wide time series combines data into a single frame with one shared, ascending time field. Time fields do not repeat and multiple values extend in separate columns.
 
 **Example: Converting from long to wide format**
 
@@ -1228,6 +1210,32 @@ Select this option to transform the time series data frame from the long format 
 | ------------------- | ------ | ------ |
 | 2023-01-01 00:00:00 | 10     | 20     |
 | 2023-01-01 01:00:00 | 15     | 25     |
+
+##### Multi-frame time series
+
+Multi-frame time series break data into multiple frames that all contain two fields: a time field and a numeric value field. Time is always ascending. String values are represented as field labels.
+
+##### Long time series
+
+A long time series combines data to one frame, with the first field being an ascending time field. The time field might have duplicates. String values are in separate fields, and there might be more than one.
+
+**Example: Converting to long format**
+
+| Value1 | Value2 | Timestamp           |
+| ------ | ------ | ------------------- |
+| 10     | 20     | 2023-01-03 00:00:00 |
+| 30     | 40     | 2023-01-02 00:00:00 |
+| 50     | 60     | 2023-01-01 00:00:00 |
+| 70     | 80     | 2023-01-01 00:00:00 |
+
+**Transformed to:**
+
+| Timestamp           | Value1 | Value2 |
+| ------------------- | ------ | ------ |
+| 2023-01-01 00:00:00 | 70     | 80     |
+| 2023-01-01 01:00:00 | 50     | 60     |
+| 2023-01-02 01:00:00 | 30     | 40     |
+| 2023-01-03 01:00:00 | 10     | 20     |
 
 ### Reduce
 

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -1218,30 +1218,11 @@ Use this transformation to address issues when a data source returns time series
 
 #### Available options
 
-##### Multi-frame time series
-
-Use this option to transform the time series data frame from the wide format to the long format. This is particularly helpful when your data source delivers time series information in a format that needs to be reshaped for optimal compatibility with your visualization.
-
-**Example: Converting from wide to long format**
-
-| Timestamp           | Value1 | Value2 |
-|---------------------|--------|--------|
-| 2023-01-01 00:00:00 | 10     | 20     |
-| 2023-01-01 01:00:00 | 15     | 25     |
-
-**Transformed to:**
-
-| Timestamp           | Variable | Value |
-|---------------------|----------|-------|
-| 2023-01-01 00:00:00 | Value1   | 10    |
-| 2023-01-01 00:00:00 | Value2   | 20    |
-| 2023-01-01 01:00:00 | Value1   | 15    |
-| 2023-01-01 01:00:00 | Value2   | 25    |
-
-
 ##### Wide time series
 
 Select this option to transform the time series data frame from the long format to the wide format. If your data source returns time series data in a long format and your visualization requires a wide format, this transformation simplifies the process.
+
+A wide time series combines data into a single frame with one shared, ascending time field. Time fields do not repeat and multiple values extend in separate columns.
 
 **Example: Converting from long to wide format**
 
@@ -1258,6 +1239,32 @@ Select this option to transform the time series data frame from the long format 
 |---------------------|--------|--------|
 | 2023-01-01 00:00:00 | 10     | 20     |
 | 2023-01-01 01:00:00 | 15     | 25     |
+
+##### Multi-frame time series
+
+Multi-frame time series break data into multiple frames that all contain two fields: a time field and a numeric value field. Time is always ascending. String values are represented as field labels.
+
+##### Long time series
+
+A long time series combines data to one frame, with the first field being an ascending time field. The time field might have duplicates. String values are in separate fields, and there might be more than one. 
+
+**Example: Converting to long format**
+
+| Value1 | Value2 |  Timestamp          |
+|--------|--------|---------------------|
+| 10     | 20     | 2023-01-03 00:00:00 |
+| 30     | 40     | 2023-01-02 00:00:00 |
+| 50     | 60     | 2023-01-01 00:00:00 |
+| 70     | 80     | 2023-01-01 00:00:00 |
+
+**Transformed to:**
+
+| Timestamp           | Value1 | Value2 |
+|---------------------|--------|--------|
+| 2023-01-01 00:00:00 | 70     | 80     |
+| 2023-01-01 01:00:00 | 50     | 60     |
+| 2023-01-02 01:00:00 | 30     | 40     |
+| 2023-01-03 01:00:00 | 10     | 20     |
 
   `;
     },

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -1246,7 +1246,7 @@ Multi-frame time series break data into multiple frames that all contain two fie
 
 ##### Long time series
 
-A long time series combines data to one frame, with the first field being an ascending time field. The time field might have duplicates. String values are in separate fields, and there might be more than one. 
+A long time series combines data into one frame, with the first field being an ascending time field. The time field might have duplicates. String values are in separate fields, and there might be more than one. 
 
 **Example: Converting to long format**
 


### PR DESCRIPTION
This corrects, clarifies and reorganizes documentation around the Prepare Time Series transformation. Much of the text here was taken from @imatwawana 's edits on #102400 . 

Fixes https://github.com/grafana/support-escalations/issues/15239