### PR TITLE
[release-10.4.18] AuthN: Refetch user on "ErrUserAlreadyExists"

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -75,29 +75,38 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 	}
 
 	// Does user exist in the database?
-	usr, userAuth, errUserInDB := s.getUser(ctx, id)
-	if errUserInDB != nil && !errors.Is(errUserInDB, user.ErrUserNotFound) {
-		s.log.FromContext(ctx).Error("Failed to fetch user", "error", errUserInDB, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
+	usr, userAuth, err := s.getUser(ctx, id)
+	if err != nil && !errors.Is(err, user.ErrUserNotFound) {
+		s.log.FromContext(ctx).Error("Failed to fetch user", "error", err, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
 		return errSyncUserInternal.Errorf("unable to retrieve user")
 	}
 
-	if errors.Is(errUserInDB, user.ErrUserNotFound) {
+	if errors.Is(err, user.ErrUserNotFound) {
 		if !id.ClientParams.AllowSignUp {
 			s.log.FromContext(ctx).Warn("Failed to create user, signup is not allowed for module", "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
 			return errUserSignupDisabled.Errorf("%w", errSignupNotAllowed)
 		}
 
 		// create user
-		var errCreate error
-		usr, errCreate = s.createUser(ctx, id)
-		if errCreate != nil {
-			s.log.FromContext(ctx).Error("Failed to create user", "error", errCreate, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
-			return errSyncUserInternal.Errorf("unable to create user: %w", errCreate)
+		usr, err = s.createUser(ctx, id)
+
+		// There is a possibility for a race condition when creating a user. Most clients will probably not hit this
+		// case but others will. The one we have seen this issue for is auth proxy. First time a new user loads grafana
+		// several requests can get "user.ErrUserNotFound" at the same time but only one of the request will be allowed
+		// to actually create the user, resulting in all other requests getting "user.ErrUserAlreadyExists". So we can
+		// just try to fetch the user one more to make the other request work.
+		if errors.Is(err, user.ErrUserAlreadyExists) {
+			usr, _, err = s.getUser(ctx, id)
+		}
+
+		if err != nil {
+			s.log.FromContext(ctx).Error("Failed to create user", "error", err, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
+			return errSyncUserInternal.Errorf("unable to create user: %w", err)
 		}
 	} else {
 		// update user
-		if errUpdate := s.updateUserAttributes(ctx, usr, id, userAuth); errUpdate != nil {
-			s.log.FromContext(ctx).Error("Failed to update user", "error", errUpdate, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
+		if err := s.updateUserAttributes(ctx, usr, id, userAuth); err != nil {
+			s.log.FromContext(ctx).Error("Failed to update user", "error", err, "auth_module", id.AuthenticatedBy, "auth_id", id.AuthID)
 			return errSyncUserInternal.Errorf("unable to update user")
 		}
 	}
@@ -281,19 +290,18 @@ func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.Us
 		isAdmin = *id.IsGrafanaAdmin
 	}
 
-	usr, errCreateUser := s.userService.Create(ctx, &user.CreateUserCommand{
+	usr, err := s.userService.Create(ctx, &user.CreateUserCommand{
 		Login:        id.Login,
 		Email:        id.Email,
 		Name:         id.Name,
 		IsAdmin:      isAdmin,
 		SkipOrgSetup: len(id.OrgRoles) > 0,
 	})
-	if errCreateUser != nil {
-		return nil, errCreateUser
+	if err != nil {
+		return nil, err
 	}
 
-	err := s.upsertAuthConnection(ctx, usr.ID, id, true)
-	if err != nil {
+	if err := s.upsertAuthConnection(ctx, usr.ID, id, true); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -438,6 +439,35 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 			require.EqualValues(t, tt.wantID, tt.args.id)
 		})
 	}
+}
+
+func TestUserSync_SyncUserRetryFetch(t *testing.T) {
+	userSrv := usertest.NewMockService(t)
+	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
+	userSrv.On("Create", mock.Anything, mock.Anything).Return(nil, user.ErrUserAlreadyExists).Once()
+	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(&user.User{ID: 1}, nil).Once()
+
+	s := ProvideUserSync(
+		userSrv,
+		authinfoimpl.ProvideOSSUserProtectionService(),
+		&authinfotest.FakeService{},
+		&quotatest.FakeQuotaService{},
+		tracing.NewNoopTracerService(),
+		featuremgmt.WithFeatures(),
+	)
+
+	email := "test@test.com"
+
+	err := s.SyncUserHook(context.Background(), &authn.Identity{
+		ClientParams: authn.ClientParams{
+			SyncUser:    true,
+			AllowSignUp: true,
+			LookUpParams: login.UserLookupParams{
+				Email: &email,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
 }
 
 func TestUserSync_FetchSyncedUserHook(t *testing.T) {

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -439,35 +438,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 			require.EqualValues(t, tt.wantID, tt.args.id)
 		})
 	}
-}
-
-func TestUserSync_SyncUserRetryFetch(t *testing.T) {
-	userSrv := usertest.NewMockService(t)
-	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(nil, user.ErrUserNotFound).Once()
-	userSrv.On("Create", mock.Anything, mock.Anything).Return(nil, user.ErrUserAlreadyExists).Once()
-	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(&user.User{ID: 1}, nil).Once()
-
-	s := ProvideUserSync(
-		userSrv,
-		authinfoimpl.ProvideOSSUserProtectionService(),
-		&authinfotest.FakeService{},
-		&quotatest.FakeQuotaService{},
-		tracing.NewNoopTracerService(),
-		featuremgmt.WithFeatures(),
-	)
-
-	email := "test@test.com"
-
-	err := s.SyncUserHook(context.Background(), &authn.Identity{
-		ClientParams: authn.ClientParams{
-			SyncUser:    true,
-			AllowSignUp: true,
-			LookUpParams: login.UserLookupParams{
-				Email: &email,
-			},
-		},
-	}, nil)
-	require.NoError(t, err)
 }
 
 func TestUserSync_FetchSyncedUserHook(t *testing.T) {


### PR DESCRIPTION
Backport 0b4c622df8e3796d02b714f7d261215e23178eb6 from #100346 
---
**What is this feature?**
 We have a potential race condition during `SyncUserHook`. For most clients this is a none issue but for something like auth proxy it happens regularly.
 
 To solve the issue we try to fetch the user again if we get `user.ErrUserAlreadyExists`. This should be safe because we fetch with the same params we do in the first call. 
 
 **Which issue(s) does this PR fix?**:
 Fixes #
 
 **Special notes for your reviewer:**
 
 Please check that:
 - [ ] It works as expected from a user's perspective.
 - [ ] If this is a pre-GA feature, it is behind a feature toggle.
 - [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
