### PR TITLE
Extensions: Fix a bug with the observable APIs

### DIFF
--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -54,15 +54,13 @@ export const getObservablePluginExtensions = (
 
 export const getObservablePluginLinks: GetObservablePluginLinks = (options) => {
   return getObservablePluginExtensions(options).pipe(
-    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.link)),
-    filter((extensions) => extensions.length > 0)
+    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.link))
   );
 };
 
 export const getObservablePluginComponents: GetObservablePluginComponents = (options) => {
   return getObservablePluginExtensions(options).pipe(
-    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.component)),
-    filter((extensions) => extensions.length > 0)
+    map((value) => value.extensions.filter((extension) => extension.type === PluginExtensionTypes.component))
   );
 };
 


### PR DESCRIPTION
### What changed?
We were filtering out emits from the observables that would have emitted an empty array of extensions (link or component). This seemed to be fine, but actually causes issues in cases when there are no extensions registered to an extension point,  as the observable never emits anything.