### PR TITLE
AzureMonitor: Improve selection of Basic Logs tables in the query builder

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -7,23 +7,26 @@ import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/run
 import { getCredentials } from '../credentials';
 import TimegrainConverter from '../time_grain_converter';
 import {
+  AzureAPIResponse,
+  AzureMetricQuery,
   AzureMonitorDataSourceInstanceSettings,
   AzureMonitorDataSourceJsonData,
+  AzureMonitorLocations,
   AzureMonitorMetricsMetadataResponse,
+  AzureMonitorProvidersResponse,
   AzureMonitorQuery,
   AzureQueryType,
   DatasourceValidationResult,
+  GetLogAnalyticsTableResponse,
+  GetMetricMetadataQuery,
   GetMetricNamespacesQuery,
   GetMetricNamesQuery,
-  GetMetricMetadataQuery,
-  AzureMetricQuery,
-  AzureMonitorLocations,
-  AzureMonitorProvidersResponse,
-  AzureAPIResponse,
-  Subscription,
+  instanceOfLogAnalyticsTableError,
   Location,
   Metric,
   MetricNamespace,
+  Subscription,
+  TablePlan,
 } from '../types';
 import { replaceTemplateVariables, routeNames } from '../utils/common';
 import migrateQuery from '../utils/migrateQuery';
@@ -272,6 +275,36 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     }
 
     return undefined;
+  }
+
+  async getWorkspaceTablePlan(query: AzureMonitorQuery, tableName: string): Promise<TablePlan> {
+    let workspaceUri = '';
+
+    if (query.azureLogAnalytics?.resources) {
+      workspaceUri = query.azureLogAnalytics?.resources[0];
+    }
+
+    if (!workspaceUri) {
+      return TablePlan.Analytics;
+    }
+
+    if (workspaceUri && !workspaceUri.toLowerCase().includes('microsoft.operationalinsights/workspaces')) {
+      // Not a Log Analytics workspace so default to Analytics
+      return TablePlan.Analytics;
+    }
+
+    const url = UrlBuilder.buildAzureMonitorGetLogsTableUrl(
+      this.resourcePath,
+      this.templateSrv.replace(workspaceUri),
+      this.templateSrv.replace(tableName)
+    );
+    const tableResult = await this.getResource<GetLogAnalyticsTableResponse>(url);
+
+    if (!tableResult || instanceOfLogAnalyticsTableError(tableResult)) {
+      return TablePlan.Analytics;
+    }
+
+    return tableResult.properties.plan || TablePlan.Analytics;
   }
 
   private isValidConfigField(field?: string): boolean {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -277,11 +277,11 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     return undefined;
   }
 
-  async getWorkspaceTablePlan(query: AzureMonitorQuery, tableName: string): Promise<TablePlan> {
+  async getWorkspaceTablePlan(resources: string[], tableName: string): Promise<TablePlan> {
     let workspaceUri = '';
 
-    if (query.azureLogAnalytics?.resources) {
-      workspaceUri = query.azureLogAnalytics?.resources[0];
+    if (resources) {
+      workspaceUri = resources[0];
     }
 
     if (!workspaceUri) {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.ts
@@ -113,4 +113,13 @@ export default class UrlBuilder {
 
     return url;
   }
+
+  static buildAzureMonitorGetLogsTableUrl(
+    baseUrl: string,
+    resourceUri: string,
+    tableName: string,
+    apiVersion = '2025-02-01'
+  ) {
+    return `${baseUrl}${resourceUri}/tables/${tableName}?api-version=${apiVersion}`;
+  }
 }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
@@ -124,7 +124,7 @@ export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
           ...query.azureLogAnalytics,
           builderQuery: updatedBuilderQuery,
           query: updatedQueryString,
-          basicLogsQuery,
+          basicLogsQuery: from ? basicLogsQuery : query.azureLogAnalytics?.basicLogsQuery,
         },
       });
     },

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
@@ -42,10 +42,11 @@ interface LogsQueryBuilderProps {
   templateVariableOptions: SelectableValue<string>;
   datasource: Datasource;
   timeRange?: TimeRange;
+  isLoadingSchema: boolean;
 }
 
 export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
-  const { query, onQueryChange, schema, datasource, timeRange } = props;
+  const { query, onQueryChange, schema, datasource, timeRange, isLoadingSchema } = props;
   const [isKQLPreviewHidden, setIsKQLPreviewHidden] = useState<boolean>(true);
 
   const tables: AzureLogAnalyticsMetadataTable[] = useMemo(() => {
@@ -137,7 +138,13 @@ export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
         {schema && tables.length === 0 && (
           <Alert severity="warning" title="Resource loaded successfully but without any tables" />
         )}
-        <TableSection {...props} tables={tables} allColumns={allColumns} buildAndUpdateQuery={buildAndUpdateQuery} />
+        <TableSection
+          {...props}
+          tables={tables}
+          allColumns={allColumns}
+          buildAndUpdateQuery={buildAndUpdateQuery}
+          isLoadingSchema={isLoadingSchema}
+        />
         <FilterSection
           {...props}
           allColumns={allColumns}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
@@ -70,6 +70,7 @@ export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
       orderBy,
       columns,
       from,
+      basicLogsQuery,
     }: {
       limit?: number;
       reduce?: BuilderQueryEditorReduceExpression[];
@@ -79,6 +80,7 @@ export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
       orderBy?: BuilderQueryEditorOrderByExpression[];
       columns?: string[];
       from?: BuilderQueryEditorPropertyExpression;
+      basicLogsQuery?: boolean;
     }) => {
       const datetimeColumn = allColumns.find((col) => col.type === 'datetime')?.name || 'TimeGenerated';
 
@@ -122,6 +124,7 @@ export const LogsQueryBuilder: React.FC<LogsQueryBuilderProps> = (props) => {
           ...query.azureLogAnalytics,
           builderQuery: updatedBuilderQuery,
           query: updatedQueryString,
+          basicLogsQuery,
         },
       });
     },

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
@@ -5,7 +5,12 @@ import { EditorField, EditorFieldGroup, EditorRow, InputGroup } from '@grafana/p
 import { Button, Select } from '@grafana/ui';
 
 import { BuilderQueryEditorExpressionType, BuilderQueryEditorPropertyType } from '../../dataquery.gen';
-import { AzureMonitorQuery, AzureLogAnalyticsMetadataColumn, AzureLogAnalyticsMetadataTable } from '../../types';
+import {
+  AzureMonitorQuery,
+  AzureLogAnalyticsMetadataColumn,
+  AzureLogAnalyticsMetadataTable,
+  TablePlan,
+} from '../../types';
 
 import { BuildAndUpdateOptions, inputFieldSize } from './utils';
 
@@ -15,6 +20,7 @@ interface TableSectionProps {
   query: AzureMonitorQuery;
   buildAndUpdateQuery: (options: Partial<BuildAndUpdateOptions>) => void;
   templateVariableOptions?: SelectableValue<string>;
+  onQueryChange: (newQuery: AzureMonitorQuery) => void;
 }
 
 export const TableSection: React.FC<TableSectionProps> = (props) => {
@@ -25,6 +31,7 @@ export const TableSection: React.FC<TableSectionProps> = (props) => {
   const tableOptions: Array<SelectableValue<string>> = tables.map((t) => ({
     label: t.name,
     value: t.name,
+    description: t.plan === TablePlan.Basic ? 'Selecting this table will switch the query mode to Basic Logs' : '',
   }));
 
   const columnOptions: Array<SelectableValue<string>> = allColumns.map((col) => ({
@@ -68,6 +75,7 @@ export const TableSection: React.FC<TableSectionProps> = (props) => {
       groupBy: [],
       orderBy: [],
       columns: [],
+      basicLogsQuery: selectedTable.plan === TablePlan.Basic,
     });
   };
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
@@ -21,10 +21,11 @@ interface TableSectionProps {
   buildAndUpdateQuery: (options: Partial<BuildAndUpdateOptions>) => void;
   templateVariableOptions?: SelectableValue<string>;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
+  isLoadingSchema: boolean;
 }
 
 export const TableSection: React.FC<TableSectionProps> = (props) => {
-  const { allColumns, query, tables, buildAndUpdateQuery, templateVariableOptions } = props;
+  const { allColumns, query, tables, buildAndUpdateQuery, templateVariableOptions, isLoadingSchema } = props;
   const builderQuery = query.azureLogAnalytics?.builderQuery;
   const selectedColumns = query.azureLogAnalytics?.builderQuery?.columns?.columns || [];
 
@@ -146,6 +147,7 @@ export const TableSection: React.FC<TableSectionProps> = (props) => {
             placeholder="Select a table"
             onChange={handleTableChange}
             width={inputFieldSize}
+            isLoading={isLoadingSchema}
           />
         </EditorField>
         <EditorField label="Columns">

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/utils.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/utils.ts
@@ -3,14 +3,14 @@ import { escapeRegExp } from 'lodash';
 import { SelectableValue } from '@grafana/data';
 
 import {
-  BuilderQueryExpression,
   BuilderQueryEditorExpressionType,
-  BuilderQueryEditorPropertyType,
-  BuilderQueryEditorReduceExpression,
-  BuilderQueryEditorWhereExpression,
   BuilderQueryEditorGroupByExpression,
   BuilderQueryEditorOrderByExpression,
   BuilderQueryEditorPropertyExpression,
+  BuilderQueryEditorPropertyType,
+  BuilderQueryEditorReduceExpression,
+  BuilderQueryEditorWhereExpression,
+  BuilderQueryExpression,
 } from '../../dataquery.gen';
 import { AzureLogAnalyticsMetadataColumn, AzureMonitorQuery } from '../../types';
 
@@ -88,6 +88,7 @@ export interface BuildAndUpdateOptions {
   orderBy?: BuilderQueryEditorOrderByExpression[];
   columns?: string[];
   from?: BuilderQueryEditorPropertyExpression;
+  basicLogsQuery?: boolean;
 }
 
 export const aggregateOptions = [

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -67,6 +67,7 @@ const LogsQueryEditor = ({
   const to = templateSrv?.replace('$__to');
   const templateVariableOptions = templateSrv.getVariables();
   const isBasicLogsQuery = (basicLogsEnabled && query.azureLogAnalytics?.basicLogsQuery) ?? false;
+  const [isLoadingSchema, setIsLoadingSchema] = useState<boolean>(false);
 
   const disableRow = (row: ResourceRow, selectedRows: ResourceRowGroup) => {
     if (selectedRows.length === 0) {
@@ -92,6 +93,7 @@ const LogsQueryEditor = ({
   useEffect(() => {
     const resources = query.azureLogAnalytics?.resources;
     if (resources) {
+      setIsLoadingSchema(true);
       const fetchAllPlans = async (tables: AzureLogAnalyticsMetadataTable[]) => {
         const promises = [];
         for (const table of tables) {
@@ -113,6 +115,7 @@ const LogsQueryEditor = ({
             setSchema(schema);
           });
         }
+        setIsLoadingSchema(false);
       });
     }
   }, [query.azureLogAnalytics?.resources, datasource.azureLogAnalyticsDatasource, datasource.azureMonitorDatasource]);
@@ -281,6 +284,7 @@ const LogsQueryEditor = ({
             templateVariableOptions={templateVariableOptions}
             datasource={datasource}
             timeRange={timeRange}
+            isLoadingSchema={isLoadingSchema}
           />
         ) : (
           <QueryField

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -90,20 +90,21 @@ const LogsQueryEditor = ({
   const [schema, setSchema] = useState<EngineSchema | undefined>();
 
   useEffect(() => {
-    if (query.azureLogAnalytics?.resources && query.azureLogAnalytics.resources.length) {
+    const resources = query.azureLogAnalytics?.resources;
+    if (resources) {
       const fetchAllPlans = async (tables: AzureLogAnalyticsMetadataTable[]) => {
         const promises = [];
         for (const table of tables) {
           promises.push({
             ...table,
-            plan: await datasource.azureMonitorDatasource.getWorkspaceTablePlan(query, table.name),
+            plan: await datasource.azureMonitorDatasource.getWorkspaceTablePlan(resources, table.name),
           });
         }
 
         const tablesWithPlan = await Promise.all(promises);
         return tablesWithPlan;
       };
-      datasource.azureLogAnalyticsDatasource.getKustoSchema(query.azureLogAnalytics.resources[0]).then((schema) => {
+      datasource.azureLogAnalyticsDatasource.getKustoSchema(resources[0]).then((schema) => {
         if (schema?.database?.tables) {
           fetchAllPlans(schema?.database?.tables).then(async (t) => {
             if (schema.database?.tables) {
@@ -114,12 +115,7 @@ const LogsQueryEditor = ({
         }
       });
     }
-  }, [
-    query.azureLogAnalytics?.resources,
-    datasource.azureLogAnalyticsDatasource,
-    datasource.azureMonitorDatasource,
-    query,
-  ]);
+  }, [query.azureLogAnalytics?.resources, datasource.azureLogAnalyticsDatasource, datasource.azureMonitorDatasource]);
 
   useEffect(() => {
     if (shouldShowBasicLogsToggle(query.azureLogAnalytics?.resources || [], basicLogsEnabled)) {

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
@@ -64,6 +64,7 @@ export const QueryHeader = ({
         azureLogAnalytics: {
           ...query.azureLogAnalytics,
           mode: LogsEditorMode.Builder,
+          dashboardTime: true,
         },
       };
       onQueryChange(updatedQuery);
@@ -97,6 +98,7 @@ export const QueryHeader = ({
         mode,
         query: '',
         builderQuery: mode === LogsEditorMode.Raw ? undefined : query.azureLogAnalytics?.builderQuery,
+        dashboardTime: mode === LogsEditorMode.Builder ? true : undefined,
       },
     };
     onQueryChange(updatedQuery);

--- a/public/app/plugins/datasource/azuremonitor/types/logAnalyticsMetadata.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/logAnalyticsMetadata.ts
@@ -1,3 +1,5 @@
+import { TablePlan } from './types';
+
 export interface AzureLogAnalyticsMetadata {
   functions: AzureLogAnalyticsMetadataFunction[];
   resourceTypes: AzureLogAnalyticsMetadataResourceType[];
@@ -68,6 +70,8 @@ export interface AzureLogAnalyticsMetadataTable {
   related: AzureLogAnalyticsMetadataTableRelated;
   isTroubleshootingAllowed?: boolean;
   hasData?: boolean;
+  // TablePlan does not come directly from the API - we determine it
+  plan?: TablePlan;
 }
 
 export interface AzureLogAnalyticsMetadataColumn {

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -1,6 +1,6 @@
-import { ScalarParameter, TabularParameter, Function, EntityGroup } from '@kusto/monaco-kusto';
+import { EntityGroup, Function, ScalarParameter, TabularParameter } from '@kusto/monaco-kusto';
 
-import { AzureDataSourceSecureJsonData, AzureDataSourceJsonData } from '@grafana/azure-sdk';
+import { AzureDataSourceJsonData, AzureDataSourceSecureJsonData } from '@grafana/azure-sdk';
 import { DataSourceInstanceSettings, DataSourceSettings, PanelData, SelectableValue, TimeRange } from '@grafana/data';
 
 import Datasource from '../datasource';
@@ -468,4 +468,61 @@ export enum AggregateFunctions {
   Max = 'max',
   Min = 'min',
   Percentile = 'percentile',
+}
+
+export enum TablePlan {
+  Analytics = 'Analytics',
+  Basic = 'Basic',
+}
+
+export interface GetLogAnalyticsTableSuccessResponse {
+  properties: {
+    totalRetentionInDays: number;
+    archiveRetentionInDays: number;
+    lastPlanModifiedDate?: string;
+    plan: TablePlan;
+    restoredLogs?: Record<string, string | undefined>;
+    retentionInDaysAsDefault: boolean;
+    totalRetentionInDaysAsDefault: boolean;
+    schema: {
+      tableSubType: string;
+      name: string;
+      tableType: string;
+      columns: Array<Record<string, string | undefined>>;
+      standardColumns: Array<Record<string, string | undefined>>;
+      solutions: string[];
+      isTroubleshootingAllowed: boolean;
+      description?: string;
+      displayName?: string;
+      labels?: string[];
+      source?: string;
+    };
+    resultStatistics: Record<string, string | number | undefined>;
+    provisioningState: string;
+    retentionInDays: number;
+    searchResults?: Record<string, string | number | undefined>;
+    systemData?: Record<string, string | number | undefined>;
+  };
+  id: string;
+  name: string;
+  type?: string;
+}
+
+export interface GetLogAnalyticsTableErrorResponse {
+  error: {
+    target: string;
+    message: string;
+    code: string;
+  };
+}
+
+export type GetLogAnalyticsTableResponse = GetLogAnalyticsTableSuccessResponse | GetLogAnalyticsTableErrorResponse;
+
+export function instanceOfLogAnalyticsTableError(
+  response: GetLogAnalyticsTableSuccessResponse | GetLogAnalyticsTableErrorResponse
+): response is GetLogAnalyticsTableErrorResponse {
+  if (!response) {
+    return false;
+  }
+  return response.hasOwnProperty('error');
 }


### PR DESCRIPTION
Currently the builder doesn't undertake any special handling for tables with the plan `Basic` which will cause the queries to fail unless the user explicitly sets the mode to `Basic`.

This PR does the following:

- Adds a helper function to retrieve the table plan for all tables in the schema.
- Adds a description to tables with the plan `Basic` to make the user aware of the plan and notify them that selecting the table will switch the query mode to `Basic`.
- Correctly sets the `dashboardTime` property for builder queries.
- Adds a loading property for the `TableSection` to make it clear that table information is being retrieved.

https://github.com/user-attachments/assets/d457a276-fde7-423b-a298-64062cc33057


