### PR TITLE
Chore: Declare required pkg/build dependency from Enterprise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,6 +217,7 @@ require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250314071911-14e2784e6979 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250319110241-5a004939da2a // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana/pkg/apiserver v0.0.0-20250325075903-77fa2271be7a // @grafana/grafana-app-platform-squad
+	github.com/grafana/grafana/pkg/build v0.0.0-20250325142824-d3468105d760 // @grafana/grafana-developer-enablement-squad
 
 	// This needs to be here for other projects that import grafana/grafana
 	// For local development grafana/grafana will always use the local files

--- a/go.sum
+++ b/go.sum
@@ -1617,6 +1617,8 @@ github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250319110241-5a004939da2a h1
 github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250319110241-5a004939da2a/go.mod h1:K/fP4kODJmABug5b90PhACUZD6Xh/veEz2b1VRKNyuA=
 github.com/grafana/grafana/pkg/apiserver v0.0.0-20250325075903-77fa2271be7a h1:NN0j9zdqYpfliR0P+au/PAJ5lqP7IZPNe8tAX5eaQNE=
 github.com/grafana/grafana/pkg/apiserver v0.0.0-20250325075903-77fa2271be7a/go.mod h1:3Z958XEs20R6Wf5y4TFD07PGuGld6grB+wZ1qP/iyqg=
+github.com/grafana/grafana/pkg/build v0.0.0-20250325142824-d3468105d760 h1:vECuNHNJ+LvdPEtfODFYKoRJntM3pdJVbUTCNVli35w=
+github.com/grafana/grafana/pkg/build v0.0.0-20250325142824-d3468105d760/go.mod h1:oRT4FujT0y73JaklBs7emjC0XmVBfVyFFaUaPrIbttA=
 github.com/grafana/grafana/pkg/promlib v0.0.8 h1:VUWsqttdf0wMI4j9OX9oNrykguQpZcruudDAFpJJVw0=
 github.com/grafana/grafana/pkg/promlib v0.0.8/go.mod h1:U1ezG/MGaEPoThqsr3lymMPN5yIPdVTJnDZ+wcXT+ao=
 github.com/grafana/grafana/pkg/semconv v0.0.0-20250220164708-c8d4ff28a450 h1:wSqgLKFwI7fyeqf3djRXGClBLb/UPjZ4XPm/UsKFDB0=

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -37,4 +37,5 @@ import (
 	_ "github.com/grafana/e2e"
 	_ "github.com/grafana/gofpdf"
 	_ "github.com/grafana/gomemcache/memcache"
+	_ "github.com/grafana/grafana/pkg/build"
 )


### PR DESCRIPTION
**What is this feature?**

Adds `github.com/grafana/grafana/pkg/build` to the list of declared/required dependencies coming from Enterprise.

**Why do we need this feature?**

This dependency is being used in the Enterprise codebase, but because it was not declared in the `enterprise_imports.go`, if you ran `make update-workspace` with the Enterprise codebase, it would be modifying the `go.mod`+`go.sum`.

Ideally we want to have 0 diffs regardless of running in OSS or Enterprise modes.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
