### PR TITLE
Google Cloud Montioring: Add Frame type to metric ts queries

### DIFF
--- a/pkg/tsdb/cloud-monitoring/time_series_query.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_query.go
@@ -67,6 +67,7 @@ func (timeSeriesQuery *cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *b
 				Custom:              customFrameMeta,
 			}
 			frame.Meta = frameMeta
+			frame.Meta.Type = data.FrameTypeTimeSeriesMulti
 
 			var err error
 			iterator := timeSeriesDataIterator{series, d}


### PR DESCRIPTION
**What is this feature?**

Adds FrameType to the metrics (non-prom) queries, which should make this work with SQL Expressions.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #103552

**Special notes for your reviewer:**

 - I didn't test this yet, as I don't have GCloud monitoring set up locally.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
