### PR TITLE
MetricsDrilldown: Mark `exploreMetricsUseExternalAppPlugin` as not frontend-only

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1650,7 +1650,7 @@ var (
 			Description:     "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
 			Stage:           FeatureStagePublicPreview,
 			Owner:           grafanaObservabilityMetricsSquad,
-			FrontendOnly:    true,
+			FrontendOnly:    false,
 			RequiresRestart: true,
 		},
 		{

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1652,6 +1652,7 @@ var (
 			Owner:           grafanaObservabilityMetricsSquad,
 			FrontendOnly:    false,
 			RequiresRestart: true,
+			HideFromDocs:    false,
 		},
 		{
 			Name:            "datasourceConnectionsTab",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1652,7 +1652,6 @@ var (
 			Owner:           grafanaObservabilityMetricsSquad,
 			FrontendOnly:    false,
 			RequiresRestart: true,
-			HideFromDocs:    false,
 		},
 		{
 			Name:            "datasourceConnectionsTab",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -218,7 +218,7 @@ templateVariablesUsesCombobox,experimental,@grafana/grafana-frontend-platform,fa
 ABTestFeatureToggleB,experimental,@grafana/sharing-squad,false,false,false
 grafanaAdvisor,experimental,@grafana/plugins-platform-backend,false,false,false
 elasticsearchImprovedParsing,experimental,@grafana/aws-datasources,false,false,false
-exploreMetricsUseExternalAppPlugin,preview,@grafana/observability-metrics,false,true,true
+exploreMetricsUseExternalAppPlugin,preview,@grafana/observability-metrics,false,true,false
 datasourceConnectionsTab,privatePreview,@grafana/plugins-platform-backend,false,false,true
 fetchRulesUsingPost,experimental,@grafana/alerting-squad,false,false,false
 alertingConversionAPI,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1677,17 +1677,16 @@
     {
       "metadata": {
         "name": "exploreMetricsUseExternalAppPlugin",
-        "resourceVersion": "1741883352541",
+        "resourceVersion": "1743019185639",
         "creationTimestamp": "2025-01-21T23:24:50Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-03-13 16:29:12.541156 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-03-26 19:59:45.639604 +0000 UTC"
         }
       },
       "spec": {
         "description": "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
         "stage": "preview",
         "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
         "requiresRestart": true
       }
     },


### PR DESCRIPTION
## What is this change?

This PR updates the definition of the `exploreMetricsUseExternalAppPlugin` feature toggle, to correctly mark this feature toggle as `FrontendOnly: false`. This should have been done in https://github.com/grafana/grafana/pull/99481.