### PR TITLE
Dynamic dashboards: Keyboard shortcuts for copy/paste

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -16,6 +16,8 @@ import { getPanelIdForVizPanel } from '../utils/utils';
 import { DashboardScene } from './DashboardScene';
 import { onRemovePanel, toggleVizPanelLegend } from './PanelMenuBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+import { RowItem } from './layout-rows/RowItem';
+import { TabItem } from './layout-tabs/TabItem';
 
 export function setupKeyboardShortcuts(scene: DashboardScene) {
   const keybindings = new KeybindingSet();
@@ -138,6 +140,40 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   keybindings.addBinding({
     key: 'p l',
     onTrigger: withFocusedPanel(scene, toggleVizPanelLegend),
+  });
+
+  // Copy selected object
+  keybindings.addBinding({
+    key: 'mod+c',
+    onTrigger: () => {
+      const selectedObject = scene.state.editPane.getSelection();
+      if (!selectedObject) {
+        return;
+      }
+      if (selectedObject instanceof TabItem || selectedObject instanceof RowItem) {
+        selectedObject.onCopy();
+      } else if (selectedObject instanceof VizPanel) {
+        scene.copyPanel(selectedObject);
+      }
+    },
+  });
+
+  // Paste selected object
+  keybindings.addBinding({
+    key: 'mod+v',
+    onTrigger: () => {
+      const selectedObject = scene.state.editPane.getSelection();
+      if (!selectedObject) {
+        return;
+      }
+      if (
+        selectedObject instanceof TabItem ||
+        selectedObject instanceof RowItem ||
+        selectedObject instanceof VizPanel
+      ) {
+        scene.pasteFromClipboardTo(selectedObject);
+      }
+    },
   });
 
   // Refresh

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
@@ -45,7 +45,7 @@ export function RowLayoutManagerRenderer({ model }: SceneComponentProps<RowsLayo
                   <Trans i18nKey="dashboard.canvas-actions.new-row">New row</Trans>
                 </Button>
                 {hasCopiedRow && (
-                  <Button icon="plus" variant="primary" fill="text" onClick={() => model.pasteRow()}>
+                  <Button icon="clipboard-alt" variant="primary" fill="text" onClick={() => model.pasteRow()}>
                     <Trans i18nKey="dashboard.canvas-actions.paste-row">Paste row</Trans>
                   </Button>
                 )}

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -55,7 +55,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
                   <Trans i18nKey="dashboard.canvas-actions.new-tab">New tab</Trans>
                 </Button>
                 {hasCopiedTab && (
-                  <Button icon="plus" variant="primary" fill="text" onClick={() => model.pasteTab()}>
+                  <Button icon="clipboard-alt" variant="primary" fill="text" onClick={() => model.pasteTab()}>
                     <Trans i18nKey="dashboard.canvas-actions.paste-tab">Paste tab</Trans>
                   </Button>
                 )}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -56,7 +56,7 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
         <Button
           variant="primary"
           fill="text"
-          icon="layers"
+          icon="clipboard-alt"
           onClick={() => {
             layoutManager.pastePanel?.();
           }}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -10,14 +10,14 @@ import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 
-export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
+export function addNewTabTo(layout: DashboardLayoutManager, tab?: TabItem): TabItem {
   const layoutParent = layout.parent!;
   if (!isLayoutParent(layoutParent)) {
     throw new Error('Parent layout is not a LayoutParent');
   }
 
   if (layout instanceof TabsLayoutManager) {
-    return layout.addNewTab();
+    return layout.addNewTab(tab);
   }
 
   // Create new tabs layout and wrap the current layout in the first tab
@@ -26,13 +26,15 @@ export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
 
   layoutParent.switchLayout(tabsLayout);
 
-  const tab = tabsLayout.state.tabs[0];
-  layout.publishEvent(new NewObjectAddedToCanvasEvent(tab), true);
+  const newTab = tabsLayout.state.tabs[0];
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(newTab), true);
 
-  return tab;
+  tabsLayout.addNewTab(tab);
+
+  return newTab;
 }
 
-export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGridRow {
+export function addNewRowTo(layout: DashboardLayoutManager, row?: RowItem): RowItem | SceneGridRow {
   /**
    * If new layouts feature is disabled we add old school rows to the custom grid layout
    */
@@ -45,12 +47,12 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   }
 
   if (layout instanceof RowsLayoutManager) {
-    return layout.addNewRow();
+    return layout.addNewRow(row);
   }
 
   if (layout instanceof TabsLayoutManager) {
     const currentTab = layout.getCurrentTab();
-    return addNewRowTo(currentTab.state.layout);
+    return addNewRowTo(currentTab.state.layout, row);
   }
 
   const layoutParent = layout.parent!;
@@ -64,8 +66,10 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   const rowsLayout = RowsLayoutManager.createFromLayout(layoutParent.getLayout());
   layoutParent.switchLayout(rowsLayout);
 
-  const row = rowsLayout.state.rows[0];
-  layout.publishEvent(new NewObjectAddedToCanvasEvent(row), true);
+  const newRow = rowsLayout.state.rows[0];
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(newRow), true);
 
-  return row;
+  rowsLayout.addNewRow(row);
+
+  return newRow;
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -10,14 +10,14 @@ import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 
-export function addNewTabTo(layout: DashboardLayoutManager, tab?: TabItem): TabItem {
+export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   const layoutParent = layout.parent!;
   if (!isLayoutParent(layoutParent)) {
     throw new Error('Parent layout is not a LayoutParent');
   }
 
   if (layout instanceof TabsLayoutManager) {
-    return layout.addNewTab(tab);
+    return layout.addNewTab();
   }
 
   // Create new tabs layout and wrap the current layout in the first tab
@@ -26,15 +26,13 @@ export function addNewTabTo(layout: DashboardLayoutManager, tab?: TabItem): TabI
 
   layoutParent.switchLayout(tabsLayout);
 
-  const newTab = tabsLayout.state.tabs[0];
-  layout.publishEvent(new NewObjectAddedToCanvasEvent(newTab), true);
+  const tab = tabsLayout.state.tabs[0];
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(tab), true);
 
-  tabsLayout.addNewTab(tab);
-
-  return newTab;
+  return tab;
 }
 
-export function addNewRowTo(layout: DashboardLayoutManager, row?: RowItem): RowItem | SceneGridRow {
+export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGridRow {
   /**
    * If new layouts feature is disabled we add old school rows to the custom grid layout
    */
@@ -47,12 +45,12 @@ export function addNewRowTo(layout: DashboardLayoutManager, row?: RowItem): RowI
   }
 
   if (layout instanceof RowsLayoutManager) {
-    return layout.addNewRow(row);
+    return layout.addNewRow();
   }
 
   if (layout instanceof TabsLayoutManager) {
     const currentTab = layout.getCurrentTab();
-    return addNewRowTo(currentTab.state.layout, row);
+    return addNewRowTo(currentTab.state.layout);
   }
 
   const layoutParent = layout.parent!;
@@ -66,10 +64,8 @@ export function addNewRowTo(layout: DashboardLayoutManager, row?: RowItem): RowI
   const rowsLayout = RowsLayoutManager.createFromLayout(layoutParent.getLayout());
   layoutParent.switchLayout(rowsLayout);
 
-  const newRow = rowsLayout.state.rows[0];
-  layout.publishEvent(new NewObjectAddedToCanvasEvent(newRow), true);
+  const row = rowsLayout.state.rows[0];
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(row), true);
 
-  rowsLayout.addNewRow(row);
-
-  return newRow;
+  return row;
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -41,6 +41,21 @@ export interface PanelStore {
   gridItem: GridLayoutItemKind | AutoGridLayoutItemKind;
 }
 
+export type ClipboardType = 'panel' | 'row' | 'tab';
+
+export function whatIsInClipboard(): ClipboardType | null {
+  if (store.exists(LS_PANEL_COPY_KEY)) {
+    return 'panel';
+  }
+  if (store.exists(LS_ROW_COPY_KEY)) {
+    return 'row';
+  }
+  if (store.exists(LS_TAB_COPY_KEY)) {
+    return 'tab';
+  }
+  return null;
+}
+
 export function getRowFromClipboard(scene: DashboardScene): RowItem {
   const jsonData = store.get(LS_ROW_COPY_KEY);
 


### PR DESCRIPTION
**What is this feature?**

Let's a user copy and paste panels, rows and tabs using ctrl/cmd+c ctrl/cmd+v

Trying to be a bit careful with where a user can paste what type of item.

Pasting a row onto a row adds it as a sibling row.
Pasting a row onto a tab only works if the tab has a row layout as child.

Same idea applies to tabs.

Panels can be pasted onto a tab item or row item if it has a grid layout as child.
If a panel is pasted onto a panel it will create a sibling panel.