### PR TITLE
Identity: Grant service identity access to org namespace

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -58,7 +58,7 @@ func newInternalIdentity(name string, namespace string, orgID int64) Requester {
 // This is useful for background tasks that has to communicate with unfied storage. It also returns a Requester with
 // static permissions so it can be used in legacy code paths.
 func WithServiceIdentity(ctx context.Context, orgID int64) (context.Context, Requester) {
-	r := newInternalIdentity(serviceName, "", orgID)
+	r := newInternalIdentity(serviceName, "*", orgID)
 	return WithRequester(ctx, r), r
 }
 

--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -58,7 +58,7 @@ func newInternalIdentity(name string, namespace string, orgID int64) Requester {
 // This is useful for background tasks that has to communicate with unfied storage. It also returns a Requester with
 // static permissions so it can be used in legacy code paths.
 func WithServiceIdentity(ctx context.Context, orgID int64) (context.Context, Requester) {
-	r := newInternalIdentity(serviceName, "*", orgID)
+	r := newInternalIdentity(serviceName, types.OrgNamespaceFormatter(orgID), orgID)
 	return WithRequester(ctx, r), r
 }
 

--- a/pkg/apimachinery/identity/context_test.go
+++ b/pkg/apimachinery/identity/context_test.go
@@ -2,6 +2,7 @@ package identity_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,11 +36,15 @@ func TestServiceIdentityInContext(t *testing.T) {
 		require.Equal(t, identity.GetName(), "service")
 	})
 
-	t.Run("has permission to all namespaces", func(t *testing.T) {
-		ctx := t.Context()
-		ctx, _ = identity.WithServiceIdentity(ctx, 1)
-		identity, err := identity.GetRequester(ctx)
-		require.NoError(t, err)
-		require.True(t, types.NamespaceMatches(identity.GetNamespace(), "unit-test"), "namespace of identity and an arbitrary example should match")
-	})
+	for i := range 2 {
+		i += 1 // We start from 1
+		t.Run(fmt.Sprintf("orgID=%d has permission to its namespace", i), func(t *testing.T) {
+			ctx := t.Context()
+			ctx, _ = identity.WithServiceIdentity(ctx, int64(i))
+			identity, err := identity.GetRequester(ctx)
+			require.NoError(t, err)
+			ns := types.OrgNamespaceFormatter(int64(i))
+			require.True(t, types.NamespaceMatches(identity.GetNamespace(), ns), "namespace of identity and an arbitrary example should match")
+		})
+	}
 }

--- a/pkg/apimachinery/identity/context_test.go
+++ b/pkg/apimachinery/identity/context_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
@@ -22,5 +23,23 @@ func TestRequesterFromContext(t *testing.T) {
 		actual, err := identity.GetRequester(ctx)
 		require.NoError(t, err)
 		require.Equal(t, expected.GetUID(), actual.GetUID())
+	})
+}
+
+func TestServiceIdentityInContext(t *testing.T) {
+	t.Run("is assigned to the context", func(t *testing.T) {
+		ctx := t.Context()
+		ctx, _ = identity.WithServiceIdentity(ctx, 1)
+		identity, err := identity.GetRequester(ctx)
+		require.NoError(t, err)
+		require.Equal(t, identity.GetName(), "service")
+	})
+
+	t.Run("has permission to all namespaces", func(t *testing.T) {
+		ctx := t.Context()
+		ctx, _ = identity.WithServiceIdentity(ctx, 1)
+		identity, err := identity.GetRequester(ctx)
+		require.NoError(t, err)
+		require.True(t, types.NamespaceMatches(identity.GetNamespace(), "unit-test"), "namespace of identity and an arbitrary example should match")
 	})
 }


### PR DESCRIPTION
Currently, the identity has no access to any API server at all.

I ran into this when testing the new secrets manager, where we failed with the following error:
> $ kubectl --kubeconfig grafana.kubeconfig --namespace default get securevalues
> Error from server: failed to list secure values: failed to compile checker: namespace missmatch: got  but expected default

I think it makes sense to grant the service identity access to all namespaces, as there is no good mapping of orgs in namespaces (however stacks are mapped, so ideally we'd communicate that somehow...).