### PR TITLE
Gracefully handle metrics query error when max range is exceeded

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -678,6 +678,18 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       return EMPTY;
     }
 
+    // Check if the time range exceeds 24 hours
+    const timeRangeMs = options.range.to.valueOf() - options.range.from.valueOf();
+    const limitMs = 24 * 60 * 60 * 1000;
+    if (timeRangeMs > limitMs) {
+      return of({
+        error: {
+          message: 'Metrics query time range exceeds the maximum allowed duration of 24 hours.',
+        },
+        data: [],
+      });
+    }
+
     const startTime = performance.now();
     const request = { ...options, targets: validTargets };
     return super.query(request).pipe(


### PR DESCRIPTION
**What is this feature?**

Gracefully handle metrics query error when max range is exceeded.

**Why do we need this feature?**

So users know what the error message means.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/traces-drilldown/issues/378
