### PR TITLE
AWS: Add flag for multitenant temp credentials

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1080,6 +1080,10 @@ export interface FeatureToggles {
   */
   xrayApplicationSignals?: boolean;
   /**
+  * use multi-tenant path for awsTempCredentials
+  */
+  multiTenantTempCredentials?: boolean;
+  /**
   * Enables localization for plugins
   */
   localizationForPlugins?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1859,6 +1859,13 @@ var (
 			HideFromDocs:      true,
 		},
 		{
+			Name:         "multiTenantTempCredentials",
+			Description:  "use multi-tenant path for awsTempCredentials",
+			Stage:        FeatureStageExperimental,
+			HideFromDocs: true,
+			Owner:        awsDatasourcesSquad,
+		},
+		{
 			Name:         "localizationForPlugins",
 			Description:  "Enables localization for plugins",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -244,4 +244,5 @@ localeFormatPreference,experimental,@grafana/grafana-frontend-platform,false,fal
 unifiedStorageGrpcConnectionPool,experimental,@grafana/search-and-storage,false,false,false
 alertingRuleRecoverDeleted,GA,@grafana/alerting-squad,false,false,true
 xrayApplicationSignals,experimental,@grafana/aws-datasources,false,false,true
+multiTenantTempCredentials,experimental,@grafana/aws-datasources,false,false,false
 localizationForPlugins,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -987,6 +987,10 @@ const (
 	// Support Application Signals queries in the X-Ray datasource
 	FlagXrayApplicationSignals = "xrayApplicationSignals"
 
+	// FlagMultiTenantTempCredentials
+	// use multi-tenant path for awsTempCredentials
+	FlagMultiTenantTempCredentials = "multiTenantTempCredentials"
+
 	// FlagLocalizationForPlugins
 	// Enables localization for plugins
 	FlagLocalizationForPlugins = "localizationForPlugins"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2862,6 +2862,19 @@
     },
     {
       "metadata": {
+        "name": "multiTenantTempCredentials",
+        "resourceVersion": "1743614635650",
+        "creationTimestamp": "2025-04-02T17:23:55Z"
+      },
+      "spec": {
+        "description": "use multi-tenant path for awsTempCredentials",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "mysqlAnsiQuotes",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2022-10-12T11:43:35Z"


### PR DESCRIPTION
Adds a flag to use the multitenant pathway for temp credentials