### PR TITLE
K8s: Fix error conversion for provisioned dashboards

### DIFF
--- a/pkg/api/apierrors/dashboard.go
+++ b/pkg/api/apierrors/dashboard.go
@@ -46,5 +46,10 @@ func ToDashboardErrorResponse(ctx context.Context, pluginStore pluginstore.Store
 		return response.Error(http.StatusRequestEntityTooLarge, fmt.Sprintf("Dashboard is too large, max is %d MB", apiserver.MaxRequestBodyBytes/1024/1024), err)
 	}
 
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return response.Error(int(statusErr.ErrStatus.Code), statusErr.ErrStatus.Message, err)
+	}
+
 	return response.Error(http.StatusInternalServerError, "Failed to save dashboard", err)
 }

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -504,6 +505,12 @@ func (hs *HTTPServer) deleteDashboard(c *contextmodel.ReqContext) response.Respo
 				return response.Error(dashboardErr.StatusCode, dashboardErr.Error(), err)
 			}
 		}
+
+		var statusErr *k8serrors.StatusError
+		if errors.As(err, &statusErr) {
+			return response.Error(int(statusErr.ErrStatus.Code), statusErr.ErrStatus.Message, err)
+		}
+
 		return response.Error(http.StatusInternalServerError, "Failed to delete dashboard", err)
 	}
 

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -173,7 +173,7 @@ func (b *DashboardsAPIBuilder) Validate(ctx context.Context, a admission.Attribu
 			}
 
 			if provisioningData != nil {
-				return dashboards.ErrDashboardCannotDeleteProvisionedDashboard
+				return apierrors.NewBadRequest(dashboards.ErrDashboardCannotDeleteProvisionedDashboard.Reason)
 			}
 		}
 	}

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -140,9 +141,23 @@ func TestIntegrationUpdatingProvisionionedDashboards(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
+	testUpdatingProvisionionedDashboards(t, []string{})
+}
+
+func TestIntegrationUpdatingProvisionionedDashboardsK8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// will be the default in g12
+	testUpdatingProvisionionedDashboards(t, []string{featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testUpdatingProvisionionedDashboards(t *testing.T, featureToggles []string) {
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-		DisableAnonymous: true,
+		DisableAnonymous:     true,
+		EnableFeatureToggles: featureToggles,
 	})
 
 	provDashboardsDir := filepath.Join(dir, "conf", "provisioning", "dashboards")


### PR DESCRIPTION
**What is this feature?**

This PR fixes the status code returned when trying to delete a provisioned dashboard in the k8s flow (currently 500, and should be a 400). And then enables the integration tests on both this flow and the current flow.

It also adds the same k8s status error conversion that folders has, which is called on the create/update path, not the delete path, but should be called.
