### PR TITLE
docs: Add missing RBAC Action Definition Contact Point Receiver Test

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -228,6 +228,7 @@ To use these permissions, enable the `alertingApiServer` feature toggle.
 | `alert.notifications.receivers:create`       | None                               | Create a new contact points. The creator is automatically granted full access to the created contact point. |
 | `alert.notifications.receivers:write`        | `receivers:*`<br>`receivers:uid:*` | Update existing contact points.                                                                             |
 | `alert.notifications.receivers:delete`       | `receivers:*`<br>`receivers:uid:*` | Update and delete existing contact points.                                                                  |
+| `alert.notifications.receivers:test`         | None                               | Test contact point notification.                                                                            |
 | `receivers.permissions:read`                 | `receivers:*`<br>`receivers:uid:*` | Read permissions for contact points.                                                                        |
 | `receivers.permissions:write`                | `receivers:*`<br>`receivers:uid:*` | Manage permissions for contact points.                                                                      |
 | `alert.notifications.time-intervals:read`    | None                               | Read mute time intervals.                                                                                   |


### PR DESCRIPTION
**What is this feature?**

Add missing documentation.

**Why do we need this feature?**

Prevent confusion to Grafana administrators.

**Who is this feature for?**

Documentation consumers.

**Which issue(s) does this PR fix?**:

Incomplete documentation.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
