### PR TITLE
Storage: Fix resource history sorting and pagination in Spanner backend

### DIFF
--- a/pkg/storage/unified/resource/migrations.go
+++ b/pkg/storage/unified/resource/migrations.go
@@ -1,0 +1,30 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// MigrateVersionMatch handles backwards compatibility for ResourceVersionMatch
+// by migrating from the deprecated version_match to version_match_v2.
+// It returns an error if the version match is unknown.
+func MigrateListRequestVersionMatch(req *ListRequest, logger log.Logger) error {
+	if req.VersionMatch != nil && req.GetVersionMatchV2() == ResourceVersionMatchV2_UNKNOWN {
+		switch req.GetVersionMatch() {
+		case ResourceVersionMatch_DEPRECATED_NotOlderThan:
+			// This is not a typo. The old implementation actually did behave like Unset.
+			req.VersionMatchV2 = ResourceVersionMatchV2_Unset
+		case ResourceVersionMatch_DEPRECATED_Exact:
+			req.VersionMatchV2 = ResourceVersionMatchV2_Exact
+		default:
+			return fmt.Errorf("unknown version match: %v", req.GetVersionMatch())
+		}
+
+		// Log the migration to measure whether we have successfully migrated all clients
+		logger.Info("Old client request received, migrating from version_match to version_match_v2",
+			"oldValue", req.GetVersionMatch(),
+			"newValue", req.GetVersionMatchV2())
+	}
+	return nil
+}


### PR DESCRIPTION
**What is this feature?**
This PR aligns the Spanner backend's resource history implementation with the SQL backend changes introduced in PR XYZ, fixing version matching, sorting order, and pagination behavior.

**Why do we need this feature?**
The Spanner backend wasn't updated when https://github.com/grafana/grafana/pull/102505 changed how resource history queries work in the SQL backend, causing inconsistent behavior between backends. This PR ensures history queries return consistent results regardless of the storage backend used.

**Who is this feature for?**
Developers and users who rely on resource history functionality when using Spanner as the storage backend, particularly in grafana-enterprise.

**Which issue(s) does this PR fix?**:
Didn't create one.

**Special notes for your reviewer:**
Tested via `GRAFANA_TEST_DB=spanner SPANNER_DB=emulator go test  -tags="enterprise" -p=1 -count=1 -v -run "^TestIntegration" -covermode=atomic -timeout=2m ./pkg/extensions/storage/unified/spanner/`

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
