### PR TITLE
SQL Expressions: Add JSON support

### DIFF
--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -211,19 +211,19 @@ func TestFrameToSQLAndBack_JSONRoundtrip(t *testing.T) {
 		RefID: "json_test",
 		Name:  "json_test",
 		Fields: []*data.Field{
-			data.NewField("id", nil, []*int64{p(int64(1)), p(int64(2))}),
-			data.NewField("payload", nil, []*json.RawMessage{
-				p(json.RawMessage(`{"foo":1}`)),
-				p(json.RawMessage(`{"bar":"baz"}`)),
+			data.NewField("id", nil, []int64{1, 2}),
+			data.NewField("payload", nil, []json.RawMessage{
+				json.RawMessage(`{"foo":1}`),
+				json.RawMessage(`{"bar":"baz"}`),
 			}),
 		},
 	}
 
-	sqlDB := &DB{}
+	db := DB{}
 
 	query := `SELECT * FROM json_test`
 
-	resultFrame, err := sqlDB.QueryFrames(context.Background(), "json_test", query, data.Frames{expectedFrame})
+	resultFrame, err := db.QueryFrames(context.Background(), "json_test", query, data.Frames{expectedFrame})
 	require.NoError(t, err)
 
 	// Ensure consistent names for comparison
@@ -240,13 +240,10 @@ func TestQueryFrames_JSONFilter(t *testing.T) {
 		RefID: "A",
 		Name:  "A",
 		Fields: []*data.Field{
-			data.NewField("title", nil, []*string{
-				p("Bug report"),
-				p("Feature request"),
-			}),
-			data.NewField("labels", nil, []*json.RawMessage{
-				p(json.RawMessage(`["type/bug", "priority/high"]`)),
-				p(json.RawMessage(`["type/feature", "priority/low"]`)),
+			data.NewField("title", nil, []string{"Bug report", "Feature request"}),
+			data.NewField("labels", nil, []json.RawMessage{
+				json.RawMessage(`["type/bug", "priority/high"]`),
+				json.RawMessage(`["type/feature", "priority/low"]`),
 			}),
 		},
 	}
@@ -255,20 +252,18 @@ func TestQueryFrames_JSONFilter(t *testing.T) {
 		RefID: "B",
 		Name:  "B",
 		Fields: []*data.Field{
-			data.NewField("title", nil, []*string{
-				p("Bug report"),
-			}),
-			data.NewField("labels", nil, []*json.RawMessage{
-				p(json.RawMessage(`["type/bug", "priority/high"]`)),
+			data.NewField("title", nil, []string{"Bug report"}),
+			data.NewField("labels", nil, []json.RawMessage{
+				json.RawMessage(`["type/bug", "priority/high"]`),
 			}),
 		},
 	}
 
-	sqlDB := &DB{}
+	db := DB{}
 
 	query := `SELECT title, labels FROM A WHERE json_contains(labels, '"type/bug"')`
 
-	result, err := sqlDB.QueryFrames(context.Background(), "B", query, data.Frames{input})
+	result, err := db.QueryFrames(context.Background(), "B", query, data.Frames{input})
 	require.NoError(t, err)
 
 	// Ensure frame names match for comparison

--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -226,11 +226,15 @@ func TestFrameToSQLAndBack_JSONRoundtrip(t *testing.T) {
 	resultFrame, err := db.QueryFrames(context.Background(), "json_test", query, data.Frames{expectedFrame})
 	require.NoError(t, err)
 
-	// Ensure consistent names for comparison
-	resultFrame.Name = expectedFrame.Name
-	resultFrame.RefID = expectedFrame.RefID
+	// Use custom compare options that ignore Name and RefID
+	opts := append(
+		data.FrameTestCompareOptions(),
+		cmp.FilterPath(func(p cmp.Path) bool {
+			return p.String() == "Name" || p.String() == "RefID"
+		}, cmp.Ignore()),
+	)
 
-	if diff := cmp.Diff(expectedFrame, resultFrame, data.FrameTestCompareOptions()...); diff != "" {
+	if diff := cmp.Diff(expectedFrame, resultFrame, opts...); diff != "" {
 		require.FailNowf(t, "Frame mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -266,11 +270,15 @@ func TestQueryFrames_JSONFilter(t *testing.T) {
 	result, err := db.QueryFrames(context.Background(), "B", query, data.Frames{input})
 	require.NoError(t, err)
 
-	// Ensure frame names match for comparison
-	result.Name = expected.Name
-	result.RefID = expected.RefID
+	// Use custom compare options that ignore Name and RefID
+	opts := append(
+		data.FrameTestCompareOptions(),
+		cmp.FilterPath(func(p cmp.Path) bool {
+			return p.String() == "Name" || p.String() == "RefID"
+		}, cmp.Ignore()),
+	)
 
-	if diff := cmp.Diff(expected, result, data.FrameTestCompareOptions()...); diff != "" {
+	if diff := cmp.Diff(expected, result, opts...); diff != "" {
 		require.FailNowf(t, "Result mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/expr/sql/frame_db_conv.go
+++ b/pkg/expr/sql/frame_db_conv.go
@@ -175,20 +175,6 @@ func fieldValFromRowVal(fieldType data.FieldType, val interface{}) (interface{},
 			}
 			return raw, nil
 
-		case string:
-			raw := json.RawMessage(v)
-			if nullable {
-				return &raw, nil
-			}
-			return raw, nil
-
-		case []byte:
-			raw := json.RawMessage(v)
-			if nullable {
-				return &raw, nil
-			}
-			return raw, nil
-
 		default:
 			return nil, fmt.Errorf("unexpected type for JSON field: %T", val)
 		}

--- a/pkg/expr/sql/frame_db_conv.go
+++ b/pkg/expr/sql/frame_db_conv.go
@@ -165,7 +165,6 @@ func fieldValFromRowVal(fieldType data.FieldType, val interface{}) (interface{},
 	case data.FieldTypeJSON, data.FieldTypeNullableJSON:
 		switch v := val.(type) {
 		case types.JSONDocument:
-			// Use fmt.Sprintf to serialize JSONDocument to []byte
 			raw := json.RawMessage(v.String())
 			if nullable {
 				return &raw, nil

--- a/pkg/expr/sql/frame_db_conv.go
+++ b/pkg/expr/sql/frame_db_conv.go
@@ -176,11 +176,11 @@ func fieldValFromRowVal(fieldType data.FieldType, val interface{}) (interface{},
 			return raw, nil
 
 		default:
-			return nil, fmt.Errorf("unexpected type for JSON field: %T", val)
+			return nil, fmt.Errorf("JSON field does not support val %v of type %T", val, val)
 		}
 
 	default:
-		return nil, fmt.Errorf("unsupported field type %s for val %v", fieldType, val)
+		return nil, fmt.Errorf("unsupported field type %s for val %v of type %T", fieldType, val, val)
 	}
 }
 

--- a/pkg/expr/sql/frame_db_conv.go
+++ b/pkg/expr/sql/frame_db_conv.go
@@ -95,9 +95,6 @@ func MySQLColToFieldType(col *mysql.Column) (data.FieldType, error) {
 		fT = data.FieldTypeBool
 	case types.JSON:
 		fT = data.FieldTypeJSON
-		if col.Nullable {
-			fT = data.FieldTypeNullableJSON
-		}
 	default:
 		switch {
 		case types.IsDecimal(col.Type):

--- a/pkg/expr/sql/frame_db_conv.go
+++ b/pkg/expr/sql/frame_db_conv.go
@@ -174,21 +174,21 @@ func fieldValFromRowVal(fieldType data.FieldType, val interface{}) (interface{},
 				return &raw, nil
 			}
 			return raw, nil
-	
+
 		case string:
 			raw := json.RawMessage(v)
 			if nullable {
 				return &raw, nil
 			}
 			return raw, nil
-	
+
 		case []byte:
 			raw := json.RawMessage(v)
 			if nullable {
 				return &raw, nil
 			}
 			return raw, nil
-	
+
 		default:
 			return nil, fmt.Errorf("unexpected type for JSON field: %T", val)
 		}

--- a/pkg/expr/sql/frame_table.go
+++ b/pkg/expr/sql/frame_table.go
@@ -95,12 +95,12 @@ func (ri *rowIter) Next(_ *mysql.Context) (mysql.Row, error) {
 
 		// If the field is JSON, convert json.RawMessage to types.JSONDocument
 		if raw, ok := val.(json.RawMessage); ok {
-			doc, converted, err := types.JSON.Convert(raw)
+			doc, inRange, err := types.JSON.Convert(raw)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert json.RawMessage to JSONDocument: %w", err)
 			}
-			if !converted {
-				return nil, fmt.Errorf("unexpected JSON conversion issue at row %d, column %s: value required type coercion", ri.row, ri.ft.Frame.Fields[colIndex].Name)
+			if !inRange {
+				return nil, fmt.Errorf("invalid JSON value detected at row %d, column %s: value required type coercion", ri.row, ri.ft.Frame.Fields[colIndex].Name)
 			}
 			val = doc
 		}

--- a/pkg/expr/sql/frame_table.go
+++ b/pkg/expr/sql/frame_table.go
@@ -156,6 +156,8 @@ func convertDataType(fieldType data.FieldType) mysql.Type {
 		return types.Boolean
 	case data.FieldTypeTime, data.FieldTypeNullableTime:
 		return types.Timestamp
+	case data.FieldTypeJSON, data.FieldTypeNullableJSON:
+		return types.JSON
 	default:
 		fmt.Printf("------- Unsupported field type: %v", fieldType)
 		return types.JSON

--- a/pkg/expr/sql/frame_table.go
+++ b/pkg/expr/sql/frame_table.go
@@ -95,9 +95,12 @@ func (ri *rowIter) Next(_ *mysql.Context) (mysql.Row, error) {
 
 		// If the field is JSON, convert json.RawMessage to types.JSONDocument
 		if raw, ok := val.(json.RawMessage); ok {
-			doc, _, err := types.JSON.Convert(raw)
+			doc, converted, err := types.JSON.Convert(raw)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert json.RawMessage to JSONDocument: %w", err)
+			}
+			if !converted {
+				return nil, fmt.Errorf("unexpected JSON conversion issue at row %d, column %s: value required type coercion", ri.row, ri.ft.Frame.Fields[colIndex].Name)
 			}
 			val = doc
 		}

--- a/pkg/expr/sql/frame_table.go
+++ b/pkg/expr/sql/frame_table.go
@@ -103,7 +103,6 @@ func (ri *rowIter) Next(_ *mysql.Context) (mysql.Row, error) {
 		}
 
 		row[colIndex] = val
-
 	}
 
 	ri.row++

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -210,6 +210,12 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 	case "cast":
 		return
 
+	// JSON functions
+	case "json_extract", "json_unquote", "json_contains",
+		"json_object", "json_array", "json_set", "json_remove",
+		"json_length", "json_search", "json_type":
+		return
+
 	default:
 		return false
 	}

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -67,6 +67,11 @@ func TestAllowQuery(t *testing.T) {
 			q:    `SELECT __value__, SUBSTRING_INDEX(name, '.', -1) AS code FROM A`,
 			err:  nil,
 		},
+		{
+			name: "json functions",
+			q:    example_json_functions,
+			err:  nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -239,3 +244,15 @@ SELECT
 FROM sample_data
 GROUP BY name, value, created_at
 LIMIT 10`
+
+var example_json_functions = `SELECT 
+  JSON_OBJECT('key1', 'value1', 'key2', 10) AS json_obj,
+  JSON_ARRAY(1, 'abc', NULL, TRUE) AS json_arr,
+  JSON_EXTRACT('{"id": 123, "name": "test"}', '$.id') AS json_ext,
+  JSON_UNQUOTE(JSON_EXTRACT('{"name": "test"}', '$.name')) AS json_unq,
+  JSON_CONTAINS('{"a": 1, "b": 2}', '{"a": 1}') AS json_contains,
+  JSON_SET('{"a": 1}', '$.b', 2) AS json_set,
+  JSON_REMOVE('{"a": 1, "b": 2}', '$.b') AS json_remove,
+  JSON_LENGTH('{"a": 1, "b": {"c": 3}}') AS json_len,
+  JSON_SEARCH('{"a": "xyz", "b": "abc"}', 'one', 'abc') AS json_search,
+  JSON_TYPE('{"a": 1}') AS json_type`


### PR DESCRIPTION
**What is this feature?**

Support json column types.

Replaces #102998, which went wrong when merging `main` and resolving conflicts.

Before (GH Datasource):

![image](https://github.com/user-attachments/assets/9fb587a0-705e-425f-86d7-e78b81079b9a)

Now:

![image](https://github.com/user-attachments/assets/746a4b83-3b82-4754-a78c-f26df9e61d01)

**Why do we need this feature?**

For working with Data sources that speak JSON.

Potentially:

- Github
- Logs data sources (Loki, etc) - depending on the log format, perhaps
- Infinity and other JSON datasources?