### PR TITLE
Chore: Disable snapshot flag for plugins API test

### DIFF
--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -36,7 +36,7 @@ const (
 	defaultPassword  = "password"
 )
 
-var updateSnapshotFlag = true
+var updateSnapshotFlag = false
 
 func TestMain(m *testing.M) {
 	testsuite.Run(m)


### PR DESCRIPTION
This was done in error as part of the Angular deprecation PR - it should only be enabled when a plugin is added/removed.