### PR TITLE
Chore: Update Postgres version to 17.4-alpine3.21 in devenv

### DIFF
--- a/devenv/docker/blocks/postgres/.env
+++ b/devenv/docker/blocks/postgres/.env
@@ -1,1 +1,1 @@
-postgres_version=11.20-alpine3.18
+postgres_version=17.4-alpine3.21

--- a/devenv/docker/blocks/postgres_tests/.env
+++ b/devenv/docker/blocks/postgres_tests/.env
@@ -1,1 +1,1 @@
-postgres_version=11.20-alpine3.18
+postgres_version=17.4-alpine3.21

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,4 +1,4 @@
-ARG postgres_version=11.20-alpine3.18
+ARG postgres_version=17.4-alpine3.21
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Postgres version 11 is deprecated. https://www.postgresql.org/support/versioning/

I changed the version for devenv to use the latest postgresql version.