### PR TITLE
CI: Allow Bench conversion to fail

### DIFF
--- a/.github/workflows/pr-backend-coverage.yml
+++ b/.github/workflows/pr-backend-coverage.yml
@@ -62,7 +62,7 @@ jobs:
             --report-output log \
             --grafana-version "$(git rev-parse HEAD)" \
             --suite-name grafana-oss-unit-tests \
-            /tmp/unit.log
+            /tmp/unit.log || true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
We shouldn't mark PRs and commits as X if they fail to convert logs with Bench.