### PR TITLE
Alerting: Set ExecErrState to Normal for imported Prometheus rules

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -72,7 +72,7 @@ var (
 	defaultConfig = Config{
 		FromTimeRange:              &defaultTimeRange,
 		EvaluationOffset:           &defaultEvaluationOffset,
-		ExecErrState:               models.ErrorErrState,
+		ExecErrState:               models.OkErrState,
 		NoDataState:                models.OK,
 		KeepOriginalRuleDefinition: util.Pointer(true),
 	}

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -354,6 +354,9 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				require.Equal(t, models.Duration(10*time.Minute+evalOffset), grafanaRule.Data[0].RelativeTimeRange.From)
 				require.Equal(t, util.Pointer(1), grafanaRule.MissingSeriesEvalsToResolve)
 
+				require.Equal(t, models.OkErrState, grafanaRule.ExecErrState)
+				require.Equal(t, models.OK, grafanaRule.NoDataState)
+
 				originalRuleDefinition, err := yaml.Marshal(promRule)
 				require.NoError(t, err)
 				require.Equal(t, string(originalRuleDefinition), grafanaRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)


### PR DESCRIPTION
Set ExecErrState to Normal for imported Prometheus rules.

Part of https://github.com/grafana/alerting-squad/issues/971