### PR TITLE
spanner: Disable running alerting integration tests when using spanner.

### DIFF
--- a/pkg/infra/db/db.go
+++ b/pkg/infra/db/db.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"xorm.io/core"
+
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -53,6 +54,7 @@ type InitTestDBOpt = sqlstore.InitTestDBOpt
 var SetupTestDB = sqlstore.SetupTestDB
 var CleanupTestDB = sqlstore.CleanupTestDB
 var ProvideService = sqlstore.ProvideService
+var SkipTestsOnSpanner = sqlstore.SkipTestsOnSpanner
 
 func InitTestDB(t sqlutil.ITestDB, opts ...InitTestDBOpt) *sqlstore.SQLStore {
 	db, _ := InitTestDBWithCfg(t, opts...)

--- a/pkg/services/ngalert/store/alertmanager_test.go
+++ b/pkg/services/ngalert/store/alertmanager_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func TestIntegrationAlertmanagerStore(t *testing.T) {

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -17,6 +17,7 @@ type ITestDB interface {
 	Logf(format string, args ...any)
 	Log(args ...any)
 	Cleanup(func())
+	Skipf(format string, args ...any)
 }
 
 type TestDB struct {

--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func TestGrafanaRuleConfig(t *testing.T) {

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -53,7 +53,7 @@ import (
 var testData embed.FS
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func getTestHelper(t *testing.T) *apis.K8sTestHelper {

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func getTestHelper(t *testing.T) *apis.K8sTestHelper {

--- a/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func getTestHelper(t *testing.T) *apis.K8sTestHelper {

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -43,7 +43,7 @@ import (
 var testData embed.FS
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	testsuite.RunButSkipOnSpanner(m)
 }
 
 func getTestHelper(t *testing.T) *apis.K8sTestHelper {

--- a/pkg/tests/testsuite/testsuite.go
+++ b/pkg/tests/testsuite/testsuite.go
@@ -13,3 +13,8 @@ func Run(m *testing.M) {
 	db.CleanupTestDB()
 	os.Exit(code)
 }
+
+func RunButSkipOnSpanner(m *testing.M) {
+	db.SkipTestsOnSpanner()
+	Run(m)
+}


### PR DESCRIPTION
This PR adds `testsuite.RunButSkipOnSpanner` function to disable running integration tests when using spanner database. Used in `services/ngalert/store`, `tests/api/alerting`, `tests/apis/alerting/notifications/{receivers, routingtree, timeinterval, templategroup}`. These features are currently expected to fail their integration tests on spanner, and we're downprioritizing their fixing.