### PR TITLE
Provisioning: validate files we read

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/safepath"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DualReadWriter is a wrapper around a repository that can read and write resources
@@ -36,7 +37,7 @@ func (r *DualReadWriter) Read(ctx context.Context, path string, ref string) (*Pa
 		return nil, err
 	}
 
-	parsed, err := r.parser.Parse(ctx, info, false)
+	parsed, err := r.parser.Parse(ctx, info, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -261,8 +261,17 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	require.NoError(t, err)
 
 	// Make sure the repo can see the file
-	_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
+	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
 	require.NoError(t, err, "valid path should be fine")
+
+	resource, _, err := unstructured.NestedMap(obj.Object, "resource")
+	require.NoError(t, err, "missing resource")
+	action, _, err := unstructured.NestedString(resource, "action")
+	require.NoError(t, err, "invalid action")
+
+	require.NotNil(t, resource["file"], "the raw file")
+	require.NotNil(t, resource["dryRun"], "dryRun result")
+	require.Equal(t, "create", action)
 
 	// But the dashboard shouldn't exist yet
 	const allPanels = "n1jR8vnnz"

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -260,7 +260,7 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	_, err := helper.Repositories.Resource.Create(ctx, localTmp, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Make sure the repo can see the file
+	// Make sure the repo can read and validate the file
 	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
 	require.NoError(t, err, "valid path should be fine")
 


### PR DESCRIPTION
Only return files that validate.

This logic was lost in https://github.com/grafana/grafana/pull/102972/files#diff-2896f010dc1a912edba457e346bb0928ddb99ab48f1d268e000e6ccd8f0303feL179