### PR TITLE
I18n: Add 13 new languages for translations

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -223,7 +223,6 @@ Experimental features might be changed or removed without prior notice.
 | `newLogsPanel`                              | Enables the new logs panel in Explore                                                                                                                                                                                                                                             |
 | `pluginsCDNSyncLoader`                      | Load plugins from CDN synchronously                                                                                                                                                                                                                                               |
 | `assetSriChecks`                            | Enables SRI checks for Grafana JavaScript assets                                                                                                                                                                                                                                  |
-| `extraLanguages`                            | Enables additional languages                                                                                                                                                                                                                                                      |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1038,10 +1038,6 @@ export interface FeatureToggles {
   */
   inviteUserExperimental?: boolean;
   /**
-  * Enables additional languages
-  */
-  extraLanguages?: boolean;
-  /**
   * Disables backdrop blur
   */
   noBackdropBlur?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1780,13 +1780,6 @@ var (
 			FrontendOnly:      true,
 		},
 		{
-			Name:         "extraLanguages",
-			Description:  "Enables additional languages",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaFrontendPlatformSquad,
-			FrontendOnly: true,
-		},
-		{
 			Name:              "noBackdropBlur",
 			Description:       "Disables backdrop blur",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -235,7 +235,6 @@ alertRuleRestore,preview,@grafana/alerting-squad,false,false,false
 grafanaManagedRecordingRulesDatasources,experimental,@grafana/alerting-squad,false,false,false
 infinityRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 inviteUserExperimental,experimental,@grafana/sharing-squad,false,false,true
-extraLanguages,experimental,@grafana/grafana-frontend-platform,false,false,true
 noBackdropBlur,experimental,@grafana/grafana-frontend-platform,false,false,true
 alertingMigrationUI,experimental,@grafana/alerting-squad,false,false,true
 unifiedStorageHistoryPruner,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -951,10 +951,6 @@ const (
 	// Renders invite user button along the app
 	FlagInviteUserExperimental = "inviteUserExperimental"
 
-	// FlagExtraLanguages
-	// Enables additional languages
-	FlagExtraLanguages = "extraLanguages"
-
 	// FlagNoBackdropBlur
 	// Disables backdrop blur
 	FlagNoBackdropBlur = "noBackdropBlur"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1735,7 +1735,8 @@
       "metadata": {
         "name": "extraLanguages",
         "resourceVersion": "1741626708204",
-        "creationTimestamp": "2025-03-10T17:11:48Z"
+        "creationTimestamp": "2025-03-10T17:11:48Z",
+        "deletionTimestamp": "2025-03-27T09:58:35Z"
       },
       "spec": {
         "description": "Enables additional languages",

--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -1,8 +1,6 @@
 import { ResourceKey } from 'i18next';
 import { uniq } from 'lodash';
 
-import { config } from '@grafana/runtime';
-
 export const ENGLISH_US = 'en-US';
 export const FRENCH_FRANCE = 'fr-FR';
 export const SPANISH_SPAIN = 'es-ES';
@@ -40,8 +38,55 @@ export interface LanguageDefinition<Namespace extends string = string> {
   loader: Record<Namespace, LocaleFileLoader>;
 }
 
-// New languages added recently without translations available yet
-const NEW_LANGUAGES: LanguageDefinition[] = [
+export const LANGUAGES: LanguageDefinition[] = [
+  {
+    code: ENGLISH_US,
+    name: 'English',
+    loader: {
+      grafana: () => import('../../../locales/en-US/grafana.json'),
+    },
+  },
+
+  {
+    code: FRENCH_FRANCE,
+    name: 'Français',
+    loader: {
+      grafana: () => import('../../../locales/fr-FR/grafana.json'),
+    },
+  },
+
+  {
+    code: SPANISH_SPAIN,
+    name: 'Español',
+    loader: {
+      grafana: () => import('../../../locales/es-ES/grafana.json'),
+    },
+  },
+
+  {
+    code: GERMAN_GERMANY,
+    name: 'Deutsch',
+    loader: {
+      grafana: () => import('../../../locales/de-DE/grafana.json'),
+    },
+  },
+
+  {
+    code: CHINESE_SIMPLIFIED,
+    name: '中文（简体）',
+    loader: {
+      grafana: () => import('../../../locales/zh-Hans/grafana.json'),
+    },
+  },
+
+  {
+    code: BRAZILIAN_PORTUGUESE,
+    name: 'Português Brasileiro',
+    loader: {
+      grafana: () => import('../../../locales/pt-BR/grafana.json'),
+    },
+  },
+
   {
     code: CHINESE_TRADITIONAL,
     name: '中文（繁體）',
@@ -145,61 +190,7 @@ const NEW_LANGUAGES: LanguageDefinition[] = [
       grafana: () => import('../../../locales/tr-TR/grafana.json'),
     },
   },
-];
-
-export const LANGUAGES: LanguageDefinition[] = [
-  {
-    code: ENGLISH_US,
-    name: 'English',
-    loader: {
-      grafana: () => import('../../../locales/en-US/grafana.json'),
-    },
-  },
-
-  {
-    code: FRENCH_FRANCE,
-    name: 'Français',
-    loader: {
-      grafana: () => import('../../../locales/fr-FR/grafana.json'),
-    },
-  },
-
-  {
-    code: SPANISH_SPAIN,
-    name: 'Español',
-    loader: {
-      grafana: () => import('../../../locales/es-ES/grafana.json'),
-    },
-  },
-
-  {
-    code: GERMAN_GERMANY,
-    name: 'Deutsch',
-    loader: {
-      grafana: () => import('../../../locales/de-DE/grafana.json'),
-    },
-  },
-
-  {
-    code: CHINESE_SIMPLIFIED,
-    name: '中文（简体）',
-    loader: {
-      grafana: () => import('../../../locales/zh-Hans/grafana.json'),
-    },
-  },
-
-  {
-    code: BRAZILIAN_PORTUGUESE,
-    name: 'Português Brasileiro',
-    loader: {
-      grafana: () => import('../../../locales/pt-BR/grafana.json'),
-    },
-  },
 ] satisfies Array<LanguageDefinition<'grafana'>>;
-
-if (config.featureToggles?.extraLanguages) {
-  LANGUAGES.push(...NEW_LANGUAGES);
-}
 
 if (process.env.NODE_ENV === 'development') {
   LANGUAGES.push({


### PR DESCRIPTION
As the translations for the new languages came in last night https://github.com/grafana/grafana/pull/102953, this pull request unflags them and makes the following translations available:

 - Italian `it-IT`
 - Japanese `ja-JP`
 - Indonesian `id-ID`
 - Korean `ko-KR`
 - Russian `ru-RU`
 - Czech `cs-CZ`
 - Dutch `nl-NL`
 - Hungarian `hu-HU`
 - Portugese (Portugal) `pt-PT`
 - Polish `pl-PL`
 - Swedish `sv-SE`
 - Turkish `tr-TR`
 - Chinese (Traditional) `zh-Hant`