### PR TITLE
Traces: Preinstall Traces Drilldown app with Grafana

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -29,8 +29,9 @@ func extractPluginSettings(sections []*ini.Section) PluginSettings {
 var (
 	defaultPreinstallPlugins = map[string]InstallPlugin{
 		// Default preinstalled plugins
-		"grafana-lokiexplore-app": {"grafana-lokiexplore-app", "", ""},
-		"grafana-pyroscope-app":   {"grafana-pyroscope-app", "", ""},
+		"grafana-lokiexplore-app":   {"grafana-lokiexplore-app", "", ""},
+		"grafana-pyroscope-app":     {"grafana-pyroscope-app", "", ""},
+		"grafana-exploretraces-app": {"grafana-exploretraces-app", "", ""},
 	}
 )
 


### PR DESCRIPTION
Fixes #96305

For testing disable 

```
[paths]
plugins = ...
```

if you have any.

You should see latest version from the catalog installed:

<img width="220" alt="Screenshot 2025-03-27 at 14 27 03" src="https://github.com/user-attachments/assets/f32acd53-1a38-414d-99ca-6ecb8b59c06b" />
 

It might be worth adding the following option to your custom.ini for **after this PR is merged** to avoid any conflicts:

```
[plugins]
preinstall_disabled = true
```