### PR TITLE
OptionCategory: Use text.secondary for closed categories 

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
@@ -20,7 +20,9 @@ export function ElementEditPane({ element, editPane }: Props) {
   return (
     <div className={styles.wrapper}>
       <EditPaneHeader element={element} editPane={editPane} />
-      <ScrollContainer showScrollIndicators={true}>{categories.map((cat) => cat.render())}</ScrollContainer>
+      <ScrollContainer showScrollIndicators={true}>
+        <div className={styles.categories}>{categories.map((cat) => cat.render())}</div>
+      </ScrollContainer>
     </div>
   );
 }
@@ -32,6 +34,11 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
       flex: '1 1 0',
       height: '100%',
+    }),
+    categories: css({
+      display: 'flex',
+      flexDirection: 'column',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
   };
 }

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -107,7 +107,7 @@ export const OptionsPaneCategory = React.memo(
         {/* this just provides a better experience for mouse users */}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div className={headerStyles} onClick={onToggle}>
-          <h6 id={`button-${id}`} className={styles.title}>
+          <h6 id={`button-${id}`} className={cx(styles.title, isExpanded && styles.titleExpanded)}>
             {renderTitle(isExpanded)}
           </h6>
 
@@ -149,6 +149,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: '1rem',
     fontWeight: theme.typography.fontWeightMedium,
     margin: 0,
+    color: theme.colors.text.secondary,
+  }),
+  titleExpanded: css({
+    color: theme.colors.text.primary,
   }),
   header: css({
     display: 'flex',


### PR DESCRIPTION
Before: 
<img width="300" alt="Screenshot 2025-03-26 at 17 29 13" src="https://github.com/user-attachments/assets/ea94699e-87f1-4ebf-a344-157705e78f0a" />

After:

Default dark theme

<img width="304" alt="Screenshot 2025-03-26 at 17 30 07" src="https://github.com/user-attachments/assets/6b4d88a5-7abe-4a0d-b7e7-c0d4a2ba4127" />

Other dark theme 

<img width="306" alt="Screenshot 2025-03-26 at 17 30 22" src="https://github.com/user-attachments/assets/e90d087f-6db7-4842-8c8c-f05a49963616" />

Dashboard edit pane 
<img width="301" alt="Screenshot 2025-03-26 at 17 31 10" src="https://github.com/user-attachments/assets/ba7f20bc-025e-417c-8d76-5834ba53a08d" />

