### PR TITLE
PreviewLogRow: add missing preview styles

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1132,6 +1132,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                       onUnpinLine={onPinToContentOutlineClick}
                       onPinLine={onPinToContentOutlineClick}
                       pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
+                      renderPreview
                     />
                   </InfiniteScroll>
                 </div>

--- a/public/app/features/logs/components/PreviewLogRow.tsx
+++ b/public/app/features/logs/components/PreviewLogRow.tsx
@@ -21,9 +21,9 @@ export const PreviewLogRow = ({ row, showDuplicates, showLabels, showTime, displ
           preview
         />
       ) : (
-        <td>{row.entry}</td>
+        <td className={rest.styles.logsRowMessage}>{row.entry}</td>
       )}
-      <td></td>
+      <td className={`log-row-menu-cell ${rest.styles.logRowMenuCell}`}></td>
     </tr>
   );
 };


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/103401 where we disabled preview in Explore, this PR adds a few missing CSS classes to the preview component. Without it, it was causing a rendering/scroll jump that caused line wrapping to behave in an unexpected way.

Before:

https://github.com/user-attachments/assets/3c612e4e-9f7a-431f-8a7a-6922825cf7c0

After:

https://github.com/user-attachments/assets/7cde3bf0-78a3-49b3-b01c-f07460323cf1

ControlledLogRows will not use the preview because it doesn't play well with the "scroll to bottom" button.
The main beneficiary from these changes, Dashboards, will remain unchanged for now.

Fixes #103538
