### PR TITLE
Dynamic dashboards: fix paste tab button looking weird when many tabs or small viewport

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/dashboardGrid.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/dashboardGrid.ts
@@ -91,6 +91,7 @@ export function getDashboardGridStyles(theme: GrafanaTheme2) {
     },
 
     '.dashboard-canvas-add-button': {
+      display: 'flex',
       opacity: 0.5,
       transition: theme.transitions.create('opacity'),
       filter: `grayscale(100%)`,


### PR DESCRIPTION
**What is this feature?**

With many tabs the past tab button ends up below the new tab button.

before:
![image](https://github.com/user-attachments/assets/9f4b709d-f19b-4d13-88ea-4e4f08f7c6be)

after:
![image](https://github.com/user-attachments/assets/268d40fb-8d7d-4fec-be47-66ba7979c54f)
