### PR TITLE
Include rule for correct use of grafana.com

### DIFF
--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -15,5 +15,5 @@ jobs:
           persist-credentials: false
       - uses: grafana/writers-toolkit/vale-action@vale-action/v1
         with:
-          filter: '.Name in ["Grafana.WordList", "Grafana.Spelling", "Grafana.ProductPossessives"]'
+          filter: '.Name in ["Grafana.GrafanaCom", "Grafana.WordList", "Grafana.Spelling", "Grafana.ProductPossessives"]'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[The Grafana.GrafanaCom rule](https://grafana.com/docs/writers-toolkit/review/lint-prose/rules/#grafanagrafanacom) provides guidance for avoiding `grafana.com` and instead using a more specific term depending on the context. It inhibits the general `grafana` -> `Grafana` rule that could also apply. That's to say, use of `grafana.com` triggers this rule, whereas use of grafana triggers [Grafana.WordList](https://grafana.com/docs/writers-toolkit/review/lint-prose/rules/#grafanawordlist)