### PR TITLE
OpionsPane: Minor padding fix

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor.tsx
@@ -61,7 +61,7 @@ export class OptionsPaneCategoryDescriptor {
 
     if (this.props.title === '') {
       return (
-        <Box padding={2} key={this.props.title}>
+        <Box padding={2} paddingBottom={1} key={this.props.title}>
           {this.items.map((item) => item.render(searchQuery))}
         </Box>
       );


### PR DESCRIPTION

Very subtle 8px fix to the bottom padding of the "category" at the top of the dashboard edit pane. This aligns it with the spacing of normal categories (the ones with header) 

![Screenshot 2025-04-03 at 11 28 48](https://github.com/user-attachments/assets/a2f1d3bf-f5de-4683-9e36-90c7ab90c0f3)

