### PR TITLE
Remove dependency from OSS to enterprise packages by moving Spanner functions to xorm.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -554,12 +554,12 @@ require (
 )
 
 require (
+	github.com/1NCE-GmbH/grpc-go-pool v0.0.0-20231117122434-2a5bb974daa2 // @grafana/grafana-search-and-storage
 	github.com/open-feature/go-sdk v1.14.1 // @grafana/grafana-backend-group
 	github.com/open-feature/go-sdk-contrib/providers/go-feature-flag v0.2.3 // @grafana/grafana-backend-group
 )
 
 require (
-	github.com/1NCE-GmbH/grpc-go-pool v0.0.0-20231117122434-2a5bb974daa2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.49.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.49.0 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect

--- a/pkg/services/sqlstore/migrator/spanner_dialect.go
+++ b/pkg/services/sqlstore/migrator/spanner_dialect.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"xorm.io/core"
 
-	spannerext "github.com/grafana/grafana/pkg/extensions/spanner"
 	"xorm.io/xorm"
 
 	_ "embed"
@@ -291,7 +290,7 @@ func (s *SpannerDialect) executeDDLStatements(ctx context.Context, engine *xorm.
 		return err
 	}
 
-	opts := spannerext.SpannerConnectorConfigToClientOptions(cfg)
+	opts := xorm.SpannerConnectorConfigToClientOptions(cfg)
 
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx, opts...)
 	if err != nil {

--- a/pkg/util/xorm/go.mod
+++ b/pkg/util/xorm/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/googleapis/go-sql-spanner v1.11.1
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.10.0
+	google.golang.org/api v0.220.0
+	google.golang.org/grpc v1.70.0
 	xorm.io/builder v0.3.6
 	xorm.io/core v0.7.3
 )
@@ -55,11 +57,9 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
-	google.golang.org/api v0.220.0 // indirect
 	google.golang.org/genproto v0.0.0-20250122153221-138b5a5a4fd4 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250204164813-702378808489 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250207221924-e9438ea467c6 // indirect
-	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
This PR removes dependency from `github.com/grafana/grafana/pkg/services/sqlstore/migrator` package to `github.com/grafana/grafana/pkg/extensions/spanner`, by copying two functions back to OSS repository (into `util/xorm` package, which `migrator` already depends on).

Fixes problem introduced in https://github.com/grafana/grafana/pull/102522