### PR TITLE
Themes: Gloom update

### DIFF
--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -19,8 +19,8 @@ const gloomTheme: NewThemeOptions = {
   colors: {
     mode: 'dark',
     border: {
-      weak: `rgba(${whiteBase}, 0.08)`,
-      medium: `rgba(${whiteBase}, 0.15)`,
+      weak: `rgba(${whiteBase}, 0.12)`,
+      medium: `rgba(${whiteBase}, 0.20)`,
       strong: `rgba(${whiteBase}, 0.30)`,
     },
 

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -6,13 +6,13 @@ import { NewThemeOptions } from '../createTheme';
  */
 
 const whiteBase = `210, 210, 220`;
-const secondaryBase = `210, 210, 220`;
+const secondaryBase = `186, 186, 230`;
+
 //const brandMain = '#3d71d9';
 //const brandText = '#6e9fff';
 const brandMain = '#ff934d';
 const brandText = '#f99a5c';
-
-const disabledText = `rgba(${whiteBase}, 0.6)`;
+const disabledText = `rgba(${whiteBase}, 0.48)`;
 
 const gloomTheme: NewThemeOptions = {
   name: 'Gloom',
@@ -50,16 +50,16 @@ const gloomTheme: NewThemeOptions = {
 
     background: {
       canvas: '#000',
-      primary: '#0d0b14',
-      secondary: '#19171f',
-      elevated: '#19171f',
+      primary: '#121118',
+      secondary: '#211e28',
+      elevated: '#211e28',
     },
 
     action: {
-      hover: `rgba(${secondaryBase}, 0.10)`,
-      selected: `rgba(${secondaryBase}, 0.12)`,
+      hover: `rgba(${secondaryBase}, 0.07)`,
+      selected: `rgba(${secondaryBase}, 0.11)`,
       selectedBorder: brandMain,
-      focus: `rgba(${secondaryBase}, 0.10)`,
+      focus: `rgba(${secondaryBase}, 0.07)`,
       hoverOpacity: 0.05,
       disabledText: disabledText,
       disabledBackground: `rgba(${whiteBase}, 0.04)`,

--- a/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/gloom.ts
@@ -6,7 +6,7 @@ import { NewThemeOptions } from '../createTheme';
  */
 
 const whiteBase = `210, 210, 220`;
-const secondaryBase = `186, 186, 230`;
+const secondaryBase = `195, 195, 245`;
 
 //const brandMain = '#3d71d9';
 //const brandText = '#6e9fff';


### PR DESCRIPTION
* Slightly brightens the primary and secondary (on a laptop with brightness low in the evening it was very hard to see any separation between canvas and panels) 
* Change the secondary color base used for secondary button and hover / selected highlights (menu items etc), this was too gray and did not fit the saturation in the other surface colors. 

Before
![Screenshot 2025-04-04 at 07 45 00](https://github.com/user-attachments/assets/2964c8e6-e9df-41fd-a193-267b1ed86787)

After:  (See secondary button saturation, and the hover of one the table rows) 

![Screenshot 2025-04-04 at 07 36 45](https://github.com/user-attachments/assets/c176fcc1-ed39-411a-98c7-b0fc00a78965)

