### PR TITLE
alerting: update UI text to clarify recovery threshold for pending state

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -503,7 +503,9 @@ function ThresholdExpressionViewer({ model }: { model: ExpressionQuery }) {
         {unloadEvaluator && (
           <>
             <div className={styles.label}>
-              <Trans i18nKey="alerting.threshold-expression-viewer.stop-alerting-when">Stop alerting when </Trans>
+              <Trans i18nKey="alerting.threshold-expression-viewer.stop-alerting-when">
+                Stop alerting (or pending state) when{' '}
+              </Trans>
             </div>
             <div className={styles.value}>{expression}</div>
 

--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -222,7 +222,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
               <InlineField
                 label={t(
                   'alerting.rule-form.threshold.recovery.stop-alerting-outside-range',
-                  'Stop alerting when outside range'
+                  'Stop alerting (or pending state) when outside range'
                 )}
                 labelWidth={'auto'}
               >
@@ -259,7 +259,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
             <InlineField
               label={t(
                 'alerting.rule-form.threshold.recovery.stop-alerting-inside-range',
-                'Stop alerting when inside range'
+                'Stop alerting (or pending state) when inside range'
               )}
               labelWidth={'auto'}
             >
@@ -296,7 +296,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
             <InlineField
               label={t(
                 'alerting.rule-form.threshold.recovery.stop-alerting-inside-range',
-                'Stop alerting when inside range'
+                'Stop alerting (or pending state) when inside range'
               )}
               labelWidth={'auto'}
             >
@@ -332,7 +332,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
             <InlineField
               label={t(
                 'alerting.rule-form.threshold.recovery.stop-alerting-outside-range',
-                'Stop alerting when outside range'
+                'Stop alerting (or pending state) when outside range'
               )}
               labelWidth={'auto'}
             >
@@ -373,7 +373,10 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
-              label={t('alerting.rule-form.threshold.recovery.stop-alerting-bellow', 'Stop alerting when below')}
+              label={t(
+                'alerting.rule-form.threshold.recovery.stop-alerting-bellow',
+                'Stop alerting (or pending state) when below'
+              )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
               error={invalidErrorMsg}
@@ -393,7 +396,10 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
-              label={t('alerting.rule-form.threshold.recovery.stop-alerting-above', 'Stop alerting when above')}
+              label={t(
+                'alerting.rule-form.threshold.recovery.stop-alerting-above',
+                'Stop alerting (or pending state) when above'
+              )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
               error={invalidErrorMsg}
@@ -413,7 +419,10 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
-              label={t('alerting.rule-form.threshold.recovery.stop-alerting-equal', 'Stop alerting when equal to')}
+              label={t(
+                'alerting.rule-form.threshold.recovery.stop-alerting-equal',
+                'Stop alerting (or pending state) when equal to'
+              )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
               error={invalidErrorMsg}
@@ -435,7 +444,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
             <InlineField
               label={t(
                 'alerting.rule-form.threshold.recovery.stop-alerting-not-equal',
-                'Stop alerting when not equal to'
+                'Stop alerting (or pending state) when not equal to'
               )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
@@ -456,7 +465,10 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
-              label={t('alerting.rule-form.threshold.recovery.stop-alerting-less', 'Stop alerting when less than')}
+              label={t(
+                'alerting.rule-form.threshold.recovery.stop-alerting-less',
+                'Stop alerting (or pending state) when less than'
+              )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
               error={invalidErrorMsg}
@@ -476,7 +488,10 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
-              label={t('alerting.rule-form.threshold.recovery.stop-alerting-more', 'Stop alerting when more than')}
+              label={t(
+                'alerting.rule-form.threshold.recovery.stop-alerting-more',
+                'Stop alerting (or pending state) when more than'
+              )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}
               error={invalidErrorMsg}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1932,14 +1932,14 @@
       },
       "threshold": {
         "recovery": {
-          "stop-alerting-above": "Stop alerting when above",
-          "stop-alerting-bellow": "Stop alerting when below",
-          "stop-alerting-equal": "Stop alerting when equal to",
-          "stop-alerting-inside-range": "Stop alerting when inside range",
-          "stop-alerting-less": "Stop alerting when less than",
-          "stop-alerting-more": "Stop alerting when more than",
-          "stop-alerting-not-equal": "Stop alerting when not equal to",
-          "stop-alerting-outside-range": "Stop alerting when outside range",
+          "stop-alerting-above": "Stop alerting (or pending state) when above",
+          "stop-alerting-bellow": "Stop alerting (or pending state) when below",
+          "stop-alerting-equal": "Stop alerting (or pending state) when equal to",
+          "stop-alerting-inside-range": "Stop alerting (or pending state) when inside range",
+          "stop-alerting-less": "Stop alerting (or pending state) when less than",
+          "stop-alerting-more": "Stop alerting (or pending state) when more than",
+          "stop-alerting-not-equal": "Stop alerting (or pending state) when not equal to",
+          "stop-alerting-outside-range": "Stop alerting (or pending state) when outside range",
           "title": "Custom recovery threshold"
         }
       }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2327,7 +2327,7 @@
     },
     "threshold-expression-viewer": {
       "input": "Input",
-      "stop-alerting-when": "Stop alerting when "
+      "stop-alerting-when": "Stop alerting (or pending state) when "
     },
     "timeseries-row": {
       "time-series-data": "Time series data",


### PR DESCRIPTION
Minor UI copy updates which are related to https://github.com/grafana/support-escalations/issues/13342 and this [recent doc updates](https://github.com/grafana/grafana/pull/102780 ).  

## To be decided

As discussed in [this review comment](https://github.com/grafana/grafana/pull/102788#discussion_r2052440918), we're still deciding between two wording options: 

1 - Return to normal when
2 - Stop alerting (or pending state) when
3 - Return to normal or recovering state when
4 - ...



![Screenshot 2025-03-25 at 13 18 03](https://github.com/user-attachments/assets/f30d17c2-159d-4e12-ad16-bc6d8f0e4b0f)


