### PR TITLE
Combobox: Refactor sortByGroup for performance

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-import { useOptions } from './useOptions';
+import { sortByGroup, useOptions } from './useOptions';
 
 describe('useOptions', () => {
   it('should handle a large number of synchronous options without throwing an error', () => {
@@ -99,5 +99,59 @@ describe('useOptions', () => {
 
     expect(result.current.asyncLoading).toBe(false);
     expect(result.current.asyncError).toBe(true);
+  });
+});
+
+describe('sortByGroup', () => {
+  it('should return original array when no groups exist', () => {
+    const options = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Banana', value: 'banana' },
+      { label: 'Carrot', value: 'carrot' },
+    ];
+
+    const { options: sortedOptions, groupStartIndices } = sortByGroup(options);
+
+    expect(sortedOptions).toBe(options); // Check reference equality
+    expect(groupStartIndices.size).toBe(1);
+    expect(groupStartIndices.get(undefined)).toBe(0);
+  });
+
+  it('should return original array when only one group exists', () => {
+    const options = [
+      { label: 'Apple', value: 'apple', group: 'fruits' },
+      { label: 'Banana', value: 'banana', group: 'fruits' },
+      { label: 'Tomato', value: 'tomato', group: 'fruits' },
+    ];
+
+    const { options: sortedOptions, groupStartIndices } = sortByGroup(options);
+
+    expect(sortedOptions).toEqual(options);
+    expect(groupStartIndices.size).toBe(1);
+    expect(groupStartIndices.get('fruits')).toBe(0);
+  });
+
+  it('should group options and track group start indices', () => {
+    const options = [
+      { label: 'Apple', value: 'apple', group: 'fruits' },
+      { label: 'Carrot', value: 'carrot', group: 'vegetables' },
+      { label: 'Banana', value: 'banana', group: 'fruits' },
+      { label: 'Celery', value: 'celery', group: 'vegetables' },
+      { label: 'Other', value: 'other' }, // Ungrouped
+    ];
+
+    const { options: sortedOptions, groupStartIndices } = sortByGroup(options);
+
+    expect(sortedOptions).toEqual([
+      { label: 'Apple', value: 'apple', group: 'fruits' },
+      { label: 'Banana', value: 'banana', group: 'fruits' },
+      { label: 'Carrot', value: 'carrot', group: 'vegetables' },
+      { label: 'Celery', value: 'celery', group: 'vegetables' },
+      { label: 'Other', value: 'other' },
+    ]);
+
+    expect(groupStartIndices.get('fruits')).toBe(0);
+    expect(groupStartIndices.get('vegetables')).toBe(2);
+    expect(groupStartIndices.get('undefined')).toBe(4);
   });
 });

--- a/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.test.ts
@@ -113,8 +113,7 @@ describe('sortByGroup', () => {
     const { options: sortedOptions, groupStartIndices } = sortByGroup(options);
 
     expect(sortedOptions).toBe(options); // Check reference equality
-    expect(groupStartIndices.size).toBe(1);
-    expect(groupStartIndices.get(undefined)).toBe(0);
+    expect(groupStartIndices.size).toBe(0);
   });
 
   it('should return original array when only one group exists', () => {
@@ -150,8 +149,8 @@ describe('sortByGroup', () => {
       { label: 'Other', value: 'other' },
     ]);
 
+    expect(groupStartIndices.size).toBe(2);
     expect(groupStartIndices.get('fruits')).toBe(0);
     expect(groupStartIndices.get('vegetables')).toBe(2);
-    expect(groupStartIndices.get('undefined')).toBe(4);
   });
 });

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -115,10 +115,12 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
   return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError };
 }
 
+/**
+ * Sorts options by group and returns the sorted options and the starting index of each group
+ */
 export function sortByGroup<T extends string | number>(options: Array<ComboboxOption<T>>) {
   // Group options by their group
   const groupedOptions = new Map<string | undefined, Array<ComboboxOption<T>>>();
-
   const groupStartIndices = new Map<string | undefined, number>();
 
   for (const option of options) {
@@ -133,7 +135,10 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
 
   // If we only have one group (either the undefined group, or a single group), return the original array
   if (groupedOptions.size <= 1) {
-    groupStartIndices.set(options[0]?.group, 0);
+    if (options[0]?.group) {
+      groupStartIndices.set(options[0]?.group, 0);
+    }
+
     return {
       options,
       groupStartIndices,
@@ -142,6 +147,7 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
 
   // 'Preallocate' result array with same size as input - very minor optimization
   const result: Array<ComboboxOption<T>> = new Array(options.length);
+
   let currentIndex = 0;
 
   // Fill result array with grouped options
@@ -157,7 +163,6 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
   // Add ungrouped options at the end
   const ungrouped = groupedOptions.get(undefined);
   if (ungrouped) {
-    groupStartIndices.set('undefined', currentIndex);
     for (const option of ungrouped) {
       result[currentIndex++] = option;
     }

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -115,41 +115,56 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
   return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError };
 }
 
-function sortByGroup<T extends string | number>(options: Array<ComboboxOption<T>>) {
+export function sortByGroup<T extends string | number>(options: Array<ComboboxOption<T>>) {
+  // Group options by their group
   const groupedOptions = new Map<string | undefined, Array<ComboboxOption<T>>>();
+
+  const groupStartIndices = new Map<string | undefined, number>();
+
   for (const option of options) {
-    const groupExists = groupedOptions.has(option.group);
-    if (groupExists) {
-      groupedOptions.get(option.group)?.push(option);
+    const group = option.group;
+    const existing = groupedOptions.get(group);
+    if (existing) {
+      existing.push(option);
     } else {
-      groupedOptions.set(option.group, [option]);
+      groupedOptions.set(group, [option]);
     }
   }
 
-  // Create a map to track the starting index of each group
-  const groupStartIndices = new Map<string, number>();
+  // If we only have one group (either the undefined group, or a single group), return the original array
+  if (groupedOptions.size <= 1) {
+    groupStartIndices.set(options[0]?.group, 0);
+    return {
+      options,
+      groupStartIndices,
+    };
+  }
+
+  // 'Preallocate' result array with same size as input - very minor optimization
+  const result: Array<ComboboxOption<T>> = new Array(options.length);
   let currentIndex = 0;
 
-  // Reorganize options to have groups first, then undefined group
-  let reorganizeOptions: Array<ComboboxOption<T>> = [];
+  // Fill result array with grouped options
   for (const [group, groupOptions] of groupedOptions) {
-    if (!group) {
-      continue;
+    if (group) {
+      groupStartIndices.set(group, currentIndex);
+      for (const option of groupOptions) {
+        result[currentIndex++] = option;
+      }
     }
-
-    groupStartIndices.set(group, currentIndex);
-    reorganizeOptions = reorganizeOptions.concat(groupOptions);
-    currentIndex += groupOptions.length;
   }
 
-  const undefinedGroupOptions = groupedOptions.get(undefined);
-  if (undefinedGroupOptions) {
+  // Add ungrouped options at the end
+  const ungrouped = groupedOptions.get(undefined);
+  if (ungrouped) {
     groupStartIndices.set('undefined', currentIndex);
-    reorganizeOptions = reorganizeOptions.concat(undefinedGroupOptions);
+    for (const option of ungrouped) {
+      result[currentIndex++] = option;
+    }
   }
 
   return {
-    options: reorganizeOptions,
+    options: result,
     groupStartIndices,
   };
 }


### PR DESCRIPTION
Following up from https://github.com/grafana/grafana/pull/102452, this PR introduces a few optimisations for the sortByGroup function in Combobox. Based on some not-very-rigorous benchmarking, this is about 10-20% faster depending on browser https://jsbench.me/u0m8k7p12m/1. 

Summary of changes:

 - bails out early if there's no groups (or all items are the same single)
 - creates the results array with the final size - really a micro optimisation that I don't think does a lot, but improves consistency
 - loops over items in the group and sets them in the results array, rather than allocating new arrays all the time with `arr = arr.concat(arr)`

I did investigate a different strategy where you loop over options just once, push them into the array, and then keep a map of the 'tail' indexes for the groups for where new items are inserted into the array at, but this ended up being overwhelmingly a terrible idea due to having to shift items down each item something is inserted into the middle of the array.