### PR TITLE
Folders: Save description in dashboard table

### DIFF
--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -80,11 +80,14 @@ func NewDashboard(title string) *Dashboard {
 }
 
 // NewDashboardFolder creates a new dashboard folder
-func NewDashboardFolder(title string) *Dashboard {
+func NewDashboardFolder(title string, description string) *Dashboard {
 	folder := NewDashboard(title)
 	folder.IsFolder = true
-	folder.Data.Set("schemaVersion", 17)
+	folder.Data.Set("schemaVersion", 18) // v17 has no description
 	folder.Data.Set("version", 0)
+	if description != "" {
+		folder.Data.Set("description", description)
+	}
 	folder.IsFolder = true
 	return folder
 }

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"golang.org/x/exp/slices"
+
 	dashboardv1alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -41,7 +43,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"golang.org/x/exp/slices"
 )
 
 func TestDashboardService(t *testing.T) {
@@ -94,7 +95,7 @@ func TestDashboardService(t *testing.T) {
 			})
 
 			t.Run("Should return validation error if folder is named General", func(t *testing.T) {
-				dto.Dashboard = dashboards.NewDashboardFolder("General")
+				dto.Dashboard = dashboards.NewDashboardFolder("General", "")
 				_, err := service.SaveDashboard(context.Background(), dto, false)
 				require.Equal(t, err, dashboards.ErrDashboardFolderNameExists)
 			})

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -739,7 +739,7 @@ func (s *Service) CreateLegacy(ctx context.Context, cmd *folder.CreateFolderComm
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	dashFolder := dashboards.NewDashboardFolder(cmd.Title)
+	dashFolder := dashboards.NewDashboardFolder(cmd.Title, cmd.Description)
 	dashFolder.OrgID = cmd.OrgID
 
 	if s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) && cmd.ParentUID != "" {

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -197,7 +197,7 @@ func TestIntegrationFolderService(t *testing.T) {
 			service.features = featuremgmt.WithFeatures()
 
 			t.Run("When creating folder should not return access denied error", func(t *testing.T) {
-				dash := dashboards.NewDashboardFolder("Test-Folder")
+				dash := dashboards.NewDashboardFolder("Test-Folder", "")
 				dash.ID = rand.Int63()
 				dash.UID = util.GenerateShortUID()
 				f := dashboards.FromDashboard(dash)
@@ -216,7 +216,7 @@ func TestIntegrationFolderService(t *testing.T) {
 			})
 
 			t.Run("When creating folder should return error if uid is general", func(t *testing.T) {
-				dash := dashboards.NewDashboardFolder("Test-Folder")
+				dash := dashboards.NewDashboardFolder("Test-Folder", "")
 				dash.ID = rand.Int63()
 
 				_, err := service.Create(context.Background(), &folder.CreateFolderCommand{
@@ -930,7 +930,7 @@ func TestNestedFolderService(t *testing.T) {
 			})
 
 			// dash is needed here because folderSvc.Create expects SaveDashboard to return it
-			dash := dashboards.NewDashboardFolder("myFolder")
+			dash := dashboards.NewDashboardFolder("myFolder", "")
 			dash.ID = rand.Int63()
 			dash.UID = "some_uid"
 
@@ -969,7 +969,7 @@ func TestNestedFolderService(t *testing.T) {
 				guardian.New = g
 			})
 
-			dash := dashboards.NewDashboardFolder("myFolder")
+			dash := dashboards.NewDashboardFolder("myFolder", "")
 			dash.ID = rand.Int63()
 			dash.UID = "some_uid"
 
@@ -1033,7 +1033,7 @@ func TestNestedFolderService(t *testing.T) {
 				guardian.New = g
 			})
 
-			dash := dashboards.NewDashboardFolder("Test-Folder")
+			dash := dashboards.NewDashboardFolder("Test-Folder", "")
 			dash.ID = rand.Int63()
 			dash.UID = "some_uid"
 
@@ -1064,7 +1064,7 @@ func TestNestedFolderService(t *testing.T) {
 				guardian.New = g
 			})
 
-			dash := dashboards.NewDashboardFolder("Test-Folder")
+			dash := dashboards.NewDashboardFolder("Test-Folder", "")
 			dash.ID = rand.Int63()
 			dash.UID = "some_uid"
 
@@ -1144,7 +1144,7 @@ func TestNestedFolderService(t *testing.T) {
 				guardian.New = g
 			})
 
-			dashboardFolder := dashboards.NewDashboardFolder("myFolder")
+			dashboardFolder := dashboards.NewDashboardFolder("myFolder", "")
 			dashboardFolder.ID = rand.Int63()
 			dashboardFolder.UID = "myFolder"
 			f := dashboards.FromDashboard(dashboardFolder)

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -233,7 +233,7 @@ func TestIntegrationFolderService(t *testing.T) {
 			})
 
 			t.Run("When updating folder should not return access denied error", func(t *testing.T) {
-				dashboardFolder := dashboards.NewDashboardFolder("Folder")
+				dashboardFolder := dashboards.NewDashboardFolder("Folder", "descr")
 				dashboardFolder.ID = rand.Int63()
 				dashboardFolder.UID = util.GenerateShortUID()
 				dashboardFolder.OrgID = orgID
@@ -246,6 +246,7 @@ func TestIntegrationFolderService(t *testing.T) {
 				})
 				require.NoError(t, err)
 				assert.Equal(t, "Folder", f.Title)
+				assert.Equal(t, "descr", f.Description)
 
 				dashStore.On("ValidateDashboardBeforeSave", mock.Anything, mock.AnythingOfType("*dashboards.Dashboard"), mock.AnythingOfType("bool")).Return(true, nil)
 				title := "TEST-Folder"


### PR DESCRIPTION
This is a minor change that I am surprised did not exist long ago... when saving a folder with description, we should include the description in the dashboard table body.

For this to be really helpful, we would need to run a migration from the folder table for anything that has a description (likely very very few things!)