### PR TITLE
Annotations: Fix annotations scope resolver

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -600,9 +600,20 @@ func AnnotationTypeScopeResolver(annotationsRepo annotations.Repository, feature
 			Permissions: map[int64]map[string][]string{
 				orgID: {
 					dashboards.ActionDashboardsRead:     {dashboards.ScopeDashboardsAll},
-					accesscontrol.ActionAnnotationsRead: {accesscontrol.ScopeAnnotationsTypeOrganization, accesscontrol.ScopeAnnotationsAll},
+					accesscontrol.ActionAnnotationsRead: {accesscontrol.ScopeAnnotationsAll},
 				},
 			},
+		}
+
+		if features.IsEnabled(ctx, featuremgmt.FlagAnnotationPermissionUpdate) {
+			tempUser = &user.SignedInUser{
+				OrgID: orgID,
+				Permissions: map[int64]map[string][]string{
+					orgID: {
+						accesscontrol.ActionAnnotationsRead: {accesscontrol.ScopeAnnotationsTypeOrganization, dashboards.ScopeDashboardsAll},
+					},
+				},
+			}
 		}
 
 		annotation, resp := findAnnotationByID(ctx, annotationsRepo, int64(annotationId), tempUser)

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -436,8 +436,8 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 	dashSvc := &dashboards.FakeDashboardService{}
 	rootDash := &dashboards.Dashboard{ID: 1, OrgID: 1, UID: rootDashUID}
 	folderDash := &dashboards.Dashboard{ID: 2, OrgID: 1, UID: folderDashUID, FolderUID: folderUID}
-	dashSvc.On("GetDashboard", context.Background(), &dashboards.GetDashboardQuery{ID: rootDash.ID, OrgID: 1}).Return(rootDash, nil)
-	dashSvc.On("GetDashboard", context.Background(), &dashboards.GetDashboardQuery{ID: folderDash.ID, OrgID: 1}).Return(folderDash, nil)
+	dashSvc.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{ID: rootDash.ID, OrgID: 1}).Return(rootDash, nil)
+	dashSvc.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{ID: folderDash.ID, OrgID: 1}).Return(folderDash, nil)
 
 	rootDashboardAnnotation := annotations.Item{ID: 1, DashboardID: rootDash.ID}
 	folderDashboardAnnotation := annotations.Item{ID: 3, DashboardID: folderDash.ID}


### PR DESCRIPTION
**What is this feature?**
When resolving scopes for annotations we should use the service identity to make sure we can retrieve them when using unified storage


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
