### PR TITLE
K8s: Enable integration tests on folders and dashboards

### DIFF
--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -315,9 +316,22 @@ func TestIntegrationCreate(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
+	testCreate(t, []string{})
+}
+
+func TestIntegrationCreateK8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	testCreate(t, []string{featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testCreate(t *testing.T, featureToggles []string) {
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-		DisableAnonymous: true,
+		DisableAnonymous:     true,
+		EnableFeatureToggles: featureToggles,
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)

--- a/pkg/tests/api/folders/api_folder_test.go
+++ b/pkg/tests/api/folders/api_folder_test.go
@@ -28,10 +28,21 @@ func TestIntegrationUpdateFolder(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	testUpdateFolder(t, []string{})
+}
 
+func TestIntegrationUpdateFolderK8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	testUpdateFolder(t, []string{featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testUpdateFolder(t *testing.T, featureToggles []string) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-		DisableAnonymous: true,
-		EnableQuota:      true,
+		DisableAnonymous:     true,
+		EnableQuota:          true,
+		EnableFeatureToggles: featureToggles,
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
@@ -65,10 +76,21 @@ func TestIntegrationCreateFolder(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	testCreateFolder(t, []string{})
+}
 
+func TestIntegrationCreateFolderK8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	testCreateFolder(t, []string{featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testCreateFolder(t *testing.T, featureToggles []string) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-		DisableAnonymous: true,
-		EnableQuota:      true,
+		DisableAnonymous:     true,
+		EnableQuota:          true,
+		EnableFeatureToggles: featureToggles,
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
@@ -103,11 +125,21 @@ func TestIntegrationNestedFoldersOn(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	testNestedFoldersOn(t, []string{})
+}
 
+func TestIntegrationNestedFoldersOnK8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	testNestedFoldersOn(t, []string{featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testNestedFoldersOn(t *testing.T, featureToggles []string) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableAnonymous:     true,
 		EnableQuota:          true,
-		EnableFeatureToggles: []string{featuremgmt.FlagNestedFolders},
+		EnableFeatureToggles: featureToggles,
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -26,13 +26,21 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetFolders(t *testing.T) {
+	testGetFolders(t, []string{featuremgmt.FlagNestedFolders})
+}
+
+func TestGetFoldersK8s(t *testing.T) {
+	testGetFolders(t, []string{featuremgmt.FlagNestedFolders, featuremgmt.FlagKubernetesClientDashboardsFolders})
+}
+
+func testGetFolders(t *testing.T, featureToggles []string) {
 	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
-		EnableFeatureToggles:  []string{featuremgmt.FlagNestedFolders},
+		EnableFeatureToggles:  featureToggles,
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)


### PR DESCRIPTION
**What is this feature?**

This PR runs the api integration tests we have for folders & dashboards for both the k8s flow (which will be default for g12) and the current flow.

It misses two tests, which needed fixes for them before we could enable them:
https://github.com/grafana/grafana/pull/103074
https://github.com/grafana/grafana/pull/103073