### PR TITLE
Chore: Move grafana docker image to distroless 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@
 # to maintain formatting of multiline commands in vscode, add the following to settings.json:
 # "docker.languageserver.formatter.ignoreMultilineInstructions": true
 
-ARG ALPINE_IMAGE=alpine:3.21
-ARG DISTROLESS_IMAGE=gcr.io/distroless/static-debian12
-ARG UBUNTU_IMAGE=ubuntu:22.04
+ARG BASE_IMAGE=alpine:3.21
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.24.1-alpine
@@ -13,15 +11,6 @@ ARG GO_IMAGE=golang:1.24.1-alpine
 # Default to building locally
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder
-
-ARG GF_UID="472"
-ARG GF_GID="0"
-ARG GF_PATHS_CONFIG="/etc/grafana/grafana.ini"
-ARG GF_PATHS_DATA="/var/lib/grafana"
-ARG GF_PATHS_HOME="/usr/share/grafana"
-ARG GF_PATHS_LOGS="/var/log/grafana"
-ARG GF_PATHS_PLUGINS="/var/lib/grafana/plugins"
-ARG GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 # Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
@@ -126,7 +115,7 @@ ENV BUILD_BRANCH=${BUILD_BRANCH}
 RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 
 # From-tarball build stage
-FROM ${ALPINE_IMAGE} AS tgz-builder
+FROM ${BASE_IMAGE} AS tgz-builder
 
 WORKDIR /tmp/grafana
 
@@ -141,49 +130,44 @@ RUN tar x -z -f /tmp/grafana.tar.gz --strip-components=1
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
+# Final stage
+FROM ${BASE_IMAGE}
 
-# Create common base image containing Grafana files
-FROM scratch as grafana-base
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
 
-ARG GF_UID
-ARG GF_GID
-ARG GF_PATHS_HOME
-ARG GF_PATHS_CONFIG
-ARG GF_PATHS_DATA
-ARG GF_PATHS_LOGS
-ARG GF_PATHS_PLUGINS
-ARG GF_PATHS_PROVISIONING
+ARG GF_UID="472"
+ARG GF_GID="0"
 
-# Set environment variables
-ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
-    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
-    GF_PATHS_DATA="${GF_PATHS_DATA}" \
-    GF_PATHS_HOME="${GF_PATHS_HOME}" \
-    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
-    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
-    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+ENV PATH="/usr/share/grafana/bin:$PATH" \
+  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+  GF_PATHS_DATA="/var/lib/grafana" \
+  GF_PATHS_HOME="/usr/share/grafana" \
+  GF_PATHS_LOGS="/var/log/grafana" \
+  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
-WORKDIR ${GF_PATHS_HOME}
+WORKDIR $GF_PATHS_HOME
 
-# Copy configuration files from go-src
-COPY --from=go-src /tmp/grafana/conf ./conf
+# Install dependencies
+RUN if grep -i -q alpine /etc/issue; then \
+  apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
+  apk info -vv | sort; \
+  elif grep -i -q ubuntu /etc/issue; then \
+  DEBIAN_FRONTEND=noninteractive && \
+  apt-get update && \
+  apt-get install -y ca-certificates curl tzdata musl && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*; \
+  else \
+  echo 'ERROR: Unsupported base image' && /bin/false; \
+  fi
 
-# Copy binaries and assets
-COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
+# glibc support for alpine x86_64 only
+# docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
+ARG GLIBC_VERSION=2.40
 
-ARG RUN_SH=./packaging/docker/run.sh
-COPY ${RUN_SH} /run.sh
-
-# Prepare libs required by Grafana on distroless image
-FROM alpine:latest as distroless-libs
-
-# Install bash, glibc, and musl
-RUN apk add --no-cache ca-certificates shadow coreutils curl tzdata musl-utils
-
-# Install glibc for x86_64 architecture
-RUN if [ `arch` = "x86_64" ]; then \
+RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
   wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
   usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
   usr/glibc-compat/lib/libc.so.6 \
@@ -196,71 +180,22 @@ RUN if [ `arch` = "x86_64" ]; then \
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
   fi
 
-# Compensate for the flat copy
-RUN if [ ! `arch` = "x86_64" ]; then \
-    mkdir /lib64 && \
-    mkdir -p /usr/glibc-compat; \
-    fi
-
-# Build distroless image
-FROM ${DISTROLESS_IMAGE} as distroless
-
-LABEL maintainer="Grafana Labs <hello@grafana.com>"
-LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
-
-ARG GF_UID
-ARG GF_GID
-ARG GF_PATHS_HOME
-ARG GF_PATHS_CONFIG
-ARG GF_PATHS_DATA
-ARG GF_PATHS_LOGS
-ARG GF_PATHS_PLUGINS
-ARG GF_PATHS_PROVISIONING
-
-# Set environment variables
-ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
-    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
-    GF_PATHS_DATA="${GF_PATHS_DATA}" \
-    GF_PATHS_HOME="${GF_PATHS_HOME}" \
-    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
-    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
-    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
-
-# Copy sh and common utilities
-COPY --from=distroless-libs /bin/chmod /bin/chmod
-COPY --from=distroless-libs /bin/grep /bin/grep
-COPY --from=distroless-libs /bin/chown /bin/chown
-COPY --from=distroless-libs /bin/mkdir /bin/mkdir
-COPY --from=distroless-libs /bin/sh /bin/sh
-COPY --from=distroless-libs /bin/cp /bin/cp
-COPY --from=distroless-libs /bin/ls /bin/ls
-COPY --from=distroless-libs /usr/bin/cut /usr/bin/cut
-COPY --from=distroless-libs /usr/bin/getent /usr/bin/getent
-COPY --from=distroless-libs /usr/sbin/adduser /sbin/adduser
-COPY --from=distroless-libs /usr/sbin/addgroup /sbin/addgroup
-
-COPY --from=distroless-libs /usr/glibc-compat /usr/glibc-compat
-COPY --from=distroless-libs /usr/lib/* /usr/lib/
-COPY --from=distroless-libs /lib/* /lib/
-COPY --from=distroless-libs /lib64 /lib64
-
-# Copy Grafana files
-COPY --from=grafana-base / /
-
-WORKDIR ${GF_PATHS_HOME}
-
-# Only available on amd64
-RUN if [ ! `arch` = "x86_64" ]; then \
-    rm -rf /lib64 && \
-    rm -rf /usr/glibc-compat; \
-    fi
+COPY --from=go-src /tmp/grafana/conf ./conf
 
 RUN if [ ! $(getent group "$GF_GID") ]; then \
+  if grep -i -q alpine /etc/issue; then \
   addgroup -S -g $GF_GID grafana; \
+  else \
+  addgroup --system --gid $GF_GID grafana; \
+  fi; \
   fi && \
   GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
   mkdir -p "$GF_PATHS_HOME/.aws" && \
-  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
+  if grep -i -q alpine /etc/issue; then \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
+  else \
+  adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
+  fi && \
   mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
   "$GF_PATHS_PROVISIONING/dashboards" \
   "$GF_PATHS_PROVISIONING/notifiers" \
@@ -275,68 +210,15 @@ RUN if [ ! $(getent group "$GF_GID") ]; then \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
-EXPOSE 3000
-
-USER "$GF_UID"
-#ENTRYPOINT [ "/run.sh" ]
-
-# Build ubuntu-based image
-FROM ${UBUNTU_IMAGE} as ubuntu
-
-LABEL maintainer="Grafana Labs <hello@grafana.com>"
-LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
-
-ARG GF_UID
-ARG GF_GID
-ARG GF_PATHS_HOME
-ARG GF_PATHS_CONFIG
-ARG GF_PATHS_DATA
-ARG GF_PATHS_LOGS
-ARG GF_PATHS_PLUGINS
-ARG GF_PATHS_PROVISIONING
-
-# Set environment variables
-ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
-    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
-    GF_PATHS_DATA="${GF_PATHS_DATA}" \
-    GF_PATHS_HOME="${GF_PATHS_HOME}" \
-    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
-    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
-    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
-
-WORKDIR ${GF_PATHS_HOME}
-
-# Install required packages
-RUN DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install -y ca-certificates curl tzdata musl && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY --from=grafana-base / /
-
- # Setup user and permissions - use Ubuntu-style commands
-RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
-    if [ ! $(getent group "$GF_GID") ]; then \
-      addgroup --system --gid $GF_GID grafana; \
-    fi && \
-    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
-    useradd --system --uid $GF_UID --gid "$GF_GID_NAME" grafana && \
-    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
-    "$GF_PATHS_PROVISIONING/dashboards" \
-    "$GF_PATHS_PROVISIONING/notifiers" \
-    "$GF_PATHS_PROVISIONING/plugins" \
-    "$GF_PATHS_PROVISIONING/access-control" \
-    "$GF_PATHS_PROVISIONING/alerting" \
-    "$GF_PATHS_LOGS" \
-    "$GF_PATHS_PLUGINS" \
-    "$GF_PATHS_DATA" && \
-    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
-    cp conf/ldap.toml /etc/grafana/ldap.toml && \
-    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
 
 EXPOSE 3000
+
+ARG RUN_SH=./packaging/docker/run.sh
+
+COPY ${RUN_SH} /run.sh
 
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # to maintain formatting of multiline commands in vscode, add the following to settings.json:
 # "docker.languageserver.formatter.ignoreMultilineInstructions": true
 
-ARG BASE_IMAGE=alpine:3.21
+ARG ALPINE_IMAGE=alpine:3.21
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static-debian12
+ARG UBUNTU_IMAGE=ubuntu:22.04
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.24.1-alpine
@@ -11,6 +13,15 @@ ARG GO_IMAGE=golang:1.24.1-alpine
 # Default to building locally
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder
+
+ARG GF_UID="472"
+ARG GF_GID="0"
+ARG GF_PATHS_CONFIG="/etc/grafana/grafana.ini"
+ARG GF_PATHS_DATA="/var/lib/grafana"
+ARG GF_PATHS_HOME="/usr/share/grafana"
+ARG GF_PATHS_LOGS="/var/log/grafana"
+ARG GF_PATHS_PLUGINS="/var/lib/grafana/plugins"
+ARG GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 
 # Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
@@ -115,7 +126,7 @@ ENV BUILD_BRANCH=${BUILD_BRANCH}
 RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 
 # From-tarball build stage
-FROM ${BASE_IMAGE} AS tgz-builder
+FROM ${ALPINE_IMAGE} AS tgz-builder
 
 WORKDIR /tmp/grafana
 
@@ -130,44 +141,49 @@ RUN tar x -z -f /tmp/grafana.tar.gz --strip-components=1
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
-# Final stage
-FROM ${BASE_IMAGE}
 
-LABEL maintainer="Grafana Labs <hello@grafana.com>"
-LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+# Create common base image containing Grafana files
+FROM scratch as grafana-base
 
-ARG GF_UID="472"
-ARG GF_GID="0"
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
 
-ENV PATH="/usr/share/grafana/bin:$PATH" \
-  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
-  GF_PATHS_DATA="/var/lib/grafana" \
-  GF_PATHS_HOME="/usr/share/grafana" \
-  GF_PATHS_LOGS="/var/log/grafana" \
-  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
-  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+# Set environment variables
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
 
-WORKDIR $GF_PATHS_HOME
+WORKDIR ${GF_PATHS_HOME}
 
-# Install dependencies
-RUN if grep -i -q alpine /etc/issue; then \
-  apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
-  apk info -vv | sort; \
-  elif grep -i -q ubuntu /etc/issue; then \
-  DEBIAN_FRONTEND=noninteractive && \
-  apt-get update && \
-  apt-get install -y ca-certificates curl tzdata musl && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*; \
-  else \
-  echo 'ERROR: Unsupported base image' && /bin/false; \
-  fi
+# Copy configuration files from go-src
+COPY --from=go-src /tmp/grafana/conf ./conf
 
-# glibc support for alpine x86_64 only
-# docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
-ARG GLIBC_VERSION=2.40
+# Copy binaries and assets
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
 
-RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
+ARG RUN_SH=./packaging/docker/run.sh
+COPY ${RUN_SH} /run.sh
+
+# Prepare libs required by Grafana on distroless image
+FROM alpine:latest as distroless-libs
+
+# Install bash, glibc, and musl
+RUN apk add --no-cache ca-certificates shadow coreutils curl tzdata musl-utils
+
+# Install glibc for x86_64 architecture
+RUN if [ `arch` = "x86_64" ]; then \
   wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
   usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
   usr/glibc-compat/lib/libc.so.6 \
@@ -180,22 +196,71 @@ RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
   fi
 
-COPY --from=go-src /tmp/grafana/conf ./conf
+# Compensate for the flat copy
+RUN if [ ! `arch` = "x86_64" ]; then \
+    mkdir /lib64 && \
+    mkdir -p /usr/glibc-compat; \
+    fi
+
+# Build distroless image
+FROM ${DISTROLESS_IMAGE} as distroless
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+# Set environment variables
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+# Copy sh and common utilities
+COPY --from=distroless-libs /bin/chmod /bin/chmod
+COPY --from=distroless-libs /bin/grep /bin/grep
+COPY --from=distroless-libs /bin/chown /bin/chown
+COPY --from=distroless-libs /bin/mkdir /bin/mkdir
+COPY --from=distroless-libs /bin/sh /bin/sh
+COPY --from=distroless-libs /bin/cp /bin/cp
+COPY --from=distroless-libs /bin/ls /bin/ls
+COPY --from=distroless-libs /usr/bin/cut /usr/bin/cut
+COPY --from=distroless-libs /usr/bin/getent /usr/bin/getent
+COPY --from=distroless-libs /usr/sbin/adduser /sbin/adduser
+COPY --from=distroless-libs /usr/sbin/addgroup /sbin/addgroup
+
+COPY --from=distroless-libs /usr/glibc-compat /usr/glibc-compat
+COPY --from=distroless-libs /usr/lib/* /usr/lib/
+COPY --from=distroless-libs /lib/* /lib/
+COPY --from=distroless-libs /lib64 /lib64
+
+# Copy Grafana files
+COPY --from=grafana-base / /
+
+WORKDIR ${GF_PATHS_HOME}
+
+# Only available on amd64
+RUN if [ ! `arch` = "x86_64" ]; then \
+    rm -rf /lib64 && \
+    rm -rf /usr/glibc-compat; \
+    fi
 
 RUN if [ ! $(getent group "$GF_GID") ]; then \
-  if grep -i -q alpine /etc/issue; then \
   addgroup -S -g $GF_GID grafana; \
-  else \
-  addgroup --system --gid $GF_GID grafana; \
-  fi; \
   fi && \
   GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
   mkdir -p "$GF_PATHS_HOME/.aws" && \
-  if grep -i -q alpine /etc/issue; then \
-  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
-  else \
-  adduser --system --uid $GF_UID --ingroup "$GF_GID_NAME" grafana; \
-  fi && \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
   mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
   "$GF_PATHS_PROVISIONING/dashboards" \
   "$GF_PATHS_PROVISIONING/notifiers" \
@@ -210,15 +275,68 @@ RUN if [ ! $(getent group "$GF_GID") ]; then \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
-COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
-
 EXPOSE 3000
 
-ARG RUN_SH=./packaging/docker/run.sh
+USER "$GF_UID"
+#ENTRYPOINT [ "/run.sh" ]
 
-COPY ${RUN_SH} /run.sh
+# Build ubuntu-based image
+FROM ${UBUNTU_IMAGE} as ubuntu
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+# Set environment variables
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+WORKDIR ${GF_PATHS_HOME}
+
+# Install required packages
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y ca-certificates curl tzdata musl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=grafana-base / /
+
+ # Setup user and permissions - use Ubuntu-style commands
+RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
+    if [ ! $(getent group "$GF_GID") ]; then \
+      addgroup --system --gid $GF_GID grafana; \
+    fi && \
+    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+    useradd --system --uid $GF_UID --gid "$GF_GID_NAME" grafana && \
+    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+    "$GF_PATHS_PROVISIONING/dashboards" \
+    "$GF_PATHS_PROVISIONING/notifiers" \
+    "$GF_PATHS_PROVISIONING/plugins" \
+    "$GF_PATHS_PROVISIONING/access-control" \
+    "$GF_PATHS_PROVISIONING/alerting" \
+    "$GF_PATHS_LOGS" \
+    "$GF_PATHS_PLUGINS" \
+    "$GF_PATHS_DATA" && \
+    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+    cp conf/ldap.toml /etc/grafana/ldap.toml && \
+    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+EXPOSE 3000
 
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]

--- a/draft.Dockerfile
+++ b/draft.Dockerfile
@@ -1,0 +1,341 @@
+# syntax=docker/dockerfile:1
+
+# to maintain formatting of multiline commands in vscode, add the following to settings.json:
+# "docker.languageserver.formatter.ignoreMultilineInstructions": true
+
+ARG ALPINE_IMAGE=alpine:3.21
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static-debian12
+ARG UBUNTU_IMAGE=ubuntu:22.04
+ARG JS_IMAGE=node:22-alpine
+ARG JS_PLATFORM=linux/amd64
+ARG GO_IMAGE=golang:1.24.1-alpine
+
+# Default to building locally
+ARG GO_SRC=go-builder
+ARG JS_SRC=js-builder
+
+ARG GF_UID="472"
+ARG GF_GID="0"
+ARG GF_PATHS_CONFIG="/etc/grafana/grafana.ini"
+ARG GF_PATHS_DATA="/var/lib/grafana"
+ARG GF_PATHS_HOME="/usr/share/grafana"
+ARG GF_PATHS_LOGS="/var/log/grafana"
+ARG GF_PATHS_PLUGINS="/var/lib/grafana/plugins"
+ARG GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
+# Javascript build stage
+FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
+
+ENV NODE_OPTIONS=--max_old_space_size=8000
+
+WORKDIR /tmp/grafana
+
+COPY package.json project.json nx.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
+COPY packages packages
+COPY public public
+COPY LICENSE ./
+COPY conf/defaults.ini ./conf/defaults.ini
+COPY e2e e2e
+
+RUN apk add --no-cache make build-base python3
+
+RUN yarn install --immutable
+
+COPY tsconfig.json eslint.config.js .editorconfig .browserslistrc .prettierrc.js ./
+COPY scripts scripts
+COPY emails emails
+
+ENV NODE_ENV=production
+RUN yarn build
+
+# Golang build stage
+FROM ${GO_IMAGE} AS go-builder
+
+ARG COMMIT_SHA=""
+ARG BUILD_BRANCH=""
+ARG GO_BUILD_TAGS="oss"
+ARG WIRE_TAGS="oss"
+ARG BINGO="true"
+
+RUN if grep -i -q alpine /etc/issue; then \
+  apk add --no-cache \
+  # This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
+  binutils-gold \
+  bash \
+  # Install build dependencies
+  gcc g++ make git; \
+  fi
+
+WORKDIR /tmp/grafana
+
+COPY go.* ./
+COPY .bingo .bingo
+COPY .citools/bra .citools/bra
+COPY .citools/cue .citools/cue
+COPY .citools/cog .citools/cog
+COPY .citools/lefthook .citools/lefthook
+COPY .citools/jb .citools/jb
+COPY .citools/golangci-lint .citools/golangci-lint
+COPY .citools/swagger .citools/swagger
+
+# Include vendored dependencies
+COPY pkg/util/xorm pkg/util/xorm
+COPY pkg/apis/secret pkg/apis/secret
+COPY pkg/apiserver pkg/apiserver
+COPY pkg/apimachinery pkg/apimachinery
+COPY pkg/build pkg/build
+COPY pkg/build/wire pkg/build/wire
+COPY pkg/promlib pkg/promlib
+COPY pkg/storage/unified/resource pkg/storage/unified/resource
+COPY pkg/storage/unified/apistore pkg/storage/unified/apistore
+COPY pkg/semconv pkg/semconv
+COPY pkg/aggregator pkg/aggregator
+COPY apps/playlist apps/playlist
+COPY apps/investigations apps/investigations
+COPY apps/advisor apps/advisor
+COPY apps/dashboard apps/dashboard
+COPY apps apps
+COPY kindsv2 kindsv2
+COPY apps/alerting/notifications apps/alerting/notifications
+COPY pkg/codegen pkg/codegen
+COPY pkg/plugins/codegen pkg/plugins/codegen
+
+RUN go mod download
+RUN if [[ "$BINGO" = "true" ]]; then \
+  go install github.com/bwplotka/bingo@latest && \
+  bingo get -v; \
+  fi
+
+COPY embed.go Makefile build.go package.json ./
+COPY cue.mod cue.mod
+COPY kinds kinds
+COPY local local
+COPY packages/grafana-schema packages/grafana-schema
+COPY public/app/plugins public/app/plugins
+COPY public/api-merged.json public/api-merged.json
+COPY pkg pkg
+COPY scripts scripts
+COPY conf conf
+COPY .github .github
+
+ENV COMMIT_SHA=${COMMIT_SHA}
+ENV BUILD_BRANCH=${BUILD_BRANCH}
+
+RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
+
+# From-tarball build stage
+FROM ${ALPINE_IMAGE} AS tgz-builder
+
+WORKDIR /tmp/grafana
+
+ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"
+
+COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
+
+# add -v to make tar print every file it extracts
+RUN tar x -z -f /tmp/grafana.tar.gz --strip-components=1
+
+# helpers for COPY --from
+FROM ${GO_SRC} AS go-src
+FROM ${JS_SRC} AS js-src
+
+
+# Create common base image containing Grafana files
+FROM scratch AS grafana-base
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+# Set environment variables
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+WORKDIR ${GF_PATHS_HOME}
+
+# Copy configuration files from go-src
+COPY --from=go-src /tmp/grafana/conf ./conf
+
+# Copy binaries and assets
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
+
+ARG RUN_SH=./packaging/docker/run.sh
+COPY ${RUN_SH} /run.sh
+
+# Prepare libs required by Grafana on distroless image
+FROM alpine:latest AS distroless-libs
+
+# Install bash, glibc, and musl
+RUN apk add --no-cache ca-certificates shadow coreutils curl tzdata musl-utils
+
+# Install glibc for x86_64 architecture
+RUN if [ `arch` = "x86_64" ]; then \
+  wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
+  usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
+  usr/glibc-compat/lib/libc.so.6 \
+  usr/glibc-compat/lib/libdl.so.2 \
+  usr/glibc-compat/lib/libm.so.6 \
+  usr/glibc-compat/lib/libpthread.so.0 \
+  usr/glibc-compat/lib/librt.so.1 \
+  usr/glibc-compat/lib/libresolv.so.2 && \
+  mkdir /lib64 && \
+  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64; \
+  fi
+
+# We don't need glibc-compat on non x86_64, but COPY will fail othewise
+RUN if [ ! `arch` = "x86_64" ]; then \
+    mkdir /lib64 && \
+    mkdir -p /usr/glibc-compat; \
+    fi
+
+# Build distroless image
+FROM ${DISTROLESS_IMAGE} AS distroless
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+# Copy sh and common utils
+COPY --from=distroless-libs /bin/chmod /bin/chmod
+COPY --from=distroless-libs /bin/grep /bin/grep
+COPY --from=distroless-libs /bin/chown /bin/chown
+COPY --from=distroless-libs /bin/mkdir /bin/mkdir
+COPY --from=distroless-libs /bin/sh /bin/sh
+COPY --from=distroless-libs /bin/cp /bin/cp
+COPY --from=distroless-libs /bin/ls /bin/ls
+COPY --from=distroless-libs /usr/bin/cut /usr/bin/cut
+COPY --from=distroless-libs /usr/bin/getent /usr/bin/getent
+COPY --from=distroless-libs /usr/sbin/adduser /sbin/adduser
+COPY --from=distroless-libs /usr/sbin/addgroup /sbin/addgroup
+
+COPY --from=distroless-libs /usr/lib/* /usr/lib/
+COPY --from=distroless-libs /lib/* /lib/
+
+# Copy gclib-commpat
+COPY --from=distroless-libs /usr/glibc-compat /usr/glibc-compat
+COPY --from=distroless-libs /lib64 /lib64
+
+# Copy Grafana files
+COPY --from=grafana-base / /
+
+WORKDIR ${GF_PATHS_HOME}
+
+# gclib-compat is only available on x86_64 arch
+RUN if [ ! `arch` = "x86_64" ]; then \
+    rm -rf /lib64 && \
+    rm -rf /usr/glibc-compat; \
+    fi
+
+RUN if [ ! $(getent group "$GF_GID") ]; then \
+  addgroup -S -g $GF_GID grafana; \
+  fi && \
+  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+  mkdir -p "$GF_PATHS_HOME/.aws" && \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
+  mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+  "$GF_PATHS_PROVISIONING/dashboards" \
+  "$GF_PATHS_PROVISIONING/notifiers" \
+  "$GF_PATHS_PROVISIONING/plugins" \
+  "$GF_PATHS_PROVISIONING/access-control" \
+  "$GF_PATHS_PROVISIONING/alerting" \
+  "$GF_PATHS_LOGS" \
+  "$GF_PATHS_PLUGINS" \
+  "$GF_PATHS_DATA" && \
+  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+  cp conf/ldap.toml /etc/grafana/ldap.toml && \
+  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+EXPOSE 3000
+
+USER "$GF_UID"
+ENTRYPOINT [ "/run.sh" ]
+
+# Build ubuntu-based image
+FROM ${UBUNTU_IMAGE} AS ubuntu
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+# Copy Grafana files
+COPY --from=grafana-base / /
+
+WORKDIR ${GF_PATHS_HOME}
+
+# Install required packages
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y ca-certificates curl tzdata musl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if [ ! $(getent group "$GF_GID") ]; then \
+    addgroup --system --gid $GF_GID grafana;  \
+    fi && \
+    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+    mkdir -p "$GF_PATHS_HOME/.aws" && \
+    useradd --system --uid $GF_UID --gid "$GF_GID_NAME" grafana && \
+    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+    "$GF_PATHS_PROVISIONING/dashboards" \
+    "$GF_PATHS_PROVISIONING/notifiers" \
+    "$GF_PATHS_PROVISIONING/plugins" \
+    "$GF_PATHS_PROVISIONING/access-control" \
+    "$GF_PATHS_PROVISIONING/alerting" \
+    "$GF_PATHS_LOGS" \
+    "$GF_PATHS_PLUGINS" \
+    "$GF_PATHS_DATA" && \
+    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+    cp conf/ldap.toml /etc/grafana/ldap.toml && \
+    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+EXPOSE 3000
+
+USER "$GF_UID"
+ENTRYPOINT [ "/run.sh" ]

--- a/draft.Dockerfile
+++ b/draft.Dockerfile
@@ -237,7 +237,6 @@ COPY --from=distroless-libs /bin/chown /bin/chown
 COPY --from=distroless-libs /bin/mkdir /bin/mkdir
 COPY --from=distroless-libs /bin/sh /bin/sh
 COPY --from=distroless-libs /bin/cp /bin/cp
-COPY --from=distroless-libs /bin/ls /bin/ls
 COPY --from=distroless-libs /usr/bin/cut /usr/bin/cut
 COPY --from=distroless-libs /usr/bin/getent /usr/bin/getent
 COPY --from=distroless-libs /usr/sbin/adduser /sbin/adduser

--- a/draft.Dockerfile
+++ b/draft.Dockerfile
@@ -54,7 +54,8 @@ FROM ${GO_IMAGE} AS go-builder
 
 ARG COMMIT_SHA=""
 ARG BUILD_BRANCH=""
-ARG GO_BUILD_TAGS="oss"
+# By building app with timetzdata tag we instruct golang to use embedded tzdata if tzdata files is missing on the system
+ARG GO_BUILD_TAGS="oss,timetzdata"
 ARG WIRE_TAGS="oss"
 ARG BINGO="true"
 
@@ -82,6 +83,7 @@ COPY .citools/swagger .citools/swagger
 # Include vendored dependencies
 COPY pkg/util/xorm pkg/util/xorm
 COPY pkg/apis/secret pkg/apis/secret
+COPY pkg/apis/folder pkg/apis/folder
 COPY pkg/apiserver pkg/apiserver
 COPY pkg/apimachinery pkg/apimachinery
 COPY pkg/build pkg/build
@@ -179,7 +181,7 @@ COPY ${RUN_SH} /run.sh
 FROM alpine:latest AS distroless-libs
 
 # Install bash, glibc, and musl
-RUN apk add --no-cache ca-certificates shadow coreutils curl tzdata musl-utils
+RUN apk add --no-cache ca-certificates shadow coreutils curl musl-utils
 
 # glibc support for alpine x86_64 only
 # docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
@@ -315,7 +317,7 @@ WORKDIR ${GF_PATHS_HOME}
 # Install required packages
 RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y ca-certificates curl tzdata musl && \
+    apt-get install -y ca-certificates curl musl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/draft.Dockerfile
+++ b/draft.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 
 # to maintain formatting of multiline commands in vscode, add the following to settings.json:
 # "docker.languageserver.formatter.ignoreMultilineInstructions": true
@@ -143,6 +143,39 @@ FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
 
+FROM alpine:3.20 as grafana-dirs
+
+ARG GF_UID
+ARG GF_GID
+ARG GF_PATHS_HOME
+ARG GF_PATHS_CONFIG
+ARG GF_PATHS_DATA
+ARG GF_PATHS_LOGS
+ARG GF_PATHS_PLUGINS
+ARG GF_PATHS_PROVISIONING
+
+# Set environment variables
+ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
+    GF_PATHS_CONFIG="${GF_PATHS_CONFIG}" \
+    GF_PATHS_DATA="${GF_PATHS_DATA}" \
+    GF_PATHS_HOME="${GF_PATHS_HOME}" \
+    GF_PATHS_LOGS="${GF_PATHS_LOGS}" \
+    GF_PATHS_PLUGINS="${GF_PATHS_PLUGINS}" \
+    GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
+
+
+# --mount is a BuildKit feature, build has to be executed with DOCKER_BUILDKIT=1
+RUN mkdir -p "/tmp/$GF_PATHS_HOME/.aws" && \
+    mkdir -p "/tmp/$GF_PATHS_PROVISIONING/datasources" \
+             "/tmp/$GF_PATHS_PROVISIONING/dashboards" \
+             "/tmp/$GF_PATHS_PROVISIONING/notifiers" \
+             "/tmp/$GF_PATHS_PROVISIONING/plugins" \
+             "/tmp/$GF_PATHS_PROVISIONING/access-control" \
+             "/tmp/$GF_PATHS_PROVISIONING/alerting" \
+             "/tmp/$GF_PATHS_LOGS" \
+             "/tmp/$GF_PATHS_PLUGINS" \
+             "/tmp/$GF_PATHS_DATA"
+
 # Create common base image containing Grafana files
 FROM scratch AS grafana-base
 
@@ -167,17 +200,29 @@ ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
 WORKDIR ${GF_PATHS_HOME}
 
 # Copy configuration files from go-src
-COPY --from=go-src /tmp/grafana/conf ./conf
+COPY --from=go-src  /tmp/grafana/conf ./conf
+COPY --from=go-src  /tmp/grafana/conf/sample.ini $GF_PATHS_CONFIG
+COPY --from=go-src  /tmp/grafana/conf/ldap.toml /etc/grafana/ldap.toml
 
 # Copy binaries and assets
-COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
+COPY --from=go-src  /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+
+COPY --from=grafana-dirs /tmp /
 
 ARG RUN_SH=./packaging/docker/run.sh
 COPY ${RUN_SH} /run.sh
 
-# Prepare libs required by Grafana on distroless image
+FROM scratch as grafana-front
+
+ARG GF_PATHS_HOME
+# Set environment variables
+ENV GF_PATHS_HOME="${GF_PATHS_HOME}"
+
+WORKDIR ${GF_PATHS_HOME}
+COPY --from=js-src  /tmp/grafana/public ./public
+COPY --from=js-src  /tmp/grafana/LICENSE .
+
+#/ Prepare libs required by Grafana on distroless image
 FROM alpine:latest AS distroless-libs
 
 # Install bash, glibc, and musl
@@ -231,28 +276,24 @@ ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
     GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
 
 # Copy sh and common utils
-COPY --from=distroless-libs /bin/chmod /bin/chmod
-COPY --from=distroless-libs /bin/grep /bin/grep
-COPY --from=distroless-libs /bin/chown /bin/chown
-COPY --from=distroless-libs /bin/mkdir /bin/mkdir
-COPY --from=distroless-libs /bin/sh /bin/sh
-COPY --from=distroless-libs /bin/cp /bin/cp
-COPY --from=distroless-libs /usr/bin/cut /usr/bin/cut
-COPY --from=distroless-libs /usr/bin/getent /usr/bin/getent
-COPY --from=distroless-libs /usr/sbin/adduser /sbin/adduser
-COPY --from=distroless-libs /usr/sbin/addgroup /sbin/addgroup
+COPY --from=distroless-libs  /bin/chmod /bin/chmod
+COPY --from=distroless-libs  /bin/grep /bin/grep
+COPY --from=distroless-libs  /bin/chown /bin/chown
+COPY --from=distroless-libs  /bin/mkdir /bin/mkdir
+COPY --from=distroless-libs  /bin/sh /bin/sh
+COPY --from=distroless-libs  /bin/cp /bin/cp
+COPY --from=distroless-libs  /bin/ls /bin/ls
+COPY --from=distroless-libs  /usr/bin/cut /usr/bin/cut
+COPY --from=distroless-libs  /usr/bin/getent /usr/bin/getent
+COPY --from=distroless-libs  /usr/sbin/adduser /sbin/adduser
+COPY --from=distroless-libs  /usr/sbin/addgroup /sbin/addgroup
 
-COPY --from=distroless-libs /usr/lib/* /usr/lib/
-COPY --from=distroless-libs /lib/* /lib/
+COPY --from=distroless-libs  /usr/lib/* /usr/lib/
+COPY --from=distroless-libs  /lib/* /lib/
 
 # Copy gclib-commpat
-COPY --from=distroless-libs /usr/glibc-compat /usr/glibc-compat
-COPY --from=distroless-libs /lib64 /lib64
-
-# Copy Grafana files
-COPY --from=grafana-base / /
-
-WORKDIR ${GF_PATHS_HOME}
+COPY --from=distroless-libs  /usr/glibc-compat /usr/glibc-compat
+COPY --from=distroless-libs  /lib64 /lib64
 
 # gclib-compat is only available on x86_64 arch
 RUN if [ ! `arch` = "x86_64" ]; then \
@@ -260,29 +301,18 @@ RUN if [ ! `arch` = "x86_64" ]; then \
     rm -rf /usr/glibc-compat; \
     fi
 
-RUN if [ ! $(getent group "$GF_GID") ]; then \
-  addgroup -S -g $GF_GID grafana; \
-  fi && \
-  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
-  mkdir -p "$GF_PATHS_HOME/.aws" && \
-  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
-  mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
-  "$GF_PATHS_PROVISIONING/dashboards" \
-  "$GF_PATHS_PROVISIONING/notifiers" \
-  "$GF_PATHS_PROVISIONING/plugins" \
-  "$GF_PATHS_PROVISIONING/access-control" \
-  "$GF_PATHS_PROVISIONING/alerting" \
-  "$GF_PATHS_LOGS" \
-  "$GF_PATHS_PLUGINS" \
-  "$GF_PATHS_DATA" && \
-  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
-  cp conf/ldap.toml /etc/grafana/ldap.toml && \
-  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+# Copy Grafana files
+COPY --from=grafana-base --chmod=777 / /
+COPY --from=grafana-front --chmod=755 / /
 
-EXPOSE 3000
+WORKDIR ${GF_PATHS_HOME}
+
+RUN GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+    adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana
 
 USER "$GF_UID"
+EXPOSE 3000
+
 ENTRYPOINT [ "/run.sh" ]
 
 # Build ubuntu-based image
@@ -309,36 +339,19 @@ ENV PATH="${GF_PATHS_HOME}/bin:$PATH" \
     GF_PATHS_PROVISIONING="${GF_PATHS_PROVISIONING}"
 
 # Copy Grafana files
-COPY --from=grafana-base / /
+COPY --chmod=755 --from=grafana-base  / /
 
 WORKDIR ${GF_PATHS_HOME}
 
 # Install required packages
 RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y ca-certificates curl musl && \
+    apt-get install -y ca-certificates musl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN if [ ! $(getent group "$GF_GID") ]; then \
-    addgroup --system --gid $GF_GID grafana;  \
-    fi && \
-    GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
-    mkdir -p "$GF_PATHS_HOME/.aws" && \
-    useradd --system --uid $GF_UID --gid "$GF_GID_NAME" grafana && \
-    mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
-    "$GF_PATHS_PROVISIONING/dashboards" \
-    "$GF_PATHS_PROVISIONING/notifiers" \
-    "$GF_PATHS_PROVISIONING/plugins" \
-    "$GF_PATHS_PROVISIONING/access-control" \
-    "$GF_PATHS_PROVISIONING/alerting" \
-    "$GF_PATHS_LOGS" \
-    "$GF_PATHS_PLUGINS" \
-    "$GF_PATHS_DATA" && \
-    cp conf/sample.ini "$GF_PATHS_CONFIG" && \
-    cp conf/ldap.toml /etc/grafana/ldap.toml && \
-    chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+RUN GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+    useradd --system --uid $GF_UID --gid "$GF_GID_NAME" grafana
 
 EXPOSE 3000
 

--- a/draft.Dockerfile
+++ b/draft.Dockerfile
@@ -181,6 +181,10 @@ FROM alpine:latest AS distroless-libs
 # Install bash, glibc, and musl
 RUN apk add --no-cache ca-certificates shadow coreutils curl tzdata musl-utils
 
+# glibc support for alpine x86_64 only
+# docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
+ARG GLIBC_VERSION=2.40
+
 # Install glibc for x86_64 architecture
 RUN if [ `arch` = "x86_64" ]; then \
   wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 PERMISSIONS_OK=0
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 PERMISSIONS_OK=0
 


### PR DESCRIPTION
### What as done

The final stage was split into two separate stages: `distroless` and `ubuntu` with common part moved to a separate stage `grafana-base`


### Build `distroless` image:
For distroless-based image the graph is
```bash
docker build --target=distroless -t grafana-draft -f draft.Dockerfile .
```

#### Build graph:
`xxx-builder -> grafana-base -> distroless-libs -> distroless`

### Build the `ubuntu` image:
```bash
docker build --target=ubuntu -t grafana-ubuntu-draft -f draft.Dockerfile .
```

#### Build graph:
`xxx-builder -> grafana-base -> ubuntu`