### PR TITLE
[release-11.5.4] Azure: Support more complex variable interpolation

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -2,7 +2,7 @@ import { find, startsWith } from 'lodash';
 
 import { AzureCredentials } from '@grafana/azure-sdk';
 import { ScopedVars } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv, TemplateSrv, VariableInterpolation } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
 import TimegrainConverter from '../time_grain_converter';
@@ -355,19 +355,32 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     const workingQueries: Array<{ [K in keyof T]: string }> = [{ ...query }];
     const keys = Object.keys(query) as Array<keyof T>;
     keys.forEach((key) => {
-      const replaced = this.templateSrv.replace(workingQueries[0][key], scopedVars, 'raw');
-      if (replaced.includes(',')) {
-        const multiple = replaced.split(',');
-        const currentQueries = [...workingQueries];
-        multiple.forEach((value, i) => {
-          currentQueries.forEach((q) => {
-            if (i === 0) {
-              q[key] = value;
-            } else {
-              workingQueries.push({ ...q, [key]: value });
-            }
-          });
-        });
+      const rawValue = workingQueries[0][key];
+      let interpolated: VariableInterpolation[] = [];
+      const replaced = this.templateSrv.replace(rawValue, scopedVars, 'raw', interpolated);
+      if (interpolated.length > 0) {
+        for (const variable of interpolated) {
+          if (variable.found === false) {
+            continue;
+          }
+          if (variable.value.includes(',')) {
+            const multiple = variable.value.split(',');
+            const currentQueries = [...workingQueries];
+            multiple.forEach((value, i) => {
+              currentQueries.forEach((q) => {
+                if (i === 0) {
+                  q[key] = rawValue.replace(variable.match, value);
+                } else {
+                  workingQueries.push({ ...q, [key]: rawValue.replace(variable.match, value) });
+                }
+              });
+            });
+          } else {
+            workingQueries.forEach((q) => {
+              q[key] = replaced;
+            });
+          }
+        }
       } else {
         workingQueries.forEach((q) => {
           q[key] = replaced;


### PR DESCRIPTION
Backport 763f0bac90d6296f034939627e9058bf2071b484 from #99284

---

Updates variable interpolation for Azure resources to handle more complex cases.

Previously, cases that were simply the template variable would fail to interpolate correctly.

e.g. a variable with values `["test1","test2"]` and a resource name `$resourceName` would be interpolated to `test1,test2` normally and then split on the comma to be expanded to multiple queries. However, something like `test-$resourceName-testSuffix` would incorrectly be interpolated to `test-test1` missing the `testSuffix` and leading to the resource URI being incorrectly defined.

In order to test this PR import the attached dashboard and compare the result on `main` vs this branch. You should not see the below error.

![image](https://github.com/user-attachments/assets/ccb81a52-fd20-4a35-a1f7-002cd7da63c4)
[multi-variable-test-dashboard.json](https://github.com/user-attachments/files/18480947/multi-variable-test-dashboard.json)

Fixes grafana/support-escalations#13981
