### PR TITLE
Alerting: Fix typo in the recording_rules ini section

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1544,7 +1544,7 @@ basic_auth_password =
 timeout = 10s
 
 # Default data source UID to write to if not specified in the rule definition.
-# Only has effect if the grafanaManagedRecordRulesDatasources feature toggle is enabled.
+# Only has effect if the grafanaManagedRecordingRulesDatasources feature toggle is enabled.
 default_datasource_uid =
 
 # Optional custom headers to include in recording rule write requests.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1526,7 +1526,7 @@ basic_auth_password =
 timeout = 30s
 
 # Default data source UID to write to if not specified in the rule definition.
-# Only has effect if the grafanaManagedRecordRulesDatasources feature toggle is enabled.
+# Only has effect if the grafanaManagedRecordingRulesDatasources feature toggle is enabled.
 default_datasource_uid =
 
 # Optional custom headers to include in recording rule write requests.


### PR DESCRIPTION
It's `grafanaManagedRecordingRulesDatasources`:

https://github.com/grafana/grafana/blob/b4758d06a3f47884373aa0c703b172ee576955f5/pkg/services/featuremgmt/registry.go#L1769-L1777