### PR TITLE
Alerting: Fix state transition from Recovering back to Alerting

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -417,8 +417,9 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 		}
 	default:
 		nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
-		if rule.For > 0 {
-			// If the alert rule has a For duration that should be observed then the state should be set to Pending
+		if state.State != eval.Recovering && rule.For > 0 {
+			// If the alert rule has a For duration that should be observed then the state should be set to Pending.
+			// If the alert is currently in the Recovering state then we skip Pending and set it directly to Alerting.
 			logger.Debug("Changing state",
 				"previous_state",
 				state.State,


### PR DESCRIPTION
**What is this feature?**

This PR fixes a state transition issue where alerts transitioning from the `Recovering` state back to the `Alerting` state incorrectly entered the `Pending` state first if the rule had a `For` duration configured.

**Why do we need this feature?**

When an alert goes from `Alerting` to `Recovering` (when using the `Keep firing for`) and then back to `Alerting`, the existing logic would incorrectly put the alert into `Pending` state while it should be alerting and still sending notifications to the Alertmanager.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/986

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
