### PR TITLE
Alerting: Improve displaying small numbers in query preview

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -402,7 +402,7 @@ function FrameRow({ frame, index, isAlertCondition, isRecordingRule }: FrameProp
   const styles = useStyles2(getStyles);
 
   const name = getSeriesName(frame) || 'Series ' + index;
-  const value = frame.fields.at(0)?.values.at(0);
+  const value = getSeriesValue(frame);
   const labelsRecord = getSeriesLabels(frame);
   const labels = Object.entries(labelsRecord);
   const hasLabels = labels.length > 0;

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -35,7 +35,7 @@ import { Spacer } from '../Spacer';
 import { AlertStateTag } from '../rules/AlertStateTag';
 
 import { ExpressionStatusIndicator } from './ExpressionStatusIndicator';
-import { formatLabels, getSeriesLabels, getSeriesName, getSeriesValue, isEmptySeries } from './util';
+import { formatLabels, formatSeriesValue, getSeriesLabels, getSeriesName, getSeriesValue, isEmptySeries } from './util';
 
 interface ExpressionProps {
   isAlertCondition?: boolean;
@@ -402,7 +402,7 @@ function FrameRow({ frame, index, isAlertCondition, isRecordingRule }: FrameProp
   const styles = useStyles2(getStyles);
 
   const name = getSeriesName(frame) || 'Series ' + index;
-  const value = getSeriesValue(frame);
+  const value = frame.fields.at(0)?.values.at(0);
   const labelsRecord = getSeriesLabels(frame);
   const labels = Object.entries(labelsRecord);
   const hasLabels = labels.length > 0;
@@ -438,7 +438,7 @@ function FrameRow({ frame, index, isAlertCondition, isRecordingRule }: FrameProp
             )}
           </Text>
         </div>
-        <div className={styles.expression.resultValue}>{value}</div>
+        <div className={styles.expression.resultValue}>{formatSeriesValue(value)}</div>
         {shouldRenderSumary && (
           <>
             {showFiring && <AlertStateTag state={PromAlertingRuleState.Firing} size="sm" />}

--- a/public/app/features/alerting/unified/components/expressions/util.ts
+++ b/public/app/features/alerting/unified/components/expressions/util.ts
@@ -22,13 +22,22 @@ const getSeriesName = (frame: DataFrame): string | undefined => {
 };
 
 const getSeriesValue = (frame: DataFrame) => {
-  const value = frame.fields[0]?.values[0];
+  return frame.fields[0]?.values[0];
+};
 
-  if (Number.isFinite(value)) {
-    return roundDecimals(value, 5);
+const smallNumberFormatter = new Intl.NumberFormat(undefined, {
+  maximumSignificantDigits: 5,
+});
+
+const formatSeriesValue = (value: unknown): string => {
+  if (Number.isFinite(value) && typeof value === 'number') {
+    const absValue = Math.abs(value);
+    if (absValue < 1) {
+      return smallNumberFormatter.format(value);
+    }
+    return roundDecimals(value, 5).toString(10);
   }
-
-  return value;
+  return String(value);
 };
 
 const getSeriesLabels = (frame: DataFrame): Record<string, string> => {
@@ -103,5 +112,6 @@ export {
   getSeriesLabels,
   getSeriesName,
   getSeriesValue,
+  formatSeriesValue,
   isEmptySeries,
 };

--- a/public/app/features/alerting/unified/components/expressions/util.ts
+++ b/public/app/features/alerting/unified/components/expressions/util.ts
@@ -15,14 +15,14 @@ import { isCloudRulesSource } from '../../utils/datasource';
  */
 
 const getSeriesName = (frame: DataFrame): string | undefined => {
-  const firstField = frame.fields[0];
+  const firstField = frame.fields.at(0);
 
   const displayNameFromDS = firstField?.config?.displayNameFromDS;
   return displayNameFromDS ?? frame.name ?? firstField?.labels?.__name__;
 };
 
 const getSeriesValue = (frame: DataFrame) => {
-  return frame.fields[0]?.values[0];
+  return frame.fields.at(0)?.values.at(0);
 };
 
 const smallNumberFormatter = new Intl.NumberFormat(undefined, {


### PR DESCRIPTION
**What is this feature?**
This PR improves displaying small numbers in the alert query preview - for all fractional numbers (-1, 1) rounding won't be applied and we'll display 5 most significant digits

**Why do we need this feature?**
The query preview rounds the query results to 5 decimal places. For small numbers (< 0.00001) this effectively means the UI will display `0` which is not true

**Special notes for your reviewer:**
BEFORE
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/998f24ab-1909-4671-a58c-d517d953ce80" />

AFTER
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/21b9bab0-b9b0-4400-8a8e-3e619e944303" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
