### PR TITLE
Dashboard: Fixes layout switching crash

### DIFF
--- a/public/app/features/dashboard-scene/scene/layouts-shared/LayoutRestorer.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/LayoutRestorer.ts
@@ -1,4 +1,5 @@
-import { vizPanelToSchemaV2 } from '../../serialization/transformSceneToSaveModelSchemaV2';
+import { VizPanel } from '@grafana/scenes';
+
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 
 export class LayoutRestorer {
@@ -8,12 +9,10 @@ export class LayoutRestorer {
     newLayout: DashboardLayoutManager,
     currentLayout: DashboardLayoutManager
   ): DashboardLayoutManager | undefined {
-    // If we have an old version of this layout and panels are the same we can reuse it
+    //If we have an old version of this layout and panels are the same we can reuse it
     const prevLayout = this.layoutMap[newLayout.descriptor.id];
     if (prevLayout) {
-      const oldPanelSchema = prevLayout.getVizPanels().map(vizPanelToSchemaV2);
-      const newPanelSchema = newLayout.getVizPanels().map(vizPanelToSchemaV2);
-      if (JSON.stringify(oldPanelSchema) === JSON.stringify(newPanelSchema)) {
+      if (panelsAreUnchanged(prevLayout.getVizPanels(), newLayout.getVizPanels())) {
         return prevLayout;
       }
     }
@@ -22,4 +21,29 @@ export class LayoutRestorer {
 
     return newLayout;
   }
+}
+
+/**
+ * Simple check that panels are in same order and same options but not a comprehensive check
+ * Ideally we should check if persisted state is the same but not possible anymore with current serialization code that requires all panels be connected to a DashboardScene
+ */
+function panelsAreUnchanged(a: VizPanel[], b: VizPanel[]) {
+  for (let i = 0; i < a.length; i++) {
+    const ap = a[i];
+    const bp = b[i];
+
+    if (ap.state.key !== bp.state.key) {
+      return false;
+    }
+
+    if (JSON.stringify(ap.state.options) !== JSON.stringify(bp.state.options)) {
+      return false;
+    }
+
+    if (JSON.stringify(ap.state.fieldConfig) !== JSON.stringify(bp.state.fieldConfig)) {
+      return false;
+    }
+  }
+
+  return true;
 }


### PR DESCRIPTION
after https://github.com/grafana/grafana/pull/101661 was merged yesterday we can no longer get the save state of isolated VizPanels as the serialization code requires all panels be fully connected to a DashboardScene. 

To fix that looks like it requires a pretty big refactoring of the serialization code so doing a temp fix here 