### PR TITLE
K8s: Folders: fix error conversion

### DIFF
--- a/docs/sources/developers/http_api/folder.md
+++ b/docs/sources/developers/http_api/folder.md
@@ -205,7 +205,7 @@ Status Codes:
 - **400** – Errors (invalid json, missing or invalid fields, etc)
 - **401** – Unauthorized
 - **403** – Access Denied
-- **409** - Folder already exists
+- **412** - Folder already exists
 
 ## Update folder
 

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -41,11 +41,11 @@ func ToFolderErrorResponse(err error) response.Response {
 	}
 
 	if errors.Is(err, dashboards.ErrFolderVersionMismatch) {
-		return response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": "the folder has been changed by someone else"})
+		return response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrFolderVersionMismatch.Error()})
 	}
 
 	if errors.Is(err, folder.ErrMaximumDepthReached) {
-		return response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": "Maximum nested folder depth reached"})
+		return response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": folder.ErrMaximumDepthReached.Error()})
 	}
 
 	var statusErr *k8sErrors.StatusError

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestToFolderErrorResponse(t *testing.T) {
@@ -72,6 +74,21 @@ func TestToFolderErrorResponse(t *testing.T) {
 			name:  "fallback error",
 			input: errors.New("some error"),
 			want:  response.ErrOrFallback(http.StatusInternalServerError, "Folder API error", errors.New("some error")),
+		},
+		{
+			name: "kubernetes status error",
+			input: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    412,
+					Message: "the folder has been changed by someone else",
+				},
+			},
+			want: response.Error(412, "the folder has been changed by someone else", &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    412,
+					Message: "the folder has been changed by someone else",
+				},
+			}),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -68,7 +68,7 @@ func TestToFolderErrorResponse(t *testing.T) {
 		{
 			name:  "folder max depth reached",
 			input: folder.ErrMaximumDepthReached,
-			want:  response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": "Maximum nested folder depth reached"}),
+			want:  response.JSON(http.StatusBadRequest, util.DynMap{"messageId": "folder.maximum-depth-reached", "message": folder.ErrMaximumDepthReached.Error()}),
 		},
 		{
 			name:  "fallback error",


### PR DESCRIPTION
**What is this feature?**

This PR fixes the error conversion in the k8s flow for folders. It was missing any errors that were returned by /apis, which are being returned as k8s status errors. This is why the max folder depth check had to be a string comparison before.

This PR also updates the doc to say the true error status we return / have been returning. TBD if we want to keep it as a 412, but at least now the docs are accurate.

**Why do we need this feature?**

We are returning 500s when we shouldn't

**Local logs**
For max folder depth (both apis and api are returning the same)
```
ERROR[03-24|11:37:04] error saving folder to nested folder store logger=folder-service error="[folder.maximum-depth-reached] failed to validate parent folder"
INFO [03-24|11:37:04] POST https://[::1]:6443/apis/folder.grafana.app/v0alpha1/namespaces/default/folders 400 Bad Request in 15 milliseconds logger=grafana-apiserver
INFO [03-24|11:37:04] HTTP Statistics: DNSLookup 0 ms Dial 0 ms TLSHandshake 0 ms Duration 15 ms logger=grafana-apiserver
INFO [03-24|11:37:04] Response Headers:                        logger=grafana-apiserver
INFO [03-24|11:37:04]     Cache-Control: no-cache, private     logger=grafana-apiserver
INFO [03-24|11:37:04]     Content-Type: application/json       logger=grafana-apiserver
INFO [03-24|11:37:04]     Audit-Id: b5e25aa8-dc33-4ada-b25d-11f85a1cc63a logger=grafana-apiserver
INFO [03-24|11:37:04] Request Completed                        logger=context userId=1 orgId=1 uname=admin method=POST path=/api/folders status=400 remote_addr=[::1] time_ms=30 duration=30.110167ms size=49 referer=http://localhost:3000/dashboards/f/cegtrrhiyn4e8b/c handler=/api/folders/ status_source=server error="Maximum nested folder depth reached"
```

For already exists:
```
INFO [03-24|11:38:30] curl -v -XPOST  -H "Accept: application/json" -H "Content-Type: application/json" -H "User-Agent: grafana/v0.0.0 (darwin/arm64) kubernetes/$Format" -H "Authorization: Bearer <masked>" 'https://[::1]:6443/apis/folder.grafana.app/v0alpha1/namespaces/default/folders' logger=grafana-apiserver
INFO [03-24|11:38:30] POST https://[::1]:6443/apis/folder.grafana.app/v0alpha1/namespaces/default/folders 412 Precondition Failed in 2 milliseconds logger=grafana-apiserver
INFO [03-24|11:38:30] HTTP Statistics: DNSLookup 0 ms Dial 0 ms TLSHandshake 0 ms Duration 2 ms logger=grafana-apiserver
INFO [03-24|11:38:30] Response Headers:                        logger=grafana-apiserver
INFO [03-24|11:38:30]     Audit-Id: 7314f2b6-2476-4a29-bc0c-78e1736e3e04 logger=grafana-apiserver
INFO [03-24|11:38:30]     Cache-Control: no-cache, private     logger=grafana-apiserver
INFO [03-24|11:38:30]     Content-Type: application/json       logger=grafana-apiserver
INFO [03-24|11:38:30] Request Completed                        logger=context userId=2 orgId=1 uname=sa-1-test method=POST path=/api/folders status=412 remote_addr=[::1] time_ms=32 duration=32.399375ms size=57 referer= handler=/api/folders/ status_source=server error="the folder has been changed by someone else"
```
