### PR TITLE
Alerting: Fix path for cortex-style Prometheus namespaces conversion endpoint

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -1284,6 +1284,46 @@ func createRequestCtx() *contextmodel.ReqContext {
 	}
 }
 
+// Test parseBooleanHeader function which handles boolean header values
+func TestParseBooleanHeader(t *testing.T) {
+	headerName := "X-Test-Header"
+
+	t.Run("should return false when header is not present", func(t *testing.T) {
+		result, err := parseBooleanHeader("", headerName)
+		require.NoError(t, err)
+		require.False(t, result)
+	})
+
+	t.Run("should return true when header is 'true'", func(t *testing.T) {
+		result, err := parseBooleanHeader("true", headerName)
+		require.NoError(t, err)
+		require.True(t, result)
+	})
+
+	t.Run("should return false when header is 'false'", func(t *testing.T) {
+		result, err := parseBooleanHeader("false", headerName)
+		require.NoError(t, err)
+		require.False(t, result)
+	})
+
+	t.Run("should return true when header is 'TRUE' (case insensitive)", func(t *testing.T) {
+		result, err := parseBooleanHeader("TRUE", headerName)
+		require.NoError(t, err)
+		require.True(t, result)
+	})
+
+	t.Run("should return error when header has invalid value", func(t *testing.T) {
+		_, err := parseBooleanHeader("invalid", headerName)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid value for header")
+	})
+
+	t.Run("should return error when header is numeric but not 0/1", func(t *testing.T) {
+		_, err := parseBooleanHeader("2", headerName)
+		require.Error(t, err)
+	})
+}
+
 func TestGetWorkingFolderUID(t *testing.T) {
 	t.Run("should return root folder UID when header is not present", func(t *testing.T) {
 		rc := createRequestCtx()

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -130,7 +130,7 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodPost + "/api/convert/prometheus/config/v1/rules/{NamespaceTitle}",
 		http.MethodPost + "/api/convert/api/prom/rules/{NamespaceTitle}",
 		http.MethodPost + "/api/convert/prometheus/config/v1/rules",
-		http.MethodPost + "/api/convert/api/prom/config/v1/rules":
+		http.MethodPost + "/api/convert/api/prom/rules":
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleCreate),
 			ac.EvalPermission(ac.ActionAlertingProvisioningSetStatus),

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -41,7 +41,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 64)
+	require.Len(t, paths, 63)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac, FeatureManager: featuremgmt.WithFeatures()}

--- a/pkg/services/ngalert/api/generated_base_api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_convert_prometheus.go
@@ -177,13 +177,13 @@ func (api *API) RegisterConvertPrometheusApiEndpoints(srv ConvertPrometheusApi, 
 			),
 		)
 		group.Post(
-			toMacaronPath("/api/convert/api/prom/config/v1/rules"),
+			toMacaronPath("/api/convert/api/prom/rules"),
 			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow),
-			api.authorize(http.MethodPost, "/api/convert/api/prom/config/v1/rules"),
+			api.authorize(http.MethodPost, "/api/convert/api/prom/rules"),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/convert/api/prom/config/v1/rules",
+				"/api/convert/api/prom/rules",
 				api.Hooks.Wrap(srv.RouteConvertPrometheusCortexPostRuleGroups),
 				m,
 			),

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1454,6 +1454,12 @@
      },
      "type": "array"
     },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
+     },
+     "type": "array"
+    },
     "msteams_configs": {
      "items": {
       "$ref": "#/definitions/MSTeamsConfig"
@@ -1815,6 +1821,9 @@
     "http_config": {
      "$ref": "#/definitions/HTTPClientConfig"
     },
+    "jira_api_url": {
+     "$ref": "#/definitions/URL"
+    },
     "opsgenie_api_key": {
      "$ref": "#/definitions/Secret"
     },
@@ -1862,6 +1871,9 @@
     },
     "smtp_smarthost": {
      "$ref": "#/definitions/HostPort"
+    },
+    "smtp_tls_config": {
+     "$ref": "#/definitions/TLSConfig"
     },
     "telegram_api_url": {
      "$ref": "#/definitions/URL"
@@ -2049,6 +2061,57 @@
       "$ref": "#/definitions/LinkTransformationConfig"
      },
      "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "JiraConfig": {
+   "properties": {
+    "api_url": {
+     "$ref": "#/definitions/URL"
+    },
+    "custom_fields": {
+     "additionalProperties": {},
+     "type": "object"
+    },
+    "description": {
+     "type": "string"
+    },
+    "http_config": {
+     "$ref": "#/definitions/HTTPClientConfig"
+    },
+    "issue_type": {
+     "type": "string"
+    },
+    "labels": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "priority": {
+     "type": "string"
+    },
+    "project": {
+     "type": "string"
+    },
+    "reopen_duration": {
+     "$ref": "#/definitions/Duration"
+    },
+    "reopen_transition": {
+     "type": "string"
+    },
+    "resolve_transition": {
+     "type": "string"
+    },
+    "send_resolved": {
+     "type": "boolean"
+    },
+    "summary": {
+     "type": "string"
+    },
+    "wont_fix_resolution": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -2656,6 +2719,12 @@
     "grafana_managed_receiver_configs": {
      "items": {
       "$ref": "#/definitions/PostableGrafanaReceiver"
+     },
+     "type": "array"
+    },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
      },
      "type": "array"
     },
@@ -3398,6 +3467,12 @@
     "email_configs": {
      "items": {
       "$ref": "#/definitions/EmailConfig"
+     },
+     "type": "array"
+    },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
      },
      "type": "array"
     },
@@ -4470,6 +4545,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4505,7 +4581,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -4656,6 +4732,9 @@
     "send_resolved": {
      "type": "boolean"
     },
+    "timeout": {
+     "$ref": "#/definitions/Duration"
+    },
     "url": {
      "$ref": "#/definitions/SecretURL"
     },
@@ -4747,6 +4826,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup",
     "type": "object"
@@ -4908,7 +4988,6 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert",
     "type": "object"

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -97,7 +97,7 @@ import (
 //       202: ConvertPrometheusResponse
 //       403: ForbiddenError
 
-// swagger:route POST /convert/api/prom/config/v1/rules convert_prometheus RouteConvertPrometheusCortexPostRuleGroups
+// swagger:route POST /convert/api/prom/rules convert_prometheus RouteConvertPrometheusCortexPostRuleGroups
 //
 // Converts the submitted rule groups into Grafana-Managed Rules.
 //

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1454,6 +1454,12 @@
      },
      "type": "array"
     },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
+     },
+     "type": "array"
+    },
     "msteams_configs": {
      "items": {
       "$ref": "#/definitions/MSTeamsConfig"
@@ -1815,6 +1821,9 @@
     "http_config": {
      "$ref": "#/definitions/HTTPClientConfig"
     },
+    "jira_api_url": {
+     "$ref": "#/definitions/URL"
+    },
     "opsgenie_api_key": {
      "$ref": "#/definitions/Secret"
     },
@@ -1862,6 +1871,9 @@
     },
     "smtp_smarthost": {
      "$ref": "#/definitions/HostPort"
+    },
+    "smtp_tls_config": {
+     "$ref": "#/definitions/TLSConfig"
     },
     "telegram_api_url": {
      "$ref": "#/definitions/URL"
@@ -2049,6 +2061,57 @@
       "$ref": "#/definitions/LinkTransformationConfig"
      },
      "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "JiraConfig": {
+   "properties": {
+    "api_url": {
+     "$ref": "#/definitions/URL"
+    },
+    "custom_fields": {
+     "additionalProperties": {},
+     "type": "object"
+    },
+    "description": {
+     "type": "string"
+    },
+    "http_config": {
+     "$ref": "#/definitions/HTTPClientConfig"
+    },
+    "issue_type": {
+     "type": "string"
+    },
+    "labels": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "priority": {
+     "type": "string"
+    },
+    "project": {
+     "type": "string"
+    },
+    "reopen_duration": {
+     "$ref": "#/definitions/Duration"
+    },
+    "reopen_transition": {
+     "type": "string"
+    },
+    "resolve_transition": {
+     "type": "string"
+    },
+    "send_resolved": {
+     "type": "boolean"
+    },
+    "summary": {
+     "type": "string"
+    },
+    "wont_fix_resolution": {
+     "type": "string"
     }
    },
    "type": "object"
@@ -2656,6 +2719,12 @@
     "grafana_managed_receiver_configs": {
      "items": {
       "$ref": "#/definitions/PostableGrafanaReceiver"
+     },
+     "type": "array"
+    },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
      },
      "type": "array"
     },
@@ -3398,6 +3467,12 @@
     "email_configs": {
      "items": {
       "$ref": "#/definitions/EmailConfig"
+     },
+     "type": "array"
+    },
+    "jira_configs": {
+     "items": {
+      "$ref": "#/definitions/JiraConfig"
      },
      "type": "array"
     },
@@ -4657,6 +4732,9 @@
     "send_resolved": {
      "type": "boolean"
     },
+    "timeout": {
+     "$ref": "#/definitions/Duration"
+    },
     "url": {
      "$ref": "#/definitions/SecretURL"
     },
@@ -4909,6 +4987,7 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert",
     "type": "object"
@@ -6376,36 +6455,6 @@
     ]
    }
   },
-  "/convert/api/prom/config/v1/rules": {
-   "post": {
-    "consumes": [
-     "application/json",
-     "application/yaml"
-    ],
-    "operationId": "RouteConvertPrometheusCortexPostRuleGroups",
-    "produces": [
-     "application/json"
-    ],
-    "responses": {
-     "202": {
-      "description": "ConvertPrometheusResponse",
-      "schema": {
-       "$ref": "#/definitions/ConvertPrometheusResponse"
-      }
-     },
-     "403": {
-      "description": "ForbiddenError",
-      "schema": {
-       "$ref": "#/definitions/ForbiddenError"
-      }
-     }
-    },
-    "summary": "Converts the submitted rule groups into Grafana-Managed Rules.",
-    "tags": [
-     "convert_prometheus"
-    ]
-   }
-  },
   "/convert/api/prom/rules": {
    "get": {
     "operationId": "RouteConvertPrometheusCortexGetRules",
@@ -6433,6 +6482,34 @@
      }
     },
     "summary": "Gets all Grafana-managed alert rules that were imported from Prometheus-compatible sources, grouped by namespace.",
+    "tags": [
+     "convert_prometheus"
+    ]
+   },
+   "post": {
+    "consumes": [
+     "application/json",
+     "application/yaml"
+    ],
+    "operationId": "RouteConvertPrometheusCortexPostRuleGroups",
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "202": {
+      "description": "ConvertPrometheusResponse",
+      "schema": {
+       "$ref": "#/definitions/ConvertPrometheusResponse"
+      }
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     }
+    },
+    "summary": "Converts the submitted rule groups into Grafana-Managed Rules.",
     "tags": [
      "convert_prometheus"
     ]

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1102,36 +1102,6 @@
         }
       }
     },
-    "/convert/api/prom/config/v1/rules": {
-      "post": {
-        "consumes": [
-          "application/json",
-          "application/yaml"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "convert_prometheus"
-        ],
-        "summary": "Converts the submitted rule groups into Grafana-Managed Rules.",
-        "operationId": "RouteConvertPrometheusCortexPostRuleGroups",
-        "responses": {
-          "202": {
-            "description": "ConvertPrometheusResponse",
-            "schema": {
-              "$ref": "#/definitions/ConvertPrometheusResponse"
-            }
-          },
-          "403": {
-            "description": "ForbiddenError",
-            "schema": {
-              "$ref": "#/definitions/ForbiddenError"
-            }
-          }
-        }
-      }
-    },
     "/convert/api/prom/rules": {
       "get": {
         "produces": [
@@ -1159,6 +1129,34 @@
             "description": "NotFound",
             "schema": {
               "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json",
+          "application/yaml"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "convert_prometheus"
+        ],
+        "summary": "Converts the submitted rule groups into Grafana-Managed Rules.",
+        "operationId": "RouteConvertPrometheusCortexPostRuleGroups",
+        "responses": {
+          "202": {
+            "description": "ConvertPrometheusResponse",
+            "schema": {
+              "$ref": "#/definitions/ConvertPrometheusResponse"
+            }
+          },
+          "403": {
+            "description": "ForbiddenError",
+            "schema": {
+              "$ref": "#/definitions/ForbiddenError"
             }
           }
         }
@@ -5588,6 +5586,12 @@
             "$ref": "#/definitions/GettableGrafanaReceiver"
           }
         },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
+          }
+        },
         "msteams_configs": {
           "type": "array",
           "items": {
@@ -5949,6 +5953,9 @@
         "http_config": {
           "$ref": "#/definitions/HTTPClientConfig"
         },
+        "jira_api_url": {
+          "$ref": "#/definitions/URL"
+        },
         "opsgenie_api_key": {
           "$ref": "#/definitions/Secret"
         },
@@ -5996,6 +6003,9 @@
         },
         "smtp_smarthost": {
           "$ref": "#/definitions/HostPort"
+        },
+        "smtp_tls_config": {
+          "$ref": "#/definitions/TLSConfig"
         },
         "telegram_api_url": {
           "$ref": "#/definitions/URL"
@@ -6183,6 +6193,57 @@
           "items": {
             "$ref": "#/definitions/LinkTransformationConfig"
           }
+        }
+      }
+    },
+    "JiraConfig": {
+      "type": "object",
+      "properties": {
+        "api_url": {
+          "$ref": "#/definitions/URL"
+        },
+        "custom_fields": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "description": {
+          "type": "string"
+        },
+        "http_config": {
+          "$ref": "#/definitions/HTTPClientConfig"
+        },
+        "issue_type": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "priority": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "reopen_duration": {
+          "$ref": "#/definitions/Duration"
+        },
+        "reopen_transition": {
+          "type": "string"
+        },
+        "resolve_transition": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "wont_fix_resolution": {
+          "type": "string"
         }
       }
     },
@@ -6792,6 +6853,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/PostableGrafanaReceiver"
+          }
+        },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
           }
         },
         "msteams_configs": {
@@ -7535,6 +7602,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/EmailConfig"
+          }
+        },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
           }
         },
         "msteams_configs": {
@@ -8793,6 +8866,9 @@
         "send_resolved": {
           "type": "boolean"
         },
+        "timeout": {
+          "$ref": "#/definitions/Duration"
+        },
         "url": {
           "$ref": "#/definitions/SecretURL"
         },
@@ -9043,6 +9119,7 @@
       }
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1110,6 +1110,48 @@ func (a apiClient) GetRuleByUID(t *testing.T, ruleUID string) apimodels.Gettable
 	return rule
 }
 
+func (a apiClient) ConvertPrometheusPostRuleGroups(t *testing.T, datasourceUID string, promNamespaces map[string][]apimodels.PrometheusRuleGroup, headers map[string]string) apimodels.ConvertPrometheusResponse {
+	t.Helper()
+
+	resp, status, body := a.RawConvertPrometheusPostRuleGroups(t, datasourceUID, promNamespaces, headers)
+	requireStatusCode(t, http.StatusAccepted, status, body)
+
+	return resp
+}
+
+func (a apiClient) RawConvertPrometheusPostRuleGroups(t *testing.T, datasourceUID string, promNamespaces map[string][]apimodels.PrometheusRuleGroup, headers map[string]string) (apimodels.ConvertPrometheusResponse, int, string) {
+	t.Helper()
+
+	path := "%s/api/convert/prometheus/config/v1/rules"
+	if a.prometheusConversionUseLokiPaths {
+		path = "%s/api/convert/api/prom/rules"
+	}
+
+	// Based on the content-type header, marshal the data to JSON or YAML
+	contentType := headers["Content-Type"]
+	var data []byte
+	var err error
+	if contentType == "application/json" {
+		data, err = json.Marshal(promNamespaces)
+		require.NoError(t, err)
+	} else {
+		data, err = yaml.Marshal(promNamespaces)
+		require.NoError(t, err)
+	}
+
+	buf := bytes.NewReader(data)
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf(path, a.url), buf)
+	require.NoError(t, err)
+	req.Header.Set("X-Grafana-Alerting-Datasource-UID", datasourceUID)
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
+}
+
 func (a apiClient) ConvertPrometheusPostRuleGroup(t *testing.T, namespaceTitle, datasourceUID string, promGroup apimodels.PrometheusRuleGroup, headers map[string]string) apimodels.ConvertPrometheusResponse {
 	t.Helper()
 
@@ -1173,7 +1215,7 @@ func (a apiClient) RawConvertPrometheusGetRuleGroupRules(t *testing.T, namespace
 	require.NoError(t, err)
 
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header.Set(key, value)
 	}
 
 	rule, status, raw := sendRequestYAML[apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
@@ -1193,7 +1235,7 @@ func (a apiClient) ConvertPrometheusGetNamespaceRules(t *testing.T, namespaceTit
 	require.NoError(t, err)
 
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header.Set(key, value)
 	}
 
 	ns, status, raw := sendRequestYAML[map[string][]apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
@@ -1214,7 +1256,7 @@ func (a apiClient) ConvertPrometheusGetAllRules(t *testing.T, headers map[string
 	require.NoError(t, err)
 
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header.Set(key, value)
 	}
 
 	result, status, raw := sendRequestYAML[map[string][]apimodels.PrometheusRuleGroup](t, req, http.StatusOK)
@@ -1242,7 +1284,7 @@ func (a apiClient) RawConvertPrometheusDeleteRuleGroup(t *testing.T, namespaceTi
 	require.NoError(t, err)
 
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header.Set(key, value)
 	}
 
 	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
@@ -1267,7 +1309,7 @@ func (a apiClient) RawConvertPrometheusDeleteNamespace(t *testing.T, namespaceTi
 	require.NoError(t, err)
 
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header.Set(key, value)
 	}
 
 	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15925,6 +15925,12 @@
             "$ref": "#/definitions/GettableGrafanaReceiver"
           }
         },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
+          }
+        },
         "msteams_configs": {
           "type": "array",
           "items": {
@@ -16286,6 +16292,9 @@
         "http_config": {
           "$ref": "#/definitions/HTTPClientConfig"
         },
+        "jira_api_url": {
+          "$ref": "#/definitions/URL"
+        },
         "opsgenie_api_key": {
           "$ref": "#/definitions/Secret"
         },
@@ -16333,6 +16342,9 @@
         },
         "smtp_smarthost": {
           "$ref": "#/definitions/HostPort"
+        },
+        "smtp_tls_config": {
+          "$ref": "#/definitions/TLSConfig"
         },
         "telegram_api_url": {
           "$ref": "#/definitions/URL"
@@ -16789,6 +16801,57 @@
         },
         "Use": {
           "description": "Key use, parsed from `use` header.",
+          "type": "string"
+        }
+      }
+    },
+    "JiraConfig": {
+      "type": "object",
+      "properties": {
+        "api_url": {
+          "$ref": "#/definitions/URL"
+        },
+        "custom_fields": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "description": {
+          "type": "string"
+        },
+        "http_config": {
+          "$ref": "#/definitions/HTTPClientConfig"
+        },
+        "issue_type": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "priority": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "reopen_duration": {
+          "$ref": "#/definitions/Duration"
+        },
+        "reopen_transition": {
+          "type": "string"
+        },
+        "resolve_transition": {
+          "type": "string"
+        },
+        "send_resolved": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "wont_fix_resolution": {
           "type": "string"
         }
       }
@@ -18281,6 +18344,12 @@
             "$ref": "#/definitions/PostableGrafanaReceiver"
           }
         },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
+          }
+        },
         "msteams_configs": {
           "type": "array",
           "items": {
@@ -19320,6 +19389,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/EmailConfig"
+          }
+        },
+        "jira_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JiraConfig"
           }
         },
         "msteams_configs": {
@@ -22601,6 +22676,9 @@
         "send_resolved": {
           "type": "boolean"
         },
+        "timeout": {
+          "$ref": "#/definitions/Duration"
+        },
         "url": {
           "$ref": "#/definitions/SecretURL"
         },
@@ -22690,6 +22768,7 @@
       }
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "type": "object",
@@ -22894,7 +22973,6 @@
       }
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5986,6 +5986,12 @@
             },
             "type": "array"
           },
+          "jira_configs": {
+            "items": {
+              "$ref": "#/components/schemas/JiraConfig"
+            },
+            "type": "array"
+          },
           "msteams_configs": {
             "items": {
               "$ref": "#/components/schemas/MSTeamsConfig"
@@ -6347,6 +6353,9 @@
           "http_config": {
             "$ref": "#/components/schemas/HTTPClientConfig"
           },
+          "jira_api_url": {
+            "$ref": "#/components/schemas/URL"
+          },
           "opsgenie_api_key": {
             "$ref": "#/components/schemas/Secret"
           },
@@ -6394,6 +6403,9 @@
           },
           "smtp_smarthost": {
             "$ref": "#/components/schemas/HostPort"
+          },
+          "smtp_tls_config": {
+            "$ref": "#/components/schemas/TLSConfig"
           },
           "telegram_api_url": {
             "$ref": "#/components/schemas/URL"
@@ -6850,6 +6862,57 @@
           },
           "Use": {
             "description": "Key use, parsed from `use` header.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "JiraConfig": {
+        "properties": {
+          "api_url": {
+            "$ref": "#/components/schemas/URL"
+          },
+          "custom_fields": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "http_config": {
+            "$ref": "#/components/schemas/HTTPClientConfig"
+          },
+          "issue_type": {
+            "type": "string"
+          },
+          "labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "reopen_duration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "reopen_transition": {
+            "type": "string"
+          },
+          "resolve_transition": {
+            "type": "string"
+          },
+          "send_resolved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "wont_fix_resolution": {
             "type": "string"
           }
         },
@@ -8342,6 +8405,12 @@
             },
             "type": "array"
           },
+          "jira_configs": {
+            "items": {
+              "$ref": "#/components/schemas/JiraConfig"
+            },
+            "type": "array"
+          },
           "msteams_configs": {
             "items": {
               "$ref": "#/components/schemas/MSTeamsConfig"
@@ -9379,6 +9448,12 @@
           "email_configs": {
             "items": {
               "$ref": "#/components/schemas/EmailConfig"
+            },
+            "type": "array"
+          },
+          "jira_configs": {
+            "items": {
+              "$ref": "#/components/schemas/JiraConfig"
             },
             "type": "array"
           },
@@ -12660,6 +12735,9 @@
           "send_resolved": {
             "type": "boolean"
           },
+          "timeout": {
+            "$ref": "#/components/schemas/Duration"
+          },
           "url": {
             "$ref": "#/components/schemas/SecretURL"
           },
@@ -12751,6 +12829,7 @@
         "type": "object"
       },
       "alertGroups": {
+        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -12954,7 +13033,6 @@
         "type": "object"
       },
       "gettableAlerts": {
-        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },


### PR DESCRIPTION
Recently two paths [were added](https://github.com/grafana/grafana/pull/102231) to import multiple namespaces at once:
* "mimir-style" `POST /api/convert/prometheus/config/v1/rules`
* "cortex-style" `POST /api/convert/api/prom/config/v1/rules`

The last one is incorrect and should be `/api/convert/api/prom/rules` to match other existing endpoints. For example, [GET /api/convert/api/prom/rules](https://github.com/grafana/grafana/blob/365bd2b2089c2c021aaa27288fe970eb2f13c4d4/pkg/services/ngalert/api/generated_base_api_convert_prometheus.go#L156)

This PR fixes the URL and adds integration tests for both new paths.