### PR TITLE
CloudMigrations: Add sorting and error filtering to Snapshot Results backend

### DIFF
--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -369,6 +369,7 @@ func (cma *CloudMigrationAPI) GetSnapshot(c *contextmodel.ReqContext) response.R
 	lim := getQueryPageParams(c.QueryInt("resultLimit"), cloudmigration.ResultLimit(100))
 	col := getQueryCol(c.Query("resultSortColumn"), cloudmigration.SortColumnID)
 	dir := getQueryOrder(c.Query("resultSortOrder"), cloudmigration.SortOrderAsc)
+	errorsOnly := c.QueryBool("errorsOnly")
 
 	q := cloudmigration.GetSnapshotsQuery{
 		SnapshotUID: snapshotUid,
@@ -377,9 +378,9 @@ func (cma *CloudMigrationAPI) GetSnapshot(c *contextmodel.ReqContext) response.R
 		SnapshotResultQueryParams: cloudmigration.SnapshotResultQueryParams{
 			ResultPage:  page,
 			ResultLimit: lim,
-			// These wrapper types sanitize the user input and handles defaults
-			SortColumn: cloudmigration.ResultSortColumn(col),
-			SortOrder:  cloudmigration.SortOrder(dir),
+			SortColumn:  col,
+			SortOrder:   dir,
+			ErrorsOnly:  errorsOnly,
 		},
 	}
 

--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -368,7 +368,7 @@ func (cma *CloudMigrationAPI) GetSnapshot(c *contextmodel.ReqContext) response.R
 	page := getQueryPageParams(c.QueryInt("resultPage"), cloudmigration.ResultPage(1))
 	lim := getQueryPageParams(c.QueryInt("resultLimit"), cloudmigration.ResultLimit(100))
 	col := getQueryCol(c.Query("resultSortColumn"), cloudmigration.SortColumnID)
-	dir := getQueryOrder(c.Query("resultSortOrder"), cloudmigration.SortOrderAsc)
+	order := getQueryOrder(c.Query("resultSortOrder"), cloudmigration.SortOrderAsc)
 	errorsOnly := c.QueryBool("errorsOnly")
 
 	q := cloudmigration.GetSnapshotsQuery{
@@ -379,7 +379,7 @@ func (cma *CloudMigrationAPI) GetSnapshot(c *contextmodel.ReqContext) response.R
 			ResultPage:  page,
 			ResultLimit: lim,
 			SortColumn:  col,
-			SortOrder:   dir,
+			SortOrder:   order,
 			ErrorsOnly:  errorsOnly,
 		},
 	}

--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -496,8 +496,9 @@ func (cma *CloudMigrationAPI) GetSnapshotList(c *contextmodel.ReqContext) respon
 		SessionUID: uid,
 		Limit:      getQueryPageParams(c.QueryInt("limit"), 100),
 		Page:       getQueryPageParams(c.QueryInt("page"), 1),
-		Sort:       c.Query("sort"),
-		OrgID:      c.SignedInUser.OrgID,
+		// TODO: change to pattern used by GetSnapshot results
+		Sort:  c.Query("sort"),
+		OrgID: c.SignedInUser.OrgID,
 	}
 
 	snapshotList, err := cma.cloudMigrationService.GetSnapshotList(ctx, q)

--- a/pkg/services/cloudmigration/api/api.go
+++ b/pkg/services/cloudmigration/api/api.go
@@ -365,7 +365,7 @@ func (cma *CloudMigrationAPI) GetSnapshot(c *contextmodel.ReqContext) response.R
 	}
 
 	// parse and validate query params
-	page, lim, col, dir := c.QueryInt("resultPage"), c.QueryInt("resultLimit"), c.Query("sortColumn"), c.Query("sortOrder")
+	page, lim, col, dir := c.QueryInt("resultPage"), c.QueryInt("resultLimit"), c.Query("resultSortColumn"), c.Query("resultSortOrder")
 	if lim == 0 {
 		lim = 100
 	}

--- a/pkg/services/cloudmigration/api/api_test.go
+++ b/pkg/services/cloudmigration/api/api_test.go
@@ -664,7 +664,7 @@ func TestGetQueryCol(t *testing.T) {
 		},
 		{
 			name:       "returns type column",
-			col:        "type",
+			col:        "resource_type",
 			defaultCol: cloudmigration.SortColumnID,
 			expected:   cloudmigration.SortColumnType,
 		},

--- a/pkg/services/cloudmigration/api/api_test.go
+++ b/pkg/services/cloudmigration/api/api_test.go
@@ -601,3 +601,138 @@ func runSimpleApiTest(tt TestCase) func(t *testing.T) {
 		}
 	}
 }
+
+func TestGetQueryPageParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		page     int
+		def      int
+		expected int
+	}{
+		{
+			name:     "returns default when page is 0",
+			page:     0,
+			def:      1,
+			expected: 1,
+		},
+		{
+			name:     "returns default when page is negative",
+			page:     -1,
+			def:      1,
+			expected: 1,
+		},
+		{
+			name:     "returns default when page exceeds max",
+			page:     10001,
+			def:      1,
+			expected: 1,
+		},
+		{
+			name:     "returns page when within valid range",
+			page:     100,
+			def:      1,
+			expected: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getQueryPageParams(tt.page, tt.def)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetQueryCol(t *testing.T) {
+	tests := []struct {
+		name       string
+		col        string
+		defaultCol cloudmigration.ResultSortColumn
+		expected   cloudmigration.ResultSortColumn
+	}{
+		{
+			name:       "returns id column",
+			col:        "id",
+			defaultCol: cloudmigration.SortColumnName,
+			expected:   cloudmigration.SortColumnID,
+		},
+		{
+			name:       "returns name column",
+			col:        "name",
+			defaultCol: cloudmigration.SortColumnID,
+			expected:   cloudmigration.SortColumnName,
+		},
+		{
+			name:       "returns type column",
+			col:        "type",
+			defaultCol: cloudmigration.SortColumnID,
+			expected:   cloudmigration.SortColumnType,
+		},
+		{
+			name:       "returns status column",
+			col:        "status",
+			defaultCol: cloudmigration.SortColumnID,
+			expected:   cloudmigration.SortColumnStatus,
+		},
+		{
+			name:       "returns default for unknown column",
+			col:        "unknown",
+			defaultCol: cloudmigration.SortColumnID,
+			expected:   cloudmigration.SortColumnID,
+		},
+		{
+			name:       "case insensitive column matching",
+			col:        "NaMe",
+			defaultCol: cloudmigration.SortColumnID,
+			expected:   cloudmigration.SortColumnName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getQueryCol(tt.col, tt.defaultCol)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetQueryOrder(t *testing.T) {
+	tests := []struct {
+		name         string
+		order        string
+		defaultOrder cloudmigration.SortOrder
+		expected     cloudmigration.SortOrder
+	}{
+		{
+			name:         "returns ASC order",
+			order:        "ASC",
+			defaultOrder: cloudmigration.SortOrderDesc,
+			expected:     cloudmigration.SortOrderAsc,
+		},
+		{
+			name:         "returns DESC order",
+			order:        "DESC",
+			defaultOrder: cloudmigration.SortOrderAsc,
+			expected:     cloudmigration.SortOrderDesc,
+		},
+		{
+			name:         "returns default for unknown order",
+			order:        "unknown",
+			defaultOrder: cloudmigration.SortOrderAsc,
+			expected:     cloudmigration.SortOrderAsc,
+		},
+		{
+			name:         "case insensitive order matching",
+			order:        "aSc",
+			defaultOrder: cloudmigration.SortOrderDesc,
+			expected:     cloudmigration.SortOrderAsc,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getQueryOrder(tt.order, tt.defaultOrder)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -313,7 +313,7 @@ type GetSnapshotParams struct {
 	// default: 100
 	ResultLimit int `json:"resultLimit"`
 
-	// ResultSortColumn can be used to override the default system sort. Valid values are "default", "name", "type", and "status".
+	// ResultSortColumn can be used to override the default system sort. Valid values are "name", "resource_type", and "status".
 	// in:query
 	// required:false
 	// default: default
@@ -324,6 +324,12 @@ type GetSnapshotParams struct {
 	// required:false
 	// default: ASC
 	ResultSortOrder string `json:"resultSortOrder"`
+
+	// ErrorsOnly is used to only return resources with error statuses
+	// in:query
+	// required:false
+	// default: false
+	ErrorsOnly string `json:"errorsOnly"`
 
 	// Session UID of a session
 	// in: path

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -329,7 +329,7 @@ type GetSnapshotParams struct {
 	// in:query
 	// required:false
 	// default: false
-	ErrorsOnly string `json:"errorsOnly"`
+	ErrorsOnly bool `json:"errorsOnly"`
 
 	// Session UID of a session
 	// in: path

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -281,24 +281,6 @@ type CreateSnapshotResponseDTO struct {
 	SnapshotUID string `json:"uid"`
 }
 
-// swagger:enum ResultSortColumn
-type ResultSortColumn string
-
-const (
-	ResultSortColumnDefault ResultSortColumn = "default"
-	ResultSortColumnName    ResultSortColumn = "name"
-	ResultSortColumnType    ResultSortColumn = "type"
-	ResultSortColumnStatus  ResultSortColumn = "status"
-)
-
-// swagger:enum ResultSortDirection
-type ResultSortDirection string
-
-const (
-	ResultSortDirectionAsc  ResultSortColumn = "ASC"
-	ResultSortDirectionDesc ResultSortColumn = "DESC"
-)
-
 // swagger:parameters getSnapshot
 type GetSnapshotParams struct {
 	// ResultPage is used for pagination with ResultLimit

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -313,17 +313,17 @@ type GetSnapshotParams struct {
 	// default: 100
 	ResultLimit int `json:"resultLimit"`
 
-	// ResultSortColumn can be used to override the default system sort. It should be one of the values in the ResultSortColumn enum.
+	// ResultSortColumn can be used to override the default system sort. Valid values are "default", "name", "type", and "status".
 	// in:query
 	// required:false
 	// default: default
-	ResultSortColumn ResultSortColumn `json:"resultSortColumn"`
+	ResultSortColumn string `json:"resultSortColumn"`
 
 	// ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC.
 	// in:query
 	// required:false
 	// default: ASC
-	ResultSortOrder ResultSortDirection `json:"resultSortOrder"`
+	ResultSortOrder string `json:"resultSortOrder"`
 
 	// Session UID of a session
 	// in: path

--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -281,6 +281,24 @@ type CreateSnapshotResponseDTO struct {
 	SnapshotUID string `json:"uid"`
 }
 
+// swagger:enum ResultSortColumn
+type ResultSortColumn string
+
+const (
+	ResultSortColumnDefault ResultSortColumn = "default"
+	ResultSortColumnName    ResultSortColumn = "name"
+	ResultSortColumnType    ResultSortColumn = "type"
+	ResultSortColumnStatus  ResultSortColumn = "status"
+)
+
+// swagger:enum ResultSortDirection
+type ResultSortDirection string
+
+const (
+	ResultSortDirectionAsc  ResultSortColumn = "ASC"
+	ResultSortDirectionDesc ResultSortColumn = "DESC"
+)
+
 // swagger:parameters getSnapshot
 type GetSnapshotParams struct {
 	// ResultPage is used for pagination with ResultLimit
@@ -294,6 +312,18 @@ type GetSnapshotParams struct {
 	// required:false
 	// default: 100
 	ResultLimit int `json:"resultLimit"`
+
+	// ResultSortColumn can be used to override the default system sort. It should be one of the values in the ResultSortColumn enum.
+	// in:query
+	// required:false
+	// default: default
+	ResultSortColumn ResultSortColumn `json:"resultSortColumn"`
+
+	// ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC.
+	// in:query
+	// required:false
+	// default: ASC
+	ResultSortOrder ResultSortDirection `json:"resultSortOrder"`
 
 	// Session UID of a session
 	// in: path

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -566,7 +566,7 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 	defer span.End()
 
 	orgID, sessionUid, snapshotUid := query.OrgID, query.SessionUID, query.SnapshotUID
-	snapshot, err := s.store.GetSnapshotByUID(ctx, orgID, sessionUid, snapshotUid, query.ResultPage, query.ResultLimit)
+	snapshot, err := s.store.GetSnapshotByUID(ctx, orgID, sessionUid, snapshotUid, query.SnapshotResultQueryParams)
 	if err != nil {
 		return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
 	}
@@ -615,7 +615,7 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		}
 
 		// Refresh the snapshot after the update
-		snapshot, err = s.store.GetSnapshotByUID(ctx, orgID, sessionUid, snapshotUid, query.ResultPage, query.ResultLimit)
+		snapshot, err = s.store.GetSnapshotByUID(ctx, orgID, sessionUid, snapshotUid, query.SnapshotResultQueryParams)
 		if err != nil {
 			return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
 		}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -343,6 +343,12 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: snapshotUID,
 			SessionUID:  sessionUID,
+			SnapshotResultQueryParams: cloudmigration.SnapshotResultQueryParams{
+				ResultLimit: 10,
+				ResultPage:  1,
+				SortColumn:  cloudmigration.SortColumnID,
+				SortOrder:   cloudmigration.SortOrderAsc,
+			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, snapshot)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/store.go
@@ -14,6 +14,6 @@ type store interface {
 
 	CreateSnapshot(ctx context.Context, snapshot cloudmigration.CloudMigrationSnapshot) (string, error)
 	UpdateSnapshot(ctx context.Context, snapshot cloudmigration.UpdateSnapshotCmd) error
-	GetSnapshotByUID(ctx context.Context, orgID int64, sessUid, id string, resultPage int, resultLimit int) (*cloudmigration.CloudMigrationSnapshot, error)
+	GetSnapshotByUID(ctx context.Context, orgID int64, sessUid, id string, params cloudmigration.SnapshotResultQueryParams) (*cloudmigration.CloudMigrationSnapshot, error)
 	GetSnapshotList(ctx context.Context, query cloudmigration.ListSnapshotsQuery) ([]cloudmigration.CloudMigrationSnapshot, error)
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -422,15 +422,7 @@ func (ss *sqlStore) UpdateSnapshotResources(ctx context.Context, snapshotUid str
 }
 
 func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string, params cloudmigration.SnapshotResultQueryParams) ([]cloudmigration.CloudMigrationResource, error) {
-	page, limit := params.ResultPage, params.ResultLimit
-	if page < 1 {
-		page = 1
-	}
-	if limit == 0 {
-		limit = 100
-	}
-
-	col, dir := params.SortColumn.String(), params.SortOrder.String() // get sanitized values
+	page, limit, col, dir := int(params.ResultPage), int(params.ResultLimit), string(params.SortColumn), string(params.SortOrder)
 
 	var resources []cloudmigration.CloudMigrationResource
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -241,7 +241,7 @@ func (ss *sqlStore) deleteSnapshot(ctx context.Context, snapshotUid string) erro
 	})
 }
 
-func (ss *sqlStore) GetSnapshotByUID(ctx context.Context, orgID int64, sessionUid, uid string, resultPage int, resultLimit int) (*cloudmigration.CloudMigrationSnapshot, error) {
+func (ss *sqlStore) GetSnapshotByUID(ctx context.Context, orgID int64, sessionUid, uid string, params cloudmigration.SnapshotResultQueryParams) (*cloudmigration.CloudMigrationSnapshot, error) {
 	// first we check if the session exists, using orgId and sessionUid
 	session, err := ss.GetMigrationSessionByUID(ctx, orgID, sessionUid)
 	if err != nil || session == nil {
@@ -272,7 +272,7 @@ func (ss *sqlStore) GetSnapshotByUID(ctx context.Context, orgID int64, sessionUi
 		snapshot.EncryptionKey = []byte(secret)
 	}
 
-	resources, err := ss.getSnapshotResources(ctx, uid, resultPage, resultLimit)
+	resources, err := ss.getSnapshotResources(ctx, uid, params)
 	if err == nil {
 		snapshot.Resources = resources
 	}
@@ -421,7 +421,8 @@ func (ss *sqlStore) UpdateSnapshotResources(ctx context.Context, snapshotUid str
 	})
 }
 
-func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string, page int, limit int) ([]cloudmigration.CloudMigrationResource, error) {
+func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string, params cloudmigration.SnapshotResultQueryParams) ([]cloudmigration.CloudMigrationResource, error) {
+	page, limit := params.ResultPage, params.ResultLimit
 	if page < 1 {
 		page = 1
 	}
@@ -429,11 +430,13 @@ func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string
 		limit = 100
 	}
 
+	col, dir := params.SortColumn.String(), params.SortOrder.String() // get sanitized values
+
 	var resources []cloudmigration.CloudMigrationResource
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		offset := (page - 1) * limit
 		sess.Limit(limit, offset)
-		return sess.OrderBy("id ASC").Find(&resources, &cloudmigration.CloudMigrationResource{
+		return sess.OrderBy(fmt.Sprintf("%s %s", col, dir)).Find(&resources, &cloudmigration.CloudMigrationResource{
 			SnapshotUID: snapshotUid,
 		})
 	})

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -362,6 +362,15 @@ func Test_SnapshotResources(t *testing.T) {
 			assert.Equal(t, "1", results[0].UID)
 			assert.Equal(t, "5", results[4].UID)
 		})
+
+		t.Run("only errors filter returns only error status resources", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				ErrorsOnly: true,
+			})
+			require.NoError(t, err)
+			assert.Len(t, results, 1)
+			assert.Equal(t, "2", results[0].UID)
+		})
 	})
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -292,8 +292,13 @@ func Test_SnapshotResources(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		t.Run("default sorting and paging when no params provided", func(t *testing.T) {
-			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{})
+		t.Run("default sorting and paging and default params", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				ResultPage:  1,
+				ResultLimit: 100,
+				SortColumn:  cloudmigration.SortColumnID,
+				SortOrder:   cloudmigration.SortOrderAsc,
+			})
 			require.NoError(t, err)
 			assert.Len(t, results, 5)
 			// Default sort is by ID ascending
@@ -303,8 +308,10 @@ func Test_SnapshotResources(t *testing.T) {
 
 		t.Run("sort by name descending", func(t *testing.T) {
 			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				SortColumn: cloudmigration.SortColumnName,
-				SortOrder:  cloudmigration.SortOrderDesc,
+				ResultPage:  1,
+				ResultLimit: 100,
+				SortColumn:  cloudmigration.SortColumnName,
+				SortOrder:   cloudmigration.SortOrderDesc,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, "Folder 1", results[0].Name)
@@ -313,8 +320,10 @@ func Test_SnapshotResources(t *testing.T) {
 
 		t.Run("sort by type ascending", func(t *testing.T) {
 			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				SortColumn: cloudmigration.SortColumnType,
-				SortOrder:  cloudmigration.SortOrderAsc,
+				ResultPage:  1,
+				ResultLimit: 100,
+				SortColumn:  cloudmigration.SortColumnType,
+				SortOrder:   cloudmigration.SortOrderAsc,
 			})
 			require.NoError(t, err)
 			assert.Equal(t, "2", results[0].UID)
@@ -335,37 +344,13 @@ func Test_SnapshotResources(t *testing.T) {
 			assert.Equal(t, "5", results[1].UID)
 		})
 
-		t.Run("invalid page number defaults to 1", func(t *testing.T) {
-			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				ResultPage:  -1,
-				ResultLimit: 2,
-			})
-			require.NoError(t, err)
-			assert.Len(t, results, 2)
-			assert.Equal(t, "1", results[0].UID)
-		})
-
-		t.Run("invalid sort column defaults to id", func(t *testing.T) {
-			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				SortColumn: "invalid",
-			})
-			require.NoError(t, err)
-			assert.Equal(t, "1", results[0].UID)
-			assert.Equal(t, "5", results[4].UID)
-		})
-
-		t.Run("invalid sort order defaults to asc", func(t *testing.T) {
-			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				SortOrder: "invalid",
-			})
-			require.NoError(t, err)
-			assert.Equal(t, "1", results[0].UID)
-			assert.Equal(t, "5", results[4].UID)
-		})
-
 		t.Run("only errors filter returns only error status resources", func(t *testing.T) {
 			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-				ErrorsOnly: true,
+				ResultPage:  1,
+				ResultLimit: 100,
+				SortColumn:  cloudmigration.SortColumnID,
+				SortOrder:   cloudmigration.SortOrderAsc,
+				ErrorsOnly:  true,
 			})
 			require.NoError(t, err)
 			assert.Len(t, results, 1)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/cloudmigration"
 	fakeSecrets "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretskv "github.com/grafana/grafana/pkg/services/secrets/kvstore"
@@ -138,7 +139,12 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.NotEmpty(t, snapshotUid)
 
 		//retrieve it from the db
-		snapshot, err := s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, 0, 0)
+		snapshot, err := s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		require.NoError(t, err)
 		require.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
 
@@ -147,7 +153,12 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.NoError(t, err)
 
 		//retrieve it again
-		snapshot, err = s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, 0, 0)
+		snapshot, err = s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		require.NoError(t, err)
 		require.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
 
@@ -162,7 +173,12 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.NoError(t, err)
 
 		// now we expect not to find the snapshot
-		snapshot, err = s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, 0, 0)
+		snapshot, err = s.GetSnapshotByUID(ctx, 1, session.UID, snapshotUid, cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		require.ErrorIs(t, err, cloudmigration.ErrSnapshotNotFound)
 		require.Nil(t, snapshot)
 	})
@@ -174,9 +190,14 @@ func Test_SnapshotResources(t *testing.T) {
 	_, s := setUpTest(t)
 	ctx := context.Background()
 
-	t.Run("tests CRUD of snapshot resources", func(t *testing.T) {
+	t.Run("test CRUD of snapshot resources", func(t *testing.T) {
 		// Get the default rows from the test
-		resources, err := s.getSnapshotResources(ctx, "poiuy", 0, 100)
+		resources, err := s.getSnapshotResources(ctx, "poiuy", cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		assert.NoError(t, err)
 		assert.Len(t, resources, 3)
 		for _, r := range resources {
@@ -204,7 +225,12 @@ func Test_SnapshotResources(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Get resources again
-		resources, err = s.getSnapshotResources(ctx, "poiuy", 0, 100)
+		resources, err = s.getSnapshotResources(ctx, "poiuy", cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		assert.NoError(t, err)
 		assert.Len(t, resources, 4)
 		// ensure existing resource was updated from ERROR
@@ -240,9 +266,102 @@ func Test_SnapshotResources(t *testing.T) {
 		err = s.deleteSnapshotResources(ctx, "poiuy")
 		assert.NoError(t, err)
 		// make sure they're gone
-		resources, err = s.getSnapshotResources(ctx, "poiuy", 0, 100)
+		resources, err = s.getSnapshotResources(ctx, "poiuy", cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnID,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
 		assert.NoError(t, err)
 		assert.Len(t, resources, 0)
+	})
+
+	t.Run("test pagination and sorting", func(t *testing.T) {
+		// Create test data
+		resources := []cloudmigration.CloudMigrationResource{
+			{UID: "1", SnapshotUID: "abc123", Name: "Dashboard 1", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
+			{UID: "2", SnapshotUID: "abc123", Name: "Alert 1", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusError},
+			{UID: "3", SnapshotUID: "abc123", Name: "Dashboard 2", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusPending},
+			{UID: "4", SnapshotUID: "abc123", Name: "Folder 1", Type: cloudmigration.FolderDataType, Status: cloudmigration.ItemStatusOK},
+			{UID: "5", SnapshotUID: "abc123", Name: "Alert 2", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
+		}
+
+		err := s.db.WithDbSession(ctx, func(sess *db.Session) error {
+			_, err := sess.Insert(resources)
+			return err
+		})
+		require.NoError(t, err)
+
+		t.Run("default sorting and paging when no params provided", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{})
+			require.NoError(t, err)
+			assert.Len(t, results, 5)
+			// Default sort is by ID ascending
+			assert.Equal(t, "1", results[0].UID)
+			assert.Equal(t, "5", results[4].UID)
+		})
+
+		t.Run("sort by name descending", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				SortColumn: cloudmigration.SortColumnName,
+				SortOrder:  cloudmigration.SortOrderDesc,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "Folder 1", results[0].Name)
+			assert.Equal(t, "Alert 1", results[4].Name)
+		})
+
+		t.Run("sort by type ascending", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				SortColumn: cloudmigration.SortColumnType,
+				SortOrder:  cloudmigration.SortOrderAsc,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "2", results[0].UID)
+			assert.Equal(t, "5", results[1].UID)
+		})
+
+		t.Run("sort by status with pagination", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				ResultPage:  2,
+				ResultLimit: 2,
+				SortColumn:  cloudmigration.SortColumnStatus,
+				SortOrder:   cloudmigration.SortOrderAsc,
+			})
+			require.NoError(t, err)
+			assert.Len(t, results, 2)
+			// secondary sort is by ID ascending by default
+			assert.Equal(t, "4", results[0].UID)
+			assert.Equal(t, "5", results[1].UID)
+		})
+
+		t.Run("invalid page number defaults to 1", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				ResultPage:  -1,
+				ResultLimit: 2,
+			})
+			require.NoError(t, err)
+			assert.Len(t, results, 2)
+			assert.Equal(t, "1", results[0].UID)
+		})
+
+		t.Run("invalid sort column defaults to id", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				SortColumn: "invalid",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "1", results[0].UID)
+			assert.Equal(t, "5", results[4].UID)
+		})
+
+		t.Run("invalid sort order defaults to asc", func(t *testing.T) {
+			results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+				SortOrder: "invalid",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "1", results[0].UID)
+			assert.Equal(t, "5", results[4].UID)
+		})
 	})
 }
 

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -189,6 +189,7 @@ type SnapshotResultQueryParams struct {
 	ResultLimit ResultLimit
 	SortColumn  ResultSortColumn
 	SortOrder   SortOrder
+	ErrorsOnly  bool
 }
 
 type GetSnapshotsQuery struct {

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -171,23 +171,6 @@ const (
 	SortColumnStatus ResultSortColumn = "status"
 )
 
-func (s ResultSortColumn) String() string {
-	switch s {
-	case SortColumnID:
-		return string(SortColumnID)
-	case SortColumnName:
-		return string(SortColumnName)
-	case "type":
-		fallthrough
-	case SortColumnType:
-		return string(SortColumnType)
-	case SortColumnStatus:
-		return string(SortColumnStatus)
-	default:
-		return string(SortColumnID)
-	}
-}
-
 type SortOrder string
 
 const (
@@ -195,20 +178,15 @@ const (
 	SortOrderDesc SortOrder = "DESC"
 )
 
-func (s SortOrder) String() string {
-	switch s {
-	case SortOrderAsc:
-		return string(SortOrderAsc)
-	case SortOrderDesc:
-		return string(SortOrderDesc)
-	default:
-		return string(SortOrderAsc)
-	}
-}
+// ResultPage should be in the range [1, 10000]
+type ResultPage int
+
+// ResultLimit should be in the rage [1, 10000]
+type ResultLimit int
 
 type SnapshotResultQueryParams struct {
-	ResultPage  int
-	ResultLimit int
+	ResultPage  ResultPage
+	ResultLimit ResultLimit
 	SortColumn  ResultSortColumn
 	SortOrder   SortOrder
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -162,12 +162,60 @@ type CloudMigrationSessionListResponse struct {
 	Sessions []CloudMigrationSessionResponse
 }
 
+type ResultSortColumn string
+
+const (
+	SortColumnID     ResultSortColumn = "id"
+	SortColumnName   ResultSortColumn = "name"
+	SortColumnType   ResultSortColumn = "resource_type"
+	SortColumnStatus ResultSortColumn = "status"
+)
+
+func (s ResultSortColumn) String() string {
+	switch s {
+	case SortColumnID:
+		return string(SortColumnID)
+	case SortColumnName:
+		return string(SortColumnName)
+	case SortColumnType:
+		return string(SortColumnType)
+	case SortColumnStatus:
+		return string(SortColumnStatus)
+	default:
+		return string(SortColumnID)
+	}
+}
+
+type SortOrder string
+
+const (
+	SortOrderAsc  SortOrder = "ASC"
+	SortOrderDesc SortOrder = "DESC"
+)
+
+func (s SortOrder) String() string {
+	switch s {
+	case SortOrderAsc:
+		return string(SortOrderAsc)
+	case SortOrderDesc:
+		return string(SortOrderDesc)
+	default:
+		return string(SortOrderAsc)
+	}
+}
+
+type SnapshotResultQueryParams struct {
+	ResultPage  int
+	ResultLimit int
+	SortColumn  ResultSortColumn
+	SortOrder   SortOrder
+}
+
 type GetSnapshotsQuery struct {
 	SnapshotUID string
 	OrgID       int64
 	SessionUID  string
-	ResultPage  int
-	ResultLimit int
+	SnapshotResultQueryParams
 }
 
 type ListSnapshotsQuery struct {

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -177,6 +177,8 @@ func (s ResultSortColumn) String() string {
 		return string(SortColumnID)
 	case SortColumnName:
 		return string(SortColumnName)
+	case "type":
+		fallthrough
 	case SortColumnType:
 		return string(SortColumnType)
 	case SortColumnStatus:

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2472,8 +2472,8 @@
             "in": "query"
           },
           {
-            "type": "string",
-            "default": "false",
+            "type": "boolean",
+            "default": false,
             "description": "ErrorsOnly is used to only return resources with error statuses",
             "name": "errorsOnly",
             "in": "query"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2460,7 +2460,7 @@
           {
             "type": "string",
             "default": "default",
-            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"default\", \"name\", \"type\", and \"status\".",
+            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"name\", \"resource_type\", and \"status\".",
             "name": "resultSortColumn",
             "in": "query"
           },
@@ -2469,6 +2469,13 @@
             "default": "ASC",
             "description": "ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC.",
             "name": "resultSortOrder",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "false",
+            "description": "ErrorsOnly is used to only return resources with error statuses",
+            "name": "errorsOnly",
             "in": "query"
           },
           {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2459,6 +2459,20 @@
           },
           {
             "type": "string",
+            "default": "default",
+            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"default\", \"name\", \"type\", and \"status\".",
+            "name": "resultSortColumn",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "ASC",
+            "description": "ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC.",
+            "name": "resultSortOrder",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "description": "Session UID of a session",
             "name": "uid",
             "in": "path",

--- a/public/app/features/migrate-to-cloud/api/README.md
+++ b/public/app/features/migrate-to-cloud/api/README.md
@@ -4,3 +4,5 @@ The [`endpoints.gen.ts`](./endpoints.gen.ts) file is machine generated. In order
 
 - Run: `make swagger-clean && make openapi3-gen`
 - Run: `yarn generate-apis`
+
+If you run into issues, try updating your Node.js version.

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -105,7 +105,7 @@ export type GetSnapshotApiArg = {
   /** ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC. */
   resultSortOrder?: string;
   /** ErrorsOnly is used to only return resources with error statuses */
-  errorsOnly?: string;
+  errorsOnly?: boolean;
   /** Session UID of a session */
   uid: string;
   /** UID of a snapshot */

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -26,6 +26,9 @@ const injectedRtkApi = api.injectEndpoints({
         params: {
           resultPage: queryArg.resultPage,
           resultLimit: queryArg.resultLimit,
+          resultSortColumn: queryArg.resultSortColumn,
+          resultSortOrder: queryArg.resultSortOrder,
+          errorsOnly: queryArg.errorsOnly,
         },
       }),
     }),
@@ -97,6 +100,12 @@ export type GetSnapshotApiArg = {
   resultPage?: number;
   /** Max limit for snapshot results returned. */
   resultLimit?: number;
+  /** ResultSortColumn can be used to override the default system sort. Valid values are "name", "resource_type", and "status". */
+  resultSortColumn?: string;
+  /** ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC. */
+  resultSortOrder?: string;
+  /** ErrorsOnly is used to only return resources with error statuses */
+  errorsOnly?: string;
   /** Session UID of a session */
   uid: string;
   /** UID of a snapshot */

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -16133,8 +16133,8 @@
             "in": "query",
             "name": "errorsOnly",
             "schema": {
-              "default": "false",
-              "type": "string"
+              "default": false,
+              "type": "boolean"
             }
           },
           {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -16111,7 +16111,7 @@
             }
           },
           {
-            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"default\", \"name\", \"type\", and \"status\".",
+            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"name\", \"resource_type\", and \"status\".",
             "in": "query",
             "name": "resultSortColumn",
             "schema": {
@@ -16125,6 +16125,15 @@
             "name": "resultSortOrder",
             "schema": {
               "default": "ASC",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ErrorsOnly is used to only return resources with error statuses",
+            "in": "query",
+            "name": "errorsOnly",
+            "schema": {
+              "default": "false",
               "type": "string"
             }
           },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -16111,6 +16111,24 @@
             }
           },
           {
+            "description": "ResultSortColumn can be used to override the default system sort. Valid values are \"default\", \"name\", \"type\", and \"status\".",
+            "in": "query",
+            "name": "resultSortColumn",
+            "schema": {
+              "default": "default",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ResultSortOrder is used with ResultSortColumn. Valid values are ASC and DESC.",
+            "in": "query",
+            "name": "resultSortOrder",
+            "schema": {
+              "default": "ASC",
+              "type": "string"
+            }
+          },
+          {
             "description": "Session UID of a session",
             "in": "path",
             "name": "uid",


### PR DESCRIPTION
**What is this feature?**

Adds optional sort (column + order) and error filtering to snapshot queries. 

**Why do we need this feature?**

Allow users to more easily filter through their data sets

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1279

**Note:** The swagger 2.0 spec doesn't allow us to use enums in query parameters, so we have to use strings instead.