### PR TITLE
Add 5 seconds timeout to queries in DashboardPermissionFilter tests.

### DIFF
--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -186,8 +186,11 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			t.Run(tt.desc+" with features "+strings.Join(keys, ","), func(t *testing.T) {
 				filter := permissions.NewAccessControlDashboardPermissionFilter(usr, tt.permission, tt.queryType, features, recursiveQueriesAreSupported, store.GetDialect())
 
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
 				var result int
-				err = store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+				err = store.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 					q, params := filter.Where()
 					recQry, recQryParams := filter.With()
 					params = append(recQryParams, params...)


### PR DESCRIPTION
This PR adds 5 seconds timeout for running queries in `TestIntegration_DashboardPermissionFilter` test. This doesn't fix the test but makes it fail faster (compared to 2 minutes timeout), when running on Spanner emulator.

Note that this test succeeds on cloud Spanner instance, but on emulator it currently times out. To be further investigated and hopefully fixed. 