### PR TITLE
fix: disable workspace cache

### DIFF
--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Set go version
       uses: actions/setup-go@v4
+      cache: false
       with:
         go-version-file: go.mod
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The workspace action takes about 2m to run while the post action takes about 3m. I don't think we need to do this step, so this disables the `cache` for `setup-go`.
![image](https://github.com/user-attachments/assets/26eae40e-3c81-4118-8108-1a89667d2b61)


