### PR TITLE
Prometheus: fix labels infinite loading state in aggregations

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
 import { useState } from 'react';
 
-import { DataSourceApi, SelectableValue, toOption } from '@grafana/data';
+import { DataSourceApi, SelectableValue, toOption, getDefaultTimeRange } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
 import { promQueryModeller } from '../PromQueryModeller';
@@ -52,7 +52,7 @@ async function loadGroupByLabels(query: PromVisualQuery, datasource: DataSourceA
   }
 
   const expr = promQueryModeller.renderLabels(labels);
-  const result = await datasource.languageProvider.fetchLabelsWithMatch(expr);
+  const result = await datasource.languageProvider.fetchLabelsWithMatch(getDefaultTimeRange(), expr);
 
   return Object.keys(result).map((x) => ({
     label: x,

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
@@ -44,7 +44,11 @@ export function LabelParamEditor({
   );
 }
 
-async function loadGroupByLabels(timeRange: TimeRange, query: PromVisualQuery, datasource: DataSourceApi): Promise<SelectableValue[]> {
+async function loadGroupByLabels(
+  timeRange: TimeRange,
+  query: PromVisualQuery,
+  datasource: DataSourceApi
+): Promise<SelectableValue[]> {
   let labels: QueryBuilderLabelFilter[] = query.labels;
 
   // This function is used by both Prometheus and Loki and this the only difference.

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
 import { useState } from 'react';
 
-import { DataSourceApi, SelectableValue, toOption, getDefaultTimeRange } from '@grafana/data';
+import { DataSourceApi, SelectableValue, TimeRange, toOption } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
 import { promQueryModeller } from '../PromQueryModeller';
@@ -16,6 +16,7 @@ export function LabelParamEditor({
   value,
   query,
   datasource,
+  timeRange,
 }: QueryBuilderOperationParamEditorProps) {
   const [state, setState] = useState<{
     options?: SelectableValue[];
@@ -29,7 +30,7 @@ export function LabelParamEditor({
       openMenuOnFocus
       onOpenMenu={async () => {
         setState({ isLoading: true });
-        const options = await loadGroupByLabels(query, datasource);
+        const options = await loadGroupByLabels(timeRange, query, datasource);
         setState({ options, isLoading: undefined });
       }}
       isLoading={state.isLoading}
@@ -43,7 +44,7 @@ export function LabelParamEditor({
   );
 }
 
-async function loadGroupByLabels(query: PromVisualQuery, datasource: DataSourceApi): Promise<SelectableValue[]> {
+async function loadGroupByLabels(timeRange: TimeRange, query: PromVisualQuery, datasource: DataSourceApi): Promise<SelectableValue[]> {
   let labels: QueryBuilderLabelFilter[] = query.labels;
 
   // This function is used by both Prometheus and Loki and this the only difference.
@@ -52,7 +53,7 @@ async function loadGroupByLabels(query: PromVisualQuery, datasource: DataSourceA
   }
 
   const expr = promQueryModeller.renderLabels(labels);
-  const result = await datasource.languageProvider.fetchLabelsWithMatch(getDefaultTimeRange(), expr);
+  const result = await datasource.languageProvider.fetchLabelsWithMatch(timeRange, expr);
 
   return Object.keys(result).map((x) => ({
     label: x,

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.tsx
@@ -83,6 +83,7 @@ export const PromQueryBuilder = memo<PromQueryBuilderProps>((props) => {
           onChange={onChange}
           onRunQuery={onRunQuery}
           highlightedOp={highlightedOp}
+          timeRange={data?.timeRange ?? getDefaultTimeRange()}
         />
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.builder.hints}>
           <QueryBuilderHints<PromVisualQuery>

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -30,7 +30,7 @@ export interface Props {
   onRunQuery: () => void;
   flash?: boolean;
   highlight?: boolean;
-  timeRange?: TimeRange;
+  timeRange: TimeRange;
 }
 
 export function OperationEditor({

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
@@ -13,6 +13,7 @@ import { addOperationInQueryBuilder } from '../testUtils';
 import { PromVisualQuery } from '../types';
 
 import { OperationList } from './OperationList';
+import { getMockTimeRange } from '../../test/__mocks__/datasource';
 
 const defaultQuery: PromVisualQuery = {
   metric: 'random_metric',
@@ -78,6 +79,7 @@ function setup(query: PromVisualQuery = defaultQuery) {
     onRunQuery: () => {},
     onChange: jest.fn(),
     queryModeller: promQueryModeller,
+    timeRange: getMockTimeRange(),
   };
 
   render(<OperationList {...props} query={query} />);

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
@@ -7,13 +7,13 @@ import { DataSourceApi, DataSourceInstanceSettings } from '@grafana/data';
 import { PrometheusDatasource } from '../../datasource';
 import PromQlLanguageProvider from '../../language_provider';
 import { EmptyLanguageProviderMock } from '../../language_provider.mock';
+import { getMockTimeRange } from '../../test/__mocks__/datasource';
 import { PromOptions } from '../../types';
 import { promQueryModeller } from '../PromQueryModeller';
 import { addOperationInQueryBuilder } from '../testUtils';
 import { PromVisualQuery } from '../types';
 
 import { OperationList } from './OperationList';
-import { getMockTimeRange } from '../../test/__mocks__/datasource';
 
 const defaultQuery: PromVisualQuery = {
   metric: 'random_metric',

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.tsx
@@ -18,7 +18,7 @@ export interface Props<T extends QueryWithOperations> {
   queryModeller: VisualQueryModeller;
   explainMode?: boolean;
   highlightedOp?: QueryBuilderOperation;
-  timeRange?: TimeRange;
+  timeRange: TimeRange;
 }
 
 export function OperationList<T extends QueryWithOperations>({

--- a/packages/grafana-prometheus/src/querybuilder/shared/types.ts
+++ b/packages/grafana-prometheus/src/querybuilder/shared/types.ts
@@ -92,7 +92,7 @@ export interface QueryBuilderOperationParamEditorProps {
   operationId: string;
   query: any;
   datasource: DataSourceApi;
-  timeRange?: TimeRange;
+  timeRange: TimeRange;
   onChange: (index: number, value: QueryBuilderOperationParamValue) => void;
   onRunQuery: () => void;
 }


### PR DESCRIPTION
This PR fixes a bug introduced in #101889 where the `fetchLabelsWithMatch` function signature was updated to require a time range parameter, but not all call were updated accordingly. 

Specifically, the query builder's label selector within operations was still calling the function without the time range parameter, causing labels to fail to load.

Before the fix:
<img width="2302" alt="Screenshot 2025-03-27 at 15 44 32" src="https://github.com/user-attachments/assets/52879950-8d78-4a92-b9f4-9c18561598d9" />

After the fix:
<img width="2300" alt="Screenshot 2025-03-27 at 15 45 21" src="https://github.com/user-attachments/assets/c96bab28-5552-47aa-9487-c335616efa98" />
