### PR TITLE
Chore: remove lefthook.rc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -461,7 +461,6 @@
 /stylelint.config.js @grafana/frontend-ops
 /tools/ @grafana/frontend-ops
 /lefthook.yml @grafana/frontend-ops
-/lefthook.rc @grafana/frontend-ops
 /.husky/pre-commit @grafana/frontend-ops
 /cypress.config.js @grafana/grafana-frontend-platform
 /.levignore.js @grafana/plugins-platform-frontend

--- a/lefthook.rc
+++ b/lefthook.rc
@@ -1,8 +1,0 @@
-# This file is used by lefthook to 'expose' the bingo-installed lefthook under
-# the name `lefthook`, as expected by the lefthook pre-commit scripts
-
-. .bingo/variables.env
-
-lefthook () {
-  ${LEFTHOOK} "$@"
-}


### PR DESCRIPTION
Recent changes to lefthook seem to leave the environments unusable.  Removing lefthook.rc seems to fix it 🤷🏻 