### PR TITLE
Extensions: Expose new observable APIs for accessing components and links 

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -16,3 +16,12 @@ export { type PageInfoItem, setPluginPage } from '../components/PluginPage';
 
 export { ExpressionDatasourceRef } from '../utils/DataSourceWithBackend';
 export { standardStreamOptionsProvider, toStreamingDataResponse } from '../utils/DataSourceWithBackend';
+
+export {
+  setGetObservablePluginComponents,
+  type GetObservablePluginComponents,
+} from '../services/pluginExtensions/getObservablePluginComponents';
+export {
+  setGetObservablePluginLinks,
+  type GetObservablePluginLinks,
+} from '../services/pluginExtensions/getObservablePluginLinks';

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginComponents.ts
@@ -1,0 +1,36 @@
+import { Observable } from 'rxjs';
+
+import { PluginExtensionComponent } from '@grafana/data';
+
+type GetObservablePluginComponentsOptions = {
+  context?: object | Record<string, unknown>;
+  extensionPointId: string;
+  limitPerPlugin?: number;
+};
+
+export type GetObservablePluginComponents = (
+  options: GetObservablePluginComponentsOptions
+) => Observable<PluginExtensionComponent[]>;
+
+let singleton: GetObservablePluginComponents | undefined;
+
+export function setGetObservablePluginComponents(fn: GetObservablePluginComponents): void {
+  // We allow overriding the registry in tests
+  if (singleton && process.env.NODE_ENV !== 'test') {
+    throw new Error(
+      'setGetObservablePluginComponents() function should only be called once, when Grafana is starting.'
+    );
+  }
+
+  singleton = fn;
+}
+
+export function getObservablePluginComponents(
+  options: GetObservablePluginComponentsOptions
+): Observable<PluginExtensionComponent[]> {
+  if (!singleton) {
+    throw new Error('setGetObservablePluginComponents() can only be used after the Grafana instance has started.');
+  }
+
+  return singleton(options);
+}

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginComponents.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginComponents.ts
@@ -29,7 +29,7 @@ export function getObservablePluginComponents(
   options: GetObservablePluginComponentsOptions
 ): Observable<PluginExtensionComponent[]> {
   if (!singleton) {
-    throw new Error('setGetObservablePluginComponents() can only be used after the Grafana instance has started.');
+    throw new Error('getObservablePluginComponents() can only be used after the Grafana instance has started.');
   }
 
   return singleton(options);

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginLinks.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginLinks.ts
@@ -23,7 +23,7 @@ export function setGetObservablePluginLinks(fn: GetObservablePluginLinks): void 
 
 export function getObservablePluginLinks(options: GetObservablePluginLinksOptions): Observable<PluginExtensionLink[]> {
   if (!singleton) {
-    throw new Error('setGetObservablePluginLinks() can only be used after the Grafana instance has started.');
+    throw new Error('getObservablePluginLinks() can only be used after the Grafana instance has started.');
   }
 
   return singleton(options);

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginLinks.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginLinks.ts
@@ -1,0 +1,30 @@
+import { Observable } from 'rxjs';
+
+import { PluginExtensionLink } from '@grafana/data';
+
+type GetObservablePluginLinksOptions = {
+  context?: object | Record<string | symbol, unknown>;
+  extensionPointId: string;
+  limitPerPlugin?: number;
+};
+
+export type GetObservablePluginLinks = (options: GetObservablePluginLinksOptions) => Observable<PluginExtensionLink[]>;
+
+let singleton: GetObservablePluginLinks | undefined;
+
+export function setGetObservablePluginLinks(fn: GetObservablePluginLinks): void {
+  // We allow overriding the registry in tests
+  if (singleton && process.env.NODE_ENV !== 'test') {
+    throw new Error('setGetObservablePluginLinks() function should only be called once, when Grafana is starting.');
+  }
+
+  singleton = fn;
+}
+
+export function getObservablePluginLinks(options: GetObservablePluginLinksOptions): Observable<PluginExtensionLink[]> {
+  if (!singleton) {
+    throw new Error('setGetObservablePluginLinks() can only be used after the Grafana instance has started.');
+  }
+
+  return singleton(options);
+}

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -11,3 +11,6 @@
 
 export { useTranslate, setUseTranslateHook, setTransComponent, Trans } from './utils/i18n';
 export type { TransProps } from './types/i18n';
+
+export { getObservablePluginLinks } from './services/pluginExtensions/getObservablePluginLinks';
+export { getObservablePluginComponents } from './services/pluginExtensions/getObservablePluginComponents';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -42,7 +42,13 @@ import {
   setCorrelationsService,
   setPluginFunctionsHook,
 } from '@grafana/runtime';
-import { setPanelDataErrorView, setPanelRenderer, setPluginPage } from '@grafana/runtime/internal';
+import {
+  setGetObservablePluginComponents,
+  setGetObservablePluginLinks,
+  setPanelDataErrorView,
+  setPanelRenderer,
+  setPluginPage,
+} from '@grafana/runtime/internal';
 import config, { updateConfig } from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -76,7 +82,11 @@ import { initGrafanaLive } from './features/live';
 import { PanelDataErrorView } from './features/panel/components/PanelDataErrorView';
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
-import { createPluginExtensionsGetter } from './features/plugins/extensions/getPluginExtensions';
+import {
+  createPluginExtensionsGetter,
+  getObservablePluginComponents,
+  getObservablePluginLinks,
+} from './features/plugins/extensions/getPluginExtensions';
 import { pluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
 import { usePluginComponent } from './features/plugins/extensions/usePluginComponent';
 import { usePluginComponents } from './features/plugins/extensions/usePluginComponents';
@@ -222,6 +232,8 @@ export class GrafanaApp {
       setPluginComponentHook(usePluginComponent);
       setPluginComponentsHook(usePluginComponents);
       setPluginFunctionsHook(usePluginFunctions);
+      setGetObservablePluginLinks(getObservablePluginLinks);
+      setGetObservablePluginComponents(getObservablePluginComponents);
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -4,8 +4,6 @@ import {
   type PluginExtensionAddedLinkConfig,
   type PluginExtensionAddedComponentConfig,
   PluginExtensionTypes,
-  PluginExtensionLink,
-  PluginExtensionComponent,
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -611,30 +611,21 @@ describe('getObservablePluginExtensions()', () => {
     });
   });
 
-  it('should emit the initial state when no changes are made to the registries', () => {
-    const observable = getObservablePluginExtensions({ extensionPointId });
+it('should emit the initial state when no changes are made to the registries', async () => {
+    const observable = getObservablePluginExtensions({ extensionPointId }).pipe(first());
 
-    observable.subscribe((value: ReturnType<GetExtensions>) => {
-      expect(value.extensions).toHaveLength(2);
-      expect(value.extensions[0].pluginId).toBe(pluginId);
-      expect(value.extensions[1].pluginId).toBe(pluginId);
+    await expect(observable).toEmitValuesWith((received) => {
+      const { extensions } = received[0];
+      expect(extensions).toHaveLength(2);
+      expect(extensions[0].pluginId).toBe(pluginId);
+      expect(extensions[1].pluginId).toBe(pluginId);
     });
   });
 
-  it('should emit the new state when the registries change', (done) => {
-    const observable = getObservablePluginExtensions({ extensionPointId });
-    const subscriber = jest.fn();
+it('should emit the new state when the registries change', async () => {
+    const observable = getObservablePluginExtensions({ extensionPointId }).pipe(take(2));
 
-    observable.subscribe(subscriber);
-
-    // Initial state
     setTimeout(() => {
-      expect(subscriber).toHaveBeenCalledTimes(2);
-      expect(subscriber.mock.calls[1][0].extensions).toHaveLength(2);
-      expect(subscriber.mock.calls[1][0].extensions[0].pluginId).toBe(pluginId);
-      expect(subscriber.mock.calls[1][0].extensions[1].pluginId).toBe(pluginId);
-
-      // Register new link extension
       pluginExtensionRegistries.addedLinksRegistry.register({
         pluginId,
         configs: [
@@ -647,15 +638,20 @@ describe('getObservablePluginExtensions()', () => {
           },
         ],
       });
+    }, 10);
 
-      expect(subscriber).toHaveBeenCalledTimes(3);
-      expect(subscriber.mock.calls[2][0].extensions).toHaveLength(3);
-      expect(subscriber.mock.calls[2][0].extensions[0].pluginId).toBe(pluginId);
-      expect(subscriber.mock.calls[2][0].extensions[1].pluginId).toBe(pluginId);
-      expect(subscriber.mock.calls[2][0].extensions[2].pluginId).toBe(pluginId);
+    await expect(observable).toEmitValuesWith((received) => {
+      const { extensions } = received[0];
+      expect(extensions).toHaveLength(2);
+      expect(extensions[0].pluginId).toBe(pluginId);
+      expect(extensions[1].pluginId).toBe(pluginId);
 
-      done();
-    }, 0);
+      const { extensions: extensions2 } = received[1];
+      expect(extensions2).toHaveLength(3);
+      expect(extensions2[0].pluginId).toBe(pluginId);
+      expect(extensions2[1].pluginId).toBe(pluginId);
+      expect(extensions2[2].pluginId).toBe(pluginId);
+    });
   });
 });
 
@@ -694,10 +690,11 @@ describe('getObservablePluginLinks()', () => {
     });
   });
 
-  it('should only emit the links', () => {
-    const observable = getObservablePluginLinks({ extensionPointId });
+  it('should only emit the links', async () => {
+    const observable = getObservablePluginLinks({ extensionPointId }).pipe(first());
 
-    observable.subscribe((links) => {
+    await expect(observable).toEmitValuesWith((received) => {
+      const links = received[0];
       expect(links).toHaveLength(1);
       expect(links[0].pluginId).toBe(pluginId);
       expect(links[0].type).toBe(PluginExtensionTypes.link);
@@ -740,10 +737,11 @@ describe('getObservablePluginComponents()', () => {
     });
   });
 
-  it('should only emit the components', () => {
-    const observable = getObservablePluginComponents({ extensionPointId });
+it('should only emit the components', async () => {
+    const observable = getObservablePluginComponents({ extensionPointId }).pipe(first());
 
-    observable.subscribe((components) => {
+    await expect(observable).toEmitValuesWith((received) => {
+      const components = received[0];
       expect(components).toHaveLength(1);
       expect(components[0].pluginId).toBe(pluginId);
       expect(components[0].type).toBe(PluginExtensionTypes.component);

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { first, take } from 'rxjs';
 
 import {
   type PluginExtensionAddedLinkConfig,
@@ -18,7 +19,6 @@ import { resetLogMock } from './logs/testUtils';
 import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
 import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
 import { pluginExtensionRegistries } from './registry/setup';
-import type { GetExtensions } from './types';
 import { isReadOnlyProxy } from './utils';
 import { assertPluginExtensionLink } from './validators';
 
@@ -611,7 +611,7 @@ describe('getObservablePluginExtensions()', () => {
     });
   });
 
-it('should emit the initial state when no changes are made to the registries', async () => {
+  it('should emit the initial state when no changes are made to the registries', async () => {
     const observable = getObservablePluginExtensions({ extensionPointId }).pipe(first());
 
     await expect(observable).toEmitValuesWith((received) => {
@@ -622,7 +622,7 @@ it('should emit the initial state when no changes are made to the registries', a
     });
   });
 
-it('should emit the new state when the registries change', async () => {
+  it('should emit the new state when the registries change', async () => {
     const observable = getObservablePluginExtensions({ extensionPointId }).pipe(take(2));
 
     setTimeout(() => {
@@ -638,7 +638,7 @@ it('should emit the new state when the registries change', async () => {
           },
         ],
       });
-    }, 10);
+    }, 0);
 
     await expect(observable).toEmitValuesWith((received) => {
       const { extensions } = received[0];
@@ -737,7 +737,7 @@ describe('getObservablePluginComponents()', () => {
     });
   });
 
-it('should only emit the components', async () => {
+  it('should only emit the components', async () => {
     const observable = getObservablePluginComponents({ extensionPointId }).pipe(first());
 
     await expect(observable).toEmitValuesWith((received) => {

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -699,7 +699,7 @@ describe('getObservablePluginLinks()', () => {
   it('should only emit the links', () => {
     const observable = getObservablePluginLinks({ extensionPointId });
 
-    observable.subscribe((links: PluginExtensionLink[]) => {
+    observable.subscribe((links) => {
       expect(links).toHaveLength(1);
       expect(links[0].pluginId).toBe(pluginId);
       expect(links[0].type).toBe(PluginExtensionTypes.link);
@@ -745,7 +745,7 @@ describe('getObservablePluginComponents()', () => {
   it('should only emit the components', () => {
     const observable = getObservablePluginComponents({ extensionPointId });
 
-    observable.subscribe((components: PluginExtensionComponent[]) => {
+    observable.subscribe((components) => {
       expect(components).toHaveLength(1);
       expect(components[0].pluginId).toBe(pluginId);
       expect(components[0].type).toBe(PluginExtensionTypes.component);

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -623,37 +623,41 @@ describe('getObservablePluginExtensions()', () => {
     });
   });
 
-  it('should emit the new state when the registries change', () => {
+  it('should emit the new state when the registries change', (done) => {
     const observable = getObservablePluginExtensions({ extensionPointId });
     const subscriber = jest.fn();
 
     observable.subscribe(subscriber);
 
     // Initial state
-    expect(subscriber).toHaveBeenCalledTimes(2);
-    expect(subscriber.mock.calls[1][0].extensions).toHaveLength(2);
-    expect(subscriber.mock.calls[1][0].extensions[0].pluginId).toBe(pluginId);
-    expect(subscriber.mock.calls[1][0].extensions[1].pluginId).toBe(pluginId);
+    setTimeout(() => {
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.calls[1][0].extensions).toHaveLength(2);
+      expect(subscriber.mock.calls[1][0].extensions[0].pluginId).toBe(pluginId);
+      expect(subscriber.mock.calls[1][0].extensions[1].pluginId).toBe(pluginId);
 
-    // Register new link extension
-    pluginExtensionRegistries.addedLinksRegistry.register({
-      pluginId,
-      configs: [
-        {
-          title: 'Link 2',
-          description: 'Link 2 description',
-          path: `/a/${pluginId}/declare-incident`,
-          targets: extensionPointId,
-          configure: jest.fn().mockReturnValue({}),
-        },
-      ],
-    });
+      // Register new link extension
+      pluginExtensionRegistries.addedLinksRegistry.register({
+        pluginId,
+        configs: [
+          {
+            title: 'Link 2',
+            description: 'Link 2 description',
+            path: `/a/${pluginId}/declare-incident`,
+            targets: extensionPointId,
+            configure: jest.fn().mockReturnValue({}),
+          },
+        ],
+      });
 
-    expect(subscriber).toHaveBeenCalledTimes(3);
-    expect(subscriber.mock.calls[2][0].extensions).toHaveLength(3);
-    expect(subscriber.mock.calls[2][0].extensions[0].pluginId).toBe(pluginId);
-    expect(subscriber.mock.calls[2][0].extensions[1].pluginId).toBe(pluginId);
-    expect(subscriber.mock.calls[2][0].extensions[2].pluginId).toBe(pluginId);
+      expect(subscriber).toHaveBeenCalledTimes(3);
+      expect(subscriber.mock.calls[2][0].extensions).toHaveLength(3);
+      expect(subscriber.mock.calls[2][0].extensions[0].pluginId).toBe(pluginId);
+      expect(subscriber.mock.calls[2][0].extensions[1].pluginId).toBe(pluginId);
+      expect(subscriber.mock.calls[2][0].extensions[2].pluginId).toBe(pluginId);
+
+      done();
+    }, 0);
   });
 });
 

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.tsx
@@ -1,13 +1,26 @@
 import * as React from 'react';
 
-import { PluginExtensionAddedComponentConfig, PluginExtensionAddedLinkConfig } from '@grafana/data';
+import {
+  type PluginExtensionAddedLinkConfig,
+  type PluginExtensionAddedComponentConfig,
+  PluginExtensionTypes,
+  PluginExtensionLink,
+  PluginExtensionComponent,
+} from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 
-import { getPluginExtensions } from './getPluginExtensions';
+import {
+  getObservablePluginComponents,
+  getObservablePluginExtensions,
+  getObservablePluginLinks,
+  getPluginExtensions,
+} from './getPluginExtensions';
 import { log } from './logs/log';
 import { resetLogMock } from './logs/testUtils';
 import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
 import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { pluginExtensionRegistries } from './registry/setup';
+import type { GetExtensions } from './types';
 import { isReadOnlyProxy } from './utils';
 import { assertPluginExtensionLink } from './validators';
 
@@ -61,9 +74,9 @@ describe('getPluginExtensions()', () => {
   const extensionPoint3 = 'grafana/datasources/config/v1';
   const pluginId = 'grafana-basic-app';
   // Sample extension configs that are used in the tests below
-  let link1: PluginExtensionAddedLinkConfig,
-    link2: PluginExtensionAddedLinkConfig,
-    component1: PluginExtensionAddedComponentConfig;
+  let link1: PluginExtensionAddedLinkConfig;
+  let link2: PluginExtensionAddedLinkConfig;
+  let component1: PluginExtensionAddedComponentConfig;
 
   beforeEach(() => {
     link1 = {
@@ -562,5 +575,176 @@ describe('getPluginExtensions()', () => {
         description: component1.description,
       })
     );
+  });
+});
+
+describe('getObservablePluginExtensions()', () => {
+  const extensionPointId = 'grafana/dashboard/panel/menu/v1';
+  const pluginId = 'grafana-basic-app';
+
+  beforeEach(() => {
+    pluginExtensionRegistries.addedLinksRegistry = new AddedLinksRegistry();
+    pluginExtensionRegistries.addedComponentsRegistry = new AddedComponentsRegistry();
+    pluginExtensionRegistries.addedLinksRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Link 1',
+          description: 'Link 1 description',
+          path: `/a/${pluginId}/declare-incident`,
+          targets: extensionPointId,
+          configure: jest.fn().mockReturnValue({}),
+        },
+      ],
+    });
+
+    pluginExtensionRegistries.addedComponentsRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Component 1',
+          description: 'Component 1 description',
+          targets: extensionPointId,
+          component: () => {
+            return <div>Hello world!</div>;
+          },
+        },
+      ],
+    });
+  });
+
+  it('should emit the initial state when no changes are made to the registries', () => {
+    const observable = getObservablePluginExtensions({ extensionPointId });
+
+    observable.subscribe((value: ReturnType<GetExtensions>) => {
+      expect(value.extensions).toHaveLength(2);
+      expect(value.extensions[0].pluginId).toBe(pluginId);
+      expect(value.extensions[1].pluginId).toBe(pluginId);
+    });
+  });
+
+  it('should emit the new state when the registries change', () => {
+    const observable = getObservablePluginExtensions({ extensionPointId });
+    const subscriber = jest.fn();
+
+    observable.subscribe(subscriber);
+
+    // Initial state
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(subscriber.mock.calls[1][0].extensions).toHaveLength(2);
+    expect(subscriber.mock.calls[1][0].extensions[0].pluginId).toBe(pluginId);
+    expect(subscriber.mock.calls[1][0].extensions[1].pluginId).toBe(pluginId);
+
+    // Register new link extension
+    pluginExtensionRegistries.addedLinksRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Link 2',
+          description: 'Link 2 description',
+          path: `/a/${pluginId}/declare-incident`,
+          targets: extensionPointId,
+          configure: jest.fn().mockReturnValue({}),
+        },
+      ],
+    });
+
+    expect(subscriber).toHaveBeenCalledTimes(3);
+    expect(subscriber.mock.calls[2][0].extensions).toHaveLength(3);
+    expect(subscriber.mock.calls[2][0].extensions[0].pluginId).toBe(pluginId);
+    expect(subscriber.mock.calls[2][0].extensions[1].pluginId).toBe(pluginId);
+    expect(subscriber.mock.calls[2][0].extensions[2].pluginId).toBe(pluginId);
+  });
+});
+
+describe('getObservablePluginLinks()', () => {
+  const extensionPointId = 'grafana/dashboard/panel/menu/v1';
+  const pluginId = 'grafana-basic-app';
+
+  beforeEach(() => {
+    pluginExtensionRegistries.addedLinksRegistry = new AddedLinksRegistry();
+    pluginExtensionRegistries.addedComponentsRegistry = new AddedComponentsRegistry();
+    pluginExtensionRegistries.addedLinksRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Link 1',
+          description: 'Link 1 description',
+          path: `/a/${pluginId}/declare-incident`,
+          targets: extensionPointId,
+          configure: jest.fn().mockReturnValue({}),
+        },
+      ],
+    });
+
+    pluginExtensionRegistries.addedComponentsRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Component 1',
+          description: 'Component 1 description',
+          targets: extensionPointId,
+          component: () => {
+            return <div>Hello world!</div>;
+          },
+        },
+      ],
+    });
+  });
+
+  it('should only emit the links', () => {
+    const observable = getObservablePluginLinks({ extensionPointId });
+
+    observable.subscribe((links: PluginExtensionLink[]) => {
+      expect(links).toHaveLength(1);
+      expect(links[0].pluginId).toBe(pluginId);
+      expect(links[0].type).toBe(PluginExtensionTypes.link);
+    });
+  });
+});
+
+describe('getObservablePluginComponents()', () => {
+  const extensionPointId = 'grafana/dashboard/panel/menu/v1';
+  const pluginId = 'grafana-basic-app';
+
+  beforeEach(() => {
+    pluginExtensionRegistries.addedLinksRegistry = new AddedLinksRegistry();
+    pluginExtensionRegistries.addedComponentsRegistry = new AddedComponentsRegistry();
+    pluginExtensionRegistries.addedLinksRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Link 1',
+          description: 'Link 1 description',
+          path: `/a/${pluginId}/declare-incident`,
+          targets: extensionPointId,
+          configure: jest.fn().mockReturnValue({}),
+        },
+      ],
+    });
+
+    pluginExtensionRegistries.addedComponentsRegistry.register({
+      pluginId,
+      configs: [
+        {
+          title: 'Component 1',
+          description: 'Component 1 description',
+          targets: extensionPointId,
+          component: () => {
+            return <div>Hello world!</div>;
+          },
+        },
+      ],
+    });
+  });
+
+  it('should only emit the components', () => {
+    const observable = getObservablePluginComponents({ extensionPointId });
+
+    observable.subscribe((components: PluginExtensionComponent[]) => {
+      expect(components).toHaveLength(1);
+      expect(components[0].pluginId).toBe(pluginId);
+      expect(components[0].type).toBe(PluginExtensionTypes.component);
+    });
   });
 });

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -1,5 +1,5 @@
 import { isString } from 'lodash';
-import { combineLatest, filter, map, Observable, from, of, merge, switchMap, shareReplay } from 'rxjs';
+import { combineLatest, filter, map, Observable } from 'rxjs';
 
 import {
   PluginExtensionTypes,
@@ -48,22 +48,21 @@ export const getObservablePluginExtensions = (
         addedComponentsRegistry: components,
         addedLinksRegistry: links,
       })
-    ),
-    shareReplay(1)
+    )
   );
 };
 
 export const getObservablePluginLinks: GetObservablePluginLinks = (options) => {
   return getObservablePluginExtensions(options).pipe(
     map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.link)),
-    filter((extensions) => extensions.length)
+    filter((extensions) => extensions.length > 0)
   );
 };
 
 export const getObservablePluginComponents: GetObservablePluginComponents = (options) => {
   return getObservablePluginExtensions(options).pipe(
     map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.component)),
-    filter((extensions) => extensions.length)
+    filter((extensions) => extensions.length > 0)
   );
 };
 

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -1,5 +1,5 @@
 import { isString } from 'lodash';
-import { BehaviorSubject, combineLatest, filter, map, Observable, from, of, merge, switchMap, shareReplay } from 'rxjs';
+import { combineLatest, filter, map, Observable, from, of, merge, switchMap, shareReplay } from 'rxjs';
 
 import {
   PluginExtensionTypes,

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -1,4 +1,5 @@
 import { isString } from 'lodash';
+import { filter, map, Observable } from 'rxjs';
 
 import {
   PluginExtensionTypes,
@@ -6,13 +7,15 @@ import {
   type PluginExtensionLink,
   type PluginExtensionComponent,
 } from '@grafana/data';
-import { GetPluginExtensions } from '@grafana/runtime';
+import { type GetObservablePluginLinks, type GetObservablePluginComponents } from '@grafana/runtime/internal';
 
 import { log } from './logs/log';
 import { AddedComponentRegistryItem } from './registry/AddedComponentsRegistry';
 import { AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { RegistryType } from './registry/Registry';
+import { pluginExtensionRegistries } from './registry/setup';
 import type { PluginExtensionRegistries } from './registry/types';
+import { GetExtensions, GetExtensionsOptions, GetPluginExtensions } from './types';
 import {
   getReadOnlyProxy,
   generateExtensionId,
@@ -22,19 +25,77 @@ import {
   getLinkExtensionPathWithTracking,
 } from './utils';
 
-type GetExtensions = ({
-  context,
-  extensionPointId,
-  limitPerPlugin,
-  addedLinksRegistry,
-  addedComponentsRegistry,
-}: {
-  context?: object | Record<string | symbol, unknown>;
-  extensionPointId: string;
-  limitPerPlugin?: number;
-  addedComponentsRegistry: RegistryType<AddedComponentRegistryItem[]> | undefined;
-  addedLinksRegistry: RegistryType<AddedLinkRegistryItem[]> | undefined;
-}) => { extensions: PluginExtension[] };
+/**
+ * Returns an observable that emits plugin extensions whenever the core extensions registries change.
+ * The observable will emit the initial state of the extensions and then emit again whenever
+ * either the added components registry or the added links registry changes.
+ *
+ * @param options - The options for getting plugin extensions
+ * @returns An Observable that emits the plugin extensions for the given extension point any time the registries change
+ */
+
+export const getObservablePluginExtensions = (
+  options: Omit<GetExtensionsOptions, 'addedComponentsRegistry' | 'addedLinksRegistry'>
+): Observable<ReturnType<GetExtensions>> => {
+  return new Observable((subscriber) => {
+    let addedComponentsRegistry: RegistryType<AddedComponentRegistryItem[]> | undefined;
+    let addedLinksRegistry: RegistryType<Array<AddedLinkRegistryItem<object>>> | undefined;
+
+    const emitExtensions = () => {
+      subscriber.next(
+        getPluginExtensions({
+          ...options,
+          addedComponentsRegistry,
+          addedLinksRegistry,
+        })
+      );
+    };
+
+    // Reading the initial state of the registries
+    Promise.all([
+      pluginExtensionRegistries.addedComponentsRegistry.getState(),
+      pluginExtensionRegistries.addedLinksRegistry.getState(),
+    ]).then(([currentAddedComponentsRegistry, currentAddedLinksRegistry]) => {
+      addedComponentsRegistry = currentAddedComponentsRegistry;
+      addedLinksRegistry = currentAddedLinksRegistry;
+      emitExtensions();
+    });
+
+    const addedComponentsSub = pluginExtensionRegistries.addedComponentsRegistry
+      .asObservable()
+      .subscribe((currentAddedComponentsRegistry) => {
+        addedComponentsRegistry = currentAddedComponentsRegistry;
+        emitExtensions();
+      });
+
+    const addedLinksSub = pluginExtensionRegistries.addedLinksRegistry
+      .asObservable()
+      .subscribe((currentAddedLinksRegistry) => {
+        addedLinksRegistry = currentAddedLinksRegistry;
+        emitExtensions();
+      });
+
+    // Cleanup subscriptions
+    return () => {
+      addedComponentsSub?.unsubscribe();
+      addedLinksSub?.unsubscribe();
+    };
+  });
+};
+
+export const getObservablePluginLinks: GetObservablePluginLinks = (options) => {
+  return getObservablePluginExtensions(options).pipe(
+    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.link)),
+    filter((extensions) => extensions.length > 0)
+  );
+};
+
+export const getObservablePluginComponents: GetObservablePluginComponents = (options) => {
+  return getObservablePluginExtensions(options).pipe(
+    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.component)),
+    filter((extensions) => extensions.length > 0)
+  );
+};
 
 export function createPluginExtensionsGetter(registries: PluginExtensionRegistries): GetPluginExtensions {
   let addedComponentsRegistry: RegistryType<AddedComponentRegistryItem[]>;

--- a/public/app/features/plugins/extensions/types.ts
+++ b/public/app/features/plugins/extensions/types.ts
@@ -1,0 +1,22 @@
+import { PluginExtension } from '@grafana/data';
+
+import { AddedComponentRegistryItem } from './registry/AddedComponentsRegistry';
+import { AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
+import { RegistryType } from './registry/Registry';
+
+export type GetExtensionsOptions = {
+  context?: object | Record<string | symbol, unknown>;
+  extensionPointId: string;
+  limitPerPlugin?: number;
+  addedComponentsRegistry: RegistryType<AddedComponentRegistryItem[]> | undefined;
+  addedLinksRegistry: RegistryType<AddedLinkRegistryItem[]> | undefined;
+};
+
+export type GetExtensions = (options: GetExtensionsOptions) => { extensions: PluginExtension[] };
+
+export type GetPluginExtensions<T = PluginExtension> = (options: {
+  extensionPointId: string;
+  // Make sure this object is properly memoized and not mutated.
+  context?: object | Record<string | symbol, unknown>;
+  limitPerPlugin?: number;
+}) => { extensions: T[] };


### PR DESCRIPTION
**Related:** https://github.com/grafana/grafana/pull/102102

### What changed?
**Exposed two new API functions** for getting hold of added components and links as observables. This can be useful (or even necessary) when accessing extensions from a non-React context.

🆕 **`getObservablePluginLinks()`**
```ts
import { getObservablePluginLinks } from "@grafana/runtime/unstable";

getObservablePluginLinks({ extensionPointId }).subscribe((links) => {
  // `links` is the currently available link extensions for an extension point
});
```

🆕 **`getObservablePluginComponents()`**
```ts
import { getObservablePluginLinks } from "@grafana/runtime/unstable";

getObservablePluginLinks({ extensionPointId }).subscribe((links) => {
  // `links` is the currently available link extensions for an extension point
});
```

### Why?
The [logs-drilldown](https://github.com/grafana/logs-drilldown/issues/1140) and [metrics-drilldown](https://github.com/grafana/metrics-drilldown/issues/213) app plugins are depending on a non-react-hook API for accessing extensions due to using Scenes classes.