### PR TITLE
Fix failing integration tests in folderimpl package when running on Spanner.

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -674,7 +674,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		{SQL: "DELETE FROM dashboard_tag WHERE dashboard_uid = ? AND org_id = ?", args: []any{dashboard.UID, dashboard.OrgID}},
 		{SQL: "DELETE FROM star WHERE dashboard_id = ? ", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard WHERE id = ?", args: []any{dashboard.ID}},
-		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(dashboard.ID, 10)}},
+		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(dashboard.ID, 10)}}, // Column has TEXT type.
 		{SQL: "DELETE FROM dashboard_version WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_provisioning WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_acl WHERE dashboard_id = ?", args: []any{dashboard.ID}},
@@ -738,7 +738,7 @@ func (d *dashboardStore) CleanupAfterDelete(ctx context.Context, cmd *dashboards
 	sqlStatements := []statement{
 		{SQL: "DELETE FROM dashboard_tag WHERE dashboard_uid = ? AND org_id = ?", args: []any{cmd.UID, cmd.OrgID}},
 		{SQL: "DELETE FROM star WHERE dashboard_uid = ? AND org_id = ?", args: []any{cmd.UID, cmd.OrgID}},
-		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(cmd.ID, 10)}},
+		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(cmd.ID, 10)}}, // Column has TEXT type.
 		{SQL: "DELETE FROM dashboard_version WHERE dashboard_id = ?", args: []any{cmd.ID}},
 		{SQL: "DELETE FROM dashboard_provisioning WHERE dashboard_id = ?", args: []any{cmd.ID}},
 		{SQL: "DELETE FROM dashboard_acl WHERE dashboard_id = ?", args: []any{cmd.ID}},

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -673,7 +674,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		{SQL: "DELETE FROM dashboard_tag WHERE dashboard_uid = ? AND org_id = ?", args: []any{dashboard.UID, dashboard.OrgID}},
 		{SQL: "DELETE FROM star WHERE dashboard_id = ? ", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard WHERE id = ?", args: []any{dashboard.ID}},
-		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{dashboard.ID}},
+		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(dashboard.ID, 10)}},
 		{SQL: "DELETE FROM dashboard_version WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_provisioning WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_acl WHERE dashboard_id = ?", args: []any{dashboard.ID}},
@@ -737,7 +738,7 @@ func (d *dashboardStore) CleanupAfterDelete(ctx context.Context, cmd *dashboards
 	sqlStatements := []statement{
 		{SQL: "DELETE FROM dashboard_tag WHERE dashboard_uid = ? AND org_id = ?", args: []any{cmd.UID, cmd.OrgID}},
 		{SQL: "DELETE FROM star WHERE dashboard_uid = ? AND org_id = ?", args: []any{cmd.UID, cmd.OrgID}},
-		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{cmd.ID}},
+		{SQL: "DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?", args: []any{strconv.FormatInt(cmd.ID, 10)}},
 		{SQL: "DELETE FROM dashboard_version WHERE dashboard_id = ?", args: []any{cmd.ID}},
 		{SQL: "DELETE FROM dashboard_provisioning WHERE dashboard_id = ?", args: []any{cmd.ID}},
 		{SQL: "DELETE FROM dashboard_acl WHERE dashboard_id = ?", args: []any{cmd.ID}},

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -607,9 +607,9 @@ func (ss *FolderStoreImpl) GetDescendants(ctx context.Context, orgID int64, ance
 }
 
 func getFullpathSQL(dialect migrator.Dialect) string {
-	escaped := "\\/"
-	if dialect.DriverName() == migrator.MySQL {
-		escaped = "\\\\/"
+	escaped := `\/`
+	if dialect.DriverName() == migrator.MySQL || dialect.DriverName() == migrator.Spanner {
+		escaped = `\\/`
 	}
 	concatCols := make([]string, 0, folder.MaxNestedFolderDepth)
 	concatCols = append(concatCols, fmt.Sprintf("COALESCE(REPLACE(f0.title, '/', '%s'), '')", escaped))

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -26,7 +26,7 @@ type LibraryElement struct {
 	Kind        int64
 	Type        string
 	Description string
-	Model       json.RawMessage
+	Model       json.RawMessage `xorm:"TEXT"` // Column is defined as TEXT in `library_element`.
 	Version     int64
 
 	Created time.Time


### PR DESCRIPTION
This PR fixes failures in integration tests in `github.com/grafana/grafana/pkg/services/folder/folderimpl` package when running on Spanner.

* `TestIntegrationNestedFolderService/Should_get_descendant_counts/With_nested_folder_feature_flag_on`
* `TestIntegrationNestedFolderService/Should_get_descendant_counts/With_nested_folder_feature_flag_off`
* `TestIntegrationNestedFolderService/Should_delete_folders`
* `TestIntegrationNestedFolderService/Should_delete_folders/With_nested_folder_feature_flag_on_and_force_deletion_of_rules`
* `TestIntegrationNestedFolderService/Should_delete_folders/With_nested_folder_feature_flag_on_and_no_force_deletion_of_rules`
* `TestIntegrationNestedFolderService/Should_delete_folders/With_nested_folder_feature_flag_off_and_force_deletion_of_rules`
* `TestIntegrationNestedFolderService/Should_delete_folders/With_nested_folder_feature_flag_off_and_no_force_deletion_of_rules`
* `TestIntegrationNestedFolderSharedWithMe/Should_get_org_folders_visible`
* `TestIntegrationNestedFolderSharedWithMe/Should_get_org_folders_visible/Should_get_all_org_folders_visible_to_the_user_with_fullpath`
* `TestIntegrationGet/get_folder_with_fullpath_should_set_fullpath_as_expected`
* `TestIntegrationGetFolders/get_folders_by_UIDs_with_fullpath_should_succeed`

This PR also fixes tests in `TestIntegrationDashboardDataAccess`:

* `TestIntegrationDashboardDataAccess/Should_be_able_to_delete_dashboard_and_associated_tags`
* `TestIntegrationDashboardDataAccess/Should_delete_associated_provisioning_info,_even_without_the_dashboard_existing_in_the_db`
* `TestIntegrationDashboardDataAccess/Should_be_able_to_delete_empty_folder`

