### PR TITLE
Alerting: Import UI - Add folder creation & add to new list view

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1823,11 +1823,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
-    "public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
-    ],
     "public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],

--- a/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
+++ b/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
@@ -1,0 +1,108 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Button, Field, Input, Label, Modal, Stack, useStyles2 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/core';
+import { Trans, t } from 'app/core/internationalization';
+import { useNewFolderMutation } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
+import { AccessControlAction } from 'app/types';
+
+import { Folder } from '../../types/rule-form';
+
+export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => void }) => {
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const handleCreate = (folder: Folder) => {
+    onCreate(folder);
+    setIsCreatingFolder(false);
+  };
+  return (
+    <>
+      <Button
+        onClick={() => setIsCreatingFolder(true)}
+        type="button"
+        icon="plus"
+        fill="outline"
+        variant="secondary"
+        disabled={!contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
+      >
+        <Trans i18nKey="alerting.rule-form.folder.new-folder">New folder</Trans>
+      </Button>
+      {isCreatingFolder && <FolderCreationModal onCreate={handleCreate} onClose={() => setIsCreatingFolder(false)} />}
+    </>
+  );
+};
+
+function FolderCreationModal({
+  onClose,
+  onCreate,
+}: {
+  onClose: () => void;
+  onCreate: (folder: Folder) => void;
+}): React.ReactElement {
+  const styles = useStyles2(getStyles);
+  const notifyApp = useAppNotification();
+  const [title, setTitle] = useState('');
+  const [createFolder] = useNewFolderMutation();
+
+  const onSubmit = async () => {
+    const { data, error } = await createFolder({ title });
+
+    if (error) {
+      notifyApp.error('Failed to create folder');
+    } else if (data) {
+      onCreate({ title: data.title, uid: data.uid });
+      notifyApp.success('Folder created');
+    }
+  };
+
+  return (
+    <Modal
+      className={styles.modal}
+      isOpen={true}
+      title={t('alerting.folder-creation-modal.title-new-folder', 'New folder')}
+      onDismiss={onClose}
+      onClickBackdrop={onClose}
+    >
+      <Stack direction="column" gap={2}>
+        <Field
+          label={
+            <Label htmlFor="folder">
+              <Trans i18nKey="alerting.rule-form.folder.name">Folder name</Trans>
+            </Label>
+          }
+        >
+          <Input
+            data-testid={selectors.components.AlertRules.newFolderNameField}
+            autoFocus={true}
+            id="folderName"
+            placeholder={t('alerting.folder-creation-modal.placeholder-enter-a-name', 'Enter a name')}
+            value={title}
+            onChange={(e) => setTitle(e.currentTarget.value)}
+          />
+        </Field>
+
+        <Modal.ButtonRow>
+          <Button variant="secondary" type="button" onClick={onClose}>
+            <Trans i18nKey="alerting.rule-form.folder.cancel">Cancel</Trans>
+          </Button>
+          <Button
+            onClick={onSubmit}
+            disabled={!title}
+            data-testid={selectors.components.AlertRules.newFolderNameCreateButton}
+          >
+            <Trans i18nKey="alerting.rule-form.folder.create">Create</Trans>
+          </Button>
+        </Modal.ButtonRow>
+      </Stack>
+    </Modal>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modal: css({
+    width: `${theme.breakpoints.values.sm}px`,
+  }),
+});

--- a/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
+++ b/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
@@ -31,7 +31,7 @@ export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => vo
         variant="secondary"
         disabled={!contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
       >
-        <Trans i18nKey="alerting.rule-form.folder.new-folder">New folder</Trans>
+        <Trans i18nKey="alerting.create-new-folder.new-folder">New folder</Trans>
       </Button>
       {isCreatingFolder && <FolderCreationModal onCreate={handleCreate} onClose={() => setIsCreatingFolder(false)} />}
     </>
@@ -65,7 +65,7 @@ function FolderCreationModal({
     <Modal
       className={styles.modal}
       isOpen
-      title={t('alerting.folder-creation-modal.title-new-folder', 'New folder')}
+      title={t('alerting.create-new-folder.title-new-folder', 'New folder')}
       onDismiss={onClose}
       onClickBackdrop={onClose}
     >
@@ -73,7 +73,7 @@ function FolderCreationModal({
         <Field
           label={
             <Label htmlFor="folder">
-              <Trans i18nKey="alerting.rule-form.folder.name">Folder name</Trans>
+              <Trans i18nKey="alerting.create-new-folder.folder.name">Folder name</Trans>
             </Label>
           }
         >
@@ -81,7 +81,7 @@ function FolderCreationModal({
             data-testid={selectors.components.AlertRules.newFolderNameField}
             autoFocus={true}
             id="folderName"
-            placeholder={t('alerting.folder-creation-modal.placeholder-enter-a-name', 'Enter a name')}
+            placeholder={t('alerting.create-new-folder.placeholder-enter-a-name', 'Enter a name')}
             value={title}
             onChange={(e) => setTitle(e.currentTarget.value)}
           />
@@ -89,14 +89,14 @@ function FolderCreationModal({
 
         <Modal.ButtonRow>
           <Button variant="secondary" type="button" onClick={onClose}>
-            <Trans i18nKey="alerting.rule-form.folder.cancel">Cancel</Trans>
+            <Trans i18nKey="alerting.create-new-folder.folder.cancel">Cancel</Trans>
           </Button>
           <Button
             onClick={onSubmit}
             disabled={!title}
             data-testid={selectors.components.AlertRules.newFolderNameCreateButton}
           >
-            <Trans i18nKey="alerting.rule-form.folder.create">Create</Trans>
+            <Trans i18nKey="alerting.create-new-folder.folder.create">Create</Trans>
           </Button>
         </Modal.ButtonRow>
       </Stack>

--- a/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
+++ b/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
@@ -12,6 +12,9 @@ import { AccessControlAction } from 'app/types';
 
 import { Folder } from '../../types/rule-form';
 
+/**
+ * Provides a button and associated modal for creating a new folder
+ */
 export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => void }) => {
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const handleCreate = (folder: Folder) => {
@@ -61,7 +64,7 @@ function FolderCreationModal({
   return (
     <Modal
       className={styles.modal}
-      isOpen={true}
+      isOpen
       title={t('alerting.folder-creation-modal.title-new-folder', 'New folder')}
       onDismiss={onClose}
       onClickBackdrop={onClose}

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -90,7 +90,7 @@ export const ConfirmConversionModal = ({ isOpen, onDismiss }: ModalProps) => {
       confirmButtonVariant="primary"
       body={
         <Stack direction="column" gap={2}>
-          <Alert title={t('alerting.confirm-conversion-modal.title-warning', 'Warning')} severity="warning">
+          <Alert title={t('alerting.to-gma.confirm-modal.title-warning', 'Warning')} severity="warning">
             <Text variant="body">
               <Trans i18nKey="alerting.to-gma.confirm-modal.body">
                 If the target folder is not empty, some rules may be overwritten or removed. Are you sure you want to

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -4,7 +4,7 @@ import { ComponentProps } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { locationService } from '@grafana/runtime';
-import { Alert, CodeEditor, ConfirmModal, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, CodeEditor, ConfirmModal, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { Trans, t } from 'app/core/internationalization';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
@@ -47,7 +47,6 @@ export const ConfirmConversionModal = ({ isOpen, onDismiss }: ModalProps) => {
   const [convert] = convertToGMAApi.useConvertToGMAMutation();
   const notifyApp = useAppNotification();
   const rulerRulesToPayload = filterRulerRulesConfig(rulerRules, namespace, ruleGroup);
-  debugger;
 
   async function onConvertConfirm() {
     try {

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -4,7 +4,7 @@ import { ComponentProps } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { locationService } from '@grafana/runtime';
-import { CodeEditor, ConfirmModal, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, CodeEditor, ConfirmModal, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { Trans, t } from 'app/core/internationalization';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
@@ -47,6 +47,7 @@ export const ConfirmConversionModal = ({ isOpen, onDismiss }: ModalProps) => {
   const [convert] = convertToGMAApi.useConvertToGMAMutation();
   const notifyApp = useAppNotification();
   const rulerRulesToPayload = filterRulerRulesConfig(rulerRules, namespace, ruleGroup);
+  debugger;
 
   async function onConvertConfirm() {
     try {
@@ -90,15 +91,14 @@ export const ConfirmConversionModal = ({ isOpen, onDismiss }: ModalProps) => {
       confirmButtonVariant="primary"
       body={
         <Stack direction="column" gap={2}>
-          <Stack direction="row" gap={1} alignItems={'self-start'}>
-            <Text color="warning">
-              <Icon name="exclamation-triangle" />
+          <Alert title={t('alerting.confirm-conversion-modal.title-warning', 'Warning')} severity="warning">
+            <Text variant="body">
+              <Trans i18nKey="alerting.to-gma.confirm-modal.body">
+                If the target folder is not empty, some rules may be overwritten or removed. Are you sure you want to
+                import these alert rules to Grafana-managed rules?
+              </Trans>
             </Text>
-            <Trans i18nKey="alerting.to-gma.confirm-modal.body">
-              If the target folder is not empty, some rules may be overwritten or removed. Are you sure you want to
-              import these alert rules to Grafana-managed rules?
-            </Trans>
-          </Stack>
+          </Alert>
           <Text variant="h6">
             <Trans i18nKey="alerting.to-gma.confirm-modal.summary">
               These are the list of rules that will be imported:

--- a/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
@@ -1,19 +1,12 @@
-import { css } from '@emotion/css';
-import * as React from 'react';
 import { useCallback, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
-import { Button, Field, Input, Label, Modal, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Field, Label, Stack } from '@grafana/ui';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
-import { useAppNotification } from 'app/core/copy/appNotification';
-import { contextSrv } from 'app/core/services/context_srv';
-import { useNewFolderMutation } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
-import { AccessControlAction } from 'app/types';
 
 import { Trans } from '../../../../../core/internationalization/index';
 import { Folder, RuleFormValues } from '../../types/rule-form';
+import { CreateNewFolder } from '../create-folder/CreateNewFolder';
 
 export function FolderSelector() {
   const {
@@ -26,161 +19,55 @@ export function FolderSelector() {
     setValue('group', '');
   }, [setValue]);
 
-  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const folder = watch('folder');
-
-  const onOpenFolderCreationModal = () => setIsCreatingFolder(true);
 
   const handleFolderCreation = (folder: Folder) => {
     resetGroup();
     setValue('folder', folder);
-    setIsCreatingFolder(false);
   };
 
   return (
-    <>
-      <Stack alignItems="center">
-        {
-          <Field
-            label={
-              <Label htmlFor="folder" description={'Select a folder to store your rule in.'}>
-                <Trans i18nKey="alerting.rule-form.folder.label">Folder</Trans>
-              </Label>
-            }
-            error={errors.folder?.message}
-            data-testid="folder-picker"
-          >
-            <Stack direction="row" alignItems="center">
-              {(!isCreatingFolder && (
-                <>
-                  <Controller
-                    render={({ field: { ref, ...field } }) => (
-                      <div style={{ width: 420 }}>
-                        <NestedFolderPicker
-                          showRootFolder={false}
-                          invalid={!!errors.folder?.message}
-                          {...field}
-                          value={folder?.uid}
-                          onChange={(uid, title) => {
-                            if (uid && title) {
-                              setValue('folder', { title, uid });
-                            } else {
-                              setValue('folder', undefined);
-                            }
+    <Stack alignItems="center">
+      {
+        <Field
+          label={
+            <Label htmlFor="folder" description={'Select a folder to store your rule in.'}>
+              <Trans i18nKey="alerting.rule-form.folder.label">Folder</Trans>
+            </Label>
+          }
+          error={errors.folder?.message}
+          data-testid="folder-picker"
+        >
+          <Stack direction="row" alignItems="center">
+            <Controller
+              render={({ field: { ref, ...field } }) => (
+                <div style={{ width: 420 }}>
+                  <NestedFolderPicker
+                    showRootFolder={false}
+                    invalid={!!errors.folder?.message}
+                    {...field}
+                    value={folder?.uid}
+                    onChange={(uid, title) => {
+                      if (uid && title) {
+                        setValue('folder', { title, uid });
+                      } else {
+                        setValue('folder', undefined);
+                      }
 
-                            resetGroup();
-                          }}
-                        />
-                      </div>
-                    )}
-                    name="folder"
-                    rules={{
-                      required: { value: true, message: 'Select a folder' },
+                      resetGroup();
                     }}
                   />
-                  <Text color="secondary">
-                    <Trans i18nKey="alerting.rule-form.folder.new-folder-or">or</Trans>
-                  </Text>
-                  <Button
-                    onClick={onOpenFolderCreationModal}
-                    type="button"
-                    icon="plus"
-                    fill="outline"
-                    variant="secondary"
-                    disabled={!contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
-                    data-testid={selectors.components.AlertRules.newFolderButton}
-                  >
-                    <Trans i18nKey="alerting.rule-form.folder.new-folder">New folder</Trans>
-                  </Button>
-                </>
-              )) || (
-                <div>
-                  <Trans i18nKey="alerting.rule-form.folder.creating-new-folder">Creating new folder</Trans>
-                  {'...'}
                 </div>
               )}
-            </Stack>
-          </Field>
-        }
-      </Stack>
-
-      {isCreatingFolder && (
-        <FolderCreationModal onCreate={handleFolderCreation} onClose={() => setIsCreatingFolder(false)} />
-      )}
-    </>
-  );
-}
-
-function FolderCreationModal({
-  onClose,
-  onCreate,
-}: {
-  onClose: () => void;
-  onCreate: (folder: Folder) => void;
-}): React.ReactElement {
-  const styles = useStyles2(getStyles);
-  const notifyApp = useAppNotification();
-  const [title, setTitle] = useState('');
-  const [createFolder] = useNewFolderMutation();
-
-  const onSubmit = async () => {
-    const { data, error } = await createFolder({ title });
-
-    if (error) {
-      notifyApp.error('Failed to create folder');
-    } else if (data) {
-      onCreate({ title: data.title, uid: data.uid });
-      notifyApp.success('Folder created');
-    }
-  };
-
-  return (
-    <Modal className={styles.modal} isOpen={true} title={'New folder'} onDismiss={onClose} onClickBackdrop={onClose}>
-      <Stack direction="column" gap={2}>
-        <Text color="secondary">
-          <Trans i18nKey="alerting.rule-form.folder.create-folder">
-            Create a new folder to store your alert rule in.
-          </Trans>
-        </Text>
-
-        <form onSubmit={onSubmit}>
-          <Field
-            label={
-              <Label htmlFor="folder">
-                <Trans i18nKey="alerting.rule-form.folder.name">Folder name</Trans>
-              </Label>
-            }
-          >
-            <Input
-              data-testid={selectors.components.AlertRules.newFolderNameField}
-              autoFocus={true}
-              id="folderName"
-              placeholder="Enter a name"
-              value={title}
-              onChange={(e) => setTitle(e.currentTarget.value)}
+              name="folder"
+              rules={{
+                required: { value: true, message: 'Select a folder' },
+              }}
             />
-          </Field>
-
-          <Modal.ButtonRow>
-            <Button variant="secondary" type="button" onClick={onClose}>
-              <Trans i18nKey="alerting.rule-form.folder.cancel">Cancel</Trans>
-            </Button>
-            <Button
-              type="submit"
-              disabled={!title}
-              data-testid={selectors.components.AlertRules.newFolderNameCreateButton}
-            >
-              <Trans i18nKey="alerting.rule-form.folder.create">Create</Trans>
-            </Button>
-          </Modal.ButtonRow>
-        </form>
-      </Stack>
-    </Modal>
+            <CreateNewFolder onCreate={handleFolderCreation} />
+          </Stack>
+        </Field>
+      }
+    </Stack>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  modal: css({
-    width: `${theme.breakpoints.values.sm}px`,
-  }),
-});

--- a/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Field, Label, Stack } from '@grafana/ui';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
+import { t } from 'app/core/internationalization';
 
 import { Trans } from '../../../../../core/internationalization/index';
 import { Folder, RuleFormValues } from '../../types/rule-form';
@@ -31,7 +32,13 @@ export function FolderSelector() {
       {
         <Field
           label={
-            <Label htmlFor="folder" description={'Select a folder to store your rule in.'}>
+            <Label
+              htmlFor="folder"
+              description={t(
+                'alerting.folder-selector.description-select-folder',
+                'Select a folder to store your rule in.'
+              )}
+            >
               <Trans i18nKey="alerting.rule-form.folder.label">Folder</Trans>
             </Label>
           }

--- a/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
@@ -12,7 +12,6 @@ import { Spacer } from '../../components/Spacer';
 import { WithReturnButton } from '../../components/WithReturnButton';
 import { supportedImportTypes } from '../../components/import-to-gma/ImportFromDSRules';
 import { useRulesSourcesWithRuler } from '../../hooks/useRuleSourcesWithRuler';
-import { DataSourceType } from '../../utils/datasource';
 import { isAdmin } from '../../utils/misc';
 
 import { DataSourceIcon } from './Namespace';

--- a/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
@@ -10,6 +10,9 @@ import { RulesSourceApplication } from 'app/types/unified-alerting-dto';
 
 import { Spacer } from '../../components/Spacer';
 import { WithReturnButton } from '../../components/WithReturnButton';
+import { supportedImportTypes } from '../../components/import-to-gma/ImportFromDSRules';
+import { useRulesSourcesWithRuler } from '../../hooks/useRuleSourcesWithRuler';
+import { DataSourceType } from '../../utils/datasource';
 import { isAdmin } from '../../utils/misc';
 
 import { DataSourceIcon } from './Namespace';
@@ -34,6 +37,12 @@ export const DataSourceSection = ({
   description = null,
 }: DataSourceSectionProps) => {
   const styles = useStyles2(getStyles);
+  const { rulesSourcesWithRuler } = useRulesSourcesWithRuler();
+
+  const showImportLink =
+    uid !== GrafanaRulesSourceSymbol &&
+    rulesSourcesWithRuler.some(({ uid: dsUid, type }) => dsUid === uid && supportedImportTypes.includes(type));
+
   const [isCollapsed, toggleCollapsed] = useToggle(false);
   const configureLink = (() => {
     if (uid === GrafanaRulesSourceSymbol) {
@@ -70,6 +79,16 @@ export const DataSourceSection = ({
                   </>
                 )}
                 <Spacer />
+                {showImportLink && (
+                  <LinkButton
+                    variant="secondary"
+                    size="sm"
+                    href={`/alerting/import-datasource-managed-rules?datasourceUid=${String(uid)}`}
+                    icon="arrow-up"
+                  >
+                    <Trans i18nKey="alerting.data-source-section.import-to-grafana">Import to Grafana rules</Trans>
+                  </LinkButton>
+                )}
                 {configureLink && (
                   <WithReturnButton
                     title={t('alerting.rule-list.return-button.title', 'Alert rules')}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -608,7 +608,7 @@
       },
       "datasource": {
         "label": "Data source",
-        "required-message": "Please select a datasource"
+        "required-message": "Please select a data source"
       },
       "error": "Failed to import alert rules: {{error}}",
       "group": {
@@ -620,7 +620,7 @@
         "description": "Type to search for an existing namespace",
         "label": "Namespace"
       },
-      "pageTitle": "Import alert rules from a datasource to Grafana-managed rules",
+      "pageTitle": "Import alert rules from a data source to Grafana-managed rules",
       "pause": {
         "label": "Pause imported alerting rules"
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -427,6 +427,9 @@
       },
       "view": "View"
     },
+    "confirm-conversion-modal": {
+      "title-warning": "Warning"
+    },
     "contact-points": {
       "create": "Create contact point",
       "custom-template-value": "Custom template value",
@@ -521,6 +524,9 @@
         "one-format": "Download the file or copy the contents to clipboard"
       }
     },
+    "folder-creation-modal": {
+      "title-new-folder": "New folder"
+    },
     "folderAndGroup": {
       "evaluation": {
         "modal": {
@@ -587,6 +593,7 @@
     },
     "import-to-gma": {
       "action-button": "Import",
+      "additional-settings": "Additional settings",
       "alert-rules": "Alert rules",
       "confirm-modal": {
         "confirm": "Yes, import",
@@ -606,7 +613,6 @@
         "description": "Type to search for an existing namespace",
         "label": "Namespace"
       },
-      "optional-settings": "Optional settings",
       "pageTitle": "Import alert rules from a datasource to Grafana-managed rules",
       "pause": {
         "label": "Pause imported alerting rules"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -427,9 +427,6 @@
       },
       "view": "View"
     },
-    "confirm-conversion-modal": {
-      "title-warning": "Warning"
-    },
     "contact-points": {
       "create": "Create contact point",
       "custom-template-value": "Custom template value",
@@ -471,6 +468,16 @@
       "label": "Contact point"
     },
     "copy-to-clipboard": "Copy \"{{label}}\" to clipboard",
+    "create-new-folder": {
+      "folder": {
+        "cancel": "Cancel",
+        "create": "Create",
+        "name": "Folder name"
+      },
+      "new-folder": "New folder",
+      "placeholder-enter-a-name": "Enter a name",
+      "title-new-folder": "New folder"
+    },
     "dag": {
       "missing-reference": "Expression \"{{source}}\" failed to run because \"{{target}}\" is missing or also failed.",
       "self-reference": "You can't link an expression to itself"
@@ -526,10 +533,6 @@
         "formats": "Select the format and download the file or copy the contents to clipboard",
         "one-format": "Download the file or copy the contents to clipboard"
       }
-    },
-    "folder-creation-modal": {
-      "placeholder-enter-a-name": "Enter a name",
-      "title-new-folder": "New folder"
     },
     "folder-selector": {
       "description-select-folder": "Select a folder to store your rule in."
@@ -831,11 +834,7 @@
         "validation": "Pending period must be greater than or equal to the evaluation interval."
       },
       "folder": {
-        "cancel": "Cancel",
-        "create": "Create",
-        "label": "Folder",
-        "name": "Folder name",
-        "new-folder": "New folder"
+        "label": "Folder"
       },
       "folder-and-labels": "Organize your alert rule with a folder and set of labels.",
       "folders": {
@@ -998,7 +997,8 @@
     "to-gma": {
       "confirm-modal": {
         "body": "If the target folder is not empty, some rules may be overwritten or removed. Are you sure you want to import these alert rules to Grafana-managed rules?",
-        "summary": "These are the list of rules that will be imported:"
+        "summary": "These are the list of rules that will be imported:",
+        "title-warning": "Warning"
       }
     }
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -475,6 +475,9 @@
       "missing-reference": "Expression \"{{source}}\" failed to run because \"{{target}}\" is missing or also failed.",
       "self-reference": "You can't link an expression to itself"
     },
+    "data-source-section": {
+      "import-to-grafana": "Import to Grafana rules"
+    },
     "delete-rule-modal": {
       "title": "Delete rule",
       "with-soft-delete": "Are you sure you want to delete this rule? This rule will be recoverable from the Recently deleted page by a user with an admin role.",
@@ -525,7 +528,11 @@
       }
     },
     "folder-creation-modal": {
+      "placeholder-enter-a-name": "Enter a name",
       "title-new-folder": "New folder"
+    },
+    "folder-selector": {
+      "description-select-folder": "Select a folder to store your rule in."
     },
     "folderAndGroup": {
       "evaluation": {
@@ -826,12 +833,9 @@
       "folder": {
         "cancel": "Cancel",
         "create": "Create",
-        "create-folder": "Create a new folder to store your alert rule in.",
-        "creating-new-folder": "Creating new folder",
         "label": "Folder",
         "name": "Folder name",
-        "new-folder": "New folder",
-        "new-folder-or": "or"
+        "new-folder": "New folder"
       },
       "folder-and-labels": "Organize your alert rule with a folder and set of labels.",
       "folders": {


### PR DESCRIPTION
**What is this feature?**
* Adds CreateNewFolder component for reuse in import UI and to replace existing logic in Alert Rule Form
* Updates styling of the warning in the import modal to be an Alert 
* Makes recording rule target always a required field (for now, as its easiest, potentially in the future this will be relaxed to only be when there are recording rules to be imported)
* Allows specifying the data source UID via query param so that we can...
* ... Link to the import UI on individual data sources on the new list view
  *  <img width="867" alt="image" src="https://github.com/user-attachments/assets/94b79f88-7f7a-49c4-b8bb-1ac0c888e1f7" />
* FIxes some typos (datasource -> data source)

**Why do we need this feature?**
More flexible/user friendly implementation for rules import UI

**Who is this feature for?**
Alerting users with Prom/Loki datasource managed alerts
