### PR TITLE
TableNG: Persist scrollbars during re render

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -698,8 +698,8 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "packages/grafana-ui/src/components/Table/TableNG/utils.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 import { applyFieldOverrides, createTheme, DataFrame, FieldType, toDataFrame } from '@grafana/data';
 import { TableCellDisplayMode } from '@grafana/schema';
@@ -1351,6 +1351,48 @@ describe('TableNG', () => {
 
       // Expected color is red
       expect(computedStyle.color).toBe('rgb(255, 0, 0)');
+    });
+  });
+
+  describe('scroll position persistence', () => {
+    it('should persist scroll position after revId change', () => {
+      const data = createBasicDataFrame();
+      const { rerender } = render(<TableNG data={data} width={300} height={200} enableVirtualization={false} />);
+
+      // Find the DataGrid element
+      const dataGrid = screen.getByRole('grid');
+
+      // Simulate scrolling
+      act(() => {
+        fireEvent.scroll(dataGrid, {
+          target: {
+            scrollLeft: 100,
+            scrollTop: 50,
+          },
+        });
+      });
+
+      // Rerender with the same data but different fieldConfig to trigger revId change
+      rerender(
+        <TableNG
+          data={data}
+          width={300}
+          height={200}
+          enableVirtualization={false}
+          fieldConfig={{
+            defaults: {
+              custom: {
+                width: 200, // Different width to trigger revId change
+              },
+            },
+            overrides: [],
+          }}
+        />
+      );
+
+      // Verify scroll position was restored
+      expect(dataGrid.scrollLeft).toBe(100);
+      expect(dataGrid.scrollTop).toBe(50);
     });
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,7 +1,7 @@
 import 'react-data-grid/lib/styles.css';
 import { css } from '@emotion/css';
 import { useMemo, useState, useLayoutEffect, useCallback, useRef, useEffect } from 'react';
-import DataGrid, { RenderCellProps, RenderRowProps, Row, SortColumn } from 'react-data-grid';
+import DataGrid, { RenderCellProps, RenderRowProps, Row, SortColumn, DataGridHandle } from 'react-data-grid';
 import { useMeasure } from 'react-use';
 
 import {
@@ -35,6 +35,7 @@ import {
   ColumnTypes,
   TableColumnResizeActionCallback,
   TableColumn,
+  ScrollPosition,
 } from './types';
 import {
   frameToRecords,
@@ -83,6 +84,8 @@ export function TableNG(props: TableNGProps) {
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
   const [expandedRows, setExpandedRows] = useState<number[]>([]);
   const [isNestedTable, setIsNestedTable] = useState(false);
+  const scrollPositionRef = useRef<ScrollPosition>({ x: 0, y: 0 });
+  const dataGridRef = useRef<DataGridHandle>(null);
 
   /* ------------------------------- Local refs ------------------------------- */
   const crossFilterOrder = useRef<string[]>([]);
@@ -400,10 +403,27 @@ export function TableNG(props: TableNGProps) {
     [expandedRows, defaultRowHeight, columnTypes, headerCellRefs, osContext, defaultLineHeight]
   );
 
+  const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLDivElement;
+    scrollPositionRef.current = {
+      x: target.scrollLeft,
+      y: target.scrollTop,
+    };
+  };
+
+  // Restore scroll position after re-renders
+  useEffect(() => {
+    if (dataGridRef.current?.element) {
+      dataGridRef.current.element.scrollLeft = scrollPositionRef.current.x;
+      dataGridRef.current.element.scrollTop = scrollPositionRef.current.y;
+    }
+  }, [revId]);
+
   return (
     <>
       <ScrollContainer>
         <DataGrid<TableRow, TableSummaryRow>
+          ref={dataGridRef}
           className={styles.dataGrid}
           // Default to true, overridden to false for testing
           enableVirtualization={enableVirtualization}
@@ -419,6 +439,7 @@ export function TableNG(props: TableNGProps) {
           // TODO: This doesn't follow current table behavior
           style={{ width, height: height - (enablePagination ? paginationHeight : 0) }}
           renderers={{ renderRow: (key, props) => myRowRenderer(key, props, expandedRows) }}
+          onScroll={handleScroll}
           onCellContextMenu={({ row, column }, event) => {
             event.preventGridDefault();
             // Do not show the default context menu
@@ -654,7 +675,9 @@ export function mapFrameToDataGrid({
         if (isCountRowsSet && fieldIndex === 0) {
           return (
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span>Count</span>
+              <span>
+                <Trans i18nKey="grafana-ui.table.count">Count</Trans>
+              </span>
               <span>{calcsRef.current[fieldIndex]}</span>
             </div>
           );

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -223,3 +223,8 @@ export type FrameToRowsConverter = (frame: DataFrame) => TableRow[];
 
 // Type for mapping column names to their field types
 export type ColumnTypes = Record<string, FieldType>;
+
+export interface ScrollPosition {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
Persists scrollbar position for when revId is incremented, during re-render.

Before:
![Mar-20-2025 12-39-32](https://github.com/user-attachments/assets/68b4733d-c21a-4b1a-bdeb-44ada2c19db1)

After:
![Mar-20-2025 12-40-04](https://github.com/user-attachments/assets/dad3386d-0789-4316-b097-3653156c6b2f)


Fixes #102552