### PR TITLE
Dashboard versions: disable show more when last page

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -108,6 +108,45 @@ describe('VersionsEditView', () => {
 
       expect(versionsView.state.isNewLatest).toBe(true);
     });
+
+    it('should correctly identify last page when partial page is returned without version 1', async () => {
+      jest.mocked(historySrv.getHistoryList).mockResolvedValueOnce({
+        continueToken: '',
+        versions: [
+          {
+            id: 4,
+            dashboardId: 1,
+            dashboardUID: '_U4zObQMz',
+            parentVersion: 3,
+            restoredFrom: 0,
+            version: 4,
+            created: '2017-02-22T17:43:01-08:00',
+            createdBy: 'admin',
+            message: '',
+            checked: false,
+          },
+          {
+            id: 3,
+            dashboardId: 1,
+            dashboardUID: '_U4zObQMz',
+            parentVersion: 1,
+            restoredFrom: 1,
+            version: 3,
+            created: '2017-02-22T17:43:01-08:00',
+            createdBy: 'admin',
+            message: '',
+            checked: false,
+          },
+        ],
+      });
+
+      versionsView.reset();
+      versionsView.fetchVersions();
+      await new Promise(process.nextTick);
+
+      expect(versionsView.versions.length).toBeLessThan(VERSIONS_FETCH_LIMIT);
+      expect(versionsView.versions.find((rev) => rev.version === 1)).toBeUndefined();
+    });
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -1,4 +1,5 @@
 import { SceneTimeRange } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { activateFullSceneTree } from '../utils/test-utils';
@@ -146,6 +147,53 @@ describe('VersionsEditView', () => {
 
       expect(versionsView.versions.length).toBeLessThan(VERSIONS_FETCH_LIMIT);
       expect(versionsView.versions.find((rev) => rev.version === 1)).toBeUndefined();
+    });
+
+    it('should correctly identify last page when kubernetesClientDashboardsFolders is enabled and continueToken is empty', async () => {
+      // @ts-ignore
+      config.featureToggles.kubernetesClientDashboardsFolders = true;
+
+      jest.mocked(historySrv.getHistoryList).mockResolvedValueOnce({
+        continueToken: '',
+        versions: [
+          {
+            id: 4,
+            dashboardId: 1,
+            dashboardUID: '_U4zObQMz',
+            parentVersion: 3,
+            restoredFrom: 0,
+            version: 4,
+            created: '2017-02-22T17:43:01-08:00',
+            createdBy: 'admin',
+            message: '',
+            checked: false,
+          },
+          {
+            id: 3,
+            dashboardId: 1,
+            dashboardUID: '_U4zObQMz',
+            parentVersion: 1,
+            restoredFrom: 1,
+            version: 3,
+            created: '2017-02-22T17:43:01-08:00',
+            createdBy: 'admin',
+            message: '',
+            checked: false,
+          },
+        ],
+      });
+
+      versionsView.reset();
+      versionsView.fetchVersions();
+      await new Promise(process.nextTick);
+
+      expect(versionsView.versions.length).toBeLessThan(VERSIONS_FETCH_LIMIT);
+      expect(versionsView.versions.find((rev) => rev.version === 1)).toBeUndefined();
+      expect(versionsView.continueToken).toBe('');
+
+      // reset feature flag
+      // @ts-ignore
+      config.featureToggles.kubernetesClientDashboardsFolders = false;
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -202,7 +202,8 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const canCompare = model.versions.filter((version) => version.checked).length === 2;
   const showButtons = model.versions.length > 1;
   const hasMore = model.versions.length >= model.limit;
-  const isLastPage = model.versions.find((rev) => rev.version === 1);
+  // older versions may have been cleaned up in the db, so also check if the last page is less than the limit, if so, we are at the end
+  const isLastPage = model.versions.find((rev) => rev.version === 1) || model.versions.length % model.limit !== 0;
 
   const viewModeCompare = (
     <>

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -83,6 +83,10 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     return this._start;
   }
 
+  public get continueToken(): string {
+    return this._continueToken;
+  }
+
   public getUrlKey(): string {
     return 'versions';
   }
@@ -203,7 +207,10 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const showButtons = model.versions.length > 1;
   const hasMore = model.versions.length >= model.limit;
   // older versions may have been cleaned up in the db, so also check if the last page is less than the limit, if so, we are at the end
-  const isLastPage = model.versions.find((rev) => rev.version === 1) || model.versions.length % model.limit !== 0;
+  let isLastPage = model.versions.find((rev) => rev.version === 1) || model.versions.length % model.limit !== 0;
+  if (config.featureToggles.kubernetesClientDashboardsFolders) {
+    isLastPage = isLastPage || model.continueToken === '';
+  }
 
   const viewModeCompare = (
     <>

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -1,8 +1,8 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
-import { config } from '@grafana/runtime';
 
+import { config } from '@grafana/runtime';
 import { historySrv } from 'app/features/dashboard-scene/settings/version-history/HistorySrv';
 
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
@@ -57,8 +57,7 @@ describe('VersionSettings', () => {
   });
 
   test('renders a header and a loading indicator followed by results in a table', async () => {
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValue(versions);
+    historySrv.getHistoryList = jest.fn().mockResolvedValue(versions);
     setup();
 
     expect(screen.getByRole('heading', { name: /versions/i })).toBeInTheDocument();
@@ -76,8 +75,7 @@ describe('VersionSettings', () => {
   });
 
   test('does not render buttons if versions === 1', async () => {
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValue({
+    historySrv.getHistoryList = jest.fn().mockResolvedValue({
       continueToken: versions.continueToken,
       versions: versions.versions.slice(0, 1),
     });
@@ -94,8 +92,7 @@ describe('VersionSettings', () => {
   });
 
   test('does not render show more button if versions < VERSIONS_FETCH_LIMIT', async () => {
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValue({
+    historySrv.getHistoryList = jest.fn().mockResolvedValue({
       continueToken: versions.continueToken,
       versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT - 5),
     });
@@ -112,8 +109,7 @@ describe('VersionSettings', () => {
   });
 
   test('renders buttons if versions >= VERSIONS_FETCH_LIMIT', async () => {
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValue({
+    historySrv.getHistoryList = jest.fn().mockResolvedValue({
       continueToken: versions.continueToken,
       versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT),
     });
@@ -135,8 +131,8 @@ describe('VersionSettings', () => {
   });
 
   test('clicking show more appends results to the table', async () => {
-    historySrv.getHistoryList
-      // @ts-ignore
+    historySrv.getHistoryList = jest
+      .fn()
       .mockImplementationOnce(() =>
         Promise.resolve({
           continueToken: versions.continueToken,
@@ -173,8 +169,7 @@ describe('VersionSettings', () => {
 
   test('does not show more button when receiving partial page without version 1', async () => {
     // Mock a partial page response (less than VERSIONS_FETCH_LIMIT)
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValueOnce({
+    historySrv.getHistoryList = jest.fn().mockResolvedValueOnce({
       continueToken: '',
       versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT - 5),
     });
@@ -190,10 +185,8 @@ describe('VersionSettings', () => {
   });
 
   test('does not show more button when kubernetesClientDashboardsFolders is enabled and continueToken is empty', async () => {
-    // @ts-ignore
     config.featureToggles.kubernetesClientDashboardsFolders = true;
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValueOnce({
+    historySrv.getHistoryList = jest.fn().mockResolvedValueOnce({
       continueToken: '',
       versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT - 1),
     });
@@ -205,18 +198,16 @@ describe('VersionSettings', () => {
     expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
 
-    // @ts-ignore
     config.featureToggles.kubernetesClientDashboardsFolders = false;
   });
 
   test('selecting two versions and clicking compare button should render compare view', async () => {
-    // @ts-ignore
-    historySrv.getHistoryList.mockResolvedValue({
+    historySrv.getHistoryList = jest.fn().mockResolvedValue({
       continueToken: versions.continueToken,
       versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT),
     });
-    historySrv.getDashboardVersion
-      // @ts-ignore
+    historySrv.getDashboardVersion = jest
+      .fn()
       .mockImplementationOnce(() => Promise.resolve(diffs.lhs))
       .mockImplementationOnce(() => Promise.resolve(diffs.rhs));
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
+import { config } from '@grafana/runtime';
 
 import { historySrv } from 'app/features/dashboard-scene/settings/version-history/HistorySrv';
 
@@ -186,6 +187,26 @@ describe('VersionSettings', () => {
     expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
     // Verify that compare button is still present
     expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+  });
+
+  test('does not show more button when kubernetesClientDashboardsFolders is enabled and continueToken is empty', async () => {
+    // @ts-ignore
+    config.featureToggles.kubernetesClientDashboardsFolders = true;
+    // @ts-ignore
+    historySrv.getHistoryList.mockResolvedValueOnce({
+      continueToken: '',
+      versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT - 1),
+    });
+
+    setup();
+
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+
+    // @ts-ignore
+    config.featureToggles.kubernetesClientDashboardsFolders = false;
   });
 
   test('selecting two versions and clicking compare button should render compare view', async () => {

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -170,6 +170,24 @@ describe('VersionSettings', () => {
     });
   });
 
+  test('does not show more button when receiving partial page without version 1', async () => {
+    // Mock a partial page response (less than VERSIONS_FETCH_LIMIT)
+    // @ts-ignore
+    historySrv.getHistoryList.mockResolvedValueOnce({
+      continueToken: '',
+      versions: versions.versions.slice(0, VERSIONS_FETCH_LIMIT - 5),
+    });
+
+    setup();
+
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+    // Verify that show more button is not present since we got a partial page
+    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
+    // Verify that compare button is still present
+    expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+  });
+
   test('selecting two versions and clicking compare button should render compare view', async () => {
     // @ts-ignore
     historySrv.getHistoryList.mockResolvedValue({

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -125,6 +125,13 @@ export class VersionsSettings extends PureComponent<Props, State> {
     }));
 
   isLastPage() {
+    if (config.featureToggles.kubernetesClientDashboardsFolders) {
+      return (
+        this.state.versions.find((rev) => rev.version === 1) ||
+        this.state.versions.length % this.limit !== 0 ||
+        this.continueToken === ''
+      );
+    }
     return this.state.versions.find((rev) => rev.version === 1) || this.state.versions.length % this.limit !== 0;
   }
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -125,7 +125,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
     }));
 
   isLastPage() {
-    return this.state.versions.find((rev) => rev.version === 1);
+    return this.state.versions.find((rev) => rev.version === 1) || this.state.versions.length % this.limit !== 0;
   }
 
   onCheck = (ev: React.FormEvent<HTMLInputElement>, versionId: number) => {


### PR DESCRIPTION
**What is this feature?**

Currently, on the dashboard history page, it will have the "show more" button enable, even when there are no more dashboard versions (due to a dashboard version cleanup), which leads to an error:

![Screenshot 2025-03-21 at 2 48 20 PM](https://github.com/user-attachments/assets/ddb2352a-9635-44f8-91fe-71efe54bf43d)

This PR adds two checks to the isLastPage function - to try to prevent this from happening as often. Unfortunately in the non-k8s flow I couldn't find a perfect way to do this, for that, it checks if the last page returned was < the limit by taking the total amount of versions we have gotten vs the limit. If so, it's the last page.

In the k8s flow, we have the continue token, so we can check if that is empty and know to stop.

Ends up looking like this:
![Screenshot 2025-03-21 at 2 53 44 PM](https://github.com/user-attachments/assets/e219dc60-cb3f-4bbe-9619-bcac14f17ae1)

**Why do we need this feature?**

If version cleanup is done in the database, we may not have a dashboard version equal to 1.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/255
