### PR TITLE
Chore: Make alerting frontend codeowners of unified alerting types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -570,6 +570,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/types/ @grafana/grafana-frontend-platform
 /public/app/types/alerting.ts @grafana/alerting-frontend
 /public/app/types/unified-alerting-dto.ts @grafana/alerting-frontend
+/public/app/types/unified-alerting.ts @grafana/alerting-frontend
 /public/dashboards/ @grafana/dashboards-squad
 /public/gazetteer/ @ryantxu
 /public/img/ @grafana/grafana-frontend-platform


### PR DESCRIPTION
**What is this feature?**
Makes alerting frontend codeowner of `/public/app/types/unified-alerting.ts` (I think it was missed previously?)