### PR TITLE
Provisioning: Show in nav tree without feature enabled

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -60,7 +60,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 			Url:      s.cfg.AppSubURL + "/admin/migrate-to-cloud",
 		})
 	}
-	if hasAccess(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)) && s.features.IsEnabled(ctx, featuremgmt.FlagProvisioning) {
+	if hasAccess(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)) {
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
 			Text:     "Remote provisioning",
 			Id:       "provisioning",


### PR DESCRIPTION
This enables the nav bar item without the feature flag enabled. The example is tested locally with no feature flags configured.

![image](https://github.com/user-attachments/assets/d505c668-972d-435f-abd3-7eb641cb807f)

Fixes: https://github.com/grafana/git-ui-sync-project/issues/165