### PR TITLE
Alerting: Do not export MissingSeriesEvalsToResolve if it is not set

### DIFF
--- a/pkg/services/ngalert/api/compat/compat.go
+++ b/pkg/services/ngalert/api/compat/compat.go
@@ -207,20 +207,19 @@ func AlertRuleExportFromAlertRule(rule models.AlertRule) (definitions.AlertRuleE
 	}
 
 	result := definitions.AlertRuleExport{
-		UID:                         rule.UID,
-		Title:                       rule.Title,
-		For:                         model.Duration(rule.For),
-		KeepFiringFor:               model.Duration(rule.KeepFiringFor),
-		Condition:                   cPtr,
-		Data:                        data,
-		DashboardUID:                rule.DashboardUID,
-		PanelID:                     rule.PanelID,
-		NoDataState:                 ndsPtr,
-		ExecErrState:                eesPtr,
-		IsPaused:                    rule.IsPaused,
-		NotificationSettings:        AlertRuleNotificationSettingsExportFromNotificationSettings(rule.NotificationSettings),
-		Record:                      AlertRuleRecordExportFromRecord(rule.Record),
-		MissingSeriesEvalsToResolve: rule.MissingSeriesEvalsToResolve,
+		UID:                  rule.UID,
+		Title:                rule.Title,
+		For:                  model.Duration(rule.For),
+		KeepFiringFor:        model.Duration(rule.KeepFiringFor),
+		Condition:            cPtr,
+		Data:                 data,
+		DashboardUID:         rule.DashboardUID,
+		PanelID:              rule.PanelID,
+		NoDataState:          ndsPtr,
+		ExecErrState:         eesPtr,
+		IsPaused:             rule.IsPaused,
+		NotificationSettings: AlertRuleNotificationSettingsExportFromNotificationSettings(rule.NotificationSettings),
+		Record:               AlertRuleRecordExportFromRecord(rule.Record),
 	}
 	if rule.For.Seconds() > 0 {
 		result.ForString = util.Pointer(model.Duration(rule.For).String())
@@ -233,6 +232,9 @@ func AlertRuleExportFromAlertRule(rule models.AlertRule) (definitions.AlertRuleE
 	}
 	if rule.Labels != nil {
 		result.Labels = &rule.Labels
+	}
+	if rule.MissingSeriesEvalsToResolve != nil && *rule.MissingSeriesEvalsToResolve != -1 {
+		result.MissingSeriesEvalsToResolve = rule.MissingSeriesEvalsToResolve
 	}
 
 	return result, nil

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -88,6 +88,46 @@ resource "grafana_rule_group" "rule_group_d3e8424bfbf66bc3" {
     }
   }
   rule {
+    name      = "alert with uid"
+    condition = "B"
+
+    data {
+      ref_id = "A"
+
+      relative_time_range {
+        from = 18000
+        to   = 10800
+      }
+
+      datasource_uid = "000000004"
+      model          = "{\"alias\":\"just-testing\",\"intervalMs\":1000,\"maxDataPoints\":100,\"orgId\":0,\"refId\":\"A\",\"scenarioId\":\"csv_metric_values\",\"stringInput\":\"1,20,90,30,5,0\"}"
+    }
+    data {
+      ref_id = "B"
+
+      relative_time_range {
+        from = 18000
+        to   = 10800
+      }
+
+      datasource_uid = "__expr__"
+      model          = "{\"expression\":\"$A\",\"intervalMs\":2000,\"maxDataPoints\":200,\"orgId\":0,\"reducer\":\"mean\",\"refId\":\"B\",\"type\":\"reduce\"}"
+    }
+
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+    is_paused      = false
+
+    notification_settings {
+      contact_point   = "Test-Receiver"
+      group_by        = ["alertname", "grafana_folder", "test"]
+      group_wait      = "1s"
+      group_interval  = "5s"
+      repeat_interval = "5m"
+      mute_timings    = ["test-mute"]
+    }
+  }
+  rule {
     name = "recording rule"
 
     data {

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
@@ -119,6 +119,60 @@
           }
         },
         {
+          "title": "alert with uid",
+          "uid": "alert-with-uid",
+          "condition": "B",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 18000,
+                "to": 10800
+              },
+              "datasourceUid": "000000004",
+              "model": {
+                "alias": "just-testing",
+                "intervalMs": 1000,
+                "maxDataPoints": 100,
+                "orgId": 0,
+                "refId": "A",
+                "scenarioId": "csv_metric_values",
+                "stringInput": "1,20,90,30,5,0"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 18000,
+                "to": 10800
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "$A",
+                "intervalMs": 2000,
+                "maxDataPoints": 200,
+                "orgId": 0,
+                "reducer": "mean",
+                "refId": "B",
+                "type": "reduce"
+              }
+            }
+          ],
+          "noDataState": "NoData",
+          "execErrState": "Alerting",
+          "isPaused": false,
+          "for": "0s",
+          "keepFiringFor": "0s",
+          "notification_settings":{
+            "receiver":"Test-Receiver",
+            "group_by":["alertname","grafana_folder","test"],
+            "group_wait":"1s",
+            "group_interval":"5s",
+            "repeat_interval":"5m",
+            "mute_time_intervals":["test-mute"]
+          }
+        },
+        {
           "title": "recording rule",
           "data": [
             {

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
@@ -93,6 +93,52 @@ groups:
             repeat_interval: 5m
             mute_time_intervals:
                 - test-mute
+        - uid: alert-with-uid
+          title: alert with uid
+          condition: B
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 18000
+                to: 10800
+              datasourceUid: "000000004"
+              model:
+                alias: just-testing
+                intervalMs: 1000
+                maxDataPoints: 100
+                orgId: 0
+                refId: A
+                scenarioId: csv_metric_values
+                stringInput: 1,20,90,30,5,0
+            - refId: B
+              relativeTimeRange:
+                from: 18000
+                to: 10800
+              datasourceUid: __expr__
+              model:
+                expression: $A
+                intervalMs: 2000
+                maxDataPoints: 200
+                orgId: 0
+                reducer: mean
+                refId: B
+                type: reduce
+          noDataState: NoData
+          execErrState: Alerting
+          for: 0s
+          keepFiringFor: 0s
+          isPaused: false
+          notification_settings:
+            receiver: Test-Receiver
+            group_by:
+                - alertname
+                - grafana_folder
+                - test
+            group_wait: 1s
+            group_interval: 5s
+            repeat_interval: 5m
+            mute_time_intervals:
+                - test-mute
         - title: recording rule
           data:
             - refId: query

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101.json
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101.json
@@ -122,6 +122,61 @@
     },
     {
       "grafana_alert": {
+        "title": "alert with uid",
+        "uid": "alert-with-uid",
+        "condition": "B",
+        "data": [
+          {
+            "refId": "A",
+            "queryType": "",
+            "relativeTimeRange": {
+              "from": 18000,
+              "to": 10800
+            },
+            "datasourceUid": "000000004",
+            "model": {
+              "alias": "just-testing",
+              "intervalMs": 1000,
+              "maxDataPoints": 100,
+              "orgId": 0,
+              "refId": "A",
+              "scenarioId": "csv_metric_values",
+              "stringInput": "1,20,90,30,5,0"
+            }
+          },
+          {
+            "refId": "B",
+            "queryType": "",
+            "relativeTimeRange": {
+              "from": 18000,
+              "to": 10800
+            },
+            "datasourceUid": "__expr__",
+            "model": {
+              "expression": "$A",
+              "intervalMs": 2000,
+              "maxDataPoints": 200,
+              "orgId": 0,
+              "reducer": "mean",
+              "refId": "B",
+              "type": "reduce"
+            }
+          }
+        ],
+        "no_data_state": "NoData",
+        "exec_err_state": "Alerting",
+        "notification_settings":{
+          "receiver":"Test-Receiver",
+          "group_by":["alertname","grafana_folder","test"],
+          "group_wait":"1s",
+          "group_interval":"5s",
+          "repeat_interval":"5m",
+          "mute_time_intervals":["test-mute"]
+        }
+      }
+    },
+    {
+      "grafana_alert": {
         "title": "recording rule",
         "data": [
           {


### PR DESCRIPTION
**What is this feature?**

If an existing alert rule is exported, and `MissingSeriesEvalsToResolve` is not set, we export it with an invalid value of `-1`. This PR fixes that and exports the field only if it's actually set on the rule.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/15622