### PR TITLE
Add a run query button for the logs builder

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -47,6 +47,7 @@ describe('LogsQueryEditor', () => {
     delete query?.subscription;
     delete query?.azureLogAnalytics?.resources;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
     const basicLogsEnabled = false;
 
     render(
@@ -55,6 +56,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -98,6 +100,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -105,6 +108,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -133,6 +137,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -140,6 +145,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -168,6 +174,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -175,6 +182,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -207,6 +215,7 @@ describe('LogsQueryEditor', () => {
     const query = createMockQuery();
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -214,6 +223,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -237,6 +247,7 @@ describe('LogsQueryEditor', () => {
       const query = createMockQuery();
       const basicLogsEnabled = false;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       const date = dateTime(new Date());
       render(
@@ -245,6 +256,7 @@ describe('LogsQueryEditor', () => {
           datasource={mockDatasource}
           variableOptionGroup={variableOptionGroup}
           onChange={onChange}
+          onQueryChange={onQueryChange}
           setError={() => {}}
           basicLogsEnabled={basicLogsEnabled}
           data={{
@@ -278,6 +290,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -286,6 +299,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -304,6 +318,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -312,6 +327,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -332,6 +348,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = false;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -340,6 +357,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -358,6 +376,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -366,6 +385,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -386,6 +406,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -394,6 +415,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -416,6 +438,7 @@ describe('LogsQueryEditor', () => {
           basicLogsQuery: true,
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0);
       await act(async () => {
@@ -425,6 +448,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -451,6 +475,7 @@ describe('LogsQueryEditor', () => {
           basicLogsQuery: true,
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0.45);
       await act(async () => {
@@ -460,6 +485,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -485,6 +511,7 @@ describe('LogsQueryEditor', () => {
           query: '',
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0.5);
       await act(async () => {
@@ -494,6 +521,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -513,6 +541,7 @@ describe('LogsQueryEditor', () => {
         },
       });
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -521,6 +550,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={false}
           />
@@ -536,6 +566,7 @@ describe('LogsQueryEditor', () => {
       const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
       const query = { ...createMockQuery(), azureLogAnalytics: undefined };
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -544,6 +575,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={false}
           />

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -29,6 +29,7 @@ interface LogsQueryEditorProps {
   basicLogsEnabled: boolean;
   subscriptionId?: string;
   onChange: (newQuery: AzureMonitorQuery) => void;
+  onQueryChange: (newQuery: AzureMonitorQuery) => void;
   variableOptionGroup: { label: string; options: AzureMonitorOption[] };
   setError: (source: string, error: AzureMonitorErrorish | undefined) => void;
   hideFormatAs?: boolean;
@@ -43,6 +44,7 @@ const LogsQueryEditor = ({
   subscriptionId,
   variableOptionGroup,
   onChange,
+  onQueryChange,
   setError,
   hideFormatAs,
   timeRange,
@@ -100,7 +102,7 @@ const LogsQueryEditor = ({
     const hasRawKql = !!query.azureLogAnalytics?.query;
     const hasNoBuilder = !query.azureLogAnalytics?.builderQuery;
     const modeUnset = query.azureLogAnalytics?.mode === undefined;
-  
+
     if (hasRawKql && hasNoBuilder && modeUnset) {
       onChange({
         ...query,
@@ -111,7 +113,6 @@ const LogsQueryEditor = ({
       });
     }
   }, [query, onChange]);
-  
 
   useEffect(() => {
     const getBasicLogsUsage = async (query: AzureMonitorQuery) => {
@@ -224,7 +225,7 @@ const LogsQueryEditor = ({
             query={query}
             schema={schema!}
             basicLogsEnabled={basicLogsEnabled}
-            onQueryChange={onChange}
+            onQueryChange={onQueryChange}
             templateVariableOptions={templateVariableOptions}
             datasource={datasource}
             timeRange={timeRange}

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
@@ -100,6 +100,9 @@ const QueryEditor = ({
         query={query}
         onQueryChange={onQueryChange}
         setAzureLogsCheatSheetModalOpen={setAzureLogsCheatSheetModalOpen}
+        onRunQuery={baseOnRunQuery}
+        data={data}
+        app={app}
       />
       <EditorForQueryType
         data={data}
@@ -108,6 +111,7 @@ const QueryEditor = ({
         query={query}
         datasource={datasource}
         onChange={onQueryChange}
+        onQueryChange={onChange}
         variableOptionGroup={variableOptionGroup}
         setError={setError}
         range={range}
@@ -129,6 +133,8 @@ interface EditorForQueryTypeProps extends Omit<AzureMonitorQueryEditorProps, 'on
   basicLogsEnabled: boolean;
   variableOptionGroup: { label: string; options: AzureMonitorOption[] };
   setError: (source: string, error: AzureMonitorErrorish | undefined) => void;
+  // Used to update the query without running it
+  onQueryChange: (newQuery: AzureMonitorQuery) => void;
 }
 
 const EditorForQueryType = ({
@@ -140,6 +146,7 @@ const EditorForQueryType = ({
   variableOptionGroup,
   onChange,
   setError,
+  onQueryChange,
   range,
 }: EditorForQueryTypeProps) => {
   switch (query.queryType) {
@@ -167,6 +174,7 @@ const EditorForQueryType = ({
           variableOptionGroup={variableOptionGroup}
           setError={setError}
           timeRange={range}
+          onQueryChange={onQueryChange}
         />
       );
 

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { SelectableValue } from '@grafana/data';
+import { CoreApp, LoadingState, PanelData, SelectableValue } from '@grafana/data';
 import { EditorHeader, FlexItem, InlineSelect } from '@grafana/plugin-ui';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, RadioButtonGroup } from '@grafana/ui';
@@ -13,6 +13,9 @@ interface QueryTypeFieldProps {
   query: AzureMonitorQuery;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
   setAzureLogsCheatSheetModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  data: PanelData | undefined;
+  onRunQuery: () => void;
+  app: CoreApp | undefined;
 }
 
 const EDITOR_MODES = [
@@ -20,7 +23,16 @@ const EDITOR_MODES = [
   { label: 'KQL', value: LogsEditorMode.Raw },
 ];
 
-export const QueryHeader = ({ query, onQueryChange, setAzureLogsCheatSheetModalOpen }: QueryTypeFieldProps) => {
+export const QueryHeader = ({
+  query,
+  onQueryChange,
+  setAzureLogsCheatSheetModalOpen,
+  data,
+  app,
+  onRunQuery,
+}: QueryTypeFieldProps) => {
+  const isLoading = useMemo(() => data?.state === LoadingState.Loading, [data?.state]);
+
   const queryTypes: Array<{ value: AzureQueryType; label: string }> = [
     { value: AzureQueryType.AzureMonitor, label: 'Metrics' },
     { value: AzureQueryType.LogAnalytics, label: 'Logs' },
@@ -106,6 +118,19 @@ export const QueryHeader = ({ query, onQueryChange, setAzureLogsCheatSheetModalO
             data-testid="azure-query-header-logs-radio-button"
           />
         )}
+        {query.azureLogAnalytics?.mode === LogsEditorMode.Builder &&
+          !!config.featureToggles.azureMonitorLogsBuilderEditor &&
+          app !== CoreApp.Explore && (
+            <Button
+              variant="primary"
+              icon={isLoading ? 'spinner' : 'play'}
+              size="sm"
+              onClick={onRunQuery}
+              data-testid={selectors.components.queryEditor.logsQueryEditor.runQuery.button}
+            >
+              Run query
+            </Button>
+          )}
       </EditorHeader>
     </span>
   );

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -291,6 +291,8 @@ const VariableEditor = (props: Props) => {
             query={query}
             datasource={datasource}
             onChange={onQueryChange}
+            // Not applicable as the builder isn't available in the variable editor yet
+            onQueryChange={onQueryChange}
             variableOptionGroup={variableOptionGroup}
             setError={setError}
             hideFormatAs={true}

--- a/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
+++ b/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
@@ -76,6 +76,9 @@ export const components = {
       formatSelection: {
         input: 'data-testid format-selection',
       },
+      runQuery: {
+        button: 'data-testid run-query',
+      },
     },
     argsQueryEditor: {
       container: {


### PR DESCRIPTION
Adds a run query button for the logs query builder. This button will be displayed everywhere except for the Explore app, which already has a run query button.

Additionally, this button will reflect the loading state of the data.

![image](https://github.com/user-attachments/assets/7b25f594-6deb-41c3-a721-4ae5429cf55d)

![image](https://github.com/user-attachments/assets/fd3c3bcc-8070-4c89-913c-8277d896f702)
