### PR TITLE
K8s: Dashboards: Set v1alpha1 as priority

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	claims "github.com/grafana/authlib/types"
-	dashboardsV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardsV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -167,7 +167,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		creator = hs.getIdentityName(ctx, dash.OrgID, dash.CreatedBy)
 	}
 
-	annotationPermissions := &dashboardsV0.AnnotationPermission{}
+	annotationPermissions := &dashboardsV1.AnnotationPermission{}
 	if hs.Features.IsEnabled(ctx, featuremgmt.FlagAnnotationPermissionUpdate) {
 		hs.getAnnotationPermissionsByScope(c, &annotationPermissions.Dashboard, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(dash.UID))
 	} else {
@@ -275,7 +275,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 	return response.JSON(http.StatusOK, dto)
 }
 
-func (hs *HTTPServer) getAnnotationPermissionsByScope(c *contextmodel.ReqContext, actions *dashboardsV0.AnnotationActions, scope string) {
+func (hs *HTTPServer) getAnnotationPermissionsByScope(c *contextmodel.ReqContext, actions *dashboardsV1.AnnotationActions, scope string) {
 	ctx, span := tracer.Start(c.Req.Context(), "api.getAnnotationPermissionsByScope")
 	defer span.End()
 	c.Req = c.Req.WithContext(ctx)

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -3,7 +3,7 @@ package dtos
 import (
 	"time"
 
-	dashboardsV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardsV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
@@ -34,7 +34,7 @@ type DashboardMeta struct {
 	FolderUrl              string                             `json:"folderUrl"`
 	Provisioned            bool                               `json:"provisioned"`
 	ProvisionedExternalId  string                             `json:"provisionedExternalId"`
-	AnnotationsPermissions *dashboardsV0.AnnotationPermission `json:"annotationsPermissions"`
+	AnnotationsPermissions *dashboardsV1.AnnotationPermission `json:"annotationsPermissions"`
 	PublicDashboardEnabled bool                               `json:"publicDashboardEnabled,omitempty"`
 }
 

--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	folders "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 
 	authlib "github.com/grafana/authlib/types"

--- a/pkg/registry/apis/dashboard/large_test.go
+++ b/pkg/registry/apis/dashboard/large_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	dashboardv0alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 )
 
 func TestLargeDashboardSupport(t *testing.T) {
@@ -21,7 +21,7 @@ func TestLargeDashboardSupport(t *testing.T) {
 	f, err := os.ReadFile(devdash)
 	require.NoError(t, err)
 
-	dash := &dashboardv0alpha1.Dashboard{
+	dash := &dashboardv1alpha1.Dashboard{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -38,7 +38,7 @@ func TestLargeDashboardSupport(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 
-	err = dashboardv0alpha1.AddToScheme(scheme)
+	err = dashboardv1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
 
 	largeObject := NewDashboardLargeObjectSupport(scheme)
@@ -56,7 +56,7 @@ func TestLargeDashboardSupport(t *testing.T) {
 	}`, string(small))
 
 	// Now make it big again
-	rehydratedDash := &dashboardv0alpha1.Dashboard{
+	rehydratedDash := &dashboardv1alpha1.Dashboard{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -15,7 +15,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	dashboardOG "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -132,7 +132,7 @@ func TestBuildSaveDashboardCommand(t *testing.T) {
 	}
 	dash := &dashboard.Dashboard{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "dashboard.grafana.app/v0alpha1",
+			APIVersion: "dashboard.grafana.app/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-dash",
@@ -170,7 +170,7 @@ func TestBuildSaveDashboardCommand(t *testing.T) {
 		&dashboards.Dashboard{
 			ID:         1234,
 			Version:    2,
-			APIVersion: "dashboard.grafana.app/v0alpha1",
+			APIVersion: "dashboard.grafana.app/v1alpha1",
 		}, nil).Once()
 	cmd, created, err = access.buildSaveDashboardCommand(ctx, 1, dash)
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestBuildSaveDashboardCommand(t *testing.T) {
 	require.Equal(t, "test-dash", cmd.Dashboard.Get("uid").MustString())
 	require.Equal(t, cmd.Dashboard.Get("id").MustInt64(), int64(1234))       // should set to existing ID
 	require.Equal(t, cmd.Dashboard.Get("version").MustFloat64(), float64(2)) // version must be set - otherwise seen as a new dashboard in NewDashboardFromJson
-	require.Equal(t, cmd.APIVersion, "v0alpha1")                             // should trim prefix
+	require.Equal(t, cmd.APIVersion, "v1alpha1")                             // should trim prefix
 	require.Equal(t, cmd.OrgID, int64(1))
 	require.True(t, cmd.Overwrite)
 }

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -9,7 +9,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"

--- a/pkg/registry/apis/dashboard/legacy/storage_test.go
+++ b/pkg/registry/apis/dashboard/legacy/storage_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"

--- a/pkg/registry/apis/dashboard/legacy/types.go
+++ b/pkg/registry/apis/dashboard/legacy/types.go
@@ -3,7 +3,7 @@ package legacy
 import (
 	"context"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	claims "github.com/grafana/authlib/types"
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	folderv0alpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/selection"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -118,10 +118,9 @@ func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
 		}
 	}
 
-	// TODO (@radiohead): should we switch to v1alpha1 by default?
 	return []schema.GroupVersion{
-		v0alpha1.DashboardResourceInfo.GroupVersion(),
 		v1alpha1.DashboardResourceInfo.GroupVersion(),
+		v0alpha1.DashboardResourceInfo.GroupVersion(),
 		v2alpha1.DashboardResourceInfo.GroupVersion(),
 	}
 }

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -24,7 +24,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 	zeroInt64 := int64(0)
 	tests := []struct {
 		name                   string
-		inputObj               *v0alpha1.Dashboard
+		inputObj               *v1alpha1.Dashboard
 		deletionOptions        metav1.DeleteOptions
 		dashboardResponse      *dashboards.DashboardProvisioning
 		dashboardErrorResponse error
@@ -33,7 +33,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 	}{
 		{
 			name: "should return an error if data is found",
-			inputObj: &v0alpha1.Dashboard{
+			inputObj: &v1alpha1.Dashboard{
 				Spec: common.Unstructured{},
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Dashboard",
@@ -52,7 +52,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 		},
 		{
 			name: "should return an error if unable to check",
-			inputObj: &v0alpha1.Dashboard{
+			inputObj: &v1alpha1.Dashboard{
 				Spec: common.Unstructured{},
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Dashboard",
@@ -71,7 +71,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 		},
 		{
 			name: "should be okay if error is provisioned dashboard not found",
-			inputObj: &v0alpha1.Dashboard{
+			inputObj: &v1alpha1.Dashboard{
 				Spec: common.Unstructured{},
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Dashboard",
@@ -90,7 +90,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 		},
 		{
 			name: "Should still run the check for delete if grace period is not 0",
-			inputObj: &v0alpha1.Dashboard{
+			inputObj: &v1alpha1.Dashboard{
 				Spec: common.Unstructured{},
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Dashboard",
@@ -109,7 +109,7 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 		},
 		{
 			name: "should not run the check for delete if grace period is set to 0",
-			inputObj: &v0alpha1.Dashboard{
+			inputObj: &v1alpha1.Dashboard{
 				Spec: common.Unstructured{},
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Dashboard",
@@ -137,10 +137,10 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
 				tt.inputObj,
 				nil,
-				v0alpha1.DashboardResourceInfo.GroupVersionKind(),
+				v1alpha1.DashboardResourceInfo.GroupVersionKind(),
 				"stacks-123",
 				tt.inputObj.Name,
-				v0alpha1.DashboardResourceInfo.GroupVersionResource(),
+				v1alpha1.DashboardResourceInfo.GroupVersionResource(),
 				"",
 				admission.Operation("DELETE"),
 				&tt.deletionOptions,

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -170,22 +170,22 @@ func TestDashboardAPIBuilder_GetGroupVersions(t *testing.T) {
 		expected        []schema.GroupVersion
 	}{
 		{
-			name:            "should return v0alpha1 by default",
+			name:            "should return v1alpha1 by default",
 			enabledFeatures: []string{},
 			expected: []schema.GroupVersion{
-				v0alpha1.DashboardResourceInfo.GroupVersion(),
 				v1alpha1.DashboardResourceInfo.GroupVersion(),
+				v0alpha1.DashboardResourceInfo.GroupVersion(),
 				v2alpha1.DashboardResourceInfo.GroupVersion(),
 			},
 		},
 		{
-			name: "should return v0alpha1 as the default if some other feature is enabled",
+			name: "should return v1alpha1 as the default if some other feature is enabled",
 			enabledFeatures: []string{
 				featuremgmt.FlagKubernetesDashboards,
 			},
 			expected: []schema.GroupVersion{
-				v0alpha1.DashboardResourceInfo.GroupVersion(),
 				v1alpha1.DashboardResourceInfo.GroupVersion(),
+				v0alpha1.DashboardResourceInfo.GroupVersion(),
 				v2alpha1.DashboardResourceInfo.GroupVersion(),
 			},
 		},

--- a/pkg/services/apiserver/standalone/runtime_test.go
+++ b/pkg/services/apiserver/standalone/runtime_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestReadRuntimeCOnfig(t *testing.T) {
-	out, err := ReadRuntimeConfig("all/all=true,dashboard.grafana.app/v0alpha1=false")
+	out, err := ReadRuntimeConfig("all/all=true,dashboard.grafana.app/v1alpha1=false")
 	require.NoError(t, err)
 	require.Equal(t, []RuntimeConfig{
 		{Group: "all", Version: "all", Enabled: true},
-		{Group: "dashboard.grafana.app", Version: "v0alpha1", Enabled: false},
+		{Group: "dashboard.grafana.app", Version: "v1alpha1", Enabled: false},
 	}, out)
 	require.Equal(t, "all/all=true", fmt.Sprintf("%v", out[0]))
 

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -6,7 +6,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 )

--- a/pkg/services/authz/zanzana/translations.go
+++ b/pkg/services/authz/zanzana/translations.go
@@ -1,7 +1,7 @@
 package zanzana
 
 import (
-	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	folderalpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 )
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashboardv0alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	folderv0alpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
@@ -368,7 +369,7 @@ func ProvideDashboardServiceImpl(
 	serverLockService *serverlock.ServerLockService,
 	kvstore kvstore.KVStore,
 ) (*DashboardServiceImpl, error) {
-	k8sHandler := client.NewK8sHandler(dual, request.GetNamespaceMapper(cfg), dashboardv0alpha1.DashboardResourceInfo.GroupVersionResource(), restConfigProvider.GetRestConfig, dashboardStore, userService, resourceClient, sorter)
+	k8sHandler := client.NewK8sHandler(dual, request.GetNamespaceMapper(cfg), dashboardv1alpha1.DashboardResourceInfo.GroupVersionResource(), restConfigProvider.GetRestConfig, dashboardStore, userService, resourceClient, sorter)
 
 	dashSvc := &DashboardServiceImpl{
 		cfg:                       cfg,
@@ -2050,13 +2051,13 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	switch query.Type {
 	case "":
 		// When no type specified, search for dashboards
-		request.Options.Key, err = resource.AsResourceKey(namespace, dashboardv0alpha1.DASHBOARD_RESOURCE)
+		request.Options.Key, err = resource.AsResourceKey(namespace, dashboardv1alpha1.DASHBOARD_RESOURCE)
 		// Currently a search query is across folders and dashboards
 		if err == nil {
 			federate, err = resource.AsResourceKey(namespace, folderv0alpha1.RESOURCE)
 		}
 	case searchstore.TypeDashboard, searchstore.TypeAnnotation:
-		request.Options.Key, err = resource.AsResourceKey(namespace, dashboardv0alpha1.DASHBOARD_RESOURCE)
+		request.Options.Key, err = resource.AsResourceKey(namespace, dashboardv1alpha1.DASHBOARD_RESOURCE)
 	case searchstore.TypeFolder, searchstore.TypeAlertFolder:
 		request.Options.Key, err = resource.AsResourceKey(namespace, folderv0alpha1.RESOURCE)
 	default:
@@ -2212,7 +2213,7 @@ func (dr *DashboardServiceImpl) UnstructuredToLegacyDashboard(ctx context.Contex
 		FolderUID:  obj.GetFolder(),
 		Version:    int(dashVersion),
 		Data:       simplejson.NewFromAny(spec),
-		APIVersion: strings.TrimPrefix(item.GetAPIVersion(), dashboardv0alpha1.GROUP+"/"),
+		APIVersion: strings.TrimPrefix(item.GetAPIVersion(), dashboardv1alpha1.GROUP+"/"),
 	}
 
 	out.Created = obj.GetCreationTimestamp().Time
@@ -2306,7 +2307,7 @@ func LegacySaveCommandToUnstructured(cmd *dashboards.SaveDashboardCommand, names
 	finalObj.Object["spec"] = obj
 	finalObj.SetName(uid)
 	finalObj.SetNamespace(namespace)
-	finalObj.SetGroupVersionKind(dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind())
+	finalObj.SetGroupVersionKind(dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind())
 
 	meta, err := utils.MetaAccessor(finalObj)
 	if err != nil {

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1123,7 +1123,7 @@ func TestUnprovisionDashboard(t *testing.T) {
 		}}
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(dash, nil)
 		dashWithoutAnnotations := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"apiVersion": "dashboard.grafana.app/v1alpha1",
 			"kind":       "Dashboard",
 			"metadata": map[string]any{
 				"name":        "uid",

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	dashboardv0alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -545,8 +545,8 @@ func TestGetProvisionedDashboardData(t *testing.T) {
 		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": dashboardv0alpha1.DashboardResourceInfo.GroupVersion().String(),
-				"kind":       dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": dashboardv1alpha1.DashboardResourceInfo.GroupVersion().String(),
+				"kind":       dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"name": "uid",
 					"labels": map[string]interface{}{
@@ -651,8 +651,8 @@ func TestGetProvisionedDashboardDataByDashboardID(t *testing.T) {
 		provisioningTimestamp := int64(1234567)
 		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": dashboardv0alpha1.DashboardResourceInfo.GroupVersion().String(),
-			"kind":       dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
+			"apiVersion": dashboardv1alpha1.DashboardResourceInfo.GroupVersion().String(),
+			"kind":       dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
 			"metadata": map[string]interface{}{
 				"name": "uid",
 				"labels": map[string]interface{}{
@@ -745,8 +745,8 @@ func TestGetProvisionedDashboardDataByDashboardUID(t *testing.T) {
 		provisioningTimestamp := int64(1234567)
 		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": dashboardv0alpha1.DashboardResourceInfo.GroupVersion().String(),
-			"kind":       dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
+			"apiVersion": dashboardv1alpha1.DashboardResourceInfo.GroupVersion().String(),
+			"kind":       dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
 			"metadata": map[string]interface{}{
 				"name": "uid",
 				"labels": map[string]interface{}{
@@ -978,8 +978,8 @@ func TestDeleteOrphanedProvisionedDashboards(t *testing.T) {
 		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": dashboardv0alpha1.DashboardResourceInfo.GroupVersion().String(),
-				"kind":       dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": dashboardv1alpha1.DashboardResourceInfo.GroupVersion().String(),
+				"kind":       dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"name": "uid",
 					"labels": map[string]interface{}{
@@ -2628,8 +2628,8 @@ func TestK8sDashboardCleanupJob(t *testing.T) {
 func createTestUnstructuredDashboard(uid, title string, resourceVersion string) unstructured.Unstructured {
 	return unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": dashboardv0alpha1.DashboardResourceInfo.GroupVersion().String(),
-			"kind":       dashboardv0alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
+			"apiVersion": dashboardv1alpha1.DashboardResourceInfo.GroupVersion().String(),
+			"kind":       dashboardv1alpha1.DashboardResourceInfo.GroupVersionKind().Kind,
 			"metadata": map[string]interface{}{
 				"name":              uid,
 				"deletionTimestamp": "2023-01-01T00:00:00Z",

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -55,7 +55,7 @@ func ProvideService(cfg *setting.Cfg, db db.DB, dashboardService dashboards.Dash
 		k8sclient: client.NewK8sHandler(
 			dual,
 			request.GetNamespaceMapper(cfg),
-			v0alpha1.DashboardResourceInfo.GroupVersionResource(),
+			v1alpha1.DashboardResourceInfo.GroupVersionResource(),
 			restConfigProvider.GetRestConfig,
 			dashboardStore,
 			userService,

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/grafana/dskit/concurrency"
 
-	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/bus"

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"

--- a/pkg/storage/legacysql/dualwrite/utils.go
+++ b/pkg/storage/legacysql/dualwrite/utils.go
@@ -4,7 +4,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	folders "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 )
 

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	dashboardv0alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	folderv0alpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 
 	"github.com/grafana/authlib/types"
@@ -689,8 +689,8 @@ func AsResourceKey(ns string, t string) (*ResourceKey, error) {
 	case "dashboards", "dashboard":
 		return &ResourceKey{
 			Namespace: ns,
-			Group:     dashboardv0alpha1.GROUP,
-			Resource:  dashboardv0alpha1.DASHBOARD_RESOURCE,
+			Group:     dashboardv1alpha1.GROUP,
+			Resource:  dashboardv1alpha1.DASHBOARD_RESOURCE,
 		}, nil
 
 	// NOT really supported in the dashboard search UI, but useful for manual testing

--- a/pkg/storage/unified/search/dashboard.go
+++ b/pkg/storage/unified/search/dashboard.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -208,7 +208,7 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 		}
 	}
 	return resource.DocumentBuilderInfo{
-		GroupResource: v0alpha1.DashboardResourceInfo.GroupResource(),
+		GroupResource: v1alpha1.DashboardResourceInfo.GroupResource(),
 		Fields:        fields,
 		Namespaced:    namespaced,
 	}, err


### PR DESCRIPTION
**What is this feature?**

This PR defaults us to using v1alpha1 by default. Still work to come before we can make it `v1`, but starting to move towards that direction.

Notes: 
- Intentionally keeping all search definitions solely in v0alpha1, as we are not going to have those ready to be stable for g12.
- Intentionally keeping the dashboards stored in legacy [default as v0alpha1](https://github.com/grafana/grafana/blob/1e4555c79b327c44df9b8061a5e82361a6eecb13/pkg/registry/apis/dashboard/legacy/sql_dashboards.go#L277), as we want to start adding validation on the typescript schema that they have saved and we cannot guarantee anything yet for those dashboards 

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/app-platform-wg/issues/241
