### PR TITLE
Alerting: Add extended definition to prometheus alert rules api

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -349,7 +349,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 
 	t.Run("with a rule that only has one query", func(t *testing.T) {
 		fakeStore, fakeAIM, api := setupAPI(t)
-		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery())
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery(), gen.WithNoNotificationSettings(), gen.WithIsPaused(false))
 		folder := fakeStore.Folders[orgID][0]
 
 		r := api.RouteGetRuleStatuses(c)
@@ -390,6 +390,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 					"__a_private_label_on_the_rule__": "a_value"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "2022-03-10T14:01:00Z",
 				"duration": 180,
@@ -411,9 +412,89 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 `, folder.Fullpath), string(r.Body()))
 	})
 
+	t.Run("with a rule that is paused", func(t *testing.T) {
+		fakeStore, fakeAIM, api := setupAPI(t)
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery(), gen.WithNoNotificationSettings(), gen.WithIsPaused(true))
+		folder := fakeStore.Folders[orgID][0]
+
+		r := api.RouteGetRuleStatuses(c)
+		require.Equal(t, http.StatusOK, r.Status())
+		require.JSONEq(t, fmt.Sprintf(`
+{
+	"status": "success",
+	"data": {
+		"groups": [{
+			"name": "rule-group",
+			"file": "%s",
+			"folderUid": "namespaceUID",
+			"rules": [{
+				"state": "inactive",
+				"name": "AlwaysFiring",
+				"folderUid": "namespaceUID",
+				"uid": "RuleUID",
+				"query": "vector(1)",
+				"queriedDatasourceUIDs": ["AUID"],
+				"alerts": [{
+					"labels": {
+						"job": "prometheus"
+					},
+					"annotations": {
+						"severity": "critical"
+					},
+					"state": "Normal",
+					"activeAt": "0001-01-01T00:00:00Z",
+					"value": ""
+				}],
+				"totals": {
+					"normal": 1
+				},
+				"totalsFiltered": {
+					"normal": 1
+				},
+				"labels": {
+					"__a_private_label_on_the_rule__": "a_value"
+				},
+				"health": "ok",
+				"isPaused": true,
+				"type": "alerting",
+				"lastEvaluation": "2022-03-10T14:01:00Z",
+				"duration": 180,
+				"keepFiringFor": 10,
+				"evaluationTime": 60
+			}],
+			"totals": {
+				"inactive": 1
+			},
+			"interval": 60,
+			"lastEvaluation": "2022-03-10T14:01:00Z",
+			"evaluationTime": 60
+		}],
+		"totals": {
+			"inactive": 1
+		}
+	}
+}
+`, folder.Fullpath), string(r.Body()))
+	})
+
+	t.Run("with a rule that has notification settings", func(t *testing.T) {
+		fakeStore, fakeAIM, api := setupAPI(t)
+		notificationSettings := ngmodels.NotificationSettings{
+			Receiver: "test-receiver",
+			GroupBy:  []string{"job"},
+		}
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery(), gen.WithNotificationSettings(notificationSettings), gen.WithIsPaused(false))
+		r := api.RouteGetRuleStatuses(c)
+		require.Equal(t, http.StatusOK, r.Status())
+		var res apimodels.RuleResponse
+		require.NoError(t, json.Unmarshal(r.Body(), &res))
+		require.NotNil(t, res.Data.RuleGroups[0].Rules[0].NotificationSettings)
+		require.Equal(t, notificationSettings.Receiver, res.Data.RuleGroups[0].Rules[0].NotificationSettings.Receiver)
+	})
+
 	t.Run("with the inclusion of internal Labels", func(t *testing.T) {
 		fakeStore, fakeAIM, api := setupAPI(t)
-		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery())
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery(), gen.WithNoNotificationSettings(), gen.WithIsPaused(false))
 		folder := fakeStore.Folders[orgID][0]
 
 		req, err := http.NewRequest("GET", "/api/v1/rules?includeInternalLabels=true", nil)
@@ -461,6 +542,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 					"__alert_rule_uid__": "RuleUID"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "2022-03-10T14:01:00Z",
 				"duration": 180,
@@ -484,7 +566,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 
 	t.Run("with a rule that has multiple queries", func(t *testing.T) {
 		fakeStore, fakeAIM, api := setupAPI(t)
-		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withExpressionsMultiQuery())
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withExpressionsMultiQuery(), gen.WithNoNotificationSettings(), gen.WithIsPaused(false))
 		folder := fakeStore.Folders[orgID][0]
 
 		r := api.RouteGetRuleStatuses(c)
@@ -525,6 +607,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 					"__a_private_label_on_the_rule__": "a_value"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "2022-03-10T14:01:00Z",
 				"duration": 180,
@@ -1684,11 +1767,11 @@ func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, Promet
 	return fakeStore, fakeAIM, api
 }
 
-func generateRuleAndInstanceWithQuery(t *testing.T, orgID int64, fakeAIM *fakeAlertInstanceManager, fakeStore *fakes.RuleStore, query ngmodels.AlertRuleMutator) {
+func generateRuleAndInstanceWithQuery(t *testing.T, orgID int64, fakeAIM *fakeAlertInstanceManager, fakeStore *fakes.RuleStore, query ngmodels.AlertRuleMutator, additionalMutators ...ngmodels.AlertRuleMutator) {
 	t.Helper()
 
 	gen := ngmodels.RuleGen
-	r := gen.With(gen.WithOrgID(orgID), asFixture(), query).GenerateRef()
+	r := gen.With(append([]ngmodels.AlertRuleMutator{gen.WithOrgID(orgID), asFixture(), query}, additionalMutators...)...).GenerateRef()
 
 	fakeAIM.GenerateAlertInstances(orgID, r.UID, 1, func(s *state.State) *state.State {
 		s.Labels = data.Labels{

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -488,6 +488,8 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		require.Equal(t, http.StatusOK, r.Status())
 		var res apimodels.RuleResponse
 		require.NoError(t, json.Unmarshal(r.Body(), &res))
+		require.Len(t, res.Data.RuleGroups, 1)
+		require.Len(t, res.Data.RuleGroups[0].Rules, 1)
 		require.NotNil(t, res.Data.RuleGroups[0].Rules[0].NotificationSettings)
 		require.Equal(t, notificationSettings.Receiver, res.Data.RuleGroups[0].Rules[0].NotificationSettings.Receiver)
 	})

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -475,6 +475,9 @@
     "health": {
      "type": "string"
     },
+    "isPaused": {
+     "type": "boolean"
+    },
     "keepFiringFor": {
      "format": "double",
      "type": "number"
@@ -491,6 +494,9 @@
     },
     "name": {
      "type": "string"
+    },
+    "notificationSettings": {
+     "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
     "queriedDatasourceUIDs": {
      "items": {
@@ -3769,6 +3775,9 @@
     "health": {
      "type": "string"
     },
+    "isPaused": {
+     "type": "boolean"
+    },
     "labels": {
      "$ref": "#/definitions/Labels"
     },
@@ -3781,6 +3790,9 @@
     },
     "name": {
      "type": "string"
+    },
+    "notificationSettings": {
+     "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
     "query": {
      "type": "string"

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -180,9 +180,11 @@ type Rule struct {
 	Health    string `json:"health"`
 	LastError string `json:"lastError,omitempty"`
 	// required: true
-	Type           string    `json:"type"`
-	LastEvaluation time.Time `json:"lastEvaluation"`
-	EvaluationTime float64   `json:"evaluationTime"`
+	Type                 string                         `json:"type"`
+	LastEvaluation       time.Time                      `json:"lastEvaluation"`
+	EvaluationTime       float64                        `json:"evaluationTime"`
+	IsPaused             bool                           `json:"isPaused"`
+	NotificationSettings *AlertRuleNotificationSettings `json:"notificationSettings,omitempty"`
 }
 
 // Alert has info for an alert.

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -475,6 +475,9 @@
     "health": {
      "type": "string"
     },
+    "isPaused": {
+     "type": "boolean"
+    },
     "keepFiringFor": {
      "format": "double",
      "type": "number"
@@ -491,6 +494,9 @@
     },
     "name": {
      "type": "string"
+    },
+    "notificationSettings": {
+     "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
     "queriedDatasourceUIDs": {
      "items": {
@@ -3769,6 +3775,9 @@
     "health": {
      "type": "string"
     },
+    "isPaused": {
+     "type": "boolean"
+    },
     "labels": {
      "$ref": "#/definitions/Labels"
     },
@@ -3781,6 +3790,9 @@
     },
     "name": {
      "type": "string"
+    },
+    "notificationSettings": {
+     "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
     "query": {
      "type": "string"
@@ -4876,6 +4888,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup",
     "type": "object"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4583,6 +4583,9 @@
         "health": {
           "type": "string"
         },
+        "isPaused": {
+          "type": "boolean"
+        },
         "keepFiringFor": {
           "type": "number",
           "format": "double"
@@ -4599,6 +4602,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "notificationSettings": {
+          "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
         "queriedDatasourceUIDs": {
           "type": "array",
@@ -7876,6 +7882,9 @@
         "health": {
           "type": "string"
         },
+        "isPaused": {
+          "type": "boolean"
+        },
         "labels": {
           "$ref": "#/definitions/Labels"
         },
@@ -7888,6 +7897,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "notificationSettings": {
+          "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
         "query": {
           "type": "string"
@@ -8976,6 +8988,7 @@
       }
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "type": "object",

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -260,6 +260,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 					"label1": "val1"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -270,6 +271,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 				"folderUid": "default",
 				"uid": "%s",
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -323,6 +325,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 					"label1": "val1"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -333,6 +336,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 				"folderUid": "default",
 				"uid": "%s",
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -483,6 +487,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 					"__panelId__": "1"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -493,6 +498,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 				"folderUid": "default",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0
@@ -530,6 +536,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 					"__panelId__": "1"
 				},
 				"health": "ok",
+				"isPaused": false,
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
 				"evaluationTime": 0

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12894,6 +12894,9 @@
         "health": {
           "type": "string"
         },
+        "isPaused": {
+          "type": "boolean"
+        },
         "keepFiringFor": {
           "type": "number",
           "format": "double"
@@ -12910,6 +12913,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "notificationSettings": {
+          "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
         "queriedDatasourceUIDs": {
           "type": "array",
@@ -20152,6 +20158,9 @@
         "health": {
           "type": "string"
         },
+        "isPaused": {
+          "type": "boolean"
+        },
         "labels": {
           "$ref": "#/definitions/Labels"
         },
@@ -20164,6 +20173,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "notificationSettings": {
+          "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
         "query": {
           "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2946,6 +2946,9 @@
           "health": {
             "type": "string"
           },
+          "isPaused": {
+            "type": "boolean"
+          },
           "keepFiringFor": {
             "format": "double",
             "type": "number"
@@ -2962,6 +2965,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "notificationSettings": {
+            "$ref": "#/components/schemas/AlertRuleNotificationSettings"
           },
           "queriedDatasourceUIDs": {
             "items": {
@@ -10207,6 +10213,9 @@
           "health": {
             "type": "string"
           },
+          "isPaused": {
+            "type": "boolean"
+          },
           "labels": {
             "$ref": "#/components/schemas/Labels"
           },
@@ -10219,6 +10228,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "notificationSettings": {
+            "$ref": "#/components/schemas/AlertRuleNotificationSettings"
           },
           "query": {
             "type": "string"


### PR DESCRIPTION
**What is this feature?**

This adds `isPaused` and `notificationSettings` to the paginated rules api to enable the paginated view of GMA rules.

**Why do we need this feature?**

These fields are used by the new list page which uses the paginated api

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
