### PR TITLE
Dashboard: Remove global add button

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
@@ -100,12 +100,6 @@ export const RightActions = ({ dashboard }: { dashboard: DashboardScene }) => {
             condition: showPanelButtons && isEditingLibraryPanel,
           },
           {
-            key: 'dashboard-add-button',
-            component: DashboardAddButton,
-            group: 'dashboard',
-            condition: isEditingAndShowingDashboard && dashboard.canEditDashboard(),
-          },
-          {
             key: 'edit-schema-v2-button',
             component: EditSchemaV2Button,
             group: 'dashboard',

--- a/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
@@ -8,7 +8,6 @@ import { isLibraryPanel } from '../../utils/utils';
 import { DashboardScene } from '../DashboardScene';
 
 import { BackToDashboardButton } from './actions/BackToDashboardButton';
-import { DashboardAddButton } from './actions/DashboardAddButton';
 import { DashboardSettingsButton } from './actions/DashboardSettingsButton';
 import { DiscardLibraryPanelButton } from './actions/DiscardLibraryPanelButton';
 import { DiscardPanelButton } from './actions/DiscardPanelButton';


### PR DESCRIPTION

Looking at the bug bash videos and thinking I think this global add button will just add confusing and does more harm than good. 

It allows you to add a panel when all rows are collapsed for example. And add a tab or row and end up with nested rows or tabs (as it takes selected object into account), when that was not intended (hard to know what the user intends). 

Unlike the canvas actions where it's much easier to know what the user intends. Also just good to have a single way to do things vs many. 