### PR TITLE
SQL Expressions: Allow substring_index func

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -189,7 +189,7 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 		return
 	case "lower", "upper":
 		return
-	case "substring":
+	case "substring", "substring_index":
 		return
 
 	// Date functions

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -62,6 +62,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT 'some text' COLLATE utf8mb4_bin`,
 			err:  nil,
 		},
+		{
+			name: "allow substring_index",
+			q:    `SELECT __value__, SUBSTRING_INDEX(name, '.', -1) AS code FROM A`,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Permits the substring_index function in SQL Expressions.

**Why do we need this feature?**

Useful for extract parts of strings. For example:

![image](https://github.com/user-attachments/assets/c88fa655-028a-45c2-9c9d-991d28be028d)

**Who is this feature for?**

SQL Expression users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
