### PR TITLE
SCIM: Add a distinctive label for externally provisioned users

### DIFF
--- a/pkg/services/org/model.go
+++ b/pkg/services/org/model.go
@@ -157,6 +157,7 @@ type OrgUserDTO struct {
 	IsDisabled         bool            `json:"isDisabled"`
 	AuthLabels         []string        `json:"authLabels" xorm:"-"`
 	IsExternallySynced bool            `json:"isExternallySynced"`
+	IsProvisioned      bool            `json:"isProvisioned"`
 }
 
 type RemoveOrgUserCommand struct {

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -611,6 +611,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 			"u.created",
 			"u.updated",
 			"u.is_disabled",
+			"u.is_provisioned",
 		)
 
 		if len(query.SortOpts) > 0 {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -141,7 +141,6 @@ type UserSearchHitDTO struct {
 	LastSeenAtAge string               `json:"lastSeenAtAge"`
 	AuthLabels    []string             `json:"authLabels"`
 	AuthModule    AuthModuleConversion `json:"-"`
-	IsProvisioned bool                 `json:"isProvisioned" xorm:"is_provisioned"`
 }
 
 type GetUserProfileQuery struct {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -141,7 +141,7 @@ type UserSearchHitDTO struct {
 	LastSeenAtAge string               `json:"lastSeenAtAge"`
 	AuthLabels    []string             `json:"authLabels"`
 	AuthModule    AuthModuleConversion `json:"-"`
-	IsProvisioned bool                 `json:"-" xorm:"is_provisioned"`
+	IsProvisioned bool                 `json:"isProvisioned" xorm:"is_provisioned"`
 }
 
 type GetUserProfileQuery struct {
@@ -166,7 +166,7 @@ type UserProfileDTO struct {
 	CreatedAt                      time.Time       `json:"createdAt"`
 	AvatarURL                      string          `json:"avatarUrl"`
 	AccessControl                  map[string]bool `json:"accessControl,omitempty"`
-	IsProvisioned                  bool            `json:"-"`
+	IsProvisioned                  bool            `json:"isProvisioned"`
 }
 
 // implement Conversion interface to define custom field mapping (xorm feature)

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -137,6 +137,7 @@ type UserSearchHitDTO struct {
 	AvatarURL     string               `json:"avatarUrl" xorm:"avatar_url"`
 	IsAdmin       bool                 `json:"isAdmin"`
 	IsDisabled    bool                 `json:"isDisabled"`
+	IsProvisioned bool                 `json:"isProvisioned"`
 	LastSeenAt    time.Time            `json:"lastSeenAt"`
 	LastSeenAtAge string               `json:"lastSeenAtAge"`
 	AuthLabels    []string             `json:"authLabels"`

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -374,6 +374,7 @@ func (ss *sqlStore) GetProfile(ctx context.Context, query *user.GetUserProfileQu
 			Theme:          usr.Theme,
 			IsGrafanaAdmin: usr.IsAdmin,
 			IsDisabled:     usr.IsDisabled,
+			IsProvisioned:  usr.IsProvisioned,
 			OrgID:          usr.OrgID,
 			UpdatedAt:      usr.Updated,
 			CreatedAt:      usr.Created,

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -526,7 +526,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			sess.Limit(query.Limit, offset)
 		}
 
-		sess.Cols("u.id", "u.uid", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module")
+		sess.Cols("u.id", "u.uid", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module", "u.is_provisioned")
 
 		if len(query.SortOpts) > 0 {
 			for i := range query.SortOpts {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -5913,6 +5913,9 @@
         "isExternallySynced": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"
@@ -8605,6 +8608,9 @@
         "isGrafanaAdminExternallySynced": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "login": {
           "type": "string"
         },
@@ -8650,6 +8656,9 @@
           "type": "boolean"
         },
         "isDisabled": {
+          "type": "boolean"
+        },
+        "isProvisioned": {
           "type": "boolean"
         },
         "lastSeenAt": {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -8658,6 +8658,9 @@
         "isDisabled": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -8658,9 +8658,6 @@
         "isDisabled": {
           "type": "boolean"
         },
-        "isProvisioned": {
-          "type": "boolean"
-        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -17760,6 +17760,9 @@
         "isExternallySynced": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"
@@ -22367,6 +22370,9 @@
         "isGrafanaAdminExternallySynced": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "login": {
           "type": "string"
         },
@@ -22412,6 +22418,9 @@
           "type": "boolean"
         },
         "isDisabled": {
+          "type": "boolean"
+        },
+        "isProvisioned": {
           "type": "boolean"
         },
         "lastSeenAt": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22420,6 +22420,9 @@
         "isDisabled": {
           "type": "boolean"
         },
+        "isProvisioned": {
+          "type": "boolean"
+        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22420,9 +22420,6 @@
         "isDisabled": {
           "type": "boolean"
         },
-        "isProvisioned": {
-          "type": "boolean"
-        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -115,7 +115,10 @@ export const UserAdminPage = ({
   const isLDAPUser = user?.isExternal && user?.authLabels?.includes('LDAP');
   const canReadSessions = contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList);
   const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
-  const authSource = user?.authLabels?.[0];
+  let authSource = user?.authLabels?.[0];
+  if (user?.isProvisioned) {
+    authSource = 'SCIM';
+  }
   const lockMessage = authSource ? `Synced via ${authSource}` : '';
   const pageNav: NavModelItem = {
     text: user?.login ?? '',

--- a/public/app/features/admin/UserProfile.tsx
+++ b/public/app/features/admin/UserProfile.tsx
@@ -71,12 +71,18 @@ export function UserProfile({
     });
   };
 
-  const authSource = user.authLabels?.length && user.authLabels[0];
+  let authSource = user.authLabels?.length && user.authLabels[0];
+  if (user.isProvisioned) {
+    authSource = 'SCIM';
+  }
   const lockMessage = authSource ? `Synced via ${authSource}` : '';
 
-  const editLocked = user.isExternal || !contextSrv.hasPermissionInMetadata(AccessControlAction.UsersWrite, user);
+  const editLocked =
+    user.isExternal || user.isProvisioned || !contextSrv.hasPermissionInMetadata(AccessControlAction.UsersWrite, user);
   const passwordChangeLocked =
-    user.isExternal || !contextSrv.hasPermissionInMetadata(AccessControlAction.UsersPasswordUpdate, user);
+    user.isExternal ||
+    user.isProvisioned ||
+    !contextSrv.hasPermissionInMetadata(AccessControlAction.UsersPasswordUpdate, user);
   const canDelete = contextSrv.hasPermissionInMetadata(AccessControlAction.UsersDelete, user);
   const canDisable = contextSrv.hasPermissionInMetadata(AccessControlAction.UsersDisable, user);
   const canEnable = contextSrv.hasPermissionInMetadata(AccessControlAction.UsersEnable, user);

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -217,6 +217,13 @@ export const OrgUsersTable = ({
         ),
       },
       {
+        id: 'isProvisioned',
+        header: 'Provisioned',
+        cell: ({ cell: { value } }: Cell<'isProvisioned'>) => (
+          <>{value && <Tag colorIndex={14} name={'Provisioned'} />}</>
+        ),
+      },
+      {
         id: 'isDisabled',
         header: '',
         cell: ({ cell: { value } }: Cell<'isDisabled'>) => <>{value && <Tag colorIndex={9} name={'Disabled'} />}</>,

--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -153,6 +153,13 @@ export const UsersTable = ({
         ),
       },
       {
+        id: 'isProvisioned',
+        header: 'Provisioned',
+        cell: ({ cell: { value } }: Cell<'isProvisioned'>) => (
+          <>{value && <Tag colorIndex={14} name={'Provisioned'} />}</>
+        ),
+      },
+      {
         id: 'isDisabled',
         header: '',
         cell: ({ cell: { value } }: Cell<'isDisabled'>) => <>{value && <Tag colorIndex={9} name={'Disabled'} />}</>,

--- a/public/app/features/profile/UserProfileEditForm.tsx
+++ b/public/app/features/profile/UserProfileEditForm.tsx
@@ -22,7 +22,10 @@ export const UserProfileEditForm = ({ user, isSavingUser, updateProfile }: Props
 
   // check if authLabels is longer than 0 otherwise false
   const isExternalUser: boolean = (user && user.isExternal) ?? false;
-  const authSource = isExternalUser && user && user.authLabels ? user.authLabels[0] : '';
+  let authSource = isExternalUser && user && user.authLabels ? user.authLabels[0] : '';
+  if (user?.isProvisioned) {
+    authSource = 'SCIM';
+  }
   const lockMessage = authSource ? ` (Synced via ${authSource})` : '';
   const disabledEdit = disableLoginForm || isExternalUser;
 

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -19,6 +19,8 @@ export interface OrgUser extends WithAccessControlMetadata {
   isDisabled: boolean;
   authLabels?: string[];
   isExternallySynced?: boolean;
+  // Externally provisioned
+  isProvisioned?: boolean;
 }
 
 export interface User {
@@ -56,6 +58,7 @@ export interface UserDTO extends WithAccessControlMetadata {
   orgs?: Unit[];
   isExternallySynced?: boolean;
   isGrafanaAdminExternallySynced?: boolean;
+  isProvisioned?: boolean;
 }
 
 export interface Invitee {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7822,6 +7822,9 @@
           "isExternallySynced": {
             "type": "boolean"
           },
+          "isProvisioned": {
+            "type": "boolean"
+          },
           "lastSeenAt": {
             "format": "date-time",
             "type": "string"
@@ -12428,6 +12431,9 @@
           "isGrafanaAdminExternallySynced": {
             "type": "boolean"
           },
+          "isProvisioned": {
+            "type": "boolean"
+          },
           "login": {
             "type": "string"
           },
@@ -12473,6 +12479,9 @@
             "type": "boolean"
           },
           "isDisabled": {
+            "type": "boolean"
+          },
+          "isProvisioned": {
             "type": "boolean"
           },
           "lastSeenAt": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -12481,6 +12481,9 @@
           "isDisabled": {
             "type": "boolean"
           },
+          "isProvisioned": {
+            "type": "boolean"
+          },
           "lastSeenAt": {
             "format": "date-time",
             "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -12481,9 +12481,6 @@
           "isDisabled": {
             "type": "boolean"
           },
-          "isProvisioned": {
-            "type": "boolean"
-          },
           "lastSeenAt": {
             "format": "date-time",
             "type": "string"


### PR DESCRIPTION
**What is this feature?**

This feature adds a new label for externally provisioned users.

**Why do we need this feature?**

With the development of the SCIM feature, we acknowledge the need to distinctively label users that are provisioned via an external system.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1220

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
