### PR TITLE
Explore: Use fixed dates to prevent DST issues in tests

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -250,27 +250,35 @@ describe('when buildQueryTransaction', () => {
   it('it should calculate interval based on time range', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
-    const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+    const from = dateTime('2023-01-01T12:00:00Z');
+    const to = dateTime('2023-01-02T12:00:00Z');
+    const range = { from, to, raw: { from: '1h', to: '1h' } };
     const transaction = buildQueryTransaction('left', queries, queryOptions, range, false);
     expect(transaction.request.intervalMs).toEqual(60000);
   });
   it('it should calculate interval taking minInterval into account', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
-    const range = { from: dateTime().subtract(1, 'm'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+    const from = dateTime('2023-01-01T12:00:00Z');
+    const to = dateTime('2023-01-01T12:01:00Z');
+    const range = { from, to, raw: { from: '1h', to: '1h' } };
     const transaction = buildQueryTransaction('left', queries, queryOptions, range, false);
     expect(transaction.request.intervalMs).toEqual(15000);
   });
   it('it should calculate interval taking maxDataPoints into account', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 10, minInterval: '15s' };
-    const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+    const from = dateTime('2023-01-01T12:00:00Z');
+    const to = dateTime('2023-01-02T12:00:00Z');
+    const range = { from, to, raw: { from: '1h', to: '1h' } };
     const transaction = buildQueryTransaction('left', queries, queryOptions, range, false);
     expect(transaction.request.interval).toEqual('2h');
   });
   it('it should create a request with X-Cache-Skip set to true', () => {
     const queries = [{ refId: 'A' }];
-    const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+    const from = dateTime('2023-01-01T12:00:00Z');
+    const to = dateTime('2023-01-02T12:00:00Z');
+    const range = { from, to, raw: { from: '1h', to: '1h' } };
     const transaction = buildQueryTransaction('left', queries, {}, range, false);
     expect(transaction.request.skipQueryCache).toBe(true);
   });

--- a/public/app/features/query/state/PanelQueryRunner.test.ts
+++ b/public/app/features/query/state/PanelQueryRunner.test.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 // Importing this way to be able to spy on grafana/data
 
 import * as grafanaData from '@grafana/data';
-import { DataSourceApi, TypedVariableModel } from '@grafana/data';
+import { DataSourceApi, dateTime, TypedVariableModel } from '@grafana/data';
 import { DataSourceSrv, setDataSourceSrv, setEchoSrv } from '@grafana/runtime';
 import { TemplateSrvMock } from 'app/features/templating/template_srv.mock';
 
@@ -155,8 +155,8 @@ function describeQueryRunnerScenario(
         minInterval: ctx.minInterval,
         maxDataPoints: ctx.maxDataPoints ?? Infinity,
         timeRange: {
-          from: grafanaData.dateTime().subtract(1, 'days'),
-          to: grafanaData.dateTime(),
+          from: dateTime('2023-01-01T12:00:00Z'),
+          to: dateTime('2023-01-02T12:00:00Z'),
           raw: { from: '1d', to: 'now' },
         },
         panelId: 1,


### PR DESCRIPTION
**What is this feature?**

Tests fail when `dateTime()` and `dateTime().subtract(1, 'd')` are called on days which just changed daylight saving times. Prevent this by just using fixed dates.