### PR TITLE
spanner: use emulator by default when running integration tests with Spanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ test-go-integration-memcached: ## Run integration tests for memcached cache.
 test-go-integration-spanner: ## Run integration tests for Spanner backend with flags. Uses spanner-emulator on localhost:9010 and localhost:9020.
 	@if [ "${WIRE_TAGS}" != "enterprise" ]; then echo "Spanner integration test require enterprise setup"; exit 1; fi
 	@echo "test backend integration spanner tests"
-	GRAFANA_TEST_DB=spanner SPANNER_DB=emulator \
+	GRAFANA_TEST_DB=spanner \
 	$(GO) test $(GO_RACE_FLAG) $(GO_TEST_FLAGS) -p=1 -count=1 -v -run "^TestIntegration" -covermode=atomic -timeout=2m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-js

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -161,7 +161,7 @@ func spannerTestDB() (*TestDB, error) {
 
 	spannerDB := os.Getenv("SPANNER_DB")
 	if spannerDB == "" {
-		return nil, errors.New("SPANNER_DB environment variable not set")
+		spannerDB = "emulator"
 	}
 
 	if spannerDB == "spannertest" {


### PR DESCRIPTION
This PR changes default value of `SPANNER_DB` variable that specificies which Spanner database to use when running integration tests with Spanner (ie. when `GRAFANA_TEST_DB=spanner`). Previously it errored out, now it default to `emulator`.