### PR TITLE
KeeperMetadataStorage: add method to get keeper config

### DIFF
--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -21,6 +21,7 @@ type KeeperMetadataStorage interface {
 	Update(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
+	GetKeeperConfig(ctx context.Context, namespace string, name string) (KeeperType, secretv0alpha1.KeeperConfig, error)
 }
 
 // ErrKeeperInvalidSecureValues is returned when a Keeper references SecureValues that do not exist.

--- a/pkg/registry/apis/secret/reststorage/keeper_fake.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_fake.go
@@ -102,3 +102,7 @@ func (s *fakeKeeperMetadataStorage) List(ctx context.Context, namespace xkube.Na
 		Items: l,
 	}, nil
 }
+
+func (s *fakeKeeperMetadataStorage) GetKeeperConfig(ctx context.Context, namespace string, name string) (contracts.KeeperType, secretv0alpha1.KeeperConfig, error) {
+	panic("unimplemented: fakeKeeperMetadataStorage.GetKeeperConfig")
+}

--- a/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 )
 
@@ -19,10 +18,10 @@ type FakeKeeper struct {
 
 var _ contracts.Keeper = (*FakeKeeper)(nil)
 
-func NewFakeKeeper(tracer tracing.Tracer, encryptionManager contracts.EncryptionManager, store contracts.EncryptedValueStorage) (*FakeKeeper, error) {
+func NewFakeKeeper() *FakeKeeper {
 	return &FakeKeeper{
 		values: make(map[string]map[string]string),
-	}, nil
+	}
 }
 
 func (s *FakeKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {

--- a/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
@@ -18,10 +18,10 @@ type FakeKeeper struct {
 
 var _ contracts.Keeper = (*FakeKeeper)(nil)
 
-func NewFakeKeeper() *FakeKeeper {
+func NewFakeKeeper() (*FakeKeeper, error) {
 	return &FakeKeeper{
 		values: make(map[string]map[string]string),
-	}
+	}, nil
 }
 
 func (s *FakeKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {

--- a/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 )
 
@@ -18,7 +19,7 @@ type FakeKeeper struct {
 
 var _ contracts.Keeper = (*FakeKeeper)(nil)
 
-func NewFakeKeeper() (*FakeKeeper, error) {
+func NewFakeKeeper(tracer tracing.Tracer, encryptionManager contracts.EncryptionManager, store contracts.EncryptedValueStorage) (*FakeKeeper, error) {
 	return &FakeKeeper{
 		values: make(map[string]map[string]string),
 	}, nil


### PR DESCRIPTION
`panic("unimplemented: ...")` means the method is not being used but needs to be implemented to satisfy an interface