### PR TITLE
SQL Expressions: (WIP) Set now() to end time of query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -339,7 +339,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -339,7 +339,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -136,7 +136,7 @@ func (h *ExpressionQueryReader) ReadQuery(
 			eq.Properties = q
 			// TODO: Cascade limit from Grafana config in this (new Expression Parser) branch of the code
 			cellLimit := 0 // zero means no limit
-			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, int64(cellLimit))
+			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, AbsoluteTimeRange{}, int64(cellLimit))
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/sql/db.go
+++ b/pkg/expr/sql/db.go
@@ -5,6 +5,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	mysql "github.com/dolthub/go-mysql-server/sql"
@@ -14,7 +15,10 @@ import (
 )
 
 // DB is a database that can execute SQL queries against a set of Frames.
-type DB struct{}
+type DB struct {
+	// Now is the current time to use for queries which impacts functions like NOW()
+	Now time.Time
+}
 
 // GoMySQLServerError represents an error from the underlying Go MySQL Server
 type GoMySQLServerError struct {
@@ -71,6 +75,7 @@ func (db *DB) QueryFrames(ctx context.Context, name string, query string, frames
 
 	// Select the database in the context
 	mCtx.SetCurrentDatabase(dbName)
+	mCtx.SetQueryTime(db.Now)
 
 	// Empty dir does not disable secure_file_priv
 	//ctx.SetSessionVariable(ctx, "secure_file_priv", "")

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -30,10 +30,11 @@ type SQLCommand struct {
 	varsToQuery []string
 	refID       string
 	limit       int64
+	timeRange   TimeRange
 }
 
 // NewSQLCommand creates a new SQLCommand.
-func NewSQLCommand(refID, rawSQL string, limit int64) (*SQLCommand, error) {
+func NewSQLCommand(refID, rawSQL string, tr TimeRange, limit int64) (*SQLCommand, error) {
 	if rawSQL == "" {
 		return nil, ErrMissingSQLQuery
 	}
@@ -62,6 +63,7 @@ func NewSQLCommand(refID, rawSQL string, limit int64) (*SQLCommand, error) {
 		varsToQuery: tables,
 		refID:       refID,
 		limit:       limit,
+		timeRange:   tr,
 	}, nil
 }
 
@@ -83,7 +85,7 @@ func UnmarshalSQLCommand(rn *rawNode, limit int64) (*SQLCommand, error) {
 		return nil, fmt.Errorf("expected sql expression to be type string, but got type %T", expressionRaw)
 	}
 
-	return NewSQLCommand(rn.RefID, expression, limit)
+	return NewSQLCommand(rn.RefID, expression, rn.TimeRange, limit)
 }
 
 // NeedsVars returns the variable names (refIds) that are dependencies
@@ -122,7 +124,10 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 
 	logger.Debug("Executing query", "query", gr.query, "frames", len(allFrames))
 
-	db := sql.DB{}
+	db := sql.DB{
+		Now: gr.timeRange.AbsoluteTime(now).To,
+	}
+
 	frame, err := db.QueryFrames(ctx, gr.refID, gr.query, allFrames)
 
 	rsp := mathexp.Results{}

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
-	cmd, err := NewSQLCommand("a", "select a from foo, bar", 0)
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", AbsoluteTimeRange{}, 0)
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
 	}
@@ -123,7 +123,7 @@ func TestSQLCommandCellLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewSQLCommand("a", "select a from foo, bar", tt.limit)
+			cmd, err := NewSQLCommand("a", "select a from foo, bar", AbsoluteTimeRange{}, tt.limit)
 			require.NoError(t, err, "Failed to create SQL command")
 
 			vars := mathexp.Vars{}


### PR DESCRIPTION
Set the query time, which is what `now()` inside SQL bases its time on. Overriding the functions is tricky it seems. 

Adding funcs is not so hard, so maybe we also add time_from() time_to() functions as well (or perhaps instead)

Don't like macros if we can avoid them, as the can confuse error messages and positioning in the text, and people have to look at the expanded query.


**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
