### PR TITLE
Tempo: Temporarily skip new proto fields

### DIFF
--- a/pkg/tsdb/tempo/traceql_query.go
+++ b/pkg/tsdb/tempo/traceql_query.go
@@ -101,7 +101,12 @@ func (s *Service) runTraceQlQueryMetrics(ctx context.Context, pCtx backend.Plugi
 		result.Frames = frames
 	} else {
 		var queryResponse tempopb.QueryRangeResponse
-		err = jsonpb.Unmarshal(bytes.NewReader(responseBody), &queryResponse)
+		// Temporarily allow extra fields until proto changes are available (https://github.com/grafana/tempo/pull/4525)
+		unmarshaler := jsonpb.Unmarshaler{
+			AllowUnknownFields: true,
+		}
+
+		err = unmarshaler.Unmarshal(bytes.NewReader(responseBody), &queryResponse)
 
 		if res, err := handleConversionError(ctxLogger, span, err); err != nil {
 			return res, err


### PR DESCRIPTION
This is to make sure new fields defined in https://github.com/grafana/tempo/pull/4525 will not break queries in Grafana. Once the PR is merged we can move back to use proto types + show a message in the UI about partial results

I tested it with:
- using https://github.com/grafana/tempo/pull/4525 locally
- run `make docker-images`
- `cd example/docker/local`
- `mkdir tempo-data/`
- added `max_response_series: 1` in `example/docker-compose/local/tempo.yaml` in `query_frontend` settings
- `docker compose up -d`

Checked with streaming enabled and disabled.