### PR TITLE
publicdashboards: Don't format timestamp before passing it to database.

### DIFF
--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -242,7 +242,7 @@ func (d *PublicDashboardStoreImpl) Update(ctx context.Context, cmd SavePublicDas
 			cmd.PublicDashboard.Share,
 			string(timeSettingsJSON),
 			cmd.PublicDashboard.UpdatedBy,
-			cmd.PublicDashboard.UpdatedAt.UTC().Format("2006-01-02 15:04:05"),
+			cmd.PublicDashboard.UpdatedAt.UTC(),
 			cmd.PublicDashboard.Uid)
 
 		if err != nil {


### PR DESCRIPTION
This PR removes formatting of timestamp before passing it to the database. This is not necessary and in fact format between databases is not consistent (In Spanner timestamp without timezone is always assumed to be in Los Angeles, so timestamp ends up being wrong).

Found via `TestIntegrationUpdatePublicDashboard` test, which now passes on Spanner.

Related to https://github.com/grafana/grafana/pull/102227.