### PR TITLE
Logs Panel: panel options only tabbable after going through every log line

### DIFF
--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -105,6 +105,7 @@ const LogRowsComponent = ({ loading, loadMoreLogs, deduplicatedRows = [], range,
 
   return (
     <div className={styles.logRowsContainer}>
+      <LogListControls eventBus={eventBus} />
       <div
         ref={scrollElementRef}
         className={config.featureToggles.logsInfiniteScrolling ? styles.scrollableLogRows : styles.logRows}
@@ -133,7 +134,6 @@ const LogRowsComponent = ({ loading, loadMoreLogs, deduplicatedRows = [], range,
           />
         </InfiniteScroll>
       </div>
-      <LogListControls eventBus={eventBus} />
     </div>
   );
 };
@@ -159,5 +159,6 @@ const styles = {
   }),
   logRowsContainer: css({
     display: 'flex',
+    flexDirection: 'row-reverse',
   }),
 };

--- a/public/app/features/logs/components/ControlledLogsTable.tsx
+++ b/public/app/features/logs/components/ControlledLogsTable.tsx
@@ -34,6 +34,7 @@ export const ControlledLogsTable = ({
 
   return (
     <div className={styles.logRowsContainer}>
+      <LogListControls eventBus={eventBus} visualisationType={visualisationType} />
       <div className={styles.logRows} data-testid="logRowsTable">
         {/* Width should be full width minus logs navigation and padding */}
         <LogsTableWrap
@@ -51,7 +52,6 @@ export const ControlledLogsTable = ({
           datasourceType={datasourceType}
         />
       </div>
-      <LogListControls eventBus={eventBus} visualisationType={visualisationType} />
     </div>
   );
 };
@@ -64,6 +64,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     logRowsContainer: css({
       display: 'flex',
+      flexDirection: 'row-reverse',
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**
Fixes a11y issue with logs panel options (feature toggle: `logsPanelControls`), where the options are keyboard accessible, but only after going through every log line.

**Why do we need this feature?**
To keep log users that rely on keyboard navigation from throwing their keyboard out the window in frustration.

**Who is this feature for?**
Logs panel users that rely on keyboard navigation.


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
