### PR TITLE
CloudMigrations: Add /cloudmigration/resources/dependencies endpoint

### DIFF
--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -65,6 +65,9 @@ func (cma *CloudMigrationAPI) registerEndpoints(acHandler accesscontrol.AccessCo
 		cloudMigrationRoute.Get("/migration/:uid/snapshots", routing.Wrap(cma.GetSnapshotList))
 		cloudMigrationRoute.Post("/migration/:uid/snapshot/:snapshotUid/upload", routing.Wrap(cma.UploadSnapshot))
 		cloudMigrationRoute.Post("/migration/:uid/snapshot/:snapshotUid/cancel", routing.Wrap(cma.CancelSnapshot))
+
+		// resource dependency list
+		cloudMigrationRoute.Get("/resources/dependencies", routing.Wrap(cma.GetResourceDependencies))
 	}, authorize(cloudmigration.MigrationAssistantAccess))
 }
 
@@ -591,4 +594,32 @@ func (cma *CloudMigrationAPI) CancelSnapshot(c *contextmodel.ReqContext) respons
 	}
 
 	return response.JSON(http.StatusOK, nil)
+}
+
+// swagger:route GET /cloudmigration/resources/dependencies migrations getResourceDependencies
+//
+// Get the resource dependencies graph for the current set of migratable resources.
+//
+// Responses:
+// 200: resourceDependenciesResponse
+func (cma *CloudMigrationAPI) GetResourceDependencies(c *contextmodel.ReqContext) response.Response {
+	_, span := cma.tracer.Start(c.Req.Context(), "MigrationAPI.GetResourceDependencies")
+	defer span.End()
+
+	resourceDependencies := make([]ResourceDependencyDTO, 0, len(cma.resourceDependencyMap))
+	for resourceType, dependencies := range cma.resourceDependencyMap {
+		dependencyNames := make([]MigrateDataType, 0, len(dependencies))
+		for _, dependency := range dependencies {
+			dependencyNames = append(dependencyNames, MigrateDataType(dependency))
+		}
+
+		resourceDependencies = append(resourceDependencies, ResourceDependencyDTO{
+			ResourceType: MigrateDataType(resourceType),
+			Dependencies: dependencyNames,
+		})
+	}
+
+	return response.JSON(http.StatusOK, ResourceDependenciesResponseDTO{
+		ResourceDependencies: resourceDependencies,
+	})
 }

--- a/pkg/services/cloudmigration/api/api_test.go
+++ b/pkg/services/cloudmigration/api/api_test.go
@@ -598,6 +598,31 @@ func TestCloudMigrationAPI_CancelSnapshot(t *testing.T) {
 	}
 }
 
+func TestCloudMigrationAPI_GetResourceDependencies(t *testing.T) {
+	tests := []TestCase{
+		{
+			desc:               "returns 200 if the user has the right permissions",
+			requestHttpMethod:  http.MethodGet,
+			requestUrl:         "/api/cloudmigration/resources/dependencies",
+			user:               userWithPermissions,
+			expectedHttpResult: http.StatusOK,
+			expectedBody:       `{"resourceDependencies":[{"resourceType":"PLUGIN","dependencies":[]}]}`,
+		},
+		{
+			desc:               "returns 403 if the user does not have the right permissions",
+			requestHttpMethod:  http.MethodGet,
+			requestUrl:         "/api/cloudmigration/resources/dependencies",
+			user:               userWithoutPermissions,
+			expectedHttpResult: http.StatusForbidden,
+			expectedBody:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, runSimpleApiTest(tt))
+	}
+}
+
 func runSimpleApiTest(tt TestCase) func(t *testing.T) {
 	return func(t *testing.T) {
 		// setup server

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -385,3 +385,20 @@ type CancelSnapshotParams struct {
 	// in: path
 	SnapshotUID string `json:"snapshotUid"`
 }
+
+// swagger:response resourceDependenciesResponse
+type ResourceDependenciesResponse struct {
+	// in: body
+	Body ResourceDependenciesResponseDTO
+}
+
+// swagger:model ResourceDependenciesResponseDTO
+type ResourceDependenciesResponseDTO struct {
+	ResourceDependencies []ResourceDependencyDTO `json:"resourceDependencies"`
+}
+
+// swagger:model ResourceDependencyDTO
+type ResourceDependencyDTO struct {
+	ResourceType MigrateDataType   `json:"resourceType"`
+	Dependencies []MigrateDataType `json:"dependencies"`
+}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -48,6 +48,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.PluginDataType,
 }
 
+//nolint:gocyclo
 func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser, resourceTypes cloudmigration.ResourceTypes) (*cloudmigration.MigrateDataRequest, error) {
 	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.getMigrationDataJSON")
 	defer span.End()

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2641,6 +2641,20 @@
         }
       }
     },
+    "/cloudmigration/resources/dependencies": {
+      "get": {
+        "tags": [
+          "migrations"
+        ],
+        "summary": "Get the resource dependencies graph for the current set of migratable resources.",
+        "operationId": "getResourceDependencies",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/resourceDependenciesResponse"
+          }
+        }
+      }
+    },
     "/cloudmigration/token": {
       "get": {
         "tags": [
@@ -19790,6 +19804,57 @@
         }
       }
     },
+    "ResourceDependenciesResponseDTO": {
+      "type": "object",
+      "properties": {
+        "resourceDependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceDependencyDTO"
+          }
+        }
+      }
+    },
+    "ResourceDependencyDTO": {
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER",
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "ALERT_RULE_GROUP",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING",
+              "PLUGIN"
+            ]
+          }
+        },
+        "resourceType": {
+          "type": "string",
+          "enum": [
+            "DASHBOARD",
+            "DATASOURCE",
+            "FOLDER",
+            "LIBRARY_ELEMENT",
+            "ALERT_RULE",
+            "ALERT_RULE_GROUP",
+            "CONTACT_POINT",
+            "NOTIFICATION_POLICY",
+            "NOTIFICATION_TEMPLATE",
+            "MUTE_TIMING",
+            "PLUGIN"
+          ]
+        }
+      }
+    },
     "ResponseDetails": {
       "type": "object",
       "properties": {
@@ -24731,6 +24796,12 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/ActiveUserStats"
+      }
+    },
+    "resourceDependenciesResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/ResourceDependenciesResponseDTO"
       }
     },
     "resourcePermissionsDescription": {

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -55,6 +55,9 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    getResourceDependencies: build.query<GetResourceDependenciesApiResponse, GetResourceDependenciesApiArg>({
+      query: () => ({ url: `/cloudmigration/resources/dependencies` }),
+    }),
     getCloudMigrationToken: build.query<GetCloudMigrationTokenApiResponse, GetCloudMigrationTokenApiArg>({
       query: () => ({ url: `/cloudmigration/token` }),
     }),
@@ -132,6 +135,8 @@ export type GetShapshotListApiArg = {
   /** Sort with value latest to return results sorted in descending order. */
   sort?: string;
 };
+export type GetResourceDependenciesApiResponse = /** status 200 (empty) */ ResourceDependenciesResponseDto;
+export type GetResourceDependenciesApiArg = void;
 export type GetCloudMigrationTokenApiResponse = /** status 200 (empty) */ GetAccessTokenResponseDto;
 export type GetCloudMigrationTokenApiArg = void;
 export type CreateCloudMigrationTokenApiResponse = /** status 200 (empty) */ CreateAccessTokenResponseDto;
@@ -269,6 +274,36 @@ export type SnapshotDto = {
 export type SnapshotListResponseDto = {
   snapshots?: SnapshotDto[];
 };
+export type ResourceDependencyDto = {
+  dependencies?: (
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING'
+    | 'PLUGIN'
+  )[];
+  resourceType?:
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'ALERT_RULE_GROUP'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING'
+    | 'PLUGIN';
+};
+export type ResourceDependenciesResponseDto = {
+  resourceDependencies?: ResourceDependencyDto[];
+};
 export type GetAccessTokenResponseDto = {
   createdAt?: string;
   displayName?: string;
@@ -367,6 +402,7 @@ export const {
   useCancelSnapshotMutation,
   useUploadSnapshotMutation,
   useGetShapshotListQuery,
+  useGetResourceDependenciesQuery,
   useGetCloudMigrationTokenQuery,
   useCreateCloudMigrationTokenMutation,
   useDeleteCloudMigrationTokenMutation,

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -26,7 +26,12 @@ export const cloudMigrationAPI = generatedAPI
     }),
   })
   .enhanceEndpoints({
-    addTagTypes: ['cloud-migration-token', 'cloud-migration-session', 'cloud-migration-snapshot'],
+    addTagTypes: [
+      'cloud-migration-token',
+      'cloud-migration-session',
+      'cloud-migration-snapshot',
+      'cloud-migration-resource-dependencies',
+    ],
 
     endpoints: {
       // Cloud-side - create token
@@ -66,6 +71,11 @@ export const cloudMigrationAPI = generatedAPI
       },
       uploadSnapshot: {
         invalidatesTags: ['cloud-migration-snapshot'],
+      },
+
+      // Resource dependencies
+      getResourceDependencies: {
+        providesTags: ['cloud-migration-resource-dependencies'],
       },
 
       getDashboardByUid: suppressErrorsOnQuery,

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1849,6 +1849,16 @@
         },
         "description": "(empty)"
       },
+      "resourceDependenciesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ResourceDependenciesResponseDTO"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "resourcePermissionsDescription": {
         "content": {
           "application/json": {
@@ -9845,6 +9855,57 @@
         },
         "type": "object"
       },
+      "ResourceDependenciesResponseDTO": {
+        "properties": {
+          "resourceDependencies": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceDependencyDTO"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ResourceDependencyDTO": {
+        "properties": {
+          "dependencies": {
+            "items": {
+              "enum": [
+                "DASHBOARD",
+                "DATASOURCE",
+                "FOLDER",
+                "LIBRARY_ELEMENT",
+                "ALERT_RULE",
+                "ALERT_RULE_GROUP",
+                "CONTACT_POINT",
+                "NOTIFICATION_POLICY",
+                "NOTIFICATION_TEMPLATE",
+                "MUTE_TIMING",
+                "PLUGIN"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "resourceType": {
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER",
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "ALERT_RULE_GROUP",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING",
+              "PLUGIN"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ResponseDetails": {
         "properties": {
           "msg": {
@@ -16352,6 +16413,20 @@
           }
         },
         "summary": "Get a list of snapshots for a session.",
+        "tags": [
+          "migrations"
+        ]
+      }
+    },
+    "/cloudmigration/resources/dependencies": {
+      "get": {
+        "operationId": "getResourceDependencies",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/resourceDependenciesResponse"
+          }
+        },
+        "summary": "Get the resource dependencies graph for the current set of migratable resources.",
         "tags": [
           "migrations"
         ]

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -30,6 +30,8 @@ const config: ConfigFile = {
 
         'getDashboardByUid',
         'getLibraryElementByUid',
+
+        'getResourceDependencies',
       ],
     },
     '../public/app/features/preferences/api/user/endpoints.gen.ts': {


### PR DESCRIPTION
**What is this feature?**

Adds a new API endpoint `/cloudmigration/resources/dependencies`.

**Why do we need this feature?**

The Frontend will use this endpoint to get the source of truth for the resource dependency list in order to automatically (de)select items in the list.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1281

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
