### PR TITLE
search: remove dashboard IncludeFields mapping

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -2036,8 +2036,6 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	if query.Title != "" {
 		// allow wildcard search
 		request.Query = "*" + strings.ToLower(query.Title) + "*"
-		// if using query, you need to specify the fields you want
-		request.Fields = dashboardsearch.IncludeFields
 	}
 
 	if len(query.Tags) > 0 {

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -19,22 +19,6 @@ var (
 		resource.SEARCH_FIELD_FOLDER:  "",
 		resource.SEARCH_FIELD_TAGS:    "",
 	}
-
-	IncludeFields = []string{
-		resource.SEARCH_FIELD_TITLE,
-		resource.SEARCH_FIELD_TAGS,
-		resource.SEARCH_FIELD_LABELS,
-		resource.SEARCH_FIELD_FOLDER,
-		resource.SEARCH_FIELD_CREATED,
-		resource.SEARCH_FIELD_CREATED_BY,
-		resource.SEARCH_FIELD_UPDATED,
-		resource.SEARCH_FIELD_UPDATED_BY,
-		resource.SEARCH_FIELD_MANAGER_KIND,
-		resource.SEARCH_FIELD_MANAGER_ID,
-		resource.SEARCH_FIELD_SOURCE_PATH,
-		resource.SEARCH_FIELD_SOURCE_CHECKSUM,
-		resource.SEARCH_FIELD_SOURCE_TIME,
-	}
 )
 
 func ParseResults(result *resource.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -196,8 +196,6 @@ func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.S
 	if query.Title != "" {
 		// allow wildcard search
 		request.Query = "*" + strings.ToLower(query.Title) + "*"
-		// if using query, you need to specify the fields you want
-		request.Fields = dashboardsearch.IncludeFields
 	}
 
 	if query.Limit > 0 {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashboardsearch "github.com/grafana/grafana/pkg/services/dashboards/service/search"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/guardian"
@@ -708,7 +707,6 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 				Labels: []*resource.Requirement{},
 			},
 			Query:  "*test*",
-			Fields: dashboardsearch.IncludeFields,
 			Limit:  folderSearchLimit}).Return(&resource.ResourceSearchResponse{
 			Results: &resource.ResourceTable{
 				Columns: []*resource.ResourceTableColumnDefinition{

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -706,8 +706,8 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 				Fields: []*resource.Requirement{},
 				Labels: []*resource.Requirement{},
 			},
-			Query:  "*test*",
-			Limit:  folderSearchLimit}).Return(&resource.ResourceSearchResponse{
+			Query: "*test*",
+			Limit: folderSearchLimit}).Return(&resource.ResourceSearchResponse{
 			Results: &resource.ResourceTable{
 				Columns: []*resource.ResourceTableColumnDefinition{
 					{


### PR DESCRIPTION
This was added in https://github.com/grafana/grafana/pull/99787 a few months ago to fix a bug when searching for dashboards in the playlist view. Not sure why this was needed in the first place, as we already return all fields if none is set: https://github.com/grafana/grafana/blob/main/pkg/storage/unified/search/bleve.go#L537

In any case, I tested the playlist view page in mode 4 and everything works fine. So removing this as it's one less place for us to maintain a list of fields returned from search. cc @stephaniehingtgen 