### PR TITLE
[release-11.6.1] GrafanaUI: Use safePolygon close handler for interactive tooltips instead of a delay

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -10,6 +10,7 @@ import {
   useFocus,
   useHover,
   useInteractions,
+  safePolygon,
 } from '@floating-ui/react';
 import { forwardRef, cloneElement, isValidElement, useCallback, useId, useRef, useState } from 'react';
 
@@ -67,9 +68,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
     const tooltipId = useId();
 
     const hover = useHover(context, {
-      delay: {
-        close: interactive ? 100 : 0,
-      },
+      handleClose: interactive ? safePolygon() : undefined,
       move: false,
     });
     const focus = useFocus(context);


### PR DESCRIPTION
Backport 2c10b35b339326f04df953f92164a0b76d64d68f from #101871

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Uses the [safePolygon](https://floating-ui.com/docs/usehover#safepolygon) close handler for `interactive` tooltips instead of using a 100ms delay.

**Why do we need this feature?**

The tooltip can close before the user has moved the mouse over it. We currently allow the user 100ms to traverse the gap between the trigger and the content but this isn't much time and the tooltip often closes before they make it – this issue has been raised to the IRM team a couple of times by users attempting to edit their oncall schedules. The library we use provides a close handler method which will prevent the tooltip from closing whilst the mouse is moving from the trigger to the content even if it is moving very slowly. We can use this instead to prevent the tooltip from closing before the user can hover over it.

### Demo

https://github.com/user-attachments/assets/c8daac06-ef44-49e3-b66e-330c62068451

**Who is this feature for?**

All users of interactive tooltips.

**Which issue(s) does this PR fix?**:
N/A

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

I do not have permission to merge PRs in grafana/grafana even after they're approved so, if you approve, could you also merge please?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
