### PR TITLE
UniStore: Add non interactive mode for CLI migration

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -148,6 +148,13 @@ var adminCommands = []*cli.Command{
 				Name:   "to-unified-storage",
 				Usage:  "Migrates classic SQL data into unified storage",
 				Action: runDbCommand(datamigrations.ToUnifiedStorage),
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "non-interactive",
+						Usage: "Non interactive mode. Just run the migration.",
+						Value: false,
+					},
+				},
 			},
 		},
 	},

--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
@@ -67,6 +67,26 @@ func ToUnifiedStorage(c utils.CommandLine, cfg *setting.Cfg, sqlStore db.DB) err
 		nil, provisioning, sort.ProvideService(),
 	)
 
+	if c.Bool("non-interactive") {
+		client, err := newUnifiedClient(cfg, sqlStore)
+		if err != nil {
+			return err
+		}
+
+		opts.Store = client
+		opts.BlobStore = client
+		rsp, err := migrator.Migrate(ctx, opts)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Unified storage export: %s\n", time.Since(start))
+		if rsp != nil {
+			jj, _ := json.MarshalIndent(rsp, "", "  ")
+			fmt.Printf("%s\n", string(jj))
+		}
+		return nil
+	}
+
 	yes, err := promptYesNo(fmt.Sprintf("Count legacy resources for namespace: %s?", opts.Namespace))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR introduces a non-interactive mode for the `grafana cli admin datamigration to-unified-storage` migration.

**Why do we need this feature?**

The goal is to make it easier for running the command as part of scripts and automation

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/search-and-storage-team/issues/227

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
