### PR TITLE
Alerting(ui-copy): update IRM contact point description when IRM is not installed

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.tsx
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.tsx
@@ -264,7 +264,7 @@ export function useOnCallIntegration() {
       order: -1, // The default is 0. We want OnCall to be the first on the list
       description: isOnCallEnabled
         ? t('alerting.irm-integration.enabled-description', 'Seamless way to handle alerts and manage incidents')
-        : t('alerting.irm-integration.disabled-description', 'Enable Grafana IRM to use this integration'),
+        : t('alerting.irm-integration.disabled-description', 'Enable IRM through a Webhook integration'),
       badge: <Badge color="blue" text={t('alerting.irm-integration.recommended', 'Recommended')} />,
     },
     extendOnCallNotifierFeatures,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1099,7 +1099,7 @@
     },
     "irm-integration": {
       "connection-method": "How to connect to IRM",
-      "disabled-description": "Enable Grafana IRM to use this integration",
+      "disabled-description": "Enable IRM through a Webhook integration",
       "enabled-description": "Seamless way to handle alerts and manage incidents",
       "existing-integration": "Existing IRM integration",
       "existing-integration-description": "Use an existing IRM integration",


### PR DESCRIPTION
This PR updates a minor UI text to clarify that IRM can be configured via a Webhook integration when IRM is not installed—such as in Grafana OSS or Enterprise without IRM.

The [Alerting OSS documentation for configuring IRM](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/) was recently updated.

**Before**

<img width="340" alt="Screenshot 2025-04-09 at 04 20 27" src="https://github.com/user-attachments/assets/837a2ac4-81eb-48e7-a8b5-620fb3a0fd05" />


**Updated**


<img width="340" alt="Screenshot 2025-04-09 at 04 19 13" src="https://github.com/user-attachments/assets/371ed2c6-cd2e-4917-9963-7c60f353851e" />

cc - @joeyorlando 


