### PR TITLE
CloudMigrations: Update footer copy to reflect a wider range of resources can be migrated

### DIFF
--- a/public/app/features/migrate-to-cloud/onprem/SupportedTypesDisclosure.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/SupportedTypesDisclosure.tsx
@@ -5,10 +5,14 @@ export function SupportedTypesDisclosure() {
   return (
     <Text color="secondary" textAlignment="center">
       <Trans i18nKey="migrate-to-cloud.support-types-disclosure.text">
-        Dashboards, Folders, and built-in core data sources are migrated to your Grafana Cloud stack.{' '}
-        <TextLink external href="https://grafana.com/docs/grafana-cloud/account-management/migration-guide">
-          Learn about migrating other settings.
-        </TextLink>
+        Resources are copied to your Grafana Cloud stack.{' '}
+        <TextLink
+          external
+          href="https://grafana.com/docs/grafana-cloud/security-and-account-management/migration-guide/"
+        >
+          Learn more
+        </TextLink>{' '}
+        about the full set of supported resources and migrating other settings.
       </Trans>
     </Text>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5434,7 +5434,7 @@
       "upload-migration": "Upload snapshot"
     },
     "support-types-disclosure": {
-      "text": "Dashboards, Folders, and built-in core data sources are migrated to your Grafana Cloud stack. <2>Learn about migrating other settings.</2>"
+      "text": "Resources are copied to your Grafana Cloud stack. <2>Learn more</2> about the full set of supported resources and migrating other settings."
     },
     "token-status": {
       "active": "Token created and active",


### PR DESCRIPTION
**What is this feature?**

Updates the copy in the Migration Assistant's page footer.

**Why do we need this feature?**

Clarify that we support more resources and link to the updated docs.

**Who is this feature for?**

Migration Assistant users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1314

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
