### PR TITLE
Loki: Hide `__aggregated_metric__` label

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -566,7 +566,13 @@ describe('Language completion provider', () => {
     });
 
     it('should filter internal labels', async () => {
-      const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
+      const datasourceWithLabels = setup({
+        foo: [],
+        bar: [],
+        __name__: [],
+        __stream_shard__: [],
+        __aggregated_metric__: [],
+      });
 
       const instance = new LanguageProvider(datasourceWithLabels);
       const labels = await instance.fetchLabels();

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -17,7 +17,7 @@ import { DetectedFieldsResult, LabelType, LokiQuery, LokiQueryType, ParserAndLab
 
 const NS_IN_MS = 1000000;
 const EMPTY_SELECTOR = '{}';
-const HIDDEN_LABELS = ['__aggregrated_metric__', '__tenant_id__', '__stream_shard__'];
+const HIDDEN_LABELS = ['__aggregated_metric__', '__tenant_id__', '__stream_shard__'];
 
 export default class LokiLanguageProvider extends LanguageProvider {
   labelKeys: string[];


### PR DESCRIPTION
**What is this feature?**

Well...I think we always wanted to hide `__aggregated_metric__` instead `__aggreg**R**ated_metric__`.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #102114

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
