### PR TITLE
Azure: Ensure basic logs queries are limited to a single resource

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/__mocks__/resourcePickerRows.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/resourcePickerRows.ts
@@ -105,6 +105,22 @@ export const mockResourcesByResourceGroup = (): ResourceRowGroup => [
     location: 'northeurope',
   },
   {
+    id: 'la-workspace',
+    uri: '/subscriptions/def-456/resourceGroups/dev-3/providers/microsoft.operationalinsights/workspaces/la-workspace',
+    name: 'la-workspace',
+    typeLabel: 'Microsoft.OperationalInsights',
+    type: ResourceRowType.Resource,
+    location: 'northeurope',
+  },
+  {
+    id: 'la-workspace-1',
+    uri: '/subscriptions/def-456/resourceGroups/dev-3/providers/microsoft.operationalinsights/workspaces/la-workspace-1',
+    name: 'la-workspace-1',
+    typeLabel: 'Microsoft.OperationalInsights',
+    type: ResourceRowType.Resource,
+    location: 'northeurope',
+  },
+  {
     id: 'app-insights-1',
     uri: '/subscriptions/def-456/resourceGroups/dev-3/providers/microsoft.insights/components/app-insights-1',
     name: 'app-insights-1',

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -424,6 +424,46 @@ describe('LogsQueryEditor', () => {
 
       expect(await screen.queryByLabelText('Basic')).not.toBeInTheDocument();
     });
+
+    it('should disable other resources with a basic logs query when one resource is selected', async () => {
+      const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
+      const query = createMockQuery({
+        azureLogAnalytics: {
+          resources: [
+            '/subscriptions/def-456/resourceGroups/dev-3/providers/microsoft.operationalinsights/workspaces/la-workspace',
+          ],
+          basicLogsQuery: true,
+        },
+      });
+      const basicLogsEnabled = true;
+      const onChange = jest.fn();
+      const onQueryChange = jest.fn();
+
+      render(
+        <LogsQueryEditor
+          query={query}
+          datasource={mockDatasource}
+          variableOptionGroup={variableOptionGroup}
+          onChange={onChange}
+          onQueryChange={onQueryChange}
+          setError={() => {}}
+          basicLogsEnabled={basicLogsEnabled}
+        />
+      );
+
+      expect(await screen.findByLabelText('Basic')).toBeInTheDocument();
+
+      const resourcePickerButton = await screen.findByRole('button', { name: 'la-workspace' });
+      await userEvent.click(resourcePickerButton);
+
+      const checkbox = await screen.findByLabelText('la-workspace');
+      expect(checkbox).toBeChecked();
+
+      expect(await screen.findByLabelText('la-workspace-1')).toBeDisabled();
+      expect(
+        await screen.findByText('When using Basic Logs, you may only select one resource at a time.')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('data ingestion warning', () => {

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -59,12 +59,19 @@ const LogsQueryEditor = ({
   const from = templateSrv?.replace('$__from');
   const to = templateSrv?.replace('$__to');
   const templateVariableOptions = templateSrv.getVariables();
+  const isBasicLogsQuery = (basicLogsEnabled && query.azureLogAnalytics?.basicLogsQuery) ?? false;
 
   const disableRow = (row: ResourceRow, selectedRows: ResourceRowGroup) => {
     if (selectedRows.length === 0) {
       // Only if there is some resource(s) selected we should disable rows
       return false;
     }
+
+    if (isBasicLogsQuery && selectedRows.length === 1) {
+      // Basic logs queries can only have one resource selected
+      return true;
+    }
+
     const rowResourceNS = parseResourceDetails(row.uri, row.location).metricNamespace?.toLowerCase();
     const selectedRowSampleNs = parseResourceDetails(
       selectedRows[0].uri,
@@ -210,7 +217,12 @@ const LogsQueryEditor = ({
                 // eslint-disable-next-line
                 <AdvancedResourcePicker resources={resources as string[]} onChange={onChange} />
               )}
-              selectionNotice={() => 'You may only choose items of the same resource type.'}
+              selectionNotice={(selected) => {
+                if (selected.length === 1 && isBasicLogsQuery) {
+                  return 'When using Basic Logs, you may only select one resource at a time.';
+                }
+                return 'You may only choose items of the same resource type.';
+              }}
             />
             {showBasicLogsToggle && (
               <LogsManagement


### PR DESCRIPTION
Basic logs does not support cross-resource queries. This change ensures that when a user selects a resource and selects the basic logs option then they will not be able to select another resource. 