### PR TITLE
fix(unified-storage): fix graceful termination for grafana target servers

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1117,8 +1117,8 @@ github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250121113133-e7
 github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250317130411-3f270d1de043/go.mod h1:usON2sfgh4qjGs4GLhH6+PL7Q6g5ezOP6M/9vOeHpAM=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20240930132144-b5e64e81e8d3 h1:6D2gGAwyQBElSrp3E+9lSr7k8gLuP3Aiy20rweLWeBw=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20240930132144-b5e64e81e8d3/go.mod h1:YeND+6FDA7OuFgDzYODN8kfPhXLCehcpxe4T9mdnpCY=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250403152731-b0a305952f0c h1:KH22wMjV61ysp8igdHpuP3zJYsaaIL/GJj4y67Vr/7M=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250403152731-b0a305952f0c/go.mod h1:FGdGvhI40Dq+CTQaSzK9evuve774cgOUdGfVO04OXkw=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250331083058-4563aec7a975 h1:4/BZkGObFWZf4cLbE2Vqg/1VTz67Q0AJ7LHspWLKJoQ=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250331083058-4563aec7a975/go.mod h1:FGdGvhI40Dq+CTQaSzK9evuve774cgOUdGfVO04OXkw=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -101,12 +101,7 @@ func (m *service) Run(ctx context.Context) error {
 	}
 
 	stopCtx := context.Background()
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- m.serviceManager.AwaitStopped(stopCtx)
-	}()
-
-	if err = <-errChan; err != nil {
+	if err = m.serviceManager.AwaitStopped(stopCtx); err != nil {
 		m.log.Error("Failed to stop module service manager", "error", err)
 		return err
 	}

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -100,8 +100,14 @@ func (m *service) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = m.serviceManager.AwaitStopped(ctx)
-	if err != nil {
+	stopCtx := context.Background()
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- m.serviceManager.AwaitStopped(stopCtx)
+	}()
+
+	if err = <-errChan; err != nil {
+		m.log.Error("Failed to stop module service manager", "error", err)
 		return err
 	}
 

--- a/pkg/server/module_server_test.go
+++ b/pkg/server/module_server_test.go
@@ -32,9 +32,9 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 		t.Skip("skipping - sqlite not supported for storage server target")
 	}
 	// TODO - fix this test for postgres
-	if dbType == "postgres" {
-		t.Skip("skipping - test not working with postgres in Drone. Works locally.")
-	}
+	// if dbType == "postgres" {
+	// 	t.Skip("skipping - test not working with postgres in Drone. Works locally.")
+	// }
 
 	_, cfg := db.InitTestDBWithCfg(t)
 	cfg.HTTPPort = "3001"
@@ -59,7 +59,7 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 		}
 		defer res.Body.Close()
 		return res.StatusCode == http.StatusOK
-	}, 10*time.Second, 200*time.Millisecond)
+	}, 10*time.Second, 1*time.Second)
 
 	err = ms.Shutdown(context.Background(), "test over")
 	require.NoError(t, err)

--- a/pkg/server/module_server_test.go
+++ b/pkg/server/module_server_test.go
@@ -32,6 +32,10 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 	if dbType == "sqlite3" {
 		t.Skip("skipping - sqlite not supported for storage server target")
 	}
+	// TODO: remove this when drone integration tests are removed
+	if dbType == "postgres" {
+		t.Skip("skipping - enable test when drone integration tests are removed")
+	}
 
 	_, cfg := db.InitTestDBWithCfg(t)
 	cfg.HTTPPort = "3001"
@@ -54,6 +58,11 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 		if err != nil {
 			return false
 		}
+		defer func() {
+			if err := res.Body.Close(); err != nil {
+				t.Fatalf("failed to close response body: %v", err)
+			}
+		}()
 		return res.StatusCode == http.StatusOK
 	}, 10*time.Second, 1*time.Second)
 
@@ -77,7 +86,7 @@ func addStorageServerToConfig(t *testing.T, cfg *setting.Cfg, dbType string) {
 	require.NoError(t, err)
 
 	if dbType == "postgres" {
-		_, _ = s.NewKey("db_host", "postgres")
+		_, _ = s.NewKey("db_host", "localhost")
 		_, _ = s.NewKey("db_name", "grafanatest")
 		_, _ = s.NewKey("db_user", "grafanatest")
 		_, _ = s.NewKey("db_pass", "grafanatest")

--- a/pkg/server/module_server_test.go
+++ b/pkg/server/module_server_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
-	"cuelang.org/go/pkg/regexp"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/modules"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/stretchr/testify/require"
 )
@@ -25,23 +22,14 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	dbType := os.Getenv("GRAFANA_TEST_DB")
-	if dbType == "" {
-		t.Skip("skipping - GRAFANA_TEST_DB not defined")
-	}
-	if dbType == "sqlite3" {
-		t.Skip("skipping - sqlite not supported for storage server target")
-	}
-	// TODO: remove this when drone integration tests are removed
-	if dbType == "postgres" {
-		t.Skip("skipping - enable test when drone integration tests are removed")
+	if db.IsTestDbSQLite() {
+		t.Skip("sqlite is not supported by the storage server target")
 	}
 
 	_, cfg := db.InitTestDBWithCfg(t)
 	cfg.HTTPPort = "3001"
 	cfg.GRPCServer.Network = "tcp"
 	cfg.GRPCServer.Address = "localhost:10000"
-	addStorageServerToConfig(t, cfg, dbType)
 	cfg.Target = []string{modules.StorageServer}
 
 	ms, err := InitializeModuleServer(cfg, Options{}, api.ServerOptions{})
@@ -71,35 +59,10 @@ func TestIntegrationWillRunInstrumentationServerWhenTargetHasNoHttpServer(t *tes
 
 	select {
 	case err := <-errChan:
-		if err != nil && errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			t.Fatalf("unexpected error from module server: %v", err)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for module server to shut down")
-	}
-}
-
-func addStorageServerToConfig(t *testing.T, cfg *setting.Cfg, dbType string) {
-	s, err := cfg.Raw.NewSection("resource_api")
-	require.NoError(t, err)
-	_, err = s.NewKey("db_type", dbType)
-	require.NoError(t, err)
-
-	if dbType == "postgres" {
-		_, _ = s.NewKey("db_host", "localhost")
-		_, _ = s.NewKey("db_name", "grafanatest")
-		_, _ = s.NewKey("db_user", "grafanatest")
-		_, _ = s.NewKey("db_pass", "grafanatest")
-	} else {
-		// cant use localhost as hostname in drone tests for mysql, so need to parse it from connection string
-		sec, err := cfg.Raw.GetSection("database")
-		require.NoError(t, err)
-		connString := sec.Key("connection_string").String()
-		matches, err := regexp.FindSubmatch("(.+):(.+)@tcp\\((.+):(\\d+)\\)/(.+)\\?", connString)
-		require.NoError(t, err)
-		_, _ = s.NewKey("db_host", matches[3])
-		_, _ = s.NewKey("db_name", matches[5])
-		_, _ = s.NewKey("db_user", matches[1])
-		_, _ = s.NewKey("db_pass", matches[2])
 	}
 }


### PR DESCRIPTION
**Ticket:** https://github.com/grafana/search-and-storage-team/issues/228

**TL;DR:** The issue arises from the permature context cancellation. 

- The `AwaitStopped` method is either waiting for the `stoppedCh` to be populated (which only occurs when all listened/registered services are in `failed`/`terminated` state [[ref](https://github.com/grafana/dskit/blob/5ff25a4351b6b0fb631ee13dea3eaa99d9eecaf4/services/manager.go#L215)]) or for the root context for module server to be done/cancelled [[rootContext](https://github.com/grafana/grafana/blob/d3f58d7892ac8ecff96047f10bbd4d31ab97beca/pkg/server/module_server.go#L71)]. The latter is the cause of the error, we are depending on the root context in this method which does not wait for the above mentioned channel population.
- In the light of this background; when we initiate the graceful termination [[ref](https://github.com/grafana/grafana/blob/d3f58d7892ac8ecff96047f10bbd4d31ab97beca/pkg/cmd/grafana-server/commands/cli.go#L142)], this method in turn triggers the `shutdownFn` which is cancelling the root context. We need to avoid this case if we want the target servers to perform real graceful terminations...

**Note:** Just added a `stopping` method to unified storage server for increased visibility in case of an error, which is irrelevant of the bug itself.