### PR TITLE
Unistore: Change to 404 rather than 403 if not found

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -650,6 +650,9 @@ func (s *server) Read(ctx context.Context, req *ReadRequest) (*ReadResponse, err
 	}
 
 	rsp := s.backend.ReadResource(ctx, req)
+	if rsp.Error != nil && rsp.Error.Code == http.StatusNotFound {
+		return &ReadResponse{Error: rsp.Error}, nil
+	}
 
 	a, err := s.access.Check(ctx, user, claims.CheckRequest{
 		Verb:      "get",

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -94,6 +95,12 @@ func TestSimpleServer(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, all.Items, 0)
 
+		// should return 404 if not found
+		found, err := server.Read(ctx, &ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.NotNil(t, found.Error)
+		require.Equal(t, int32(http.StatusNotFound), found.Error.Code)
+
 		created, err := server.Create(ctx, &CreateRequest{
 			Value: raw,
 			Key:   key,
@@ -103,7 +110,7 @@ func TestSimpleServer(t *testing.T) {
 		require.True(t, created.ResourceVersion > 0)
 
 		// The key does not include resource version
-		found, err := server.Read(ctx, &ReadRequest{Key: key})
+		found, err = server.Read(ctx, &ReadRequest{Key: key})
 		require.NoError(t, err)
 		require.Nil(t, found.Error)
 		require.Equal(t, created.ResourceVersion, found.ResourceVersion)


### PR DESCRIPTION
**What is this feature?**

This PR changes the read request to return a 404, rather than a 403, if the resource is not found. If we do the access check when its not found, it will always result in a 403.

Closes https://github.com/grafana/app-platform-wg/issues/257