### PR TITLE
[release-11.6.1] docs(alerting): add missing port setting for the HA k8s example

### DIFF
--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -96,12 +96,15 @@ For a demo, see this [example using Docker Compose](https://github.com/grafana/a
 
    ```yaml
    ports:
-     - containerPort: 3000
-       name: http-grafana
+     - name: grafana
+       containerPort: 3000
        protocol: TCP
-     - containerPort: 9094
-       name: grafana-alert
+     - name: gossip-tcp
+       containerPort: 9094
        protocol: TCP
+     - name: gossip-udp
+       containerPort: 9094
+       protocol: UDP
    ```
 
 1. Add the environment variables to the Grafana deployment:


### PR DESCRIPTION
Backport d44a9953d3db8d6dfd335e960f3157f0832c0500 from #103017\n\n---\n\nfixes https://github.com/grafana/grafana/issues/99462 (`Enable alerting high availability using Kubernetes" looks incomplete`) with settings from [opentelemetry-demo](https://github.com/grafana/opentelemetry-demo/blob/grafana/kubernetes/opentelemetry-demo.yaml#L8953)
