### PR TITLE
K8s: Fix dashboard history list timestamps

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -308,6 +308,10 @@ func (s *Service) UnstructuredToLegacyDashboardVersion(ctx context.Context, item
 			createdBy = updatedBy
 		}
 	}
+	created := obj.GetCreationTimestamp().Time
+	if updated, err := obj.GetUpdatedTimestamp(); err == nil && updated != nil {
+		created = *updated
+	}
 
 	id, err := obj.GetResourceVersionInt64()
 	if err != nil {
@@ -323,7 +327,7 @@ func (s *Service) UnstructuredToLegacyDashboardVersion(ctx context.Context, item
 		ID:            id,
 		DashboardID:   obj.GetDeprecatedInternalID(), // nolint:staticcheck
 		DashboardUID:  uid,
-		Created:       obj.GetCreationTimestamp().Time,
+		Created:       created,
 		CreatedBy:     createdBy.ID,
 		Message:       obj.GetMessage(),
 		RestoredFrom:  restoreVer,


### PR DESCRIPTION
**What is this feature?**

The list view with the get trash label (http://localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards?labelSelector=grafana.app/get-trash=true) has the same timestamp for all objects of the originally created object timestamp.

This resulted in the dashboard history tab showing the same timestamp for every version. We should use the updated timestamp instead, if available, which corresponds to when that version was saved.

Before:
<img width="600" alt="Screenshot 2025-03-21 at 1 10 10 AM" src="https://github.com/user-attachments/assets/12f1c332-7c51-4554-beb3-9ee73cb725ee" />

After:
<img width="605" alt="Screenshot 2025-03-21 at 1 11 11 AM" src="https://github.com/user-attachments/assets/22d05067-2b1f-45be-9f84-1de48344924c" />
