### PR TITLE
K8s: Folders: Remove unneeded parent calls

### DIFF
--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -216,32 +216,17 @@ func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.S
 	}
 
 	hitList := make([]*model.Hit, len(parsedResults.Hits))
-	foldersMap := map[string]*folder.Folder{}
 	for i, item := range parsedResults.Hits {
-		f, ok := foldersMap[item.Folder]
-		if !ok {
-			f, err = s.Get(ctx, &folder.GetFolderQuery{
-				UID:          &item.Folder,
-				OrgID:        query.OrgID,
-				SignedInUser: query.SignedInUser,
-			})
-			if err != nil {
-				return nil, err
-			}
-			foldersMap[item.Folder] = f
-		}
 		slug := slugify.Slugify(item.Title)
 		hitList[i] = &model.Hit{
-			ID:          item.Field.GetNestedInt64(search.DASHBOARD_LEGACY_ID),
-			UID:         item.Name,
-			OrgID:       query.OrgID,
-			Title:       item.Title,
-			URI:         "db/" + slug,
-			URL:         dashboards.GetFolderURL(item.Name, slug),
-			Type:        model.DashHitFolder,
-			FolderUID:   item.Folder,
-			FolderTitle: f.Title,
-			FolderID:    f.ID, // nolint:staticcheck
+			ID:        item.Field.GetNestedInt64(search.DASHBOARD_LEGACY_ID),
+			UID:       item.Name,
+			OrgID:     query.OrgID,
+			Title:     item.Title,
+			URI:       "db/" + slug,
+			URL:       dashboards.GetFolderURL(item.Name, slug),
+			Type:      model.DashHitFolder,
+			FolderUID: item.Folder,
 		}
 	}
 

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -602,9 +602,6 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 		expectedResult := model.HitList{
 			{
 				UID: "uid1",
-				// no parent folder is returned, so the general folder should be set
-				FolderID:    0,
-				FolderTitle: "General",
 				// orgID should be taken from signed in user
 				OrgID: 1,
 				// the rest should be automatically set when parsing the hit results from search
@@ -614,14 +611,12 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 				URL:   "/dashboards/f/uid1/folder0",
 			},
 			{
-				UID:         "uid2",
-				FolderID:    0,
-				FolderTitle: "General",
-				OrgID:       1,
-				Type:        model.DashHitFolder,
-				URI:         "db/folder1",
-				Title:       "folder1",
-				URL:         "/dashboards/f/uid2/folder1",
+				UID:   "uid2",
+				OrgID: 1,
+				Type:  model.DashHitFolder,
+				URI:   "db/folder1",
+				Title: "folder1",
+				URL:   "/dashboards/f/uid2/folder1",
 			},
 		}
 		require.Equal(t, expectedResult, result)
@@ -681,14 +676,12 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 		require.NoError(t, err)
 		expectedResult := model.HitList{
 			{
-				UID:         "foo",
-				FolderID:    0,
-				FolderTitle: "General",
-				OrgID:       1,
-				Type:        model.DashHitFolder,
-				URI:         "db/folder1",
-				Title:       "folder1",
-				URL:         "/dashboards/f/foo/folder1",
+				UID:   "foo",
+				OrgID: 1,
+				Type:  model.DashHitFolder,
+				URI:   "db/folder1",
+				Title: "folder1",
+				URL:   "/dashboards/f/foo/folder1",
 			},
 		}
 		require.Equal(t, expectedResult, result)
@@ -753,15 +746,13 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 
 		expectedResult := model.HitList{
 			{
-				UID:         "uid",
-				FolderID:    2,
-				FolderTitle: "parent title",
-				FolderUID:   "parent-uid",
-				OrgID:       1,
-				Type:        model.DashHitFolder,
-				URI:         "db/testing-123",
-				Title:       "testing-123",
-				URL:         "/dashboards/f/uid/testing-123",
+				UID:       "uid",
+				FolderUID: "parent-uid",
+				OrgID:     1,
+				Type:      model.DashHitFolder,
+				URI:       "db/testing-123",
+				Title:     "testing-123",
+				URL:       "/dashboards/f/uid/testing-123",
 			},
 		}
 		require.Equal(t, expectedResult, result)


### PR DESCRIPTION
**What is this feature?**

When searching for folders, we do not need to return the parent folder information.

The only place that is calling it is the dashboard service [here](https://github.com/grafana/grafana/blob/ac30bd432ab16117f4412794801752966b1dde56/pkg/services/dashboards/service/dashboard_service.go#L1588), and all it needs from that is the original queried for [folder's title](https://github.com/grafana/grafana/blob/ac30bd432ab16117f4412794801752966b1dde56/pkg/services/dashboards/service/dashboard_service.go#L1538), given it's uid.

This should help us reduce the number of folder get calls. For example, annotations auth calls this to get all visible dashboards for a user, and then we call get user for each of those for created by / updated by (see [trace](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22a0v%22%3A%7B%22datasource%22%3A%22fds8vtxx3ao74b%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22fds8vtxx3ao74b%22%7D%2C%22queryType%22%3A%22traceqlSearch%22%2C%22limit%22%3A20%2C%22tableType%22%3A%22traces%22%2C%22metricsQueryType%22%3A%22range%22%2C%22filters%22%3A%5B%7B%22id%22%3A%22571b7dc6%22%2C%22operator%22%3A%22%3D%22%2C%22scope%22%3A%22unscoped%22%2C%22tag%22%3A%22slug%22%2C%22value%22%3A%5B%22ops%22%5D%2C%22valueType%22%3A%22string%22%7D%2C%7B%22id%22%3A%22service-name%22%2C%22operator%22%3A%22%3D%22%2C%22scope%22%3A%22resource%22%2C%22tag%22%3A%22service.name%22%2C%22value%22%3A%5B%22grafana%22%5D%2C%22valueType%22%3A%22string%22%7D%2C%7B%22id%22%3A%22span-name%22%2C%22operator%22%3A%22%3D%22%2C%22scope%22%3A%22span%22%2C%22tag%22%3A%22name%22%2C%22value%22%3A%5B%22HTTP+GET+%2Fapi%2Fannotations%22%5D%2C%22valueType%22%3A%22string%22%7D%2C%7B%22id%22%3A%22min-duration%22%2C%22tag%22%3A%22duration%22%2C%22operator%22%3A%22%3E%22%2C%22valueType%22%3A%22duration%22%2C%22value%22%3A%225s%22%7D%5D%2C%22query%22%3A%22%7Bresource.service.name%3D%5C%22grafana%5C%22+%26%26+name%3D%5C%22HTTP+GET+%2Fapi%2Fannotations%5C%22+%26%26+duration%3E1s%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-24h%22%2C%22to%22%3A%22now%22%7D%7D%2C%22guh%22%3A%7B%22datasource%22%3A%22fds8vtxx3ao74b%22%2C%22queries%22%3A%5B%7B%22query%22%3A%223d7f66e5b363cb70cff54c1c164bc09c%22%2C%22queryType%22%3A%22traceql%22%2C%22refId%22%3A%22A%22%2C%22limit%22%3A20%2C%22tableType%22%3A%22traces%22%2C%22metricsQueryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22fds8vtxx3ao74b%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221743045867073%22%2C%22to%22%3A%221743132267073%22%7D%7D%7D&orgId=1)):
https://github.com/grafana/grafana/blob/ac30bd432ab16117f4412794801752966b1dde56/pkg/services/annotations/accesscontrol/accesscontrol.go#L139

Relates to https://github.com/grafana/app-platform-wg/issues/224

