### PR TITLE
[release-11.5.4] Azure: Variable editor and resource picker improvements

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/__mocks__/argResourcePickerResponse.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/argResourcePickerResponse.ts
@@ -10,26 +10,38 @@ export const createMockARGSubscriptionResponse = (): AzureGraphResponse<RawAzure
     {
       subscriptionId: '1',
       subscriptionName: 'Primary Subscription',
+      subscriptionURI: '/subscriptions/1',
+      count: 1,
     },
     {
       subscriptionId: '2',
       subscriptionName: 'Dev Subscription',
+      subscriptionURI: '/subscriptions/2',
+      count: 1,
     },
     {
       subscriptionId: '3',
       subscriptionName: 'Dev Subscription',
+      subscriptionURI: '/subscriptions/3',
+      count: 1,
     },
     {
       subscriptionId: '4',
       subscriptionName: 'Primary Subscription',
+      subscriptionURI: '/subscriptions/4',
+      count: 1,
     },
     {
       subscriptionId: '5',
       subscriptionName: 'Primary Subscription',
+      subscriptionURI: '/subscriptions/5',
+      count: 1,
     },
     {
       subscriptionId: '6',
       subscriptionName: 'Dev Subscription',
+      subscriptionURI: '/subscriptions/6',
+      count: 1,
     },
   ],
 });
@@ -39,31 +51,37 @@ export const createMockARGResourceGroupsResponse = (): AzureGraphResponse<RawAzu
     {
       resourceGroupURI: '/subscriptions/abc-123/resourceGroups/prod',
       resourceGroupName: 'Production',
+      count: 1,
     },
 
     {
       resourceGroupURI: '/subscriptions/def-456/resourceGroups/dev',
       resourceGroupName: 'Development',
+      count: 1,
     },
 
     {
       resourceGroupURI: '/subscriptions/def-456/resourceGroups/test',
       resourceGroupName: 'Test',
+      count: 1,
     },
 
     {
       resourceGroupURI: '/subscriptions/abc-123/resourceGroups/test',
       resourceGroupName: 'Test',
+      count: 1,
     },
 
     {
       resourceGroupURI: '/subscriptions/abc-123/resourceGroups/pre-prod',
       resourceGroupName: 'Pre-production',
+      count: 1,
     },
 
     {
       resourceGroupURI: '/subscriptions/def-456/resourceGroups/qa',
       resourceGroupName: 'QA',
+      count: 1,
     },
   ],
 });

--- a/public/app/plugins/datasource/azuremonitor/__mocks__/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/datasource.ts
@@ -75,7 +75,10 @@ export default function createMockDatasource(overrides?: DeepPartial<Datasource>
       getResourceURIDisplayProperties: jest.fn().mockResolvedValue({}),
     },
 
-    azureResourceGraphDatasource: {},
+    azureResourceGraphDatasource: {
+      pagedResourceGraphRequest: jest.fn().mockResolvedValue([]),
+      ...overrides?.azureResourceGraphDatasource,
+    },
     getVariablesRaw: jest.fn().mockReturnValue([]),
     currentUserAuth: false,
     ...overrides,

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
@@ -12,7 +12,6 @@ import {
   AzureAPIResponse,
   Location,
   Subscription,
-  Resource,
 } from '../types';
 export default class ResponseParser {
   static parseResponseValues<T>(
@@ -37,31 +36,6 @@ export default class ResponseParser {
         });
       }
     }
-    return list;
-  }
-
-  static parseResourceNames(
-    result: AzureAPIResponse<Resource>,
-    metricNamespace?: string
-  ): Array<{ text: string; value: string }> {
-    const list: Array<{ text: string; value: string }> = [];
-
-    if (!result) {
-      return list;
-    }
-
-    for (let i = 0; i < result.value.length; i++) {
-      if (
-        typeof result.value[i].type === 'string' &&
-        (!metricNamespace || result.value[i].type.toLocaleLowerCase() === metricNamespace.toLocaleLowerCase())
-      ) {
-        list.push({
-          text: result.value[i].name,
-          value: result.value[i].name,
-        });
-      }
-    }
-
     return list;
   }
 

--- a/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line lodash/import-scope
-import _ from 'lodash';
+import { startsWith, includes, find, filter } from 'lodash';
 
 import { ScopedVars } from '@grafana/data';
 import { getTemplateSrv, DataSourceWithBackend, TemplateSrv } from '@grafana/runtime';
@@ -9,10 +8,13 @@ import {
   AzureMonitorQuery,
   AzureMonitorDataSourceJsonData,
   AzureQueryType,
+  RawAzureResourceGroupItem,
+  AzureGetResourceNamesQuery,
   AzureMonitorDataSourceInstanceSettings,
   RawAzureResourceItem,
   AzureGraphResponse,
   AzureResourceGraphOptions,
+  RawAzureSubscriptionItem,
 } from '../types';
 import { interpolateVariable, replaceTemplateVariables, routeNames } from '../utils/common';
 
@@ -41,14 +43,14 @@ export default class AzureResourceGraphDatasource extends DataSourceWithBackend<
       return target;
     }
     const variableNames = ts.getVariables().map((v) => `$${v.name}`);
-    const subscriptionVar = _.find(target.subscriptions, (sub) => _.includes(variableNames, sub));
+    const subscriptionVar = find(target.subscriptions, (sub) => includes(variableNames, sub));
     const interpolatedSubscriptions = ts
       .replace(subscriptionVar, scopedVars, (v: string[] | string) => v)
       .split(',')
       .filter((v) => v.length > 0);
     const subscriptions = [
       ...interpolatedSubscriptions,
-      ..._.filter(target.subscriptions, (sub) => !_.includes(variableNames, sub)),
+      ...filter(target.subscriptions, (sub) => !includes(variableNames, sub)),
     ];
     const query = ts.replace(item.query, scopedVars, interpolateVariable);
 
@@ -63,7 +65,7 @@ export default class AzureResourceGraphDatasource extends DataSourceWithBackend<
     };
   }
 
-  async pagedResourceGraphRequest<T = unknown>(query: string, maxRetries = 1): Promise<T[]> {
+  async pagedResourceGraphRequest<T>(query: string, maxRetries = 1): Promise<T[]> {
     try {
       let allFetched = false;
       let $skipToken = undefined;
@@ -99,6 +101,90 @@ export default class AzureResourceGraphDatasource extends DataSourceWithBackend<
 
       throw error;
     }
+  }
+
+  async getSubscriptions() {
+    const query = `
+        resources
+        | join kind=inner (
+                  ResourceContainers
+                    | where type == 'microsoft.resources/subscriptions'
+                    | project subscriptionName=name, subscriptionURI=id, subscriptionId
+                  ) on subscriptionId
+        | summarize count=count() by subscriptionName, subscriptionURI, subscriptionId
+        | order by subscriptionName desc
+      `;
+
+    const subscriptions = await this.pagedResourceGraphRequest<RawAzureSubscriptionItem>(query, 1);
+
+    return subscriptions;
+  }
+
+  async getResourceGroups(subscriptionId: string, metricNamespacesFilter?: string) {
+    // We can use subscription ID for the filtering here as they're unique
+    // The logic of this query is:
+    // Retrieve _all_ resources a user/app registration/identity has access to
+    // Filter by the namespaces that support metrics (if this request is from the resource picker)
+    // Filter to resources contained within the subscription
+    // Conduct a left-outer join on the resourcecontainers table to allow us to get the case-sensitive resource group name
+    // Return the count of resources in a group, the URI, and name of the group in ascending order
+    const query = `resources 
+    ${metricNamespacesFilter || ''}
+    | where subscriptionId == '${subscriptionId}'
+    | extend resourceGroupURI = strcat("/subscriptions/", subscriptionId, "/resourcegroups/", resourceGroup) 
+    | join kind=leftouter (resourcecontainers  
+        | where type =~ 'microsoft.resources/subscriptions/resourcegroups'  
+        | project resourceGroupName=name, resourceGroupURI=tolower(id)) on resourceGroupURI 
+    | project resourceGroupName=iff(resourceGroupName != "", resourceGroupName, resourceGroup), resourceGroupURI
+    | summarize count=count() by resourceGroupName, resourceGroupURI
+    | order by tolower(resourceGroupName) asc `;
+
+    const resourceGroups = await this.pagedResourceGraphRequest<RawAzureResourceGroupItem>(query);
+
+    return resourceGroups;
+  }
+
+  async getResourceNames(query: AzureGetResourceNamesQuery, metricNamespacesFilter?: string) {
+    const promises = replaceTemplateVariables(this.templateSrv, query).map(
+      async ({ metricNamespace, subscriptionId, resourceGroup, region, uri }) => {
+        const validMetricNamespace = startsWith(metricNamespace?.toLowerCase(), 'microsoft.storage/storageaccounts/')
+          ? 'microsoft.storage/storageaccounts'
+          : metricNamespace;
+
+        // URI takes precedence over subscription ID and resource group
+        let prefix = uri;
+        if (!prefix) {
+          if (subscriptionId) {
+            prefix = `/subscriptions/${subscriptionId}`;
+          }
+          if (resourceGroup) {
+            prefix += `/resourceGroups/${resourceGroup}`;
+          }
+        }
+
+        const filters: string[] = [];
+        if (validMetricNamespace) {
+          // Ensure the namespace is always lowercase as that's how it's stored in Resource Graph
+          filters.push(`type == '${validMetricNamespace.toLowerCase()}'`);
+        }
+        if (region) {
+          filters.push(`location == '${region}'`);
+        }
+
+        // We use URIs for the filtering here because resource group names are not unique across subscriptions
+        // We also add a slash at the end of the URI to ensure we do not pull resources from a resource group
+        // that has a similar naming prefix e.g. resourceGroup1 and resourceGroup10
+        const query = `resources${metricNamespacesFilter ? '\n' + metricNamespacesFilter : ''}
+        | where id hasprefix "${prefix}/"
+        ${filters.length > 0 ? `| where ${filters.join(' and ')}` : ''}
+        | order by tolower(name) asc`;
+
+        const resources = await this.pagedResourceGraphRequest<RawAzureResourceItem>(query);
+
+        return resources;
+      }
+    );
+    return (await Promise.all(promises)).flat();
   }
 
   // Retrieve metric namespaces relevant to a subscription/resource group/resource

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -34,7 +34,8 @@ export function createMockResourcePickerData() {
   const mockDatasource = createMockDatasource();
   const mockResourcePicker = new ResourcePickerData(
     createMockInstanceSetttings(),
-    mockDatasource.azureMonitorDatasource
+    mockDatasource.azureMonitorDatasource,
+    mockDatasource.azureResourceGraphDatasource
   );
 
   mockResourcePicker.getSubscriptions = jest.fn().mockResolvedValue(createMockSubscriptions());

--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.test.tsx
@@ -10,6 +10,8 @@ import {
   mockResourcesByResourceGroup,
   mockSearchResults,
 } from '../../__mocks__/resourcePickerRows';
+import { DeepPartial } from '../../__mocks__/utils';
+import Datasource from '../../datasource';
 import ResourcePickerData, { ResourcePickerQueryType } from '../../resourcePicker/resourcePickerData';
 
 import { ResourceRowType } from './types';
@@ -32,11 +34,15 @@ const singleResourceSelectionURI =
   '/subscriptions/def-456/resourceGroups/dev-3/providers/Microsoft.Compute/virtualMachines/db-server';
 
 const noop = () => {};
-function createMockResourcePickerData(preserveImplementation?: string[]) {
-  const mockDatasource = createMockDatasource();
+function createMockResourcePickerData(
+  preserveImplementation?: string[],
+  datasourceOverrides?: DeepPartial<Datasource>
+) {
+  const mockDatasource = createMockDatasource(datasourceOverrides);
   const mockResourcePicker = new ResourcePickerData(
     createMockInstanceSetttings(),
-    mockDatasource.azureMonitorDatasource
+    mockDatasource.azureMonitorDatasource,
+    mockDatasource.azureResourceGraphDatasource
   );
 
   const mockFunctions = omit(
@@ -332,7 +338,9 @@ describe('AzureMonitor ResourcePicker', () => {
   });
 
   it('should not throw an error if no namespaces are found - fallback used', async () => {
-    const resourcePickerData = createMockResourcePickerData(['getResourceGroupsBySubscriptionId']);
+    const resourcePickerData = createMockResourcePickerData(['getResourceGroupsBySubscriptionId'], {
+      azureResourceGraphDatasource: { getResourceGroups: jest.fn().mockResolvedValue([]) },
+    });
     resourcePickerData.postResource = jest.fn().mockResolvedValueOnce({ data: [] });
     render(
       <ResourcePicker

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
@@ -26,7 +26,17 @@ jest.mock('@grafana/runtime', () => ({
     },
   }),
 }));
-
+const getResourceGroups = jest.fn().mockResolvedValue([{ resourceGroupURI: 'rg', resourceGroupName: 'rg', count: 1 }]);
+const getResourceNames = jest.fn().mockResolvedValue([
+  {
+    id: 'foobarID',
+    name: 'foobar',
+    subscriptionId: 'subID',
+    resourceGroup: 'resourceGroup',
+    type: 'foobarType',
+    location: 'london',
+  },
+]);
 const defaultProps = {
   query: {
     refId: 'A',
@@ -39,7 +49,6 @@ const defaultProps = {
   onChange: jest.fn(),
   datasource: createMockDatasource({
     getSubscriptions: jest.fn().mockResolvedValue([{ text: 'Primary Subscription', value: 'sub' }]),
-    getResourceGroups: jest.fn().mockResolvedValue([{ text: 'rg', value: 'rg' }]),
     getMetricNamespaces: jest
       .fn()
       .mockImplementation(
@@ -50,11 +59,16 @@ const defaultProps = {
           return [{ text: 'foo/custom', value: 'foo/custom' }];
         }
       ),
-    getResourceNames: jest.fn().mockResolvedValue([{ text: 'foobar', value: 'foobar' }]),
     getVariablesRaw: jest.fn().mockReturnValue([
       { label: 'query0', name: 'sub0' },
       { label: 'query1', name: 'rg', query: { queryType: AzureQueryType.ResourceGroupsQuery } },
     ]),
+    azureResourceGraphDatasource: {
+      getResourceGroups,
+      getResourceNames,
+    },
+    getResourceGroups,
+    getResourceNames,
   }),
 };
 

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -149,7 +149,7 @@ const VariableEditor = (props: Props) => {
   useEffect(() => {
     if (subscription) {
       datasource.getResourceGroups(subscription).then((rgs) => {
-        setResourceGroups(rgs.map((s) => ({ label: s.text, value: s.value })));
+        setResourceGroups(rgs.map((s) => ({ label: s.resourceGroupName, value: s.resourceGroupName })));
       });
     }
   }, [datasource, subscription]);
@@ -179,8 +179,8 @@ const VariableEditor = (props: Props) => {
   // When subscription, resource group, and namespace are all set, retrieve resource names
   useEffect(() => {
     if (subscription && resourceGroup && namespace) {
-      datasource.getResourceNames(subscription, resourceGroup, namespace).then((rgs) => {
-        setResources(rgs.map((s) => ({ label: s.text, value: s.value })));
+      datasource.getResourceNames(subscription, resourceGroup, namespace).then((resources) => {
+        setResources(resources.map((s) => ({ label: s.name, value: s.name })));
       });
     }
   }, [datasource, subscription, resourceGroup, namespace]);

--- a/public/app/plugins/datasource/azuremonitor/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/datasource.ts
@@ -49,7 +49,11 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     this.azureMonitorDatasource = new AzureMonitorDatasource(instanceSettings);
     this.azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
     this.azureLogAnalyticsDatasource = new AzureLogAnalyticsDatasource(instanceSettings);
-    this.resourcePickerData = new ResourcePickerData(instanceSettings, this.azureMonitorDatasource);
+    this.resourcePickerData = new ResourcePickerData(
+      instanceSettings,
+      this.azureMonitorDatasource,
+      this.azureResourceGraphDatasource
+    );
 
     this.pseudoDatasource = {
       [AzureQueryType.AzureMonitor]: this.azureMonitorDatasource,
@@ -164,10 +168,6 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
   }
 
   /* Azure Monitor REST API methods */
-  getResourceGroups(subscriptionId: string) {
-    return this.azureMonitorDatasource.getResourceGroups(this.templateSrv.replace(subscriptionId));
-  }
-
   getMetricNamespaces(
     subscriptionId: string,
     resourceGroup?: string,
@@ -200,10 +200,6 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     );
   }
 
-  getResourceNames(subscriptionId: string, resourceGroup?: string, metricNamespace?: string, region?: string) {
-    return this.azureMonitorDatasource.getResourceNames({ subscriptionId, resourceGroup, metricNamespace, region });
-  }
-
   getMetricNames(
     subscriptionId: string,
     resourceGroup: string,
@@ -220,13 +216,27 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     });
   }
 
+  getSubscriptions() {
+    return this.azureMonitorDatasource.getSubscriptions();
+  }
+
   /*Azure Log Analytics */
   getAzureLogAnalyticsWorkspaces(subscriptionId: string) {
     return this.azureLogAnalyticsDatasource.getWorkspaces(subscriptionId);
   }
 
-  getSubscriptions() {
-    return this.azureMonitorDatasource.getSubscriptions();
+  /*Azure Resource Graph */
+  getResourceGroups(subscriptionId: string) {
+    return this.azureResourceGraphDatasource.getResourceGroups(this.templateSrv.replace(subscriptionId));
+  }
+
+  getResourceNames(subscriptionId: string, resourceGroup?: string, metricNamespace?: string, region?: string) {
+    return this.azureResourceGraphDatasource.getResourceNames({
+      subscriptionId,
+      resourceGroup,
+      metricNamespace,
+      region,
+    });
   }
 
   interpolateVariablesInQueries(queries: AzureMonitorQuery[], scopedVars: ScopedVars): AzureMonitorQuery[] {

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -6,6 +6,7 @@ import {
 import createMockDatasource from '../__mocks__/datasource';
 import { createMockInstanceSetttings } from '../__mocks__/instanceSettings';
 import { resourceTypes } from '../azureMetadata';
+import AzureResourceGraphDatasource from '../azure_resource_graph/azure_resource_graph_datasource';
 import { ResourceRowType } from '../components/ResourcePicker/types';
 import { AzureGraphResponse } from '../types';
 
@@ -22,18 +23,24 @@ jest.mock('@grafana/runtime', () => ({
 
 const createResourcePickerData = (responses: AzureGraphResponse[], noNamespaces?: boolean) => {
   const instanceSettings = createMockInstanceSetttings();
-  const mockDatasource = createMockDatasource();
+  const azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
+  const postResource = jest.fn();
+  responses.forEach((res) => {
+    postResource.mockResolvedValueOnce(res);
+  });
+  azureResourceGraphDatasource.postResource = postResource;
+  const mockDatasource = createMockDatasource({ azureResourceGraphDatasource: azureResourceGraphDatasource });
   mockDatasource.azureMonitorDatasource.getMetricNamespaces = jest
     .fn()
     .mockResolvedValueOnce(
       noNamespaces ? [] : [{ text: 'Microsoft.Storage/storageAccounts', value: 'Microsoft.Storage/storageAccounts' }]
     );
-  const resourcePickerData = new ResourcePickerData(instanceSettings, mockDatasource.azureMonitorDatasource);
-  const postResource = jest.fn();
-  responses.forEach((res) => {
-    postResource.mockResolvedValueOnce(res);
-  });
-  resourcePickerData.postResource = postResource;
+
+  const resourcePickerData = new ResourcePickerData(
+    instanceSettings,
+    mockDatasource.azureMonitorDatasource,
+    mockDatasource.azureResourceGraphDatasource
+  );
   return { resourcePickerData, postResource, mockDatasource };
 };
 
@@ -299,32 +306,6 @@ describe('AzureMonitor resourcePickerData', () => {
         typeLabel: 'Microsoft.Compute/virtualMachines',
         uri: '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/web-server',
       });
-    });
-
-    it('throws an error if it recieves data with a malformed uri', async () => {
-      const mockResponse = {
-        data: [
-          {
-            id: '/a-differently-formatted/uri/than/the/type/we/planned/to/parse',
-            name: 'web-server',
-            type: 'Microsoft.Compute/virtualMachines',
-            resourceGroup: 'dev',
-            subscriptionId: 'def-456',
-            location: 'northeurope',
-          },
-        ],
-      };
-      const { resourcePickerData } = createResourcePickerData([mockResponse]);
-      try {
-        await resourcePickerData.getResourcesForResourceGroup('dev', 'logs');
-        throw Error('expected getResourcesForResourceGroup to fail but it succeeded');
-      } catch (err) {
-        if (err instanceof Error) {
-          expect(err.message).toEqual('unable to fetch resource details');
-        } else {
-          throw err;
-        }
-      }
     });
 
     it('should filter metrics resources', async () => {

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -145,11 +145,14 @@ export interface AzureResourceSummaryItem {
 export interface RawAzureSubscriptionItem {
   subscriptionName: string;
   subscriptionId: string;
+  subscriptionURI: string;
+  count: number;
 }
 
 export interface RawAzureResourceGroupItem {
   resourceGroupURI: string;
   resourceGroupName: string;
+  count: number;
 }
 
 export interface RawAzureResourceItem {
@@ -226,10 +229,11 @@ export interface LegacyAzureGetMetricMetadataQuery {
 }
 
 export interface AzureGetResourceNamesQuery {
-  subscriptionId: string;
+  subscriptionId?: string;
   resourceGroup?: string;
   metricNamespace?: string;
   region?: string;
+  uri?: string;
 }
 
 export interface AzureMonitorLocations {

--- a/public/app/plugins/datasource/azuremonitor/variables.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/variables.test.ts
@@ -91,7 +91,7 @@ describe('VariableSupport', () => {
     });
 
     it('can fetch resourceNames with a subscriptionId', async () => {
-      const expectedResults = ['test'];
+      const expectedResults = [{ name: 'test' }];
       const variableSupport = new VariableSupport(
         createMockDatasource({
           getResourceNames: jest.fn().mockResolvedValueOnce(expectedResults),
@@ -113,7 +113,7 @@ describe('VariableSupport', () => {
         ],
       } as DataQueryRequest<AzureMonitorQuery>;
       const result = await lastValueFrom(variableSupport.query(mockRequest));
-      expect(result.data[0].fields[0].values).toEqual(expectedResults);
+      expect(result.data[0].fields[0].values).toEqual([expectedResults[0].name]);
     });
 
     it('can fetch a metricNamespace with a subscriptionId', async () => {
@@ -448,7 +448,7 @@ describe('VariableSupport', () => {
     });
 
     it('can fetch resource names', async () => {
-      const expectedResults = ['test'];
+      const expectedResults = [{ name: 'test' }];
       const variableSupport = new VariableSupport(
         createMockDatasource({
           getResourceNames: jest.fn().mockResolvedValueOnce(expectedResults),
@@ -464,7 +464,7 @@ describe('VariableSupport', () => {
         ],
       } as DataQueryRequest<AzureMonitorQuery>;
       const result = await lastValueFrom(variableSupport.query(mockRequest));
-      expect(result.data[0].fields[0].values).toEqual(expectedResults);
+      expect(result.data[0].fields[0].values).toEqual([expectedResults[0].name]);
     });
 
     it('returns no data if calling resourceNames but the subscription is a template variable with no value', async () => {


### PR DESCRIPTION
Backport c7b0bbd262458a21fa81981b945097f1b017cad1 from #101695

---

Building on the work done in #100325, the variable editor's requests have been refactored to ensure they function as expected for users/app registrations with restricted permissions.

A quick summary of the changes:

- Resource group and resource name retrieval methods have been moved to the Resource Graph data source rather than the Azure Monitor data source.
- A subscription retrieval method has been added to the Resource Graph data source.
- The logic for making paged requests to Resource Graph has been extracted to the Resource Graph data source so that it's reusable.
- Response parser has had a redundant method removed.

These changes allow the `resourcePickerData` file to be simplified as the logic for retrieving resource details is gradually being moved to the Resource Graph data source, allowing for better separation of concerns.

Queries in the variable editor will now appropriately return values based on what the user can truly access (which is the correct behaviour). e.g. when making a variable query against namespaces, the namespaces query would previously fail if the app registration didn't have sufficient permissions. The query will now display a list of namespaces the app registration has access to (and similarly for resource groups and resource names).

Fixes #92153
Fixes #94500
