### PR TITLE
spanner: Fix star migration that fills NULL dashboard_uid and org_id fields from dashboard table.

### DIFF
--- a/pkg/services/sqlstore/migrations/star_mig.go
+++ b/pkg/services/sqlstore/migrations/star_mig.go
@@ -59,28 +59,37 @@ func (m *FillDashbordUIDMigration) Exec(sess *xorm.Session, mg *Migrator) error 
 func RunStarMigrations(sess *xorm.Session, driverName string) error {
 	// sqlite
 	sql := `UPDATE star
-	SET 
+	SET
     	dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = star.dashboard_id),
     	org_id = (SELECT org_id FROM dashboard WHERE dashboard.id = star.dashboard_id),
     	updated = DATETIME('now')
-	WHERE 
+	WHERE
     	(dashboard_uid IS NULL OR org_id IS NULL)
     	AND EXISTS (SELECT 1 FROM dashboard WHERE dashboard.id = star.dashboard_id);`
 	if driverName == Postgres {
-		sql = `UPDATE star 
-		SET dashboard_uid = dashboard.uid, 
+		sql = `UPDATE star
+		SET dashboard_uid = dashboard.uid,
 			org_id = dashboard.org_id,
 			updated = NOW()
-		FROM dashboard 
+		FROM dashboard
 		WHERE star.dashboard_id = dashboard.id
 			AND (star.dashboard_uid IS NULL OR star.org_id IS NULL);`
 	} else if driverName == MySQL {
-		sql = `UPDATE star 
-		LEFT JOIN dashboard ON star.dashboard_id = dashboard.id 
-		SET star.dashboard_uid = dashboard.uid, 
+		sql = `UPDATE star
+		LEFT JOIN dashboard ON star.dashboard_id = dashboard.id
+		SET star.dashboard_uid = dashboard.uid,
 			star.org_id = dashboard.org_id,
 			star.updated = NOW()
 		WHERE star.dashboard_uid IS NULL OR star.org_id IS NULL;`
+	} else if driverName == Spanner {
+		sql = `UPDATE star
+				SET
+					dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = star.dashboard_id),
+					org_id = (SELECT org_id FROM dashboard WHERE dashboard.id = star.dashboard_id),
+					updated = CURRENT_TIMESTAMP()
+				WHERE
+					(dashboard_uid IS NULL OR org_id IS NULL)
+				  AND EXISTS (SELECT 1 FROM dashboard WHERE dashboard.id = star.dashboard_id)`
 	}
 
 	if _, err := sess.Exec(sql); err != nil {

--- a/pkg/services/star/starimpl/store_test.go
+++ b/pkg/services/star/starimpl/store_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
@@ -144,4 +146,35 @@ func testIntegrationUserStarsDataAccess(t *testing.T, fn getStore) {
 			require.Equal(t, 1, len(res.UserStars))
 		})
 	})
+}
+
+func TestIntegration_StarMigrations(t *testing.T) {
+	testDB := db.InitTestDB(t)
+
+	d := dashboards.Dashboard{
+		UID:     "test",
+		Slug:    "org",
+		Created: time.Now(),
+		Updated: time.Now(),
+		OrgID:   100,
+	}
+	_, err := testDB.GetEngine().Insert(&d)
+	require.NoError(t, err)
+	require.NotZero(t, d.ID)
+
+	// Insert star record with NULL org_id and dashboard_uid
+	_, err = testDB.GetEngine().Exec(`INSERT INTO star (id, user_id, dashboard_id, dashboard_uid, org_id, updated) VALUES (?,?,?,?,?,?)`,
+		1000, 1, d.ID, nil, nil, time.Now())
+	require.NoError(t, err)
+
+	// Migration will update NULL user_id and dashboard_uid
+	require.NoError(t, migrations.RunStarMigrations(testDB.GetEngine().NewSession(), testDB.GetDialect().DriverName()))
+
+	// Check that star has updated fields
+	var s []star.Star
+	require.NoError(t, testDB.GetEngine().Find(&s))
+
+	require.Len(t, s, 1)
+	require.Equal(t, "test", s[0].DashboardUID)
+	require.Equal(t, int64(100), s[0].OrgID)
 }


### PR DESCRIPTION
This migration runs on each Grafana start, but migration fails when using Spanner.