### PR TITLE
Dashboards: Fix dashboard UID inconsistency between creation and retrieval in legacy storage

### DIFF
--- a/pkg/registry/apis/dashboard/legacy_storage.go
+++ b/pkg/registry/apis/dashboard/legacy_storage.go
@@ -15,6 +15,7 @@ import (
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -82,8 +83,21 @@ func (s *storeWrapper) Create(ctx context.Context, obj runtime.Object, createVal
 		}
 	}
 
+	meta, metaErr := utils.MetaAccessor(obj)
+	if metaErr == nil {
+		// Reconstruc the same UID as done at the storage level
+		// https://github.com/grafana/grafana/blob/a84e96fba29c3a1bb384fdbad1c9c658cc79ec8f/pkg/registry/apis/dashboard/legacy/sql_dashboards.go#L287
+		// This is necessary because the UID generated during the creation via legacy storage is actually never stored in the database
+		// and the one returned here is wrong.
+		meta.SetUID(gapiutil.CalculateClusterWideUID(obj))
+	}
+
 	if err != nil {
 		return obj, err
+	}
+
+	if metaErr != nil {
+		return obj, metaErr
 	}
 
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)


### PR DESCRIPTION
**What is this feature?**
This PR fixes an issue where the UID generated during dashboard creation via legacy storage was inconsistent with the UID returned when retrieving the same dashboard. The implementation now ensures that UIDs are calculated consistently for both creation and retrieval operations.

**Why do we need this feature?**
The UID generated and returned during dashboard creation was mismatching with the one generated (as they are not stored in the DB) when retrieving a dashboard from legacy storage. This inconsistency could lead to problems with dashboard references and API operations that rely on stable UIDs.

**Who is this feature for?**
This fix benefits developers using the dashboard API and ensures consistent behavior in mode 0 - 2 for end users who are creating and accessing dashboards through the API. It's particularly important for maintaining referential integrity in the system.

**Which issue(s) does this PR fix?:**
Fixes the UID mismatch issue referenced in team discussions (https://raintank-corp.slack.com/archives/C05FYAPEPKP/p1743111830777889)