### PR TITLE
spanner: Store JSONB into string column.

### DIFF
--- a/pkg/util/xorm/dialect_spanner.go
+++ b/pkg/util/xorm/dialect_spanner.go
@@ -166,6 +166,8 @@ func (s *spanner) SqlType(col *core.Column) string {
 			return fmt.Sprintf("STRING(%d)", l)
 		}
 		return "STRING(MAX)"
+	case core.Jsonb:
+		return "STRING(MAX)"
 	case core.Bool, core.TinyInt:
 		return "BOOL"
 	case core.Float, core.Double:


### PR DESCRIPTION
This PR adds mapping from `JSONB` type to `STRING(MAX)` on Spanner. Why text column? Because in the migration [the single column using this feature is defined as text column](https://github.com/grafana/grafana/blob/1dd830b9f1bc741bc895b800087c610fb94691c2/pkg/services/sqlstore/migrations/correlations_mig.go#L44).

This fixes several integration tests in `pkg/tests/api/correlations` package:
* `TestIntegrationCreateCorrelation/creating_a_correlation_originating_from_a_read-only_data_source_should_work`
* `TestIntegrationCreateCorrelation/creating_a_correlation_pointing_to_a_read-only_data_source_should_work`
* `TestIntegrationCreateCorrelation/Should_correctly_create_a_correlation_with_a_correct_config`
* `TestIntegrationDeleteCorrelation/inexistent_correlation_should_result_in_a_404`