### PR TITLE
Dynamic Dashboards: Improve drag and drop for responsive grid

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -151,7 +151,7 @@ export function PanelChrome({
   const panelContentId = useId();
   const panelTitleId = useId().replace(/:/g, '_');
   const { isSelected, onSelect, isSelectable } = useElementSelection(selectionId);
-  const pointerDownEvt = useRef<React.PointerEvent | undefined>();
+  const pointerDownPos = useRef<{ screenX: number; screenY: number }>({ screenX: 0, screenY: 0 });
 
   const hasHeader = !hoverHeader;
 
@@ -203,11 +203,11 @@ export function PanelChrome({
     evt.stopPropagation();
 
     const distance = Math.hypot(
-      pointerDownEvt.current?.screenX ?? 0 - evt.screenX,
-      pointerDownEvt.current?.screenY ?? 0 - evt.screenY
+      pointerDownPos.current.screenX - evt.screenX,
+      pointerDownPos.current.screenY - evt.screenY
     );
 
-    pointerDownEvt.current = undefined;
+    pointerDownPos.current = { screenX: 0, screenY: 0 };
 
     // If we are dragging some distance or clicking on elements that should cancel dragging (panel menu, etc)
     if (
@@ -222,7 +222,10 @@ export function PanelChrome({
 
   const onPointerDown = (evt: React.PointerEvent) => {
     evt.stopPropagation();
-    pointerDownEvt.current = evt;
+
+    pointerDownPos.current = { screenX: evt.screenX, screenY: evt.screenY };
+
+    onDragStart?.(evt);
   };
 
   const headerContent = (
@@ -350,11 +353,6 @@ export function PanelChrome({
           className={cx(styles.headerContainer, dragClass)}
           style={headerStyles}
           data-testid="header-container"
-          onPointerMove={() => {
-            if (pointerDownEvt.current) {
-              onDragStart?.(pointerDownEvt.current);
-            }
-          }}
           onPointerDown={onPointerDown}
           onMouseEnter={isSelectable ? onHeaderEnter : undefined}
           onMouseLeave={isSelectable ? onHeaderLeave : undefined}

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayout.tsx
@@ -26,6 +26,9 @@ export interface ResponsiveGridLayoutState extends SceneObjectState, ResponsiveG
 
   /** True when the items should be lazy loaded */
   isLazy?: boolean;
+
+  /** True when the items should be draggable */
+  isDraggable?: boolean;
 }
 
 export interface ResponsiveGridLayoutOptions {
@@ -87,7 +90,7 @@ export class ResponsiveGridLayout
   };
 
   public isDraggable(): boolean {
-    return true;
+    return this.state.isDraggable ?? false;
   }
 
   public getDragClass(): string {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutManager.tsx
@@ -5,7 +5,12 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 import { NewObjectAddedToCanvasEvent, ObjectRemovedFromCanvasEvent } from '../../edit-pane/shared';
 import { joinCloneKeys } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
-import { getGridItemKeyForPanelId, getPanelIdForVizPanel, getVizPanelKeyForPanelId } from '../../utils/utils';
+import {
+  forceRenderChildren,
+  getGridItemKeyForPanelId,
+  getPanelIdForVizPanel,
+  getVizPanelKeyForPanelId,
+} from '../../utils/utils';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
@@ -44,14 +49,6 @@ export class ResponsiveGridLayoutManager
     templateColumns: 'repeat(auto-fit, minmax(400px, auto))',
     autoRows: 'minmax(300px, auto)',
   };
-
-  public constructor(state: ResponsiveGridLayoutManagerState) {
-    super(state);
-
-    // @ts-ignore
-    this.state.layout.getDragClassCancel = () => 'drag-cancel';
-    this.state.layout.isDraggable = () => true;
-  }
 
   public addPanel(vizPanel: VizPanel) {
     const panelId = dashboardSceneGraph.getNextPanelId(this);
@@ -129,6 +126,11 @@ export class ResponsiveGridLayoutManager
     }
 
     return panels;
+  }
+
+  public editModeChanged(isEditing: boolean) {
+    this.state.layout.setState({ isDraggable: isEditing });
+    forceRenderChildren(this.state.layout, true);
   }
 
   public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
@@ -59,8 +59,9 @@ export function ResponsiveGridLayoutRenderer({ model }: SceneComponentProps<Resp
                 ? {
                     width: item.cachedBoundingBox.right - item.cachedBoundingBox.left,
                     height: item.cachedBoundingBox.bottom - item.cachedBoundingBox.top,
+                    // adjust the panel position to mouse position
                     translate: `${-layoutOrchestrator.dragOffset.left}px ${-layoutOrchestrator.dragOffset.top}px`,
-                    // --x/y-pos are set in LayoutOrchestrator
+                    // adjust the panel position on the screen
                     transform: `translate(var(--x-pos), var(--y-pos))`,
                   }
                 : {}
@@ -106,7 +107,6 @@ const getStyles = (theme: GrafanaTheme2, state: ResponsiveGridLayoutState) => ({
     position: 'relative',
     width: '100%',
     height: '100%',
-    overflow: 'hidden',
   }),
   dragging: css({
     position: 'fixed',


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/102590

This PR brings:
- `onDragStart` on `pointerDown`
- removes unnecessary `onPointerMove` method
- create the placeholder when drag starts as opposed to the first move event
- get the layouts when drag start as opposed to getting them with every mouse move
- bring the `isDraggable` property to responsive layout so we can control dragging on dashboard edit
- remove workaround for selecting responsive layout items
- fix the outline for selected items in responsive layout