### PR TITLE
SQL Expressions: Allow `IS` keyword

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -93,6 +93,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.Into:
 		return
 
+	case *sqlparser.IsExpr:
+		return
+
 	case *sqlparser.JoinTableExpr, sqlparser.JoinCondition:
 		return
 

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -37,6 +37,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `(SELECT * FROM a_table) UNION ALL (SELECT * FROM a_table2)`,
 			err:  nil,
 		},
+		{
+			name: "allows keywords 'is', 'not', 'null'",
+			q:    `SELECT * FROM a_table WHERE a_column IS NOT NULL`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
What it says on the tin