### PR TITLE
Themes: Put experimental themes in an `Experimental` group

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -90,6 +90,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
     this.themeOptions = themes.map((theme) => ({
       value: theme.id,
       label: getTranslatedThemeName(theme),
+      group: theme.isExtra ? t('shared-preferences.theme.experimental', 'Experimental') : undefined,
     }));
 
     // Add default option

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4596,7 +4596,8 @@
       "week-start-label": "Week start"
     },
     "theme": {
-      "default-label": "Default"
+      "default-label": "Default",
+      "experimental": "Experimental"
     },
     "title": "Preferences"
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- puts experimental themes in an `Experimental` group

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/692c1d97-89f5-4e22-b280-ca43834476ee) | ![image](https://github.com/user-attachments/assets/31f788df-cd90-4fd0-a0ae-4227bb24bdf0) |

**Why do we need this feature?**

- so it's clear they're experimental

**Who is this feature for?**

- eveyrone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
