### PR TITLE
Logs builder updates

### DIFF
--- a/packages/grafana-schema/src/raw/composable/azuremonitor/dataquery/x/AzureMonitorDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/azuremonitor/dataquery/x/AzureMonitorDataQuery_types.gen.ts
@@ -352,7 +352,7 @@ export type BuilderQueryEditorOperatorType = (string | boolean | number | Select
 export interface BuilderQueryEditorOperator {
   labelValue?: string;
   name: string;
-  value: BuilderQueryEditorOperatorType;
+  value: string;
 }
 
 export interface BuilderQueryEditorWhereExpression {

--- a/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
@@ -287,33 +287,14 @@ func NewBuilderQueryEditorWhereExpression() *BuilderQueryEditorWhereExpression {
 }
 
 type BuilderQueryEditorOperator struct {
-	Name       string                         `json:"name"`
-	Value      BuilderQueryEditorOperatorType `json:"value"`
-	LabelValue *string                        `json:"labelValue,omitempty"`
+	Name       string  `json:"name"`
+	Value      string  `json:"value"`
+	LabelValue *string `json:"labelValue,omitempty"`
 }
 
 // NewBuilderQueryEditorOperator creates a new BuilderQueryEditorOperator object.
 func NewBuilderQueryEditorOperator() *BuilderQueryEditorOperator {
-	return &BuilderQueryEditorOperator{
-		Value: *NewBuilderQueryEditorOperatorType(),
-	}
-}
-
-type BuilderQueryEditorOperatorType = StringOrBoolOrFloat64OrSelectableValue
-
-// NewBuilderQueryEditorOperatorType creates a new BuilderQueryEditorOperatorType object.
-func NewBuilderQueryEditorOperatorType() *BuilderQueryEditorOperatorType {
-	return NewStringOrBoolOrFloat64OrSelectableValue()
-}
-
-type SelectableValue struct {
-	Label string `json:"label"`
-	Value string `json:"value"`
-}
-
-// NewSelectableValue creates a new SelectableValue object.
-func NewSelectableValue() *SelectableValue {
-	return &SelectableValue{}
+	return &BuilderQueryEditorOperator{}
 }
 
 type BuilderQueryEditorReduceExpressionArray struct {
@@ -615,6 +596,23 @@ const (
 	AzureQueryTypeCustomMetricNamesQuery    AzureQueryType = "Azure Custom Metric Names"
 )
 
+type SelectableValue struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+// NewSelectableValue creates a new SelectableValue object.
+func NewSelectableValue() *SelectableValue {
+	return &SelectableValue{}
+}
+
+type BuilderQueryEditorOperatorType = StringOrBoolOrFloat64OrSelectableValue
+
+// NewBuilderQueryEditorOperatorType creates a new BuilderQueryEditorOperatorType object.
+func NewBuilderQueryEditorOperatorType() *BuilderQueryEditorOperatorType {
+	return NewStringOrBoolOrFloat64OrSelectableValue()
+}
+
 type GrafanaTemplateVariableQueryType string
 
 const (
@@ -636,18 +634,6 @@ type BaseGrafanaTemplateVariableQuery struct {
 // NewBaseGrafanaTemplateVariableQuery creates a new BaseGrafanaTemplateVariableQuery object.
 func NewBaseGrafanaTemplateVariableQuery() *BaseGrafanaTemplateVariableQuery {
 	return &BaseGrafanaTemplateVariableQuery{}
-}
-
-type StringOrBoolOrFloat64OrSelectableValue struct {
-	String          *string          `json:"String,omitempty"`
-	Bool            *bool            `json:"Bool,omitempty"`
-	Float64         *float64         `json:"Float64,omitempty"`
-	SelectableValue *SelectableValue `json:"SelectableValue,omitempty"`
-}
-
-// NewStringOrBoolOrFloat64OrSelectableValue creates a new StringOrBoolOrFloat64OrSelectableValue object.
-func NewStringOrBoolOrFloat64OrSelectableValue() *StringOrBoolOrFloat64OrSelectableValue {
-	return &StringOrBoolOrFloat64OrSelectableValue{}
 }
 
 type AppInsightsMetricNameQueryOrAppInsightsGroupByQueryOrSubscriptionsQueryOrResourceGroupsQueryOrResourceNamesQueryOrMetricNamespaceQueryOrMetricDefinitionsQueryOrMetricNamesQueryOrWorkspacesQueryOrUnknownQuery struct {
@@ -804,4 +790,16 @@ func (resource *AppInsightsMetricNameQueryOrAppInsightsGroupByQueryOrSubscriptio
 	}
 
 	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+}
+
+type StringOrBoolOrFloat64OrSelectableValue struct {
+	String          *string          `json:"String,omitempty"`
+	Bool            *bool            `json:"Bool,omitempty"`
+	Float64         *float64         `json:"Float64,omitempty"`
+	SelectableValue *SelectableValue `json:"SelectableValue,omitempty"`
+}
+
+// NewStringOrBoolOrFloat64OrSelectableValue creates a new StringOrBoolOrFloat64OrSelectableValue object.
+func NewStringOrBoolOrFloat64OrSelectableValue() *StringOrBoolOrFloat64OrSelectableValue {
+	return &StringOrBoolOrFloat64OrSelectableValue{}
 }

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -8,9 +8,9 @@ import ResponseParser from '../azure_monitor/response_parser';
 import { getCredentials } from '../credentials';
 import {
   AzureAPIResponse,
+  AzureLogsVariable,
   AzureMonitorDataSourceInstanceSettings,
   AzureMonitorDataSourceJsonData,
-  AzureLogsVariable,
   AzureMonitorQuery,
   AzureQueryType,
   DatasourceValidationResult,
@@ -125,6 +125,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
         queryType: target.queryType || AzureQueryType.LogAnalytics,
 
         azureLogAnalytics: {
+          builderQuery: item.builderQuery,
           resultFormat: item.resultFormat,
           query,
           resources,

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
@@ -134,10 +134,11 @@ export const FilterSection: React.FC<FilterSectionProps> = ({
   const getFilterValues = async (filter: BuilderQueryEditorWhereExpression) => {
     const from = timeRange?.from?.toISOString();
     const to = timeRange?.to?.toISOString();
+    const timeColumn = query.azureLogAnalytics?.timeColumn || 'TimeGenerated';
 
     const kustoQuery = `
     ${query.azureLogAnalytics?.builderQuery?.from?.property.name}
-    | where TimeGenerated >= datetime(${from}) and TimeGenerated <= datetime(${to})
+    | where ${timeColumn} >= datetime(${from}) and ${timeColumn} <= datetime(${to})
     | distinct ${filter.property.name}
     | limit 1000
   `;

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
@@ -26,6 +26,12 @@ interface FilterSectionProps {
   timeRange?: TimeRange;
 }
 
+const filterDynamicColumns = (columns: string[], allColumns: AzureLogAnalyticsMetadataColumn[]) => {
+  return columns.filter((col) =>
+    allColumns.some((completeCol) => completeCol.name === col && completeCol.type !== 'dynamic')
+  );
+};
+
 export const FilterSection: React.FC<FilterSectionProps> = ({
   buildAndUpdateQuery,
   query,
@@ -45,8 +51,8 @@ export const FilterSection: React.FC<FilterSectionProps> = ({
   const variableOptions = Array.isArray(templateVariableOptions) ? templateVariableOptions : [templateVariableOptions];
 
   const availableColumns: Array<SelectableValue<string>> = builderQuery?.columns?.columns?.length
-    ? builderQuery.columns.columns.map((col) => ({ label: col, value: col }))
-    : allColumns.map((col) => ({ label: col.name, value: col.name }));
+    ? filterDynamicColumns(builderQuery.columns.columns, allColumns).map((col) => ({ label: col, value: col }))
+    : allColumns.filter((col) => col.type !== 'dynamic').map((col) => ({ label: col.name, value: col.name }));
 
   const selectableOptions = [...availableColumns, ...variableOptions];
 
@@ -180,7 +186,9 @@ export const FilterSection: React.FC<FilterSectionProps> = ({
         <EditorField
           label="Filters"
           optional={true}
-          tooltip={`Narrow results by applying conditions to specific columns...`}
+          tooltip={
+            'Narrow results by applying conditions to specific columns. Columns with the dynamic type are not available for filtering.'
+          }
         >
           <div className={styles.filters}>
             {filters.length > 0 ? (

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FilterSection.tsx
@@ -4,7 +4,7 @@ import { lastValueFrom } from 'rxjs';
 
 import { CoreApp, getDefaultTimeRange, SelectableValue, TimeRange } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorRow, InputGroup } from '@grafana/plugin-ui';
-import { AsyncSelect, Button, Combobox, Select, useStyles2 } from '@grafana/ui';
+import { Button, Combobox, Select, useStyles2 } from '@grafana/ui';
 
 import {
   AzureQueryType,

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -47,6 +47,7 @@ describe('LogsQueryEditor', () => {
     delete query?.subscription;
     delete query?.azureLogAnalytics?.resources;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
     const basicLogsEnabled = false;
 
     render(
@@ -55,6 +56,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -98,6 +100,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -105,6 +108,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -133,6 +137,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -140,6 +145,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -168,6 +174,7 @@ describe('LogsQueryEditor', () => {
     delete query?.azureLogAnalytics?.resources;
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -175,6 +182,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -207,6 +215,7 @@ describe('LogsQueryEditor', () => {
     const query = createMockQuery();
     const basicLogsEnabled = false;
     const onChange = jest.fn();
+    const onQueryChange = jest.fn();
 
     render(
       <LogsQueryEditor
@@ -214,6 +223,7 @@ describe('LogsQueryEditor', () => {
         datasource={mockDatasource}
         variableOptionGroup={variableOptionGroup}
         onChange={onChange}
+        onQueryChange={onQueryChange}
         setError={() => {}}
         basicLogsEnabled={basicLogsEnabled}
       />
@@ -237,6 +247,7 @@ describe('LogsQueryEditor', () => {
       const query = createMockQuery();
       const basicLogsEnabled = false;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       const date = dateTime(new Date());
       render(
@@ -245,6 +256,7 @@ describe('LogsQueryEditor', () => {
           datasource={mockDatasource}
           variableOptionGroup={variableOptionGroup}
           onChange={onChange}
+          onQueryChange={onQueryChange}
           setError={() => {}}
           basicLogsEnabled={basicLogsEnabled}
           data={{
@@ -278,6 +290,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -286,6 +299,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -304,6 +318,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -312,6 +327,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -332,6 +348,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = false;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -340,6 +357,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -358,6 +376,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -366,6 +385,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -386,6 +406,7 @@ describe('LogsQueryEditor', () => {
       });
       const basicLogsEnabled = true;
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -394,6 +415,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={basicLogsEnabled}
           />
@@ -416,6 +438,7 @@ describe('LogsQueryEditor', () => {
           basicLogsQuery: true,
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0);
       await act(async () => {
@@ -425,6 +448,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -451,6 +475,7 @@ describe('LogsQueryEditor', () => {
           basicLogsQuery: true,
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0.45);
       await act(async () => {
@@ -460,6 +485,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -485,6 +511,7 @@ describe('LogsQueryEditor', () => {
           query: '',
         },
       });
+      const onQueryChange = jest.fn();
 
       mockDatasource.azureLogAnalyticsDatasource.getBasicLogsQueryUsage.mockResolvedValue(0.5);
       await act(async () => {
@@ -494,6 +521,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={true}
           />
@@ -513,6 +541,7 @@ describe('LogsQueryEditor', () => {
         },
       });
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -521,6 +550,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={false}
           />
@@ -536,6 +566,7 @@ describe('LogsQueryEditor', () => {
       const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
       const query = { ...createMockQuery(), azureLogAnalytics: undefined };
       const onChange = jest.fn();
+      const onQueryChange = jest.fn();
 
       await act(async () => {
         render(
@@ -544,6 +575,7 @@ describe('LogsQueryEditor', () => {
             datasource={mockDatasource}
             variableOptionGroup={variableOptionGroup}
             onChange={onChange}
+            onQueryChange={onQueryChange}
             setError={() => {}}
             basicLogsEnabled={false}
           />

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -29,6 +29,7 @@ interface LogsQueryEditorProps {
   basicLogsEnabled: boolean;
   subscriptionId?: string;
   onChange: (newQuery: AzureMonitorQuery) => void;
+  onQueryChange: (newQuery: AzureMonitorQuery) => void;
   variableOptionGroup: { label: string; options: AzureMonitorOption[] };
   setError: (source: string, error: AzureMonitorErrorish | undefined) => void;
   hideFormatAs?: boolean;
@@ -43,6 +44,7 @@ const LogsQueryEditor = ({
   subscriptionId,
   variableOptionGroup,
   onChange,
+  onQueryChange,
   setError,
   hideFormatAs,
   timeRange,
@@ -100,7 +102,7 @@ const LogsQueryEditor = ({
     const hasRawKql = !!query.azureLogAnalytics?.query;
     const hasNoBuilder = !query.azureLogAnalytics?.builderQuery;
     const modeUnset = query.azureLogAnalytics?.mode === undefined;
-  
+
     if (hasRawKql && hasNoBuilder && modeUnset) {
       onChange({
         ...query,
@@ -111,7 +113,6 @@ const LogsQueryEditor = ({
       });
     }
   }, [query, onChange]);
-  
 
   useEffect(() => {
     const getBasicLogsUsage = async (query: AzureMonitorQuery) => {
@@ -224,7 +225,7 @@ const LogsQueryEditor = ({
             query={query}
             schema={schema!}
             basicLogsEnabled={basicLogsEnabled}
-            onQueryChange={onChange}
+            onQueryChange={onQueryChange}
             templateVariableOptions={templateVariableOptions}
             datasource={datasource}
             timeRange={timeRange}

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
@@ -100,6 +100,9 @@ const QueryEditor = ({
         query={query}
         onQueryChange={onQueryChange}
         setAzureLogsCheatSheetModalOpen={setAzureLogsCheatSheetModalOpen}
+        onRunQuery={baseOnRunQuery}
+        data={data}
+        app={app}
       />
       <EditorForQueryType
         data={data}
@@ -108,6 +111,7 @@ const QueryEditor = ({
         query={query}
         datasource={datasource}
         onChange={onQueryChange}
+        onQueryChange={onChange}
         variableOptionGroup={variableOptionGroup}
         setError={setError}
         range={range}
@@ -129,6 +133,8 @@ interface EditorForQueryTypeProps extends Omit<AzureMonitorQueryEditorProps, 'on
   basicLogsEnabled: boolean;
   variableOptionGroup: { label: string; options: AzureMonitorOption[] };
   setError: (source: string, error: AzureMonitorErrorish | undefined) => void;
+  // Used to update the query without running it
+  onQueryChange: (newQuery: AzureMonitorQuery) => void;
 }
 
 const EditorForQueryType = ({
@@ -140,6 +146,7 @@ const EditorForQueryType = ({
   variableOptionGroup,
   onChange,
   setError,
+  onQueryChange,
   range,
 }: EditorForQueryTypeProps) => {
   switch (query.queryType) {
@@ -167,6 +174,7 @@ const EditorForQueryType = ({
           variableOptionGroup={variableOptionGroup}
           setError={setError}
           timeRange={range}
+          onQueryChange={onQueryChange}
         />
       );
 

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { SelectableValue } from '@grafana/data';
+import { CoreApp, LoadingState, PanelData, SelectableValue } from '@grafana/data';
 import { EditorHeader, FlexItem, InlineSelect } from '@grafana/plugin-ui';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, RadioButtonGroup } from '@grafana/ui';
@@ -13,6 +13,9 @@ interface QueryTypeFieldProps {
   query: AzureMonitorQuery;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
   setAzureLogsCheatSheetModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  data: PanelData | undefined;
+  onRunQuery: () => void;
+  app: CoreApp | undefined;
 }
 
 const EDITOR_MODES = [
@@ -20,7 +23,16 @@ const EDITOR_MODES = [
   { label: 'KQL', value: LogsEditorMode.Raw },
 ];
 
-export const QueryHeader = ({ query, onQueryChange, setAzureLogsCheatSheetModalOpen }: QueryTypeFieldProps) => {
+export const QueryHeader = ({
+  query,
+  onQueryChange,
+  setAzureLogsCheatSheetModalOpen,
+  data,
+  app,
+  onRunQuery,
+}: QueryTypeFieldProps) => {
+  const isLoading = useMemo(() => data?.state === LoadingState.Loading, [data?.state]);
+
   const queryTypes: Array<{ value: AzureQueryType; label: string }> = [
     { value: AzureQueryType.AzureMonitor, label: 'Metrics' },
     { value: AzureQueryType.LogAnalytics, label: 'Logs' },
@@ -106,6 +118,19 @@ export const QueryHeader = ({ query, onQueryChange, setAzureLogsCheatSheetModalO
             data-testid="azure-query-header-logs-radio-button"
           />
         )}
+        {query.azureLogAnalytics?.mode === LogsEditorMode.Builder &&
+          !!config.featureToggles.azureMonitorLogsBuilderEditor &&
+          app !== CoreApp.Explore && (
+            <Button
+              variant="primary"
+              icon={isLoading ? 'spinner' : 'play'}
+              size="sm"
+              onClick={onRunQuery}
+              data-testid={selectors.components.queryEditor.logsQueryEditor.runQuery.button}
+            >
+              Run query
+            </Button>
+          )}
       </EditorHeader>
     </span>
   );

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -291,6 +291,8 @@ const VariableEditor = (props: Props) => {
             query={query}
             datasource={datasource}
             onChange={onQueryChange}
+            // Not applicable as the builder isn't available in the variable editor yet
+            onQueryChange={onQueryChange}
             variableOptionGroup={variableOptionGroup}
             setError={setError}
             hideFormatAs={true}

--- a/public/app/plugins/datasource/azuremonitor/dataquery.cue
+++ b/public/app/plugins/datasource/azuremonitor/dataquery.cue
@@ -195,7 +195,7 @@ composableKinds: DataQuery: {
 
 				#BuilderQueryEditorOperator: {
 					name: string
-					value: #BuilderQueryEditorOperatorType
+					value: string
 					labelValue?: string
 				} @cuetsy(kind="interface")
 

--- a/public/app/plugins/datasource/azuremonitor/dataquery.gen.ts
+++ b/public/app/plugins/datasource/azuremonitor/dataquery.gen.ts
@@ -350,7 +350,7 @@ export type BuilderQueryEditorOperatorType = (string | boolean | number | Select
 export interface BuilderQueryEditorOperator {
   labelValue?: string;
   name: string;
-  value: BuilderQueryEditorOperatorType;
+  value: string;
 }
 
 export interface BuilderQueryEditorWhereExpression {

--- a/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
+++ b/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
@@ -76,6 +76,9 @@ export const components = {
       formatSelection: {
         input: 'data-testid format-selection',
       },
+      runQuery: {
+        button: 'data-testid run-query',
+      },
     },
     argsQueryEditor: {
       container: {


### PR DESCRIPTION
- Asynchronously load filter options
- Update types and ensure the `builderQuery` object is included in the query object
- Correctly set the time column in the filtering query
- Don't show dynamic columns in the filter options 