### PR TITLE
Provisioning: Use a complete storage for jobs

### DIFF
--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.23.7
+go 1.24.1
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -32,6 +32,18 @@ func NewRegistryStore(scheme *runtime.Scheme, resourceInfo utils.ResourceInfo, o
 	return store, nil
 }
 
+func NewCompleteRegistryStore(scheme *runtime.Scheme, resourceInfo utils.ResourceInfo, optsGetter generic.RESTOptionsGetter) (*registry.Store, error) {
+	registryStore, err := NewRegistryStore(scheme, resourceInfo, optsGetter)
+	if err != nil {
+		return nil, err
+	}
+	strategy := NewCompleteStrategy(scheme, resourceInfo.GroupVersion())
+	registryStore.CreateStrategy = strategy
+	registryStore.UpdateStrategy = strategy
+	registryStore.DeleteStrategy = strategy
+	return registryStore, nil
+}
+
 func NewRegistryStatusStore(scheme *runtime.Scheme, specStore *registry.Store) *StatusREST {
 	gv := specStore.New().GetObjectKind().GroupVersionKind().GroupVersion()
 	strategy := NewStatusStrategy(scheme, gv)

--- a/pkg/apiserver/registry/generic/strategy.go
+++ b/pkg/apiserver/registry/generic/strategy.go
@@ -217,31 +217,7 @@ func (g *genericCompleteStrategy) PrepareForCreate(ctx context.Context, obj runt
 	meta.SetGeneration(1)
 }
 
-func (g *genericCompleteStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
-	oldMeta, err := utils.MetaAccessor(old)
-	if err != nil {
-		return
-	}
-
-	newMeta, err := utils.MetaAccessor(obj)
-	if err != nil {
-		return
-	}
-
-	spec, err := newMeta.GetSpec()
-	if err != nil {
-		return
-	}
-
-	oldSpec, err := oldMeta.GetSpec()
-	if err != nil {
-		return
-	}
-
-	if !apiequality.Semantic.DeepEqual(spec, oldSpec) {
-		newMeta.SetGeneration(oldMeta.GetGeneration() + 1)
-	}
-}
+func (g *genericCompleteStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {}
 
 func (g *genericCompleteStrategy) AllowCreateOnUpdate() bool {
 	return true

--- a/pkg/apiserver/registry/generic/strategy.go
+++ b/pkg/apiserver/registry/generic/strategy.go
@@ -16,6 +16,8 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
+// genericStrategy allows for writing objects with spec fields.
+// It ignores status fields, and does not allow for status updates.
 type genericStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
@@ -111,6 +113,8 @@ func (g *genericStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime
 	return nil
 }
 
+// genericStatusStrategy allows for writing objects with status fields, however may not create them.
+// It ignores spec and metadata fields, and does not allow for updates outside of the status field.
 type genericStatusStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
@@ -173,6 +177,95 @@ func (g *genericStatusStrategy) ValidateUpdate(ctx context.Context, obj, old run
 
 // WarningsOnUpdate returns warnings for the given update.
 func (g *genericStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return nil
+}
+
+// genericCompleteStrategy allows for writing objects with spec and status fields.
+// It does not ignore any fields, and allows for updates to both spec and status fields.
+// This is the same as having separate stores for spec and status fields.
+//
+// This can be applied to both the root object and status subresource in a Kubernetes REST API.
+type genericCompleteStrategy struct {
+	runtime.ObjectTyper
+	names.NameGenerator
+
+	gv schema.GroupVersion
+}
+
+// NewCompleteStrategy creates a new genericCompleteStrategy.
+func NewCompleteStrategy(typer runtime.ObjectTyper, gv schema.GroupVersion) *genericCompleteStrategy {
+	return &genericCompleteStrategy{typer, names.SimpleNameGenerator, gv}
+}
+
+func (g *genericCompleteStrategy) NamespaceScoped() bool {
+	return true
+}
+
+func (g *genericCompleteStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		fieldpath.APIVersion(g.gv.String()): fieldpath.NewSet(),
+	}
+
+	return fields
+}
+
+func (g *genericCompleteStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return
+	}
+	meta.SetGeneration(1)
+}
+
+func (g *genericCompleteStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	oldMeta, err := utils.MetaAccessor(old)
+	if err != nil {
+		return
+	}
+
+	newMeta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return
+	}
+
+	spec, err := newMeta.GetSpec()
+	if err != nil {
+		return
+	}
+
+	oldSpec, err := oldMeta.GetSpec()
+	if err != nil {
+		return
+	}
+
+	if !apiequality.Semantic.DeepEqual(spec, oldSpec) {
+		newMeta.SetGeneration(oldMeta.GetGeneration() + 1)
+	}
+}
+
+func (g *genericCompleteStrategy) AllowCreateOnUpdate() bool {
+	return true
+}
+
+func (g *genericCompleteStrategy) AllowUnconditionalUpdate() bool {
+	return true
+}
+
+func (g *genericCompleteStrategy) Canonicalize(obj runtime.Object) {}
+
+func (g *genericCompleteStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
+}
+
+func (g *genericCompleteStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return nil
+}
+
+func (g *genericCompleteStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	return nil
+}
+
+func (g *genericCompleteStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	return nil
 }
 

--- a/pkg/apiserver/registry/generic/strategy_test.go
+++ b/pkg/apiserver/registry/generic/strategy_test.go
@@ -1,104 +1,465 @@
 package generic_test
 
 import (
-	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/apiserver/registry/generic"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/apis/example"
-
-	"github.com/grafana/grafana/pkg/apiserver/registry/generic"
 )
 
-func TestPrepareForUpdate(t *testing.T) {
-	ctx := context.TODO()
+func TestGenericStrategy(t *testing.T) {
+	t.Parallel()
 	gv := schema.GroupVersion{Group: "test", Version: "v1"}
-	strategy := generic.NewStrategy(runtime.NewScheme(), gv)
 
-	oldObj := &example.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test",
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: example.PodSpec{
-			NodeSelector: map[string]string{"foo": "bar"},
-		},
-		Status: example.PodStatus{
-			Phase: example.PodPhase("Running"),
-		},
-	}
+	t.Run("PrepareForUpdate", func(t *testing.T) {
+		t.Parallel()
 
-	testCases := []struct {
-		name        string
-		newObj      *example.Pod
-		oldObj      *example.Pod
-		expectedGen int64
-		expectedObj *example.Pod
-	}{
-		{
-			name: "ignore status updates",
-			newObj: &example.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test",
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: example.PodSpec{
-					NodeSelector: map[string]string{"foo": "bar"},
-				},
-				Status: example.PodStatus{
-					Phase: example.PodPhase("Stopped"),
-				},
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "default",
+				Generation: 1,
 			},
-			oldObj:      oldObj.DeepCopy(),
-			expectedGen: 2,
-			expectedObj: &example.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test",
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: example.PodSpec{
-					NodeSelector: map[string]string{"foo": "bar"},
-				},
-				Status: example.PodStatus{
-					Phase: example.PodPhase("Running"),
-				},
+			Spec: example.PodSpec{
+				NodeSelector: map[string]string{"foo": "bar"},
 			},
-		},
-	}
+			Status: example.PodStatus{
+				Phase: example.PodPhase("Running"),
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			strategy.PrepareForUpdate(ctx, tc.newObj, tc.oldObj)
-			require.Equal(t, tc.expectedObj, tc.newObj)
+		t.Run("ignores status updates", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.Status.Phase = example.PodPhase("Stopped")
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
 		})
-	}
+
+		t.Run("does not increment generation if annotations, labels, finalizers, or owner references change", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.ObjectMeta.Annotations = map[string]string{"foo": "baz"}
+			newObj.ObjectMeta.Labels = map[string]string{"foo": "baz"}
+			newObj.ObjectMeta.Finalizers = []string{"foo"}
+			newObj.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Name: "foo"}}
+
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			assert.Equal(t, map[string]string{"foo": "baz"}, newObj.ObjectMeta.Annotations)
+			assert.Equal(t, map[string]string{"foo": "baz"}, newObj.ObjectMeta.Labels)
+			assert.Equal(t, []string{"foo"}, newObj.ObjectMeta.Finalizers)
+			assert.Equal(t, []metav1.OwnerReference{{Name: "foo"}}, newObj.ObjectMeta.OwnerReferences)
+			assert.Equal(t, int64(1), newObj.Generation)
+		})
+
+		t.Run("increments generation if spec changes", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.Spec.NodeSelector = map[string]string{"foo": "baz"}
+			expectedObj := newObj.DeepCopy()
+			expectedObj.Generation = 2
+
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+	})
+
+	t.Run("PrepareForCreate", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: example.PodSpec{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			Status: example.PodStatus{
+				Phase: example.PodPhase("Running"),
+			},
+		}
+
+		t.Run("assigns generation=1", func(t *testing.T) {
+			t.Parallel()
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			obj := obj.DeepCopy()
+
+			strategy.PrepareForCreate(t.Context(), obj)
+			require.Equal(t, int64(1), obj.Generation)
+		})
+
+		t.Run("clears status", func(t *testing.T) {
+			t.Parallel()
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			obj := obj.DeepCopy()
+
+			strategy.PrepareForCreate(t.Context(), obj)
+			require.Equal(t, example.PodStatus{}, obj.Status)
+		})
+
+		t.Run("leaves spec untouched", func(t *testing.T) {
+			t.Parallel()
+			strategy := generic.NewStrategy(runtime.NewScheme(), gv)
+			obj := obj.DeepCopy()
+			originalSpec := *obj.Spec.DeepCopy()
+
+			strategy.PrepareForCreate(t.Context(), obj)
+			require.Equal(t, originalSpec, obj.Spec)
+		})
+	})
 }
 
-func TestPrepareForCreate(t *testing.T) {
-	ctx := context.TODO()
+func TestStatusStrategy(t *testing.T) {
+	t.Parallel()
 	gv := schema.GroupVersion{Group: "test", Version: "v1"}
-	strategy := generic.NewStrategy(runtime.NewScheme(), gv)
 
-	obj := &example.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Spec: example.PodSpec{
-			NodeSelector: map[string]string{"foo": "bar"},
-		},
-		Status: example.PodStatus{
-			Phase: example.PodPhase("Running"),
-		},
-	}
+	t.Run("PrepareForUpdate", func(t *testing.T) {
+		t.Parallel()
 
-	strategy.PrepareForCreate(ctx, obj)
-	require.Equal(t, int64(1), obj.Generation)
-	require.Equal(t, example.PodStatus{}, obj.Status)
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Spec: example.PodSpec{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			Status: example.PodStatus{
+				Phase: example.PodPhase("Running"),
+			},
+		}
+
+		t.Run("ignores spec updates", func(t *testing.T) {
+			// The assumption here is that the status strategy should not allow for spec updates.
+			// This is drawn due to the GetResetFields function returning `metadata` and `spec`, and due to it copying old `metadata` fields to the new object (but not spec?).
+			t.Skip("assumption does not hold -- verify with app platform if this is intended")
+
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.Spec.NodeSelector = map[string]string{"foo": "baz"}
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+
+		t.Run("ignores label updates", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.ObjectMeta.Labels = map[string]string{"foo": "baz"}
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+
+		t.Run("ignores annotation updates", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.ObjectMeta.Annotations = map[string]string{"foo": "baz"}
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+
+		t.Run("ignores finalizer updates", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.ObjectMeta.Finalizers = []string{"foo"}
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+
+		t.Run("ignores owner references updates", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Name: "foo"}}
+			expectedObj := obj.DeepCopy()
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, expectedObj, newObj)
+		})
+
+		t.Run("does not increment generation on status changes", func(t *testing.T) {
+			t.Parallel()
+			oldObj := obj.DeepCopy()
+			newObj := obj.DeepCopy()
+			newObj.Status.Phase = example.PodPhase("Stopped")
+
+			strategy := generic.NewStatusStrategy(runtime.NewScheme(), gv)
+			strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+			require.Equal(t, int64(1), newObj.Generation)
+		})
+	})
+}
+
+func TestCompleteStrategy(t *testing.T) {
+	t.Parallel()
+	gv := schema.GroupVersion{Group: "test", Version: "v1"}
+
+	t.Run("PrepareForUpdate", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Spec: example.PodSpec{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			Status: example.PodStatus{
+				Phase: example.PodPhase("Running"),
+			},
+		}
+
+		t.Run("on status updates", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("keeps the change", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.Status.Phase = example.PodPhase("Stopped")
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				require.Equal(t, example.PodPhase("Stopped"), newObj.Status.Phase)
+			})
+
+			t.Run("does not change generation", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.Status.Phase = example.PodPhase("Stopped")
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				require.Equal(t, int64(1), newObj.Generation)
+			})
+		})
+
+		t.Run("on spec updates", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("keeps the change", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.Spec.NodeSelector = map[string]string{"foo": "baz"}
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				require.Equal(t, map[string]string{"foo": "baz"}, newObj.Spec.NodeSelector)
+			})
+
+			t.Run("increments generation", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.Spec.NodeSelector = map[string]string{"foo": "baz"}
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				require.Equal(t, int64(2), newObj.Generation)
+			})
+		})
+
+		t.Run("on metadata updates", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("keeps the change", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.ObjectMeta.Annotations = map[string]string{"foo": "baz"}
+				newObj.ObjectMeta.Labels = map[string]string{"foo": "baz"}
+				newObj.ObjectMeta.Finalizers = []string{"foo"}
+				newObj.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Name: "foo"}}
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				assert.Equal(t, map[string]string{"foo": "baz"}, newObj.ObjectMeta.Annotations)
+				assert.Equal(t, map[string]string{"foo": "baz"}, newObj.ObjectMeta.Labels)
+				assert.Equal(t, []string{"foo"}, newObj.ObjectMeta.Finalizers)
+				assert.Equal(t, []metav1.OwnerReference{{Name: "foo"}}, newObj.ObjectMeta.OwnerReferences)
+			})
+
+			t.Run("does not increment generation", func(t *testing.T) {
+				t.Parallel()
+				oldObj := obj.DeepCopy()
+				newObj := obj.DeepCopy()
+				newObj.ObjectMeta.Annotations = map[string]string{"foo": "baz"}
+				newObj.ObjectMeta.Labels = map[string]string{"foo": "baz"}
+				newObj.ObjectMeta.Finalizers = []string{"foo"}
+				newObj.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Name: "foo"}}
+
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				strategy.PrepareForUpdate(t.Context(), newObj, oldObj)
+				assert.Equal(t, int64(1), newObj.Generation)
+			})
+		})
+	})
+
+	t.Run("PrepareForCreate", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: example.PodSpec{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			Status: example.PodStatus{
+				Phase: example.PodPhase("Running"),
+			},
+		}
+
+		t.Run("assigns generation=1", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("when generation is not set", func(t *testing.T) {
+				t.Parallel()
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				obj := obj.DeepCopy()
+
+				strategy.PrepareForCreate(t.Context(), obj)
+				require.Equal(t, int64(1), obj.Generation)
+			})
+
+			t.Run("when generation is set to a higher value", func(t *testing.T) {
+				t.Parallel()
+				strategy := generic.NewCompleteStrategy(runtime.NewScheme(), gv)
+				obj := obj.DeepCopy()
+				obj.Generation = 2
+
+				strategy.PrepareForCreate(t.Context(), obj)
+				require.Equal(t, int64(1), obj.Generation)
+			})
+		})
+	})
+}
+
+func TestGetAttrs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns all labels", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("when labels is nil", func(t *testing.T) {
+			t.Parallel()
+
+			obj := &example.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels:    nil,
+				},
+			}
+
+			labels, _, err := generic.GetAttrs(obj)
+			require.NoError(t, err)
+
+			require.Empty(t, labels, "expected no labels")
+		})
+
+		t.Run("when there are no labels", func(t *testing.T) {
+			t.Parallel()
+
+			obj := &example.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels:    make(map[string]string),
+				},
+			}
+
+			labels, _, err := generic.GetAttrs(obj)
+			require.NoError(t, err)
+
+			require.Empty(t, labels, "expected no labels")
+		})
+
+		t.Run("when there is only 1 label", func(t *testing.T) {
+			t.Parallel()
+
+			obj := &example.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels:    map[string]string{"foo": "bar"},
+				},
+			}
+
+			labels, _, err := generic.GetAttrs(obj)
+			require.NoError(t, err)
+
+			require.Equal(t, map[string]string{"foo": "bar"}, labels, "expected labels to match")
+		})
+
+		t.Run("when there are many labels", func(t *testing.T) {
+			t.Parallel()
+
+			obj := &example.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Labels:    map[string]string{"foo": "bar", "baz": "qux", "grafana": "is-cool"},
+				},
+			}
+
+			labels, _, err := generic.GetAttrs(obj)
+			require.NoError(t, err)
+
+			require.Equal(t, map[string]string{"foo": "bar", "baz": "qux", "grafana": "is-cool"}, labels, "expected labels to match")
+		})
+	})
+
+	t.Run("includes only name in fields", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+		}
+
+		_, f, err := generic.GetAttrs(obj)
+		require.NoError(t, err)
+
+		require.Equal(t, fields.Set{"metadata.name": "test"}, f, "expected fields to match")
+	})
 }

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -36,7 +36,7 @@ type Store interface {
 	InsertNotifications() chan struct{}
 
 	// Update saves the job back to the store.
-	UpdateStatus(ctx context.Context, job *provisioning.Job) (*provisioning.Job, error)
+	Update(ctx context.Context, job *provisioning.Job) (*provisioning.Job, error)
 }
 
 var _ Store = (*persistentStore)(nil)
@@ -200,9 +200,9 @@ func (d *jobDriver) onProgress(job *provisioning.Job) ProgressFn {
 		logging.FromContext(ctx).Debug("job progress", "status", status)
 		job.Status = status
 
-		updated, err := d.store.UpdateStatus(ctx, job)
+		updated, err := d.store.Update(ctx, job)
 		if err != nil {
-			return apifmt.Errorf("failed to update job status: %w", err)
+			return apifmt.Errorf("failed to update job: %w", err)
 		}
 
 		*job = *updated

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -25,6 +25,9 @@ type JobProgressRecorder interface {
 
 type Worker interface {
 	IsSupported(ctx context.Context, job provisioning.Job) bool
+	// Process the job. The job status should be updated as the job progresses.
+	//
+	// The job spec and metadata MUST not be modified in the storage layer while this is running. All updates go via the progress type.
 	Process(ctx context.Context, repo repository.Repository, job provisioning.Job, progress JobProgressRecorder) error
 }
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -325,19 +325,17 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	repositoryStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, repositoryStorage)
 	b.getter = repositoryStorage
 
-	realJobStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, provisioning.JobResourceInfo, opts.OptsGetter)
+	realJobStore, err := grafanaregistry.NewCompleteRegistryStore(opts.Scheme, provisioning.JobResourceInfo, opts.OptsGetter)
 	if err != nil {
 		return fmt.Errorf("failed to create job storage: %w", err)
 	}
-	realJobStatusStore := grafanaregistry.NewRegistryStatusStore(opts.Scheme, realJobStore)
 
-	historicJobStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, provisioning.HistoricJobResourceInfo, opts.OptsGetter)
+	historicJobStore, err := grafanaregistry.NewCompleteRegistryStore(opts.Scheme, provisioning.HistoricJobResourceInfo, opts.OptsGetter)
 	if err != nil {
 		return fmt.Errorf("failed to create historic job storage: %w", err)
 	}
-	historicJobStatusStore := grafanaregistry.NewRegistryStatusStore(opts.Scheme, historicJobStore)
 
-	b.jobs, err = jobs.NewStore(realJobStore, realJobStatusStore, historicJobStore, historicJobStatusStore, time.Second*30)
+	b.jobs, err = jobs.NewStore(realJobStore, historicJobStore, time.Second*30)
 	if err != nil {
 		return fmt.Errorf("failed to create job store: %w", err)
 	}

--- a/pkg/storage/unified/apistore/go.mod
+++ b/pkg/storage/unified/apistore/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/apistore
 
-go 1.23.7
+go 1.24.1
 
 replace (
 	github.com/grafana/grafana => ../../../..

--- a/pkg/storage/unified/resource/go.mod
+++ b/pkg/storage/unified/resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resource
 
-go 1.23.7
+go 1.24.1
 
 replace (
 	github.com/grafana/grafana => ../../../..


### PR DESCRIPTION
Jobs don't benefit from having separate strategies for status & spec+metadata. Instead, this allows us to create & update the entire job payloads with one storage.

The Go version of apiserver was bumped for `(*testing.T).Context() context.Context`, which was added in 1.24.