### PR TITLE
Dashboards: SchemaV2 fix stateless queries incorrectly applied

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -254,7 +254,7 @@ function getVizPanelQueries(vizPanel: VizPanel, dsReferencesMapping?: DSReferenc
     vizPanelQueries.forEach((query) => {
       const queryDatasource = getElementDatasource(vizPanel, query, 'panel', queryRunner, dsReferencesMapping);
       const dataQuery: DataQueryKind = {
-        kind: getDataQueryKind(query),
+        kind: getDataQueryKind(query, queryRunner),
         spec: omit(query, 'datasource', 'refId', 'hide'),
       };
       const querySpec: PanelQuerySpec = {
@@ -272,12 +272,26 @@ function getVizPanelQueries(vizPanel: VizPanel, dsReferencesMapping?: DSReferenc
   return queries;
 }
 
-export function getDataQueryKind(query: SceneDataQuery | string): string {
+export function getDataQueryKind(query: SceneDataQuery | string, queryRunner?: SceneQueryRunner): string {
+  // Query is a string - get default data source type
   if (typeof query === 'string') {
-    return getDefaultDataSourceRef()?.type ?? '';
+    const defaultDS = getDefaultDataSourceRef();
+    return defaultDS?.type || '';
   }
 
-  return query.datasource?.type ?? getDefaultDataSourceRef()?.type ?? '';
+  // Query has explicit datasource with type
+  if (query.datasource?.type) {
+    return query.datasource.type;
+  }
+
+  // Get type from query runner's datasource
+  if (queryRunner?.state.datasource?.type) {
+    return queryRunner.state.datasource.type;
+  }
+
+  // Fall back to default datasource
+  const defaultDS = getDefaultDataSourceRef();
+  return defaultDS?.type || '';
 }
 
 export function getDataQuerySpec(query: SceneDataQuery): DataQueryKind['spec'] {

--- a/public/app/features/dashboard-scene/v2schema/SchemaV2EditorDrawer.tsx
+++ b/public/app/features/dashboard-scene/v2schema/SchemaV2EditorDrawer.tsx
@@ -74,7 +74,7 @@ export class SchemaV2EditorDrawer extends SceneObjectBase<SchemaV2EditorDrawerSt
     return (
       <Drawer
         title={'[DEV] Schema V2 editor'}
-        subtitle={'Allows editing dashboard using v2 schema. Changes are not persited in db.'}
+        subtitle={'Allows editing dashboard using v2 schema. Changes are not persisted in db.'}
         onClose={model.onClose}
       >
         {renderBody()}


### PR DESCRIPTION
### Fixes in the PR

- Refactor `getDataQueryKind` with proper datasource type resolution in this priority order:

1. Check first query's own explicit datasource type
2. Second take ds from the QueryRunner's 
3. If not found take default datasource
4. If no default, it is returning empty

- Added unit tests 
- Fixed a typo in schema editor drawer subtitle.

### Original Problem
Take this spec as example: [gist.github.com/dprokop/d0f4c6b29c356cabebae6afbf4237e08](https://gist.github.com/dprokop/d0f4c6b29c356cabebae6afbf4237e08)

Provision it and then try to save it. Observe that in the diff prometheus query kind is replaced with instance default data source kind:

<img width="665" alt="Image" src="https://github.com/user-attachments/assets/4298f925-3328-4a48-a442-9fbbd8abe3cf" />

Fixes: #102895 