### PR TITLE
fix: add index for resource history get with trash on

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -152,7 +152,7 @@ func initResourceTables(mg *migrator.Migrator) string {
 	mg.AddMigration("Migrate DeletionMarkers to real Resource objects", &deletionMarkerMigrator{})
 
 	mg.AddMigration("Add index to resource_history for get trash", migrator.NewAddIndexMigration(resource_history_table, &migrator.Index{
-		Cols: []string{"namespace", "group", "resource", "action", "resource_version"}, Type: migrator.IndexType,
+		Name: "IDX_resource_history_namespace_group_resource_action_version", Cols: []string{"namespace", "group", "resource", "action", "resource_version"}, Type: migrator.IndexType,
 	}))
 
 	return marker

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -151,5 +151,9 @@ func initResourceTables(mg *migrator.Migrator) string {
 
 	mg.AddMigration("Migrate DeletionMarkers to real Resource objects", &deletionMarkerMigrator{})
 
+	mg.AddMigration("Add index to resource_history for get trash", migrator.NewAddIndexMigration(resource_history_table, &migrator.Index{
+		Cols: []string{"namespace", "group", "resource", "action", "resource_version"}, Type: migrator.IndexType,
+	}))
+
 	return marker
 }


### PR DESCRIPTION
Add index for request history get operations including the `action` filter when trash is on.

**with index:**
```
-> Index lookup on resource_history using idx_resource_history_lookup (namespace='nn', group='gg', resource='rr', action=3)  (cost=0.35 rows=1) (actual time=0.0146..0.0172 rows=1 loops=1)
```
**without index:**
```
-> Sort row IDs: resource_history.resource_version  (cost=0.6 rows=2) (actual time=0.119..0.119 rows=1 loops=1)
    -> Filter: (resource_history.`action` = 3)  (cost=0.6 rows=2) (actual time=0.083..0.0892 rows=1 loops=1)
        -> Index lookup on resource_history using UQE_resource_history_namespace_group_name_version (namespace='nn', group='gg', resource='rr')  (cost=0.6 rows=2) (actual time=0.0774..0.0832 rows=2 loops=1)
```