### PR TITLE
SQL Expressions: Mount front-end component right first time

### DIFF
--- a/public/app/features/expressions/components/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpr.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
-import { SqlExpr } from './SqlExpr';
+
 import { ExpressionQuery } from '../types';
+
+import { SqlExpr } from './SqlExpr';
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual('@grafana/ui'),

--- a/public/app/features/expressions/components/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpr.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { SqlExpr } from './SqlExpr';
+import { ExpressionQuery } from '../types';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  useStyles2: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@grafana/plugin-ui', () => ({
+  SQLEditor: () => <div data-testid="sql-editor">SQL Editor Mock</div>,
+}));
+
+describe('SqlExpr', () => {
+  it('initializes new expressions with default query', () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'A' }];
+    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} />);
+
+    // Verify onChange was called
+    expect(onChange).toHaveBeenCalled();
+
+    // Verify essential SQL structure without exact string matching
+    const updatedQuery = onChange.mock.calls[0][0];
+    expect(updatedQuery.expression.toUpperCase()).toContain('SELECT');
+  });
+
+  it('preserves existing expressions when mounted', () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'A' }];
+    const existingExpression = 'SELECT 1 AS foo';
+    const query = { refId: 'expr1', type: 'sql', expression: existingExpression } as ExpressionQuery;
+
+    render(<SqlExpr onChange={onChange} refIds={refIds} query={query} />);
+
+    // Check if onChange was called
+    if (onChange.mock.calls.length > 0) {
+      // If called, ensure it didn't change the expression value
+      const updatedQuery = onChange.mock.calls[0][0];
+      expect(updatedQuery.expression).toBe(existingExpression);
+    }
+
+    // The SQLEditor should receive the existing expression
+    expect(query.expression).toBe(existingExpression);
+  });
+});

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -57,7 +57,10 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
 
   useEffect(() => {
     // Call the onChange method once so we have access to the initial query in consuming components
-    onEditorChange(initialQuery);
+    // But only if expression is empty
+    if (!query.expression) {
+      onEditorChange(initialQuery);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -55,6 +55,12 @@ export const SqlExpr = ({ onChange, refIds, query }: Props) => {
     return () => resizeObserver.disconnect();
   }, []);
 
+  useEffect(() => {
+    // Call the onChange method once so we have access to the initial query in consuming components
+    onEditorChange(initialQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div ref={containerRef} className={styles.editorContainer}>
       <SQLEditor


### PR DESCRIPTION
**Call onChange method once on render so we have access to the value on init**

Many thanks to @tomratcliffe for this change. I've pulled this commit from the shared branch here:
https://github.com/grafana/grafana/pull/101820/commits

Before this change, when you first add a SQL Expression and try to run it, without changing the query at all, you'd see this:

<img width="400" alt="Screenshot 2025-03-31 at 10 39 31" src="https://github.com/user-attachments/assets/51953e7a-9317-4b69-aec2-1279fc402b96" />

Because the value of the query within the React component was `""` until it was edited. Now you'll see this:

<img width="400" alt="Screenshot 2025-03-31 at 10 44 21" src="https://github.com/user-attachments/assets/e7bcca52-bf0a-4a05-8a0a-1b9322489818" />
