### PR TITLE
Alerting: Fix: ignore external alert sending errors when shutting down.

### DIFF
--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -296,7 +296,7 @@ func (n *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
 		}
 		alerts := n.nextBatch()
 
-		if !n.sendAll(alerts...) {
+		if err := n.sendAll(alerts...); err != nil {
 			n.metrics.dropped.Add(float64(len(alerts)))
 		}
 		// If the queue still has items left, kick off the next iteration.

--- a/pkg/services/ngalert/sender/notifier_test.go
+++ b/pkg/services/ngalert/sender/notifier_test.go
@@ -1,0 +1,52 @@
+package sender
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager_sendAll_CancelledContext(t *testing.T) {
+	// Create a context and cancel it immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, 100, func() float64 { return 0 }, func() float64 { return 0 })
+
+	manager := &Manager{
+		queue:   make([]*Alert, 0, 100),
+		metrics: metrics,
+		ctx:     ctx,
+		logger:  log.NewNopLogger(),
+		opts: &Options{
+			Do: func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+				return nil, ctx.Err()
+			},
+		},
+		alertmanagers: map[string]*alertmanagerSet{
+			"test": {
+				client: &http.Client{},
+				cfg: &config.AlertmanagerConfig{
+					APIVersion: config.AlertmanagerAPIVersionV2,
+					Timeout:    model.Duration(time.Second),
+				},
+				metrics: metrics,
+				logger:  log.NewNopLogger(),
+				ams: []alertmanager{
+					alertmanagerLabels{},
+				},
+			},
+		},
+	}
+
+	err := manager.sendAll(&Alert{})
+	require.Nil(t, err)
+}


### PR DESCRIPTION
**What is this feature?**

Follow-up for https://github.com/grafana/grafana/pull/102705 to handle the case when all alerts passed to `sendAll` were not sent because of the cancelled context.