### PR TITLE
Jaeger: Run dependency graph queries through backend behind the feature toggle

### DIFF
--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -199,7 +199,6 @@ func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (Depe
 
 	parsedURL.RawQuery = query.Encode()
 	u = parsedURL.String()
-	fmt.Println("URL!!", u)
 
 	res, err := j.httpClient.Get(u)
 	if err != nil {

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -26,6 +26,20 @@ type ServicesResponse struct {
 	Total  int         `json:"total"`
 }
 
+type DependenciesResponse struct {
+	Data   []ServiceDependency `json:"data"`
+	Errors []struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	} `json:"errors"`
+}
+
+type ServiceDependency struct {
+	Parent    string `json:"parent"`
+	Child     string `json:"child"`
+	CallCount int    `json:"callCount"`
+}
+
 func New(url string, hc *http.Client, logger log.Logger, traceIdTimeEnabled bool) (JaegerClient, error) {
 	client := JaegerClient{
 		logger:             logger,
@@ -157,4 +171,61 @@ func (j *JaegerClient) Trace(ctx context.Context, traceID string, start, end int
 	// this is how it was implemented in the frontend before
 	trace = response.Data[0]
 	return trace, err
+}
+
+func (j *JaegerClient) Dependencies(ctx context.Context, start, end int64) (DependenciesResponse, error) {
+	logger := j.logger.FromContext(ctx)
+	var dependencies DependenciesResponse
+
+	u, err := url.JoinPath(j.url, "/api/dependencies")
+	if err != nil {
+		return dependencies, backend.DownstreamError(fmt.Errorf("failed to join url: %w", err))
+	}
+
+	// Add time parameters
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return dependencies, backend.DownstreamError(fmt.Errorf("failed to parse url: %w", err))
+	}
+
+	query := parsedURL.Query()
+	if end > 0 {
+		query.Set("endTs", fmt.Sprintf("%d", end))
+	}
+	if start > 0 {
+		lookback := end - start
+		query.Set("lookback", fmt.Sprintf("%d", lookback))
+	}
+
+	parsedURL.RawQuery = query.Encode()
+	u = parsedURL.String()
+	fmt.Println("URL!!", u)
+
+	res, err := j.httpClient.Get(u)
+	if err != nil {
+		if backend.IsDownstreamHTTPError(err) {
+			return dependencies, backend.DownstreamError(err)
+		}
+		return dependencies, err
+	}
+
+	defer func() {
+		if err = res.Body.Close(); err != nil {
+			logger.Error("Failed to close response body", "error", err)
+		}
+	}()
+
+	if res != nil && res.StatusCode/100 != 2 {
+		err := backend.DownstreamError(fmt.Errorf("request failed: %s", res.Status))
+		if backend.ErrorSourceFromHTTPStatus(res.StatusCode) == backend.ErrorSourceDownstream {
+			return dependencies, backend.DownstreamError(err)
+		}
+		return dependencies, err
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&dependencies); err != nil {
+		return dependencies, err
+	}
+
+	return dependencies, nil
 }

--- a/pkg/tsdb/jaeger/querydata.go
+++ b/pkg/tsdb/jaeger/querydata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -282,8 +283,15 @@ func transformDependenciesResponse(dependencies DependenciesResponse, refID stri
 		)
 	}
 
-	// Add node data
+	// Convert map keys to slice and sort them - this is to ensure the returned nodes are in a consistent order
+	services := make([]string, 0, len(servicesByName))
 	for service := range servicesByName {
+		services = append(services, service)
+	}
+	sort.Strings(services)
+
+	// Add node data in sorted order
+	for _, service := range services {
 		nodesFrame.AppendRow(
 			service,
 			service,

--- a/pkg/tsdb/jaeger/querydata_test.go
+++ b/pkg/tsdb/jaeger/querydata_test.go
@@ -184,3 +184,97 @@ func TestTransformTraceResponse(t *testing.T) {
 		experimental.CheckGoldenJSONFrame(t, "./testdata", "complex_trace.golden", frame, false)
 	})
 }
+
+func TestTransformDependenciesResponse(t *testing.T) {
+	t.Run("simple_dependencies", func(t *testing.T) {
+		dependencies := DependenciesResponse{
+			Data: []ServiceDependency{
+				{
+					Parent:    "serviceA",
+					Child:     "serviceB",
+					CallCount: 1,
+				},
+				{
+					Parent:    "serviceA",
+					Child:     "serviceC",
+					CallCount: 2,
+				},
+				{
+					Parent:    "serviceB",
+					Child:     "serviceC",
+					CallCount: 3,
+				},
+			},
+		}
+
+		frames := transformDependenciesResponse(dependencies, "test")
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "simple_dependencies_nodes.golden", frames[0], false)
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "simple_dependencies_edges.golden", frames[1], false)
+	})
+
+	t.Run("empty_dependencies", func(t *testing.T) {
+		dependencies := DependenciesResponse{
+			Data: []ServiceDependency{},
+		}
+
+		frames := transformDependenciesResponse(dependencies, "test")
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "empty_dependencies_nodes.golden", frames[0], false)
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "empty_dependencies_edges.golden", frames[1], false)
+	})
+
+	t.Run("complex_dependencies", func(t *testing.T) {
+		dependencies := DependenciesResponse{
+			Data: []ServiceDependency{
+				{
+					Parent:    "frontend",
+					Child:     "auth-service",
+					CallCount: 150,
+				},
+				{
+					Parent:    "frontend",
+					Child:     "api-gateway",
+					CallCount: 300,
+				},
+				{
+					Parent:    "api-gateway",
+					Child:     "user-service",
+					CallCount: 200,
+				},
+				{
+					Parent:    "api-gateway",
+					Child:     "order-service",
+					CallCount: 100,
+				},
+				{
+					Parent:    "order-service",
+					Child:     "payment-service",
+					CallCount: 80,
+				},
+				{
+					Parent:    "order-service",
+					Child:     "inventory-service",
+					CallCount: 90,
+				},
+				{
+					Parent:    "user-service",
+					Child:     "database",
+					CallCount: 500,
+				},
+				{
+					Parent:    "payment-service",
+					Child:     "database",
+					CallCount: 200,
+				},
+				{
+					Parent:    "inventory-service",
+					Child:     "database",
+					CallCount: 300,
+				},
+			},
+		}
+
+		frames := transformDependenciesResponse(dependencies, "test")
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "complex_dependencies_nodes.golden", frames[0], false)
+		experimental.CheckGoldenJSONFrame(t, "./testdata", "complex_dependencies_edges.golden", frames[1], false)
+	})
+}

--- a/pkg/tsdb/jaeger/testdata/complex_dependencies_edges.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/complex_dependencies_edges.golden.jsonc
@@ -1,0 +1,127 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_edges
+//  Dimensions: 4 Fields by 9 Rows
+//  +----------------------------------+-------------------+-------------------+----------------+
+//  | Name: id                         | Name: source      | Name: target      | Name: mainstat |
+//  | Labels:                          | Labels:           | Labels:           | Labels:        |
+//  | Type: []string                   | Type: []string    | Type: []string    | Type: []int64  |
+//  +----------------------------------+-------------------+-------------------+----------------+
+//  | frontend--auth-service           | frontend          | auth-service      | 150            |
+//  | frontend--api-gateway            | frontend          | api-gateway       | 300            |
+//  | api-gateway--user-service        | api-gateway       | user-service      | 200            |
+//  | api-gateway--order-service       | api-gateway       | order-service     | 100            |
+//  | order-service--payment-service   | order-service     | payment-service   | 80             |
+//  | order-service--inventory-service | order-service     | inventory-service | 90             |
+//  | user-service--database           | user-service      | database          | 500            |
+//  | payment-service--database        | payment-service   | database          | 200            |
+//  | inventory-service--database      | inventory-service | database          | 300            |
+//  +----------------------------------+-------------------+-------------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_edges",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "source",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "target",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "mainstat",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            },
+            "config": {
+              "displayName": "Call count"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "frontend--auth-service",
+            "frontend--api-gateway",
+            "api-gateway--user-service",
+            "api-gateway--order-service",
+            "order-service--payment-service",
+            "order-service--inventory-service",
+            "user-service--database",
+            "payment-service--database",
+            "inventory-service--database"
+          ],
+          [
+            "frontend",
+            "frontend",
+            "api-gateway",
+            "api-gateway",
+            "order-service",
+            "order-service",
+            "user-service",
+            "payment-service",
+            "inventory-service"
+          ],
+          [
+            "auth-service",
+            "api-gateway",
+            "user-service",
+            "order-service",
+            "payment-service",
+            "inventory-service",
+            "database",
+            "database",
+            "database"
+          ],
+          [
+            150,
+            300,
+            200,
+            100,
+            80,
+            90,
+            500,
+            200,
+            300
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/complex_dependencies_nodes.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/complex_dependencies_nodes.golden.jsonc
@@ -14,14 +14,14 @@
 //  | Labels:           | Labels:           |
 //  | Type: []string    | Type: []string    |
 //  +-------------------+-------------------+
-//  | user-service      | user-service      |
-//  | order-service     | order-service     |
-//  | payment-service   | payment-service   |
+//  | api-gateway       | api-gateway       |
+//  | auth-service      | auth-service      |
 //  | database          | database          |
 //  | frontend          | frontend          |
-//  | auth-service      | auth-service      |
-//  | api-gateway       | api-gateway       |
 //  | inventory-service | inventory-service |
+//  | order-service     | order-service     |
+//  | payment-service   | payment-service   |
+//  | user-service      | user-service      |
 //  +-------------------+-------------------+
 //  
 //  
@@ -59,24 +59,24 @@
       "data": {
         "values": [
           [
-            "user-service",
-            "order-service",
-            "payment-service",
+            "api-gateway",
+            "auth-service",
             "database",
             "frontend",
-            "auth-service",
-            "api-gateway",
-            "inventory-service"
+            "inventory-service",
+            "order-service",
+            "payment-service",
+            "user-service"
           ],
           [
-            "user-service",
-            "order-service",
-            "payment-service",
+            "api-gateway",
+            "auth-service",
             "database",
             "frontend",
-            "auth-service",
-            "api-gateway",
-            "inventory-service"
+            "inventory-service",
+            "order-service",
+            "payment-service",
+            "user-service"
           ]
         ]
       }

--- a/pkg/tsdb/jaeger/testdata/complex_dependencies_nodes.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/complex_dependencies_nodes.golden.jsonc
@@ -1,0 +1,85 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_nodes
+//  Dimensions: 2 Fields by 8 Rows
+//  +-------------------+-------------------+
+//  | Name: id          | Name: title       |
+//  | Labels:           | Labels:           |
+//  | Type: []string    | Type: []string    |
+//  +-------------------+-------------------+
+//  | user-service      | user-service      |
+//  | order-service     | order-service     |
+//  | payment-service   | payment-service   |
+//  | database          | database          |
+//  | frontend          | frontend          |
+//  | auth-service      | auth-service      |
+//  | api-gateway       | api-gateway       |
+//  | inventory-service | inventory-service |
+//  +-------------------+-------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_nodes",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "user-service",
+            "order-service",
+            "payment-service",
+            "database",
+            "frontend",
+            "auth-service",
+            "api-gateway",
+            "inventory-service"
+          ],
+          [
+            "user-service",
+            "order-service",
+            "payment-service",
+            "database",
+            "frontend",
+            "auth-service",
+            "api-gateway",
+            "inventory-service"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/empty_dependencies_edges.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/empty_dependencies_edges.golden.jsonc
@@ -1,0 +1,78 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_edges
+//  Dimensions: 4 Fields by 0 Rows
+//  +----------------+----------------+----------------+----------------+
+//  | Name: id       | Name: source   | Name: target   | Name: mainstat |
+//  | Labels:        | Labels:        | Labels:        | Labels:        |
+//  | Type: []string | Type: []string | Type: []string | Type: []int64  |
+//  +----------------+----------------+----------------+----------------+
+//  +----------------+----------------+----------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_edges",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "source",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "target",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "mainstat",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            },
+            "config": {
+              "displayName": "Call count"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [],
+          [],
+          [],
+          []
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/empty_dependencies_nodes.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/empty_dependencies_nodes.golden.jsonc
@@ -1,0 +1,59 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_nodes
+//  Dimensions: 2 Fields by 0 Rows
+//  +----------------+----------------+
+//  | Name: id       | Name: title    |
+//  | Labels:        | Labels:        |
+//  | Type: []string | Type: []string |
+//  +----------------+----------------+
+//  +----------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_nodes",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [],
+          []
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/simple_dependencies_edges.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/simple_dependencies_edges.golden.jsonc
@@ -1,0 +1,97 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_edges
+//  Dimensions: 4 Fields by 3 Rows
+//  +--------------------+----------------+----------------+----------------+
+//  | Name: id           | Name: source   | Name: target   | Name: mainstat |
+//  | Labels:            | Labels:        | Labels:        | Labels:        |
+//  | Type: []string     | Type: []string | Type: []string | Type: []int64  |
+//  +--------------------+----------------+----------------+----------------+
+//  | serviceA--serviceB | serviceA       | serviceB       | 1              |
+//  | serviceA--serviceC | serviceA       | serviceC       | 2              |
+//  | serviceB--serviceC | serviceB       | serviceC       | 3              |
+//  +--------------------+----------------+----------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_edges",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "source",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "target",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "mainstat",
+            "type": "number",
+            "typeInfo": {
+              "frame": "int64"
+            },
+            "config": {
+              "displayName": "Call count"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "serviceA--serviceB",
+            "serviceA--serviceC",
+            "serviceB--serviceC"
+          ],
+          [
+            "serviceA",
+            "serviceA",
+            "serviceB"
+          ],
+          [
+            "serviceB",
+            "serviceC",
+            "serviceC"
+          ],
+          [
+            1,
+            2,
+            3
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/simple_dependencies_nodes.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/simple_dependencies_nodes.golden.jsonc
@@ -1,0 +1,70 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "preferredVisualisationType": "nodeGraph"
+//  }
+//  Name: test_nodes
+//  Dimensions: 2 Fields by 3 Rows
+//  +----------------+----------------+
+//  | Name: id       | Name: title    |
+//  | Labels:        | Labels:        |
+//  | Type: []string | Type: []string |
+//  +----------------+----------------+
+//  | serviceB       | serviceB       |
+//  | serviceC       | serviceC       |
+//  | serviceA       | serviceA       |
+//  +----------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test_nodes",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "preferredVisualisationType": "nodeGraph"
+        },
+        "fields": [
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "serviceB",
+            "serviceC",
+            "serviceA"
+          ],
+          [
+            "serviceB",
+            "serviceC",
+            "serviceA"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/jaeger/testdata/simple_dependencies_nodes.golden.jsonc
+++ b/pkg/tsdb/jaeger/testdata/simple_dependencies_nodes.golden.jsonc
@@ -14,9 +14,9 @@
 //  | Labels:        | Labels:        |
 //  | Type: []string | Type: []string |
 //  +----------------+----------------+
+//  | serviceA       | serviceA       |
 //  | serviceB       | serviceB       |
 //  | serviceC       | serviceC       |
-//  | serviceA       | serviceA       |
 //  +----------------+----------------+
 //  
 //  
@@ -54,14 +54,14 @@
       "data": {
         "values": [
           [
+            "serviceA",
             "serviceB",
-            "serviceC",
-            "serviceA"
+            "serviceC"
           ],
           [
+            "serviceA",
             "serviceB",
-            "serviceC",
-            "serviceA"
+            "serviceC"
           ]
         ]
       }

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -72,10 +72,11 @@ export class JaegerDatasource extends DataSourceWithBackend<JaegerQuery, JaegerJ
     // No query type means that the query is a trace ID query
     // If all targets are trace ID queries, we can use the backend querying
     const allTargetsTraceIdQuery = options.targets.every((target) => !target.queryType);
+    const allTargetsDependencyGraph = options.targets.every((target) => target.queryType === 'dependencyGraph');
     // We have not migrated the node graph to the backend
     // If the node graph is disabled, we can use the backend migration
     const nodeGraphDisabled = !this.nodeGraph?.enabled;
-    if (config.featureToggles.jaegerBackendMigration && allTargetsTraceIdQuery && nodeGraphDisabled) {
+    if (config.featureToggles.jaegerBackendMigration && (allTargetsTraceIdQuery || allTargetsDependencyGraph) && nodeGraphDisabled) {
       return super.query(options);
     }
 

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -76,7 +76,11 @@ export class JaegerDatasource extends DataSourceWithBackend<JaegerQuery, JaegerJ
     // We have not migrated the node graph to the backend
     // If the node graph is disabled, we can use the backend migration
     const nodeGraphDisabled = !this.nodeGraph?.enabled;
-    if (config.featureToggles.jaegerBackendMigration && (allTargetsTraceIdQuery || allTargetsDependencyGraph) && nodeGraphDisabled) {
+    if (
+      config.featureToggles.jaegerBackendMigration &&
+      (allTargetsTraceIdQuery || allTargetsDependencyGraph) &&
+      nodeGraphDisabled
+    ) {
       return super.query(options);
     }
 


### PR DESCRIPTION
Part of https://github.com/grafana/data-sources/issues/1324

This PR migrates running of dependency graph queries to backend. It ensures that we have same processing as in frontend.

I have taken frontend snapshot-ish test that has trace and dataFrame ([in here][(https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/jaeger/testResponse.ts#L5](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/jaeger/dependencyGraphTransform.test.ts#L4))) and used it to create backend snapshot test to verify the tranform trace logic (in pkg/tsdb/jaeger/querydata_test.go as simple_dependencies). 

This feature is currently behind `jaegerBackendMigration` feature flag. To test the PR, you need to enable it in `custom.ini` file:

```
[feature_toggles]
# there are currently two ways to enable feature toggles in the `grafana.ini`.
# you can either pass an array of feature you want to enable to the `enable` field or
# configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
# will take presidence over toggles in the `enable` list.

enable = jaegerBackendMigration
```

Edit: 

I was able to find the data to test it with in https://github.com/jaegertracing/jaeger/tree/main/examples/grafana-integration. You can follow README and basically just stop grafana container and use locally running grafana.


Manual testing using backend:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/652235aa-32ea-4765-a865-68386af31356" />


How it looked when querying through frontend (same)
<img width="1905" alt="image" src="https://github.com/user-attachments/assets/7de3fd62-bc04-456b-9f41-efb9fc2f8c98" />
