### PR TITLE
Dynamic Dashboards: Don't show add controls for repeated tabs and rows

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -27,7 +27,7 @@ import {
   ObjectsReorderedOnCanvasEvent,
 } from '../../edit-pane/shared';
 import { serializeDefaultGridLayout } from '../../serialization/layoutSerializers/DefaultGridLayoutSerializer';
-import { isClonedKey, joinCloneKeys } from '../../utils/clone';
+import { isClonedKey, joinCloneKeys, useHasClonedParents } from '../../utils/clone';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import {
   forceRenderChildren,
@@ -533,8 +533,9 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
   const { children } = useSceneObjectState(model.state.grid, { shouldActivateOrKeepAlive: true });
   const dashboard = useDashboard(model);
   const { isEditing } = dashboard.useState();
+  const hasClonedParents = useHasClonedParents(model);
   const styles = useStyles2(getStyles);
-  const showCanvasActions = isEditing && config.featureToggles.dashboardNewLayouts;
+  const showCanvasActions = isEditing && config.featureToggles.dashboardNewLayouts && !hasClonedParents;
 
   // If we are top level layout and we have no children, show empty state
   if (model.parent === dashboard && children.length === 0) {

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridLayoutRenderer.tsx
@@ -4,6 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { LazyLoader, SceneComponentProps, sceneGraph } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
+import { useHasClonedParents } from '../../utils/clone';
 import { useDashboardState } from '../../utils/utils';
 import { CanvasGridAddActions } from '../layouts-shared/CanvasGridAddActions';
 
@@ -12,6 +13,7 @@ import { AutoGridLayoutManager } from './ResponsiveGridLayoutManager';
 
 export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLayout>) {
   const { children, isHidden, isLazy } = model.useState();
+  const hasClonedParents = useHasClonedParents(model);
   const styles = useStyles2(getStyles, model.state);
   const { layoutOrchestrator, isEditing } = useDashboardState(model);
   const layoutManager = sceneGraph.getAncestor(model, AutoGridLayoutManager);
@@ -20,6 +22,8 @@ export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLa
   if (isHidden || !layoutOrchestrator) {
     return null;
   }
+
+  const showCanvasActions = !hasClonedParents && isEditing;
 
   return (
     <div
@@ -35,7 +39,7 @@ export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLa
           <item.Component key={item.state.key} model={item} />
         )
       )}
-      {isEditing && <CanvasGridAddActions layoutManager={layoutManager} />}
+      {showCanvasActions && <CanvasGridAddActions layoutManager={layoutManager} />}
     </div>
   );
 }

--- a/public/app/features/dashboard-scene/utils/clone.ts
+++ b/public/app/features/dashboard-scene/utils/clone.ts
@@ -1,5 +1,7 @@
 import { SceneObject } from '@grafana/scenes';
 
+import { DashboardScene } from '../scene/DashboardScene';
+
 const CLONE_KEY = '-clone-';
 const CLONE_SEPARATOR = '/';
 
@@ -81,4 +83,20 @@ export function containsCloneKey(key: string): boolean {
 export function useIsClone(scene: SceneObject): boolean {
   const { key } = scene.useState();
   return isClonedKey(key!);
+}
+
+/**
+ * Useful hook for checking if a scene is in a clone chain
+ * @param scene
+ */
+export function useHasClonedParents(scene: SceneObject): boolean {
+  if (isClonedKey(scene.state.key!)) {
+    return true;
+  }
+
+  if (!scene.parent || scene.parent instanceof DashboardScene) {
+    return false;
+  }
+
+  return useHasClonedParents(scene.parent);
 }


### PR DESCRIPTION
**What is this feature?**

Hide add/group controls for the grids placed inside repeated rows or tabs.

**Why do we need this feature?**

Prevent issues.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
