### PR TITLE
Alerting: Relax permissions for access a rule

### DIFF
--- a/pkg/services/ngalert/accesscontrol/rules.go
+++ b/pkg/services/ngalert/accesscontrol/rules.go
@@ -212,7 +212,7 @@ func (r *RuleService) AuthorizeRuleChanges(ctx context.Context, user identity.Re
 	for _, rule := range change.Update {
 		if rule.AffectsQuery() {
 			if err := r.HasAccessOrError(ctx, user, r.getRulesQueryEvaluator(rule.New), func() string {
-				return fmt.Sprintf("update alert rule '%s' (UID: %s)", rule.Existing.Title, rule.Existing.UID)
+				return fmt.Sprintf("update alert rule query '%s' (UID: %s)", rule.Existing.Title, rule.Existing.UID)
 			}); err != nil {
 				return err
 			}

--- a/pkg/services/ngalert/accesscontrol/rules.go
+++ b/pkg/services/ngalert/accesscontrol/rules.go
@@ -180,13 +180,6 @@ func (r *RuleService) AuthorizeRuleChanges(ctx context.Context, user identity.Re
 		}); err != nil {
 			return err
 		}
-		for _, rule := range change.Delete {
-			if err := r.HasAccessOrError(ctx, user, r.getRulesQueryEvaluator(rule), func() string {
-				return fmt.Sprintf("delete an alert rule '%s'", rule.UID)
-			}); err != nil {
-				return err
-			}
-		}
 	}
 
 	var addAuthorized, updateAuthorized bool // these are needed to check authorization for the rule create\update only once
@@ -217,10 +210,12 @@ func (r *RuleService) AuthorizeRuleChanges(ctx context.Context, user identity.Re
 	}
 
 	for _, rule := range change.Update {
-		if err := r.HasAccessOrError(ctx, user, r.getRulesQueryEvaluator(rule.New), func() string {
-			return fmt.Sprintf("update alert rule '%s' (UID: %s)", rule.Existing.Title, rule.Existing.UID)
-		}); err != nil {
-			return err
+		if rule.AffectsQuery() {
+			if err := r.HasAccessOrError(ctx, user, r.getRulesQueryEvaluator(rule.New), func() string {
+				return fmt.Sprintf("update alert rule '%s' (UID: %s)", rule.Existing.Title, rule.Existing.UID)
+			}); err != nil {
+				return err
+			}
 		}
 
 		// Check if the rule is moved from one folder to the current. If yes, then the user must have the authorization to delete rules from the source folder and add rules to the target folder.

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -152,16 +152,6 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *contextmodel.ReqContext, namespaceU
 				provisioned = true
 				continue
 			}
-			// XXX: Currently delete requires data source query access to all rules in the group.
-			if err := srv.authz.AuthorizeDatasourceAccessForRuleGroup(ctx, c.SignedInUser, rules); err != nil {
-				if errors.Is(err, authz.ErrAuthorizationBase) {
-					logger.Debug("User is not authorized to delete rules in the group", "group", groupKey.RuleGroup)
-					auth = false
-					continue
-				} else {
-					return err
-				}
-			}
 			uid := make([]string, 0, len(rules))
 			for _, rule := range rules {
 				uid = append(uid, rule.UID)

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -145,7 +145,6 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *contextmodel.ReqContext, namespaceU
 		}
 		rulesToDelete := make([]string, 0)
 		provisioned := false
-		auth := true
 		for groupKey, rules := range deletionCandidates {
 			if containsProvisionedAlerts(provenances, rules) {
 				logger.Debug("Alert group cannot be deleted because it is provisioned", "group", groupKey.RuleGroup)
@@ -167,17 +166,10 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *contextmodel.ReqContext, namespaceU
 			return nil
 		}
 		// if none rules were deleted return an error.
-
 		// Check whether provisioned check failed first because if it is true, then all rules that the user can access (actually read via GET API) are provisioned.
 		if provisioned {
 			return errProvisionedResource
 		}
-
-		// If auth is false, then the user is not authorized to delete any of the rules.
-		if !auth {
-			return authz.NewAuthorizationErrorGeneric("delete any existing rules in the namespace")
-		}
-
 		logger.Info("No alert rules were deleted")
 		return nil
 	})

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -80,7 +80,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 	}
 
 	t.Run("when fine-grained access is enabled", func(t *testing.T) {
-		t.Run("allow deleting without access to datasource", func(t *testing.T){
+		t.Run("allow deleting without access to datasource", func(t *testing.T) {
 			ruleStore := initFakeRuleStore(t)
 			provisioningStore := fakes.NewFakeProvisioningStore()
 
@@ -90,7 +90,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 
 			ruleStore.PutRule(context.Background(), authorizedRulesInFolder...)
 
-			permissions := createPermissionsForRulesWithoutDS(append(authorizedRulesInFolder), orgID)
+			permissions := createPermissionsForRulesWithoutDS(authorizedRulesInFolder, orgID)
 			requestCtx := createRequestContextWithPerms(orgID, permissions, nil)
 
 			response := createServiceWithProvenanceStore(ruleStore, provisioningStore).RouteDeleteAlertRules(requestCtx, folder.UID, "")

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -81,7 +81,6 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 
 	t.Run("when fine-grained access is enabled", func(t *testing.T) {
 		t.Run("and group argument is empty", func(t *testing.T) {
-
 			t.Run("allow deleting without access to datasource", func(t *testing.T) {
 				ruleStore := initFakeRuleStore(t)
 				provisioningStore := fakes.NewFakeProvisioningStore()

--- a/pkg/services/ngalert/store/deltas.go
+++ b/pkg/services/ngalert/store/deltas.go
@@ -13,7 +13,7 @@ import (
 var AlertRuleFieldsToIgnoreInDiff = [...]string{"ID", "Version", "Updated", "UpdatedBy"}
 
 // AlertRuleFieldsWhichAffectQuery contains fields which affect the rule's query(s)
-var AlertRuleFieldsWhichAffectQuery = [...]string{"Data", "Condition"}
+var AlertRuleFieldsWhichAffectQuery = [...]string{"Data", "IntervalSeconds"}
 
 type RuleDelta struct {
 	Existing *models.AlertRule

--- a/pkg/services/ngalert/store/deltas.go
+++ b/pkg/services/ngalert/store/deltas.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util/cmputil"
@@ -11,10 +12,27 @@ import (
 // AlertRuleFieldsToIgnoreInDiff contains fields that are ignored when calculating the RuleDelta.Diff.
 var AlertRuleFieldsToIgnoreInDiff = [...]string{"ID", "Version", "Updated", "UpdatedBy"}
 
+// AlertRuleFieldsWhichAffectQuery contains fields which affect the rule's query(s)
+var AlertRuleFieldsWhichAffectQuery = [...]string{"Data", "Condition"}
+
 type RuleDelta struct {
 	Existing *models.AlertRule
 	New      *models.AlertRule
 	Diff     cmputil.DiffReport
+}
+
+func (d *RuleDelta) AffectsQuery() bool {
+	if len(d.Diff) == 0 {
+		return false
+	}
+	for _, path := range d.Diff.Paths() {
+		for _, field := range AlertRuleFieldsWhichAffectQuery {
+			if strings.HasPrefix(path, field) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type GroupDelta struct {

--- a/pkg/services/ngalert/store/deltas_test.go
+++ b/pkg/services/ngalert/store/deltas_test.go
@@ -741,7 +741,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.False(t, delta.AffectsQuery())
 	})
-
 	t.Run("returns true when diff contains a field that affects query", func(t *testing.T) {
 		delta := RuleDelta{
 			Diff: cmputil.DiffReport{
@@ -754,7 +753,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.True(t, delta.AffectsQuery())
 	})
-
 	t.Run("returns false when diff contains only fields that do not affect query", func(t *testing.T) {
 		delta := RuleDelta{
 			Diff: cmputil.DiffReport{
@@ -767,7 +765,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.False(t, delta.AffectsQuery())
 	})
-
 	t.Run("returns true when diff contains multiple fields, including one that affects query", func(t *testing.T) {
 		delta := RuleDelta{
 			Diff: cmputil.DiffReport{
@@ -785,7 +782,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.True(t, delta.AffectsQuery())
 	})
-
 	t.Run("handles nested paths in diff", func(t *testing.T) {
 		delta := RuleDelta{
 			Diff: cmputil.DiffReport{
@@ -798,7 +794,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.True(t, delta.AffectsQuery())
 	})
-
 	t.Run("returns false for empty diff paths", func(t *testing.T) {
 		delta := RuleDelta{
 			Diff: cmputil.DiffReport{
@@ -811,7 +806,6 @@ func TestDeltaAffectsQuery(t *testing.T) {
 		}
 		assert.False(t, delta.AffectsQuery())
 	})
-
 }
 
 // simulateSubmitted resets some fields of the structure that are not populated by API model to model conversion

--- a/pkg/services/ngalert/store/deltas_test.go
+++ b/pkg/services/ngalert/store/deltas_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/cmputil"
 )
 
 func TestCalculateChanges(t *testing.T) {
@@ -730,6 +732,86 @@ func TestCalculateRuleCreate(t *testing.T) {
 		assert.Len(t, delta.New, 1)
 		assert.Equal(t, rule, delta.New[0])
 	})
+}
+
+func TestDeltaAffectsQuery(t *testing.T) {
+	t.Run("returns false when there are no diffs", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{},
+		}
+		assert.False(t, delta.AffectsQuery())
+	})
+
+	t.Run("returns true when diff contains a field that affects query", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{
+				{
+					Path:  "Data",
+					Left:  reflect.ValueOf("old value"),
+					Right: reflect.ValueOf("new value"),
+				},
+			},
+		}
+		assert.True(t, delta.AffectsQuery())
+	})
+
+	t.Run("returns false when diff contains only fields that do not affect query", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{
+				{
+					Path:  "Title",
+					Left:  reflect.ValueOf("old title"),
+					Right: reflect.ValueOf("new title"),
+				},
+			},
+		}
+		assert.False(t, delta.AffectsQuery())
+	})
+
+	t.Run("returns true when diff contains multiple fields, including one that affects query", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{
+				{
+					Path:  "Title",
+					Left:  reflect.ValueOf("old title"),
+					Right: reflect.ValueOf("new title"),
+				},
+				{
+					Path:  "IntervalSeconds",
+					Left:  reflect.ValueOf(10),
+					Right: reflect.ValueOf(20),
+				},
+			},
+		}
+		assert.True(t, delta.AffectsQuery())
+	})
+
+	t.Run("handles nested paths in diff", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{
+				{
+					Path:  "Data[0].Query",
+					Left:  reflect.ValueOf("old query"),
+					Right: reflect.ValueOf("new query"),
+				},
+			},
+		}
+		assert.True(t, delta.AffectsQuery())
+	})
+
+	t.Run("returns false for empty diff paths", func(t *testing.T) {
+		delta := RuleDelta{
+			Diff: cmputil.DiffReport{
+				{
+					Path:  "",
+					Left:  reflect.ValueOf("old value"),
+					Right: reflect.ValueOf("new value"),
+				},
+			},
+		}
+		assert.False(t, delta.AffectsQuery())
+	})
+
 }
 
 // simulateSubmitted resets some fields of the structure that are not populated by API model to model conversion


### PR DESCRIPTION
This makes it so that it is:
- No longer required to have datasource permissions to delete a rule.
- No longer required to have datasource permissions to update non-query related fields of a rule.


# Release notice breaking change

Relaxed access permissions for rule deletion and updates. You only need datasource permissions for edits that affect the query related fields of a rule. Deleting a rule does not check datasource permissions.