### PR TITLE
Table: Footer field selection fix

### DIFF
--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -175,7 +175,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           },
         },
         defaultValue: '',
-        showIf: (cfg) => cfg.footer?.show && !cfg.footer?.countRows,
+        showIf: (cfg) => cfg.footer?.show && !(cfg.footer?.countRows && cfg.footer?.reducer.includes(ReducerID.count)),
       })
       .addCustomEditor({
         id: 'footer.enablePagination',

--- a/public/app/plugins/panel/table/table-new/module.tsx
+++ b/public/app/plugins/panel/table/table-new/module.tsx
@@ -175,7 +175,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           },
         },
         defaultValue: '',
-        showIf: (cfg) => cfg.footer?.show && !cfg.footer?.countRows,
+        showIf: (cfg) => cfg.footer?.show && !(cfg.footer?.countRows && cfg.footer?.reducer.includes(ReducerID.count)),
       })
       .addCustomEditor({
         id: 'footer.enablePagination',


### PR DESCRIPTION
This is a fix for both old and new table. When enabling footer and selecting count reducer + count rows toggle, after changing the reducer to something else, say "last", the Fields selection SHOULD appear, but it wasn't. This PR slightly changes the logic for showing the Fields selection to also check the reducer.

Before:
![Apr-02-2025 10-32-59](https://github.com/user-attachments/assets/7a507b4b-6e8c-41e1-a5f3-7fe56fe343d0)

After:
![Apr-02-2025 10-28-53](https://github.com/user-attachments/assets/b43e5094-3975-43f1-b4bc-5cb0d1ea096a)


Fixes #102912