### PR TITLE
SQL Expressions: Add custom time_from and time_to funcs

### DIFF
--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -136,7 +136,7 @@ func (h *ExpressionQueryReader) ReadQuery(
 			eq.Properties = q
 			// TODO: Cascade limit from Grafana config in this (new Expression Parser) branch of the code
 			cellLimit := 0 // zero means no limit
-			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, int64(cellLimit))
+			eq.Command, err = NewSQLCommand(common.RefID, q.Expression, AbsoluteTimeRange{}, int64(cellLimit))
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -216,6 +216,10 @@ func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
 		"json_length", "json_search", "json_type":
 		return
 
+	// our custom functions
+	case "time_from", "time_to":
+		return
+
 	default:
 		return false
 	}

--- a/pkg/expr/sql/time_funcs.go
+++ b/pkg/expr/sql/time_funcs.go
@@ -1,0 +1,95 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	mysql "github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// Time range context helpers
+type timeRangeKey struct{}
+
+type TimeRange struct {
+	From time.Time
+	To   time.Time
+}
+
+func WithTimeRange(ctx context.Context, from, to time.Time) context.Context {
+	return context.WithValue(ctx, timeRangeKey{}, TimeRange{From: from, To: to})
+}
+
+func GetTimeRange(ctx context.Context) (TimeRange, bool) {
+	tr, ok := ctx.Value(timeRangeKey{}).(TimeRange)
+	return tr, ok
+}
+
+type TimeFromFunction struct{}
+
+func NewTimeFromFunction() func(...mysql.Expression) (mysql.Expression, error) {
+	return func(...mysql.Expression) (mysql.Expression, error) {
+		return TimeFromFunction{}, nil
+	}
+}
+
+func (f TimeFromFunction) FunctionName() string {
+	return "time_from"
+}
+
+func (f TimeFromFunction) String() string {
+	return fmt.Sprintf("%s()", f.FunctionName())
+}
+
+func (f TimeFromFunction) Resolved() bool               { return true }
+func (f TimeFromFunction) IsNullable() bool             { return true }
+func (f TimeFromFunction) Children() []mysql.Expression { return nil }
+func (f TimeFromFunction) Type() mysql.Type             { return types.Timestamp }
+func (f TimeFromFunction) Eval(ctx *mysql.Context, _ mysql.Row) (interface{}, error) {
+	if tr, ok := GetTimeRange(ctx.Context); ok {
+		return tr.From, nil
+	}
+	return nil, nil
+}
+
+func (f TimeFromFunction) WithChildren(children ...mysql.Expression) (mysql.Expression, error) {
+	if len(children) != 0 {
+		return nil, mysql.ErrInvalidChildrenNumber.New(f, len(children), 0)
+	}
+	return f, nil
+}
+
+type TimeToFunction struct{}
+
+func NewTimeToFunction() func(...mysql.Expression) (mysql.Expression, error) {
+	return func(...mysql.Expression) (mysql.Expression, error) {
+		return TimeToFunction{}, nil
+	}
+}
+
+func (f TimeToFunction) FunctionName() string {
+	return "time_to"
+}
+
+func (f TimeToFunction) String() string {
+	return fmt.Sprintf("%s()", f.FunctionName())
+}
+
+func (f TimeToFunction) Resolved() bool               { return true }
+func (f TimeToFunction) IsNullable() bool             { return true }
+func (f TimeToFunction) Children() []mysql.Expression { return nil }
+func (f TimeToFunction) Type() mysql.Type             { return types.Timestamp }
+func (f TimeToFunction) Eval(ctx *mysql.Context, _ mysql.Row) (interface{}, error) {
+	if tr, ok := GetTimeRange(ctx.Context); ok {
+		return tr.To, nil
+	}
+	return nil, nil
+}
+
+func (f TimeToFunction) WithChildren(children ...mysql.Expression) (mysql.Expression, error) {
+	if len(children) != 0 {
+		return nil, mysql.ErrInvalidChildrenNumber.New(f, len(children), 0)
+	}
+	return f, nil
+}

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
-	cmd, err := NewSQLCommand("a", "select a from foo, bar", 0)
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", AbsoluteTimeRange{}, 0)
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
 	}
@@ -123,7 +123,7 @@ func TestSQLCommandCellLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewSQLCommand("a", "select a from foo, bar", tt.limit)
+			cmd, err := NewSQLCommand("a", "select a from foo, bar", AbsoluteTimeRange{}, tt.limit)
 			require.NoError(t, err, "Failed to create SQL command")
 
 			vars := mathexp.Vars{}


### PR DESCRIPTION
Alternative, or maybe in conjunction with #103224 . These functions get the "From" and "To" for the query, which in the case of dashboard maps to the range.

Maybe we should not allow `now()`, and have these instead to avoid confusion. Or we may want to still include `now()` , but set it to actual clock time.

![image](https://github.com/user-attachments/assets/5ca84628-ec29-424c-a870-d6a89dbe5547)


**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
