### PR TITLE
[release-11.6.1] Dashboards: Limit panel title length

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -47,7 +47,7 @@ export function buildVizPanel(panel: PanelKind): VizPanel {
 
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(panel.spec.id),
-    title: panel.spec.title,
+    title: panel.spec.title?.substring(0, 5000),
     description: panel.spec.description,
     pluginId: panel.spec.vizConfig.kind,
     options: panel.spec.vizConfig.spec.options,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -324,7 +324,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
 
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(panel.id),
-    title: panel.title,
+    title: panel.title?.substring(0, 5000),
     description: panel.description,
     pluginId: panel.type ?? 'timeseries',
     options: panel.options ?? {},

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -111,6 +111,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       if (!panel.key) {
         panel.key = `panel-${panel.id}-${Date.now()}`;
       }
+      panel.title = panel.title?.substring(0, 5000);
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {


### PR DESCRIPTION
Backport 44c471d10ca1d7c7035f648d3278aacbc1c99507 from #102911

---

**What is this feature?**

Limits the length of dashboard panel titles loaded from the backend.

**Why do we need this feature?**

Excessively long panel titles will slow down the UI.
