### PR TITLE
Dashboard: Fixes issue leaving edit mode

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -61,7 +61,7 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
     if (isEditing) {
       editPane.enableSelection();
     } else {
-      editPane.clearSelection();
+      editPane.disableSelection();
     }
   }, [isEditing, editPane]);
 


### PR DESCRIPTION
In PR merged yesterday that fixed the issue with preserving selection state there was a bug, wrong function was called when leaving edit mode. Instead of disabling selection we just cleared the selection state leaving selection still enabled while in view mode 