### PR TITLE
Dashboards: Prevent saving to a non-existent folder

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -90,6 +90,8 @@ func (d *dashboardStore) ValidateDashboardBeforeSave(ctx context.Context, dash *
 
 			if folderIdFound {
 				dash.FolderID = existing.ID // nolint:staticcheck
+			} else {
+				return dashboards.ErrDashboardFolderNotFound
 			}
 		}
 

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -427,12 +427,12 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 				"tags":  []interface{}{},
 			}),
 			Overwrite: true,
-			FolderUID: "2",
+			FolderUID: savedFolder.UID,
 			UserID:    100,
 		}
 		dash, err := dashboardStore.SaveDashboard(context.Background(), cmd)
 		require.NoError(t, err)
-		require.EqualValues(t, dash.FolderUID, "2")
+		require.EqualValues(t, dash.FolderUID, savedFolder.UID)
 
 		cmd = dashboards.SaveDashboardCommand{
 			OrgID: 1,

--- a/pkg/services/publicdashboards/api/query_test.go
+++ b/pkg/services/publicdashboards/api/query_test.go
@@ -281,7 +281,7 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 	// Create Dashboard
 	saveDashboardCmd := dashboards.SaveDashboardCommand{
 		OrgID:     1,
-		FolderUID: "1",
+		FolderUID: "",
 		IsFolder:  false,
 		Dashboard: simplejson.NewFromAny(map[string]any{
 			"id":    nil,

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -189,6 +189,15 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 		})
 	})
 
+	t.Run("Dashboard folder validations", func(t *testing.T) {
+		// Test non-existent folder UID
+		t.Run("reject dashboard with non-existent folder UID", func(t *testing.T) {
+			nonExistentFolderUID := "non-existent-folder-uid"
+			_, err := createDashboard(t, adminClient, "Dashboard in Non-existent Folder", &nonExistentFolderUID, nil)
+			require.Error(t, err)
+		})
+	})
+
 	t.Run("Dashboard schema validations", func(t *testing.T) {
 		// Test invalid dashboard schema
 		t.Run("reject dashboard with invalid schema", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This PR adds validation on creating and updating dashboards that a folder does indeed exist with the folderUid specified.

If it does not, you'll get a folder not found error:
```
curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer <>' localhost:3000/api/dashboards/db -d '{"dashboard": {"title": "testing"}, "folderUid": "doesntexist"}'
{"message":"folder not found"}
```

**Why do we need this feature?**

If you create a dashboard in a folder that does not exist, it is impossible to retrieve it in the UI. We should prevent creating them in the first place.

Extracted from https://github.com/grafana/grafana/pull/103502 to simplify the change linked in the change log
