### PR TITLE
PanelEdit: Adapt panel data error view CTAs to scenes

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { PanelDataErrorViewProps, locationService } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { CardButton } from 'app/core/components/CardButton';
 import { LS_VISUALIZATION_SELECT_TAB_KEY } from 'app/core/constants';
@@ -16,6 +17,8 @@ import store from 'app/core/store';
 import { toggleVizPicker } from 'app/features/dashboard/components/PanelEditor/state/reducers';
 import { VisualizationSelectPaneTab } from 'app/features/dashboard/components/PanelEditor/types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
 import { useDispatch } from 'app/types';
 
 import { changePanelPlugin } from '../state/actions';
@@ -27,15 +30,34 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
   const { dataSummary } = builder;
   const message = getMessageFor(props, dataSummary);
   const dispatch = useDispatch();
-  const panel = getDashboardSrv().getCurrent()?.getPanelById(props.panelId);
+
+  const dashboardScene: DashboardScene | undefined = window.__grafanaSceneContext;
+  let panel;
+  if (dashboardScene instanceof DashboardScene) {
+    panel = findVizPanelByKey(dashboardScene, getVizPanelKeyForPanelId(props.panelId));
+  } else {
+    panel = getDashboardSrv().getCurrent()?.getPanelById(props.panelId);
+  }
 
   const openVizPicker = () => {
     store.setObject(LS_VISUALIZATION_SELECT_TAB_KEY, VisualizationSelectPaneTab.Suggestions);
+    if (dashboardScene) {
+      dashboardScene.state.editPanel?.state.optionsPane?.onToggleVizPicker();
+
+      return;
+    }
+
     dispatch(toggleVizPicker(true));
   };
 
   const switchToTable = () => {
     if (!panel) {
+      return;
+    }
+
+    if (panel instanceof VizPanel) {
+      panel.changePluginType('table');
+
       return;
     }
 
@@ -51,12 +73,18 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
     if (!panel) {
       return;
     }
-    dispatch(
-      changePanelPlugin({
-        ...s, // includes panelId, config, etc
-        panel,
-      })
-    );
+
+    if (panel instanceof VizPanel) {
+      panel.changePluginType(s.pluginId, s.options, s.fieldConfig);
+    } else {
+      dispatch(
+        changePanelPlugin({
+          ...s, // includes panelId, config, etc
+          panel,
+        })
+      );
+    }
+
     if (s.transformations) {
       setTimeout(() => {
         locationService.partial({ tab: 'transform' });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, the CTAs on a panel when there is no data do not work in scenes. This is probably something we missed to adapt together with the scenes migration.

**Why do we need this feature?**

Makes these buttons work with scenes.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #102882

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
