### PR TITLE
Docs: Standard Datetime units limited to millisecond precision

### DIFF
--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -187,18 +187,23 @@ You can also paste a native emoji in the **Unit** drop-down and select it as a c
 
 ![A time series visualization using custom thumbs up emoji units](/media/docs/grafana/panels-visualizations/thumbsup_panel_v11.0.png)
 
-#### Time format units
+##### Time format units
 
-All Date & time format units in Grafana (such as "Datetime ISO", "Datetime US", etc.) expect input values to be in **milliseconds** since the Unix epoch (January 1, 1970). If your data source provides timestamps in seconds, these will be incorrectly interpreted as dates very close to January 1, 1970.
+All **Date & time** format units in Grafana (such as **Datetime ISO** or **Datetime US**) expect input values to be in milliseconds since the Unix epoch (January 1, 1970). If your data source provides timestamps in seconds, these will be incorrectly interpreted as dates very close to January 1, 1970.
 
-To display timestamps that are in seconds since epoch, you need to multiply your timestamp values by 1000 using a transformation:
+To display timestamps that are in seconds since epoch, multiply your timestamp values by 1000 using a transformation following these steps:
 
-- Add a "Calculate field" transformation
-- Set "Mode" to "Binary operation"
-- Set "Operation" to "Multiply by"
-- Set "Field name" to your timestamp field
-- Set "Use" to "Numeric value" and enter "1000"
-- Check "Replace all fields" if you only want to see the calculated field
+1. In the panel editor, click the **Transformations** tab.
+1. Click **Add transformation**.
+1. Select the **Add field from calculation** transformation.
+1. Set the following options:
+
+   - **Mode** - **Binary operation**
+   - **Operation** 
+      - Select your timestamp field
+      - Select the asterisk (`*`) for multiply by
+      - Enter 1000 in the **Field or Number** field 
+  - Toggle the **Replace all fields** switch on if you want to see the calculated field.
 
 #### Control unit scaling
 

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -203,8 +203,7 @@ To display timestamps that are in seconds since epoch, multiply your timestamp v
      - Select your timestamp field
      - Select the asterisk (`*`) for multiply by
      - Enter 1000 in the **Field or Number** field
-
-- Toggle the **Replace all fields** switch on if you want to see the calculated field.
+   - Toggle the **Replace all fields** switch on if you want to see the calculated field.
 
 #### Control unit scaling
 

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -199,11 +199,12 @@ To display timestamps that are in seconds since epoch, multiply your timestamp v
 1. Set the following options:
 
    - **Mode** - **Binary operation**
-   - **Operation** 
-      - Select your timestamp field
-      - Select the asterisk (`*`) for multiply by
-      - Enter 1000 in the **Field or Number** field 
-  - Toggle the **Replace all fields** switch on if you want to see the calculated field.
+   - **Operation**
+     - Select your timestamp field
+     - Select the asterisk (`*`) for multiply by
+     - Enter 1000 in the **Field or Number** field
+
+- Toggle the **Replace all fields** switch on if you want to see the calculated field.
 
 #### Control unit scaling
 

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -187,6 +187,19 @@ You can also paste a native emoji in the **Unit** drop-down and select it as a c
 
 ![A time series visualization using custom thumbs up emoji units](/media/docs/grafana/panels-visualizations/thumbsup_panel_v11.0.png)
 
+#### Time format units
+
+All Date & time format units in Grafana (such as "Datetime ISO", "Datetime US", etc.) expect input values to be in **milliseconds** since the Unix epoch (January 1, 1970). If your data source provides timestamps in seconds, these will be incorrectly interpreted as dates very close to January 1, 1970.
+
+To display timestamps that are in seconds since epoch, you need to multiply your timestamp values by 1000 using a transformation:
+
+- Add a "Calculate field" transformation
+- Set "Mode" to "Binary operation"
+- Set "Operation" to "Multiply by"
+- Set "Field name" to your timestamp field
+- Set "Use" to "Numeric value" and enter "1000"
+- Check "Replace all fields" if you only want to see the calculated field
+
 #### Control unit scaling
 
 By default, Grafana automatically scales the unit based on the magnitude of the value. For example, if you have values of 0.14kW and 3000kW, Grafana displays them as 140W and 3MW, respectively. You can use custom units to control this behavior by setting a prefix, suffix, or custom SI unit.


### PR DESCRIPTION
## What's Changed
Added documentation clarifying that all Date & Time format units in Grafana require timestamps in milliseconds since epoch.
This issue was reported multiple times([issue 1](https://github.com/grafana/grafana/issues/77187), [issue 2](https://github.com/grafana/grafana/issues/9595)) and was difficult to identify as an existing limitation.

I verified instructions for using the "Add field from calculation" transformation for accuracy: https://play.grafana.org/goto/424qApAHg?orgId=1 