### PR TITLE
Docs: use PKCE in keycloak example

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
@@ -48,6 +48,7 @@ auth_url = https://<PROVIDER_DOMAIN>/realms/<REALM_NAME>/protocol/openid-connect
 token_url = https://<PROVIDER_DOMAIN>/realms/<REALM_NAME>/protocol/openid-connect/token
 api_url = https://<PROVIDER_DOMAIN>/realms/<REALM_NAME>/protocol/openid-connect/userinfo
 role_attribute_path = contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'
+use_pkce = true
 ```
 
 As an example, `<PROVIDER_DOMAIN>` can be `keycloak-demo.grafana.org`
@@ -84,7 +85,11 @@ It is useful as a fallback or if the user has more than 150 group memberships.
 As an example, `<grafana_root_url>` can be `https://play.grafana.org`.
 Non-listed configuration options can be left at their default values.
 
-2. In the client scopes configuration, _Assigned Default Client Scopes_ should match:
+2. In the client advanced settings
+
+- Set proof key for code exchange code challenge method to S256.
+
+3. In the client scopes configuration, _Assigned Default Client Scopes_ should match:
 
 ```
 email
@@ -97,7 +102,7 @@ roles
 These scopes do not add group claims to the `id_token`. Without group claims, teamsync will not work. Teamsync is covered further down in this document.
 {{% /admonition %}}
 
-3. For role mapping to work with the example configuration above,
+4. For role mapping to work with the example configuration above,
    you need to create the following roles and assign them to users:
 
 ```


### PR DESCRIPTION
it's of by default. 
Keycloak will accept whatever (including nothing) is given to it by default. use_pkce makes grafana send challenge. Setting advanced settings in keycloak enforces usage of PKCE

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Enable pkce in example and force it in keycloak

**Why do we need this feature?**

I set it up with it off by default and didn't realize

**Who is this feature for?**

Others who might do same as I did in previous answer

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

My language skills are lacking that's why draft

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
