### PR TITLE
[release-11.4.4] Auth: Introduce authn.SSOClientConfig to get client config from SSOSettings service

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -359,15 +359,27 @@ func (hs *HTTPServer) samlEnabled() bool {
 }
 
 func (hs *HTTPServer) samlName() string {
-	return hs.SettingsProvider.KeyValue("auth.saml", "name").MustString("SAML")
+	config, ok := hs.authnService.GetClientConfig(authn.ClientSAML)
+	if !ok {
+		return ""
+	}
+	return config.GetDisplayName()
 }
 
 func (hs *HTTPServer) samlSingleLogoutEnabled() bool {
-	return hs.samlEnabled() && hs.SettingsProvider.KeyValue("auth.saml", "single_logout").MustBool(false) && hs.samlEnabled()
+	config, ok := hs.authnService.GetClientConfig(authn.ClientSAML)
+	if !ok {
+		return false
+	}
+	return hs.samlEnabled() && config.IsSingleLogoutEnabled()
 }
 
 func (hs *HTTPServer) samlAutoLoginEnabled() bool {
-	return hs.samlEnabled() && hs.SettingsProvider.KeyValue("auth.saml", "auto_login").MustBool(false)
+	config, ok := hs.authnService.GetClientConfig(authn.ClientSAML)
+	if !ok {
+		return false
+	}
+	return hs.samlEnabled() && config.IsAutoLoginEnabled()
 }
 
 func getLoginExternalError(err error) string {

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -659,7 +659,11 @@ func TestLogoutSaml(t *testing.T) {
 	license.On("FeatureEnabled", "saml").Return(true)
 
 	hs := &HTTPServer{
-		authnService:     &authntest.FakeService{},
+		authnService: &authntest.FakeService{
+			ExpectedClientConfig: &authntest.FakeSSOClientConfig{
+				ExpectedIsSingleLogoutEnabled: true,
+			},
+		},
 		Cfg:              sc.cfg,
 		SettingsProvider: &setting.OSSImpl{Cfg: sc.cfg},
 		License:          license,

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -27,9 +27,7 @@ const (
 	LDAPProviderName       = "ldap"
 )
 
-var (
-	SocialBaseUrl = "/login/"
-)
+var SocialBaseUrl = "/login/"
 
 type Service interface {
 	GetOAuthProviders() map[string]bool
@@ -99,6 +97,19 @@ func NewOAuthInfo() *OAuthInfo {
 		AllowedGroups:  []string{},
 		Extra:          map[string]string{},
 	}
+}
+
+func (o *OAuthInfo) GetDisplayName() string {
+	return o.Name
+}
+
+func (o *OAuthInfo) IsSingleLogoutEnabled() bool {
+	// OIDC SLO is not supported
+	return false
+}
+
+func (o *OAuthInfo) IsAutoLoginEnabled() bool {
+	return o.AutoLogin
 }
 
 type BasicUserInfo struct {

--- a/pkg/services/anonymous/anonimpl/client.go
+++ b/pkg/services/anonymous/anonimpl/client.go
@@ -22,8 +22,10 @@ var (
 	errDeviceLimit = errutil.Unauthorized("anonymous.device-limit-reached", errutil.WithPublicMessage("Anonymous device limit reached. Contact Administrator"))
 )
 
-var _ authn.ContextAwareClient = new(Anonymous)
-var _ authn.IdentityResolverClient = new(Anonymous)
+var (
+	_ authn.ContextAwareClient     = new(Anonymous)
+	_ authn.IdentityResolverClient = new(Anonymous)
+)
 
 type Anonymous struct {
 	cfg               *setting.Cfg

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -86,6 +86,15 @@ type Authenticator interface {
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
 }
 
+type SSOClientConfig interface {
+	// GetDisplayName returns the display name of the client
+	GetDisplayName() string
+	// IsAutoLoginEnabled returns true if the client has auto login enabled
+	IsAutoLoginEnabled() bool
+	// IsSingleLogoutEnabled returns true if the client has single logout enabled
+	IsSingleLogoutEnabled() bool
+}
+
 type Service interface {
 	Authenticator
 	// RegisterPostAuthHook registers a hook with a priority that is called after a successful authentication.
@@ -120,6 +129,9 @@ type Service interface {
 	// - "saml" = "auth.client.saml"
 	// - "github" = "auth.client.github"
 	IsClientEnabled(client string) bool
+
+	// GetClientConfig returns the client configuration for the given client and a boolean indicating if the config was present.
+	GetClientConfig(client string) (SSOClientConfig, bool)
 }
 
 type IdentitySynchronizer interface {
@@ -166,6 +178,11 @@ type RedirectClient interface {
 type LogoutClient interface {
 	Client
 	Logout(ctx context.Context, user identity.Requester) (*Redirect, bool)
+}
+
+type SSOSettingsAwareClient interface {
+	Client
+	GetConfig() SSOClientConfig
 }
 
 type PasswordClient interface {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -380,6 +380,20 @@ func (s *Service) IsClientEnabled(name string) bool {
 	return client.IsEnabled()
 }
 
+func (s *Service) GetClientConfig(name string) (authn.SSOClientConfig, bool) {
+	client, ok := s.clients[name]
+	if !ok {
+		return nil, false
+	}
+
+	ssoSettingsAwareClient, ok := client.(authn.SSOSettingsAwareClient)
+	if !ok {
+		return nil, false
+	}
+
+	return ssoSettingsAwareClient.GetConfig(), true
+}
+
 func (s *Service) SyncIdentity(ctx context.Context, identity *authn.Identity) error {
 	ctx, span := s.tracer.Start(ctx, "authn.SyncIdentity")
 	defer span.End()

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -9,8 +9,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
-var _ authn.Service = new(MockService)
-var _ authn.IdentitySynchronizer = new(MockService)
+var (
+	_ authn.Service              = new(MockService)
+	_ authn.IdentitySynchronizer = new(MockService)
+)
 
 type MockService struct {
 	SyncIdentityFunc         func(ctx context.Context, identity *authn.Identity) error
@@ -22,6 +24,10 @@ func (m *MockService) Authenticate(ctx context.Context, r *authn.Request) (*auth
 }
 
 func (m *MockService) IsClientEnabled(name string) bool {
+	panic("unimplemented")
+}
+
+func (m *MockService) GetClientConfig(name string) (authn.SSOClientConfig, bool) {
 	panic("unimplemented")
 }
 
@@ -66,10 +72,12 @@ func (m *MockService) SyncIdentity(ctx context.Context, identity *authn.Identity
 	return nil
 }
 
-var _ authn.HookClient = new(MockClient)
-var _ authn.LogoutClient = new(MockClient)
-var _ authn.ContextAwareClient = new(MockClient)
-var _ authn.IdentityResolverClient = new(MockClient)
+var (
+	_ authn.HookClient             = new(MockClient)
+	_ authn.LogoutClient           = new(MockClient)
+	_ authn.ContextAwareClient     = new(MockClient)
+	_ authn.IdentityResolverClient = new(MockClient)
+)
 
 type MockClient struct {
 	NameFunc            func() string
@@ -98,6 +106,10 @@ func (m MockClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 
 func (m MockClient) IsEnabled() bool {
 	return true
+}
+
+func (m MockClient) GetConfig() authn.SSOClientConfig {
+	return nil
 }
 
 func (m MockClient) Test(ctx context.Context, r *authn.Request) bool {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -27,9 +27,11 @@ var (
 	errAPIKeyOrgMismatch = errutil.Unauthorized("api-key.organization-mismatch", errutil.WithPublicMessage("API key does not belong to the requested organization"))
 )
 
-var _ authn.HookClient = new(APIKey)
-var _ authn.ContextAwareClient = new(APIKey)
-var _ authn.IdentityResolverClient = new(APIKey)
+var (
+	_ authn.HookClient             = new(APIKey)
+	_ authn.ContextAwareClient     = new(APIKey)
+	_ authn.IdentityResolverClient = new(APIKey)
+)
 
 const (
 	metaKeyID           = "keyID"

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -150,7 +150,8 @@ func (s *ExtendedJWT) authenticateAsUser(
 				RestrictedActions: accessTokenClaims.Rest.DelegatedPermissions,
 			},
 			FetchSyncedUser: true,
-		}}, nil
+		},
+	}, nil
 }
 
 func (s *ExtendedJWT) authenticateAsService(accessTokenClaims authlib.Claims[authlib.AccessTokenClaims]) (*authn.Identity, error) {

--- a/pkg/services/authn/clients/form.go
+++ b/pkg/services/authn/clients/form.go
@@ -8,9 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-var (
-	errBadForm = errutil.BadRequest("form-auth.invalid", errutil.WithPublicMessage("bad login data"))
-)
+var errBadForm = errutil.BadRequest("form-auth.invalid", errutil.WithPublicMessage("bad login data"))
 
 var _ authn.Client = new(Form)
 

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -73,7 +73,8 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			SyncOrgRoles:    !s.cfg.JWTAuth.SkipOrgRoleSync,
 			AllowSignUp:     s.cfg.JWTAuth.AutoSignUp,
 			SyncTeams:       s.cfg.JWTAuth.GroupsAttributePath != "",
-		}}
+		},
+	}
 
 	if key := s.cfg.JWTAuth.UsernameClaim; key != "" {
 		id.Login, _ = claims[key].(string)
@@ -117,7 +118,6 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 
 		return role, &grafanaAdmin, nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authn/clients/render.go
+++ b/pkg/services/authn/clients/render.go
@@ -13,9 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 )
 
-var (
-	errInvalidRenderKey = errutil.Unauthorized("render-auth.invalid-key", errutil.WithPublicMessage("Invalid Render Key"))
-)
+var errInvalidRenderKey = errutil.Unauthorized("render-auth.invalid-key", errutil.WithPublicMessage("Invalid Render Key"))
 
 const (
 	renderCookieName = "renderKey"


### PR DESCRIPTION
Backport 50a635bc7e09a4eb11ffe00fbc80a46f18e5b6ec from #94618

---

**What is this feature?**
This PR ensures that the login page can fetch SAML configuration.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
