### PR TITLE
LogsPanel: Cache parseLogsFrame for 2.5x speedup

### DIFF
--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -103,9 +103,13 @@ export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
 }
 
 export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
-  if (frame.meta?.type === DataFrameType.LogLines) {
-    return parseDataplaneLogsFrame(frame);
-  } else {
-    return parseLegacyLogsFrame(frame);
+  if (frame.__parsed == null) {
+    if (frame.meta?.type === DataFrameType.LogLines) {
+      frame.__parsed = parseDataplaneLogsFrame(frame);
+    } else {
+      frame.__parsed = parseLegacyLogsFrame(frame)
+    }
   }
+
+  return frame.__parsed;
 }

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -103,13 +103,15 @@ export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
 }
 
 export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
-  if (frame.__parsed == null) {
+  frame.meta = frame.meta ?? {};
+  frame.meta.custom = frame.meta.custom ?? {};
+  if (frame.meta.custom.logsFrame == null) {
     if (frame.meta?.type === DataFrameType.LogLines) {
-      frame.__parsed = parseDataplaneLogsFrame(frame);
+      frame.meta.custom.logsFrame = parseDataplaneLogsFrame(frame);
     } else {
-      frame.__parsed = parseLegacyLogsFrame(frame)
+      frame.meta.custom.logsFrame = parseLegacyLogsFrame(frame);
     }
   }
 
-  return frame.__parsed;
+  return frame.meta.custom.logsFrame;
 }


### PR DESCRIPTION
let's _not_ reprocess the frame for each row :grimacing: 

quick PoC, will leave it up to @matyax to either add appropriate types for the parsed cache or change the caching strategy.

before:

![image](https://github.com/user-attachments/assets/af9b8fd3-6858-4dbc-8834-7488c6d9d4c3)

after:

![image](https://github.com/user-attachments/assets/26528389-34b6-43e4-8293-c1a7a8f4c7d8)