### PR TITLE
Fix: Fixing typo in Dockerfile preventing successful build of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY .citools/cog .citools/cog
 COPY .citools/lefthook .citools/lefthook
 COPY .citools/jb .citools/jb
 COPY .citools/golangci-lint .citools/golangci-lint
-COPY .citools/swagger ./citools/swagger
+COPY .citools/swagger .citools/swagger
 
 # Include vendored dependencies
 COPY pkg/util/xorm pkg/util/xorm


### PR DESCRIPTION

**What is this feature?**

Minor typo in Dockerfile causes `.citools/swagger` to be copied to a wrong directory which leads to docker image build failure