### PR TITLE
Chore: Fix panic

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -980,6 +980,9 @@ func (s *server) ListManagedObjects(ctx context.Context, req *ListManagedObjects
 }
 
 func (s *server) CountManagedObjects(ctx context.Context, req *CountManagedObjectsRequest) (*CountManagedObjectsResponse, error) {
+	if s.search == nil {
+		return nil, fmt.Errorf("search index not configured")
+	}
 	return s.search.CountManagedObjects(ctx, req)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Not sure what happened but a request to `/api/admin/usage-report-preview` ends up in a panic, crashing Grafana:

```
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10b042e44]

goroutine 2077 [running]:
github.com/grafana/grafana/pkg/storage/unified/resource.(*searchSupport).CountManagedObjects(0x0, {0x111c8cfd0, 0x14004678f90}, 0x14007386360)
	/go/github.com/grafana/grafana/pkg/storage/unified/resource/search.go:193 +0xc4
github.com/grafana/grafana/pkg/storage/unified/resource.(*server).CountManagedObjects(0x14000575a40, {0x111c8cfd0, 0x14004678f90}, 0x14007386360)
	/go/github.com/grafana/grafana/pkg/storage/unified/resource/server.go:983 +0x58
github.com/grafana/grafana/pkg/storage/unified/resource._ManagedObjectIndex_CountManagedObjects_Handler.func1({0x111c8cfd0, 0x14004678f90}, {0x1112a3040, 0x14007386360})
	/go/github.com/grafana/grafana/pkg/storage/unified/resource/resource_grpc.pb.go:708 +0xbc
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth.UnaryServerInterceptor.func1({0x111c8cfd0, 0x140046786c0}, {0x1112a3040, 0x14007386360}, 0x140004794e0, 0x14002ff0600)
	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.1/interceptors/auth/auth.go:48 +0x230
github.com/grafana/grafana/pkg/storage/unified/resource._ManagedObjectIndex_CountManagedObjects_Handler({0x1118573c0, 0x14000575a40}, {0x111c8cfd0, 0x140046786c0}, 0x14004678570, 0x14002890350)
	/go/github.com/grafana/grafana/pkg/storage/unified/resource/resource_grpc.pb.go:710 +0x1e4
github.com/fullstorydev/grpchan.InterceptServer.func1({0x1118573c0, 0x14000575a40}, {0x111c8cfd0, 0x140046786c0}, 0x14004678570, 0x0)
	/go/pkg/mod/github.com/fullstorydev/grpchan@v1.1.1/intercept.go:131 +0x128
github.com/fullstorydev/grpchan/inprocgrpc.(*Channel).Invoke.func2()
	/go/pkg/mod/github.com/fullstorydev/grpchan@v1.1.1/inprocgrpc/in_process.go:241 +0x194
created by github.com/fullstorydev/grpchan/inprocgrpc.(*Channel).Invoke in goroutine 2211
	/go/pkg/mod/github.com/fullstorydev/grpchan@v1.1.1/inprocgrpc/in_process.go:235 +0x754
```

I've copied the `nil` guard from other functions, which apparently, solves the issue.
