### PR TITLE
Renovate: Deprioritise devDependencies, group faro deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,12 +51,16 @@
       matchPackageNames: ["@grafana/scenes", "@grafana/scenes-react"],
     },
     {
+      groupName: "faro",
+      matchPackageNames: ["@grafana/faro*"],
+    },
+    {
       groupName: "visx",
       matchPackageNames: ["@visx/{/,}**"],
     },
     {
       groupName: "uLibraries",
-      matchPackageNames: ["@leeoniya/ufuzzy", "uplot"],
+      matchPackageNames: ["@leeoniya/**", "uplot"],
       reviewers: ["leeoniya"],
     },
     {
@@ -68,6 +72,10 @@
       groupName: "augurs",
       matchPackageNames: ["@bsull/augurs"],
       reviewers: ["sd2k"],
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "prPriority": -1
     },
   ],
   pin: {


### PR DESCRIPTION
Tweaks the Renovate config to try and prioritise dependencies better.

 - Groups Faro package updates together
 - Deprioritises dev dependencies to occur last.

Another thing we can do is to prioritise all `@grafana/**` packages above anything else? Or could make it (1 is highest priority)

 1. auto-mergable patch updates
 2. `@grafana/**` packages
 3. _everything else_
 4. dev dependencies

Thouughts?