### PR TITLE
Loki: Remove range options from query builder

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -169,7 +169,7 @@ describe('LokiQueryEditorSelector', () => {
 
     await screen.findByText('host.docker.internal:3000');
     expect(screen.getByText('Rate')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('$__auto')).toHaveValue('$__auto');
+    expect(screen.getByText('$__auto')).toBeInTheDocument();
   });
 
   it('renders the label browser button', async () => {

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -151,7 +151,7 @@ describe('LokiQueryEditorSelector', () => {
   it('parses query when changing to builder mode', async () => {
     const { rerender } = renderWithProps({
       refId: 'A',
-      expr: 'rate({instance="host.docker.internal:3000"}[$__interval])',
+      expr: 'rate({instance="host.docker.internal:3000"}[$__auto])',
       editorMode: QueryEditorMode.Code,
     });
     await expectCodeEditor();
@@ -161,7 +161,7 @@ describe('LokiQueryEditorSelector', () => {
         {...defaultProps}
         query={{
           refId: 'A',
-          expr: 'rate({instance="host.docker.internal:3000"}[$__interval])',
+          expr: 'rate({instance="host.docker.internal:3000"}[$__auto])',
           editorMode: QueryEditorMode.Builder,
         }}
       />
@@ -169,7 +169,7 @@ describe('LokiQueryEditorSelector', () => {
 
     await screen.findByText('host.docker.internal:3000');
     expect(screen.getByText('Rate')).toBeInTheDocument();
-    expect(screen.getByText('$__interval')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('$__auto')).toHaveValue('$__auto');
   });
 
   it('renders the label browser button', async () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -342,6 +342,7 @@ function getRangeVectorParamDef(): QueryBuilderOperationParamDef {
     name: 'Range',
     type: 'string',
     placeholder: '$__auto',
+    options: ['$__auto'],  
     description:
       'Use the default value "$__auto". Change the "step" value in the query options to change the bucket size.',
   };

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -341,7 +341,7 @@ function getRangeVectorParamDef(): QueryBuilderOperationParamDef {
   return {
     name: 'Range',
     type: 'string',
-    options: ['$__auto'],  
+    options: ['$__auto'],
     description:
       'Use the default value "$__auto". Change the "step" value in the query options to change the bucket size.',
   };

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -341,7 +341,6 @@ function getRangeVectorParamDef(): QueryBuilderOperationParamDef {
   return {
     name: 'Range',
     type: 'string',
-    placeholder: '$__auto',
     options: ['$__auto'],  
     description:
       'Use the default value "$__auto". Change the "step" value in the query options to change the bucket size.',

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -336,11 +336,14 @@ export function getLineFilterRenderer(operation: string, caseInsensitive?: boole
     return `${innerExpr} ${operation} ${delimiter}${params.join(`${delimiter} or ${delimiter}`)}${delimiter}`;
   };
 }
+
 function getRangeVectorParamDef(): QueryBuilderOperationParamDef {
   return {
     name: 'Range',
     type: 'string',
-    options: ['$__auto', '1m', '5m', '10m', '1h', '24h'],
+    placeholder: '$__auto',
+    description:
+      'Use the default value "$__auto". Change the "step" option to change the bucket size.',
   };
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -343,7 +343,7 @@ function getRangeVectorParamDef(): QueryBuilderOperationParamDef {
     type: 'string',
     placeholder: '$__auto',
     description:
-      'Use the default value "$__auto". Change the "step" option to change the bucket size.',
+      'Use the default value "$__auto". Change the "step" value in the query options to change the bucket size.',
   };
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes not needed, or even rather misleading, options for the `range` selectors in Loki's query builder. This will now default to a `$__auto` string always and does not contain prefilled range values. These should be set in the data source's query options directly.


https://github.com/user-attachments/assets/6a975915-1ed6-44aa-a88a-61e1e32e232c

