### PR TITLE
TraceView: Fix links menu position

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
@@ -61,8 +61,8 @@ export const SpanLinksMenu = ({ links, datasourceType, color }: SpanLinksProps) 
         onClick={(e) => {
           setIsMenuOpen(true);
           setMenuPosition({
-            x: e.pageX,
-            y: e.pageY,
+            x: e.clientX,
+            y: e.clientY,
           });
         }}
         className={styles.button}


### PR DESCRIPTION
Fixes #99972

Steps to reproduce/test:
- Create a data source with multiple links (you can replicate settings from this branch https://github.com/grafana/grafana/pull/101881)
- Create a dashboard with a Trace View
- Add more panels above and below Trace View panel so the scroll appears
- Scroll the dashboard down
- Open the context menu with links

The menu should show up in the correct place with the fix.