### PR TITLE
DashboardSchemeV2: Fixes crash with transformations

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -302,10 +302,7 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
         const transformationSpec: DataTransformerConfig = {
           id: transformation.id,
           disabled: transformation.disabled,
-          filter: {
-            id: transformation.filter?.id ?? '',
-            options: transformation.filter?.options ?? {},
-          },
+          filter: transformation.filter,
           ...(transformation.topic && { topic: transformation.topic }),
           options: transformation.options,
         };


### PR DESCRIPTION
Looking at the schema v2 json of https://dynamicdashboards.grafana-dev.net/d/88d681fd-fd5b-44ec-986a-507bf425c32d/billing-usage 

you get these transformations 
```
{
                "kind": "organize",
                "spec": {
                  "filter": {
                    "id": "",
                    "options": {}
                  },
                  "id": "organize",
                  "options": {
                    "excludeByName": {
                      "id": true
                    }
                  }
                }
              }
```

with filter property set but id set to empty string, this leads to errors and crashes (when you try to save and load it as v2) 