### PR TITLE
Fix subpixel rendering of NavToolbarSeparator

### DIFF
--- a/public/app/core/components/AppChrome/NavToolbar/NavToolbarSeparator.tsx
+++ b/public/app/core/components/AppChrome/NavToolbar/NavToolbarSeparator.tsx
@@ -28,6 +28,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       width: 1,
       backgroundColor: theme.colors.border.medium,
       height: 24,
+      flexShrink: 0,
+      flexGrow: 0,
     }),
   };
 };


### PR DESCRIPTION
This PR prevents the `NavToolbarSeparator` rendering on half-pixels. As it's in a flex container, we need to prevent it from shrinking below 1px in width.

Before:
![CleanShot 2025-04-03 at 15 58 36@2x](https://github.com/user-attachments/assets/e437e650-7674-40e5-b00c-930fc5b84d0f)

After:
![CleanShot 2025-04-03 at 15 58 55@2x](https://github.com/user-attachments/assets/f5feafa7-beaf-4944-a14a-87dbf5a2af8f)
