### PR TITLE
[release-11.6.1] GrafanaUI: Remove blurred background from overlay backdrops to improve performance

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -31,9 +31,6 @@ export interface ThemeComponents {
   };
   overlay: {
     background: string;
-
-    /* pixel strength for backdrop blurs */
-    blur?: number;
   };
   dashboard: {
     background: string;

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -31,6 +31,9 @@ export interface ThemeComponents {
   };
   overlay: {
     background: string;
+
+    /* pixel strength for backdrop blurs */
+    blur?: number;
   };
   dashboard: {
     background: string;
@@ -91,7 +94,7 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       padding: 1,
     },
     overlay: {
-      background: colors.mode === 'dark' ? 'rgba(63, 62, 62, 0.45)' : 'rgba(208, 209, 211, 0.24)',
+      background: colors.mode === 'dark' ? 'rgba(63, 62, 62, 0.5)' : 'rgba(208, 209, 211, 0.5)',
     },
     sidemenu: {
       width: 57,

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -292,7 +292,6 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '&:before': {
         backgroundColor: `${theme.components.overlay.background} !important`,
-        backdropFilter: 'blur(1px)',
         bottom: 0,
         content: '""',
         left: 0,

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -34,7 +34,6 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
       bottom: 0,
       left: 0,
       backgroundColor: theme.components.overlay.background,
-      backdropFilter: 'blur(1px)',
     }),
     modalHeader: css({
       label: 'modalHeader',

--- a/public/app/core/components/AppChrome/AppChromeMenu.tsx
+++ b/public/app/core/components/AppChrome/AppChromeMenu.tsx
@@ -81,7 +81,6 @@ export function AppChromeMenu({}: Props) {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     backdrop: css({
-      backdropFilter: 'blur(1px)',
       backgroundColor: theme.components.overlay.background,
       bottom: 0,
       left: 0,

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -174,7 +174,6 @@ const getSearchStyles = (theme: GrafanaTheme2, lateralSpace: number) => {
         bottom: 0,
         left: 0,
         background: theme.components.overlay.background,
-        backdropFilter: 'blur(1px)',
       },
     }),
     animator: css({


### PR DESCRIPTION
Backport 577ea8f6a9cb3baa48bd631e31f38e558ba81cd3 from #103563

This backport is a bit lighter than the original branch because the `noBackdropBlur` toggle did not make it to 11.6.0

---

In https://github.com/grafana/grafana/pull/102128 we added a temporary feature toggle to disable backdrop-filter: blur() behind overlays like modals and drawers to address performance problems we've seen reports for.

This PR removes the toggle, removes the blur from all backdrops, and tweaks the backdrop colour to improve contrast.

After doing some research into the issue it appears recent changes in browsers has made a whole-page blur less viable on certain low-powered devices. Rather than continuing to investigate deeper or attempt a 'smarter' solution, I figure it's more pragmatic to just remove the blur all together. It's extremely subtle anyway.

Without the blur, I found there wasn't enough contrast between the modal and the obscured content, especially in Light theme. As a quick improvement, I made the backdrop more opaque (light `0.24` to `0.5`, dark `0.45` to `0.5`).


| Old | New |
|-----|-----|
| ![old-nav-light](https://github.com/user-attachments/assets/78148303-08bd-4771-83d0-b63fb50977f7) | ![new-nav-light](https://github.com/user-attachments/assets/b064a511-87ba-4853-9c4d-81d3c02f2826) |
| ![old-dash-light](https://github.com/user-attachments/assets/358da24c-97eb-49b4-a0f0-576a8292e350) | ![new-dash-light](https://github.com/user-attachments/assets/6b3b467b-58e2-494d-89b6-5af354e42457) |
| ![old-nav-dark](https://github.com/user-attachments/assets/4187de86-19bf-4571-a0c2-a80bf8b513a5) | ![new-nav-dark](https://github.com/user-attachments/assets/e20bfa66-ddb5-4311-acd9-02d376bb9f90) |
| ![old-dash-dark](https://github.com/user-attachments/assets/ba533c4d-5a65-4f5b-a5c5-c57f24685b40) | ![new-dash-dark](https://github.com/user-attachments/assets/c7ec380a-3b34-4f3c-ae7a-4499cf70ce19) |

Fixes https://github.com/grafana/grafana/issues/100859
