### PR TITLE
Dynamic dashboards: Use addNewRow and addNewTab when duplicating rows and tabs

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -90,8 +90,7 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
 
   public duplicateRow(row: RowItem) {
     const newRow = row.duplicate();
-    this.setState({ rows: [...this.state.rows, newRow] });
-    this.publishEvent(new NewObjectAddedToCanvasEvent(newRow), true);
+    this.addNewRow(newRow);
   }
 
   public addNewRow(row?: RowItem): RowItem {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -70,7 +70,7 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
 
   public duplicateTab(tab: TabItem) {
     const newTab = tab.duplicate();
-    this.setState({ tabs: [...this.state.tabs, newTab] });
+    this.addNewTab(newTab);
   }
 
   public getUrlState() {


### PR DESCRIPTION
**What is this feature?**

Duplicate rows and tabs should use the `addNewRow` and `addNewTab` methods of the managers instead of adding them directly to the state.

This will make sure we're sending events and deduplicating titles correctly.