### PR TITLE
Search e2e- round 2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -817,6 +817,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/dashboards-issue-add-label.yml @grafana/dashboards-squad
 /.github/workflows/run-schema-v2-e2e.yml  @grafana/dashboards-squad
 /.github/workflows/run-dashboard-search-e2e.yml  @grafana/grafana-search-and-storage
+/.github/workflows/trigger-dashboard-search-e2e.yml  @grafana/grafana-search-and-storage
 /.github/workflows/ephemeral-instances-pr-comment.yml @grafana/grafana-backend-services-squad
 /.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/core-plugins-build-and-release.yml @grafana/plugins-platform-frontend @grafana/plugins-platform-backend

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -114,6 +114,3 @@ jobs:
           run: |
             cp -rf ${{ matrix.ini_file }} ${{ github.workspace }}/scripts/grafana-server/custom.ini
             yarn e2e:dashboards-search || echo "Test failed but marking as success since unified search is behind a feature flag and should not block PRs"
-        # - name: Always succeed # This is a workaround to make the job pass even if the previous step fails
-        #   if: failure()
-        #   run: exit 0

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -1,12 +1,10 @@
 name: Run dashboard search e2e
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Trigger Dashboard Search E2E Tests"]
+    types:
+      - completed
 
 env:
   ARCH: linux-amd64
@@ -91,7 +89,7 @@ jobs:
             path: |
               node_modules
               /home/runner/.cache/Cypress
-            key: foo
+            key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
         - name: Restore Cached Grafana Build and Dependencies
           uses: actions/cache@v3
@@ -105,8 +103,6 @@ jobs:
               e2e/test-plugins/
               devenv/
             key: ${{ runner.os }}-grafana-${{ hashFiles('go.mod', 'package-lock.json', 'Makefile', 'pkg/storage/**/*.go', 'public/app/features/search/**/*.ts', 'public/app/features/search/**/*.tsx') }}
-        - name: Prettify the name
-          run: echo "Running tests for $(basename "${{ matrix.ini_file }}")"
         - name: Set the step name
           id: set_file_name
           run: |

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    # if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     outputs:
       ini_files: ${{ steps.get_files.outputs.ini_files }}
 
@@ -76,7 +76,7 @@ jobs:
       needs: setup
       runs-on: ubuntu-latest
       continue-on-error: true
-      # if: github.event.pull_request.draft == false
+      if: github.event.pull_request.draft == false
       strategy:
         matrix:
           ini_file: ${{ fromJson(needs.setup.outputs.ini_files) }}

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -1,14 +1,11 @@
 name: run-dashboard-search-e2e
 
 on:
-  workflow_run:
-    workflows: 
-      - trigger-dashboard-search-e2e
-    branches:
-      - e2e-async-job
-      - main
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: 
+  #     - trigger-dashboard-search-e2e
+  #   types:
+  #     - completed
   workflow_dispatch:
 
 env:

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Trigger Dashboard Search E2E Tests"]
     types:
       - completed
+  workflow_dispatch:
 
 env:
   ARCH: linux-amd64
@@ -12,7 +13,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    # if: github.event.pull_request.draft == false
     outputs:
       ini_files: ${{ steps.get_files.outputs.ini_files }}
 
@@ -74,7 +75,7 @@ jobs:
       needs: setup
       runs-on: ubuntu-latest
       continue-on-error: true
-      if: github.event.pull_request.draft == false
+      # if: github.event.pull_request.draft == false
       strategy:
         matrix:
           ini_file: ${{ fromJson(needs.setup.outputs.ini_files) }}

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -112,6 +112,6 @@ jobs:
           run: |
             cp -rf ${{ matrix.ini_file }} ${{ github.workspace }}/scripts/grafana-server/custom.ini
             yarn e2e:dashboards-search || echo "Test failed but marking as success since unified search is behind a feature flag and should not block PRs"
-        - name: Always succeed # This is a workaround to make the job pass even if the previous step fails
-          if: failure()
-          run: exit 0
+        # - name: Always succeed # This is a workaround to make the job pass even if the previous step fails
+        #   if: failure()
+        #   run: exit 0

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -1,11 +1,11 @@
 name: run-dashboard-search-e2e
 
 on:
-  # workflow_run:
-  #   workflows: 
-  #     - trigger-dashboard-search-e2e
-  #   types:
-  #     - completed
+  workflow_run:
+    workflows: 
+      - trigger-dashboard-search-e2e
+    types:
+      - completed
   workflow_dispatch:
 
 env:

--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -1,8 +1,12 @@
-name: Run dashboard search e2e
+name: run-dashboard-search-e2e
 
 on:
   workflow_run:
-    workflows: ["Trigger Dashboard Search E2E Tests"]
+    workflows: 
+      - trigger-dashboard-search-e2e
+    branches:
+      - e2e-async-job
+      - main
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/trigger-dashboard-search-e2e.yml
+++ b/.github/workflows/trigger-dashboard-search-e2e.yml
@@ -1,4 +1,4 @@
-name: Trigger Dashboard Search E2E Tests
+name: trigger-dashboard-search-e2e
 # triggers the dashboard search e2e tests which runs async 
 # doesn't block prs, allows setting up notifications from grafana
 on:

--- a/.github/workflows/trigger-dashboard-search-e2e.yml
+++ b/.github/workflows/trigger-dashboard-search-e2e.yml
@@ -1,0 +1,20 @@
+name: Trigger Dashboard Search E2E Tests
+# triggers the dashboard search e2e tests which runs async 
+# doesn't block prs, allows setting up notifications from grafana
+on:
+  push:
+    branches:
+      - e2e-async-job
+  pull_request:
+    branches:
+      - main
+
+env:
+  ARCH: linux-amd64
+
+jobs:
+  trigger-search-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dashboard Search E2E
+        run: echo "Triggered Dashboard Search e2e..."


### PR DESCRIPTION
changes to the search e2e action
1. run async - since these can be slow, we don't want to slow down/block the build ( it's already painfully slow )
2. since the current job always succeeds, we don't know when it fails ( and it's currently failing from a mistake )
3. this change will allow triggering e2e, but won't slow/block the build on failure.
4. instead we will use the grafana github datasource on Ops to check the workflows and send alerts if they failed
