### PR TITLE
docs(alerting): update integration choice for IRM setup

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-irm.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-irm.md
@@ -72,15 +72,20 @@ These instructions apply only to Grafana OSS and Grafana Enterprise. To configur
 
 ## Configure an integration in Grafana IRM
 
-First, enable an integration in IRM to accept alerts from Grafana Alerting. You can either create a new integration or use an existing **Grafana Alerting** or **Webhook** integration in IRM.
+First, enable an integration in IRM to accept alerts from Grafana Alerting. You can either create a new integration or use an existing **Alertmanager** or **Webhook** integration in IRM.
 
 To create the integration, follow the same steps as described in [Configure an OnCall integration in IRM](ref:irm-configure-integrations):
 
 1. Navigate to **Alerts & IRM** -> **IRM** -> **Integrations**.
 1. Click **+ New integration**.
-1. Select either **Grafana Alerting** or **Webhook** integration from the list.
-   - **Grafana Alerting** integration – Includes preconfigured IRM templates for processing Grafana alerts.
+1. Select either **Alertmanager** or **Webhook** integration from the list.
+
+   - **Alertmanager** integration – Includes preconfigured IRM templates for processing Grafana and Prometheus alerts.
+
+     > The **Grafana Alerting** integration works similarly but may display a warning in the UI.
+
    - **Webhook** integration – Uses default IRM templates for general alert processing.
+
 1. Provide a title, description, and assign it to a team, then click **Create Integration**.
 1. On the integration details page, copy the **HTTP Endpoint** URL to use in the next section.
 


### PR DESCRIPTION
Continuation of https://github.com/grafana/grafana/pull/103614.

Minor docs change: this PR updates the Alerting IRM docs to recommend using the Alertmanager integration instead of the  Grafana Alerting integration, which may display a warning in the UI.

⭐ [Preview](https://deploy-preview-grafana-103701-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/)