### PR TITLE
Assign errorsource to InfluxDB Flux http errors

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/influxdata/influxdb-client-go/v2/api"
+	"github.com/influxdata/influxdb-client-go/v2/api/http"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -26,6 +27,11 @@ func executeQuery(ctx context.Context, logger log.Logger, query queryModel, runn
 
 	tables, err := runner.runQuery(ctx, flux)
 	if err != nil {
+		var influxHttpError *http.Error
+		if errors.As(err, &influxHttpError) {
+			dr.ErrorSource = backend.ErrorSourceFromHTTPStatus(influxHttpError.StatusCode)
+			dr.Status = backend.Status(influxHttpError.StatusCode)
+		}
 		logger.Warn("Flux query failed", "err", err, "query", flux)
 		dr.Error = err
 	} else {


### PR DESCRIPTION
InfluxDB Flux queries can return a http.Error type that we can use to assign errorsource to.

This PR checks for that type of error, and uses our errorsource machinery to assign an errorsource.

This is part of https://github.com/grafana/data-sources/issues/377