### PR TITLE
[release-11.6.1] Dashboards: Fix time range bug when use_browser_locale is enabled 2

### DIFF
--- a/packages/grafana-data/src/datetime/parser.test.ts
+++ b/packages/grafana-data/src/datetime/parser.test.ts
@@ -32,7 +32,7 @@ describe('dateTimeParse', () => {
 
     const date = dateTimeParse('2025-03-12T07:09:37.253Z', { timeZone: 'browser' });
     expect(date.isValid()).toBe(true);
-    expect(date.format()).toEqual('2025-03-12T02:09:37-05:00');
+    expect(date.format()).toEqual('2025-03-12T07:09:37Z');
   });
 
   it('should be able to parse array formats used by calendar', () => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -269,7 +269,7 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
   }
 
   if (value.endsWith('Z')) {
-    const dt = dateTimeParse(value, { timeZone: 'utc', format: 'YYYY-MM-DDTHH:mm:ss.SSSZ' });
+    const dt = dateTimeParse(value);
     return dateTimeFormat(dt, { timeZone });
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { PanelProps } from '@grafana/data';
+import { PanelProps, systemDateFormats, SystemDateFormatsState } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { selectors } from '@grafana/e2e-selectors';
 import {
@@ -229,6 +229,42 @@ describe('DashboardScenePage', () => {
     expect(await screen.findByTitle('Panel B')).toBeInTheDocument();
   });
 
+  describe('absolute time range', () => {
+    it('should render with absolute time range when use_browser_locale is true', async () => {
+      locationService.push('/d/my-dash-uid?from=2025-03-11T07:09:37.253Z&to=2025-03-12T07:09:37.253Z');
+      systemDateFormats.update({
+        fullDate: 'YYYY-MM-DD HH:mm:ss.SSS',
+        interval: {} as SystemDateFormatsState['interval'],
+        useBrowserLocale: true,
+      });
+      setup();
+
+      await waitForDashboardToRenderWithTimeRange({
+        from: '03/11/2025, 02:09:37 AM',
+        to: '03/12/2025, 02:09:37 AM',
+      });
+    });
+
+    it('should render correct time range when use_browser_locale is true and time range is other than default system date format', async () => {
+      locationService.push('/d/my-dash-uid?from=2025-03-11T07:09:37.253Z&to=2025-03-12T07:09:37.253Z');
+      // mocking navigator.languages to return 'de'
+      // this property configured in the browser settings
+      Object.defineProperty(navigator, 'languages', { value: ['de'] });
+      systemDateFormats.update({
+        // left fullDate empty to show that this should be overridden by the browser locale
+        fullDate: '',
+        interval: {} as SystemDateFormatsState['interval'],
+        useBrowserLocale: true,
+      });
+      setup();
+
+      await waitForDashboardToRenderWithTimeRange({
+        from: '11.03.2025, 02:09:37',
+        to: '12.03.2025, 02:09:37',
+      });
+    });
+  });
+
   describe('empty state', () => {
     it('Shows empty state when dashboard is empty', async () => {
       loadDashboardMock.mockResolvedValue({ dashboard: { uid: 'my-dash-uid', panels: [] }, meta: {} });
@@ -371,5 +407,10 @@ function CustomVizPanel(props: VizProps) {
 
 async function waitForDashboardToRender() {
   expect(await screen.findByText('Last 6 hours')).toBeInTheDocument();
+  expect(await screen.findByTitle('Panel A')).toBeInTheDocument();
+}
+
+async function waitForDashboardToRenderWithTimeRange(timeRange: { from: string; to: string }) {
+  expect(await screen.findByText(`${timeRange.from} to ${timeRange.to}`)).toBeInTheDocument();
   expect(await screen.findByTitle('Panel A')).toBeInTheDocument();
 }


### PR DESCRIPTION
Backport for #102750

A community member asked for this to be backported to 11.6 https://github.com/grafana/grafana/pull/102339#issuecomment-2731713218 , and I think that's okay because it will solve the issue they referenced.