### PR TITLE
Navtree: Add dashboard type to reduce query

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginsettings"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	pref "github.com/grafana/grafana/pkg/services/preference"
+	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlesimpl"
 	"github.com/grafana/grafana/pkg/setting"
@@ -334,6 +335,7 @@ func (s *ServiceImpl) buildStarredItemsNavLinks(c *contextmodel.ReqContext) ([]*
 		}
 		starredDashboards, err := s.dashboardService.SearchDashboards(c.Req.Context(), &dashboards.FindPersistedDashboardsQuery{
 			DashboardUIDs: uids,
+			Type:          searchstore.TypeDashboard,
 			OrgId:         c.SignedInUser.GetOrgID(),
 			SignedInUser:  c.SignedInUser,
 		})


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/103016

We should specify that they are dashboards so we don't also search across folders. You can't star folders, so it doesn't result in incorrect results, but it is unoptimized. 