### PR TITLE
SchemaV2: Unify layout spec items property across different layout types

### DIFF
--- a/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
@@ -541,7 +541,7 @@ RowsLayoutKind: {
 }
 
 RowsLayoutSpec: {
-	rows: [...RowsLayoutRowKind]
+	items: [...RowsLayoutRowKind]
 }
 
 RowsLayoutRowKind: {
@@ -589,7 +589,7 @@ TabsLayoutKind: {
 }
 
 TabsLayoutSpec: {
-	tabs: [...TabsLayoutTabKind]
+	items: [...TabsLayoutTabKind]
 }
 
 TabsLayoutTabKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -541,7 +541,7 @@ RowsLayoutKind: {
 }
 
 RowsLayoutSpec: {
-  rows: [...RowsLayoutRowKind]
+  items: [...RowsLayoutRowKind]
 }
 
 RowsLayoutRowKind: {
@@ -589,7 +589,7 @@ TabsLayoutKind: {
 }
 
 TabsLayoutSpec: {
-  tabs: [...TabsLayoutTabKind]
+  items: [...TabsLayoutTabKind]
 }
 
 TabsLayoutTabKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/types.gen.ts
@@ -705,11 +705,11 @@ export const defaultRowsLayoutKind = (): RowsLayoutKind => ({
 });
 
 export interface RowsLayoutSpec {
-	rows: RowsLayoutRowKind[];
+	items: RowsLayoutRowKind[];
 }
 
 export const defaultRowsLayoutSpec = (): RowsLayoutSpec => ({
-	rows: [],
+	items: [],
 });
 
 export interface RowsLayoutRowKind {
@@ -882,11 +882,11 @@ export const defaultTabsLayoutKind = (): TabsLayoutKind => ({
 });
 
 export interface TabsLayoutSpec {
-	tabs: TabsLayoutTabKind[];
+	items: TabsLayoutTabKind[];
 }
 
 export const defaultTabsLayoutSpec = (): TabsLayoutSpec => ({
-	tabs: [],
+	items: [],
 });
 
 export interface TabsLayoutTabKind {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
@@ -15,7 +15,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -37,7 +37,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -67,7 +67,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -109,7 +109,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'RowsLayout',
       spec: {
-        rows: [],
+        items: [],
       },
     };
     const serializer = new RowsLayoutSerializer();
@@ -122,7 +122,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -175,7 +175,7 @@ describe('serialization', () => {
     expect(serialized).toEqual({
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -213,7 +213,7 @@ describe('serialization', () => {
     expect(serialized).toEqual({
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {
@@ -261,7 +261,7 @@ describe('serialization', () => {
     expect(serialized).toEqual({
       kind: 'RowsLayout',
       spec: {
-        rows: [
+        items: [
           {
             kind: 'RowsLayoutRow',
             spec: {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -14,7 +14,7 @@ export class RowsLayoutSerializer implements LayoutManagerSerializer {
     return {
       kind: 'RowsLayout',
       spec: {
-        rows: layoutManager.state.rows.map((row) => {
+        items: layoutManager.state.rows.map((row) => {
           const layout = getLayout(row.state.layout);
           const rowKind: RowsLayoutRowKind = {
             kind: 'RowsLayoutRow',
@@ -55,7 +55,7 @@ export class RowsLayoutSerializer implements LayoutManagerSerializer {
     if (layout.kind !== 'RowsLayout') {
       throw new Error('Invalid layout kind');
     }
-    const rows = layout.spec.rows.map((row) => {
+    const rows = layout.spec.items.map((row) => {
       const layout = row.spec.layout;
       const behaviors: SceneObject[] = [];
       if (row.spec.repeat) {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
@@ -12,7 +12,12 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [{ kind: 'TabsLayoutTab', spec: { title: 'Tab 1', layout: { kind: 'RowsLayout', spec: { rows: [] } } } }],
+        items: [
+          {
+            kind: 'TabsLayoutTab',
+            spec: { title: 'Tab 1', layout: { kind: 'RowsLayout', spec: { items: [] } } },
+          },
+        ],
       },
     };
     const serializer = new TabsLayoutSerializer();
@@ -25,7 +30,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [
+        items: [
           {
             kind: 'TabsLayoutTab',
             spec: {
@@ -49,7 +54,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [
+        items: [
           {
             kind: 'TabsLayoutTab',
             spec: { title: 'Tab 1', layout: { kind: 'GridLayout', spec: { items: [] } } },
@@ -67,7 +72,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [
+        items: [
           {
             kind: 'TabsLayoutTab',
             spec: {
@@ -93,7 +98,7 @@ describe('deserialization', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [],
+        items: [],
       },
     };
     const serializer = new TabsLayoutSerializer();

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -12,7 +12,7 @@ export class TabsLayoutSerializer implements LayoutManagerSerializer {
     return {
       kind: 'TabsLayout',
       spec: {
-        tabs: layoutManager.state.tabs.map((tab) => {
+        items: layoutManager.state.tabs.map((tab) => {
           const layout = getLayout(tab.state.layout);
           return {
             kind: 'TabsLayoutTab',
@@ -34,7 +34,7 @@ export class TabsLayoutSerializer implements LayoutManagerSerializer {
     if (layout.kind !== 'TabsLayout') {
       throw new Error('Invalid layout kind');
     }
-    const tabs = layout.spec.tabs.map((tab) => {
+    const tabs = layout.spec.items.map((tab) => {
       const layout = tab.spec.layout;
       return new TabItem({
         title: tab.spec.title,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -540,7 +540,7 @@ describe('transformSaveModelSchemaV2ToScene', () => {
         dashboard.spec.layout = {
           kind: 'TabsLayout',
           spec: {
-            tabs: [
+            items: [
               {
                 kind: 'TabsLayoutTab',
                 spec: {
@@ -588,7 +588,7 @@ describe('transformSaveModelSchemaV2ToScene', () => {
         dashboard.spec.layout = {
           kind: 'RowsLayout',
           spec: {
-            rows: [
+            items: [
               {
                 kind: 'RowsLayoutRow',
                 spec: {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -574,9 +574,9 @@ describe('dynamic layouts', () => {
     const result = transformSceneToSaveModelSchemaV2(scene);
     expect(result.layout.kind).toBe('RowsLayout');
     const rowsLayout = result.layout.spec as RowsLayoutSpec;
-    expect(rowsLayout.rows.length).toBe(1);
-    expect(rowsLayout.rows[0].kind).toBe('RowsLayoutRow');
-    expect(rowsLayout.rows[0].spec.layout.kind).toBe('GridLayout');
+    expect(rowsLayout.items.length).toBe(1);
+    expect(rowsLayout.items[0].kind).toBe('RowsLayoutRow');
+    expect(rowsLayout.items[0].spec.layout.kind).toBe('GridLayout');
   });
 
   it('should transform scene with rows layout with multiple rows with different grids to save model schema v2', () => {
@@ -616,14 +616,14 @@ describe('dynamic layouts', () => {
     const result = transformSceneToSaveModelSchemaV2(scene);
     expect(result.layout.kind).toBe('RowsLayout');
     const rowsLayout = result.layout.spec as RowsLayoutSpec;
-    expect(rowsLayout.rows.length).toBe(2);
-    expect(rowsLayout.rows[0].kind).toBe('RowsLayoutRow');
-    expect(rowsLayout.rows[0].spec.layout.kind).toBe('ResponsiveGridLayout');
-    const layout1 = rowsLayout.rows[0].spec.layout.spec as ResponsiveGridLayoutSpec;
+    expect(rowsLayout.items.length).toBe(2);
+    expect(rowsLayout.items[0].kind).toBe('RowsLayoutRow');
+    expect(rowsLayout.items[0].spec.layout.kind).toBe('ResponsiveGridLayout');
+    const layout1 = rowsLayout.items[0].spec.layout.spec as ResponsiveGridLayoutSpec;
     expect(layout1.items[0].kind).toBe('ResponsiveGridLayoutItem');
 
-    expect(rowsLayout.rows[1].spec.layout.kind).toBe('GridLayout');
-    const layout2 = rowsLayout.rows[1].spec.layout.spec as GridLayoutSpec;
+    expect(rowsLayout.items[1].spec.layout.kind).toBe('GridLayout');
+    const layout2 = rowsLayout.items[1].spec.layout.spec as GridLayoutSpec;
     expect(layout2.items[0].kind).toBe('GridLayoutItem');
   });
 
@@ -682,9 +682,9 @@ describe('dynamic layouts', () => {
     const result = transformSceneToSaveModelSchemaV2(scene);
     expect(result.layout.kind).toBe('TabsLayout');
     const tabsLayout = result.layout.spec as TabsLayoutSpec;
-    expect(tabsLayout.tabs.length).toBe(1);
-    expect(tabsLayout.tabs[0].kind).toBe('TabsLayoutTab');
-    expect(tabsLayout.tabs[0].spec.layout.kind).toBe('GridLayout');
+    expect(tabsLayout.items.length).toBe(1);
+    expect(tabsLayout.items[0].kind).toBe('TabsLayoutTab');
+    expect(tabsLayout.items[0].spec.layout.kind).toBe('GridLayout');
   });
 });
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -587,7 +587,7 @@ function validateRowsLayout(layout: unknown) {
   if (!('spec' in layout) || typeof layout.spec !== 'object' || layout.spec === null) {
     throw new Error('Layout spec is not an object or is null');
   }
-  if (!('rows' in layout.spec) || !Array.isArray(layout.spec.rows)) {
+  if (!('items' in layout.spec) || !Array.isArray(layout.spec.items)) {
     throw new Error('Layout spec items is not an array');
   }
 }


### PR DESCRIPTION
This proposes a rename of `rows` and `tabs` for according layout types to `items` (as in grid layouts). It simplifies the diff when changing different layout types (only kind and items array change and there is no property rename), and somewhat feels right to express the same concepts using the same semantics.

Todo:
- [ ] Generate v2alpha1 go types, as currently the API validation is performed agains unchanged spec. This results in a runtime error.