### PR TITLE
Prometheus: Add back @lezer/highlight to dev dependency

### DIFF
--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -47,6 +47,7 @@
     "@hello-pangea/dnd": "17.0.0",
     "@leeoniya/ufuzzy": "1.0.18",
     "@lezer/common": "1.2.3",
+    "@lezer/highlight": "1.2.1",
     "@lezer/lr": "1.4.2",
     "@prometheus-io/lezer-promql": "0.301.0",
     "@reduxjs/toolkit": "2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,7 @@ __metadata:
     "@hello-pangea/dnd": "npm:17.0.0"
     "@leeoniya/ufuzzy": "npm:1.0.18"
     "@lezer/common": "npm:1.2.3"
+    "@lezer/highlight": "npm:1.2.1"
     "@lezer/lr": "npm:1.4.2"
     "@prometheus-io/lezer-promql": "npm:0.301.0"
     "@reduxjs/toolkit": "npm:2.5.1"


### PR DESCRIPTION
[This PR](https://github.com/grafana/grafana/pull/97398/files) removed @lezer/highlight from dev dependencies. This caused the amazonprometheus datasource build to fail because @lezer/highlight is a [peer dependency of lezer-promql](https://github.com/prometheus/prometheus/blob/main/web/ui/module/lezer-promql/package.json). It makes sense to me to revert this change then, since it will cause packages using this library to error out during build. 


<img width="976" alt="Screenshot 2025-03-21 at 18 00 07" src="https://github.com/user-attachments/assets/ef5b2058-fe80-4b2e-b9d2-07de8d9dd60e" />
