### PR TITLE
Dynamic Dashboards: Fix responsive grid select

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -107,10 +107,15 @@ interface HoverHeader {
   hoverHeaderOffset?: number;
 }
 
+interface Point {
+  x: number;
+  y: number;
+}
+
 interface PointerEventConfig {
   pointerDown: boolean;
   dragStarted: boolean;
-  initialPosition: { x: number; y: number };
+  initialPosition: Point;
 }
 
 /**
@@ -236,14 +241,10 @@ export function PanelChrome({
     }
 
     evt.stopPropagation();
-    if (
-      Math.sqrt(
-        Math.pow(pointerEventConfig.current.initialPosition.x - evt.screenX, 2) +
-          Math.pow(pointerEventConfig.current.initialPosition.y - evt.screenY, 2)
-      ) > 10
-    ) {
-      // Check if the distance between the initial position and the current position is greater than a threshold
-      pointerEventConfig.current = { ...pointerEventConfig.current, dragStarted: true };
+    const distance = pointDistance(pointerEventConfig.current.initialPosition, { x: evt.screenX, y: evt.screenY });
+    const thresholdDistance = 10;
+    if (distance > thresholdDistance) {
+      pointerEventConfig.current.dragStarted = true;
       onDragStart?.(evt);
     }
   };
@@ -631,3 +632,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+
+function pointDistance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
@@ -106,7 +106,6 @@ const getStyles = (theme: GrafanaTheme2, state: ResponsiveGridLayoutState) => ({
     position: 'relative',
     width: '100%',
     height: '100%',
-    overflow: 'hidden',
   }),
   dragging: css({
     position: 'fixed',


### PR DESCRIPTION
**What is this feature?**

After we merged drag and drop in the responsive grid, we lost the ability to select grid items. This PR brings back this behavior.

The idea behind this is pretty simple:
- when pressing the button, keep track of the initial position
- when moving the mouse, calculate the distance between the initial position and current position
   - if we traveled a little bit of distance, start the dragging process
   - if the mouse leaves the panel header, don't start the dragging process - this fixes an issue where `pointerUp` events would be ignored when releasing the button outside of the panel header
- when the mouse button is released, select the panel if drag did not start

**Why do we need this feature?**

Fix bugs.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
