### PR TITLE
Add prom flavor support for data source variables and export/import dashboards

### DIFF
--- a/packages/grafana-data/src/utils/matchPluginId.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.ts
@@ -16,7 +16,7 @@ export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
   return false;
 }
 
-export function isPromFlavor(pluginId: string): boolean {
+function isPromFlavor(pluginId: string): boolean {
   const regex = new RegExp('grafana-.*prometheus-datasource');
   return regex.test(pluginId);
 }

--- a/packages/grafana-data/src/utils/matchPluginId.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.ts
@@ -5,9 +5,18 @@ export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
     return true;
   }
 
+  if (idToMatch === 'prometheus') {
+   return isPromFlavor(pluginMeta.id);
+  }
+
   if (pluginMeta.aliasIDs) {
     return pluginMeta.aliasIDs.includes(idToMatch);
   }
 
   return false;
+}
+
+export function isPromFlavor(pluginId: string): boolean {
+  const regex = new RegExp('grafana-.*prometheus-datasource');
+  return regex.test(pluginId);
 }

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,13 +1,12 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { DataSourceRef, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
+import { DataSourceRef, matchPluginId, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import config from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { variableRegex } from 'app/features/variables/utils';
 
-import { isPromFlavor } from '../../../../../../packages/grafana-data/src/utils/matchPluginId';
 import { isPanelModelLibraryPanel } from '../../../library-panels/guard';
 import { LibraryElementKind } from '../../../library-panels/types';
 import { DashboardJson } from '../../../manage-dashboards/types';
@@ -134,7 +133,7 @@ export class DashboardExporter {
           let dataSourceName = ds.meta?.name;
           let dataSourceVersion = ds.meta.info.version || '1.0.0';
           // if this is a prom flavored data source (azure prom/ aws prom) it will be treated as a prom data source
-          if (isPromFlavor(ds.meta?.id)) {
+          if (matchPluginId('prometheus', ds.meta)) {
             dataSourceId = 'prometheus';
             dataSourceName = 'Prometheus'
             dataSourceVersion = '1.0.0';

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -29,6 +29,8 @@ import {
 } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 
+import { isPromFlavor } from '../../../../packages/grafana-data/src/utils/matchPluginId';
+
 import { importDataSourcePlugin } from './plugin_loader';
 
 // TODO: remove once a decision on how to match compatible datasources has been made
@@ -309,7 +311,7 @@ export class DatasourceSrv implements DataSourceService {
       }
     }
 
-    const sorted = base.sort((a, b) => {
+    let sorted = base.sort((a, b) => {
       if (a.name.toLowerCase() > b.name.toLowerCase()) {
         return 1;
       }
@@ -340,6 +342,12 @@ export class DatasourceSrv implements DataSourceService {
           base.push(grafanaInstanceSettings);
         }
       }
+    }
+
+    if (!filters.pluginId) {
+      sorted = sorted.filter((x) => {
+        return isPromFlavor(x.meta.id)
+      });
     }
 
     return sorted;

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -29,8 +29,6 @@ import {
 } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 
-import { isPromFlavor } from '../../../../packages/grafana-data/src/utils/matchPluginId';
-
 import { importDataSourcePlugin } from './plugin_loader';
 
 // TODO: remove once a decision on how to match compatible datasources has been made
@@ -346,7 +344,7 @@ export class DatasourceSrv implements DataSourceService {
 
     if (!filters.pluginId) {
       sorted = sorted.filter((x) => {
-        return isPromFlavor(x.meta.id)
+        return matchPluginId('prometheus', x.meta);
       });
     }
 


### PR DESCRIPTION
Different flavors of prom will be imported/exported as prometheus when importing/exporting dashboards.
Data source variables will treat different flavors of prom as prometheus