### PR TITLE
docs(alerting): New Alertmanager contact point docs

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -26,6 +26,11 @@ labels:
 title: Configure contact points
 weight: 410
 refs:
+  alertmanager:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/
   sns:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/configure-amazon-sns/
@@ -138,7 +143,7 @@ Each contact point integration has its own configuration options and setup proce
 
 {{< column-list >}}
 
-- Alertmanager
+- [Alertmanager](ref:alertmanager)
 - [AWS SNS](ref:sns)
 - Cisco Webex Teams
 - DingDing

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager.md
@@ -1,0 +1,77 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/
+description: Use the Alertmanager integration in a contact point to send specific alerts to a different Alertmanager.
+keywords:
+  - grafana
+  - alerting
+  - Alertmanager
+  - integration
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Alertmanager
+title: Configure an Alertmanager contact point
+weight: 100
+refs:
+  configure-contact-points:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/
+  configure-alertmanagers:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/
+---
+
+# Configure an Alertmanager contact point
+
+Use the Alertmanager integration in a contact point to send specific alerts to a different Alertmanager.
+
+If you have an existing Alertmanager running in your infrastructure, you can use a contact point to forward Grafana alerts to your Alertmanager.
+
+For example, a team might run its own Alertmanager to manage notifications from other alerting systems. That team can create alerts with Grafana and configure an Alertmanager contact point to forward only their alerts to their existing Alertmanager.
+
+This setup avoids duplicating Alertmanager configurations for better maintenance.
+
+{{% admonition type="note" %}}
+To send all Grafana-managed alerts to an Alertmanager, add it as a data source and enable it to receive all alerts. With this setup, you can configure multiple Alertmanagers to receive all alerts.
+
+For setup instructions, refer to [Configure Alertmanagers](ref:configure-alertmanagers).
+{{% /admonition %}}
+
+## Configure an Alertmanager for a contact point
+
+To create a contact point with Alertmanager integration, complete the following steps.
+
+1. Navigate to **Alerts & IRM** -> **Alerting** -> **Contact points**.
+1. Click **+ Add contact point**.
+1. Enter a name for the contact point.
+1. From the **Integration** list, select **Alertmanager**.
+1. In the **URL** field, enter the URL of the Alertmanager.
+1. (Optional) Configure [optional settings](#optional-settings).
+1. Click **Save contact point**.
+
+For more details on contact points, including how to test them and enable notifications, refer to [Configure contact points](ref:configure-contact-points).
+
+## Alertmanager settings
+
+| Option | Description           |
+| ------ | --------------------- |
+| URL    | The Alertmanager URL. |
+
+#### Optional settings
+
+| Option              | Description                             |
+| ------------------- | --------------------------------------- |
+| Basic Auth User     | Username for HTTP Basic Authentication. |
+| Basic Auth Password | Password for HTTP Basic Authentication. |
+
+#### Optional notification settings
+
+| Option                   | Description                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
+| Disable resolved message | Enable this option to prevent notifications when an alert resolves. |

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-amazon-sns.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-amazon-sns.md
@@ -13,7 +13,7 @@ labels:
     - oss
 menuTitle: Amazon SNS
 title: Configure Amazon SNS for Alerting
-weight: 100
+weight: 102
 refs:
   notification-templates:
     - pattern: /docs/grafana/

--- a/docs/sources/alerting/set-up/configure-alertmanager/_index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/_index.md
@@ -6,7 +6,7 @@ aliases:
   - ../fundamentals/alertmanager/ # /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alertmanager/
   - ../fundamentals/notifications/alertmanager/ # /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/alertmanager
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/configure-alertmanager/
-description: Learn about Alertmanagers and set up Alerting to use an external Alertmanager
+description: Learn about Alertmanagers and set up Alerting to use other Alertmanagers
 keywords:
   - grafana
   - alerting
@@ -21,6 +21,21 @@ labels:
 title: Configure Alertmanagers
 weight: 200
 refs:
+  configure-grafana-alerts-notifications:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#configure-notifications
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/#configure-notifications
+  configure-notification-policies:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/
+  alertmanager-contact-point:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/
   alertmanager-data-source:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/datasources/alertmanager/
@@ -39,7 +54,15 @@ Grafana Alerting is based on the architecture of the Prometheus alerting system.
 
 {{< figure src="/media/docs/alerting/alerting-alertmanager-architecture.png" max-width="750px" alt="A diagram with the alert generator and alert manager architecture" >}}
 
-Grafana can enable one or more Alertmanagers to receive Grafana-managed alerts for notification handling. It’s important to note that each Alertmanager manages its own independent alerting resources, such as:
+Grafana includes a built-in **Grafana Alertmanager** to handle notifications. This guide shows you how to:
+
+- Use different [types of Alertmanagers](#types-of-alertmanagers-in-grafana) with Grafana
+- [Add other Alertmanager](#add-an-alertmanager) and [enable it to receive all Grafana-managed alerts](#enable-an-alertmanager-to-receive-grafana-managed-alerts)
+- Use an [Alertmanager as a contact point]() to route specific alerts
+
+## Alertmanager resources
+
+It’s important to note that each Alertmanager manages its own independent alerting resources, such as:
 
 - Contact points and notification templates
 - Notification policies and mute timings
@@ -99,6 +122,18 @@ All Grafana-managed alerts are forwarded to Alertmanagers marked as `Receiving G
 {{% admonition type="note" %}}
 Grafana Alerting does not support forwarding Grafana-managed alerts to the AlertManager in Amazon Managed Service for Prometheus. For more details, refer to [this GitHub issue](https://github.com/grafana/grafana/issues/64064).
 {{% /admonition %}}
+
+## Use an Alertmanager as a contact point to receive specific alerts
+
+The previous instructions enable sending **all** Grafana-managed alerts to an Alertmanager.
+
+To send **specific** alerts to an Alertmanager, configure the Alertmanager as a contact point. You can then assign this contact point to notification policies or individual alert rules.
+
+For detailed instructions, refer to:
+
+- [Alertmanager contact point](ref:alertmanager-contact-point)
+- [Configure Grafana-managed alert rules](ref:configure-grafana-alerts-notifications)
+- [Configure notification policies](ref:configure-notification-policies)
 
 ## Manage Alertmanager configurations
 


### PR DESCRIPTION
This PR creates new documentation for the Alertmanager contact point

⭐ Preview
- [Alertmanager contact point](https://deploy-preview-grafana-103782-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-alertmanager/)
- [Configure Alertmanagers](https://deploy-preview-grafana-103782-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/configure-alertmanager/)

Closes https://github.com/grafana/alerting-squad/issues/1070

