### PR TITLE
spanner: Fix use of in-memory sequence generator

### DIFF
--- a/pkg/util/xorm/dialect_spanner.go
+++ b/pkg/util/xorm/dialect_spanner.go
@@ -383,7 +383,7 @@ func (s *spanner) CreateSequenceGenerator(db *sql.DB) (SequenceGenerator, error)
 		return nil, err
 	}
 
-	if connectorConfig.Params["inMemSequenceGenerator"] == "true" {
+	if connectorConfig.Params[strings.ToLower("inMemSequenceGenerator")] == "true" {
 		// Switch to using in-memory sequence number generator.
 		// Using database-based sequence generator doesn't work with emulator, as emulator
 		// only supports single transaction. If there is already another transaction started


### PR DESCRIPTION
Parameters in connection config are lower-cased in `ExtractConnectorConfig` (and `extractConnectorParams`) function. (https://github.com/googleapis/go-sql-spanner/blob/991d351a1620f26c9c07557d81552f92a1e2d669/driver.go#L262)

This broke in PR #103363.