### PR TITLE
AzureMonitor: Only fetch table plans in the builder

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -114,6 +114,8 @@ const LogsQueryEditor = ({
             }
             setSchema(schema);
           });
+        } else {
+          setSchema(schema);
         }
         setIsLoadingSchema(false);
       });

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -107,7 +107,7 @@ const LogsQueryEditor = ({
         return tablesWithPlan;
       };
       datasource.azureLogAnalyticsDatasource.getKustoSchema(resources[0]).then((schema) => {
-        if (schema?.database?.tables) {
+        if (schema?.database?.tables && query.azureLogAnalytics?.mode === LogsEditorMode.Builder) {
           fetchAllPlans(schema?.database?.tables).then(async (t) => {
             if (schema.database?.tables) {
               schema.database.tables = t;
@@ -118,7 +118,12 @@ const LogsQueryEditor = ({
         setIsLoadingSchema(false);
       });
     }
-  }, [query.azureLogAnalytics?.resources, datasource.azureLogAnalyticsDatasource, datasource.azureMonitorDatasource]);
+  }, [
+    query.azureLogAnalytics?.resources,
+    datasource.azureLogAnalyticsDatasource,
+    datasource.azureMonitorDatasource,
+    query.azureLogAnalytics?.mode,
+  ]);
 
   useEffect(() => {
     if (shouldShowBasicLogsToggle(query.azureLogAnalytics?.resources || [], basicLogsEnabled)) {


### PR DESCRIPTION
Follow on #103820, only request the table plans in the builder mode. The additional requests aren't useful for the raw mode.