### PR TITLE
[release-11.5.4] Azure Monitor: Filter namespaces by resource group

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6562,9 +6562,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"]
     ],
-    "public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/index.tsx:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./ArgQueryEditor\`)", "0"]
     ],
@@ -6610,6 +6607,9 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/azuremonitor/types/templateVariables.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`../dataquery.gen\`)", "0"]
+    ],
+    "public/app/plugins/datasource/azuremonitor/utils/common.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/datasource/azuremonitor/utils/messageFromError.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/docs/sources/datasources/azure-monitor/template-variables/index.md
+++ b/docs/sources/datasources/azure-monitor/template-variables/index.md
@@ -48,18 +48,18 @@ For an introduction to templating and template variables, refer to the [Templati
 
 You can specify these Azure Monitor data source queries in the Variable edit view's **Query Type** field.
 
-| Name                    | Description                                                                                                        |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Subscriptions**       | Returns subscriptions.                                                                                             |
-| **Resource Groups**     | Returns resource groups for a specified. Supports multi-value. subscription.                                       |
-| **Namespaces**          | Returns metric namespaces for the specified subscription and resource group.                                       |
-| **Regions**             | Returns regions for the specified subscription                                                                     |
-| **Resource Names**      | Returns a list of resource names for a specified subscription, resource group and namespace. Supports multi-value. |
-| **Metric Names**        | Returns a list of metric names for a resource.                                                                     |
-| **Workspaces**          | Returns a list of workspaces for the specified subscription.                                                       |
-| **Logs**                | Use a KQL query to return values.                                                                                  |
-| **Custom Namespaces**   | Returns metric namespaces for the specified resource.                                                              |
-| **Custom Metric Names** | Returns a list of custom metric names for the specified resource.                                                  |
+| Name                    | Description                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Subscriptions**       | Returns subscriptions.                                                                                                                         |
+| **Resource Groups**     | Returns resource groups for a specified subscription. Supports multi-value.                                                                    |
+| **Namespaces**          | Returns metric namespaces for the specified subscription. If a resource group is provided, only the namespaces within that group are returned. |
+| **Regions**             | Returns regions for the specified subscription                                                                                                 |
+| **Resource Names**      | Returns a list of resource names for a specified subscription, resource group and namespace. Supports multi-value.                             |
+| **Metric Names**        | Returns a list of metric names for a resource.                                                                                                 |
+| **Workspaces**          | Returns a list of workspaces for the specified subscription.                                                                                   |
+| **Logs**                | Use a KQL query to return values.                                                                                                              |
+| **Custom Namespaces**   | Returns metric namespaces for the specified resource.                                                                                          |
+| **Custom Metric Names** | Returns a list of custom metric names for the specified resource.                                                                              |
 
 {{< admonition type="note" >}}
 Custom metrics cannot be emitted against a subscription or resource group. Select resources only when you need to retrieve custom metric namespaces or custom metric names associated with a specific resource.

--- a/public/app/plugins/datasource/azuremonitor/__mocks__/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/datasource.ts
@@ -74,6 +74,8 @@ export default function createMockDatasource(overrides?: DeepPartial<Datasource>
       getResourceURIFromWorkspace: jest.fn().mockReturnValue(''),
       getResourceURIDisplayProperties: jest.fn().mockResolvedValue({}),
     },
+
+    azureResourceGraphDatasource: {},
     getVariablesRaw: jest.fn().mockReturnValue([]),
     currentUserAuth: false,
     ...overrides,

--- a/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.ts
@@ -2,15 +2,34 @@
 import _ from 'lodash';
 
 import { ScopedVars } from '@grafana/data';
-import { getTemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
+import { getTemplateSrv, DataSourceWithBackend, TemplateSrv } from '@grafana/runtime';
 
-import { AzureMonitorQuery, AzureMonitorDataSourceJsonData, AzureQueryType } from '../types';
-import { interpolateVariable } from '../utils/common';
+import { resourceTypes } from '../azureMetadata';
+import {
+  AzureMonitorQuery,
+  AzureMonitorDataSourceJsonData,
+  AzureQueryType,
+  AzureMonitorDataSourceInstanceSettings,
+  RawAzureResourceItem,
+  AzureGraphResponse,
+  AzureResourceGraphOptions,
+} from '../types';
+import { interpolateVariable, replaceTemplateVariables, routeNames } from '../utils/common';
 
 export default class AzureResourceGraphDatasource extends DataSourceWithBackend<
   AzureMonitorQuery,
   AzureMonitorDataSourceJsonData
 > {
+  resourcePath: string;
+  resourceGraphURL = '/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01';
+  constructor(
+    instanceSettings: AzureMonitorDataSourceInstanceSettings,
+    private readonly templateSrv: TemplateSrv = getTemplateSrv()
+  ) {
+    super(instanceSettings);
+    this.resourcePath = routeNames.resourceGraph;
+  }
+
   filterQuery(item: AzureMonitorQuery): boolean {
     return !!item.azureResourceGraph?.query && !!item.subscriptions && item.subscriptions.length > 0;
   }
@@ -42,5 +61,67 @@ export default class AzureResourceGraphDatasource extends DataSourceWithBackend<
         query,
       },
     };
+  }
+
+  async pagedResourceGraphRequest<T = unknown>(query: string, maxRetries = 1): Promise<T[]> {
+    try {
+      let allFetched = false;
+      let $skipToken = undefined;
+      let response: T[] = [];
+      while (!allFetched) {
+        // The response may include several pages
+        let options: Partial<AzureResourceGraphOptions> = {};
+        if ($skipToken) {
+          options = {
+            $skipToken,
+          };
+        }
+        const queryResponse = await this.postResource<AzureGraphResponse<T[]>>(
+          this.resourcePath + this.resourceGraphURL,
+          {
+            query: query,
+            options: {
+              resultFormat: 'objectArray',
+              ...options,
+            },
+          }
+        );
+        response = response.concat(queryResponse.data);
+        $skipToken = queryResponse.$skipToken;
+        allFetched = !$skipToken;
+      }
+
+      return response;
+    } catch (error) {
+      if (maxRetries > 0) {
+        return this.pagedResourceGraphRequest(query, maxRetries - 1);
+      }
+
+      throw error;
+    }
+  }
+
+  // Retrieve metric namespaces relevant to a subscription/resource group/resource
+  async getMetricNamespaces(resourceUri: string) {
+    const promises = replaceTemplateVariables(this.templateSrv, { resourceUri }).map(async ({ resourceUri }) => {
+      const namespacesFilter = resourceTypes.map((type) => `"${type}"`).join(',');
+      const query = `
+        resources
+        | where id hasprefix "${resourceUri}"
+        | where type in (${namespacesFilter})
+        | project type
+        | distinct type
+        | order by tolower(type) asc`;
+
+      const namespaces = await this.pagedResourceGraphRequest<RawAzureResourceItem>(query);
+
+      return namespaces.map((r) => {
+        return {
+          text: r.type,
+          value: r.type,
+        };
+      });
+    });
+    return (await Promise.all(promises)).flat();
   }
 }

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -158,7 +158,7 @@ const VariableEditor = (props: Props) => {
   // When resource group is set, retrieve metric namespaces (aka resource types for a custom metric and custom metric namespace query)
   useEffect(() => {
     if (subscription && resourceGroup) {
-      datasource.getMetricNamespaces(subscription, resourceGroup).then((rgs) => {
+      datasource.getMetricNamespaces(subscription, resourceGroup, undefined, false, true).then((rgs) => {
         setNamespaces(rgs.map((s) => ({ label: s.text, value: s.value })));
       });
     }

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -1,6 +1,7 @@
 import { map } from 'lodash';
 
-import { SelectableValue, VariableWithMultiSupport } from '@grafana/data';
+import { ScopedVars, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
+import { TemplateSrv, VariableInterpolation } from '@grafana/runtime';
 
 import { AzureMonitorOption, VariableOptionGroup } from '../types';
 
@@ -71,4 +72,48 @@ export function interpolateVariable(
     return "'" + val + "'";
   });
   return quotedValues.join(',');
+}
+
+export function replaceTemplateVariables<T extends { [K in keyof T]: string }>(
+  templateSrv: TemplateSrv,
+  query: T,
+  scopedVars?: ScopedVars
+) {
+  const workingQueries: Array<{ [K in keyof T]: string }> = [{ ...query }];
+  const keys = Object.keys(query) as Array<keyof T>;
+  keys.forEach((key) => {
+    const rawValue = workingQueries[0][key];
+    let interpolated: VariableInterpolation[] = [];
+    const replaced = templateSrv.replace(rawValue, scopedVars, 'raw', interpolated);
+    if (interpolated.length > 0) {
+      for (const variable of interpolated) {
+        if (variable.found === false) {
+          continue;
+        }
+        if (variable.value.includes(',')) {
+          const multiple = variable.value.split(',');
+          const currentQueries = [...workingQueries];
+          multiple.forEach((value, i) => {
+            currentQueries.forEach((q) => {
+              if (i === 0) {
+                q[key] = rawValue.replace(variable.match, value);
+              } else {
+                workingQueries.push({ ...q, [key]: rawValue.replace(variable.match, value) });
+              }
+            });
+          });
+        } else {
+          workingQueries.forEach((q) => {
+            q[key] = replaced;
+          });
+        }
+      }
+    } else {
+      workingQueries.forEach((q) => {
+        q[key] = replaced;
+      });
+    }
+  });
+
+  return workingQueries;
 }

--- a/public/app/plugins/datasource/azuremonitor/variables.ts
+++ b/public/app/plugins/datasource/azuremonitor/variables.ts
@@ -53,9 +53,15 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
             return { data: [] };
           case AzureQueryType.NamespacesQuery:
             if (queryObj.subscription && this.hasValue(queryObj.subscription)) {
-              const rgs = await this.datasource.getMetricNamespaces(queryObj.subscription, queryObj.resourceGroup);
+              const namespaces = await this.datasource.getMetricNamespaces(
+                queryObj.subscription,
+                queryObj.resourceGroup,
+                undefined,
+                false,
+                true
+              );
               return {
-                data: rgs?.length ? [toDataFrame(rgs)] : [],
+                data: namespaces?.length ? [toDataFrame(namespaces)] : [],
               };
             }
             return { data: [] };


### PR DESCRIPTION
Backport 4c5a906c835015bb3949afea5ec48aeb36de0bca from #100325

---

Currently Azure Monitor fetches namespaces at a subscription level, making it difficult to know which namespaces are relevant to a given resource group when specified in a variable query. 

This PR adjusts the namespaces variable query to use resource graph instead of the Azure Monitor REST API. This allows the namespaces query to function for users with restricted permissions and will enable us to filter namespaces when a resource group is supplied.
