### PR TITLE
Alerting: Check recording rules are enabled as well as feature toggle

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -72,6 +72,7 @@ export interface UnifiedAlertingConfig {
   alertStateHistoryBackend?: string;
   // will be undefined if implementation is not "multiple"
   alertStateHistoryPrimary?: string;
+  recordingRulesEnabled?: boolean;
 }
 
 /** Supported OAuth services

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -160,6 +160,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     minInterval: '',
     alertStateHistoryBackend: undefined,
     alertStateHistoryPrimary: undefined,
+    recordingRulesEnabled: false,
   };
   applicationInsightsConnectionString?: string;
   applicationInsightsEndpointUrl?: string;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -97,6 +97,7 @@ type FrontendSettingsUnifiedAlertingDTO struct {
 	MinInterval              string `json:"minInterval"`
 	AlertStateHistoryBackend string `json:"alertStateHistoryBackend,omitempty"`
 	AlertStateHistoryPrimary string `json:"alertStateHistoryPrimary,omitempty"`
+	RecordingRulesEnabled    bool   `json:"recordingRulesEnabled"`
 }
 
 // Enterprise-only
@@ -254,6 +255,7 @@ type FrontendSettingsDTO struct {
 	Reporting               FrontendSettingsReportingDTO       `json:"reporting"`
 	Analytics               FrontendSettingsAnalyticsDTO       `json:"analytics"`
 	UnifiedAlertingEnabled  bool                               `json:"unifiedAlertingEnabled"`
+	RecordingRulesEnabled   bool                               `json:"recordingRulesEnabled"`
 	UnifiedAlerting         FrontendSettingsUnifiedAlertingDTO `json:"unifiedAlerting"`
 	Oauth                   map[string]any                     `json:"oauth"`
 	SamlEnabled             bool                               `json:"samlEnabled"`

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -255,7 +255,6 @@ type FrontendSettingsDTO struct {
 	Reporting               FrontendSettingsReportingDTO       `json:"reporting"`
 	Analytics               FrontendSettingsAnalyticsDTO       `json:"analytics"`
 	UnifiedAlertingEnabled  bool                               `json:"unifiedAlertingEnabled"`
-	RecordingRulesEnabled   bool                               `json:"recordingRulesEnabled"`
 	UnifiedAlerting         FrontendSettingsUnifiedAlertingDTO `json:"unifiedAlerting"`
 	Oauth                   map[string]any                     `json:"oauth"`
 	SamlEnabled             bool                               `json:"samlEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -337,6 +337,8 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		frontendSettings.UnifiedAlerting.AlertStateHistoryPrimary = hs.Cfg.UnifiedAlerting.StateHistory.MultiPrimary
 	}
 
+	frontendSettings.UnifiedAlerting.RecordingRulesEnabled = hs.Cfg.UnifiedAlerting.RecordingRules.Enabled
+
 	if hs.Cfg.UnifiedAlerting.Enabled != nil {
 		frontendSettings.UnifiedAlertingEnabled = *hs.Cfg.UnifiedAlerting.Enabled
 	}

--- a/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
@@ -57,7 +57,8 @@ export const GrafanaRules = ({ namespaces, expandAll }: Props) => {
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
   const hasGrafanaAlerts = namespaces.length > 0;
 
-  const grafanaRecordingRulesEnabled = config.featureToggles.grafanaManagedRecordingRules;
+  const grafanaRecordingRulesEnabled =
+    config.featureToggles.grafanaManagedRecordingRules && config.unifiedAlerting.recordingRulesEnabled;
 
   return (
     <section className={styles.wrapper}>

--- a/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Button, LinkButton, LoadingPlaceholder, Pagination, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { Trans, t } from 'app/core/internationalization';
@@ -10,6 +9,7 @@ import { CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { LogMessages, logInfo } from '../../Analytics';
+import { useGrafanaManagedRecordingRulesSupport } from '../../featureToggles';
 import { AlertingAction, useAlertingAbility } from '../../hooks/useAbilities';
 import { flattenGrafanaManagedRules } from '../../hooks/useCombinedRuleNamespaces';
 import { usePagination } from '../../hooks/usePagination';
@@ -57,8 +57,7 @@ export const GrafanaRules = ({ namespaces, expandAll }: Props) => {
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
   const hasGrafanaAlerts = namespaces.length > 0;
 
-  const grafanaRecordingRulesEnabled =
-    config.featureToggles.grafanaManagedRecordingRules && config.unifiedAlerting.recordingRulesEnabled;
+  const grafanaRecordingRulesEnabled = useGrafanaManagedRecordingRulesSupport();
 
   return (
     <section className={styles.wrapper}>

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -6,7 +6,8 @@ import { useRulesAccess } from '../../utils/accessControlHooks';
 
 const RecordingRulesButtons = () => {
   const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
-  const grafanaRecordingRulesEnabled = config.featureToggles.grafanaManagedRecordingRules;
+  const grafanaRecordingRulesEnabled =
+    config.featureToggles.grafanaManagedRecordingRules && config.unifiedAlerting.recordingRulesEnabled;
   const canCreateAll = canCreateGrafanaRules && canCreateCloudRules && grafanaRecordingRulesEnabled;
 
   // User can create Grafana and DS-managed recording rules, show a dropdown

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -1,13 +1,12 @@
-import { config } from '@grafana/runtime';
 import { Dropdown, EmptyState, LinkButton, Menu, MenuItem, Stack, TextLink } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
+import { useGrafanaManagedRecordingRulesSupport } from '../../featureToggles';
 import { useRulesAccess } from '../../utils/accessControlHooks';
 
 const RecordingRulesButtons = () => {
   const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
-  const grafanaRecordingRulesEnabled =
-    config.featureToggles.grafanaManagedRecordingRules && config.unifiedAlerting.recordingRulesEnabled;
+  const grafanaRecordingRulesEnabled = useGrafanaManagedRecordingRulesSupport();
   const canCreateAll = canCreateGrafanaRules && canCreateCloudRules && grafanaRecordingRulesEnabled;
 
   // User can create Grafana and DS-managed recording rules, show a dropdown

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -1,3 +1,6 @@
 import { config } from '@grafana/runtime';
 
 export const shouldUsePrometheusRulesPrimary = () => config.featureToggles.alertingPrometheusRulesPrimary ?? false;
+
+export const useGrafanaManagedRecordingRulesSupport = () =>
+  config.unifiedAlerting.recordingRulesEnabled && config.featureToggles.grafanaManagedRecordingRules;


### PR DESCRIPTION
**What is this feature?**
Checks the `[recording_rules].enabled` setting as well as the feature flag when deciding whether GM recording rules are enabled.

**Why do we need this feature?**
In Cloud, the recording rules enablement flag is dependent on some prometheus config being valid. If there's an error with that datasource, then recording rules are marked as disabled. The UI was only checking for the feature toggle, and not the config value as well

**Who is this feature for?**
Alerting recording rule users