### PR TITLE
DashboardModel: Make sure uid is initialised correctly for k8s dashboards

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -176,7 +176,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
   let variables: SceneVariableSet | undefined;
   let annotationLayers: SceneDataLayerProvider[] = [];
   let alertStatesLayer: AlertStatesDataLayer | undefined;
-  const uid = dto.uid;
+  const uid = oldModel.uid;
   const serializerVersion = config.featureToggles.dashboardNewLayouts ? 'v2' : 'v1';
 
   if (oldModel.templating?.list?.length) {

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -47,6 +47,20 @@ describe('DashboardModel', () => {
     it('should have default properties', () => {
       expect(model.panels.length).toBe(0);
     });
+
+    it('should have uid if specified', () => {
+      const model = createDashboardModelFixture({ uid: '123' });
+      expect(model.uid).toBe('123');
+    });
+    it('should have null uid if not specified in spec', () => {
+      const model = createDashboardModelFixture();
+      expect(model.uid).toBe(null);
+    });
+
+    it('should have uid if specified in meta', () => {
+      const model = createDashboardModelFixture({}, { uid: '123' });
+      expect(model.uid).toBe('123');
+    });
   });
 
   describe('when storing original dashboard data', () => {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -140,7 +140,7 @@ export class DashboardModel implements TimeModel {
     this.events = new EventBusSrv();
     this.id = data.id || null;
     // UID is not there for newly created dashboards
-    this.uid = data.uid || null;
+    this.uid = data.uid || meta?.uid || null;
     this.revision = data.revision ?? undefined;
     this.title = data.title ?? 'No Title';
     this.description = data.description;


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/grafana/grafana/pull/101992 that made part of dashboard toolbar actions(including Share button) not visible when rendering k8s provided v1 dashboard.