### PR TITLE
K8s/Client: Ignore validation from dashboards frontend v1

### DIFF
--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -232,14 +232,19 @@ export interface ResourceEvent<T = object, S = object, K = string> {
   object: Resource<T, S, K>;
 }
 
+export type ResourceClientWriteParams = {
+  dryRun?: 'All';
+  fieldValidation?: 'Ignore' | 'Warn' | 'Strict';
+};
+
 export interface ResourceClient<T = object, S = object, K = string> {
-  create(obj: ResourceForCreate<T, K>): Promise<Resource<T, S, K>>;
   get(name: string): Promise<Resource<T, S, K>>;
-  watch(opts?: WatchOptions): Observable<ResourceEvent<T, S, K>>;
-  subresource<S>(name: string, path: string): Promise<S>;
-  list(opts?: ListOptions): Promise<ResourceList<T, S, K>>;
-  update(obj: ResourceForCreate<T, K>): Promise<Resource<T, S, K>>;
+  create(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>>;
+  update(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>>;
   delete(name: string, showSuccessAlert?: boolean): Promise<MetaStatus>;
+  list(opts?: ListOptions): Promise<ResourceList<T, S, K>>;
+  subresource<S>(name: string, path: string, params?: Record<string, unknown>): Promise<S>;
+  watch(opts?: WatchOptions): Observable<ResourceEvent<T, S, K>>;
 }
 
 export interface K8sAPIGroup {

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -110,9 +110,13 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
           isFolder: false,
           uid: dash.metadata.name,
           k8s: dash.metadata,
-          version: parseInt(dash.metadata.resourceVersion, 10),
+          version: dash.metadata.generation,
         },
-        dashboard: dash.spec,
+        dashboard: {
+          ...dash.spec,
+          version: dash.metadata.generation,
+          uid: dash.metadata.name,
+        },
       };
 
       if (dash.metadata.labels?.[DeprecatedInternalId]) {

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -58,11 +58,13 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       };
     }
 
+    // for v1 in g12, we will ignore the schema version validation from all default clients,
+    // as we implement the necessary backend conversions, we will drop this query param
     if (dashboard.uid) {
       obj.metadata.name = dashboard.uid;
-      return this.client.update(obj).then((v) => this.asSaveDashboardResponseDTO(v));
+      return this.client.update(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
     }
-    return this.client.create(obj).then((v) => this.asSaveDashboardResponseDTO(v));
+    return this.client.create(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
   }
 
   asSaveDashboardResponseDTO(v: Resource<DashboardDataDTO>): SaveDashboardResponseDTO {
@@ -108,13 +110,9 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
           isFolder: false,
           uid: dash.metadata.name,
           k8s: dash.metadata,
-          version: dash.metadata.generation,
+          version: parseInt(dash.metadata.resourceVersion, 10),
         },
-        dashboard: {
-          ...dash.spec,
-          version: dash.metadata.generation,
-          uid: dash.metadata.name,
-        },
+        dashboard: dash.spec,
       };
 
       if (dash.metadata.labels?.[DeprecatedInternalId]) {

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -219,7 +219,8 @@ describe('v2 dashboard API', () => {
             ...defaultSaveCommand.dashboard,
             title: 'chaing-title-dashboard',
           },
-        }
+        },
+        { params: undefined }
       );
     });
   });


### PR DESCRIPTION
This adds `fieldValidation=Ignore` to the /v1 requests for dashboards

Extracting the frontend from: https://github.com/grafana/grafana/pull/102253

Relates to https://github.com/grafana/app-platform-wg/issues/249