### PR TITLE
DashboardOutline: Support renaming by double click

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1557,6 +1557,9 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
     "public/app/features/dashboard-scene/inspect/HelpWizard/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -14,6 +14,7 @@ import { getDashboardSceneFor } from '../utils/utils';
 
 import { DashboardEditPane } from './DashboardEditPane';
 import { getEditableElementFor } from './shared';
+import { useOutlineRename } from './useOutlineRename';
 
 export interface Props {
   editPane: DashboardEditPane;
@@ -50,7 +51,7 @@ function DashboardOutlineNode({
   const noTitleText = t('dashboard.outline.tree-item.no-title', '<no title>');
   const instanceName = elementInfo.instanceName === '' ? noTitleText : elementInfo.instanceName;
   const elementCollapsed = editableElement.getCollapsedState?.();
-  const [isRenaming, setIsRenaming] = useState(false);
+  const outlineRename = useOutlineRename(editableElement);
 
   const onNameClicked = (evt: React.PointerEvent) => {
     // Only select via clicking outline never deselect
@@ -69,21 +70,6 @@ function DashboardOutlineNode({
       editableElement.setCollapsedState?.(!isCollapsed);
     }
   };
-
-  const onNameDoubleClicked = (evt: React.MouseEvent) => {
-    if (!editableElement.onChangeName) {
-      return;
-    }
-
-    setIsRenaming(true);
-  };
-
-  const selectTextOnMount = useMemo(() => {
-    return (ref: HTMLInputElement | null) => {
-      ref?.focus();
-      ref?.select();
-    };
-  }, []);
 
   // Sync canvas element expanded state with outline element
   useEffect(() => {
@@ -104,22 +90,18 @@ function DashboardOutlineNode({
           role="button"
           className={cx(styles.nodeButton, isCloned && styles.nodeButtonClone, isSelected && styles.nodeButtonSelected)}
           onPointerDown={onNameClicked}
-          onDoubleClick={onNameDoubleClicked}
+          onDoubleClick={outlineRename.onNameDoubleClicked}
         >
           <Icon size="sm" name={elementInfo.icon} />
-          {isRenaming ? (
+          {outlineRename.isRenaming ? (
             <input
-              ref={selectTextOnMount}
+              ref={outlineRename.renameInputRef}
               type="text"
               value={elementInfo.instanceName}
               className={styles.outlineInput}
-              onChange={(evt) => editableElement.onChangeName!(evt.target.value)}
-              onBlur={() => setIsRenaming(false)}
-              onKeyDown={(evt) => {
-                if (evt.key === 'Enter') {
-                  setIsRenaming(false);
-                }
-              }}
+              onChange={outlineRename.onChangeName}
+              onBlur={outlineRename.onInputBlur}
+              onKeyDown={outlineRename.onInputKeyDown}
             />
           ) : (
             <>

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -112,6 +112,10 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     dashboard.copyPanel(this.panel);
   }
 
+  public onChangeName(name: string) {
+    this.panel.setState({ title: name });
+  }
+
   public createMultiSelectedElement(items: VizPanelEditableElement[]) {
     return new MultiSelectedVizPanelsEditableElement(items);
   }

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -13,6 +13,7 @@ import {
   PanelBackgroundSwitch,
   PanelDescriptionTextArea,
   PanelFrameTitleInput,
+  setPanelTitle,
 } from '../panel-edit/getPanelFrameOptions';
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
@@ -113,7 +114,7 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
   }
 
   public onChangeName(name: string) {
-    this.panel.setState({ title: name });
+    setPanelTitle(this.panel, name);
   }
 
   public createMultiSelectedElement(items: VizPanelEditableElement[]) {

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -1,13 +1,14 @@
 import { useSessionStorage } from 'react-use';
 
 import { BusEventWithPayload } from '@grafana/data';
-import { SceneGridRow, SceneObject, SceneVariable, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { SceneGridRow, SceneObject, SceneVariableSet, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
 import { EditableDashboardElement, isEditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
+import { isSceneVariable } from '../settings/variables/utils';
 
 import { DashboardEditableElement } from './DashboardEditableElement';
 import { VizPanelEditableElement } from './VizPanelEditableElement';
@@ -46,10 +47,6 @@ export function getEditableElementFor(sceneObj: SceneObject | undefined): Editab
   }
 
   return undefined;
-}
-
-export function isSceneVariable(sceneObj: SceneObject): sceneObj is SceneVariable {
-  return 'getValue' in sceneObj;
 }
 
 export class NewObjectAddedToCanvasEvent extends BusEventWithPayload<SceneObject> {

--- a/public/app/features/dashboard-scene/edit-pane/useOutlineRename.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/useOutlineRename.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useMemo } from 'react';
+
+import { EditableDashboardElement } from '../scene/types/EditableDashboardElement';
+
+export interface OutlineRenameState {
+  isRenaming?: boolean;
+  originalName?: string;
+  error?: string;
+}
+
+export function useOutlineRename(editableElement: EditableDashboardElement) {
+  const [state, setState] = useState<OutlineRenameState>({});
+
+  const onNameDoubleClicked = (evt: React.MouseEvent) => {
+    if (!editableElement.onChangeName) {
+      return;
+    }
+
+    setState({ isRenaming: true, originalName: editableElement.getEditableElementInfo().instanceName });
+  };
+
+  const onInputBlur = () => {
+    if (state.error) {
+      editableElement.onChangeName!(state.originalName!);
+    }
+
+    setState({});
+  };
+
+  const renameInputRef = useMemo(() => {
+    return (ref: HTMLInputElement | null) => {
+      ref?.focus();
+      ref?.select();
+    };
+  }, []);
+
+  const onChangeName = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const result = editableElement.onChangeName!(evt.target.value);
+    if (result?.errorMessage) {
+      setState({ ...state, error: result.errorMessage });
+    } else if (state.error) {
+      setState({ ...state, error: undefined });
+    }
+  };
+
+  const onInputKeyDown = (evt: React.KeyboardEvent) => {
+    if (evt.key === 'Enter') {
+      onInputBlur();
+    }
+  };
+
+  return {
+    isRenaming: state.isRenaming,
+    onNameDoubleClicked,
+    renameInputRef,
+    onChangeName,
+    onInputBlur,
+    onInputKeyDown,
+  };
+}

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -154,7 +154,7 @@ export function PanelBackgroundSwitch({ panel }: { panel: VizPanel }) {
   );
 }
 
-function setPanelTitle(panel: VizPanel, title: string) {
+export function setPanelTitle(panel: VizPanel, title: string) {
   panel.setState({ title: title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
 }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -190,6 +190,10 @@ export class RowItem
     this.setState({ title });
   }
 
+  public onChangeName(name: string) {
+    this.onChangeTitle(name);
+  }
+
   public onHeaderHiddenToggle(hideHeader = !this.state.hideHeader) {
     this.setState({ hideHeader });
   }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -172,6 +172,10 @@ export class TabItem
     this.setState({ title });
   }
 
+  public onChangeName(name: string): void {
+    this.onChangeTitle(name);
+  }
+
   public setIsDropTarget(isDropTarget: boolean) {
     if (!!this.state.isDropTarget !== isDropTarget) {
       this.setState({ isDropTarget });

--- a/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
@@ -64,6 +64,11 @@ export interface EditableDashboardElement {
    * Used to sync row collapsed state with outline
    */
   setCollapsedState?(collapsed: boolean): void;
+
+  /**
+   * Used to change name from outline
+   */
+  onChangeName?(name: string): void;
 }
 
 export interface EditableDashboardElementInfo {

--- a/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
@@ -68,7 +68,7 @@ export interface EditableDashboardElement {
   /**
    * Used to change name from outline
    */
-  onChangeName?(name: string): void;
+  onChangeName?(name: string): { errorMessage?: string } | void;
 }
 
 export interface EditableDashboardElementInfo {

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -10,14 +10,7 @@ import {
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
-import {
-  SceneVariableSet,
-  CustomVariable,
-  VizPanel,
-  AdHocFiltersVariable,
-  SceneVariableState,
-  SceneTimeRange,
-} from '@grafana/scenes';
+import { SceneVariableSet, CustomVariable, VizPanel, AdHocFiltersVariable, SceneTimeRange } from '@grafana/scenes';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
@@ -209,49 +202,6 @@ describe('VariablesEditView', () => {
 
     afterEach(() => {
       jest.clearAllMocks();
-    });
-  });
-
-  describe('Variables name validation', () => {
-    let variableView: VariablesEditView;
-    let variable1: SceneVariableState;
-    let variable2: SceneVariableState;
-
-    beforeAll(async () => {
-      const result = await buildTestScene();
-      variableView = result.variableView;
-
-      const variables = variableView.getVariables();
-      variable1 = variables[0].state;
-      variable2 = variables[1].state;
-    });
-
-    it('should not return error on same name and key', () => {
-      expect(variableView.onValidateVariableName(variable1.name, variable1.key)[0]).toBe(false);
-    });
-
-    it('should not return error if name is unique', () => {
-      expect(variableView.onValidateVariableName('unique_variable_name', variable1.key)[0]).toBe(false);
-    });
-
-    it('should return error if global variable name is used', () => {
-      expect(variableView.onValidateVariableName('__', variable1.key)[0]).toBe(true);
-    });
-
-    it('should not return error if global variable name is used not at the beginning ', () => {
-      expect(variableView.onValidateVariableName('test__', variable1.key)[0]).toBe(false);
-    });
-
-    it('should return error if name is empty', () => {
-      expect(variableView.onValidateVariableName('', variable1.key)[0]).toBe(true);
-    });
-
-    it('should return error if non word characters are used', () => {
-      expect(variableView.onValidateVariableName('-', variable1.key)[0]).toBe(true);
-    });
-
-    it('should return error if variable name is taken', () => {
-      expect(variableView.onValidateVariableName(variable2.name, variable1.key)[0]).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -244,7 +244,6 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
           navModel={navModel}
           dashboard={dashboard}
           onDelete={onDelete}
-          onValidateVariableName={model.onValidateVariableName}
         />
       );
     }
@@ -276,7 +275,6 @@ interface VariableEditorSettingsEditViewProps {
   onTypeChange: (variableType: EditableVariableType) => void;
   onGoBack: () => void;
   onDelete: (variableName: string) => void;
-  onValidateVariableName: (name: string, key: string | undefined) => [true, string] | [false, null];
 }
 
 function VariableEditorSettingsView({
@@ -287,7 +285,6 @@ function VariableEditorSettingsView({
   onTypeChange,
   onGoBack,
   onDelete,
-  onValidateVariableName,
 }: VariableEditorSettingsEditViewProps) {
   const { name } = variable.useState();
 
@@ -303,7 +300,6 @@ function VariableEditorSettingsView({
         onTypeChange={onTypeChange}
         onGoBack={onGoBack}
         onDelete={onDelete}
-        onValidateVariableName={onValidateVariableName}
         // force refresh when navigating using back/forward between variables
         key={variable.state.key}
       />

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -104,19 +104,30 @@ function VariableNameInput({ variable, isNewElement }: { variable: SceneVariable
   const { name } = variable.useState();
   const ref = useEditPaneInputAutoFocus({ autoFocus: isNewElement });
   const [nameError, setNameError] = useState<string>();
+  const [validName, setValidName] = useState<string>(variable.state.name);
 
   const onChange = (e: FormEvent<HTMLInputElement>) => {
     const result = validateVariableName(variable, e.currentTarget.value);
     if (result.errorMessage !== nameError) {
       setNameError(result.errorMessage);
+    } else {
+      setValidName(variable.state.name);
     }
 
     variable.setState({ name: e.currentTarget.value });
   };
 
+  // Restore valid name if bluring while invalid
+  const onBlur = () => {
+    if (nameError) {
+      variable.setState({ name: validName });
+      setNameError(undefined);
+    }
+  };
+
   return (
     <Field label={t('dashboard-scene.variable-editor-form.name', 'Name')} invalid={!!nameError} error={nameError}>
-      <Input ref={ref} value={name} onChange={onChange} required />
+      <Input ref={ref} value={name} onChange={onChange} required onBlur={onBlur} />
     </Field>
   );
 }

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -83,6 +83,11 @@ export class VariableEditableElement implements EditableDashboardElement, BulkAc
       set.setState({ variables: set.state.variables.filter((v) => v !== this.variable) });
     }
   }
+
+  public onChangeName(name: string) {
+    // TODO add validation
+    this.variable.setState({ name });
+  }
 }
 
 interface VariableInputProps {

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
@@ -18,25 +18,24 @@ import { VariableValuesPreview } from 'app/features/dashboard-scene/settings/var
 import { VariableNameConstraints } from 'app/features/variables/editor/types';
 
 import { VariableTypeSelect } from './components/VariableTypeSelect';
-import { EditableVariableType, getVariableEditor, hasVariableOptions, isEditableVariableType } from './utils';
+import {
+  EditableVariableType,
+  getVariableEditor,
+  hasVariableOptions,
+  isEditableVariableType,
+  validateVariableName,
+} from './utils';
 
 interface VariableEditorFormProps {
   variable: SceneVariable;
   onTypeChange: (type: EditableVariableType) => void;
   onGoBack: () => void;
   onDelete: (variableName: string) => void;
-  onValidateVariableName: (name: string, key: string | undefined) => [true, string] | [false, null];
 }
-export function VariableEditorForm({
-  variable,
-  onTypeChange,
-  onGoBack,
-  onDelete,
-  onValidateVariableName,
-}: VariableEditorFormProps) {
+export function VariableEditorForm({ variable, onTypeChange, onGoBack, onDelete }: VariableEditorFormProps) {
   const styles = useStyles2(getStyles);
-  const [nameError, setNameError] = useState<string | null>(null);
-  const { name, type, label, description, hide, key } = variable.useState();
+  const [nameError, setNameError] = useState<string>();
+  const { name, type, label, description, hide } = variable.useState();
   const EditorToRender = isEditableVariableType(type) ? getVariableEditor(type) : undefined;
   const [runQueryState, onRunQuery] = useAsyncFn(async () => {
     await lastValueFrom(variable.validateAndUpdate!());
@@ -49,12 +48,12 @@ export function VariableEditorForm({
 
   const onNameChange = useCallback(
     (e: FormEvent<HTMLInputElement>) => {
-      const [, errorMessage] = onValidateVariableName(e.currentTarget.value, key);
-      if (nameError !== errorMessage) {
-        setNameError(errorMessage);
+      const result = validateVariableName(variable, e.currentTarget.value);
+      if (result.errorMessage !== nameError) {
+        setNameError(result.errorMessage);
       }
     },
-    [key, nameError, onValidateVariableName]
+    [variable, nameError]
   );
 
   const onNameBlur = (e: FormEvent<HTMLInputElement>) => {

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -413,7 +413,7 @@ describe('Variables name validation', () => {
   });
 
   it('should not return error if global variable name is used not at the beginning ', () => {
-    expect(validateVariableName(variable1, 'test__').isValid).toBe(false);
+    expect(validateVariableName(variable1, 'test__').isValid).toBe(true);
   });
 
   it('should return error if name is empty', () => {

--- a/public/app/features/dashboard-scene/settings/variables/utils.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.test.ts
@@ -10,6 +10,7 @@ import {
   GroupByVariable,
   TextBoxVariable,
   SceneVariableSet,
+  SceneVariable,
 } from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, VariableHide, VariableType } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY, DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/constants';
@@ -36,6 +37,7 @@ import {
   getNextAvailableId,
   getVariableDefault,
   isSceneVariableInstance,
+  validateVariableName,
 } from './utils';
 
 const templateSrv = {
@@ -374,5 +376,55 @@ describe('getVariableDefault', () => {
 
     expect(defaultVariable).toBeInstanceOf(QueryVariable);
     expect(defaultVariable.state.name).toBe('query0');
+  });
+});
+
+describe('Variables name validation', () => {
+  let variable1: SceneVariable;
+  let variable2: SceneVariable;
+
+  beforeAll(async () => {
+    variable1 = new CustomVariable({
+      name: 'customVar',
+      query: 'test, test2',
+      value: 'test',
+      text: 'test',
+    });
+    variable2 = new CustomVariable({
+      name: 'customVar2',
+      query: 'test3, test4, $customVar',
+      value: '$customVar',
+      text: '$customVar',
+    });
+
+    new SceneVariableSet({ variables: [variable1, variable2] });
+  });
+
+  it('should not return error on same name and key', () => {
+    expect(validateVariableName(variable1, variable1.state.name).isValid).toBe(true);
+  });
+
+  it('should not return error if name is unique', () => {
+    expect(validateVariableName(variable1, 'unique_variable_name').isValid).toBe(true);
+  });
+
+  it('should return error if global variable name is used', () => {
+    expect(validateVariableName(variable1, '__').isValid).toBe(false);
+  });
+
+  it('should not return error if global variable name is used not at the beginning ', () => {
+    expect(validateVariableName(variable1, 'test__').isValid).toBe(false);
+  });
+
+  it('should return error if name is empty', () => {
+    expect(validateVariableName(variable1, '').isValid).toBe(false);
+  });
+
+  it('should return error if non word characters are used', () => {
+    expect(validateVariableName(variable1, '-').isValid).toBe(false);
+  });
+
+  it('should return error if variable name is taken', () => {
+    expect(validateVariableName(variable1, variable2.state.name).isValid).toBe(false);
   });
 });


### PR DESCRIPTION
* Support rename by double click
* Support variable name validation in edit pane 
* Support some simple validation in rename from outline (will revert to original value if ends in invalid state) 
* Only expand outline node when clicking angle icon 
