### PR TITLE
SQL Expressions: allow ParenSelect in queries

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -96,7 +96,7 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.JoinTableExpr, sqlparser.JoinCondition:
 		return
 
-	case *sqlparser.Select, sqlparser.SelectExprs:
+	case *sqlparser.Select, sqlparser.SelectExprs, *sqlparser.ParenSelect:
 		return
 
 	case *sqlparser.SetOp:

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -32,6 +32,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    example_all_allowed_functions,
 			err:  nil,
 		},
+		{
+			name: "paren select allowed",
+			q:    `(SELECT * FROM a_table) UNION ALL (SELECT * FROM a_table2)`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Allow a query like `(SELECT * FROM a_table) UNION ALL (SELECT * FROM a_table2)` in SQL expressions, this unblocks parenSelect.

**Why do we need this feature?**

I ran into when trying to combine tables with identical schemas, and wanting to limit each before the union.

**Who is this feature for?**

SQL Expressions Users.
