### PR TITLE
Chore: Remove version specification from Docker Compose header in devenv

### DIFF
--- a/devenv/docker/compose_header.yml
+++ b/devenv/docker/compose_header.yml
@@ -1,2 +1,1 @@
-version: "3.4"
 services:


### PR DESCRIPTION
What the title says basically.

Run `make devenv sources=postgres` and observe that the obsolate version notice is not showing up anymore.