### PR TITLE
Fix: Change secure_json_data column data type to medium text only MYSQL

### DIFF
--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -142,4 +142,8 @@ func addDataSourceMigration(mg *Migrator) {
 	mg.AddMigration("Add api_version column", NewAddColumnMigration(tableV2, &Column{
 		Name: "api_version", Type: DB_Varchar, Nullable: true, Length: 20,
 	}))
+
+	mg.AddMigration("Update secure_json_data column to MediumText", NewRawSQLMigration("").
+		Mysql("ALTER TABLE data_source MODIFY COLUMN secure_json_data MEDIUMTEXT;"),
+	)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Able to store long tls certificates for a datasource.


**Why do we need this feature?**

Customer has encountered what appears to be a bug in the Grafana MongoDB datasource plugin and Grafana db schema. 
 
One of users wanted to add MongoDB data source to Grafana. They provided all required data (db url, password, username, and tls certificate).

The certificate includes the full certification chain. In this case it means 155kb in total – that is a long chain.

User was able to persist that tls certificate which immediately cut us off from Grafana UI and API.
 
Grafana tried to save this certificate in its sql database in json format. Example:
 
```
{  
"password":"<edited>",  
"tlsCACert": "<edited>"  
}
```
 

Due to mySql *text *column nature, only first 65,535 characters were saved, which resulted in following entry:
 
```
{  
"password":"<edited>",  
"tlsCACert": "<edite
```
**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of the fix for https://github.com/grafana/support-escalations/issues/15072

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
