### PR TITLE
SQL Expressions: Allow more MySQL AST node-types

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -60,7 +60,7 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.BinaryExpr, *sqlparser.UnaryExpr:
 		return
 
-	case sqlparser.BoolVal:
+	case sqlparser.BoolVal, *sqlparser.NullVal:
 		return
 
 	case *sqlparser.CaseExpr, *sqlparser.When:
@@ -136,9 +136,6 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		return
 
 	case *sqlparser.Where:
-		return
-
-	case *sqlparser.NullVal:
 		return
 
 	default:

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -138,6 +138,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.Where:
 		return
 
+	case *sqlparser.NullVal:
+		return
+
 	default:
 		return false
 	}

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -84,6 +84,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case sqlparser.Exprs:
 		return
 
+	case *sqlparser.GroupConcatExpr:
+		return
+
 	case sqlparser.GroupBy:
 		return
 

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -81,6 +81,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.ConvertExpr, *sqlparser.ConvertType:
 		return
 
+	case sqlparser.Exprs:
+		return
+
 	case sqlparser.GroupBy:
 		return
 
@@ -130,6 +133,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		return
 
 	case *sqlparser.TrimExpr:
+		return
+
+	case sqlparser.ValTuple:
 		return
 
 	case *sqlparser.With:

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -81,6 +81,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.ConvertExpr, *sqlparser.ConvertType:
 		return
 
+	case *sqlparser.CollateExpr:
+		return
+
 	case sqlparser.Exprs:
 		return
 

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -47,6 +47,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT 1 as id, NULL as null_col`,
 			err:  nil,
 		},
+		{
+			name: "val tuple in read query",
+			q:    `SELECT 1 WHERE 1 IN (1, 2, 3)`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -42,6 +42,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT * FROM a_table WHERE a_column IS NOT NULL`,
 			err:  nil,
 		},
+		{
+			name: "null literal",
+			q:    `SELECT 1 as id, NULL as null_col`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -57,6 +57,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT 1 as id, GROUP_CONCAT('will_', 'concatenate') as concat_val`,
 			err:  nil,
 		},
+		{
+			name: "collate in read query",
+			q:    `SELECT 'some text' COLLATE utf8mb4_bin`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -52,6 +52,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT 1 WHERE 1 IN (1, 2, 3)`,
 			err:  nil,
 		},
+		{
+			name: "group concat in read query",
+			q:    `SELECT 1 as id, GROUP_CONCAT('will_', 'concatenate') as concat_val`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for some additional MySQL keywords:

- NULL (literals)
- IN
- GROUP_CONCAT
- COLLATE

See the individual commits for explanation of each:

- **SQL Expressions: Add Null-literal node**
- **Retain some order in the code - put NullVal with BoolVal**
- **Add support for `IN` keyword**
- **Add GROUP_CONCAT keyword**
- **Add COLLATE keyword**

I remember when we hit a problem where `NULL` was missing, so I wanted to add `NULL` specifically (and added the others at the same time). I used Claude and Cursor to do the following:

1. Learn if the AST node can be used when making read queries
2. Write the test case and run it first, and see it fail. All test cases require zero existing data in the DB, so all can also be run on SQL Fiddle.
3. Add the code
4. Run the test again, and see it pass


When I started this work I gave Claude a free rein to add Nodes which were present in `ast.go` within the DoltHub Vitess project, but missing from our code. It proposed a few additional nodes, which I considered in [this Draft PR](https://github.com/grafana/grafana/pull/102970). But after further investigation, only the ones in this PR are useful - there are explanations in [the Draft PR](https://github.com/grafana/grafana/pull/102970) for why the others aren't useful.