### PR TITLE
GrafanaRoute: Recover from errors

### DIFF
--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -46,7 +46,7 @@ export function GrafanaRoute(props: Props) {
   navigationLogger('GrafanaRoute', false, 'Rendered', props.route);
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary dependencies={[props.route]}>
       {({ error, errorInfo }) => {
         if (error) {
           return <GrafanaRouteError error={error} errorInfo={errorInfo} />;


### PR DESCRIPTION
Noticed an annoying behavior of our error page/handling, there was no recovery. You can try go to any other page or use browser back button and nothing happens. 

I added the route descriptor as a dependency to ErrorBoundary (this clears the error when route changes). We could make this path-dependent instead as this will not clear the error when for example moving between different dashboards. What do others think? 

Other problems with the error page

* No breadcrumb so don't really know where you where when the error happened 
  * This one is pretty tricky. We could add an extra ErrorBoundary inside Page component so if the error is deeper on the page you get page title and breadcrumb 
  * The other fix is adding navId to all route descriptors so the error page can use it 
* Wish there was a grot image on it 
