### PR TITLE
Combobox: Fix option truncation w/ autoPlacement

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -33,8 +33,9 @@ export const useComboboxFloat = (items: Array<ComboboxOption<string | number>>, 
   const middleware = [
     autoPlacement({
       // see https://floating-ui.com/docs/autoplacement
-      crossAxis: true,
       allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end'],
+      boundary: document.body,
+      crossAxis: true,
     }),
     size({
       apply({ availableWidth, availableHeight }) {

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -1,4 +1,4 @@
-import { autoUpdate, flip, size, useFloating } from '@floating-ui/react';
+import { autoUpdate, autoPlacement, size, useFloating } from '@floating-ui/react';
 import { useMemo, useRef, useState } from 'react';
 
 import { measureText } from '../../utils';
@@ -31,10 +31,10 @@ export const useComboboxFloat = (items: Array<ComboboxOption<string | number>>, 
 
   // the order of middleware is important!
   const middleware = [
-    flip({
-      // see https://floating-ui.com/docs/flip#combining-with-shift
+    autoPlacement({
+      // see https://floating-ui.com/docs/autoplacement
       crossAxis: true,
-      boundary: document.body,
+      allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end'],
     }),
     size({
       apply({ availableWidth, availableHeight }) {


### PR DESCRIPTION
**What is this feature?**

This is a fix for the Combobox being truncated instead of expanding left when there is plenty of room.

***Before***:
![Screenshot 2025-03-20 at 4 59 59 PM](https://github.com/user-attachments/assets/3d528f57-dbee-435b-abcb-6e1fcd9f2a32)


***After***:
![Screenshot 2025-03-20 at 4 58 57 PM](https://github.com/user-attachments/assets/00b10365-45da-4652-96ee-5b2276599560)


**Why do we need this feature?**

Currently, combobox menus always truncate wider lists when they're on the right side of the page rather than opening the list right-aligned to allow a bigger width. This will allow users to read longer options and descriptions.

**Who is this feature for?**

Users that would like to see longer option texts when the combobox is on the right side of the page.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #[101344](https://github.com/grafana/grafana/issues/101344)

**Special notes for your reviewer:**

1. This switches from using [flip](https://floating-ui.com/docs/flip) to using [autoPlacement](https://floating-ui.com/docs/autoPlacement). It appears `flip` is more concerned with not causing overflow on an axis rather than maximizing space (which `autoplacement` prioritizes). Since we are already trimming down the menu to fit whatever size is available, `flip` isn't as relevant.
2. Upon opening a menu that would be `-right` aligned, you can sometimes see a flash of a narrower menu appearing before snapping to the desired width and position (see "Right top" config in video below). I'm not sure if this is an issue with the Floating UI library or the implementation, but this new version is still an improvement upon the current state.
3. Not sure how one would write unit tests for this with jest's limitations..

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

![flippity-flip](https://github.com/user-attachments/assets/fd94b15e-1efa-4c6e-9225-4106cbb6842a)

https://github.com/user-attachments/assets/eb3d4af5-9245-4333-92ec-3644f4fbe45b