### PR TITLE
Docs: On-prem license management

### DIFF
--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -43,7 +43,7 @@ To download your Grafana Enterprise license:
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
 1. If the license shows "License not configured" or if the URL is listed as "-", you need to update the details. This requires the Admin role.
    1. Click **Update** next to License Details. _If the **Update** button isn't visible, contact the Grafana account team._
-   1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with https://, and it cannot be `localhost` or contain wildcards.
+   1. Enter the URL. It must match the effective [`root_url`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including the trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with "https://", and it can't be `localhost` or contain wildcards.
    1. Optionally you may edit the license name. The name is only used for display purposes.
    1. Click **Save**.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -42,7 +42,7 @@ To download your Grafana Enterprise license:
 1. Sign in to your [Grafana Cloud](/) account.
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
 1. If the license shows "License not configured" or if the URL is listed as "-", you need to update the details. This requires the Admin role.
-   1. Click **Update** next to License Details. _(If the Update button is not visible, contact the Grafana account team.)_
+   1. Click **Update** next to License Details. _If the **Update** button isn't visible, contact the Grafana account team._
    1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with https://, and it cannot be `localhost` or contain wildcards.
    1. Optionally you may edit the license name. The name is only used for display purposes.
    1. Click **Save**.

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -43,7 +43,7 @@ To download your Grafana Enterprise license:
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
 1. If the license shows "License not configured" or if the URL is listed as "-", you will need to update the details. (This requires the Admin role.)
    1. Click **Update** next to License Details. _(If the Update button is not visible, contact the Grafana account team.)_
-   1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname(s). The URL must start with https://, and it cannot be `localhost` or contain wildcards.
+   1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with https://, and it cannot be `localhost` or contain wildcards.
    1. Click **Save**.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.
 

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -41,7 +41,7 @@ To download your Grafana Enterprise license:
 
 1. Sign in to your [Grafana Cloud](/) account.
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
-1. If the license shows "License not configured" or if the URL is listed as "-", you will need to update the details. (This requires the Admin role.)
+1. If the license shows "License not configured" or if the URL is listed as "-", you need to update the details. This requires the Admin role.
    1. Click **Update** next to License Details. _(If the Update button is not visible, contact the Grafana account team.)_
    1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with https://, and it cannot be `localhost` or contain wildcards.
    1. Optionally you may edit the license name. The name is only used for display purposes.

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -41,6 +41,10 @@ To download your Grafana Enterprise license:
 
 1. Sign in to your [Grafana Cloud](/) account.
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
+1. If the license shows "License not configured" or if the URL is listed as "-", you will need to update the details. (This requires the Admin role.)
+   1. Click **Update** next to License Details. _(If the Update button is not visible, contact the Grafana account team.)_
+   1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname(s). The URL must start with https://, and it cannot be `localhost` or contain wildcards.
+   1. Click **Save**.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.
 
 ### Step 2. Add your license to a Grafana instance

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -44,7 +44,7 @@ To download your Grafana Enterprise license:
 1. If the license shows "License not configured" or if the URL is listed as "-", you need to update the details. This requires the Admin role.
    1. Click **Update** next to License Details. _If the **Update** button isn't visible, contact the Grafana account team._
    1. Enter the URL. It must match the effective [`root_url`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including the trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with "https://", and it can't be `localhost` or contain wildcards.
-   1. Optionally you may edit the license name. The name is only used for display purposes.
+   1. (Optional) Edit the license name. This name is only used for display purposes.
    1. Click **Save**.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.
 

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -44,6 +44,7 @@ To download your Grafana Enterprise license:
 1. If the license shows "License not configured" or if the URL is listed as "-", you will need to update the details. (This requires the Admin role.)
    1. Click **Update** next to License Details. _(If the Update button is not visible, contact the Grafana account team.)_
    1. Enter the URL. It must match the effective [root_url](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#root_url) configuration setting (including trailing slash) of the Grafana Enterprise instance. It should be the URL that users type in their browsers to access the frontend, not the node hostname. The URL must start with https://, and it cannot be `localhost` or contain wildcards.
+   1. Optionally you may edit the license name. The name is only used for display purposes.
    1. Click **Save**.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.
 


### PR DESCRIPTION
**What is this feature?**

Customer-facing documentation for on-prem license management.

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-com/issues/13217

**Reviewer notes**

Please see the above grafana-com issue for more details.

I ran Vale and did a documentation build.

Screen shot:

![image](https://github.com/user-attachments/assets/36b8840d-7e53-4b85-8af2-15c71bac80aa)

(I checked the `root_url` link.)

The documentation instructions say to "Review publishing options"; I've never done this before and don't know what's required to get this on the website.