### PR TITLE
Correlations: Handle undefined field in logfmt

### DIFF
--- a/public/app/features/correlations/transformations.ts
+++ b/public/app/features/correlations/transformations.ts
@@ -22,7 +22,7 @@ export const getTransformationVars = (
         transformVal[transformation.mapValue || fieldName] = match[1] || match[0];
       }
     }
-  } else if (transformation.type === SupportedTransformationType.Logfmt) {
+  } else if (transformation.type === SupportedTransformationType.Logfmt && fieldValue !== undefined) {
     transformVal = logfmt.parse(fieldValue);
   }
 


### PR DESCRIPTION
**What is this feature?**

When configuring a correlation, one may mistype or otherwise misconfigure a transformation to be performed on a field that doesn't exist. This causes the entirety of Explore to crash when using the datasource with the misconfigured correlation.

**Why do we need this feature?**

So a misconfigured correlation doesn't crash explore.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
