### PR TITLE
CloudMigrations: Conditionally append resource to snapshot if enabled

### DIFF
--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -65,6 +65,9 @@ func (cma *CloudMigrationAPI) registerEndpoints(acHandler accesscontrol.AccessCo
 		cloudMigrationRoute.Get("/migration/:uid/snapshots", routing.Wrap(cma.GetSnapshotList))
 		cloudMigrationRoute.Post("/migration/:uid/snapshot/:snapshotUid/upload", routing.Wrap(cma.UploadSnapshot))
 		cloudMigrationRoute.Post("/migration/:uid/snapshot/:snapshotUid/cancel", routing.Wrap(cma.CancelSnapshot))
+
+		// resource dependency list
+		cloudMigrationRoute.Get("/resources/dependencies", routing.Wrap(cma.GetResourceDependencies))
 	}, authorize(cloudmigration.MigrationAssistantAccess))
 }
 
@@ -591,4 +594,32 @@ func (cma *CloudMigrationAPI) CancelSnapshot(c *contextmodel.ReqContext) respons
 	}
 
 	return response.JSON(http.StatusOK, nil)
+}
+
+// swagger:route GET /cloudmigration/resources/dependencies migrations getResourceDependencies
+//
+// Get the resource dependencies graph for the current set of migratable resources.
+//
+// Responses:
+// 200: resourceDependenciesResponse
+func (cma *CloudMigrationAPI) GetResourceDependencies(c *contextmodel.ReqContext) response.Response {
+	_, span := cma.tracer.Start(c.Req.Context(), "MigrationAPI.GetResourceDependencies")
+	defer span.End()
+
+	resourceDependencies := make([]ResourceDependencyDTO, 0, len(cma.resourceDependencyMap))
+	for resourceType, dependencies := range cma.resourceDependencyMap {
+		dependencyNames := make([]MigrateDataType, 0, len(dependencies))
+		for _, dependency := range dependencies {
+			dependencyNames = append(dependencyNames, MigrateDataType(dependency))
+		}
+
+		resourceDependencies = append(resourceDependencies, ResourceDependencyDTO{
+			ResourceType: MigrateDataType(resourceType),
+			Dependencies: dependencyNames,
+		})
+	}
+
+	return response.JSON(http.StatusOK, ResourceDependenciesResponseDTO{
+		ResourceDependencies: resourceDependencies,
+	})
 }

--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -342,7 +342,7 @@ func (cma *CloudMigrationAPI) CreateSnapshot(c *contextmodel.ReqContext) respons
 		rawResourceTypes = append(rawResourceTypes, cloudmigration.MigrateDataType(t))
 	}
 
-	resourceTypes, err := cloudmigration.ResourceDependency.Parse(rawResourceTypes)
+	resourceTypes, err := cma.resourceDependencyMap.Parse(rawResourceTypes)
 	if err != nil {
 		span.SetStatus(codes.Error, "invalid resource types")
 		span.RecordError(err)

--- a/pkg/services/cloudmigration/api/api_test.go
+++ b/pkg/services/cloudmigration/api/api_test.go
@@ -598,6 +598,31 @@ func TestCloudMigrationAPI_CancelSnapshot(t *testing.T) {
 	}
 }
 
+func TestCloudMigrationAPI_GetResourceDependencies(t *testing.T) {
+	tests := []TestCase{
+		{
+			desc:               "returns 200 if the user has the right permissions",
+			requestHttpMethod:  http.MethodGet,
+			requestUrl:         "/api/cloudmigration/resources/dependencies",
+			user:               userWithPermissions,
+			expectedHttpResult: http.StatusOK,
+			expectedBody:       `{"resourceDependencies":[{"resourceType":"PLUGIN","dependencies":[]}]}`,
+		},
+		{
+			desc:               "returns 403 if the user does not have the right permissions",
+			requestHttpMethod:  http.MethodGet,
+			requestUrl:         "/api/cloudmigration/resources/dependencies",
+			user:               userWithoutPermissions,
+			expectedHttpResult: http.StatusForbidden,
+			expectedBody:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, runSimpleApiTest(tt))
+	}
+}
+
 func runSimpleApiTest(tt TestCase) func(t *testing.T) {
 	return func(t *testing.T) {
 		// setup server

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -385,3 +385,20 @@ type CancelSnapshotParams struct {
 	// in: path
 	SnapshotUID string `json:"snapshotUid"`
 }
+
+// swagger:response resourceDependenciesResponse
+type ResourceDependenciesResponse struct {
+	// in: body
+	Body ResourceDependenciesResponseDTO
+}
+
+// swagger:model ResourceDependenciesResponseDTO
+type ResourceDependenciesResponseDTO struct {
+	ResourceDependencies []ResourceDependencyDTO `json:"resourceDependencies"`
+}
+
+// swagger:model ResourceDependencyDTO
+type ResourceDependencyDTO struct {
+	ResourceType MigrateDataType   `json:"resourceType"`
+	Dependencies []MigrateDataType `json:"dependencies"`
+}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -538,7 +538,7 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 		s.report(asyncCtx, session, gmsclient.EventStartBuildingSnapshot, 0, nil, signedInUser.UserUID)
 
 		start := time.Now()
-		err := s.buildSnapshot(asyncCtx, signedInUser, initResp.MaxItemsPerPartition, initResp.Metadata, snapshot)
+		err := s.buildSnapshot(asyncCtx, signedInUser, initResp.MaxItemsPerPartition, initResp.Metadata, snapshot, cmd.ResourceTypes)
 		if err != nil {
 			asyncSpan.SetStatus(codes.Error, "error building snapshot")
 			asyncSpan.RecordError(err)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -441,7 +441,7 @@ func Test_DeletedDashboardsNotMigrated(t *testing.T) {
 		nil,
 	)
 
-	data, err := s.getMigrationDataJSON(context.TODO(), &user.SignedInUser{OrgID: 1})
+	data, err := s.getMigrationDataJSON(context.TODO(), &user.SignedInUser{OrgID: 1}, cloudmigration.ResourceTypes{cloudmigration.DashboardDataType: {}})
 	assert.NoError(t, err)
 	dashCount := 0
 	for _, it := range data.Items {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -48,6 +48,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.PluginDataType,
 }
 
+//nolint:gocyclo
 func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser, resourceTypes cloudmigration.ResourceTypes) (*cloudmigration.MigrateDataRequest, error) {
 	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.getMigrationDataJSON")
 	defer span.End()

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -48,7 +48,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.PluginDataType,
 }
 
-func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser) (*cloudmigration.MigrateDataRequest, error) {
+func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser, resourceTypes cloudmigration.ResourceTypes) (*cloudmigration.MigrateDataRequest, error) {
 	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.getMigrationDataJSON")
 	defer span.End()
 
@@ -57,199 +57,219 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	folderHierarchy := make(map[cloudmigration.MigrateDataType]map[string]string, 0)
 
 	// Plugins
-	plugins, err := s.getPlugins(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get plugins", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.PluginDataType) {
+		plugins, err := s.getPlugins(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get plugins", "err", err)
+			return nil, err
+		}
 
-	for _, plugin := range plugins {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.PluginDataType,
-			RefID: plugin.ID,
-			Name:  plugin.Name,
-			Data:  plugin.SettingCmd,
-		})
+		for _, plugin := range plugins {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.PluginDataType,
+				RefID: plugin.ID,
+				Name:  plugin.Name,
+				Data:  plugin.SettingCmd,
+			})
+		}
 	}
 
 	// Data sources
-	dataSources, err := s.getDataSourceCommands(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get datasources", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.DatasourceDataType) {
+		dataSources, err := s.getDataSourceCommands(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get datasources", "err", err)
+			return nil, err
+		}
 
-	for _, ds := range dataSources {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.DatasourceDataType,
-			RefID: ds.UID,
-			Name:  ds.Name,
-			Data:  ds,
-		})
+		for _, ds := range dataSources {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.DatasourceDataType,
+				RefID: ds.UID,
+				Name:  ds.Name,
+				Data:  ds,
+			})
+		}
 	}
 
 	// Dashboards & Folders: linked via the schema, so we need to get both
-	dashs, folders, err := s.getDashboardAndFolderCommands(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get dashboards and folders", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.DashboardDataType) || resourceTypes.Has(cloudmigration.FolderDataType) {
+		dashs, folders, err := s.getDashboardAndFolderCommands(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get dashboards and folders", "err", err)
+			return nil, err
+		}
 
-	folderHierarchy[cloudmigration.DashboardDataType] = make(map[string]string, 0)
+		folderHierarchy[cloudmigration.DashboardDataType] = make(map[string]string, 0)
 
-	for _, dashboard := range dashs {
-		dashboard.Data.Del("id")
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.DashboardDataType,
-			RefID: dashboard.UID,
-			Name:  dashboard.Title,
-			Data: dashboards.SaveDashboardCommand{
-				Dashboard: dashboard.Data,
-				Overwrite: true, // currently only intended to be a push, not a sync; revisit during the preview
-				Message:   fmt.Sprintf("Created via the Grafana Cloud Migration Assistant by on-prem user \"%s\"", signedInUser.Login),
-				IsFolder:  false,
-				FolderUID: dashboard.FolderUID,
-			},
-		})
+		for _, dashboard := range dashs {
+			dashboard.Data.Del("id")
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.DashboardDataType,
+				RefID: dashboard.UID,
+				Name:  dashboard.Title,
+				Data: dashboards.SaveDashboardCommand{
+					Dashboard: dashboard.Data,
+					Overwrite: true, // currently only intended to be a push, not a sync; revisit during the preview
+					Message:   fmt.Sprintf("Created via the Grafana Cloud Migration Assistant by on-prem user \"%s\"", signedInUser.Login),
+					IsFolder:  false,
+					FolderUID: dashboard.FolderUID,
+				},
+			})
 
-		folderHierarchy[cloudmigration.DashboardDataType][dashboard.UID] = dashboard.FolderUID
-	}
+			folderHierarchy[cloudmigration.DashboardDataType][dashboard.UID] = dashboard.FolderUID
+		}
 
-	folderHierarchy[cloudmigration.FolderDataType] = make(map[string]string, 0)
+		folderHierarchy[cloudmigration.FolderDataType] = make(map[string]string, 0)
 
-	folders = sortFolders(folders)
-	for _, f := range folders {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.FolderDataType,
-			RefID: f.UID,
-			Name:  f.Title,
-			Data:  f,
-		})
+		folders = sortFolders(folders)
+		for _, f := range folders {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.FolderDataType,
+				RefID: f.UID,
+				Name:  f.Title,
+				Data:  f,
+			})
 
-		folderHierarchy[cloudmigration.FolderDataType][f.UID] = f.ParentUID
+			folderHierarchy[cloudmigration.FolderDataType][f.UID] = f.ParentUID
+		}
 	}
 
 	// Library Elements
-	libraryElements, err := s.getLibraryElementsCommands(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get library elements", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.LibraryElementDataType) {
+		libraryElements, err := s.getLibraryElementsCommands(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get library elements", "err", err)
+			return nil, err
+		}
 
-	folderHierarchy[cloudmigration.LibraryElementDataType] = make(map[string]string, 0)
+		folderHierarchy[cloudmigration.LibraryElementDataType] = make(map[string]string, 0)
 
-	for _, libraryElement := range libraryElements {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.LibraryElementDataType,
-			RefID: libraryElement.UID,
-			Name:  libraryElement.Name,
-			Data:  libraryElement,
-		})
+		for _, libraryElement := range libraryElements {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.LibraryElementDataType,
+				RefID: libraryElement.UID,
+				Name:  libraryElement.Name,
+				Data:  libraryElement,
+			})
 
-		if libraryElement.FolderUID != nil {
-			folderHierarchy[cloudmigration.LibraryElementDataType][libraryElement.UID] = *libraryElement.FolderUID
+			if libraryElement.FolderUID != nil {
+				folderHierarchy[cloudmigration.LibraryElementDataType][libraryElement.UID] = *libraryElement.FolderUID
+			}
 		}
 	}
 
 	// Alerts: Mute Timings
-	muteTimings, err := s.getAlertMuteTimings(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert mute timings", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.MuteTimingType) {
+		muteTimings, err := s.getAlertMuteTimings(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert mute timings", "err", err)
+			return nil, err
+		}
 
-	for _, muteTiming := range muteTimings {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.MuteTimingType,
-			RefID: muteTiming.UID,
-			Name:  muteTiming.Name,
-			Data:  muteTiming,
-		})
+		for _, muteTiming := range muteTimings {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.MuteTimingType,
+				RefID: muteTiming.UID,
+				Name:  muteTiming.Name,
+				Data:  muteTiming,
+			})
+		}
 	}
 
 	// Alerts: Notification Templates
-	notificationTemplates, err := s.getNotificationTemplates(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert notification templates", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.NotificationTemplateType) {
+		notificationTemplates, err := s.getNotificationTemplates(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert notification templates", "err", err)
+			return nil, err
+		}
 
-	for _, notificationTemplate := range notificationTemplates {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.NotificationTemplateType,
-			RefID: notificationTemplate.UID,
-			Name:  notificationTemplate.Name,
-			Data:  notificationTemplate,
-		})
+		for _, notificationTemplate := range notificationTemplates {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.NotificationTemplateType,
+				RefID: notificationTemplate.UID,
+				Name:  notificationTemplate.Name,
+				Data:  notificationTemplate,
+			})
+		}
 	}
 
 	// Alerts: Contact Points
-	contactPoints, err := s.getContactPoints(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert contact points", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.ContactPointType) {
+		contactPoints, err := s.getContactPoints(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert contact points", "err", err)
+			return nil, err
+		}
 
-	for _, contactPoint := range contactPoints {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.ContactPointType,
-			RefID: contactPoint.UID,
-			Name:  contactPoint.Name,
-			Data:  contactPoint,
-		})
+		for _, contactPoint := range contactPoints {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.ContactPointType,
+				RefID: contactPoint.UID,
+				Name:  contactPoint.Name,
+				Data:  contactPoint,
+			})
+		}
 	}
 
 	// Alerts: Notification Policies
-	notificationPolicies, err := s.getNotificationPolicies(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert notification policies", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.NotificationPolicyType) {
+		notificationPolicies, err := s.getNotificationPolicies(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert notification policies", "err", err)
+			return nil, err
+		}
 
-	if len(notificationPolicies.Name) > 0 {
-		// Notification Policy can only be managed by updating its entire tree, so we send the whole thing as one item.
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.NotificationPolicyType,
-			RefID: notificationPolicies.Name, // no UID available
-			Name:  notificationPolicies.Name,
-			Data:  notificationPolicies.Routes,
-		})
+		if len(notificationPolicies.Name) > 0 {
+			// Notification Policy can only be managed by updating its entire tree, so we send the whole thing as one item.
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.NotificationPolicyType,
+				RefID: notificationPolicies.Name, // no UID available
+				Name:  notificationPolicies.Name,
+				Data:  notificationPolicies.Routes,
+			})
+		}
 	}
 
 	// Alerts: Alert Rule Groups
-	alertRuleGroups, err := s.getAlertRuleGroups(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert rule groups", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.AlertRuleGroupType) {
+		alertRuleGroups, err := s.getAlertRuleGroups(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert rule groups", "err", err)
+			return nil, err
+		}
 
-	for _, alertRuleGroup := range alertRuleGroups {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.AlertRuleGroupType,
-			RefID: alertRuleGroup.Title, // no UID available
-			Name:  alertRuleGroup.Title,
-			Data:  alertRuleGroup,
-		})
+		for _, alertRuleGroup := range alertRuleGroups {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.AlertRuleGroupType,
+				RefID: alertRuleGroup.Title, // no UID available
+				Name:  alertRuleGroup.Title,
+				Data:  alertRuleGroup,
+			})
+		}
 	}
 
 	// Alerts: Alert Rules
-	alertRules, err := s.getAlertRules(ctx, signedInUser)
-	if err != nil {
-		s.log.Error("Failed to get alert rules", "err", err)
-		return nil, err
-	}
+	if resourceTypes.Has(cloudmigration.AlertRuleType) {
+		alertRules, err := s.getAlertRules(ctx, signedInUser)
+		if err != nil {
+			s.log.Error("Failed to get alert rules", "err", err)
+			return nil, err
+		}
 
-	folderHierarchy[cloudmigration.AlertRuleType] = make(map[string]string, 0)
+		folderHierarchy[cloudmigration.AlertRuleType] = make(map[string]string, 0)
 
-	for _, alertRule := range alertRules {
-		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-			Type:  cloudmigration.AlertRuleType,
-			RefID: alertRule.UID,
-			Name:  alertRule.Title,
-			Data:  alertRule,
-		})
+		for _, alertRule := range alertRules {
+			migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+				Type:  cloudmigration.AlertRuleType,
+				RefID: alertRule.UID,
+				Name:  alertRule.Title,
+				Data:  alertRule,
+			})
 
-		folderHierarchy[cloudmigration.AlertRuleType][alertRule.UID] = alertRule.FolderUID
+			folderHierarchy[cloudmigration.AlertRuleType][alertRule.UID] = alertRule.FolderUID
+		}
 	}
 
 	// Obtain the names of parent elements for data types that have folders.
@@ -514,7 +534,14 @@ func (s *Service) getPlugins(ctx context.Context, signedInUser *user.SignedInUse
 }
 
 // asynchronous process for writing the snapshot to the filesystem and updating the snapshot status
-func (s *Service) buildSnapshot(ctx context.Context, signedInUser *user.SignedInUser, maxItemsPerPartition uint32, metadata []byte, snapshotMeta cloudmigration.CloudMigrationSnapshot) error {
+func (s *Service) buildSnapshot(
+	ctx context.Context,
+	signedInUser *user.SignedInUser,
+	maxItemsPerPartition uint32,
+	metadata []byte,
+	snapshotMeta cloudmigration.CloudMigrationSnapshot,
+	resourceTypes cloudmigration.ResourceTypes,
+) error {
 	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.buildSnapshot")
 	defer span.End()
 
@@ -548,7 +575,7 @@ func (s *Service) buildSnapshot(ctx context.Context, signedInUser *user.SignedIn
 
 	s.log.Debug(fmt.Sprintf("buildSnapshot: created snapshot writing in %d ms", time.Since(start).Milliseconds()))
 
-	migrationData, err := s.getMigrationDataJSON(ctx, signedInUser)
+	migrationData, err := s.getMigrationDataJSON(ctx, signedInUser, resourceTypes)
 	if err != nil {
 		return fmt.Errorf("fetching migration data: %w", err)
 	}

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -165,6 +165,11 @@ type CloudMigrationSessionListResponse struct {
 
 type ResourceTypes map[MigrateDataType]struct{}
 
+func (r ResourceTypes) Has(t MigrateDataType) bool {
+	_, ok := r[t]
+	return ok
+}
+
 type CreateSnapshotCommand struct {
 	SessionUID    string
 	ResourceTypes ResourceTypes

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2641,6 +2641,20 @@
         }
       }
     },
+    "/cloudmigration/resources/dependencies": {
+      "get": {
+        "tags": [
+          "migrations"
+        ],
+        "summary": "Get the resource dependencies graph for the current set of migratable resources.",
+        "operationId": "getResourceDependencies",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/resourceDependenciesResponse"
+          }
+        }
+      }
+    },
     "/cloudmigration/token": {
       "get": {
         "tags": [
@@ -19790,6 +19804,57 @@
         }
       }
     },
+    "ResourceDependenciesResponseDTO": {
+      "type": "object",
+      "properties": {
+        "resourceDependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceDependencyDTO"
+          }
+        }
+      }
+    },
+    "ResourceDependencyDTO": {
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER",
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "ALERT_RULE_GROUP",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING",
+              "PLUGIN"
+            ]
+          }
+        },
+        "resourceType": {
+          "type": "string",
+          "enum": [
+            "DASHBOARD",
+            "DATASOURCE",
+            "FOLDER",
+            "LIBRARY_ELEMENT",
+            "ALERT_RULE",
+            "ALERT_RULE_GROUP",
+            "CONTACT_POINT",
+            "NOTIFICATION_POLICY",
+            "NOTIFICATION_TEMPLATE",
+            "MUTE_TIMING",
+            "PLUGIN"
+          ]
+        }
+      }
+    },
     "ResponseDetails": {
       "type": "object",
       "properties": {
@@ -24731,6 +24796,12 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/ActiveUserStats"
+      }
+    },
+    "resourceDependenciesResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/ResourceDependenciesResponseDTO"
       }
     },
     "resourcePermissionsDescription": {

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -55,6 +55,9 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    getResourceDependencies: build.query<GetResourceDependenciesApiResponse, GetResourceDependenciesApiArg>({
+      query: () => ({ url: `/cloudmigration/resources/dependencies` }),
+    }),
     getCloudMigrationToken: build.query<GetCloudMigrationTokenApiResponse, GetCloudMigrationTokenApiArg>({
       query: () => ({ url: `/cloudmigration/token` }),
     }),
@@ -132,6 +135,8 @@ export type GetShapshotListApiArg = {
   /** Sort with value latest to return results sorted in descending order. */
   sort?: string;
 };
+export type GetResourceDependenciesApiResponse = /** status 200 (empty) */ ResourceDependenciesResponseDto;
+export type GetResourceDependenciesApiArg = void;
 export type GetCloudMigrationTokenApiResponse = /** status 200 (empty) */ GetAccessTokenResponseDto;
 export type GetCloudMigrationTokenApiArg = void;
 export type CreateCloudMigrationTokenApiResponse = /** status 200 (empty) */ CreateAccessTokenResponseDto;
@@ -269,6 +274,36 @@ export type SnapshotDto = {
 export type SnapshotListResponseDto = {
   snapshots?: SnapshotDto[];
 };
+export type ResourceDependencyDto = {
+  dependencies?: (
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING'
+    | 'PLUGIN'
+  )[];
+  resourceType?:
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING'
+    | 'PLUGIN';
+};
+export type ResourceDependenciesResponseDto = {
+  resourceDependencies?: ResourceDependencyDto[];
+};
 export type GetAccessTokenResponseDto = {
   createdAt?: string;
   displayName?: string;
@@ -367,6 +402,7 @@ export const {
   useCancelSnapshotMutation,
   useUploadSnapshotMutation,
   useGetShapshotListQuery,
+  useGetResourceDependenciesQuery,
   useGetCloudMigrationTokenQuery,
   useCreateCloudMigrationTokenMutation,
   useDeleteCloudMigrationTokenMutation,

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -26,7 +26,12 @@ export const cloudMigrationAPI = generatedAPI
     }),
   })
   .enhanceEndpoints({
-    addTagTypes: ['cloud-migration-token', 'cloud-migration-session', 'cloud-migration-snapshot'],
+    addTagTypes: [
+      'cloud-migration-token',
+      'cloud-migration-session',
+      'cloud-migration-snapshot',
+      'cloud-migration-resource-dependencies',
+    ],
 
     endpoints: {
       // Cloud-side - create token
@@ -66,6 +71,11 @@ export const cloudMigrationAPI = generatedAPI
       },
       uploadSnapshot: {
         invalidatesTags: ['cloud-migration-snapshot'],
+      },
+
+      // Resource dependencies
+      getResourceDependencies: {
+        providesTags: ['cloud-migration-resource-dependencies'],
       },
 
       getDashboardByUid: suppressErrorsOnQuery,

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1849,6 +1849,16 @@
         },
         "description": "(empty)"
       },
+      "resourceDependenciesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ResourceDependenciesResponseDTO"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "resourcePermissionsDescription": {
         "content": {
           "application/json": {
@@ -9845,6 +9855,57 @@
         },
         "type": "object"
       },
+      "ResourceDependenciesResponseDTO": {
+        "properties": {
+          "resourceDependencies": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceDependencyDTO"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ResourceDependencyDTO": {
+        "properties": {
+          "dependencies": {
+            "items": {
+              "enum": [
+                "DASHBOARD",
+                "DATASOURCE",
+                "FOLDER",
+                "LIBRARY_ELEMENT",
+                "ALERT_RULE",
+                "ALERT_RULE_GROUP",
+                "CONTACT_POINT",
+                "NOTIFICATION_POLICY",
+                "NOTIFICATION_TEMPLATE",
+                "MUTE_TIMING",
+                "PLUGIN"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "resourceType": {
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER",
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "ALERT_RULE_GROUP",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING",
+              "PLUGIN"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ResponseDetails": {
         "properties": {
           "msg": {
@@ -16352,6 +16413,20 @@
           }
         },
         "summary": "Get a list of snapshots for a session.",
+        "tags": [
+          "migrations"
+        ]
+      }
+    },
+    "/cloudmigration/resources/dependencies": {
+      "get": {
+        "operationId": "getResourceDependencies",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/resourceDependenciesResponse"
+          }
+        },
+        "summary": "Get the resource dependencies graph for the current set of migratable resources.",
         "tags": [
           "migrations"
         ]

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -30,6 +30,8 @@ const config: ConfigFile = {
 
         'getDashboardByUid',
         'getLibraryElementByUid',
+
+        'getResourceDependencies',
       ],
     },
     '../public/app/features/preferences/api/user/endpoints.gen.ts': {


### PR DESCRIPTION
**What is this feature?**

Simple but important change. Now the method that appends resources to the snapshot is aware of the resource list passed in the request from the API.

It will only append a certain resource if it is present in the map. It is considered a valid set of dependencies once the map is returned, so we don't need to do any extra checks.

**Why do we need this feature?**

Be able to skip some resource types when migrating.

**Who is this feature for?**

Cloud Migration users.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1281

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
