### PR TITLE
Alerting: Add default values to AlertRule.Data queries in Prometheus conversion

### DIFF
--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -290,12 +290,10 @@ func (aq *AlertQuery) PreSave() error {
 		return fmt.Errorf("failed to set query type to query model: %w", err)
 	}
 
-	// override model
-	model, err := aq.GetModel()
-	if err != nil {
+	// Initialize defaults, which also overrides the model
+	if err := aq.InitDefaults(); err != nil {
 		return err
 	}
-	aq.Model = model
 
 	isExpression, err := aq.IsExpression()
 	if err != nil {
@@ -305,5 +303,16 @@ func (aq *AlertQuery) PreSave() error {
 	if ok := isExpression || aq.RelativeTimeRange.isValid(); !ok {
 		return ErrInvalidRelativeTimeRange(aq.RefID, aq.RelativeTimeRange)
 	}
+	return nil
+}
+
+// InitDefaults ensures all default parameters are set in the query model.
+// This helps maintain consistent query models for comparisons.
+func (aq *AlertQuery) InitDefaults() error {
+	model, err := aq.GetModel()
+	if err != nil {
+		return err
+	}
+	aq.Model = model
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

Prometheus conversion: ensures that AlertRule.Data queries always have default parameters set (`intervalMs`, `maxDataPoints`). Without this, updates of the same rule can cause version increments.

**Why do we need this feature?**

Currently, when converting Prometheus rules to Grafana alerts, some default parameters are not explicitly set in the query model. This creates a problem during rule updates:

When a user updates a rule that hasn't changed, we still detect differences in the AlertQuery.Model because the newly converted rules are missing the default fields, such as `intervalMs` and `maxDataPoints`. This causes unnecessary version increments of alert rules.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/971

**Special notes for your reviewer:**

I also considered changing the comparison logic instead, which is cleaner, but it's a bit tricky. Ideally, we'd need to distinguish between new rules (where missing fields are fine) and existing rules from the DB (where fields should exist).

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
