### PR TITLE
DashboardScene: Add library panel via canvas add panel action 

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -120,7 +120,7 @@ const OpenPanelEditViz = ({ panel }: OpenPanelEditVizProps) => {
         size="sm"
         tooltip={t('dashboard.viz-panel.options.configure-button-tooltip', 'Edit queries and visualization options')}
       >
-        <Trans i18nKey="dashboard.new-panel.configure-button">Configure panel</Trans>
+        <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
       </Button>
     </Stack>
   );

--- a/public/app/features/dashboard-scene/scene/AddLibraryPanelDrawer.tsx
+++ b/public/app/features/dashboard-scene/scene/AddLibraryPanelDrawer.tsx
@@ -10,7 +10,7 @@ import {
 import { getDashboardSceneFor, getDefaultVizPanel } from '../utils/utils';
 
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
-import { DashboardGridItem } from './layout-default/DashboardGridItem';
+import { isDashboardLayoutItem } from './types/DashboardLayoutItem';
 
 export interface AddLibraryPanelDrawerState extends SceneObjectState {
   panelToReplaceRef?: SceneObjectRef<VizPanel>;
@@ -35,13 +35,11 @@ export class AddLibraryPanelDrawer extends SceneObjectBase<AddLibraryPanelDrawer
     const panelToReplace = this.state.panelToReplaceRef?.resolve();
 
     if (panelToReplace) {
-      const gridItemToReplace = panelToReplace.parent;
+      const layoutItem = panelToReplace.parent;
 
-      if (!(gridItemToReplace instanceof DashboardGridItem)) {
-        throw new Error('Trying to replace a panel that does not have a DashboardGridItem');
+      if (layoutItem && isDashboardLayoutItem(layoutItem)) {
+        layoutItem.setElementBody(newPanel);
       }
-
-      gridItemToReplace.setState({ body: newPanel });
     } else {
       dashboard.addPanel(newPanel);
     }

--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -9,23 +9,12 @@ import { Trans, t } from 'app/core/internationalization';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
-import { DashboardGridItem } from './layout-default/DashboardGridItem';
 
 export const UNCONFIGURED_PANEL_PLUGIN_ID = '__unconfigured-panel';
 const UnconfiguredPanel = new PanelPlugin(UnconfiguredPanelComp);
 
 function UnconfiguredPanelComp(props: PanelProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const dashboard = window.__grafanaSceneContext;
-
-  if (!(dashboard instanceof DashboardScene)) {
-    throw new Error('DashboardScene not found');
-  }
-
-  const panel = findVizPanelByKey(dashboard, getVizPanelKeyForPanelId(props.id));
-  if (!panel) {
-    throw new Error('Panel not found');
-  }
 
   const onMenuClick = useCallback((isOpen: boolean) => {
     setIsOpen(isOpen);
@@ -36,10 +25,19 @@ function UnconfiguredPanelComp(props: PanelProps) {
   };
 
   const onUseLibraryPanel = () => {
+    const dashboard = window.__grafanaSceneContext;
+
+    if (!(dashboard instanceof DashboardScene)) {
+      throw new Error('DashboardScene not found');
+    }
+
+    const panel = findVizPanelByKey(dashboard, getVizPanelKeyForPanelId(props.id));
+    if (!panel) {
+      throw new Error('Panel not found');
+    }
+
     dashboard.onShowAddLibraryPanelDrawer(panel.getRef());
   };
-
-  const isInsideCustomGrid = panel.parent instanceof DashboardGridItem;
 
   const MenuActions = () => (
     <Menu>
@@ -59,24 +57,14 @@ function UnconfiguredPanelComp(props: PanelProps) {
   return (
     <Stack direction={'row'} alignItems={'center'} height={'100%'} justifyContent={'center'}>
       <Box paddingBottom={2}>
-        {/* Temporary restrict library panel usage to only panels inside custom grid */}
-        {isInsideCustomGrid ? (
-          <ButtonGroup>
-            <Button icon="sliders-v-alt" onClick={onConfigure}>
-              <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
-            </Button>
-            <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
-              <Button
-                aria-label="dashboard.new-panel.configure-button-menu"
-                icon={isOpen ? 'angle-up' : 'angle-down'}
-              />
-            </Dropdown>
-          </ButtonGroup>
-        ) : (
+        <ButtonGroup>
           <Button icon="sliders-v-alt" onClick={onConfigure}>
             <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
           </Button>
-        )}
+          <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
+            <Button aria-label="dashboard.new-panel.configure-button-menu" icon={isOpen ? 'angle-up' : 'angle-down'} />
+          </Dropdown>
+        </ButtonGroup>
       </Box>
     </Stack>
   );

--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -1,23 +1,82 @@
+import { useCallback, useState } from 'react';
+
 import { PanelPlugin, PanelProps } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { sceneUtils } from '@grafana/scenes';
-import { Box, Button, Stack } from '@grafana/ui';
-import { Trans } from 'app/core/internationalization';
+import { Box, Button, ButtonGroup, Dropdown, Menu, Stack } from '@grafana/ui';
+import { Trans, t } from 'app/core/internationalization';
+
+import { findVizPanelByKey, getVizPanelKeyForPanelId } from '../utils/utils';
+
+import { DashboardScene } from './DashboardScene';
+import { DashboardGridItem } from './layout-default/DashboardGridItem';
 
 export const UNCONFIGURED_PANEL_PLUGIN_ID = '__unconfigured-panel';
 const UnconfiguredPanel = new PanelPlugin(UnconfiguredPanelComp);
 
 function UnconfiguredPanelComp(props: PanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dashboard = window.__grafanaSceneContext;
+
+  if (!(dashboard instanceof DashboardScene)) {
+    throw new Error('DashboardScene not found');
+  }
+
+  const panel = findVizPanelByKey(dashboard, getVizPanelKeyForPanelId(props.id));
+  if (!panel) {
+    throw new Error('Panel not found');
+  }
+
+  const onMenuClick = useCallback((isOpen: boolean) => {
+    setIsOpen(isOpen);
+  }, []);
+
   const onConfigure = () => {
     locationService.partial({ editPanel: props.id });
   };
 
+  const onUseLibraryPanel = () => {
+    dashboard.onShowAddLibraryPanelDrawer(panel.getRef());
+  };
+
+  const isInsideCustomGrid = panel.parent instanceof DashboardGridItem;
+
+  const MenuActions = () => (
+    <Menu>
+      <Menu.Item
+        icon="pen"
+        label={t('dashboard.new-panel.menu-open-panel-editor', 'Configure')}
+        onClick={onConfigure}
+      ></Menu.Item>
+      <Menu.Item
+        icon="library-panel"
+        label={t('dashboard.new-panel.menu-use-library-panel', 'Use library panel')}
+        onClick={onUseLibraryPanel}
+      ></Menu.Item>
+    </Menu>
+  );
+
   return (
     <Stack direction={'row'} alignItems={'center'} height={'100%'} justifyContent={'center'}>
       <Box paddingBottom={2}>
-        <Button icon="sliders-v-alt" onClick={onConfigure}>
-          <Trans i18nKey="dashboard.new-panel.configure-button">Configure panel</Trans>
-        </Button>
+        {/* Temporary restrict library panel usage to only panels inside custom grid */}
+        {isInsideCustomGrid ? (
+          <ButtonGroup>
+            <Button icon="sliders-v-alt" onClick={onConfigure}>
+              <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
+            </Button>
+            <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
+              <Button
+                aria-label="dashboard.new-panel.configure-button-menu"
+                icon={isOpen ? 'angle-up' : 'angle-down'}
+              />
+            </Dropdown>
+          </ButtonGroup>
+        ) : (
+          <Button icon="sliders-v-alt" onClick={onConfigure}>
+            <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
+          </Button>
+        )}
       </Box>
     </Stack>
   );

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -86,6 +86,10 @@ export class DashboardGridItem
     return getDashboardGridItemOptions(this);
   }
 
+  public setElementBody(body: VizPanel): void {
+    this.setState({ body });
+  }
+
   public editingStarted() {
     if (!this.state.variableName) {
       return;

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
@@ -71,6 +71,10 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
     return getOptions(this);
   }
 
+  public setElementBody(body: VizPanel): void {
+    this.setState({ body });
+  }
+
   public performRepeat() {
     if (!this.state.variableName || sceneGraph.hasVariableDependencyInLoadingState(this)) {
       return;

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutItem.ts
@@ -1,4 +1,4 @@
-import { SceneObject } from '@grafana/scenes';
+import { SceneObject, VizPanel } from '@grafana/scenes';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 /**
  * Abstraction to handle editing of different layout elements (wrappers for VizPanels and other objects)
@@ -24,6 +24,11 @@ export interface DashboardLayoutItem extends SceneObject {
    * When coming out of panel edit
    */
   editingCompleted?(withChanges: boolean): void;
+
+  /**
+   * Change inner body / viz panel
+   */
+  setElementBody(body: VizPanel): void;
 }
 
 export function isDashboardLayoutItem(obj: SceneObject): obj is DashboardLayoutItem {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1632,7 +1632,9 @@
       }
     },
     "new-panel": {
-      "configure-button": "Configure panel"
+      "configure-button": "Configure",
+      "menu-open-panel-editor": "Configure",
+      "menu-use-library-panel": "Use library panel"
     },
     "new-panel-title": "New panel",
     "options": {


### PR DESCRIPTION

* When the panel is inside a custom grid turn Configure button into a button group with dropdown menu 
* In dropdown menu there is now a "Use library panel" action. 

Made this work for both auto grid and custom grid. Auto grid panels that are library panels still have some issues (cannot be updated) but we can solve that later 

![Screenshot 2025-04-02 at 09 57 47](https://github.com/user-attachments/assets/7b33334b-ae43-43c3-b876-1ba4370c4df0)
