### PR TITLE
DashboardOutline: Sync row collapse state with outline node collapse state 

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -185,4 +185,12 @@ export class RowItem
   public scrollIntoView() {
     scrollCanvasElementIntoView(this, this.containerRef);
   }
+
+  public getCollapsedState(): boolean {
+    return this.state.collapse ?? false;
+  }
+
+  public setCollapsedState(collapse: boolean) {
+    this.setState({ collapse });
+  }
 }

--- a/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
@@ -49,6 +49,16 @@ export interface EditableDashboardElement {
    * scroll element into view (when selected from outline)
    */
   scrollIntoView?(): void;
+
+  /**
+   * Used to sync row collapsed state with outline
+   */
+  getCollapsedState?(): boolean;
+
+  /**
+   * Used to sync row collapsed state with outline
+   */
+  setCollapsedState?(collapsed: boolean): void;
 }
 
 export interface EditableDashboardElementInfo {


### PR DESCRIPTION
Syncs row collapse state with outline node collapse state 

[row_expanded_sync.webm](https://github.com/user-attachments/assets/13aa49e4-4393-462b-bb90-85853bb06ce6)
