### PR TITLE
GrafanaUI: Remove unused blur component token

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -31,9 +31,6 @@ export interface ThemeComponents {
   };
   overlay: {
     background: string;
-
-    /* pixel strength for backdrop blurs */
-    blur?: number;
   };
   dashboard: {
     background: string;


### PR DESCRIPTION
I missed @ashharrison90's feedback on https://github.com/grafana/grafana/pull/103563 that I forgot to remove the `components.backdrop.blur` token which I added in an earlier stage of the PR.

This PR just removes that token.

This change has already been incorporated into the backport https://github.com/grafana/grafana/pull/103647 