### PR TITLE
Revert "Update sharing markers to use the new format"

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -43,6 +43,12 @@ cards:
       href: ./share-dashboards-panels/shared-dashboards/
       description: Share your dashboards with anyone without requiring access to your Grafana organization.
       height: 24
+refs:
+  panels:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-overview/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-overview/
 ---
 
 {{< docs/hero-simple key="hero" >}}
@@ -51,13 +57,13 @@ cards:
 
 ## Overview
 
-<section id="dashboard-overview">
+{{< shared id="dashboard-overview" >}}
 
-A Grafana dashboard is a set of one or more [panels](/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-overview/), organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into charts, graphs, and other visualizations.
+A Grafana dashboard is a set of one or more [panels](ref:panels), organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into charts, graphs, and other visualizations.
 
 A data source can be an SQL database, Grafana Loki, Grafana Mimir, or a JSON-based API. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards.
 
-</section>
+{{< /shared >}}
 
 Queries allow you to reduce the entirety of your data to a specific dataset, providing a more manageable visualization. Since data sources have their own distinct query languages, Grafana dashboards provide you with a query editor to accommodate these differences.
 

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -90,7 +90,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
 **To create a dashboard**:
 
-<section id="create-dashboard">
+{{< shared id="create-dashboard" >}}
 
 1. Click **Dashboards** in the main menu.
 1. Click **New** and select **New Dashboard**.
@@ -98,7 +98,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    ![Empty dashboard state](/media/docs/grafana/dashboards/empty-dashboard-10.2.png)
 
-</section>
+{{< /shared >}}
 
 1. In the dialog box that opens, do one of the following:
 


### PR DESCRIPTION
Reverts grafana/grafana#103470

The implementation changed again (hopefully for the last time) back to using shortcode markers for sharing the content. Updated docs are in https://github.com/grafana/writers-toolkit/pull/1140/files.