### PR TITLE
PanelChrome: Click inside also selects panel

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -230,6 +230,19 @@ export function PanelChrome({
     [onDragStart]
   );
 
+  const onContentPointerDown = React.useCallback(
+    (evt: React.PointerEvent) => {
+      // Ignore clicks inside buttons, links, canvas and svg elments
+      // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
+      if (evt.target instanceof Element && evt.target.closest('button,a,canvas,svg')) {
+        return;
+      }
+
+      onSelect?.(evt);
+    },
+    [onSelect]
+  );
+
   const headerContent = (
     <>
       {/* Non collapsible title */}
@@ -386,6 +399,7 @@ export function PanelChrome({
           data-testid={selectors.components.Panels.Panel.content}
           className={cx(styles.content, height === undefined && styles.containNone)}
           style={contentStyle}
+          onPointerDown={onContentPointerDown}
         >
           {typeof children === 'function' ? children(innerWidth, innerHeight) : children}
         </div>


### PR DESCRIPTION

This makes it possible to select panels by clicking inside them as well. It ignores clicks if you clicked a button, anchor canvas element or SVG. The canvas ignore does not really impact anything as you can still select a graph panel by clicking it's canvas as there is a HTML element overlayed ontop of the canvas element that takes the click.

But luckily the onSelect does not seem to interfere with the time series panel or time range selection. Time range drag does not select the panel which is good. 

This also solves the unsolved problem of being able to select panels without a title 

