### PR TITLE
[release-11.5.4] Azure: Add support for custom namespace and custom metrics variable queries

### DIFF
--- a/docs/sources/datasources/azure-monitor/template-variables/index.md
+++ b/docs/sources/datasources/azure-monitor/template-variables/index.md
@@ -48,19 +48,24 @@ For an introduction to templating and template variables, refer to the [Templati
 
 You can specify these Azure Monitor data source queries in the Variable edit view's **Query Type** field.
 
-| Name                | Description                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Subscriptions**   | Returns subscriptions.                                                                                             |
-| **Resource Groups** | Returns resource groups for a specified. Supports multi-value. subscription.                                       |
-| **Namespaces**      | Returns metric namespaces for the specified subscription and resource group.                                       |
-| **Regions**         | Returns regions for the specified subscription                                                                     |
-| **Resource Names**  | Returns a list of resource names for a specified subscription, resource group and namespace. Supports multi-value. |
-| **Metric Names**    | Returns a list of metric names for a resource.                                                                     |
-| **Workspaces**      | Returns a list of workspaces for the specified subscription.                                                       |
-| **Logs**            | Use a KQL query to return values.                                                                                  |
-| **Resource Graph**  | Use an ARG query to return values.                                                                                 |
+| Name                    | Description                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Subscriptions**       | Returns subscriptions.                                                                                             |
+| **Resource Groups**     | Returns resource groups for a specified. Supports multi-value. subscription.                                       |
+| **Namespaces**          | Returns metric namespaces for the specified subscription and resource group.                                       |
+| **Regions**             | Returns regions for the specified subscription                                                                     |
+| **Resource Names**      | Returns a list of resource names for a specified subscription, resource group and namespace. Supports multi-value. |
+| **Metric Names**        | Returns a list of metric names for a resource.                                                                     |
+| **Workspaces**          | Returns a list of workspaces for the specified subscription.                                                       |
+| **Logs**                | Use a KQL query to return values.                                                                                  |
+| **Custom Namespaces**   | Returns metric namespaces for the specified resource.                                                              |
+| **Custom Metric Names** | Returns a list of custom metric names for the specified resource.                                                  |
 
-Any Log Analytics Kusto Query Language (KQL) query that returns a single list of values can also be used in the Query field.
+{{< admonition type="note" >}}
+Custom metrics cannot be emitted against a subscription or resource group. Select resources only when you need to retrieve custom metric namespaces or custom metric names associated with a specific resource.
+{{< /admonition >}}
+
+You can use any Log Analytics Kusto Query Language (KQL) query that returns a single list of values in the `Query` field.
 For example:
 
 | Query                                                                                     | List of values returned                 |

--- a/packages/grafana-schema/src/raw/composable/azuremonitor/dataquery/x/AzureMonitorDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/azuremonitor/dataquery/x/AzureMonitorDataQuery_types.gen.ts
@@ -30,22 +30,36 @@ export interface AzureMonitorQuery extends common.DataQuery {
    */
   azureTraces?: AzureTracesQuery;
   /**
+   * Custom namespace used in template variable queries
+   */
+  customNamespace?: string;
+  /**
    * @deprecated Legacy template variable support.
    */
   grafanaTemplateVariableFn?: GrafanaTemplateVariableQuery;
+  /**
+   * Namespace used in template variable queries
+   */
   namespace?: string;
   /**
    * Used only for exemplar queries from Prometheus
    */
   query?: string;
+  /**
+   * Region used in template variable queries
+   */
   region?: string;
+  /**
+   * Resource used in template variable queries
+   */
   resource?: string;
   /**
-   * Template variables params. These exist for backwards compatiblity with legacy template variables.
+   * Resource group used in template variable queries
    */
   resourceGroup?: string;
   /**
    * Azure subscription containing the resource(s) to be queried.
+   * Also used for template variable queries
    */
   subscription?: string;
   /**
@@ -65,6 +79,8 @@ export enum AzureQueryType {
   AzureMonitor = 'Azure Monitor',
   AzureResourceGraph = 'Azure Resource Graph',
   AzureTraces = 'Azure Traces',
+  CustomMetricNamesQuery = 'Azure Custom Metric Names',
+  CustomNamespacesQuery = 'Azure Custom Namespaces',
   GrafanaTemplateVariableFn = 'Grafana Template Variable Function',
   LocationsQuery = 'Azure Regions',
   LogAnalytics = 'Azure Log Analytics',

--- a/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
@@ -21,6 +21,8 @@ const (
 
 // Defines values for AzureQueryType.
 const (
+	AzureQueryTypeAzureCustomMetricNames          AzureQueryType = "Azure Custom Metric Names"
+	AzureQueryTypeAzureCustomNamespaces           AzureQueryType = "Azure Custom Namespaces"
 	AzureQueryTypeAzureLogAnalytics               AzureQueryType = "Azure Log Analytics"
 	AzureQueryTypeAzureMetricNames                AzureQueryType = "Azure Metric Names"
 	AzureQueryTypeAzureMonitor                    AzureQueryType = "Azure Monitor"
@@ -231,6 +233,9 @@ type AzureMonitorQuery struct {
 	// Application Insights Traces sub-query properties
 	AzureTraces *AzureTracesQuery `json:"azureTraces,omitempty"`
 
+	// Custom namespace used in template variable queries
+	CustomNamespace *string `json:"customNamespace,omitempty"`
+
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
@@ -239,7 +244,9 @@ type AzureMonitorQuery struct {
 	GrafanaTemplateVariableFn *any `json:"grafanaTemplateVariableFn,omitempty"`
 
 	// If hide is set to true, Grafana will filter out the response(s) associated with this query before returning it to the panel.
-	Hide      *bool   `json:"hide,omitempty"`
+	Hide *bool `json:"hide,omitempty"`
+
+	// Namespace used in template variable queries
 	Namespace *string `json:"namespace,omitempty"`
 
 	// Used only for exemplar queries from Prometheus
@@ -252,14 +259,19 @@ type AzureMonitorQuery struct {
 	// A unique identifier for the query within the list of targets.
 	// In server side expressions, the refId is used as a variable name to identify results.
 	// By default, the UI will assign A->Z; however setting meaningful names may be useful.
-	RefId    *string `json:"refId,omitempty"`
-	Region   *string `json:"region,omitempty"`
+	RefId *string `json:"refId,omitempty"`
+
+	// Region used in template variable queries
+	Region *string `json:"region,omitempty"`
+
+	// Resource used in template variable queries
 	Resource *string `json:"resource,omitempty"`
 
-	// Template variables params. These exist for backwards compatiblity with legacy template variables.
+	// Resource group used in template variable queries
 	ResourceGroup *string `json:"resourceGroup,omitempty"`
 
 	// Azure subscription containing the resource(s) to be queried.
+	// Also used for template variable queries
 	Subscription *string `json:"subscription,omitempty"`
 
 	// Subscriptions to be queried via Azure Resource Graph.

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
@@ -40,7 +40,16 @@ const defaultProps = {
   datasource: createMockDatasource({
     getSubscriptions: jest.fn().mockResolvedValue([{ text: 'Primary Subscription', value: 'sub' }]),
     getResourceGroups: jest.fn().mockResolvedValue([{ text: 'rg', value: 'rg' }]),
-    getMetricNamespaces: jest.fn().mockResolvedValue([{ text: 'foo/bar', value: 'foo/bar' }]),
+    getMetricNamespaces: jest
+      .fn()
+      .mockImplementation(
+        async (_subscriptionId: string, _resourceGroup?: string, _resourceUri?: string, custom?: boolean) => {
+          if (custom !== true) {
+            return [{ text: 'foo/bar', value: 'foo/bar' }];
+          }
+          return [{ text: 'foo/custom', value: 'foo/custom' }];
+        }
+      ),
     getResourceNames: jest.fn().mockResolvedValue([{ text: 'foobar', value: 'foobar' }]),
     getVariablesRaw: jest.fn().mockReturnValue([
       { label: 'query0', name: 'sub0' },
@@ -347,6 +356,52 @@ describe('VariableEditor:', () => {
           queryType: AzureQueryType.LocationsQuery,
           subscription: 'sub',
           refId: 'A',
+        })
+      );
+    });
+
+    it('should run the query if requesting custom metric namespaces', async () => {
+      const onChange = jest.fn();
+      const { rerender } = render(<VariableEditor {...defaultProps} onChange={onChange} />);
+      // wait for initial load
+      await waitFor(() => expect(screen.getByText('Logs')).toBeInTheDocument());
+      await selectAndRerender('select query type', 'Custom Namespaces', onChange, rerender);
+      await selectAndRerender('select subscription', 'Primary Subscription', onChange, rerender);
+      await selectAndRerender('select resource group', 'rg', onChange, rerender);
+      await selectAndRerender('select namespace', 'foo/bar', onChange, rerender);
+      await selectAndRerender('select resource', 'foobar', onChange, rerender);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryType: AzureQueryType.CustomNamespacesQuery,
+          subscription: 'sub',
+          resourceGroup: 'rg',
+          namespace: 'foo/bar',
+          resource: 'foobar',
+          refId: 'A',
+        })
+      );
+    });
+
+    it('should run the query if requesting custom metrics for a resource', async () => {
+      const onChange = jest.fn();
+      const { rerender } = render(<VariableEditor {...defaultProps} onChange={onChange} />);
+      // wait for initial load
+      await waitFor(() => expect(screen.getByText('Logs')).toBeInTheDocument());
+      await selectAndRerender('select query type', 'Custom Metric Names', onChange, rerender);
+      await selectAndRerender('select subscription', 'Primary Subscription', onChange, rerender);
+      await selectAndRerender('select resource group', 'rg', onChange, rerender);
+      await selectAndRerender('select namespace', 'foo/bar', onChange, rerender);
+      await selectAndRerender('select resource', 'foobar', onChange, rerender);
+      await selectAndRerender('select custom namespace', 'foo/custom', onChange, rerender);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryType: AzureQueryType.CustomMetricNamesQuery,
+          subscription: 'sub',
+          resourceGroup: 'rg',
+          namespace: 'foo/bar',
+          resource: 'foobar',
+          refId: 'A',
+          customNamespace: 'foo/custom',
         })
       );
     });

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { Alert, Field, Select, Space } from '@grafana/ui';
 
+import UrlBuilder from '../../azure_monitor/url_builder';
 import DataSource from '../../datasource';
 import { selectors } from '../../e2e/selectors';
 import { migrateQuery } from '../../grafanaTemplateVariableFns';
@@ -35,6 +37,8 @@ const VariableEditor = (props: Props) => {
     { label: 'Workspaces', value: AzureQueryType.WorkspacesQuery },
     { label: 'Resource Graph', value: AzureQueryType.AzureResourceGraph },
     { label: 'Logs', value: AzureQueryType.LogAnalytics },
+    { label: 'Custom Namespaces', value: AzureQueryType.CustomNamespacesQuery },
+    { label: 'Custom Metric Names', value: AzureQueryType.CustomMetricNamesQuery },
   ];
   if (typeof props.query === 'object' && props.query.queryType === AzureQueryType.GrafanaTemplateVariableFn) {
     // Add the option for the GrafanaTemplateVariableFn only if it's already in use
@@ -53,10 +57,12 @@ const VariableEditor = (props: Props) => {
   const [hasRegion, setHasRegion] = useState(false);
   const [requireResourceGroup, setRequireResourceGroup] = useState(false);
   const [requireNamespace, setRequireNamespace] = useState(false);
+  const [requireCustomNamespace, setRequireCustomNamespace] = useState(false);
   const [requireResource, setRequireResource] = useState(false);
   const [subscriptions, setSubscriptions] = useState<SelectableValue[]>([]);
   const [resourceGroups, setResourceGroups] = useState<SelectableValue[]>([]);
   const [namespaces, setNamespaces] = useState<SelectableValue[]>([]);
+  const [customNamespaces, setCustomNamespaces] = useState<SelectableValue[]>([]);
   const [resources, setResources] = useState<SelectableValue[]>([]);
   const [regions, setRegions] = useState<SelectableValue[]>([]);
   const [errorMessage, setError] = useLastError();
@@ -77,6 +83,7 @@ const VariableEditor = (props: Props) => {
     setRequireResourceGroup(false);
     setRequireNamespace(false);
     setRequireResource(false);
+    setRequireCustomNamespace(false);
     switch (queryType) {
       case AzureQueryType.ResourceGroupsQuery:
       case AzureQueryType.WorkspacesQuery:
@@ -101,6 +108,19 @@ const VariableEditor = (props: Props) => {
       case AzureQueryType.LocationsQuery:
         setRequireSubscription(true);
         break;
+      case AzureQueryType.CustomNamespacesQuery:
+        setRequireSubscription(true);
+        setRequireResourceGroup(true);
+        setRequireNamespace(true);
+        setRequireResource(true);
+        break;
+      case AzureQueryType.CustomMetricNamesQuery:
+        setRequireSubscription(true);
+        setRequireResourceGroup(true);
+        setRequireResource(true);
+        setRequireNamespace(true);
+        setRequireCustomNamespace(true);
+        break;
     }
   }, [queryType]);
 
@@ -117,6 +137,7 @@ const VariableEditor = (props: Props) => {
     });
   }, [datasource, queryType]);
 
+  // Always retrieve subscriptions first as they're used in most template variable queries
   useEffectOnce(() => {
     datasource.getSubscriptions().then((subs) => {
       setSubscriptions(subs.map((s) => ({ label: s.text, value: s.value })));
@@ -124,6 +145,7 @@ const VariableEditor = (props: Props) => {
   });
 
   const subscription = typeof query === 'object' && query.subscription;
+  // When subscription is set, retrieve resource groups
   useEffect(() => {
     if (subscription) {
       datasource.getResourceGroups(subscription).then((rgs) => {
@@ -133,14 +155,16 @@ const VariableEditor = (props: Props) => {
   }, [datasource, subscription]);
 
   const resourceGroup = (typeof query === 'object' && query.resourceGroup) || '';
+  // When resource group is set, retrieve metric namespaces (aka resource types for a custom metric and custom metric namespace query)
   useEffect(() => {
-    if (subscription) {
+    if (subscription && resourceGroup) {
       datasource.getMetricNamespaces(subscription, resourceGroup).then((rgs) => {
         setNamespaces(rgs.map((s) => ({ label: s.text, value: s.value })));
       });
     }
   }, [datasource, subscription, resourceGroup]);
 
+  // When subscription is set also retrieve locations
   useEffect(() => {
     if (subscription) {
       datasource.azureMonitorDatasource.getLocations([subscription]).then((rgs) => {
@@ -152,13 +176,30 @@ const VariableEditor = (props: Props) => {
   }, [datasource, subscription, resourceGroup]);
 
   const namespace = (typeof query === 'object' && query.namespace) || '';
+  // When subscription, resource group, and namespace are all set, retrieve resource names
   useEffect(() => {
-    if (subscription) {
+    if (subscription && resourceGroup && namespace) {
       datasource.getResourceNames(subscription, resourceGroup, namespace).then((rgs) => {
         setResources(rgs.map((s) => ({ label: s.text, value: s.value })));
       });
     }
   }, [datasource, subscription, resourceGroup, namespace]);
+
+  const resource = (typeof query === 'object' && query.resource) || '';
+  // When subscription, resource group, namespace, and resource name are all set, retrieve custom metric namespaces
+  useEffect(() => {
+    if (subscription && resourceGroup && namespace && resource) {
+      const resourceUri = UrlBuilder.buildResourceUri(getTemplateSrv(), {
+        subscription,
+        resourceGroup,
+        metricNamespace: namespace,
+        resourceName: resource,
+      });
+      datasource.getMetricNamespaces(subscription, resourceGroup, resourceUri, true).then((rgs) => {
+        setCustomNamespaces(rgs.map((s) => ({ label: s.text, value: s.value })));
+      });
+    }
+  }, [datasource, subscription, resourceGroup, namespace, resource]);
 
   if (typeof query === 'string') {
     // still migrating the query
@@ -225,6 +266,13 @@ const VariableEditor = (props: Props) => {
     onChange(queryChange);
   };
 
+  const onChangeCustomNamespace = (selectableValue: SelectableValue) => {
+    onChange({
+      ...query,
+      customNamespace: selectableValue.value,
+    });
+  };
+
   return (
     <>
       <Field label="Query Type" data-testid={selectors.components.variableEditor.queryType.input}>
@@ -289,7 +337,14 @@ const VariableEditor = (props: Props) => {
         </Field>
       )}
       {(requireNamespace || hasNamespace) && (
-        <Field label="Namespace" data-testid={selectors.components.variableEditor.namespace.input}>
+        <Field
+          label={
+            queryType === AzureQueryType.CustomNamespacesQuery || queryType === AzureQueryType.CustomMetricNamesQuery
+              ? 'Resource Type'
+              : 'Namespace'
+          }
+          data-testid={selectors.components.variableEditor.namespace.input}
+        >
           <Select
             aria-label="select namespace"
             onChange={onChangeNamespace}
@@ -324,6 +379,22 @@ const VariableEditor = (props: Props) => {
             options={resources.concat(variableOptionGroup)}
             width={25}
             value={query.resource || null}
+          />
+        </Field>
+      )}
+      {requireCustomNamespace && (
+        <Field label={'Custom Namespace'} data-testid={selectors.components.variableEditor.customNamespace.input}>
+          <Select
+            aria-label="select custom namespace"
+            onChange={onChangeCustomNamespace}
+            options={
+              requireCustomNamespace
+                ? customNamespaces.concat(variableOptionGroup)
+                : customNamespaces.concat(variableOptionGroup, removeOption)
+            }
+            width={25}
+            value={query.customNamespace || null}
+            placeholder={requireCustomNamespace ? undefined : 'Optional'}
           />
         </Field>
       )}

--- a/public/app/plugins/datasource/azuremonitor/dataquery.cue
+++ b/public/app/plugins/datasource/azuremonitor/dataquery.cue
@@ -27,6 +27,7 @@ composableKinds: DataQuery: {
 			schema: {
 				#AzureMonitorQuery: common.DataQuery & {
 					// Azure subscription containing the resource(s) to be queried.
+					// Also used for template variable queries
 					subscription?: string
 
 					// Subscriptions to be queried via Azure Resource Graph.
@@ -43,11 +44,16 @@ composableKinds: DataQuery: {
 					// @deprecated Legacy template variable support.
 					grafanaTemplateVariableFn?: #GrafanaTemplateVariableQuery
 
-					// Template variables params. These exist for backwards compatiblity with legacy template variables.
+					// Resource group used in template variable queries
 					resourceGroup?: string
+					// Namespace used in template variable queries
 					namespace?:     string
+					// Resource used in template variable queries
 					resource?:      string
+					// Region used in template variable queries
 					region?:        string
+					// Custom namespace used in template variable queries
+					customNamespace?: string
 					// Azure Monitor query type.
 					// queryType: #AzureQueryType
 
@@ -56,7 +62,7 @@ composableKinds: DataQuery: {
 				} @cuetsy(kind="interface") @grafana(TSVeneer="type")
 
 				// Defines the supported queryTypes. GrafanaTemplateVariableFn is deprecated
-				#AzureQueryType: "Azure Monitor" | "Azure Log Analytics" | "Azure Resource Graph" | "Azure Traces" | "Azure Subscriptions" | "Azure Resource Groups" | "Azure Namespaces" | "Azure Resource Names" | "Azure Metric Names" | "Azure Workspaces" | "Azure Regions" | "Grafana Template Variable Function" | "traceql" @cuetsy(kind="enum", memberNames="AzureMonitor|LogAnalytics|AzureResourceGraph|AzureTraces|SubscriptionsQuery|ResourceGroupsQuery|NamespacesQuery|ResourceNamesQuery|MetricNamesQuery|WorkspacesQuery|LocationsQuery|GrafanaTemplateVariableFn|TraceExemplar")
+				#AzureQueryType: "Azure Monitor" | "Azure Log Analytics" | "Azure Resource Graph" | "Azure Traces" | "Azure Subscriptions" | "Azure Resource Groups" | "Azure Namespaces" | "Azure Resource Names" | "Azure Metric Names" | "Azure Workspaces" | "Azure Regions" | "Grafana Template Variable Function" | "traceql" | "Azure Custom Namespaces" | "Azure Custom Metric Names" @cuetsy(kind="enum", memberNames="AzureMonitor|LogAnalytics|AzureResourceGraph|AzureTraces|SubscriptionsQuery|ResourceGroupsQuery|NamespacesQuery|ResourceNamesQuery|MetricNamesQuery|WorkspacesQuery|LocationsQuery|GrafanaTemplateVariableFn|TraceExemplar|CustomNamespacesQuery|CustomMetricNamesQuery")
 
 				#AzureMetricQuery: {
 					// Array of resource URIs to be queried.

--- a/public/app/plugins/datasource/azuremonitor/dataquery.gen.ts
+++ b/public/app/plugins/datasource/azuremonitor/dataquery.gen.ts
@@ -28,22 +28,36 @@ export interface AzureMonitorQuery extends common.DataQuery {
    */
   azureTraces?: AzureTracesQuery;
   /**
+   * Custom namespace used in template variable queries
+   */
+  customNamespace?: string;
+  /**
    * @deprecated Legacy template variable support.
    */
   grafanaTemplateVariableFn?: GrafanaTemplateVariableQuery;
+  /**
+   * Namespace used in template variable queries
+   */
   namespace?: string;
   /**
    * Used only for exemplar queries from Prometheus
    */
   query?: string;
+  /**
+   * Region used in template variable queries
+   */
   region?: string;
+  /**
+   * Resource used in template variable queries
+   */
   resource?: string;
   /**
-   * Template variables params. These exist for backwards compatiblity with legacy template variables.
+   * Resource group used in template variable queries
    */
   resourceGroup?: string;
   /**
    * Azure subscription containing the resource(s) to be queried.
+   * Also used for template variable queries
    */
   subscription?: string;
   /**
@@ -63,6 +77,8 @@ export enum AzureQueryType {
   AzureMonitor = 'Azure Monitor',
   AzureResourceGraph = 'Azure Resource Graph',
   AzureTraces = 'Azure Traces',
+  CustomMetricNamesQuery = 'Azure Custom Metric Names',
+  CustomNamespacesQuery = 'Azure Custom Namespaces',
   GrafanaTemplateVariableFn = 'Grafana Template Variable Function',
   LocationsQuery = 'Azure Regions',
   LogAnalytics = 'Azure Log Analytics',

--- a/public/app/plugins/datasource/azuremonitor/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/datasource.ts
@@ -168,24 +168,41 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     return this.azureMonitorDatasource.getResourceGroups(this.templateSrv.replace(subscriptionId));
   }
 
-  getMetricNamespaces(subscriptionId: string, resourceGroup?: string) {
+  getMetricNamespaces(subscriptionId: string, resourceGroup?: string, resourceUri?: string, custom?: boolean) {
     let url = `/subscriptions/${subscriptionId}`;
     if (resourceGroup) {
       url += `/resourceGroups/${resourceGroup}`;
     }
-    return this.azureMonitorDatasource.getMetricNamespaces({ resourceUri: url }, true);
+    if (resourceUri) {
+      url = resourceUri;
+    }
+    return this.azureMonitorDatasource.getMetricNamespaces(
+      { resourceUri: url },
+      // If custom namespaces are being queried we do not issue the query against the global region
+      // as resources have a specific region
+      custom ? false : true,
+      undefined,
+      custom
+    );
   }
 
   getResourceNames(subscriptionId: string, resourceGroup?: string, metricNamespace?: string, region?: string) {
     return this.azureMonitorDatasource.getResourceNames({ subscriptionId, resourceGroup, metricNamespace, region });
   }
 
-  getMetricNames(subscriptionId: string, resourceGroup: string, metricNamespace: string, resourceName: string) {
+  getMetricNames(
+    subscriptionId: string,
+    resourceGroup: string,
+    metricNamespace: string,
+    resourceName: string,
+    customNamespace?: string
+  ) {
     return this.azureMonitorDatasource.getMetricNames({
       subscription: subscriptionId,
       resourceGroup,
       metricNamespace,
       resourceName,
+      customNamespace,
     });
   }
 

--- a/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
+++ b/public/app/plugins/datasource/azuremonitor/e2e/selectors.ts
@@ -113,6 +113,9 @@ export const components = {
     region: {
       input: 'data-testid region',
     },
+    customNamespace: {
+      input: 'data-testid custom-namespace',
+    },
   },
 };
 

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -343,12 +343,8 @@ export interface ResourceGroup {
   type: string;
 }
 
-export interface Namespace {
-  classification: {
-    Custom: string;
-    Platform: string;
-    Qos: string;
-  };
+export interface MetricNamespace {
+  classification: 'Custom' | 'Platform' | 'Qos';
   id: string;
   name: string;
   properties: { metricNamespaceName: string };

--- a/public/app/plugins/datasource/azuremonitor/variables.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/variables.test.ts
@@ -543,4 +543,88 @@ describe('VariableSupport', () => {
       expect(result.data[0].fields[0].values).toEqual(expectedResults);
     });
   });
+
+  it('can fetch custom namespaces', async () => {
+    const expectedResults = ['test-custom/namespace'];
+    const variableSupport = new VariableSupport(
+      createMockDatasource({
+        getMetricNamespaces: jest.fn().mockResolvedValueOnce(expectedResults),
+      })
+    );
+    const mockRequest = {
+      targets: [
+        {
+          refId: 'A',
+          queryType: AzureQueryType.CustomNamespacesQuery,
+          subscription: 'sub',
+          resourceGroup: 'rg',
+          namespace: 'ns',
+          resource: 'rn',
+        } as AzureMonitorQuery,
+      ],
+    } as DataQueryRequest<AzureMonitorQuery>;
+    const result = await lastValueFrom(variableSupport.query(mockRequest));
+    expect(result.data[0].fields[0].values).toEqual(expectedResults);
+  });
+
+  it('returns no data if calling custom namespaces but the subscription is a template variable with no value', async () => {
+    const variableSupport = new VariableSupport(createMockDatasource());
+    const mockRequest = {
+      targets: [
+        {
+          refId: 'A',
+          queryType: AzureQueryType.CustomNamespacesQuery,
+          subscription: '$sub',
+          resourceGroup: 'rg',
+          namespace: 'ns',
+          resource: 'rn',
+        } as AzureMonitorQuery,
+      ],
+    } as DataQueryRequest<AzureMonitorQuery>;
+    const result = await lastValueFrom(variableSupport.query(mockRequest));
+    expect(result.data).toEqual([]);
+  });
+
+  it('can fetch custom metric names', async () => {
+    const expectedResults = ['test-custom-metric'];
+    const variableSupport = new VariableSupport(
+      createMockDatasource({
+        getMetricNames: jest.fn().mockResolvedValueOnce(expectedResults),
+      })
+    );
+    const mockRequest = {
+      targets: [
+        {
+          refId: 'A',
+          queryType: AzureQueryType.CustomMetricNamesQuery,
+          subscription: 'sub',
+          resourceGroup: 'rg',
+          namespace: 'ns',
+          resource: 'rn',
+          customNamespace: 'test-custom/namespace',
+        } as AzureMonitorQuery,
+      ],
+    } as DataQueryRequest<AzureMonitorQuery>;
+    const result = await lastValueFrom(variableSupport.query(mockRequest));
+    expect(result.data[0].fields[0].values).toEqual(expectedResults);
+  });
+
+  it('returns no data if calling custom metric names but the subscription is a template variable with no value', async () => {
+    const variableSupport = new VariableSupport(createMockDatasource());
+    const mockRequest = {
+      targets: [
+        {
+          refId: 'A',
+          queryType: AzureQueryType.CustomMetricNamesQuery,
+          subscription: '$sub',
+          resourceGroup: 'rg',
+          namespace: 'ns',
+          resource: 'rn',
+          customNamespace: 'test-custom/namespace',
+        } as AzureMonitorQuery,
+      ],
+    } as DataQueryRequest<AzureMonitorQuery>;
+    const result = await lastValueFrom(variableSupport.query(mockRequest));
+    expect(result.data).toEqual([]);
+  });
 });


### PR DESCRIPTION
Backport e01d8ad5b5308fb1df62307acdb420e3d6d9bd94 from #99279

---

Adding template variable support for querying custom metric namespaces and custom metrics for a resource.

It should be noted that custom metrics cannot be emitted against subscriptions or resource groups, a resource must be chosen to retrieve the custom metric information.

Fixes grafana/support-escalations#14208
Fixes grafana/grafana#99278
