### PR TITLE
Dashboards: Prevent version restore to same data

### DIFF
--- a/docs/sources/developers/http_api/dashboard_versions.md
+++ b/docs/sources/developers/http_api/dashboard_versions.md
@@ -216,6 +216,7 @@ JSON response body schema:
 Status codes:
 
 - **200** - OK
+- **400** - Bad request (specified version has the same content as the current dashboard)
 - **401** - Unauthorized
 - **404** - Not found (dashboard not found or dashboard version not found)
 - **500** - Internal server error (indicates issue retrieving dashboard tags from database)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -591,6 +591,38 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			{
 				DashboardID: 2,
 				Version:     1,
+				Data: simplejson.NewFromAny(map[string]any{
+					"title": "Dash1",
+				}),
+			},
+		}
+		mockSQLStore := dbtest.NewFakeDB()
+
+		restoreDashboardVersionScenario(t, "When calling POST on", "/api/dashboards/id/1/restore",
+			"/api/dashboards/id/:dashboardId/restore", dashboardService, fakeDashboardVersionService, cmd, func(sc *scenarioContext) {
+				sc.dashboardVersionService = fakeDashboardVersionService
+
+				callRestoreDashboardVersion(sc)
+				assert.Equal(t, http.StatusOK, sc.resp.Code)
+			}, mockSQLStore)
+	})
+
+	t.Run("Should not be able to restore to the same data", func(t *testing.T) {
+		fakeDash := dashboards.NewDashboard("Child dash")
+		fakeDash.ID = 2
+		fakeDash.HasACL = false
+
+		dashboardService := dashboards.NewFakeDashboardService(t)
+		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(fakeDash, nil)
+
+		cmd := dtos.RestoreDashboardVersionCommand{
+			Version: 1,
+		}
+		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
+		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersionDTO{
+			{
+				DashboardID: 2,
+				Version:     1,
 				Data:        fakeDash.Data,
 			},
 		}
@@ -600,6 +632,42 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			"/api/dashboards/id/:dashboardId/restore", dashboardService, fakeDashboardVersionService, cmd, func(sc *scenarioContext) {
 				sc.dashboardVersionService = fakeDashboardVersionService
 
+				callRestoreDashboardVersion(sc)
+				assert.Equal(t, http.StatusBadRequest, sc.resp.Code)
+			}, mockSQLStore)
+	})
+
+	t.Run("Given dashboard in general folder being restored should restore to general folder", func(t *testing.T) {
+		fakeDash := dashboards.NewDashboard("Child dash")
+		fakeDash.ID = 2
+		fakeDash.HasACL = false
+
+		dashboardService := dashboards.NewFakeDashboardService(t)
+		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(fakeDash, nil)
+		dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).Run(func(args mock.Arguments) {
+			cmd := args.Get(1).(*dashboards.SaveDashboardDTO)
+			cmd.Dashboard = &dashboards.Dashboard{
+				ID: 2, UID: "uid", Title: "Dash", Slug: "dash", Version: 1,
+			}
+		}).Return(nil, nil)
+
+		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
+		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersionDTO{
+			{
+				DashboardID: 2,
+				Version:     1,
+				Data: simplejson.NewFromAny(map[string]any{
+					"title": "Dash1",
+				}),
+			},
+		}
+
+		cmd := dtos.RestoreDashboardVersionCommand{
+			Version: 1,
+		}
+		mockSQLStore := dbtest.NewFakeDB()
+		restoreDashboardVersionScenario(t, "When calling POST on", "/api/dashboards/id/1/restore",
+			"/api/dashboards/id/:dashboardId/restore", dashboardService, fakeDashboardVersionService, cmd, func(sc *scenarioContext) {
 				callRestoreDashboardVersion(sc)
 				assert.Equal(t, http.StatusOK, sc.resp.Code)
 			}, mockSQLStore)
@@ -624,7 +692,9 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			{
 				DashboardID: 2,
 				Version:     1,
-				Data:        fakeDash.Data,
+				Data: simplejson.NewFromAny(map[string]any{
+					"title": "Dash1",
+				}),
 			},
 		}
 


### PR DESCRIPTION
**What is this feature?**

This PR adds a check in the restore from version endpoint that a user cannot restore to a dashboard that is exactly the same as the current dashboard.

For example,

`/api/dashboards/uid/:uid/restore` with the data `{"version": 1}`

can now only be called once, not twice in a row.

**Why do we need this feature?**

In the k8s flow, we use the generation id as the dashboard version in the version table. However, the generation id is [only incremented when there is an actual change in the spec](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/apistore/prepare.go#L159), this is a requirement for controllers to be able to know when they need to preform actions.

Without this change, you can restore to the same version over and over again, and then in mode3+ (when we start using generation ids), the dashboard version looks like:
<img width="966" alt="Screenshot 2025-03-22 at 9 44 17 AM" src="https://github.com/user-attachments/assets/b96cc670-75db-4b5c-8dca-d80c87ddfd32" />

We cannot just use the version inside of the spec for this table, as that will be removed for schema v2.


Now, it'll look like:
https://github.com/user-attachments/assets/450f3507-d1ab-4752-855e-ea0f37770b07

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/254