### PR TITLE
DashboardScene: Tweak row design

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -88,7 +88,8 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
               className={cx(
                 styles.rowTitle,
                 isHeaderHidden && styles.rowTitleHidden,
-                !isTopLevel && styles.rowTitleNested
+                !isTopLevel && styles.rowTitleNested,
+                isCollapsed && styles.rowTitleCollapsed
               )}
               role="heading"
             >
@@ -147,6 +148,9 @@ function getStyles(theme: GrafanaTheme2) {
     rowTitleNested: css({
       fontSize: theme.typography.body.fontSize,
       fontWeight: theme.typography.fontWeightRegular,
+    }),
+    rowTitleCollapsed: css({
+      color: theme.colors.text.secondary,
     }),
     wrapper: css({
       display: 'flex',


### PR DESCRIPTION

* When collapsed use text.secondary to more strongly emphasize collapsed state 

<img width="659" alt="Screenshot 2025-03-27 at 17 38 55" src="https://github.com/user-attachments/assets/0551afb5-2238-4a71-8037-8edda47be27d" />
