### PR TITLE
Skip noop migrations, instead of executing SELECT 0.

### DIFF
--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -74,7 +74,6 @@ type Dialect interface {
 
 	CleanDB(engine *xorm.Engine) error
 	TruncateDBTables(engine *xorm.Engine) error
-	NoOpSQL() string
 	// CreateDatabaseFromSnapshot is called when migration log table is not found.
 	// Dialect can recreate all tables from existing snapshot. After successful (nil error) return,
 	// migrator will list migrations from the log, and apply all missing migrations.
@@ -351,10 +350,6 @@ func (b *BaseDialect) CleanDB(engine *xorm.Engine) error {
 
 func (b *BaseDialect) CreateDatabaseFromSnapshot(ctx context.Context, engine *xorm.Engine, tableName string) error {
 	return nil
-}
-
-func (b *BaseDialect) NoOpSQL() string {
-	return "SELECT 0;"
 }
 
 func (b *BaseDialect) TruncateDBTables(engine *xorm.Engine) error {

--- a/pkg/services/sqlstore/migrator/migrations.go
+++ b/pkg/services/sqlstore/migrator/migrations.go
@@ -53,7 +53,7 @@ func (m *RawSQLMigration) SQL(dialect Dialect) string {
 		}
 	}
 
-	return dialect.NoOpSQL()
+	return ""
 }
 
 func (m *RawSQLMigration) Set(dialect string, sql string) *RawSQLMigration {

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -392,8 +393,12 @@ func (mg *Migrator) exec(ctx context.Context, m Migration, sess *xorm.Session) e
 		err = codeMigration.Exec(sess, mg)
 	} else {
 		sql := m.SQL(mg.Dialect)
-		logger.Debug("Executing sql migration", "id", m.Id(), "sql", sql)
-		_, err = sess.Exec(sql)
+		if strings.TrimSpace(sql) == "" {
+			logger.Debug("Skipping empty sql migration", "id", m.Id())
+		} else {
+			logger.Debug("Executing sql migration", "id", m.Id(), "sql", sql)
+			_, err = sess.Exec(sql)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Instead of executing `SELECT 0` statement in case of "no migration", don't execute anything. This makes the latest `Update secure_json_data column to MediumText` MySQL-specific migration from PR https://github.com/grafana/grafana/pull/102557 to run on Spanner, where `exec("SELECT 0;")` fails with `Exec and ExecContext can only be used with INSERT statements with a THEN RETURN clause that return exactly one row with one column of type INT64. Use Query or QueryContext for DML statements other than INSERT and/or with THEN RETURN clauses that return other/more data.` error.