### PR TITLE
alerting docs: add note about alert rule versions limit

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -61,6 +61,8 @@ For details on how rule states and alert instance states are displayed, refer to
 
 ## View, compare and restore alert rules versions.
 
+You can view, compare, and restore previous alert rule versions. The number of alert rule versions is limited to a maximum of 10 alert rule versions for free users, and a maximum of 100 stored alert rule versions for paid tier users.
+
 To view or restore previous versions for an alert rule, complete the following steps.
 
 1. Navigate to **Alerts & IRM -> Alerting -> Alert rules**.


### PR DESCRIPTION
added note about alert rule versions limit

**What is this feature?**

an additional note about alert rule versions limit.

**Which issue(s) does this PR RELATE TO?**:

https://github.com/grafana/grafana/pull/102484

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
