### PR TITLE
Chore: Adding CVE-2024-8986 to .trivyignore 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,5 @@
 # See https://aquasecurity.github.io/trivy/v0.48/docs/configuration/filtering/#trivyignore
+
+# Adding CVE in grafana-plugin-sdk-go to exclusions as it does not have direct impact on the product
+# and updating library version requires complex changes in the codebase
+CVE-2024-8986


### PR DESCRIPTION
**What is this feature?**
Adding CVE in grafana-plugin-sdk-go to exclusions as it does not have direct impact on the product and updating library version in 11.1.x requires complex changes in the codebase

---
Result of running `govulncheck` 

```
=== Symbol Results ===

No vulnerabilities found.

=== Package Results ===

Vulnerability #1: GO-2024-3140
    Grafana plugin SDK Information Leakage in
    github.com/grafana/grafana-plugin-sdk-go
  More info: https://pkg.go.dev/vuln/GO-2024-3140
  Module: github.com/grafana/grafana-plugin-sdk-go
    Found in: github.com/grafana/grafana-plugin-sdk-go@v0.241.0
    Fixed in: github.com/grafana/grafana-plugin-sdk-go@v0.250.0

=== Module Results ===

No other vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 1 vulnerability in packages you import and 0
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
```
