### PR TITLE
DashboardSchemaV2: Fix crash in response transformer

### DIFF
--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -305,6 +305,14 @@ describe('ResponseTransformers', () => {
               ],
               current: { value: ['1'], text: ['1'] },
             },
+            // Query variable with minimal props and without current
+            {
+              name: 'org_id',
+              label: 'Org ID',
+              hide: 2,
+              type: 'query',
+              query: 'label_values(grafanacloud_org_info{org_slug="$org_slug"}, org_id)',
+            },
           ],
         },
         panels: [
@@ -627,6 +635,7 @@ describe('ResponseTransformers', () => {
       validateVariablesV1ToV2(spec.variables[5], dashboardV1.templating?.list?.[5]);
       validateVariablesV1ToV2(spec.variables[6], dashboardV1.templating?.list?.[6]);
       validateVariablesV1ToV2(spec.variables[7], dashboardV1.templating?.list?.[7]);
+      validateVariablesV1ToV2(spec.variables[8], dashboardV1.templating?.list?.[8]);
     });
   });
 
@@ -938,8 +947,9 @@ describe('ResponseTransformers', () => {
       label: v1.label,
       description: v1.description,
       hide: transformVariableHideToEnum(v1.hide),
-      skipUrlSync: v1.skipUrlSync,
+      skipUrlSync: Boolean(v1.skipUrlSync),
     };
+
     const v2Common = {
       name: v2.spec.name,
       label: v2.spec.label,

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -307,11 +307,12 @@ describe('ResponseTransformers', () => {
             },
             // Query variable with minimal props and without current
             {
+              datasource: { type: 'prometheus', uid: 'abc' },
               name: 'org_id',
               label: 'Org ID',
               hide: 2,
               type: 'query',
-              query: 'label_values(grafanacloud_org_info{org_slug="$org_slug"}, org_id)',
+              query: { refId: 'A', query: 'label_values(grafanacloud_org_info{org_slug="$org_slug"}, org_id)' },
             },
           ],
         },

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -530,8 +530,8 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
             includeAll: Boolean(v.includeAll),
             ...(v.allValue && { allValue: v.allValue }),
             current: {
-              value: v.current.value,
-              text: v.current.text,
+              value: v.current?.value,
+              text: v.current?.text,
             },
             options: v.options || [],
             refresh: transformVariableRefreshToEnum(v.refresh),

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -513,15 +513,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
       case 'query':
         let query = v.query || {};
 
-        if (typeof query === 'string') {
-          console.warn(
-            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
-          );
-          query = {
-            [LEGACY_STRING_VALUE_KEY]: query,
-          };
-        }
-
         const qv: QueryVariableKind = {
           kind: 'QueryVariable',
           spec: {

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -513,6 +513,15 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
       case 'query':
         let query = v.query || {};
 
+        if (typeof query === 'string') {
+          console.warn(
+            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
+          );
+          query = {
+            [LEGACY_STRING_VALUE_KEY]: query,
+          };
+        }
+
         const qv: QueryVariableKind = {
           kind: 'QueryVariable',
           spec: {


### PR DESCRIPTION

When trying to save https://dynamicdashboards.grafana-dev.net/d/88d681fd-fd5b-44ec-986a-507bf425c32d/billing-usage 

It crashes due to template variable not having current prop. 

The unit test is crashing due to the console warn.

```
if (typeof query === 'string') {
          console.warn(
            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
          );
          query = {
            [LEGACY_STRING_VALUE_KEY]: query,
          };
        }
```

Not sure that warn is any help here, this should be migrated by the system, since this function migrates from schema v1 to v2, and in v1 a string is allowed? 

