### PR TITLE
K8s: Reduce folder get calls in modes 0-2

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -58,6 +58,9 @@ const AnnoKeySourcePath = "grafana.app/sourcePath"
 const AnnoKeySourceChecksum = "grafana.app/sourceChecksum"
 const AnnoKeySourceTimestamp = "grafana.app/sourceTimestamp"
 
+const AnnoKeyFullpath = "grafana.app/fullpath"
+const AnnoKeyFullpathUIDs = "grafana.app/fullpathUIDs"
+
 // LabelKeyDeprecatedInternalID gives the deprecated internal ID of a resource
 // Deprecated: will be removed in grafana 13
 const LabelKeyDeprecatedInternalID = "grafana.app/deprecatedInternalID"
@@ -96,6 +99,11 @@ type GrafanaMetaAccessor interface {
 
 	// Deprecated: This will be removed in Grafana 13
 	SetDeprecatedInternalID(id int64)
+
+	GetFullpath() string
+	SetFullpath(path string)
+	GetFullpathUIDs() string
+	SetFullpathUIDs(uids string)
 
 	GetSpec() (any, error)
 	SetSpec(any) error
@@ -315,6 +323,22 @@ func (m *grafanaMetaAccessor) SetDeprecatedInternalID(id int64) {
 
 	labels[LabelKeyDeprecatedInternalID] = strconv.FormatInt(id, 10)
 	m.obj.SetLabels(labels)
+}
+
+func (m *grafanaMetaAccessor) GetFullpath() string {
+	return m.get(AnnoKeyFullpath)
+}
+
+func (m *grafanaMetaAccessor) SetFullpath(path string) {
+	m.SetAnnotation(AnnoKeyFullpath, path)
+}
+
+func (m *grafanaMetaAccessor) GetFullpathUIDs() string {
+	return m.get(AnnoKeyFullpathUIDs)
+}
+
+func (m *grafanaMetaAccessor) SetFullpathUIDs(uids string) {
+	m.SetAnnotation(AnnoKeyFullpathUIDs, uids)
 }
 
 // GetAnnotations implements GrafanaMetaAccessor.

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -72,6 +72,14 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	// We're going to have to align with that. For now we do need the user ID because the folder type stores it
 	// as the only user identifier
 
+	if v.Fullpath != "" {
+		meta.SetFullpath(v.Fullpath)
+	}
+
+	if v.FullpathUIDs != "" {
+		meta.SetFullpathUIDs(v.FullpathUIDs)
+	}
+
 	if v.CreatedBy != 0 {
 		meta.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(v.CreatedBy, 10)))
 	}

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -106,7 +107,7 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		paging.page = 1
 	}
 
-	if user.GetOrgRole() == org.RoleAdmin {
+	if user.GetOrgRole() == org.RoleAdmin && options.LabelSelector != nil && options.LabelSelector.Matches(labels.Set{utils.AnnoKeyFullpath: "true"}) {
 		query.WithFullpath = true
 		query.WithFullpathUIDs = true
 	}

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -103,6 +104,11 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		// also need to update the paging token so the continue token is correct
 		paging.limit = options.Limit
 		paging.page = 1
+	}
+
+	if user.GetOrgRole() == org.RoleAdmin {
+		query.WithFullpath = true
+		query.WithFullpathUIDs = true
 	}
 
 	hits, err := s.service.GetFoldersLegacy(ctx, query)

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -107,6 +107,7 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		paging.page = 1
 	}
 
+	// only admins can add this to the query, otherwise we may return parent folder names that are not visible to the user
 	if user.GetOrgRole() == org.RoleAdmin && options.LabelSelector != nil && options.LabelSelector.Matches(labels.Set{utils.AnnoKeyFullpath: "true"}) {
 		query.WithFullpath = true
 		query.WithFullpathUIDs = true

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -58,6 +58,7 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 	if updater.UID == "" {
 		updater = creator
 	}
+
 	manager, _ := meta.GetManagerProperties()
 	return &folder.Folder{
 		UID:         uid,
@@ -68,12 +69,14 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 		Version:     int(meta.GetGeneration()),
 		ManagedBy:   manager.Kind,
 
-		URL:       url,
-		Created:   created,
-		Updated:   *updated,
-		OrgID:     info.OrgID,
-		CreatedBy: creator.ID,
-		UpdatedBy: updater.ID,
+		Fullpath:     meta.GetFullpath(),
+		FullpathUIDs: meta.GetFullpathUIDs(),
+		URL:          url,
+		Created:      created,
+		Updated:      *updated,
+		OrgID:        info.OrgID,
+		CreatedBy:    creator.ID,
+		UpdatedBy:    updater.ID,
 	}, nil
 }
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -308,7 +308,14 @@ func (ss *FolderUnifiedStoreImpl) GetHeight(ctx context.Context, foldrUID string
 // The full path UIDs of B is "uid1/uid2".
 // The full path UIDs of A is "uid1".
 func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFoldersFromStoreQuery) ([]*folder.Folder, error) {
-	out, err := ss.k8sclient.List(ctx, q.OrgID, v1.ListOptions{})
+	opts := v1.ListOptions{}
+	if q.WithFullpath || q.WithFullpathUIDs {
+		// only supported in modes 0-2, to keep the alerting queries from causing tons of get folder requests
+		// to retrieve the parent for all folders in grafana
+		opts.LabelSelector = utils.AnnoKeyFullpath + "=true"
+	}
+
+	out, err := ss.k8sclient.List(ctx, q.OrgID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -320,6 +327,7 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 		if f == nil {
 			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
+
 		if (q.WithFullpath || q.WithFullpathUIDs) && f.Fullpath == "" {
 			parents, err := ss.GetParents(ctx, folder.GetParentsQuery{UID: f.UID, OrgID: q.OrgID})
 			if err != nil {

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -320,7 +320,7 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 		if f == nil {
 			return nil, fmt.Errorf("unable to convert unstructured item to legacy folder %w", err)
 		}
-		if q.WithFullpath || q.WithFullpathUIDs {
+		if (q.WithFullpath || q.WithFullpathUIDs) && f.Fullpath == "" {
 			parents, err := ss.GetParents(ctx, folder.GetParentsQuery{UID: f.UID, OrgID: q.OrgID})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get parents for folder %s: %w", f.UID, err)


### PR DESCRIPTION
**What is this feature?**

This PR reduces folder get calls in modes 0-2 by querying for the full path on the original database call and setting it as annotation, rather than doing a get parent call for each folder in the list, if the requester is an admin (so we do not need to do checks for if they can view the full path) and they requested the full path.

This is [especially important in alerting](https://github.com/grafana/grafana/blob/7c2890384ab820fd7153a4d916b0abb19285efa0/pkg/services/ngalert/store/alert_rule.go#L878), which gets all the folders for the scheduler.

This is not supported in modes 3-4, because if we set the annotations on the object, anytime we did a move of a folder, we would need to update the annotation on all children folders. We will think of a solution for that use case, but for now, this will help us with modes 0-2.

Added a few alerts to a test instance inside of children folders:
![Screenshot 2025-03-25 at 7 47 39 PM](https://github.com/user-attachments/assets/da6ba68a-80fa-4ca3-8d67-c236538ab16f)
