### PR TITLE
Provisioning: Show branch in save form

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/pkg/apis/provisioning/v0alpha1/settings.go
@@ -31,6 +31,9 @@ type RepositoryView struct {
 	// When syncing, where values are saved
 	Target SyncTargetType `json:"target"`
 
+	// For git, this is the target branch
+	Branch string `json:"branch,omitempty"`
+
 	// The supported workflows
 	Workflows []Workflow `json:"workflows"`
 }

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1230,6 +1230,13 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 							Enum:        []interface{}{"folder", "instance"},
 						},
 					},
+					"branch": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target branch",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"workflows": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The supported workflows",

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -162,11 +162,16 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 		LegacyStorage: dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, b.storageStatus),
 	}
 	for i, val := range all {
+		branch := ""
+		if val.Spec.GitHub != nil {
+			branch = val.Spec.GitHub.Branch
+		}
 		settings.Items[i] = provisioning.RepositoryView{
 			Name:      val.ObjectMeta.Name,
 			Title:     val.Spec.Title,
 			Type:      val.Spec.Type,
 			Target:    val.Spec.Sync.Target,
+			Branch:    branch,
 			Workflows: val.Spec.Workflows,
 		}
 	}

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -3234,6 +3234,10 @@
           "workflows"
         ],
         "properties": {
+          "branch": {
+            "description": "For git, this is the target branch",
+            "type": "string"
+          },
           "name": {
             "description": "The k8s name for this repository",
             "type": "string",

--- a/public/app/api/clients/provisioning/endpoints.gen.ts
+++ b/public/app/api/clients/provisioning/endpoints.gen.ts
@@ -1122,6 +1122,8 @@ export type WebhookResponse = {
   kind?: string;
 };
 export type RepositoryView = {
+  /** For git, this is the target branch */
+  branch?: string;
   /** The k8s name for this repository */
   name: string;
   /** When syncing, where values are saved

--- a/public/app/features/dashboard-scene/saving/provisioned/defaults.ts
+++ b/public/app/features/dashboard-scene/saving/provisioned/defaults.ts
@@ -14,6 +14,11 @@ export function getWorkflowOptions(config?: RepositoryView, ref?: string) {
     return [{ label: `Save`, value: 'write' }];
   }
 
+  // When a branch is configured, show it
+  if (!ref && config.branch) {
+    ref = config.branch;
+  }
+
   const availableOptions: Array<{ label: string; value: WorkflowOption }> = [
     { label: ref ? `Push to ${ref}` : 'Save', value: 'write' },
     { label: 'Push to different branch', value: 'branch' },


### PR DESCRIPTION
When we switched from using the raw config in the save editor, we stopped showing the branch.

This PR adds the branch back