### PR TITLE
[release-11.6.1] Alertmanager: Add Role-Based Access Control via reqAction Field

### DIFF
--- a/public/app/plugins/datasource/alertmanager/plugin.json
+++ b/public/app/plugins/datasource/alertmanager/plugin.json
@@ -5,40 +5,145 @@
   "metrics": false,
   "routes": [
     {
-      "method": "POST",
+      "method": "GET",
       "path": "alertmanager/api/v2/silences",
-      "reqRole": "Editor"
-    },
-    {
-      "method": "DELETE",
-      "path": "alertmanager/api/v2/silence",
-      "reqRole": "Editor"
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
     },
     {
       "method": "GET",
-      "path": "alertmanager/api/v2/silences",
-      "reqRole": "Viewer"
+      "path": "api/v2/silences",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
     },
     {
       "method": "POST",
-      "reqRole": "Editor"
+      "path": "alertmanager/api/v2/silences",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
     },
     {
-      "method": "PUT",
-      "reqRole": "Editor"
+      "method": "POST",
+      "path": "api/v2/silences",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
+    },
+    {
+      "method": "GET",
+      "path": "alertmanager/api/v2/silence/",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "api/v2/silence/",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
     },
     {
       "method": "DELETE",
-      "reqRole": "Editor"
+      "path": "alertmanager/api/v2/silence/",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
+    },
+    {
+      "method": "DELETE",
+      "path": "api/v2/silence/",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
+    },
+    {
+      "method": "GET",
+      "path": "alertmanager/api/v2/alerts/groups",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "api/v2/alerts/groups",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
     },
     {
       "method": "GET",
       "path": "alertmanager/api/v2/alerts",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "api/v2/alerts",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
+    },
+    {
+      "method": "POST",
+      "path": "alertmanager/api/v2/alerts",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
+    },
+    {
+      "method": "POST",
+      "path": "api/v2/alerts",
+      "reqRole": "Editor",
+      "reqAction": "alert.instances.external:write"
+    },
+    {
+      "method": "GET",
+      "path": "alertmanager/api/v2/status",
+      "reqRole": "Viewer",
+      "reqAction": "alert.notifications.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "api/v2/status",
+      "reqRole": "Viewer",
+      "reqAction": "alert.notifications.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "alertmanager/api/v2/receivers",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "api/v2/receivers",
+      "reqRole": "Viewer",
+      "reqAction": "alert.instances.external:read"
     },
     {
       "method": "GET",
       "path": "api/v1/alerts",
+      "reqRole": "Viewer",
+      "reqAction": "alert.notifications.external:read"
+    },
+    {
+      "method": "POST",
+      "path": "api/v1/alerts",
+      "reqRole": "Editor",
+      "reqAction": "alert.notifications.external:write"
+    },
+    {
+      "method": "DELETE",
+      "path": "api/v1/alerts",
+      "reqRole": "Editor",
+      "reqAction": "alert.notifications.external:write"
+    },
+    {
+      "method": "POST",
+      "reqRole": "Admin"
+    },
+    {
+      "method": "PUT",
+      "reqRole": "Admin"
+    },
+    {
+      "method": "DELETE",
+      "reqRole": "Admin"
+    },
+    {
+      "method": "GET",
       "reqRole": "Admin"
     }
   ],


### PR DESCRIPTION
Backport ac7ad27867be5c85ebde3687b59bcd7731347c60 from #101543

---

**What is this feature?**

This PR introduces Role-Based Access Control ([RBAC](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)) for the Alertmanager datasource plugin in Grafana. It adds the reqAction field to the existing API routes, specifying the required action for each route based on Grafana's RBAC system.

**Why do we need this feature?**
The current implementation of the Alertmanager plugin lacks Role-Based Access Control, making it difficult to enforce fine-grained permissions for different users. By adding the reqAction field, this PR ensures that requests to specific endpoints respect custom-configured roles, improving security and flexibility.

**Who is this feature for?**
This feature is useful for Grafana administrators and users who need to control access to Alertmanager-related API routes based on role-based permissions.

**Additional Context**
- This change follows the RBAC guidelines outlined in the [Grafana documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/).
- The implementation is similar to [another PR](https://github.com/grafana/grafana/pull/87208) that introduced reqAction fields for Prometheus plugin.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.