### PR TITLE
Enable logsPanelControls by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -116,6 +116,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `exploreMetricsUseExternalAppPlugin`  | Use the externalized Grafana Metrics Drilldown (formerly known as Explore Metrics) app plugin                                                                                       |
 | `alertRuleRestore`                    | Enables the alert rule restore feature                                                                                                                                              |
 | `azureMonitorLogsBuilderEditor`       | Enables the logs builder mode for the Azure Monitor data source                                                                                                                     |
+| `logsPanelControls`                   | Enables a control component for the logs panel in Explore                                                                                                                           |
 
 ## Experimental feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1033,7 +1033,7 @@ export interface FeatureToggles {
   unifiedNavbars?: boolean;
   /**
   * Enables a control component for the logs panel in Explore
-  * @default false
+  * @default true
   */
   logsPanelControls?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1778,10 +1778,10 @@ var (
 		{
 			Name:         "logsPanelControls",
 			Description:  "Enables a control component for the logs panel in Explore",
-			Stage:        FeatureStagePrivatePreview,
+			Stage:        FeatureStagePublicPreview,
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityLogsSquad,
-			Expression:   "false",
+			Expression:   "true",
 		},
 		{
 			Name:         "metricsFromProfiles",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -232,5 +232,5 @@ xrayApplicationSignals,experimental,@grafana/aws-datasources,false,false,true
 multiTenantTempCredentials,experimental,@grafana/aws-datasources,false,false,false
 localizationForPlugins,experimental,@grafana/plugins-platform-backend,false,false,false
 unifiedNavbars,GA,@grafana/plugins-platform-backend,false,false,true
-logsPanelControls,privatePreview,@grafana/observability-logs,false,false,true
+logsPanelControls,preview,@grafana/observability-logs,false,false,true
 metricsFromProfiles,experimental,@grafana/observability-traces-and-profiling,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1863,18 +1863,18 @@
     {
       "metadata": {
         "name": "logsPanelControls",
-        "resourceVersion": "1743772342343",
+        "resourceVersion": "1744209818391",
         "creationTimestamp": "2025-04-04T13:11:29Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-04-04 13:12:22.343052 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-04-09 14:43:38.391331 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables a control component for the logs panel in Explore",
-        "stage": "privatePreview",
+        "stage": "preview",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
Enable https://github.com/grafana/grafana/pull/103401 by default for G12.