### PR TITLE
CloudMigrations: Validate resource types dependencies in create snapshot request

### DIFF
--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -342,7 +342,7 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 		rawResourceTypes = append(rawResourceTypes, cloudmigration.MigrateDataType(t))
 	}
 
-	_, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
+	resourceTypes, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
 	if err != nil {
 		span.SetStatus(codes.Error, "invalid resource types")
 		span.RecordError(err)
@@ -350,7 +350,10 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 		return response.ErrOrFallback(http.StatusBadRequest, "invalid resource types", err)
 	}
 
-	ss, err := cma.cloudMigrationService.CreateSnapshot(ctx, c.SignedInUser, uid)
+	ss, err := cma.cloudMigrationService.CreateSnapshot(ctx, c.SignedInUser, cloudmigration.CreateSnapshotCommand{
+		SessionUID:    uid,
+		ResourceTypes: resourceTypes,
+	})
 	if err != nil {
 		span.SetStatus(codes.Error, "error creating snapshot")
 		span.RecordError(err)

--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -13,8 +15,6 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
-
-	"go.opentelemetry.io/otel/codes"
 )
 
 type CloudMigrationAPI struct {
@@ -22,6 +22,7 @@ type CloudMigrationAPI struct {
 	routeRegister         routing.RouteRegister
 	log                   log.Logger
 	tracer                tracing.Tracer
+	resourceDependencyMap cloudmigration.DependencyMap
 }
 
 func RegisterApi(
@@ -29,12 +30,14 @@ func RegisterApi(
 	cms cloudmigration.Service,
 	tracer tracing.Tracer,
 	acHandler accesscontrol.AccessControl,
+	resourceDependencyMap cloudmigration.DependencyMap,
 ) *CloudMigrationAPI {
 	api := &CloudMigrationAPI{
 		log:                   log.New("cloudmigrations.api"),
 		routeRegister:         rr,
 		cloudMigrationService: cms,
 		tracer:                tracer,
+		resourceDependencyMap: resourceDependencyMap,
 	}
 	api.registerEndpoints(acHandler)
 	return api
@@ -315,12 +318,36 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 	defer span.End()
 
 	uid := web.Params(c.Req)[":uid"]
-
 	if err := util.ValidateUID(uid); err != nil {
 		span.SetStatus(codes.Error, "invalid session uid")
 		span.RecordError(err)
 
 		return response.ErrOrFallback(http.StatusBadRequest, "invalid session uid", err)
+	}
+
+	var cmd CreateSnapshotRequestDTO
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		span.SetStatus(codes.Error, "invalid request body")
+		span.RecordError(err)
+
+		return response.ErrOrFallback(http.StatusBadRequest, "invalid request body", err)
+	}
+
+	if len(cmd.ResourceTypes) == 0 {
+		return response.ErrOrFallback(http.StatusBadRequest, "at least one resource type is required", cloudmigration.ErrEmptyResourceTypes)
+	}
+
+	rawResourceTypes := make([]cloudmigration.MigrateDataType, 0, len(cmd.ResourceTypes))
+	for _, t := range cmd.ResourceTypes {
+		rawResourceTypes = append(rawResourceTypes, cloudmigration.MigrateDataType(t))
+	}
+
+	_, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
+	if err != nil {
+		span.SetStatus(codes.Error, "invalid resource types")
+		span.RecordError(err)
+
+		return response.ErrOrFallback(http.StatusBadRequest, "invalid resource types", err)
 	}
 
 	ss, err := cma.cloudMigrationService.CreateSnapshot(ctx, c.SignedInUser, uid)

--- a/pkg/services/cloudmigration/api/api_test.go
+++ b/pkg/services/cloudmigration/api/api_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
@@ -14,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/web/webtest"
-	"github.com/stretchr/testify/require"
 )
 
 type TestCase struct {
@@ -322,14 +323,43 @@ func TestCloudMigrationAPI_CreateSnapshot(t *testing.T) {
 			desc:               "returns 200 if the user has the right permissions",
 			requestHttpMethod:  http.MethodPost,
 			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        `{"resourceTypes":["PLUGIN"]}`,
 			user:               userWithPermissions,
 			expectedHttpResult: http.StatusOK,
 			expectedBody:       `{"uid":"fake_uid"}`,
 		},
 		{
+			desc:               "returns 400 if resource types are not provided",
+			requestHttpMethod:  http.MethodPost,
+			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        `{}`,
+			user:               userWithPermissions,
+			expectedHttpResult: http.StatusBadRequest,
+			expectedBody:       "",
+		},
+		{
+			desc:               "returns 400 if request body is not a valid json",
+			requestHttpMethod:  http.MethodPost,
+			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        "asdf",
+			user:               userWithPermissions,
+			expectedHttpResult: http.StatusBadRequest,
+			expectedBody:       "",
+		},
+		{
+			desc:               "returns 400 if resource types are invalid",
+			requestHttpMethod:  http.MethodPost,
+			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        `{"resourceTypes":["INVALID"]}`,
+			user:               userWithPermissions,
+			expectedHttpResult: http.StatusBadRequest,
+			expectedBody:       "",
+		},
+		{
 			desc:               "returns 403 if the user does not have the right permissions",
 			requestHttpMethod:  http.MethodPost,
 			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        `{"resourceTypes":["PLUGIN"]}`,
 			user:               userWithoutPermissions,
 			expectedHttpResult: http.StatusForbidden,
 			expectedBody:       "",
@@ -338,6 +368,7 @@ func TestCloudMigrationAPI_CreateSnapshot(t *testing.T) {
 			desc:               "returns 500 if service returns an error",
 			requestHttpMethod:  http.MethodPost,
 			requestUrl:         "/api/cloudmigration/migration/1234/snapshot",
+			requestBody:        `{"resourceTypes":["PLUGIN"]}`,
 			user:               userWithPermissions,
 			serviceReturnError: true,
 			expectedHttpResult: http.StatusInternalServerError,
@@ -347,6 +378,7 @@ func TestCloudMigrationAPI_CreateSnapshot(t *testing.T) {
 			desc:               "returns 400 if uid is invalid",
 			requestHttpMethod:  http.MethodPost,
 			requestUrl:         "/api/cloudmigration/migration/***/snapshot",
+			requestBody:        `{"resourceTypes":["PLUGIN"]}`,
 			user:               userWithPermissions,
 			serviceReturnError: true,
 			expectedHttpResult: http.StatusBadRequest,
@@ -574,6 +606,7 @@ func runSimpleApiTest(tt TestCase) func(t *testing.T) {
 			fake.FakeServiceImpl{ReturnError: tt.serviceReturnError},
 			tracing.InitializeTracerForTest(),
 			acimpl.ProvideAccessControlTest(),
+			cloudmigration.DependencyMap{cloudmigration.PluginDataType: nil},
 		)
 
 		server := webtest.NewServer(t, api.routeRegister)

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -269,6 +269,14 @@ type CreateSnapshotRequest struct {
 	// UID of a session
 	// in: path
 	UID string `json:"uid"`
+
+	// in:body
+	// required:true
+	Body CreateSnapshotRequestDTO `json:"body"`
+}
+
+type CreateSnapshotRequestDTO struct {
+	ResourceTypes []MigrateDataType `json:"resourceTypes"`
 }
 
 // swagger:response createSnapshotResponse

--- a/pkg/services/cloudmigration/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigration.go
@@ -21,7 +21,7 @@ type Service interface {
 	DeleteSession(ctx context.Context, orgID int64, signedInUser *user.SignedInUser, migUID string) (*CloudMigrationSession, error)
 	GetSessionList(ctx context.Context, orgID int64) (*CloudMigrationSessionListResponse, error)
 
-	CreateSnapshot(ctx context.Context, signedInUser *user.SignedInUser, sessionUid string) (*CloudMigrationSnapshot, error)
+	CreateSnapshot(ctx context.Context, signedInUser *user.SignedInUser, cmd CreateSnapshotCommand) (*CloudMigrationSnapshot, error)
 	GetSnapshot(ctx context.Context, query GetSnapshotsQuery) (*CloudMigrationSnapshot, error)
 	GetSnapshotList(ctx context.Context, query ListSnapshotsQuery) ([]CloudMigrationSnapshot, error)
 	UploadSnapshot(ctx context.Context, orgID int64, signedInUser *user.SignedInUser, sessionUid string, snapshotUid string) error

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -13,6 +13,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -40,10 +45,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Service Define the cloudmigration.Service Implementation.
@@ -142,7 +143,7 @@ func ProvideService(
 		libraryElementsService: libraryElementsService,
 		ngAlert:                ngAlert,
 	}
-	s.api = api.RegisterApi(routeRegister, s, tracer, accessControl)
+	s.api = api.RegisterApi(routeRegister, s, tracer, accessControl, cloudmigration.ResourceDependency)
 
 	httpClientS3, err := httpClientProvider.New()
 	if err != nil {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
@@ -45,7 +45,7 @@ func (s *NoopServiceImpl) DeleteSession(ctx context.Context, orgID int64, signed
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 
-func (s *NoopServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, sessionUid string) (*cloudmigration.CloudMigrationSnapshot, error) {
+func (s *NoopServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, cmd cloudmigration.CreateSnapshotCommand) (*cloudmigration.CloudMigrationSnapshot, error) {
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/fake/cloudmigration_fake.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/fake/cloudmigration_fake.go
@@ -83,13 +83,13 @@ func (m FakeServiceImpl) GetSessionList(_ context.Context, _ int64) (*cloudmigra
 	}, nil
 }
 
-func (m FakeServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, sessionUid string) (*cloudmigration.CloudMigrationSnapshot, error) {
+func (m FakeServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, cmd cloudmigration.CreateSnapshotCommand) (*cloudmigration.CloudMigrationSnapshot, error) {
 	if m.ReturnError {
 		return nil, fmt.Errorf("mock error")
 	}
 	return &cloudmigration.CloudMigrationSnapshot{
 		UID:        "fake_uid",
-		SessionUID: sessionUid,
+		SessionUID: cmd.SessionUID,
 		Status:     cloudmigration.SnapshotStatusCreating,
 	}, nil
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -166,6 +166,7 @@ type CloudMigrationSessionListResponse struct {
 type ResourceTypes map[MigrateDataType]struct{}
 
 type CreateSnapshotCommand struct {
+	SessionUID    string
 	ResourceTypes ResourceTypes
 }
 

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -14,6 +14,7 @@ var (
 	ErrMigrationNotDeleted         = errutil.Internal("cloudmigrations.sessionNotDeleted").Errorf("Session not deleted")
 	ErrTokenNotFound               = errutil.NotFound("cloudmigrations.tokenNotFound").Errorf("Token not found")
 	ErrSnapshotNotFound            = errutil.NotFound("cloudmigrations.snapshotNotFound").Errorf("Snapshot not found")
+	ErrEmptyResourceTypes          = errutil.BadRequest("cloudmigrations.emptyResourceTypes").Errorf("Resource types cannot be empty")
 )
 
 // CloudMigration domain structs
@@ -163,6 +164,10 @@ type CloudMigrationSessionListResponse struct {
 }
 
 type ResourceTypes map[MigrateDataType]struct{}
+
+type CreateSnapshotCommand struct {
+	ResourceTypes ResourceTypes
+}
 
 type GetSnapshotsQuery struct {
 	SnapshotUID string

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2412,6 +2412,14 @@
             "name": "uid",
             "in": "path",
             "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSnapshotRequestDTO"
+            }
           }
         ],
         "responses": {
@@ -14393,6 +14401,30 @@
             "Admin"
           ],
           "example": "Admin"
+        }
+      }
+    },
+    "CreateSnapshotRequestDTO": {
+      "type": "object",
+      "properties": {
+        "resourceTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER",
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "ALERT_RULE_GROUP",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING",
+              "PLUGIN"
+            ]
+          }
         }
       }
     },

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -18,7 +18,11 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}` }),
     }),
     createSnapshot: build.mutation<CreateSnapshotApiResponse, CreateSnapshotApiArg>({
-      query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/snapshot`, method: 'POST' }),
+      query: (queryArg) => ({
+        url: `/cloudmigration/migration/${queryArg.uid}/snapshot`,
+        method: 'POST',
+        body: queryArg.createSnapshotRequestDto,
+      }),
     }),
     getSnapshot: build.query<GetSnapshotApiResponse, GetSnapshotApiArg>({
       query: (queryArg) => ({
@@ -90,6 +94,7 @@ export type CreateSnapshotApiResponse = /** status 200 (empty) */ CreateSnapshot
 export type CreateSnapshotApiArg = {
   /** UID of a session */
   uid: string;
+  createSnapshotRequestDto: CreateSnapshotRequestDto;
 };
 export type GetSnapshotApiResponse = /** status 200 (empty) */ GetSnapshotResponseDto;
 export type GetSnapshotApiArg = {
@@ -169,6 +174,21 @@ export type CloudMigrationSessionRequestDto = {
 };
 export type CreateSnapshotResponseDto = {
   uid?: string;
+};
+export type CreateSnapshotRequestDto = {
+  resourceTypes?: (
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING'
+    | 'PLUGIN'
+  )[];
 };
 export type MigrateDataResponseItemDto = {
   errorCode?:

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2891,7 +2891,11 @@
     },
     "onprem": {
       "cancel-snapshot-error-title": "Error cancelling creating snapshot",
+      "create-snapshot-error-duplicate-resource-type": "Duplicate resource type. See the Grafana server logs for more details",
+      "create-snapshot-error-empty-resource-types": "You need to provide at least one resource type for snapshot creation",
+      "create-snapshot-error-missing-dependency": "Missing dependency. See the Grafana server logs for more details",
       "create-snapshot-error-title": "Error creating snapshot",
+      "create-snapshot-error-unknown-resource-type": "Unknown resource type. See the Grafana server logs for more details",
       "disconnect-error-title": "Error disconnecting",
       "error-see-server-logs": "See the Grafana server logs for more details",
       "get-session-error-title": "Error loading migration configuration",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4459,6 +4459,30 @@
         },
         "type": "object"
       },
+      "CreateSnapshotRequestDTO": {
+        "properties": {
+          "resourceTypes": {
+            "items": {
+              "enum": [
+                "DASHBOARD",
+                "DATASOURCE",
+                "FOLDER",
+                "LIBRARY_ELEMENT",
+                "ALERT_RULE",
+                "ALERT_RULE_GROUP",
+                "CONTACT_POINT",
+                "NOTIFICATION_POLICY",
+                "NOTIFICATION_TEMPLATE",
+                "MUTE_TIMING",
+                "PLUGIN"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "CreateSnapshotResponseDTO": {
         "properties": {
           "uid": {
@@ -16063,6 +16087,17 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnapshotRequestDTO"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/createSnapshotResponse"


### PR DESCRIPTION
**What is this feature?**

Uses the method in https://github.com/grafana/grafana/pull/102594 to validate the incoming request to create a new snapshot.

In the frontend, we are now passing all the resource types we want to create a snapshot of to the backend for validation. Right now we hardcode to all supported types.

It also adds some error handling.

Duplicate resource types:
![Screenshot 2025-03-21 at 11 40 13](https://github.com/user-attachments/assets/6c880ea6-71d7-49c3-887a-fe6b79f3a5fa)
```
logger=context userId=1 orgId=1 uname=admin method=POST path=/api/cloudmigration/migration/fegf8bk0lpce8d/snapshot status=400 remote_addr=[::1] time_ms=1 duration=1.057333ms size=93 referer=http://localhost:3000/admin/migrate-to-cloud handler=/api/cloudmigration/migration/:uid/snapshot status_source=server errorReason=BadRequest errorMessageID=cloudmigrations.duplicateResourceType error="duplicate resource type found: DASHBOARD"
```

Missing a dependency in the declared list:
![Screenshot 2025-03-21 at 11 40 45](https://github.com/user-attachments/assets/c91ee412-3331-4f14-a791-a0ad42fe3e96)
```
logger=context userId=1 orgId=1 uname=admin method=POST path=/api/cloudmigration/migration/fegf8bk0lpce8d/snapshot status=400 remote_addr=[::1] time_ms=2 duration=2.976042ms size=89 referer=http://localhost:3000/admin/migrate-to-cloud handler=/api/cloudmigration/migration/:uid/snapshot status_source=server errorReason=BadRequest errorMessageID=cloudmigrations.missingDependency error="missing dependency: PLUGIN for resource type DATASOURCE"
```

Unknown resource type passed:
![Screenshot 2025-03-21 at 11 41 25](https://github.com/user-attachments/assets/52b611b3-9b29-4029-afa0-6550a3b18f8f)
```
logger=context userId=1 orgId=1 uname=admin method=POST path=/api/cloudmigration/migration/fegf8bk0lpce8d/snapshot status=400 remote_addr=[::1] time_ms=0 duration=971.625µs size=91 referer=http://localhost:3000/admin/migrate-to-cloud handler=/api/cloudmigration/migration/:uid/snapshot status_source=server errorReason=BadRequest errorMessageID=cloudmigrations.unknownResourceType error="unknown resource type: UNKNOWN"
```

Empty list of resources:
![Screenshot 2025-03-21 at 11 41 56](https://github.com/user-attachments/assets/b5b58c25-1a16-417d-ac3c-caf9637dff01)
```
logger=context userId=1 orgId=1 uname=admin method=POST path=/api/cloudmigration/migration/fegf8bk0lpce8d/snapshot status=400 remote_addr=[::1] time_ms=1 duration=1.044958ms size=90 referer=http://localhost:3000/admin/migrate-to-cloud handler=/api/cloudmigration/migration/:uid/snapshot status_source=server errorReason=BadRequest errorMessageID=cloudmigrations.emptyResourceTypes error="Resource types cannot be empty"
```

**Why do we need this feature?**

This is part of the work to be able to filter resource types when creating a snapshot.

**Who is this feature for?**

Cloud Migration Assistant.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1281

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
