### PR TITLE
K8s: Folders: Reduce db calls with /api/folders

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -78,13 +78,13 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagNestedFolders) {
 		q := &folder.GetChildrenQuery{
-			OrgID:          c.SignedInUser.GetOrgID(),
-			Limit:          c.QueryInt64("limit"),
-			Page:           c.QueryInt64("page"),
-			UID:            c.Query("parentUid"),
-			Permission:     permission,
-			SignedInUser:   c.SignedInUser,
-			ReturnOnlyRefs: true,
+			OrgID:        c.SignedInUser.GetOrgID(),
+			Limit:        c.QueryInt64("limit"),
+			Page:         c.QueryInt64("page"),
+			UID:          c.Query("parentUid"),
+			Permission:   permission,
+			SignedInUser: c.SignedInUser,
+			RefOnly:      true, // nolint:staticcheck
 		}
 
 		folders, err := hs.folderService.GetChildren(c.Req.Context(), q)
@@ -99,6 +99,7 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 				UID:       f.UID,
 				Title:     f.Title,
 				ParentUID: f.ParentUID,
+				ManagedBy: f.ManagedBy,
 			})
 			metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetFolders).Inc()
 		}

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -78,12 +78,13 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagNestedFolders) {
 		q := &folder.GetChildrenQuery{
-			OrgID:        c.SignedInUser.GetOrgID(),
-			Limit:        c.QueryInt64("limit"),
-			Page:         c.QueryInt64("page"),
-			UID:          c.Query("parentUid"),
-			Permission:   permission,
-			SignedInUser: c.SignedInUser,
+			OrgID:          c.SignedInUser.GetOrgID(),
+			Limit:          c.QueryInt64("limit"),
+			Page:           c.QueryInt64("page"),
+			UID:            c.Query("parentUid"),
+			Permission:     permission,
+			SignedInUser:   c.SignedInUser,
+			ReturnOnlyRefs: true,
 		}
 
 		folders, err := hs.folderService.GetChildren(c.Req.Context(), q)
@@ -98,7 +99,6 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 				UID:       f.UID,
 				Title:     f.Title,
 				ParentUID: f.ParentUID,
-				ManagedBy: f.ManagedBy,
 			})
 			metrics.MFolderIDsAPICount.WithLabelValues(metrics.GetFolders).Inc()
 		}

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -237,14 +237,22 @@ func (ss *FolderUnifiedStoreImpl) GetChildren(ctx context.Context, q folder.GetC
 			continue
 		}
 
-		// TODO: remove this check once we migrate alerting to using just the refs
-		if q.ReturnOnlyRefs {
-			hits = append(hits, &folder.Folder{
+		// TODO:  Remove this once we migrate the alerting use case.
+		// This is a temporary flag, and will be removed once we migrate the alerting use case to
+		// expect a folder ref too for children folders.
+		if q.RefOnly { // nolint:staticcheck
+			f := &folder.Folder{
 				ID:        item.Field.GetNestedInt64(search.DASHBOARD_LEGACY_ID),
 				UID:       item.Name,
 				Title:     item.Title,
 				ParentUID: item.Folder,
-			})
+			}
+
+			if item.Field.GetNestedString(resource.SEARCH_FIELD_MANAGER_KIND) != "" {
+				f.ManagedBy = utils.ParseManagerKindString(item.Field.GetNestedString(resource.SEARCH_FIELD_MANAGER_KIND))
+			}
+
+			hits = append(hits, f)
 			continue
 		}
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -15,6 +15,7 @@ import (
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -233,6 +234,17 @@ func (ss *FolderUnifiedStoreImpl) GetChildren(ctx context.Context, q folder.GetC
 	for _, item := range res.Hits {
 		// filter out k6 folders if request is not from a service account
 		if item.Name == accesscontrol.K6FolderUID && !allowK6Folder {
+			continue
+		}
+
+		// TODO: remove this check once we migrate alerting to using just the refs
+		if q.ReturnOnlyRefs {
+			hits = append(hits, &folder.Folder{
+				ID:        item.Field.GetNestedInt64(search.DASHBOARD_LEGACY_ID),
+				UID:       item.Name,
+				Title:     item.Title,
+				ParentUID: item.Folder,
+			})
 			continue
 		}
 

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -222,7 +222,8 @@ type GetChildrenQuery struct {
 	// array of folder uids to filter by
 	FolderUIDs []string `json:"-"`
 
-	ReturnOnlyRefs bool
+	// Deprecated: this is a temporary flag, and will be removed once we migrate the alerting use case
+	RefOnly bool
 }
 
 type HasEditPermissionInFoldersQuery struct {

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -221,6 +221,8 @@ type GetChildrenQuery struct {
 
 	// array of folder uids to filter by
 	FolderUIDs []string `json:"-"`
+
+	ReturnOnlyRefs bool
 }
 
 type HasEditPermissionInFoldersQuery struct {


### PR DESCRIPTION
This PR is a temporary solution to the k8s flow for getting folders - marking it as deprecated right away so we don't add usage of it.

Right now, the /api/folders endpoint (in the k8s flow) is extremely heavy on the database, because it first searches for all the children, and then loops through each child and gets that child, which also then goes and queries for the createdAt/updatedAt users.

@filewalkwithme is currently working on a permanent solution, which will change the function signature to be a FolderRef instead, but this requires changes to alerting, so putting this in as a temporary workaround.

Notes:
- The managedBy field on main is currently not being populated in mode4. I created a ticket for this: https://github.com/grafana/app-platform-wg/issues/259
- This PR will break the folder ID being returned in modes 3 & 4, as it is not being populated by search. This is also breaking /api/search already, created a ticket for that: https://github.com/grafana/app-platform-wg/issues/258

Relates to https://github.com/grafana/app-platform-wg/issues/224