### PR TITLE
K8s: Revert change around full path

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -107,8 +106,7 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		paging.page = 1
 	}
 
-	// only admins can add this to the query, otherwise we may return parent folder names that are not visible to the user
-	if user.GetOrgRole() == org.RoleAdmin && options.LabelSelector != nil && options.LabelSelector.Matches(labels.Set{utils.LabelGetFullpath: "true"}) {
+	if options.LabelSelector != nil && options.LabelSelector.Matches(labels.Set{utils.LabelGetFullpath: "true"}) {
 		query.WithFullpath = true
 		query.WithFullpathUIDs = true
 	}


### PR DESCRIPTION
We originally coupled the change to not allowing users to see the fullpath with the kubernetes workflow. This is causing significant performance issues, so we will revisit how to make this change at a later date without performance regressions.

This PR changes the functionality to be the same that is on main.