### PR TITLE
InspectJsonTab: Hide data frames option for read-only users

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -197,6 +197,27 @@ describe('InspectJsonTab', () => {
     expect(obj.spec.id).toEqual(12);
     expect(obj.spec.data.kind).toEqual('QueryGroup');
     expect(tab.isEditable()).toBe(false);
+    
+  it('Should hide data frames option when dashboard is not editable', async () => {
+    const { tab, scene } = await buildTestScene();
+
+    scene.state.meta.canEdit = false;
+
+    const actualOptions = tab.getOptions();
+
+    expect(actualOptions.length).toBe(2);
+    expect(actualOptions.some((option) => option.value === 'data-frames')).toBe(false);
+  });
+
+  it('Should show data frames option when dashboard is editable', async () => {
+    const { tab, scene } = await buildTestScene();
+
+    scene.state.meta.canEdit = true;
+
+    const actualOptions = tab.getOptions();
+
+    expect(actualOptions.length).toBe(3);
+    expect(actualOptions.some((option) => option.value === 'data-frames')).toBe(true);
   });
 });
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -67,6 +67,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
   public getOptions(): Array<SelectableValue<ShowContent>> {
     const panel = this.state.panelRef.resolve();
     const dataProvider = panel.state.$data ?? panel.parent?.state.$data;
+    const dashboard = getDashboardSceneFor(panel);
 
     const options: Array<SelectableValue<ShowContent>> = [
       {
@@ -88,14 +89,16 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         ),
         value: 'panel-data',
       });
-      options.push({
-        label: t('dashboard.inspect-json.dataframe-label', 'DataFrame JSON (from Query)'),
-        description: t(
-          'dashboard.inspect-json.dataframe-description',
-          'Raw data without transformations and field config applied. '
-        ),
-        value: 'data-frames',
-      });
+      if (dashboard.state.meta.canEdit) {
+        options.push({
+          label: t('dashboard.inspect-json.dataframe-label', 'DataFrame JSON (from Query)'),
+          description: t(
+            'dashboard.inspect-json.dataframe-description',
+            'Raw data without transformations and field config applied. '
+          ),
+          value: 'data-frames',
+        });
+      }
     }
 
     return options;


### PR DESCRIPTION
Added a check to only display the data frames option (DataFrame JSON (from Query)) if the user has edit permissions on the dashboard. Added unit tests.

Fixes #100966
