### PR TITLE
Alerting: Support JSON Content-Type in the Prometheus conversion API

### DIFF
--- a/pkg/apimachinery/errutil/errors.go
+++ b/pkg/apimachinery/errutil/errors.go
@@ -71,6 +71,17 @@ func UnprocessableEntity(msgID string, opts ...BaseOpt) Base {
 	return NewBase(StatusUnprocessableEntity, msgID, opts...)
 }
 
+// UnsupportedMediaType initializes a new [Base] error with reason StatusUnsupportedMediaType
+// that is used to construct [Error]. The msgID is passed to the caller
+// to serve as the base for user facing error messages.
+//
+// msgID should be structured as component.errorBrief, for example
+//
+//	plugin.unsupportedMediaType
+func UnsupportedMediaType(msgID string, opts ...BaseOpt) Base {
+	return NewBase(StatusUnsupportedMediaType, msgID, opts...)
+}
+
 // Conflict initializes a new [Base] error with reason StatusConflict
 // that is used to construct [Error]. The msgID is passed to the caller
 // to serve as the base for user facing error messages.

--- a/pkg/apimachinery/errutil/status.go
+++ b/pkg/apimachinery/errutil/status.go
@@ -29,6 +29,10 @@ const (
 	// contained instructions.
 	// HTTP status code 422.
 	StatusUnprocessableEntity CoreStatus = "Unprocessable Entity"
+	// StatusUnsupportedMediaType means that the server does not support
+	// the request payload's media type.
+	// HTTP status code 415.
+	StatusUnsupportedMediaType CoreStatus = CoreStatus(metav1.StatusReasonUnsupportedMediaType)
 	// StatusConflict means that the server cannot fulfill the request
 	// there is a conflict in the current state of a resource
 	// HTTP status code 409.
@@ -107,6 +111,8 @@ func (s CoreStatus) HTTPStatus() int {
 		return http.StatusGatewayTimeout
 	case StatusUnprocessableEntity:
 		return http.StatusUnprocessableEntity
+	case StatusUnsupportedMediaType:
+		return http.StatusUnsupportedMediaType
 	case StatusConflict:
 		return http.StatusConflict
 	case StatusTooManyRequests:
@@ -136,6 +142,8 @@ func (s CoreStatus) LogLevel() LogLevel {
 	case StatusNotFound:
 		return LevelInfo
 	case StatusTimeout:
+		return LevelInfo
+	case StatusUnsupportedMediaType:
 		return LevelInfo
 	case StatusUnprocessableEntity:
 		return LevelInfo


### PR DESCRIPTION
**What is this feature?**

Add support for JSON content-type request body to the Prometheus conversion API endpoints:

- `/api/convert/prometheus/config/v1/rules/{NamespaceTitle}`
- `/api/convert/api/prom/rules/{NamespaceTitle}`

**Why do we need this feature?**

Currently, the conversion API supports only POST requests with YAML content. With this PR, users can call it with JSON instead.