### PR TITLE
Prometheus: Add ability to clear metric name in PromQL query builder

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -249,7 +249,7 @@ export function MetricSelect({
     return (
       <AsyncSelect
         data-testid={selectors.components.DataSource.Prometheus.queryEditor.builder.metricSelect}
-        isClearable={Boolean(variableEditor)}
+        isClearable={true}
         inputId="prometheus-metric-select"
         className={styles.select}
         value={query.metric ? toOption(query.metric) : undefined}


### PR DESCRIPTION
**What is this feature?**

Set isClearable prop to true in AsyncSelect within `MetricSelect` component.

Originally developed by @sujalshah-bit https://github.com/grafana/grafana/pull/101622

**Why do we need this feature?**

To be able to clear the metric name after selecting it.

**Which issue(s) does this PR fix?**:

Fixes #101185

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
