### PR TITLE
authinfoimpl: Fix TestIntegrationAuthInfoStore when running on Spanner.

### DIFF
--- a/pkg/services/login/authinfoimpl/store_test.go
+++ b/pkg/services/login/authinfoimpl/store_test.go
@@ -50,7 +50,10 @@ func TestIntegrationAuthInfoStore(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, labels, 2)
 
-		require.Equal(t, login.AzureADAuthModule, labels[1])
+		// There is no guarantee that user with user_id=1 gets "oauth_azuread" or "ldap".
+		// Both are valid results for the query (basically SELECT * FROM `user_auth` WHERE `user_id` IN (1,2) ORDER BY created),
+		// Spanner emulator will randomize its output, so test cannot rely on the ordering (other than "Created" column, which is equal here).
+		require.True(t, labels[1] == login.AzureADAuthModule || labels[1] == login.LDAPAuthModule)
 		require.Equal(t, login.GoogleAuthModule, labels[2])
 	})
 


### PR DESCRIPTION
This PR fixes `TestIntegrationAuthInfoStore/should be able to auth lables for users` to not rely on unspecified ordering. This is visible when running the test on Spanner, which randomizes output from SELECT (but still respecting ORDER BY).