### PR TITLE
unified storage: check for iterator errors after each call to iter.Next.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -563,7 +563,7 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 					return err
 				}
 			}
-			return err
+			return iter.Error()
 		})
 		return rv, err
 	})

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -33,16 +33,18 @@ type ResourceServer interface {
 }
 
 type ListIterator interface {
+	// Next advances iterator and returns true if there is next value is available from the iterator.
+	// Error() should be checked after every call of Next(), even when Next() returns true.
 	Next() bool // sql.Rows
 
 	// Error returns iterator error, if any. This should be checked after any Next() call.
 	// (Some iterator implementations return true from Next, but also set the error at the same time).
 	Error() error
 
-	// The token that can be used to start iterating *after* this item
+	// ContinueToken returns the token that can be used to start iterating *after* this item
 	ContinueToken() string
 
-	// The token that can be used to start iterating *before* this item
+	// ContinueTokenWithCurrentRV returns the token that can be used to start iterating *before* this item
 	ContinueTokenWithCurrentRV() string
 
 	// ResourceVersion of the current item

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -757,11 +757,8 @@ func (s *server) List(ctx context.Context, req *ListRequest) (*ListResponse, err
 				}
 				if iter.Next() {
 					rsp.NextPageToken = t
-				} else if err := iter.Error(); err != nil {
-					return err
 				}
-
-				return nil
+				return iter.Error()
 			}
 		}
 		return iter.Error()

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -27,13 +27,14 @@ import (
 
 // Test names for the storage backend test suite
 const (
-	TestHappyPath         = "happy path"
-	TestWatchWriteEvents  = "watch write events from latest"
-	TestList              = "list"
-	TestBlobSupport       = "blob support"
-	TestGetResourceStats  = "get resource stats"
-	TestListHistory       = "list history"
-	TestCreateNewResource = "create new resource"
+	TestHappyPath                 = "happy path"
+	TestWatchWriteEvents          = "watch write events from latest"
+	TestList                      = "list"
+	TestBlobSupport               = "blob support"
+	TestGetResourceStats          = "get resource stats"
+	TestListHistory               = "list history"
+	TestListHistoryErrorReporting = "list history error reporting"
+	TestCreateNewResource         = "create new resource"
 )
 
 type NewBackendFunc func(ctx context.Context) resource.StorageBackend
@@ -76,6 +77,7 @@ func RunStorageBackendTest(t *testing.T, newBackend NewBackendFunc, opts *TestOp
 		{TestBlobSupport, runTestIntegrationBlobSupport},
 		{TestGetResourceStats, runTestIntegrationBackendGetResourceStats},
 		{TestListHistory, runTestIntegrationBackendListHistory},
+		{TestListHistoryErrorReporting, runTestIntegrationBackendListHistoryErrorReporting},
 		{TestCreateNewResource, runTestIntegrationBackendCreateNewResource},
 	}
 
@@ -838,36 +840,58 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 		require.Equal(t, "deleted-item ADDED", string(res.Items[1].Value))
 		require.Equal(t, rv1, res.Items[1].ResourceVersion)
 	})
+}
 
-	t.Run("using context with short deadline should return error", func(t *testing.T) {
-		request := &resource.ListRequest{
-			Limit:           3,
-			Source:          resource.ListRequest_HISTORY,
-			ResourceVersion: rv1,
-			VersionMatchV2:  resource.ResourceVersionMatchV2_NotOlderThan,
-			Options: &resource.ListOptions{
-				Key: &resource.ResourceKey{
-					Namespace: ns,
-					Group:     "group",
-					Resource:  "resource",
-					Name:      "item1",
-				},
-			},
-		}
+func runTestIntegrationBackendListHistoryErrorReporting(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
+	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+	server := newServer(t, backend)
 
-		res, err := server.List(ctx, request)
+	ns := nsPrefix + "-short"
+	const (
+		name         = "it1"
+		group        = "group"
+		resourceName = "resource"
+	)
+
+	start := time.Now()
+	origRv, _ := writeEvent(ctx, backend, name, resource.WatchEvent_ADDED, WithNamespace(ns), WithGroup(group), WithResource(resourceName))
+	require.Greater(t, origRv, int64(0))
+
+	const events = 500
+	prevRv := origRv
+	for i := 0; i < events; i++ {
+		rv, err := writeEvent(ctx, backend, name, resource.WatchEvent_MODIFIED, WithNamespace(ns), WithGroup(group), WithResource(resourceName))
 		require.NoError(t, err)
-		require.Nil(t, res.Error)
-		require.Len(t, res.Items, 3)
+		require.Greater(t, rv, prevRv)
+		prevRv = rv
+	}
+	t.Log("added events in ", time.Since(start))
 
-		shortContext, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
-		defer cancel()
+	req := &resource.ListRequest{
+		Limit:           2 * events,
+		Source:          resource.ListRequest_HISTORY,
+		ResourceVersion: origRv,
+		VersionMatchV2:  resource.ResourceVersionMatchV2_NotOlderThan,
+		Options: &resource.ListOptions{
+			Key: &resource.ResourceKey{
+				Namespace: ns,
+				Group:     group,
+				Resource:  resourceName,
+				Name:      name,
+			},
+		},
+	}
 
-		res, err = server.List(shortContext, request)
-		if err == nil && res != nil && res.Error == nil {
-			require.Fail(t, "expected error")
-		}
-	})
+	shortContext, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	defer cancel()
+
+	res, err := server.List(shortContext, req)
+	// We expect context deadline error, but it may be reported as a res.Error object.
+	t.Log("list error:", err)
+	if res != nil {
+		t.Log("iterator error:", res.Error)
+	}
+	require.True(t, err != nil || (res != nil && res.Error != nil))
 }
 
 func runTestIntegrationBlobSupport(t *testing.T, backend resource.StorageBackend, nsPrefix string) {


### PR DESCRIPTION
This PR adds error-checks when using List iterator from backend. 

Failure to check for errors was the cause of "mysterious" test failures reported here: https://github.com/grafana/grafana-enterprise/pull/8202#issuecomment-2751466201

This PR also increases deadline for running integration tests for listing history, since short deadline was the source of problems with truncated result list.