### PR TITLE
Update sharing markers to use the new format

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -43,12 +43,6 @@ cards:
       href: ./share-dashboards-panels/shared-dashboards/
       description: Share your dashboards with anyone without requiring access to your Grafana organization.
       height: 24
-refs:
-  panels:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-overview/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-overview/
 ---
 
 {{< docs/hero-simple key="hero" >}}
@@ -57,13 +51,13 @@ refs:
 
 ## Overview
 
-{{< shared id="dashboard-overview" >}}
+<section id="dashboard-overview">
 
-A Grafana dashboard is a set of one or more [panels](ref:panels), organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into charts, graphs, and other visualizations.
+A Grafana dashboard is a set of one or more [panels](/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-overview/), organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into charts, graphs, and other visualizations.
 
 A data source can be an SQL database, Grafana Loki, Grafana Mimir, or a JSON-based API. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards.
 
-{{< /shared >}}
+</section>
 
 Queries allow you to reduce the entirety of your data to a specific dataset, providing a more manageable visualization. Since data sources have their own distinct query languages, Grafana dashboards provide you with a query editor to accommodate these differences.
 

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -90,7 +90,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
 **To create a dashboard**:
 
-{{< shared id="create-dashboard" >}}
+<section id="create-dashboard">
 
 1. Click **Dashboards** in the main menu.
 1. Click **New** and select **New Dashboard**.
@@ -98,7 +98,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    ![Empty dashboard state](/media/docs/grafana/dashboards/empty-dashboard-10.2.png)
 
-{{< /shared >}}
+</section>
 
 1. In the dialog box that opens, do one of the following:
 


### PR DESCRIPTION
The new behavior is discussed in https://github.com/grafana/website/pull/25064. The behavior lets writers include block elements like lists and continue the list in the including source.

I've removed the `panels` `ref` URI to fix the link in learning journeys. In the learning journey, the link now resolves to the Grafana documentation.

Thanks to mount links (documented in https://github.com/grafana/writers-toolkit/pull/1098), this link automatically goes to the Grafana OSS docs when the page is rendered in the OSS docs and to the equivalent Grafana Cloud destination when the page is rendered in the Grafana Cloud docs

