### PR TITLE
K8s: Fix dashboard creation timestamp

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -404,6 +404,7 @@ func (a *dashboardSqlAccess) buildSaveDashboardCommand(ctx context.Context, orgI
 		})
 		if old != nil {
 			dash.Spec.Set("id", old.ID)
+			dash.Spec.Set("version", float64(old.Version))
 		} else {
 			dash.Spec.Remove("id") // existing of "id" makes it an update
 			created = true

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -169,6 +169,7 @@ func TestBuildSaveDashboardCommand(t *testing.T) {
 	mockStore.On("GetDashboard", mock.Anything, mock.Anything).Return(
 		&dashboards.Dashboard{
 			ID:         1234,
+			Version:    2,
 			APIVersion: "dashboard.grafana.app/v0alpha1",
 		}, nil).Once()
 	cmd, created, err = access.buildSaveDashboardCommand(ctx, 1, dash)
@@ -176,8 +177,9 @@ func TestBuildSaveDashboardCommand(t *testing.T) {
 	require.Equal(t, false, created)
 	require.NotNil(t, cmd)
 	require.Equal(t, "test-dash", cmd.Dashboard.Get("uid").MustString())
-	require.Equal(t, cmd.Dashboard.Get("id").MustInt64(), int64(1234)) // should set to existing ID
-	require.Equal(t, cmd.APIVersion, "v0alpha1")                       // should trim prefix
+	require.Equal(t, cmd.Dashboard.Get("id").MustInt64(), int64(1234))       // should set to existing ID
+	require.Equal(t, cmd.Dashboard.Get("version").MustFloat64(), float64(2)) // version must be set - otherwise seen as a new dashboard in NewDashboardFromJson
+	require.Equal(t, cmd.APIVersion, "v0alpha1")                             // should trim prefix
 	require.Equal(t, cmd.OrgID, int64(1))
 	require.True(t, cmd.Overwrite)
 }


### PR DESCRIPTION
**What is this feature?**

This PR is a follow-up to https://github.com/grafana/grafana/pull/101992, where the version began to be removed from the dashboard spec. 

When we don't have the version the spec when we go to save in legacy, we will fail this check: https://github.com/grafana/grafana/blob/08335a0068516015bc7a680cd54684f377cb6f18/pkg/services/dashboards/models.go#L114, and thus set the creation timestamp to now (so any save will update the timestamp to now)