### PR TITLE
App Platform(Provisioning): Listen to context cancel ASAP

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -266,6 +266,9 @@ func (r *syncJob) applyChanges(ctx context.Context, changes []ResourceFileChange
 	r.progress.SetMessage(ctx, "replicating changes")
 
 	for _, change := range changes {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err := r.progress.TooManyErrors(); err != nil {
 			return err
 		}
@@ -344,6 +347,9 @@ func (r *syncJob) applyVersionedChanges(ctx context.Context, repo repository.Ver
 	r.progress.SetMessage(ctx, "replicating versioned changes")
 
 	for _, change := range diff {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err := r.progress.TooManyErrors(); err != nil {
 			return err
 		}


### PR DESCRIPTION
We should not write after the context is cancelled. This causes tests to fail as they are trying to clean up. To try to accommodate this, we'll need to listen to the context in any loop where we don't immediately get other instructions from e.g. trying to do an HTTP request.

This is a relatively rare flaky circumstance, but it _seems_ to be fine when testing locally:

```
$ while go test github.com/grafana/grafana/pkg/tests/apis/provisioning/... -count=3; end
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.290s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.041s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.820s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.008s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.530s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.371s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.260s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.267s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.744s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.925s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.949s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.004s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.539s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.095s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  14.448s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  15.039s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.885s
ok      github.com/grafana/grafana/pkg/tests/apis/provisioning  13.849s
```