### PR TITLE
LogsPanel: Speed up labels processing by 50x

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3805,6 +3805,9 @@ exports[`better eslint`] = {
     "public/app/features/logs/components/LogLabelStats.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
+    "public/app/features/logs/logsFrame.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/logs/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -35,14 +35,19 @@ const DATAPLANE_SEVERITY_NAME = 'severity';
 const DATAPLANE_ID_NAME = 'id';
 const DATAPLANE_LABELS_NAME = 'labels';
 
+// NOTE: this is a hot fn, we need to avoid allocating new objects here
+// this will mutate the objects when necessary (should be only edge cases when label keys are not strings)
 export function logFrameLabelsToLabels(logFrameLabels: LogFrameLabels): Labels {
-  const result: Labels = {};
+  for (let k in logFrameLabels) {
+    const v = logFrameLabels[k];
 
-  Object.entries(logFrameLabels).forEach(([k, v]) => {
-    result[k] = typeof v === 'string' ? v : JSON.stringify(v);
-  });
+    if (typeof v !== 'string') {
+      logFrameLabels[k] = JSON.stringify(v);
+    }
+  }
 
-  return result;
+  // @ts-ignore
+  return logFrameLabels as Labels;
 }
 
 export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -36,14 +36,27 @@ const DATAPLANE_ID_NAME = 'id';
 const DATAPLANE_LABELS_NAME = 'labels';
 
 // NOTE: this is a hot fn, we need to avoid allocating new objects here
-// this will mutate the objects when necessary (should be only edge cases when label keys are not strings)
 export function logFrameLabelsToLabels(logFrameLabels: LogFrameLabels): Labels {
-  for (let k in logFrameLabels) {
+  let needsSerialization = false;
+
+  for (const k in logFrameLabels) {
     const v = logFrameLabels[k];
 
     if (typeof v !== 'string') {
-      logFrameLabels[k] = JSON.stringify(v);
+      needsSerialization = true;
+      break;
     }
+  }
+
+  if (needsSerialization) {
+    let labels: Labels = {};
+
+    for (const k in logFrameLabels) {
+      const v = logFrameLabels[k];
+      labels[k] = typeof v === 'string' ? v : JSON.stringify(v);
+    }
+
+    return labels;
   }
 
   // @ts-ignore


### PR DESCRIPTION
for 5k log lines...

before, 4.3s:

![image](https://github.com/user-attachments/assets/814a5f0e-9689-467f-ad22-4e6d94d37f0d)


after, 88ms:

![image](https://github.com/user-attachments/assets/89cfe631-b970-4028-89ed-65d31066a3df)