### PR TITLE
services/user: Fix userimpl tests when running on Spanner.

### DIFF
--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -27,7 +27,10 @@ type Dialect interface {
 	ShowCreateNull() bool
 	SQLType(col *Column) string
 	SupportEngine() bool
+	// Deprecated. This doesn't work correctly for all databases.
 	LikeStr() string
+	// LikeOperator returns SQL snippet and query parameter for case-insensitive LIKE operation, with optional wildcards (%) before/after the pattern.
+	LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string)
 	Default(col *Column) string
 	// BooleanValue can be used as an argument in SELECT or INSERT statements. For constructing
 	// raw SQL queries, please use BooleanStr instead.
@@ -151,6 +154,17 @@ func (b *BaseDialect) AndStr() string {
 
 func (b *BaseDialect) LikeStr() string {
 	return "LIKE"
+}
+
+func (b *BaseDialect) LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string) {
+	param := pattern
+	if wildcardBefore {
+		param = "%" + param
+	}
+	if wildcardAfter {
+		param = param + "%"
+	}
+	return fmt.Sprintf("%s LIKE ?", column), param
 }
 
 func (b *BaseDialect) OrStr() string {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -35,6 +35,17 @@ func (db *PostgresDialect) LikeStr() string {
 	return "ILIKE"
 }
 
+func (db *PostgresDialect) LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string) {
+	param := pattern
+	if wildcardBefore {
+		param = "%" + param
+	}
+	if wildcardAfter {
+		param = param + "%"
+	}
+	return fmt.Sprintf("%s ILIKE ?", column), param
+}
+
 func (db *PostgresDialect) AutoIncrStr() string {
 	return ""
 }

--- a/pkg/services/sqlstore/migrator/spanner_dialect.go
+++ b/pkg/services/sqlstore/migrator/spanner_dialect.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -44,6 +45,18 @@ func NewSpannerDialect() Dialect {
 func (s *SpannerDialect) AutoIncrStr() string      { return s.d.AutoIncrStr() }
 func (s *SpannerDialect) Quote(name string) string { return s.d.Quote(name) }
 func (s *SpannerDialect) SupportEngine() bool      { return s.d.SupportEngine() }
+
+func (s *SpannerDialect) LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string) {
+	param := strings.ToLower(pattern)
+	if wildcardBefore {
+		param = "%" + param
+	}
+	if wildcardAfter {
+		param = param + "%"
+	}
+	return fmt.Sprintf("LOWER(%s) LIKE ?", column), param
+}
+
 func (s *SpannerDialect) IndexCheckSQL(tableName, indexName string) (string, []any) {
 	return s.d.IndexCheckSql(tableName, indexName)
 }


### PR DESCRIPTION
This PR fixes two failing tests in userimpl package when running on Spanner: test for unique constraint error, and case-insensitive search.

PR introduces `LikeOperator` in dialect to build case-insensitive `LIKE` sql snippet, to replace existing `LikeStr` (to be done in next PR).