### PR TITLE
Theming: Subtle borders around dark buttons

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -115,7 +115,7 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   primary = {
     main: palette.blueDarkMain,
     text: palette.blueDarkText,
-    border: palette.blueDarkText,
+    border: palette.blueDarkBorder,
   };
 
   secondary = {
@@ -132,16 +132,19 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   error = {
     main: palette.redDarkMain,
     text: palette.redDarkText,
+    border: palette.redDarkBorder,
   };
 
   success = {
     main: palette.greenDarkMain,
     text: palette.greenDarkText,
+    border: palette.greenDarkBorder,
   };
 
   warning = {
     main: palette.orangeDarkMain,
     text: palette.orangeDarkText,
+    border: palette.orangeDarkBorder,
   };
 
   background = {
@@ -252,7 +255,7 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
 
   contrastThreshold = 3;
   hoverFactor = 0.03;
-  tonalOffset = 0.2;
+  tonalOffset = 0.25;
 }
 
 export function createColors(colors: ThemeColorsInput): ThemeColors {

--- a/packages/grafana-data/src/themes/palette.ts
+++ b/packages/grafana-data/src/themes/palette.ts
@@ -24,14 +24,21 @@ export const palette = {
   // from figma
   lightBorder1: '#e4e7e7',
 
-  blueDarkMain: '#3d71d9', // '#4165F5',
-  blueDarkText: '#6e9fff', // '#58a6ff', //'#33a2e5', // '#5790FF',
+  blueDarkMain: '#3d71d9',
+  blueDarkText: '#A2C1FF',
+  blueDarkBorder: '#5589EE',
+
   redDarkMain: '#d10e5c',
-  redDarkText: '#ff5286',
+  redDarkText: '#FF80A6',
+  redDarkBorder: '#F14276',
+
   greenDarkMain: '#1a7f4b',
-  greenDarkText: '#6ccf8e',
+  greenDarkText: '#79D498',
+  greenDarkBorder: '#3D9A5D',
+
   orangeDarkMain: '#ff9900',
-  orangeDarkText: '#fbad37',
+  orangeDarkText: '#FFC670',
+  orangeDarkBorder: '#FFAE34',
 
   blueLightMain: '#3871dc',
   blueLightText: '#1f62e0',

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -270,8 +270,8 @@ export const getButtonStyles = (props: StyleProps) => {
 
 function getButtonVariantStyles(theme: GrafanaTheme2, color: ThemeRichColor, fill: ButtonFill) {
   let outlineBorderColor = color.border;
-  let borderColor = 'transparent';
-  let hoverBorderColor = 'transparent';
+  let borderColor = theme.isDark ? color.border : 'transparent';
+  let hoverBorderColor = theme.isDark ? color.border : 'transparent';
 
   // Secondary button has some special rules as we lack theem color token to
   // specify border color for normal button vs border color for outline button


### PR DESCRIPTION
This change came out some explorations with @EdPoole when trying to solve https://github.com/grafana/grafana/pull/103255 

We noticed that in dark themes the buttons look a bit better and more consistent if they have a subtle visible border (like secondary button). We did no feel the same about light theme so keeping it only for dark theme for now. 

changes 

* New text colors for primary, warning, error, success  (impacts text link as well as it's using primary.text) 
* New border colors for primary, warning, error, success 

Before:
![Screenshot 2025-04-03 at 13 30 03](https://github.com/user-attachments/assets/c58f1fc4-8ca6-4da6-a2d9-be9c87a08cb8)

After: 
![Screenshot 2025-04-03 at 13 26 06](https://github.com/user-attachments/assets/03e19c6a-d34a-4244-95bf-b65b58577688)


Text Links before:
![Screenshot 2025-04-03 at 13 29 56](https://github.com/user-attachments/assets/69e85fbc-3189-48b1-aeb2-5de2bd148910)

Text links after:
![Screenshot 2025-04-03 at 13 26 37](https://github.com/user-attachments/assets/1a1c8684-7d9f-47ff-87c7-25162f17cf22)

