### PR TITLE
CloudMigrations: Update service interface to pass parsed resource types for creation

### DIFF
--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -342,7 +342,7 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 		rawResourceTypes = append(rawResourceTypes, cloudmigration.MigrateDataType(t))
 	}
 
-	_, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
+	resourceTypes, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
 	if err != nil {
 		span.SetStatus(codes.Error, "invalid resource types")
 		span.RecordError(err)
@@ -350,7 +350,10 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 		return response.ErrOrFallback(http.StatusBadRequest, "invalid resource types", err)
 	}
 
-	ss, err := cma.cloudMigrationService.CreateSnapshot(ctx, c.SignedInUser, uid)
+	ss, err := cma.cloudMigrationService.CreateSnapshot(ctx, c.SignedInUser, cloudmigration.CreateSnapshotCommand{
+		SessionUID:    uid,
+		ResourceTypes: resourceTypes,
+	})
 	if err != nil {
 		span.SetStatus(codes.Error, "error creating snapshot")
 		span.RecordError(err)

--- a/pkg/services/cloudmigration/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigration.go
@@ -21,7 +21,7 @@ type Service interface {
 	DeleteSession(ctx context.Context, orgID int64, signedInUser *user.SignedInUser, migUID string) (*CloudMigrationSession, error)
 	GetSessionList(ctx context.Context, orgID int64) (*CloudMigrationSessionListResponse, error)
 
-	CreateSnapshot(ctx context.Context, signedInUser *user.SignedInUser, sessionUid string) (*CloudMigrationSnapshot, error)
+	CreateSnapshot(ctx context.Context, signedInUser *user.SignedInUser, cmd CreateSnapshotCommand) (*CloudMigrationSnapshot, error)
 	GetSnapshot(ctx context.Context, query GetSnapshotsQuery) (*CloudMigrationSnapshot, error)
 	GetSnapshotList(ctx context.Context, query ListSnapshotsQuery) ([]CloudMigrationSnapshot, error)
 	UploadSnapshot(ctx context.Context, orgID int64, signedInUser *user.SignedInUser, sessionUid string, snapshotUid string) error

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
@@ -45,7 +45,7 @@ func (s *NoopServiceImpl) DeleteSession(ctx context.Context, orgID int64, signed
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 
-func (s *NoopServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, sessionUid string) (*cloudmigration.CloudMigrationSnapshot, error) {
+func (s *NoopServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, cmd cloudmigration.CreateSnapshotCommand) (*cloudmigration.CloudMigrationSnapshot, error) {
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/fake/cloudmigration_fake.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/fake/cloudmigration_fake.go
@@ -83,13 +83,13 @@ func (m FakeServiceImpl) GetSessionList(_ context.Context, _ int64) (*cloudmigra
 	}, nil
 }
 
-func (m FakeServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, sessionUid string) (*cloudmigration.CloudMigrationSnapshot, error) {
+func (m FakeServiceImpl) CreateSnapshot(ctx context.Context, user *user.SignedInUser, cmd cloudmigration.CreateSnapshotCommand) (*cloudmigration.CloudMigrationSnapshot, error) {
 	if m.ReturnError {
 		return nil, fmt.Errorf("mock error")
 	}
 	return &cloudmigration.CloudMigrationSnapshot{
 		UID:        "fake_uid",
-		SessionUID: sessionUid,
+		SessionUID: cmd.SessionUID,
 		Status:     cloudmigration.SnapshotStatusCreating,
 	}, nil
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -166,6 +166,7 @@ type CloudMigrationSessionListResponse struct {
 type ResourceTypes map[MigrateDataType]struct{}
 
 type CreateSnapshotCommand struct {
+	SessionUID    string
 	ResourceTypes ResourceTypes
 }
 


### PR DESCRIPTION
**What is this feature?**

Updates the interface for the CreateSnapshot method in the Service to accept the parsed and validated resource type list.

**Why do we need this feature?**

This is part of the work to be able to filter resource types when creating a snapshot.

**Who is this feature for?**

Cloud Migration Assistant.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1281

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
