### PR TITLE
Unified: use server access client for bulk operations

### DIFF
--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -141,13 +141,10 @@ func (s *server) BulkProcess(stream BulkStore_BulkProcessServer) error {
 		})
 	}
 
-	// HACK!!! always allow everything!!!!!!
-	access := authlib.FixedAccessClient(true)
-
 	if settings.RebuildCollection {
 		for _, k := range settings.Collection {
 			// Can we delete the whole collection
-			rsp, err := access.Check(ctx, user, authlib.CheckRequest{
+			rsp, err := s.access.Check(ctx, user, authlib.CheckRequest{
 				Namespace: k.Namespace,
 				Group:     k.Group,
 				Resource:  k.Resource,
@@ -163,7 +160,7 @@ func (s *server) BulkProcess(stream BulkStore_BulkProcessServer) error {
 			}
 
 			// This will be called for each request -- with the folder ID
-			runner.checker[k.NSGR()], err = access.Compile(ctx, user, authlib.ListRequest{
+			runner.checker[k.NSGR()], err = s.access.Compile(ctx, user, authlib.ListRequest{
 				Namespace: k.Namespace,
 				Group:     k.Group,
 				Resource:  k.Resource,


### PR DESCRIPTION
The command line currently allows bulk migrations using:
```
./bin/darwin-arm64/grafana cli admin data-migration to-unified-storage
```

this currently skips authz (you have to physically be on the machine to run it) and it modifies values that do not have any *read* path that is not clearly experimental/dev flags

This PR updates things so we use the standard access checker.

I tested with the a local copy of the ops database -- before+after the change are pretty similar time ~15s. (previously the access checker was +10x slower)