### PR TITLE
Update matchPluginId func to bidirectional

### DIFF
--- a/packages/grafana-data/src/utils/matchPluginId.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.ts
@@ -4,8 +4,8 @@ export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
   if (pluginMeta.id === idToMatch) {
     return true;
   }
-
-  if (idToMatch === 'prometheus') {
+  
+  if (isPromFlavor(idToMatch)) {
     return isPromFlavor(pluginMeta.id);
   }
 
@@ -17,6 +17,9 @@ export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
 }
 
 function isPromFlavor(pluginId: string): boolean {
+  if (pluginId === 'prometheus'){
+    return true;
+  }
   const regex = new RegExp('^grafana-[0-9a-z]+prometheus-datasource$');
   return regex.test(pluginId);
 }

--- a/packages/grafana-data/src/utils/matchPluginId.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.ts
@@ -17,7 +17,7 @@ export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
 }
 
 function isPromFlavor(pluginId: string): boolean {
-  if (pluginId === 'prometheus'){
+  if (pluginId === 'prometheus') {
     return true;
   }
   const regex = new RegExp('^grafana-[0-9a-z]+prometheus-datasource$');

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,6 +1,6 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { DataSourceRef, matchPluginId, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
+import { DataSourceRef, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import config from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -129,21 +129,13 @@ export class DashboardExporter {
           if (ds.meta?.builtIn) {
             return;
           }
-          let dataSourceId = ds.meta?.id;
-          let dataSourceName = ds.meta?.name;
-          let dataSourceVersion = ds.meta.info.version || '1.0.0';
-          // if this is a prom flavored data source (azure prom/ aws prom) it will be treated as a prom data source
-          if (matchPluginId('prometheus', ds.meta)) {
-            dataSourceId = 'prometheus';
-            dataSourceName = 'Prometheus';
-            dataSourceVersion = '1.0.0';
-          }
+
           // add data source type to require list
-          requires['datasource' + dataSourceId] = {
+          requires['datasource' + ds.meta?.id] = {
             type: 'datasource',
-            id: dataSourceId,
-            name: dataSourceName,
-            version: dataSourceVersion,
+            id: ds.meta.id,
+            name: ds.meta.name,
+            version: ds.meta.info.version || '1.0.0',
           };
 
           // if used via variable we can skip templatizing usage
@@ -160,8 +152,8 @@ export class DashboardExporter {
             label: ds.name,
             description: '',
             type: 'datasource',
-            pluginId: dataSourceId,
-            pluginName: dataSourceName,
+            pluginId: ds.meta?.id,
+            pluginName: ds.meta?.name,
             usage: datasources[refName]?.usage,
           };
 
@@ -174,7 +166,7 @@ export class DashboardExporter {
             };
           }
 
-          obj.datasource = { type: dataSourceId, uid: '${' + refName + '}' };
+          obj.datasource = { type: ds.meta.id, uid: '${' + refName + '}' };
         });
     };
 

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -313,7 +313,7 @@ export class DatasourceSrv implements DataSourceService {
       }
 
       if (filters.dashboard) {
-      const dashboardInstanceSettings = this.getInstanceSettings('-- Dashboard --');
+        const dashboardInstanceSettings = this.getInstanceSettings('-- Dashboard --');
         if (dashboardInstanceSettings) {
           base.push(dashboardInstanceSettings);
         }

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -294,7 +294,7 @@ export class DatasourceSrv implements DataSourceService {
       }
     }
 
-    let sorted = base.sort((a, b) => {
+    const sorted = base.sort((a, b) => {
       if (a.name.toLowerCase() > b.name.toLowerCase()) {
         return 1;
       }
@@ -313,7 +313,7 @@ export class DatasourceSrv implements DataSourceService {
       }
 
       if (filters.dashboard) {
-        const dashboardInstanceSettings = this.getInstanceSettings('-- Dashboard --');
+      const dashboardInstanceSettings = this.getInstanceSettings('-- Dashboard --');
         if (dashboardInstanceSettings) {
           base.push(dashboardInstanceSettings);
         }
@@ -325,12 +325,6 @@ export class DatasourceSrv implements DataSourceService {
           base.push(grafanaInstanceSettings);
         }
       }
-    }
-
-    if (!filters.pluginId) {
-      sorted = sorted.filter((x) => {
-        return matchPluginId('prometheus', x.meta);
-      });
     }
 
     return sorted;


### PR DESCRIPTION
This removes more changes for exporting/importing dashboards.
`matchPluginId` will match prom and prom flavors. So `azure-prometheus-datasource` will match with `prometheus` and vice-versa.