### PR TITLE
Tempo: Update lezer-traceql with new functions

### DIFF
--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -8,7 +8,7 @@
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/lezer-logql": "0.2.6",
-    "@grafana/lezer-traceql": "0.0.20",
+    "@grafana/lezer-traceql": "0.0.21",
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/plugin-ui": "0.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,7 +2821,7 @@ __metadata:
     "@grafana/data": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/lezer-logql": "npm:0.2.6"
-    "@grafana/lezer-traceql": "npm:0.0.20"
+    "@grafana/lezer-traceql": "npm:0.0.21"
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "npm:12.0.0-pre"
@@ -3163,12 +3163,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.20":
-  version: 0.0.20
-  resolution: "@grafana/lezer-traceql@npm:0.0.20"
+"@grafana/lezer-traceql@npm:0.0.21":
+  version: 0.0.21
+  resolution: "@grafana/lezer-traceql@npm:0.0.21"
   peerDependencies:
-    "@lezer/lr": ^1.3.0
-  checksum: 10/53c05149ad7390ffe5f729df74fe09f8caa2f820a5eb922283083a630aaed443d9643ccf37172eb0c4b9600841dfccc0bd200064ad6bcdda3f6b88bb27bd11a5
+    "@lezer/lr": ^1.4.2
+  checksum: 10/de27346b3f7e45cc10fae18e7172c7686a10d6979b057a33e72f3d4aeca498b7c5ba80202f1e59207f417b69c3f1703bef313dbde155b7a6ee211726d665f085
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updating lezer-traceql to include new functions (https://github.com/grafana/lezer-traceql/issues/27)

see also https://github.com/grafana/grafana/pull/101861

Before:

<img width="621" alt="Screenshot 2025-04-02 at 15 49 33" src="https://github.com/user-attachments/assets/7a24787e-05bb-400f-a575-554a4783f61b" />

After:

<img width="410" alt="Screenshot 2025-04-02 at 15 52 38" src="https://github.com/user-attachments/assets/c61fb041-a14a-491b-8100-4d2b54baf957" />
