### PR TITLE
MetricsDrilldown: Advance `exploreMetricsUseExternalAppPlugin` to GA

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -85,6 +85,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `azureMonitorEnableUserAuth`           | Enables user auth for Azure Monitor datasource only                                                                                 | Yes                |
 | `alertingNotificationsStepMode`        | Enables simplified step mode in the notifications section                                                                           | Yes                |
 | `lokiLabelNamesQueryApi`               | Defaults to using the Loki `/labels` API instead of `/series`                                                                       | Yes                |
+| `exploreMetricsUseExternalAppPlugin`   | Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin                                       | Yes                |
 | `unifiedNavbars`                       | Enables unified navbars                                                                                                             |                    |
 
 ## Public preview feature toggles
@@ -113,7 +114,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `elasticsearchCrossClusterSearch`     | Enables cross cluster search in the Elasticsearch datasource                                                                                                                        |
 | `improvedExternalSessionHandlingSAML` | Enables improved support for SAML external sessions. Ensure the NameID format is correctly configured in Grafana for SAML Single Logout to function properly.                       |
 | `teamHttpHeadersMimir`                | Enables LBAC for datasources for Mimir to apply LBAC filtering of metrics to the client requests for users in teams                                                                 |
-| `exploreMetricsUseExternalAppPlugin`  | Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin                                                                                       |
 | `alertRuleRestore`                    | Enables the alert rule restore feature                                                                                                                                              |
 | `azureMonitorLogsBuilderEditor`       | Enables the logs builder mode for the Azure Monitor data source                                                                                                                     |
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -915,6 +915,7 @@ export interface FeatureToggles {
   elasticsearchImprovedParsing?: boolean;
   /**
   * Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin
+  * @default true
   */
   exploreMetricsUseExternalAppPlugin?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1554,8 +1554,9 @@ var (
 		{
 			Name:            "exploreMetricsUseExternalAppPlugin",
 			Description:     "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
-			Stage:           FeatureStagePublicPreview,
+			Stage:           FeatureStageGeneralAvailability,
 			Owner:           grafanaObservabilityMetricsSquad,
+			Expression:      "true",
 			FrontendOnly:    false,
 			RequiresRestart: true,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -204,7 +204,7 @@ templateVariablesUsesCombobox,experimental,@grafana/grafana-frontend-platform,fa
 ABTestFeatureToggleB,experimental,@grafana/sharing-squad,false,false,false
 grafanaAdvisor,experimental,@grafana/plugins-platform-backend,false,false,false
 elasticsearchImprovedParsing,experimental,@grafana/aws-datasources,false,false,false
-exploreMetricsUseExternalAppPlugin,preview,@grafana/observability-metrics,false,true,false
+exploreMetricsUseExternalAppPlugin,GA,@grafana/observability-metrics,false,true,false
 datasourceConnectionsTab,privatePreview,@grafana/plugins-platform-backend,false,false,true
 fetchRulesUsingPost,experimental,@grafana/alerting-squad,false,false,false
 newLogsPanel,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1117,14 +1117,18 @@
     {
       "metadata": {
         "name": "exploreMetricsUseExternalAppPlugin",
-        "resourceVersion": "1743693517832",
-        "creationTimestamp": "2025-04-03T15:18:37Z"
+        "resourceVersion": "1744146547481",
+        "creationTimestamp": "2025-04-03T15:18:37Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-04-08 21:09:07.481769 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin",
-        "stage": "preview",
+        "stage": "GA",
         "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true
+        "requiresRestart": true,
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
## Related issue

This PR supports #98990.

## What is this change?

This PR advances the `exploreMetricsUseExternalAppPlugin` feature toggle stage from Public Preview to General Availability, enabling the [Grafana Metrics Drilldown app](https://github.com/grafana/metrics-drilldown) as the default experience for **Drilldown** > **Metrics**.

## What to expect when enabling the feature toggle

When enabling the `exploreMetricsUseExternalAppPlugin` feature toggle, the `grafana-metricsdrilldown-app` will be preinstalled. Clicking on **Drilldown** > **Metrics** will take you to `/a/grafana-metricsdrilldown-app` instead of `/explore/metrics`. The experience is mostly the same, and better in some ways.