### PR TITLE
Plugins: Allow provisioning to override autoEnabled

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -31,10 +31,7 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 				return ps.Enabled
 			}
 		}
-		if plugin.AutoEnabled {
-			return true
-		}
-		return false
+		return plugin.AutoEnabled
 	}
 
 	for _, plugin := range s.pluginStore.Plugins(c.Req.Context(), plugins.TypeApp) {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -26,13 +26,13 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 	}
 
 	isPluginEnabled := func(plugin pluginstore.Plugin) bool {
-		if plugin.AutoEnabled {
-			return true
-		}
 		for _, ps := range pss {
 			if ps.PluginID == plugin.ID {
 				return ps.Enabled
 			}
+		}
+		if plugin.AutoEnabled {
+			return true
 		}
 		return false
 	}

--- a/pkg/services/provisioning/plugins/plugin_provisioner.go
+++ b/pkg/services/provisioning/plugins/plugin_provisioner.go
@@ -52,7 +52,7 @@ func (ap *PluginProvisioner) apply(ctx context.Context, cfg *pluginsAsConfig) er
 			return errors.New("plugin not found")
 		}
 		if p.AutoEnabled && !app.Enabled {
-			return errors.New("plugin is auto enabled and cannot be disabled")
+			ap.log.Warn("auto enabled plugin will be disabled by provisioning", "pluginID", app.PluginID)
 		}
 
 		ps, err := ap.pluginSettings.GetPluginSettingByPluginID(ctx, &pluginsettings.GetByPluginIDArgs{

--- a/pkg/services/provisioning/plugins/plugin_provisioner_test.go
+++ b/pkg/services/provisioning/plugins/plugin_provisioner_test.go
@@ -80,7 +80,7 @@ func TestPluginProvisioner(t *testing.T) {
 		}
 	})
 
-	t.Run("Should return error trying to disable an auto-enabled plugin", func(t *testing.T) {
+	t.Run("Should return not error trying to disable an auto-enabled plugin", func(t *testing.T) {
 		cfg := []*pluginsAsConfig{
 			{
 				Apps: []*appFromConfig{
@@ -100,8 +100,7 @@ func TestPluginProvisioner(t *testing.T) {
 		}
 
 		err := ap.applyChanges(context.Background(), "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "plugin is auto enabled and cannot be disabled")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This allows the provisioning configs to override the `autoEnabled` property for plugins.

**Why do we need this feature?**

This is necessary to allow `autoEnabled` plugins to be disabled by provisioning configs without breaking grafana initialization.

**Who is this feature for?**

Grafana admins.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

In this feature we are assuming that the provisioning configs have priority over `plugin.json` configs.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
