### PR TITLE
LDAP test: Fix page crash

### DIFF
--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { Tooltip, Icon, InteractiveTable, type CellProps, Column } from '@grafana/ui';
+import { Tooltip, Icon, InteractiveTable, type CellProps, Column, Stack } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 import { LdapRole } from 'app/types';
 
@@ -28,20 +28,12 @@ export const LdapUserGroups = ({ groups }: Props) => {
         header: 'Role',
         cell: (props: CellProps<LdapRole, string | undefined>) =>
           props.value || (
-            <>
-              <Trans
-                i18nKey="admin.ldap-user-groups.no-org-found"
-                components={{
-                  InfoTooltip: (
-                    <Tooltip content="No matching organizations found">
-                      <Icon name="info-circle" />
-                    </Tooltip>
-                  ),
-                }}
-              >
-                No match {'<InfoTooltip />'}
-              </Trans>
-            </>
+            <Stack alignItems="center" wrap>
+              <Trans i18nKey="admin.ldap-user-groups.no-org-found">No match</Trans>
+              <Tooltip content="No matching organizations found">
+                <Icon name="info-circle" />
+              </Tooltip>
+            </Stack>
           ),
       },
     ],

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -29,11 +29,17 @@ export const LdapUserGroups = ({ groups }: Props) => {
         cell: (props: CellProps<LdapRole, string | undefined>) =>
           props.value || (
             <>
-              <Trans i18nKey="admin.ldap-user-groups.no-org-found">
-                No match{' '}
-                <Tooltip content="No matching organizations found">
-                  <Icon name="info-circle" />
-                </Tooltip>
+              <Trans
+                i18nKey="admin.ldap-user-groups.no-org-found"
+                components={{
+                  InfoTooltip: (
+                    <Tooltip content="No matching organizations found">
+                      <Icon name="info-circle" />
+                    </Tooltip>
+                  ),
+                }}
+              >
+                No match {'<InfoTooltip />'}
               </Trans>
             </>
           ),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -136,7 +136,7 @@
       "title": "LDAP Synchronization"
     },
     "ldap-user-groups": {
-      "no-org-found": "No match <InfoTooltip />"
+      "no-org-found": "No match"
     },
     "ldap-user-info": {
       "no-team": "No teams found via LDAP"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -136,7 +136,7 @@
       "title": "LDAP Synchronization"
     },
     "ldap-user-groups": {
-      "no-org-found": "No match <2><0></0></2>"
+      "no-org-found": "No match <InfoTooltip />"
     },
     "ldap-user-info": {
       "no-team": "No teams found via LDAP"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adjusts the translations so they don't cause a page crash
- for some reason, when using a `<Tooltip />` inside a `<Trans>` tag, the children passed to `Tooltip` are now wrapped in an array... i guess `<Trans>` does some magic? 🤔 
- this causes [this line](https://github.com/grafana/grafana/blob/ash/support-15278/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx#L99) to blow up since `Tooltip` only ever expects a single child
- this feels like an easy problem for someone else to trip over - suggestions for how to prevent this?
  - maybe a lint rule preventing `<Tooltip>` inside `<Trans>` and documenting what to do instead? 🤔 

**Why do we need this feature?**

- so the LDAP test function doesn't crash the page

**Who is this feature for?**

- everyone using LDAP

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/support-escalations/issues/15278
Fixes https://github.com/grafana/grafana/issues/100030

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
