### PR TITLE
Plugin Extensions: Move observable extension apis from the unstable entrypoint

### DIFF
--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -52,7 +52,8 @@ export {
   type UsePluginFunctionsOptions,
   type UsePluginFunctionsResult,
 } from './pluginExtensions/usePluginFunctions';
-
+export { getObservablePluginLinks } from './pluginExtensions/getObservablePluginLinks';
+export { getObservablePluginComponents } from './pluginExtensions/getObservablePluginComponents';
 export {
   isPluginExtensionLink,
   isPluginExtensionComponent,

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -11,6 +11,3 @@
 
 export { useTranslate, setUseTranslateHook, setTransComponent, Trans } from './utils/i18n';
 export type { TransProps } from './types/i18n';
-
-export { getObservablePluginLinks } from './services/pluginExtensions/getObservablePluginLinks';
-export { getObservablePluginComponents } from './services/pluginExtensions/getObservablePluginComponents';


### PR DESCRIPTION
### What changed?
The `getObservablePluginLinks()` and `getObservablePluginComponents()` apis got moved from `@grafana/runtime/unstable` to `@grafana/runtime`.

### Why?
We realised that the `/unstable` entry points are not suitable for backwards compatibility, as they are considered being a separate module by SystemJs, and will cause a runtime error in any earlier Grafana versions which don't have them.

### Breaking change?
Although technically this is a breaking change, [we only introduced the apis 4 days ago](https://github.com/grafana/grafana/pull/103063), and we are not aware of any usage of them.