### PR TITLE
Alerting: Clean up prometheus-flavored types and functions on the bac…

### DIFF
--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -15,24 +16,16 @@ type promEndpoints struct {
 	rules, alerts string
 }
 
-var dsTypeToLotexRoutes = map[string]promEndpoints{
-	"prometheus": {
+var (
+	prometheusEndpoints = promEndpoints{
 		rules:  "/api/v1/rules",
 		alerts: "/api/v1/alerts",
-	},
-	"grafana-amazonprometheus-datasource": {
-		rules:  "/api/v1/rules",
-		alerts: "/api/v1/alerts",
-	},
-	"grafana-azureprometheus-datasource": {
-		rules:  "/api/v1/rules",
-		alerts: "/api/v1/alerts",
-	},
-	"loki": {
+	}
+	lokiEndpoints = promEndpoints{
 		rules:  "/prometheus/api/v1/rules",
 		alerts: "/prometheus/api/v1/alerts",
-	},
-}
+	}
+)
 
 type LotexProm struct {
 	log log.Logger
@@ -99,9 +92,15 @@ func (p *LotexProm) getEndpoints(ctx *contextmodel.ReqContext) (*promEndpoints, 
 		return nil, fmt.Errorf("URL for this data source is empty")
 	}
 
-	routes, ok := dsTypeToLotexRoutes[ds.Type]
-	if !ok {
-		return nil, fmt.Errorf("unexpected datasource type. expecting loki or prometheus")
+	var routes promEndpoints
+	switch {
+	case isPrometheusCompatible(ds.Type):
+		routes = prometheusEndpoints
+	case ds.Type == datasources.DS_LOKI:
+		routes = lokiEndpoints
+	default:
+		return nil, unexpectedDatasourceTypeError(ds.Type, "loki, prometheus, amazon prometheus, azure prometheus")
 	}
+
 	return &routes, nil
 }

--- a/pkg/services/ngalert/api/lotex_prom_test.go
+++ b/pkg/services/ngalert/api/lotex_prom_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasourceproxy"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestLotexProm_GetEndpoints(t *testing.T) {
+	tc := []struct {
+		name            string
+		namedParams     map[string]string
+		datasourceCache datasources.CacheService
+		expectedRoutes  *promEndpoints
+		err             error
+	}{
+		{
+			name:        "with an empty datasource UID",
+			namedParams: map[string]string{":DatasourceUID": ""},
+			err:         errors.New("datasource UID is invalid"),
+		},
+		{
+			name:            "with an error while trying to fetch the datasource",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{err: datasources.ErrDataSourceNotFound},
+			err:             errors.New("data source not found"),
+		},
+		{
+			name:            "with an empty datasource URL",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{}},
+			err:             errors.New("URL for this data source is empty"),
+		},
+		{
+			name:            "with an unsupported datasource type",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{URL: "http://loki.com", Type: "unsupported-type"}},
+			err:             errors.New("unexpected datasource type 'unsupported-type', expected loki, prometheus, amazon prometheus, azure prometheus"),
+		},
+		{
+			name:            "with a Loki datasource",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{URL: "http://loki.com", Type: datasources.DS_LOKI}},
+			expectedRoutes:  &lokiEndpoints,
+			err:             nil,
+		},
+		{
+			name:            "with a Prometheus datasource",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{URL: "http://prom.com", Type: datasources.DS_PROMETHEUS}},
+			expectedRoutes:  &prometheusEndpoints,
+			err:             nil,
+		},
+		{
+			name:            "with an Amazon Prometheus datasource",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{URL: "http://amp.com", Type: datasources.DS_AMAZON_PROMETHEUS}},
+			expectedRoutes:  &prometheusEndpoints,
+			err:             nil,
+		},
+		{
+			name:            "with an Azure Prometheus datasource",
+			namedParams:     map[string]string{":DatasourceUID": "d164"},
+			datasourceCache: fakeCacheService{datasource: &datasources.DataSource{URL: "http://azp.com", Type: datasources.DS_AZURE_PROMETHEUS}},
+			expectedRoutes:  &prometheusEndpoints,
+			err:             nil,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := &AlertingProxy{DataProxy: &datasourceproxy.DataSourceProxyService{DataSourceCache: tt.datasourceCache}}
+			prom := &LotexProm{AlertingProxy: proxy, log: log.NewNopLogger()}
+
+			// Setup request context.
+			httpReq, err := http.NewRequest(http.MethodGet, "http://grafanacloud.com", nil)
+			require.NoError(t, err)
+			ctx := &contextmodel.ReqContext{Context: &web.Context{Req: web.SetURLParams(httpReq, tt.namedParams)}}
+
+			endpoints, err := prom.getEndpoints(ctx)
+
+			if tt.err != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedRoutes, endpoints)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -23,24 +24,12 @@ const (
 )
 
 const (
-	PrometheusDatasourceType       = "prometheus"
-	AmazonPrometheusDatasourceType = "grafana-amazonprometheus-datasource"
-	AzurePrometheusDatasourceType  = "grafana-azureprometheus-datasource"
-	LokiDatasourceType             = "loki"
-
 	mimirPrefix      = "/config/v1/rules"
 	prometheusPrefix = "/rules"
 	lokiPrefix       = "/api/prom/rules"
 
 	subtypeQuery = "subtype"
 )
-
-var dsTypeToRulerPrefix = map[string]string{
-	PrometheusDatasourceType:       prometheusPrefix,
-	AmazonPrometheusDatasourceType: prometheusPrefix,
-	AzurePrometheusDatasourceType:  prometheusPrefix,
-	LokiDatasourceType:             lokiPrefix,
-}
 
 var subtypeToPrefix = map[string]string{
 	Prometheus: prometheusPrefix,
@@ -241,13 +230,18 @@ func (r *LotexRuler) validateAndGetPrefix(ctx *contextmodel.ReqContext) (string,
 		return "", fmt.Errorf("URL for this data source is empty")
 	}
 
-	prefix, ok := dsTypeToRulerPrefix[ds.Type]
-	if !ok {
-		return "", fmt.Errorf("unexpected datasource type. expecting loki or prometheus")
+	var prefix string
+	switch {
+	case isPrometheusCompatible(ds.Type):
+		prefix = prometheusPrefix
+	case ds.Type == datasources.DS_LOKI:
+		prefix = lokiPrefix
+	default:
+		return "", unexpectedDatasourceTypeError(ds.Type, "loki, prometheus, amazon prometheus, azure prometheus")
 	}
 
 	// If the datasource is Loki, there's nothing else for us to do - it doesn't have subtypes.
-	if ds.Type == LokiDatasourceType {
+	if ds.Type == datasources.DS_LOKI {
 		return prefix, nil
 	}
 

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -31,7 +31,28 @@ const (
 	groupQueryTag     = "QUERY_GROUP"
 )
 
-var searchRegex = regexp.MustCompile(`\{(\w+)\}`)
+var (
+	searchRegex = regexp.MustCompile(`\{(\w+)\}`)
+
+	prometheusCompatibleDsTypes = []string{
+		datasources.DS_PROMETHEUS,
+		datasources.DS_AMAZON_PROMETHEUS,
+		datasources.DS_AZURE_PROMETHEUS,
+	}
+)
+
+func isPrometheusCompatible(dsType string) bool {
+	for _, t := range prometheusCompatibleDsTypes {
+		if dsType == t {
+			return true
+		}
+	}
+	return false
+}
+
+func isLotexRulerCompatible(dsType string) bool {
+	return dsType == datasources.DS_LOKI || isPrometheusCompatible(dsType)
+}
 
 func toMacaronPath(path string) string {
 	return string(searchRegex.ReplaceAllFunc([]byte(path), func(s []byte) []byte {
@@ -52,7 +73,7 @@ func getDatasourceByUID(ctx *contextmodel.ReqContext, cache datasources.CacheSer
 			return nil, unexpectedDatasourceTypeError(ds.Type, "alertmanager")
 		}
 	case apimodels.LoTexRulerBackend:
-		if ds.Type != "loki" && ds.Type != "prometheus" && ds.Type != "grafana-amazonprometheus-datasource" && ds.Type != "grafana-azureprometheus-datasource" {
+		if !isLotexRulerCompatible(ds.Type) {
 			return nil, unexpectedDatasourceTypeError(ds.Type, "loki, prometheus, amazon prometheus, azure prometheus")
 		}
 	default:

--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -13,6 +13,7 @@ import (
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/auth"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	models2 "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -176,3 +177,85 @@ func (r *recordingConditionValidator) Validate(_ eval.EvaluationContext, conditi
 }
 
 var _ ConditionValidator = &recordingConditionValidator{}
+
+func TestIsPrometheusCompatible(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dsType   string
+		expected bool
+	}{
+		{
+			name:     "prometheus datasource should be compatible",
+			dsType:   datasources.DS_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "amazon prometheus datasource should be compatible",
+			dsType:   datasources.DS_AMAZON_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "azure prometheus datasource should be compatible",
+			dsType:   datasources.DS_AZURE_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "loki datasource should not be prometheus compatible",
+			dsType:   datasources.DS_LOKI,
+			expected: false,
+		},
+		{
+			name:     "other datasource types should not be compatible",
+			dsType:   "some-other-datasource",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isPrometheusCompatible(tc.dsType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsLotexRulerCompatible(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dsType   string
+		expected bool
+	}{
+		{
+			name:     "prometheus datasource should be compatible",
+			dsType:   datasources.DS_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "amazon prometheus datasource should be compatible",
+			dsType:   datasources.DS_AMAZON_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "azure prometheus datasource should be compatible",
+			dsType:   datasources.DS_AZURE_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "loki datasource should be compatible",
+			dsType:   datasources.DS_LOKI,
+			expected: true,
+		},
+		{
+			name:     "other datasource types should not be compatible",
+			dsType:   "some-other-datasource",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isLotexRulerCompatible(tc.dsType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Small clean up to make the usage of Prometheus-style datasources simpler in the ngalert/api.

Adds `isPrometheusCompatible` function to the `ngalert/api/util.go` and uses it to get the routes and the prefix. Plus some tests.