### PR TITLE
PanelPlugin: Add shouldMigrate callback to setMigrationHandler()

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -202,7 +202,7 @@ export class PanelPlugin<
    * This function is called before the panel first loads if
    * the current version is different than the version that was saved.
    *
-   * If shouldMigrate is provided, it will be called regaedless of whether
+   * If shouldMigrate is provided, it will be called regardless of whether
    * the version has changed, and can explicitly opt into running the
    * migration handler
    *

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -202,6 +202,10 @@ export class PanelPlugin<
    * This function is called before the panel first loads if
    * the current version is different than the version that was saved.
    *
+   * If shouldMigrate is provided, it will be called regaedless of whether
+   * the version has changed, and can explicitly opt into running the
+   * migration handler
+   *
    * This is a good place to support any changes to the options model
    */
   setMigrationHandler(

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -113,6 +113,7 @@ export class PanelPlugin<
   panel: ComponentType<PanelProps<TOptions>> | null;
   editor?: ComponentClass<PanelEditorProps<TOptions>>;
   onPanelMigration?: PanelMigrationHandler<TOptions>;
+  shouldMigrate?: (panel: ComponentType<PanelProps<TOptions>> | null) => boolean;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
   dataSupport: PanelPluginDataSupport = {
@@ -203,8 +204,12 @@ export class PanelPlugin<
    *
    * This is a good place to support any changes to the options model
    */
-  setMigrationHandler(handler: PanelMigrationHandler<TOptions>) {
+  setMigrationHandler(
+    handler: PanelMigrationHandler<TOptions>,
+    shouldMigrate?: (panel: ComponentType<PanelProps<TOptions>> | null) => boolean
+  ) {
     this.onPanelMigration = handler;
+    this.shouldMigrate = shouldMigrate;
     return this;
   }
 


### PR DESCRIPTION
we need to be able to migrate purely based on detecting an old panel plugin schema structure (and maybe checking feature toggles) instead of only relying on versions.