### PR TITLE
[Remote Provisioning] Remove resource and file delete buttons

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4737,10 +4737,8 @@ exports[`better eslint`] = {
     ],
     "public/app/features/provisioning/File/FilesView.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/provisioning/GettingStarted/EnhancedFeatures.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -4841,11 +4839,9 @@ exports[`better eslint`] = {
     ],
     "public/app/features/provisioning/Repository/RepositoryResources.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/provisioning/Repository/RepositoryStatusPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -1,21 +1,7 @@
 import { useState } from 'react';
 
-import {
-  Button,
-  CellProps,
-  Column,
-  ConfirmModal,
-  FilterInput,
-  InteractiveTable,
-  LinkButton,
-  Spinner,
-  Stack,
-} from '@grafana/ui';
-import {
-  Repository,
-  useGetRepositoryFilesQuery,
-  useDeleteRepositoryFilesWithPathMutation,
-} from 'app/api/clients/provisioning';
+import { CellProps, Column, FilterInput, InteractiveTable, LinkButton, Spinner, Stack } from '@grafana/ui';
+import { Repository, useGetRepositoryFilesQuery } from 'app/api/clients/provisioning';
 
 import { PROVISIONING_URL } from '../constants';
 import { FileDetails } from '../types';
@@ -29,10 +15,7 @@ type FileCell<T extends keyof FileDetails = keyof FileDetails> = CellProps<FileD
 export function FilesView({ repo }: FilesViewProps) {
   const name = repo.metadata?.name ?? '';
   const query = useGetRepositoryFilesQuery({ name });
-  const [deleteFile, deleteFileStatus] = useDeleteRepositoryFilesWithPathMutation();
-
   const [searchQuery, setSearchQuery] = useState('');
-  const [pathToDelete, setPathToDelete] = useState<string>();
   const data = [...(query.data?.items ?? [])].filter((file) =>
     file.path.toLowerCase().includes(searchQuery.toLowerCase())
   );
@@ -72,9 +55,6 @@ export function FilesView({ repo }: FilesViewProps) {
               <LinkButton href={`${PROVISIONING_URL}/${name}/file/${path}`}>View</LinkButton>
             )}
             <LinkButton href={`${PROVISIONING_URL}/${name}/history/${path}`}>History</LinkButton>
-            <Button variant="destructive" onClick={() => setPathToDelete(path)}>
-              Delete
-            </Button>
           </Stack>
         );
       },
@@ -91,22 +71,6 @@ export function FilesView({ repo }: FilesViewProps) {
 
   return (
     <Stack grow={1} direction={'column'} gap={2}>
-      <ConfirmModal
-        isOpen={Boolean(pathToDelete?.length) || deleteFileStatus.isLoading}
-        title="Delete file in repository?"
-        body={deleteFileStatus.isLoading ? 'Deleting file...' : pathToDelete}
-        confirmText="Delete"
-        icon={deleteFileStatus.isLoading ? `spinner` : `exclamation-triangle`}
-        onConfirm={() => {
-          deleteFile({
-            name: name,
-            path: pathToDelete!,
-            message: `Deleted from repo test UI`,
-          });
-          setPathToDelete('');
-        }}
-        onDismiss={() => setPathToDelete('')}
-      />
       <Stack gap={2}>
         <FilterInput placeholder="Search" autoFocus={true} value={searchQuery} onChange={setSearchQuery} />
       </Stack>

--- a/public/app/features/provisioning/Repository/RepositoryResources.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryResources.tsx
@@ -1,23 +1,7 @@
 import { useMemo, useState } from 'react';
 
-import {
-  Column,
-  CellProps,
-  Link,
-  Stack,
-  Spinner,
-  FilterInput,
-  InteractiveTable,
-  LinkButton,
-  ConfirmModal,
-  Button,
-} from '@grafana/ui';
-import {
-  Repository,
-  ResourceListItem,
-  useGetRepositoryResourcesQuery,
-  useDeleteRepositoryFilesWithPathMutation,
-} from 'app/api/clients/provisioning';
+import { CellProps, Column, FilterInput, InteractiveTable, Link, LinkButton, Spinner, Stack } from '@grafana/ui';
+import { Repository, ResourceListItem, useGetRepositoryResourcesQuery } from 'app/api/clients/provisioning';
 
 import { PROVISIONING_URL } from '../constants';
 
@@ -34,8 +18,6 @@ export function RepositoryResources({ repo }: RepoProps) {
   const name = repo.metadata?.name ?? '';
   const query = useGetRepositoryResourcesQuery({ name });
   const [searchQuery, setSearchQuery] = useState('');
-  const [deleteFile, deleteFileStatus] = useDeleteRepositoryFilesWithPathMutation();
-  const [pathToDelete, setPathToDelete] = useState<string>();
   const data = (query.data?.items ?? []).filter((Resource) =>
     Resource.path.toLowerCase().includes(searchQuery.toLowerCase())
   );
@@ -107,9 +89,6 @@ export function RepositoryResources({ repo }: RepoProps) {
               {resource === 'dashboards' && <LinkButton href={`/d/${name}`}>View</LinkButton>}
               {resource === 'folders' && <LinkButton href={`/dashboards/f/${name}`}>View</LinkButton>}
               <LinkButton href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}`}>History</LinkButton>
-              <Button variant="destructive" onClick={() => setPathToDelete(path)}>
-                Delete
-              </Button>
             </Stack>
           );
         },
@@ -128,24 +107,6 @@ export function RepositoryResources({ repo }: RepoProps) {
 
   return (
     <Stack grow={1} direction={'column'} gap={2}>
-      <ConfirmModal
-        isOpen={Boolean(pathToDelete?.length) || deleteFileStatus.isLoading}
-        title="Delete resource in repository?"
-        body={deleteFileStatus.isLoading ? 'Deleting resource...' : pathToDelete}
-        confirmText="Delete"
-        icon={deleteFileStatus.isLoading ? `spinner` : `exclamation-triangle`}
-        onConfirm={() => {
-          if (pathToDelete) {
-            deleteFile({
-              name: name,
-              path: pathToDelete,
-              message: `Deleted from repo test UI`,
-            });
-            setPathToDelete('');
-          }
-        }}
-        onDismiss={() => setPathToDelete('')}
-      />
       <Stack gap={2}>
         <FilterInput placeholder="Search" autoFocus={true} value={searchQuery} onChange={setSearchQuery} />
       </Stack>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Remove delete file button in files tab
- Remove delete resource button in resources tab

**Why do we need this feature?**

The feature is not fully implemented.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/173>

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Pictures**


<img width="1687" alt="image" src="https://github.com/user-attachments/assets/cecf8b2a-ce13-4d4b-97c2-1ea604d15da4" />
<img width="1650" alt="image" src="https://github.com/user-attachments/assets/0bd38cfe-33a7-407c-b1f0-3b51c5b3b4fb" />

