### PR TITLE
Combobox: Fix Group Label Styling - Option Groups + Top Border

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.mdx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.mdx
@@ -35,6 +35,10 @@ Options can be an array of objects with seperate label and values, or an array o
 
 While Combobox can handle large sets of options, you should consider both the user experience of searching through many options, and the performance of loading many options from an API.
 
+### Grouping
+
+Each option object may also have a `group` string property. Options with matching group names will be sorted together, as will options with undefined groups. Combobox will order these based on the first occurence of each `group` (or absence of `group`) in the `options` prop.
+
 ### Async behaviour
 
 When using Combobox with options from a remote source as the user types, you can supply the `options` prop as an function that is called on each keypress with the current input value and returns a promise resolving to an array of options matching the input.
@@ -116,7 +120,6 @@ Some differences to note:
 - `isLoading: boolean` has been renamed to `loading: boolean`
 - `allowCustomValue` has been renamed to `createCustomValue`.
 - When specifying `width="auto"`, `minWidth` is also required.
-- Groups are not supported at this time.
 - Many props used to control subtle behaviour have been removed to simplify the API and improve performance.
   - Custom render props, or label as ReactNode is not supported at this time. Reach out if you have a hard requirement for this and we can discuss.
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -110,9 +110,9 @@ export const CustomValue: Story = {
 export const GroupsWithMixedLabels: Story = {
   args: {
     options: [
-      { label: 'One', value: 'one' },
+      { label: 'One', value: 'one', group: 'Group 1' },
       { label: 'Two', value: 'two', group: 'Group 1' },
-      { label: 'Three', value: 'three', group: 'Group 1' },
+      { label: 'Three', value: 'three', group: 'Group 3' },
       { label: 'Four', value: 'four', group: 'Group 1' },
       { label: 'Five', value: 'five' },
       { label: 'Six', value: 'six' },

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -107,6 +107,26 @@ export const CustomValue: Story = {
   render: BaseCombobox,
 };
 
+export const GroupsWithMixedLabels: Story = {
+  args: {
+    options: [
+      { label: 'One', value: 'one' },
+      { label: 'Two', value: 'two', group: 'Group 1' },
+      { label: 'Three', value: 'three', group: 'Group 1' },
+      { label: 'Four', value: 'four', group: 'Group 1' },
+      { label: 'Five', value: 'five' },
+      { label: 'Six', value: 'six' },
+      { label: 'Seven', value: 'seven', group: 'Group 2' },
+      { label: 'Eight', value: 'eight', group: 'Group 3' },
+      { label: 'Nine', value: 'nine', group: 'Group 3' },
+      { label: 'Ten', value: 'ten', group: 'Group 3' },
+      { label: 'Eleven', value: 'eleven' },
+    ],
+    value: '',
+  },
+  render: BaseCombobox,
+};
+
 export const Groups: Story = {
   args: {
     options: await generateGroupingOptions(500),

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -15,8 +15,8 @@ const options: ComboboxOption[] = [
   { label: 'Option 4', value: '4' },
 ];
 const optionsWithGroups: ComboboxOption[] = [
-  { label: 'Option 1', value: '1' },
-  { label: 'Option 2', value: '2', group: 'Group 1' },
+  { label: 'Option 1', value: '1', group: 'Group 1' },
+  { label: 'Option 2', value: '2' },
   { label: 'Option 3', value: '3', group: 'Group 1' },
   { label: 'Option 4', value: '4' },
   { label: 'Option 5', value: '5', group: 'Group 2' },
@@ -201,7 +201,7 @@ describe('Combobox', () => {
       );
     });
 
-    it('puts ungrouped options at the end', async () => {
+    it('puts ungrouped options relative to first occurrence', async () => {
       render(<Combobox options={optionsWithGroups} value={null} onChange={onChangeHandler} />);
 
       const input = screen.getByRole('combobox');
@@ -209,7 +209,7 @@ describe('Combobox', () => {
 
       const listbox = await screen.findByRole('listbox');
       expect(listbox).toHaveTextContent(
-        ['Group 1', 'Option 2', 'Option 3', 'Group 2', 'Option 5', 'Option 6', 'Option 1', 'Option 4'].join('')
+        ['Group 1', 'Option 1', 'Option 3', 'Option 2', 'Option 4', 'Group 2', 'Option 5', 'Option 6'].join('')
       );
     });
 
@@ -221,8 +221,8 @@ describe('Combobox', () => {
 
       const allHeaders = await screen.findAllByRole('presentation');
 
-      expect(allHeaders[1]).toHaveTextContent('Group 2');
-      expect(allHeaders[2]).toHaveTextContent('');
+      expect(allHeaders[0]).toHaveTextContent('Group 1');
+      expect(allHeaders[1]).toHaveTextContent('');
     });
 
     it('does not render a top border for the first group header', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -14,6 +14,14 @@ const options: ComboboxOption[] = [
   { label: 'Option 3', value: '3', description: 'This is option 3' },
   { label: 'Option 4', value: '4' },
 ];
+const optionsWithGroups: ComboboxOption[] = [
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2', group: 'Group 1' },
+  { label: 'Option 3', value: '3', group: 'Group 1' },
+  { label: 'Option 4', value: '4' },
+  { label: 'Option 5', value: '5', group: 'Group 2' },
+  { label: 'Option 6', value: '6', group: 'Group 2' },
+];
 
 describe('Combobox', () => {
   const onChangeHandler = jest.fn();
@@ -191,6 +199,41 @@ describe('Combobox', () => {
       expect(listbox).toHaveTextContent(
         ['Group 1', 'Option 1', 'Option 3', 'Option 6', 'Group 2', 'Option 2', 'Option 4', 'Option 5'].join('')
       );
+    });
+
+    it('puts ungrouped options at the end', async () => {
+      render(<Combobox options={optionsWithGroups} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).toHaveTextContent(
+        ['Group 1', 'Option 2', 'Option 3', 'Group 2', 'Option 5', 'Option 6', 'Option 1', 'Option 4'].join('')
+      );
+    });
+
+    it('does not render group header labels for ungrouped options', async () => {
+      render(<Combobox options={optionsWithGroups} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      const allHeaders = await screen.findAllByRole('presentation');
+
+      expect(allHeaders[1]).toHaveTextContent('Group 2');
+      expect(allHeaders[2]).toHaveTextContent('');
+    });
+
+    it('does not render a top border for the first group header', async () => {
+      render(<Combobox options={optionsWithGroups} value={null} onChange={onChangeHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      const allHeaders = await screen.findAllByRole('presentation');
+
+      expect(allHeaders[0]).toHaveStyle('border-top: none');
     });
   });
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -204,11 +204,13 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     estimateSize: (index: number) => {
       const firstGroupItem = isNewGroup(filteredOptions[index], index > 0 ? filteredOptions[index - 1] : undefined);
       const hasDescription = 'description' in filteredOptions[index];
+      const hasGroup = 'group' in filteredOptions[index];
+
       let itemHeight = MENU_OPTION_HEIGHT;
       if (hasDescription) {
         itemHeight = MENU_OPTION_HEIGHT_DESCRIPTION;
       }
-      if (firstGroupItem && filteredOptions[index].group) {
+      if (firstGroupItem && hasGroup) {
         itemHeight += MENU_OPTION_HEIGHT;
       }
       return itemHeight;

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -208,7 +208,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       if (hasDescription) {
         itemHeight = MENU_OPTION_HEIGHT_DESCRIPTION;
       }
-      if (firstGroupItem) {
+      if (firstGroupItem && filteredOptions[index].group) {
         itemHeight += MENU_OPTION_HEIGHT;
       }
       return itemHeight;
@@ -402,7 +402,15 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
                         }}
                       >
                         {startingNewGroup && (
-                          <div role="presentation" id={groupHeaderId} className={styles.newOptionGroup}>
+                          <div
+                            role="presentation"
+                            id={groupHeaderId}
+                            className={cx(
+                              styles.newOptionGroup,
+                              item.group && styles.newOptionGroupLabel,
+                              virtualRow.index === 0 && styles.newOptionGroupNoBorder
+                            )}
+                          >
                             {item.group}
                           </div>
                         )}

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -43,6 +43,10 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     // New class used in single combobox group headers
     newOptionGroup: css({
       label: 'combobox-new-option-group',
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+    }),
+
+    newOptionGroupLabel: css({
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       letterSpacing: 0,
@@ -50,7 +54,10 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.bodySmall.fontSize,
       fontWeight: theme.typography.fontWeightLight,
       padding: MENU_ITEM_PADDING,
-      borderTop: `1px solid ${theme.colors.border.weak}`,
+    }),
+
+    newOptionGroupNoBorder: css({
+      borderTop: 'none',
     }),
 
     optionBasic: css({

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -150,20 +150,12 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
 
   let currentIndex = 0;
 
-  // Fill result array with grouped options
+  // Fill result array with grouped and undefined grouped options
   for (const [group, groupOptions] of groupedOptions) {
     if (group) {
       groupStartIndices.set(group, currentIndex);
-      for (const option of groupOptions) {
-        result[currentIndex++] = option;
-      }
     }
-  }
-
-  // Add ungrouped options at the end
-  const ungrouped = groupedOptions.get(undefined);
-  if (ungrouped) {
-    for (const option of ungrouped) {
+    for (const option of groupOptions) {
       result[currentIndex++] = option;
     }
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This does ~~two~~ three small fixes for Combobox:
1. It places ungrouped options together based on their first occurrence in the list.
2. It fixes spacing issues for ungrouped options by tidying the padding and heights added to make labels look nice.
3. It removes the top border of the first group in the combobox since it isn't needed and looks cluttered visually.

**Why do we need this feature?**

It will be very visually pleasing for users.

**Who is this feature for?**

Users of Combobox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #102215 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

## Top Border ##
#### Before: ####
![Screenshot 2025-03-24 at 5 00 28 PM](https://github.com/user-attachments/assets/f3d21b21-f08f-49f8-9021-c9115e162f08)

#### After: ####
![Screenshot 2025-03-24 at 4 59 01 PM](https://github.com/user-attachments/assets/d3846381-f396-4ac3-9d70-d2e2761c257f)

## Ungrouped Options Spacing ##
#### Before: ####
![Screenshot 2025-03-24 at 5 01 25 PM](https://github.com/user-attachments/assets/a6f91175-fe4d-47be-be2a-c00f9cb56c94)

#### After: ####
![Screenshot 2025-03-24 at 4 59 09 PM](https://github.com/user-attachments/assets/648c6268-5c0a-4ffc-88cb-228ea5066d53)

## Ungrouped Options Placement ##
<img width="225" alt="Screenshot 2025-03-25 at 1 04 07 PM" src="https://github.com/user-attachments/assets/42e309e7-64ed-46da-82a8-2f247a061726" />
