### PR TITLE
Search: Remove unifiedStorageSearch feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -806,10 +806,6 @@ export interface FeatureToggles {
   */
   rolePickerDrawer?: boolean;
   /**
-  * Enable unified storage search
-  */
-  unifiedStorageSearch?: boolean;
-  /**
   * Enable sprinkles on unified storage search
   */
   unifiedStorageSearchSprinkles?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1381,14 +1381,6 @@ var (
 			Owner:       identityAccessTeam,
 		},
 		{
-			Name:              "unifiedStorageSearch",
-			Description:       "Enable unified storage search",
-			Stage:             FeatureStageExperimental,
-			Owner:             grafanaSearchAndStorageSquad,
-			HideFromDocs:      true,
-			HideFromAdminPage: true,
-		},
-		{
 			Name:              "unifiedStorageSearchSprinkles",
 			Description:       "Enable sprinkles on unified storage search",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -181,7 +181,6 @@ alertingQueryAndExpressionsStepMode,GA,@grafana/alerting-squad,false,false,true
 improvedExternalSessionHandling,preview,@grafana/identity-access-team,false,false,false
 useSessionStorageForRedirection,GA,@grafana/identity-access-team,false,false,false
 rolePickerDrawer,experimental,@grafana/identity-access-team,false,false,false
-unifiedStorageSearch,experimental,@grafana/search-and-storage,false,false,false
 unifiedStorageSearchSprinkles,experimental,@grafana/search-and-storage,false,false,false
 unifiedStorageSearchPermissionFiltering,GA,@grafana/search-and-storage,false,false,false
 managedDualWriter,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -735,10 +735,6 @@ const (
 	// Enables the new role picker drawer design
 	FlagRolePickerDrawer = "rolePickerDrawer"
 
-	// FlagUnifiedStorageSearch
-	// Enable unified storage search
-	FlagUnifiedStorageSearch = "unifiedStorageSearch"
-
 	// FlagUnifiedStorageSearchSprinkles
 	// Enable sprinkles on unified storage search
 	FlagUnifiedStorageSearchSprinkles = "unifiedStorageSearchSprinkles"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4315,7 +4315,8 @@
       "metadata": {
         "name": "unifiedStorageSearch",
         "resourceVersion": "1726771421439",
-        "creationTimestamp": "2024-09-30T19:46:14Z"
+        "creationTimestamp": "2024-09-30T19:46:14Z",
+        "deletionTimestamp": "2025-04-01T11:06:18Z"
       },
       "spec": {
         "description": "Enable unified storage search",

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -11,32 +11,28 @@ import (
 )
 
 func NewSearchOptions(features featuremgmt.FeatureToggles, cfg *setting.Cfg, tracer tracing.Tracer, docs resource.DocumentBuilderSupplier, indexMetrics *resource.BleveIndexMetrics) (resource.SearchOptions, error) {
-	// Setup the search server
-	if features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearch) {
-		root := cfg.IndexPath
-		if root == "" {
-			root = filepath.Join(cfg.DataPath, "unified-search", "bleve")
-		}
-		err := os.MkdirAll(root, 0750)
-		if err != nil {
-			return resource.SearchOptions{}, err
-		}
-		bleve, err := NewBleveBackend(BleveOptions{
-			Root:          root,
-			FileThreshold: int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
-			BatchSize:     cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
-		}, tracer, features, indexMetrics)
-
-		if err != nil {
-			return resource.SearchOptions{}, err
-		}
-
-		return resource.SearchOptions{
-			Backend:       bleve,
-			Resources:     docs,
-			WorkerThreads: cfg.IndexWorkers,
-			InitMinCount:  cfg.IndexMinCount,
-		}, nil
+	root := cfg.IndexPath
+	if root == "" {
+		root = filepath.Join(cfg.DataPath, "unified-search", "bleve")
 	}
-	return resource.SearchOptions{}, nil
+	err := os.MkdirAll(root, 0750)
+	if err != nil {
+		return resource.SearchOptions{}, err
+	}
+	bleve, err := NewBleveBackend(BleveOptions{
+		Root:          root,
+		FileThreshold: int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
+		BatchSize:     cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
+	}, tracer, features, indexMetrics)
+
+	if err != nil {
+		return resource.SearchOptions{}, err
+	}
+
+	return resource.SearchOptions{
+		Backend:       bleve,
+		Resources:     docs,
+		WorkerThreads: cfg.IndexWorkers,
+		InitMinCount:  cfg.IndexMinCount,
+	}, nil
 }

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -201,7 +201,6 @@ func runGrafana(t *testing.T, options ...grafanaOption) *provisioningTestHelper 
 		AppModeProduction: false, // required for experimental APIs
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagProvisioning,
-			featuremgmt.FlagUnifiedStorageSearch,
 			featuremgmt.FlagKubernetesClientDashboardsFolders,
 		},
 		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{

--- a/public/app/features/provisioning/GettingStarted/features.ts
+++ b/public/app/features/provisioning/GettingStarted/features.ts
@@ -5,7 +5,6 @@ export const requiredFeatureToggles: Array<keyof FeatureToggles> = [
   'provisioning',
   'kubernetesDashboards',
   'kubernetesClientDashboardsFolders',
-  'unifiedStorageSearch',
 ];
 
 /**

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -82,7 +82,7 @@ export class UnthemedQueryEditor extends PureComponent<Props, State> {
         description: 'Search for grafana resources',
       });
     }
-    if (config.featureToggles.unifiedStorageSearch) {
+    if (config.featureToggles.unifiedStorageSearchUI) {
       this.queryTypes.push({
         label: 'Search (experimental)',
         value: GrafanaQueryType.SearchNext,


### PR DESCRIPTION
This one is a bit weird... we have not rolled this out in cloud because the search index is always multi-tenant, and managed by the multi-tenant unified search server.

However -- this is required for `kubernetesClientDashboardsFolders` to work and we aim to make that enabled by default for G12.

