### PR TITLE
Panel: link using windows.host rather than conf.appurl

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
@@ -34,7 +34,14 @@ describe('ShareLinkTab', () => {
   beforeAll(() => {
     advanceTo(fakeCurrentDate);
 
-    config.appUrl = 'http://dashboards.grafana.com/grafana/';
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        host: 'dashboards.grafana.com',
+      },
+      writable: true,
+    });
+    config.appSubUrl= '/grafana'
     config.rendererAvailable = true;
     config.bootData.user.orgId = 1;
     config.featureToggles.dashboardSceneForViewers = true;

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
@@ -41,7 +41,7 @@ describe('ShareLinkTab', () => {
       },
       writable: true,
     });
-    config.appSubUrl= '/grafana'
+    config.appSubUrl = '/grafana';
     config.rendererAvailable = true;
     config.bootData.user.orgId = 1;
     config.featureToggles.dashboardSceneForViewers = true;

--- a/public/app/features/dashboard-scene/utils/getDashboardUrl.test.ts
+++ b/public/app/features/dashboard-scene/utils/getDashboardUrl.test.ts
@@ -65,4 +65,14 @@ describe('dashboard utils', () => {
 
     expect(url).toBe('/dashboard/new?orgId=1&filter=A');
   });
+
+  it('Use windows.host as hostname and port', () => {
+    const url = getDashboardUrl({
+      uid: '',
+      currentQueryParams: '?orgId=1&filter=A',
+      absolute: true,
+    });
+
+    expect(url).toBe('http://localhost/dashboard/new?orgId=1&filter=A');
+  });
 });

--- a/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
+++ b/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
@@ -1,5 +1,5 @@
 import { UrlQueryMap, urlUtil } from '@grafana/data';
-import { config, locationSearchToObject } from '@grafana/runtime';
+import { locationSearchToObject } from '@grafana/runtime';
 
 export interface DashboardUrlOptions {
   uid?: string;
@@ -77,7 +77,7 @@ export function getDashboardUrl(options: DashboardUrlOptions) {
   const relativeUrl = urlUtil.renderUrl(path, params);
 
   if (options.absolute) {
-    return config.appUrl + relativeUrl.slice(1);
+    return window.location.host + relativeUrl;
   }
 
   return relativeUrl;

--- a/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
+++ b/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
@@ -1,5 +1,5 @@
 import { UrlQueryMap, urlUtil } from '@grafana/data';
-import { locationSearchToObject } from '@grafana/runtime';
+import {config, locationSearchToObject} from '@grafana/runtime';
 
 export interface DashboardUrlOptions {
   uid?: string;
@@ -77,7 +77,7 @@ export function getDashboardUrl(options: DashboardUrlOptions) {
   const relativeUrl = urlUtil.renderUrl(path, params);
 
   if (options.absolute) {
-    return window.location.host + relativeUrl;
+    return `${window.location.protocol}//${window.location.host}${relativeUrl}`;
   }
 
   return relativeUrl;

--- a/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
+++ b/public/app/features/dashboard-scene/utils/getDashboardUrl.ts
@@ -1,5 +1,5 @@
 import { UrlQueryMap, urlUtil } from '@grafana/data';
-import {config, locationSearchToObject} from '@grafana/runtime';
+import { config, locationSearchToObject } from '@grafana/runtime';
 
 export interface DashboardUrlOptions {
   uid?: string;
@@ -77,7 +77,7 @@ export function getDashboardUrl(options: DashboardUrlOptions) {
   const relativeUrl = urlUtil.renderUrl(path, params);
 
   if (options.absolute) {
-    return `${window.location.protocol}//${window.location.host}${relativeUrl}`;
+    return `${window.location.protocol}//${window.location.host}${config.appSubUrl}${relativeUrl}`;
   }
 
   return relativeUrl;


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
1. start grafana without special config.
2. use 127.0.0.1:3000 login grafana
3. create a panel and use share, click button
![image](https://github.com/user-attachments/assets/bfef6ac1-3828-4499-83c0-f3022e4a9db3)
4. you will find its a link with localhost:3000, you should login to access this panel.




