### PR TITLE
ssosettings: Don't update primary key in sso_setting table.

### DIFF
--- a/pkg/services/ssosettings/database/database.go
+++ b/pkg/services/ssosettings/database/database.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	idColumn        = "id"
 	isDeletedColumn = "is_deleted"
 	updatedColumn   = "updated"
 )
@@ -143,7 +144,10 @@ func (s *SSOSettingsStore) Delete(ctx context.Context, provider string) error {
 		existing.Updated = time.Now().UTC()
 		existing.IsDeleted = true
 
-		_, err = sess.ID(existing.ID).MustCols(updatedColumn, isDeletedColumn).Update(existing)
+		// We must explicitly omit ID column from updates, because some databases (e.g. Spanner) don't allow updating
+		// primary key. Xorm ignores autoincrement columns during updates, but since ID column here is a string,
+		// it's not ignored by default.
+		_, err = sess.ID(existing.ID).Omit(idColumn).MustCols(updatedColumn, isDeletedColumn).Update(existing)
 		return err
 	})
 }


### PR DESCRIPTION
This PR avoids updating column `id` (PK), since Spanner doesn't like that and complains with `Cannot modify a primary key column with UPDATE` error. Normally Xorm would ignore the column during updates, if it was marked as autoincrement, but `id` column in `sso_setting` table is a string.

This fixes integration tests `TestIntegrationDeleteSSOSettings/soft_deletes_the_settings_successfully` and `TestIntegrationDeleteSSOSettings/delete_one_record_if_more_valid_sso_settings_are_available_for_a_provider` when running with Spanner emulator.