### PR TITLE
SecretsManager: Remove encryption scope option

### DIFF
--- a/pkg/registry/apis/secret/contracts/encryption.go
+++ b/pkg/registry/apis/secret/contracts/encryption.go
@@ -8,29 +8,11 @@ type EncryptionManager interface {
 	// For those specific use cases where the encryption operation cannot be moved outside
 	// the database transaction, look at database-specific methods present at the specific
 	// implementation present at manager.EncryptionService.
-	Encrypt(ctx context.Context, namespace string, payload []byte, opt EncryptionOptions) ([]byte, error)
+	Encrypt(ctx context.Context, namespace string, payload []byte) ([]byte, error)
 	Decrypt(ctx context.Context, namespace string, payload []byte) ([]byte, error)
 
 	RotateDataKeys(ctx context.Context, namespace string) error
 	ReEncryptDataKeys(ctx context.Context, namespace string) error
-}
-
-type EncryptionOptions func() string
-
-// EncryptWithoutScope uses a root level data key for encryption (DEK),
-// in other words this DEK is not bound to any specific scope (not attached to any user, org, etc.).
-func EncryptWithoutScope() EncryptionOptions {
-	return func() string {
-		return "root"
-	}
-}
-
-// EncryptWithScope uses a data key for encryption bound to some specific scope (i.e., user, org, etc.).
-// Scope should look like "user:10", "org:1".
-func EncryptWithScope(scope string) EncryptionOptions {
-	return func() string {
-		return scope
-	}
 }
 
 type EncryptedValue struct {

--- a/pkg/registry/apis/secret/encryption/migrator/reencrypt.go
+++ b/pkg/registry/apis/secret/encryption/migrator/reencrypt.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
@@ -37,7 +36,7 @@ func (s simpleSecret) ReEncrypt(ctx context.Context, namespace string, secretsSr
 				return err
 			}
 
-			encrypted, err := secretsSrv.Encrypt(ctx, namespace, decrypted, contracts.EncryptWithoutScope())
+			encrypted, err := secretsSrv.Encrypt(ctx, namespace, decrypted)
 			if err != nil {
 				logger.Warn("Could not encrypt secret while re-encrypting it", "table", s.tableName, "id", row.Id, "error", err)
 				return err

--- a/pkg/registry/apis/secret/encryption/secrets.go
+++ b/pkg/registry/apis/secret/encryption/secrets.go
@@ -28,8 +28,8 @@ func (id ProviderID) Kind() (string, error) {
 	return parts[0], nil
 }
 
-func KeyLabel(scope string, providerID ProviderID) string {
-	return fmt.Sprintf("%s/%s@%s", time.Now().Format("2006-01-02"), scope, providerID)
+func KeyLabel(providerID ProviderID) string {
+	return fmt.Sprintf("%s@%s", time.Now().Format("2006-01-02"), providerID)
 }
 
 type ProviderMap map[ProviderID]Provider

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
@@ -33,7 +33,7 @@ func (s *SQLKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, 
 	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Store")
 	defer span.End()
 
-	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef), contracts.EncryptWithoutScope())
+	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef))
 	if err != nil {
 		return "", fmt.Errorf("unable to encrypt value: %w", err)
 	}
@@ -79,7 +79,7 @@ func (s *SQLKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Update")
 	defer span.End()
 
-	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef), contracts.EncryptWithoutScope())
+	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef))
 	if err != nil {
 		return fmt.Errorf("unable to encrypt value: %w", err)
 	}

--- a/pkg/storage/secret/encryption/data_key_model.go
+++ b/pkg/storage/secret/encryption/data_key_model.go
@@ -12,7 +12,6 @@ type SecretDataKey struct {
 	Active        bool                  `xorm:"active"`
 	Namespace     string                `xorm:"namespace"`
 	Label         string                `xorm:"label"`
-	Scope         string                `xorm:"scope"`
 	Provider      encryption.ProviderID `xorm:"provider"`
 	EncryptedData []byte                `xorm:"encrypted_data"`
 	Created       time.Time             `xorm:"created"`

--- a/pkg/storage/secret/encryption/data_key_store.go
+++ b/pkg/storage/secret/encryption/data_key_store.go
@@ -227,13 +227,13 @@ func (ss *encryptionStoreImpl) ReEncryptDataKeys(
 		if i == 0 {
 			statement = fmt.Sprintf("SELECT '%s' AS %s, '%s' AS %s, '%s' AS %s",
 				k.UID, "uid",
-				encryption.KeyLabel(k.Scope, currProvider), "label",
+				encryption.KeyLabel(currProvider), "label",
 				encryptedData, "encrypted_data",
 			)
 		} else {
 			statement = fmt.Sprintf("SELECT '%s', '%s', x'%s'",
 				k.UID,
-				encryption.KeyLabel(k.Scope, currProvider),
+				encryption.KeyLabel(currProvider),
 				encryptedData,
 			)
 		}

--- a/pkg/storage/secret/encryption/data_key_store_test.go
+++ b/pkg/storage/secret/encryption/data_key_store_test.go
@@ -5,11 +5,12 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -37,7 +38,6 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 		Label:         "test-label",
 		Active:        true,
 		EncryptedData: []byte("test-data"),
-		Scope:         "test-scope",
 		Provider:      passThroughProvider, // so that the Decrypt() method just gets us the input test data
 	}
 

--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -93,28 +93,27 @@ func initSecretStore(mg *migrator.Migrator) string {
 		Name: TableNameDataKey,
 		Columns: []*migrator.Column{
 			{Name: "uid", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: true},
-			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // in this table, it isn't used by k8s, but we will track it for added security
+			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
 			{Name: "label", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: false},
-			{Name: "active", Type: migrator.DB_Bool},
-			{Name: "scope", Type: migrator.DB_NVarchar, Length: 30, Nullable: false},
+			{Name: "active", Type: migrator.DB_Bool, Nullable: false},
 			{Name: "provider", Type: migrator.DB_NVarchar, Length: 50, Nullable: false},
 			{Name: "encrypted_data", Type: migrator.DB_Blob, Nullable: false},
 			{Name: "created", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 		},
-		Indices: []*migrator.Index{},
+		Indices: []*migrator.Index{}, // TODO: add indexes based on the queries we make.
 	})
 
 	tables = append(tables, migrator.Table{
 		Name: TableNameEncryptedValue,
 		Columns: []*migrator.Column{
-			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},
-			{Name: "uid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
+			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
+			{Name: "uid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},     // Fixed size of a UUID.
 			{Name: "encrypted_data", Type: migrator.DB_Blob, Nullable: false},
 			{Name: "created", Type: migrator.DB_BigInt, Nullable: false},
 			{Name: "updated", Type: migrator.DB_BigInt, Nullable: false},
 		},
-		Indices: []*migrator.Index{},
+		Indices: []*migrator.Index{}, // TODO: add indexes based on the queries we make.
 	})
 
 	// Initialize all tables


### PR DESCRIPTION
We already should be scoping secrets to a `namespace` (which can be `org` or `stack`) and we won't have any other use for custom scoping, so we can get rid of this option and simplify a bit the model.