### PR TITLE
Retry aborted transactions on Spanner.

### DIFF
--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -2,11 +2,9 @@ package sqlstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	"github.com/mattn/go-sqlite3"
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -64,15 +62,17 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 	}
 
 	// special handling of database locked errors for sqlite, then we can retry 5 times
-	var sqlError sqlite3.Error
-	if errors.As(err, &sqlError) && retry < ss.dbCfg.TransactionRetries && (sqlError.Code == sqlite3.ErrLocked || sqlError.Code == sqlite3.ErrBusy) {
-		if rollErr := sess.Rollback(); rollErr != nil {
-			return fmt.Errorf("rolling back transaction due to error failed: %s: %w", rollErr, err)
-		}
+	r, ok := engine.Dialect().(xorm.DialectWithRetryableErrors)
+	if ok {
+		if retry < ss.dbCfg.TransactionRetries && r.RetryOnError(err) {
+			if rollErr := sess.Rollback(); rollErr != nil {
+				return fmt.Errorf("rolling back transaction due to error failed: %s: %w", rollErr, err)
+			}
 
-		time.Sleep(time.Millisecond * time.Duration(10))
-		ctxLogger.Info("Database locked, sleeping then retrying", "error", err, "retry", retry, "code", sqlError.Code)
-		return ss.inTransactionWithRetryCtx(ctx, engine, bus, callback, retry+1)
+			time.Sleep(time.Millisecond * time.Duration(10))
+			ctxLogger.Info("Database locked, sleeping then retrying", "error", err, "retry", retry)
+			return ss.inTransactionWithRetryCtx(ctx, engine, bus, callback, retry+1)
+		}
 	}
 
 	if err != nil {

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -62,8 +62,7 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 	}
 
 	// special handling of database locked errors for sqlite, then we can retry 5 times
-	r, ok := engine.Dialect().(xorm.DialectWithRetryableErrors)
-	if ok {
+	if r, ok := engine.Dialect().(xorm.DialectWithRetryableErrors); ok {
 		if retry < ss.dbCfg.TransactionRetries && r.RetryOnError(err) {
 			if rollErr := sess.Rollback(); rollErr != nil {
 				return fmt.Errorf("rolling back transaction due to error failed: %s: %w", rollErr, err)

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -61,7 +61,7 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 		return err
 	}
 
-	// special handling of database locked errors for sqlite, then we can retry 5 times
+	// special handling of database locked errors for sqlite and spanner, then we can retry 5 times
 	if r, ok := engine.Dialect().(xorm.DialectWithRetryableErrors); ok {
 		if retry < ss.dbCfg.TransactionRetries && r.RetryOnError(err) {
 			if rollErr := sess.Rollback(); rollErr != nil {

--- a/pkg/util/xorm/dialect_spanner.go
+++ b/pkg/util/xorm/dialect_spanner.go
@@ -8,10 +8,12 @@ import (
 	"strconv"
 	"strings"
 
+	spannerclient "cloud.google.com/go/spanner"
 	_ "github.com/googleapis/go-sql-spanner"
 	spannerdriver "github.com/googleapis/go-sql-spanner"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"xorm.io/core"
 )
@@ -424,4 +426,8 @@ func SpannerConnectorConfigToClientOptions(connectorConfig spannerdriver.Connect
 			option.WithoutAuthentication())
 	}
 	return opts
+}
+
+func (s *spanner) RetryOnError(err error) bool {
+	return err != nil && spannerclient.ErrCode(spannerclient.ToSpannerError(err)) == codes.Aborted
 }

--- a/pkg/util/xorm/dialect_sqlite3.go
+++ b/pkg/util/xorm/dialect_sqlite3.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	a "github.com/mattn/go-sqlite3"
 	"xorm.io/core"
 )
 
@@ -472,6 +473,14 @@ func (db *sqlite3) GetIndexes(tableName string) (map[string]*core.Index, error) 
 
 func (db *sqlite3) Filters() []core.Filter {
 	return []core.Filter{&core.IdFilter{}}
+}
+
+func (db *sqlite3) RetryOnError(err error) bool {
+	var sqlError a.Error
+	if errors.As(err, &sqlError) && (sqlError.Code == a.ErrLocked || sqlError.Code == a.ErrBusy) {
+		return true
+	}
+	return false
 }
 
 type sqlite3Driver struct {

--- a/pkg/util/xorm/dialect_sqlite3.go
+++ b/pkg/util/xorm/dialect_sqlite3.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	a "github.com/mattn/go-sqlite3"
+	sqlite "github.com/mattn/go-sqlite3"
 	"xorm.io/core"
 )
 
@@ -476,8 +476,8 @@ func (db *sqlite3) Filters() []core.Filter {
 }
 
 func (db *sqlite3) RetryOnError(err error) bool {
-	var sqlError a.Error
-	if errors.As(err, &sqlError) && (sqlError.Code == a.ErrLocked || sqlError.Code == a.ErrBusy) {
+	var sqlError sqlite.Error
+	if errors.As(err, &sqlError) && (sqlError.Code == sqlite.ErrLocked || sqlError.Code == sqlite.ErrBusy) {
 		return true
 	}
 	return false

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -117,7 +117,7 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 
 	runtime.SetFinalizer(engine, close)
 
-	if ext, ok := dialect.(DialectExt); ok {
+	if ext, ok := dialect.(DialectWithSequenceGenerator); ok {
 		engine.sequenceGenerator, err = ext.CreateSequenceGenerator(db.DB)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create sequence generator: %w", err)
@@ -138,9 +138,14 @@ type SequenceGenerator interface {
 	Reset()
 }
 
-type DialectExt interface {
+type DialectWithSequenceGenerator interface {
 	core.Dialect
 
 	// CreateSequenceGenerator returns optional generator used to create AUTOINCREMENT ids for inserts.
 	CreateSequenceGenerator(db *sql.DB) (SequenceGenerator, error)
+}
+
+type DialectWithRetryableErrors interface {
+	core.Dialect
+	RetryOnError(err error) bool
 }


### PR DESCRIPTION
Spanner aborts transaction in case of concurrent modifications. Aborted transactions are typically handled by client library, but since we also have mechanism for retrying transactions in our code, we can use it. This PR adds Spanner support (in addition to sqlite), and moves DB-specific checks to dialect.

Packages whose integration tests (on Spanner emulator) that were previously failing with `Transaction was aborted due to a concurrent modification` error, and don't fail anymore (tested with count=10):
* `TestIntegrationLoki` under `pkg/tests/api/loki`
* `TestIntegrationOpenTSDB` under `pkg/tests/api/opentdsb`

Possibly more.