### PR TITLE
Annotations fixes for Spanner

### DIFF
--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -119,8 +119,8 @@ func TestIntegrationAnnotationCleanUp(t *testing.T) {
 
 			t.Cleanup(func() {
 				err := fakeSQL.WithDbSession(context.Background(), func(session *db.Session) error {
-					_, deleteAnnotationErr := session.Exec("DELETE FROM annotation")
-					_, deleteAnnotationTagErr := session.Exec("DELETE FROM annotation_tag")
+					_, deleteAnnotationErr := session.Exec("DELETE FROM annotation WHERE true")
+					_, deleteAnnotationTagErr := session.Exec("DELETE FROM annotation_tag WHERE true")
 					return errors.Join(deleteAnnotationErr, deleteAnnotationTagErr)
 				})
 				assert.NoError(t, err)
@@ -157,7 +157,7 @@ func TestIntegrationOldAnnotationsAreDeletedFirst(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := fakeSQL.WithDbSession(context.Background(), func(session *db.Session) error {
-			_, err := session.Exec("DELETE FROM annotation")
+			_, err := session.Exec("DELETE FROM annotation WHERE true")
 			return err
 		})
 		assert.NoError(t, err)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -333,10 +333,11 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query annotations.ItemQuer
 			}
 
 			if len(tags) > 0 {
+				// "at" is a keyword in Spanner and needs to be quoted.
 				tagsSubQuery := fmt.Sprintf(`
-			SELECT SUM(1) FROM annotation_tag at
-			INNER JOIN tag on tag.id = at.tag_id
-			WHERE at.annotation_id = a.id
+			SELECT SUM(1) FROM annotation_tag `+r.db.Quote("at")+`
+			INNER JOIN tag on tag.id = `+r.db.Quote("at")+`.tag_id
+			WHERE `+r.db.Quote("at")+`.annotation_id = a.id
 				AND (
 				%s
 				)

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -628,6 +628,8 @@ func TestMain(m *testing.M) {
 	if err := testSQLStore.dialect.TruncateDBTables(testSQLStore.GetEngine()); err != nil {
 		return nil, err
 	}
+	testSQLStore.engine.ResetSequenceGenerator()
+
 	if err := testSQLStore.Reset(); err != nil {
 		return nil, err
 	}

--- a/pkg/services/sqlstore/sqlstore_testinfra.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra.go
@@ -183,6 +183,7 @@ func NewTestStore(tb TestingTB, opts ...TestOption) *SQLStore {
 			tb.Fatalf("failed to truncate DB tables after migrations: %v", err)
 			panic("unreachable")
 		}
+		testSQLStore.engine.ResetSequenceGenerator()
 	}
 
 	return store

--- a/pkg/util/xorm/sequence.go
+++ b/pkg/util/xorm/sequence.go
@@ -19,6 +19,10 @@ func newSequenceGenerator(db *sql.DB) *sequenceGenerator {
 	}
 }
 
+func (sg *sequenceGenerator) Reset() {
+	// Nothing to do. This generator always uses state from DB.
+}
+
 func (sg *sequenceGenerator) Next(ctx context.Context, table, column string) (int64, error) {
 	// Current implementation fetches new value for each Next call.
 	key := fmt.Sprintf("%s:%s", table, column)

--- a/pkg/util/xorm/sequence_inmem.go
+++ b/pkg/util/xorm/sequence_inmem.go
@@ -18,6 +18,13 @@ func newInMemSequenceGenerator() *inMemSequenceGenerator {
 	}
 }
 
+func (g *inMemSequenceGenerator) Reset() {
+	g.sequencesMu.Lock()
+	defer g.sequencesMu.Unlock()
+
+	g.nextValues = make(map[string]int)
+}
+
 func (g *inMemSequenceGenerator) Next(_ context.Context, table, column string) (int64, error) {
 	if table == "migration_log" {
 		// Don't use sequential IDs for migration log entries, as we don't clean up migration_log table between tests,

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -127,8 +127,15 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 	return engine, nil
 }
 
+func (engine *Engine) ResetSequenceGenerator() {
+	if engine.sequenceGenerator != nil {
+		engine.sequenceGenerator.Reset()
+	}
+}
+
 type SequenceGenerator interface {
 	Next(ctx context.Context, table, column string) (int64, error)
+	Reset()
 }
 
 type DialectExt interface {


### PR DESCRIPTION
Fixes for integration tests in annotationsimpl when running on Spanner:
* Fix for `DELETE` statement without `WHERE` condition
* Fix for unquoted `at` keyword, used as table alias.
* Fix for tests that expect that truncated tables reset their autoincrement sequences (done implicitly by truncating in MySQL and Postgres, and explicitly in our truncation code for sqlite)

Fixes:
* `TestIntegrationAnnotationCleanUp/default_settings_should_not_delete_any_annotations`
* `TestIntegrationAnnotationCleanUp/should_remove_annotations_created_before_cut_off_point`
* `TestIntegrationAnnotationCleanUp/should_only_keep_three_annotations`
* `TestIntegrationAnnotationCleanUp/running_the_max_count_delete_again_should_not_remove_any_annotations`
* `TestIntegrationOldAnnotationsAreDeletedFirst`
* `TestIntegrationAnnotations/Testing_annotation_create,_read,_update_and_delete/Should_not_find_one_when_tag_filter_does_not_match`
* `TestIntegrationAnnotations/Testing_annotation_create,_read,_update_and_delete/Should_find_one_when_all_tag_filters_does_match`
* `TestIntegrationAnnotations/Testing_annotation_create,_read,_update_and_delete/Should_find_two_annotations_using_partial_match`
* `TestIntegrationAnnotations/Testing_annotation_create,_read,_update_and_delete/Should_find_one_when_all_key_value_tag_filters_does_match`
* `TestIntegrationAnnotations/Testing_annotation_create,_read,_update_and_delete/Can_update_annotation_and_remove_all_tags`

