### PR TITLE
Logs Panel: Add ISO8601 date to log download files

### DIFF
--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -273,7 +273,7 @@ describe('LogsMetaRow', () => {
             {
               name: 'time',
               type: FieldType.time,
-              values: ['1970-01-02T00:00:00Z'],
+              values: [1],
             },
             {
               name: 'message',
@@ -315,6 +315,6 @@ describe('LogsMetaRow', () => {
     const blob = (saveAs as unknown as jest.Mock).mock.lastCall[0];
     expect(blob.type).toBe('text/csv;charset=utf-8');
     const text = await blob.text();
-    expect(text).toBe(`"time","message bar"\r\n1970-01-02T00:00:00Z,INFO 1`);
+    expect(text).toBe(`"Date","time","message bar"\r\n1970-01-01T00:00:00.001Z,1,INFO 1`);
   });
 });

--- a/public/app/features/inspector/utils/download.test.ts
+++ b/public/app/features/inspector/utils/download.test.ts
@@ -105,7 +105,7 @@ describe('inspector download', () => {
           rows: [{ timeEpochMs: 100, entry: 'testEntry' } as unknown as LogRowModel],
         },
         'test',
-        `testLabel: 1\nsecondTestLabel: 2\n\n\n100\ttestEntry\n`,
+        `testLabel: 1\nsecondTestLabel: 2\n\n\n100\t1970-01-01T00:00:00.100Z\ttestEntry\n`,
       ],
     ])('should, when logsModel is %s and title is %s, resolve in %s', async (logsModel, title, expected) => {
       downloadLogsModelAsTxt(logsModel, title);

--- a/public/app/features/inspector/utils/download.ts
+++ b/public/app/features/inspector/utils/download.ts
@@ -4,6 +4,7 @@ import {
   CSVConfig,
   DataFrame,
   DataTransformerID,
+  dateTime,
   dateTimeFormat,
   LogsModel,
   MutableDataFrame,
@@ -30,7 +31,7 @@ export function downloadLogsModelAsTxt(logsModel: Pick<LogsModel, 'meta' | 'rows
   textToDownload = textToDownload + '\n\n';
 
   logsModel.rows.forEach((row) => {
-    const newRow = row.timeEpochMs + '\t' + row.entry + '\n';
+    const newRow = row.timeEpochMs + '\t' + dateTime(row.timeEpochMs).toISOString() + '\t' + row.entry + '\n';
     textToDownload = textToDownload + newRow;
   });
 

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -356,13 +356,22 @@ describe('logRowsToReadableJson', () => {
   it('should format a single row', () => {
     const result = logRowsToReadableJson([testRow]);
 
-    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar' } }]);
+    expect(result).toEqual([
+      { date: '1970-01-01T00:00:00.010Z', line: 'test entry', timestamp: '123456789', fields: { foo: 'bar' } },
+    ]);
   });
 
   it('should format a df field row', () => {
     const result = logRowsToReadableJson([testRow2]);
 
-    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar', foo2: 'bar2' } }]);
+    expect(result).toEqual([
+      {
+        date: '1970-01-01T00:00:00.010Z',
+        line: 'test entry',
+        timestamp: '123456789',
+        fields: { foo: 'bar', foo2: 'bar2' },
+      },
+    ]);
   });
 });
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -19,6 +19,7 @@ import {
   getDefaultTimeRange,
   locationUtil,
   urlUtil,
+  dateTime,
 } from '@grafana/data';
 import { getConfig } from 'app/core/config';
 
@@ -176,6 +177,7 @@ export function logRowsToReadableJson(logs: LogRowModel[]) {
     return {
       line: log.entry,
       timestamp: log.timeEpochNs,
+      date: dateTime(log.timeEpochMs).toISOString(),
       fields: {
         ...fields,
         ...log.labels,


### PR DESCRIPTION
**What is this feature?**
Adding ISO8601 date to log download files (CSV, JSON, .txt).

**Why do we need this feature?**
To make it easier to read downloaded log files.

**Who is this feature for?**
Logs users

**Special notes for your reviewer:**


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
