### PR TITLE
Provisioning: Ensure path to file exists in Files endpoints

### DIFF
--- a/pkg/registry/apis/provisioning/resources/id.go
+++ b/pkg/registry/apis/provisioning/resources/id.go
@@ -92,12 +92,12 @@ func appendHashSuffix(hashKey, repositoryName string) func(string) string {
 }
 
 // Will pick a name based on the hashed repository and path
-func NamesFromHashedRepoPath(repo string, fpath string) (string, string) {
+func FileNameFromHashedRepoPath(repo string, fpath string) string {
 	// Remove the extension: we don't want the extension to impact the ID. This lets the user change between all supported formats.
 	fpath = safepath.RemoveExt(fpath)
 	hasher := appendHashSuffix(fpath, repo)
 
-	return hasher(safepath.Base(fpath)), hasher(strings.Trim(safepath.Dir(fpath), "/"))
+	return hasher(safepath.Base(fpath))
 }
 
 // Folder contains the data for a folder we use in provisioning.

--- a/pkg/registry/apis/provisioning/resources/id_test.go
+++ b/pkg/registry/apis/provisioning/resources/id_test.go
@@ -67,18 +67,11 @@ func TestAppendHashSuffix(t *testing.T) {
 	}
 }
 
-func TestNamesFromHashedRepoPath(t *testing.T) {
-	dashName, folderName := NamesFromHashedRepoPath("xyz", "path/to/folder/dashboard.json")
+func TestFileNameFromHashedRepoPath(t *testing.T) {
+	dashName := FileNameFromHashedRepoPath("xyz", "path/to/folder/dashboard.json")
 	assert.Equal(t, "dashboard-fy2kflbmskvt6u-9uecoahd1ekwbb7", dashName, "dashboard name of dashboard.json")
-	assert.Equal(t, "path-to-folder-3ehfurpmbvs4yxfp7a0r2uskr", folderName, "folder name of dashboard.json")
 	// We only want 40 characters because UIDs support no more. When we get rid of legacy storage, we can extend the support to 253 character long strings.
 	assert.LessOrEqual(t, len(dashName), 40, "dashName after hashing needs to be <=40 chars long")
-	assert.LessOrEqual(t, len(folderName), 40, "folderName after hashing needs to be <=40 chars long")
-
-	name1, f1 := NamesFromHashedRepoPath("xyz", "path/to/folder.json")
-	name2, f2 := NamesFromHashedRepoPath("xyz", "path/to/folder")
-	assert.Equal(t, name1, name2, "folder.json should have same object name as folder (no extension)")
-	assert.Equal(t, f1, f2, "folder.json and folder should have same folder name as each other")
 }
 
 func TestParseFolderID(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/safepath"
 )
 
 var (
@@ -169,10 +170,14 @@ func (r *Parser) Parse(ctx context.Context, info *repository.FileInfo, validate 
 
 	// Calculate name+folder from the file path
 	if info.Path != "" {
-		objName, folderName := NamesFromHashedRepoPath(r.repo.Name, info.Path)
-		parsed.Meta.SetFolder(folderName)
+		objName := FileNameFromHashedRepoPath(r.repo.Name, info.Path)
 		if obj.GetName() == "" {
 			obj.SetName(objName) // use the name saved in config
+		}
+
+		dirPath := safepath.Dir(info.Path)
+		if dirPath != "" {
+			parsed.Meta.SetFolder(ParseFolder(dirPath, r.repo.Name).ID)
 		}
 	}
 	obj.SetUID("")             // clear identifiers

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -189,7 +189,7 @@ func (r *ResourcesManager) RemoveResourceFromFile(ctx context.Context, path stri
 	objName := obj.GetName()
 	if objName == "" {
 		// Find the referenced file
-		objName, _ = NamesFromHashedRepoPath(r.repo.Config().Name, path)
+		objName = FileNameFromHashedRepoPath(r.repo.Config().Name, path)
 	}
 
 	client, _, err := r.clients.ForKind(*gvk)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensure path to file exists in `/files` APIs. Also fixed a bug in which the folder name in sync and files API.


**Why do we need this feature?**

`/files` API can accept a file path within the repository that points to files located in nested directories (e.g., `/files/dir1/dir2/file.txt`). Currently, this API will only work for files that are located in the root directory of the repository.

**Who is this feature for?**

Users of Provisioning / Git Sync.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/103295

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


## Example payload

```bash
curl -X 'POST' \
  'http://localhost:3000/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/github-demo-2/files/dir1%2Fdir2%2Fdir3%2Fdeepinside.json' \
  -H 'accept: */*' \
  -H 'Content-Type: application/json' \
  -d '{
  "apiVersion": "dashboard.grafana.app/v1alpha1",
  "kind": "Dashboard",
  "spec": {
    "annotations": {
      "list": [
        {
          "builtIn": 1,
          "datasource": {
            "type": "grafana",
            "uid": "-- Grafana --"
          },
          "enable": true,
          "hide": true,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "type": "dashboard"
        }
      ]
    },
    "editable": true,
    "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
    "links": [],
    "panels": [],
    "preload": false,
    "schemaVersion": 41,
    "tags": [],
    "templating": {
      "list": []
    },
    "time": {
      "from": "now-6h",
      "to": "now"
    },
    "timepicker": {},
    "timezone": "browser",
    "title": "deepinside"
  }
}'

```


Response: 

```json

{
  "kind": "ResourceWrapper",
  "apiVersion": "provisioning.grafana.app/v0alpha1",
  "path": "dir1/dir2/dir3/deepinside.json",
  "repository": {
    "type": "github",
    "title": "Github UI Sync Demo",
    "namespace": "default",
    "name": "github-demo-2"
  },
  "urls": {
    "sourceURL": "https://github.com/grafana/git-ui-sync-demo/blob/robertoonboarding/dir1/dir2/dir3/deepinside.json",
    "repositoryURL": "https://github.com/grafana/git-ui-sync-demo"
  },
  "resource": {
    "type": {
      "group": "dashboard.grafana.app",
      "version": "v1alpha1",
      "kind": "Dashboard",
      "resource": "dashboards"
    },
    "file": {
      "apiVersion": "dashboard.grafana.app/v1alpha1",
      "kind": "Dashboard",
      "metadata": {
        "annotations": {
          "grafana.app/folder": "dir3-vunp88u2ssnrp6pibssvjh2nd9jpe9g22ve",
          "grafana.app/managedBy": "repo",
          "grafana.app/managerId": "github-demo-2",
          "grafana.app/sourcePath": "dir1/dir2/dir3/deepinside.json"
        },
        "name": "deepinside-ahlfsmqqixfsztpni2nys-md0w4ro",
        "namespace": "default"
      },
      "spec": {
        "annotations": {
          "list": [
            {
              "builtIn": 1,
              "datasource": {
                "type": "grafana",
                "uid": "-- Grafana --"
              },
              "enable": true,
              "hide": true,
              "iconColor": "rgba(0, 211, 255, 1)",
              "name": "Annotations & Alerts",
              "type": "dashboard"
            }
          ]
        },
        "editable": true,
        "fiscalYearStartMonth": 0,
        "graphTooltip": 0,
        "links": [],
        "panels": [],
        "preload": false,
        "schemaVersion": 41,
        "tags": [],
        "templating": {
          "list": []
        },
        "time": {
          "from": "now-6h",
          "to": "now"
        },
        "timepicker": {},
        "timezone": "browser",
        "title": "deepinside"
      }
    },
    "existing": null,
    "action": "create",
    "dryRun": null,
    "upsert": {
      "apiVersion": "dashboard.grafana.app/v1alpha1",
      "kind": "Dashboard",
      "metadata": {
        "annotations": {
          "grafana.app/createdBy": "user:dehhdv7fkc45cf",
          "grafana.app/folder": "dir3-vunp88u2ssnrp6pibssvjh2nd9jpe9g22ve",
          "grafana.app/managedBy": "repo",
          "grafana.app/managerId": "github-demo-2",
          "grafana.app/sourcePath": "dir1/dir2/dir3/deepinside.json"
        },
        "creationTimestamp": "2025-04-03T11:11:48Z",
        "generation": 1,
        "labels": {
          "grafana.app/deprecatedInternalID": "2730251385135104"
        },
        "managedFields": [
          {
            "apiVersion": "dashboard.grafana.app/v1alpha1",
            "fieldsType": "FieldsV1",
            "fieldsV1": {
              "f:metadata": {
                "f:annotations": {
                  ".": {},
                  "f:grafana.app/folder": {},
                  "f:grafana.app/managedBy": {},
                  "f:grafana.app/managerId": {},
                  "f:grafana.app/sourcePath": {}
                }
              },
              "f:spec": {
                "f:annotations": {
                  ".": {},
                  "f:list": {}
                },
                "f:editable": {},
                "f:fiscalYearStartMonth": {},
                "f:graphTooltip": {},
                "f:links": {},
                "f:panels": {},
                "f:preload": {},
                "f:schemaVersion": {},
                "f:tags": {},
                "f:templating": {
                  ".": {},
                  "f:list": {}
                },
                "f:time": {
                  ".": {},
                  "f:from": {},
                  "f:to": {}
                },
                "f:timepicker": {},
                "f:timezone": {},
                "f:title": {}
              }
            },
            "manager": "grafana",
            "operation": "Update",
            "time": "2025-04-03T11:11:48Z"
          }
        ],
        "name": "deepinside-ahlfsmqqixfsztpni2nys-md0w4ro",
        "namespace": "default",
        "resourceVersion": "1743678708865007",
        "uid": "9eb55d15-2a7e-4ce6-ada5-1dc182568551"
      },
      "spec": {
        "annotations": {
          "list": [
            {
              "builtIn": 1,
              "datasource": {
                "type": "grafana",
                "uid": "-- Grafana --"
              },
              "enable": true,
              "hide": true,
              "iconColor": "rgba(0, 211, 255, 1)",
              "name": "Annotations & Alerts",
              "type": "dashboard"
            }
          ]
        },
        "editable": true,
        "fiscalYearStartMonth": 0,
        "graphTooltip": 0,
        "links": [],
        "panels": [],
        "preload": false,
        "schemaVersion": 41,
        "tags": [],
        "templating": {
          "list": []
        },
        "time": {
          "from": "now-6h",
          "to": "now"
        },
        "timepicker": {},
        "timezone": "browser",
        "title": "deepinside"
      },
      "status": {}
    }
  }
}
```
Result: 

![image](https://github.com/user-attachments/assets/e342841e-214a-460f-a016-6b90ad5f8b6c)


