### PR TITLE
K8s: Fix legacy dashboard folder check

### DIFF
--- a/pkg/registry/apis/dashboard/legacy_storage.go
+++ b/pkg/registry/apis/dashboard/legacy_storage.go
@@ -39,6 +39,10 @@ func (s *DashboardStorage) NewStore(dash utils.ResourceInfo, scheme *runtime.Sch
 	optsGetter := apistore.NewRESTOptionsGetterForClient(client,
 		defaultOpts.StorageConfig.Config,
 	)
+	optsGetter.RegisterOptions(dash.GroupResource(), apistore.StorageOptions{
+		EnableFolderSupport:         true,
+		RequireDeprecatedInternalID: true,
+	})
 
 	store, err := grafanaregistry.NewRegistryStore(scheme, dash, optsGetter)
 	return &storeWrapper{


### PR DESCRIPTION
**What is this feature?**

This PR fixes creating dashboards inside of a folder in modes 0-2.

With the [addition](https://github.com/grafana/grafana/pull/102260 ) of the check of only having the folder annotations set if the storage opts say it is okay (i.e. only allowing folder & dashboards to be inside a folder), we need to also allow it in legacy storage fallback