### PR TITLE
Live: Updated note on Live redis sentinel support

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2536,7 +2536,8 @@ Address string of selected the high availability (HA) Live engine. For Redis, it
 ```ini
 [live]
 ha_engine = redis
-ha_engine_address = 127.0.0.1:6379
+ha_engine_address: redis-headless.grafana.svc.cluster.local:6379
+ha_engine_password: $__file{/your/redis/password/secret/mount}
 ```
 
 <hr>

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -207,6 +207,8 @@ To bypass these limitations, Grafana v8.1 has an experimental Live HA engine tha
 
 When the Redis engine is configured, Grafana Live keeps its state in Redis and uses Redis PUB/SUB functionality to deliver messages to all subscribers throughout all Grafana server nodes.
 
+
+
 Here is an example configuration:
 
 ```
@@ -223,26 +225,11 @@ After running:
 - Streaming from Telegraf delivers messages to all subscribers.
 - A separate unidirectional stream between Grafana and backend data source opens on different Grafana servers. Publishing data to a channel delivers messages to instance subscribers, as a result, publications from different instances on different machines do not produce duplicate data on panels.
 
-At the moment we only support single Redis node.
-
-> **Note:** It's possible to use Redis Sentinel and Haproxy to achieve a highly available Redis setup. Redis nodes should be managed by [Redis Sentinel](https://redis.io/topics/sentinel) to achieve automatic failover. Haproxy configuration example:
+> **Note:** Live currently does not support Redis Sentinel.  We recommend using a Redis Cluster for high-availability via a k8s helm chart such as the Bitnami Redis chart which has values to provision a Redis Cluster.  Grafana Live can then be pointed to the `redis-headless` service
 >
 > ```
-> listen redis
->   server redis-01 127.0.0.1:6380 check port 6380 check inter 2s weight 1 inter 2s downinter 5s rise 10 fall 2 on-marked-down shutdown-sessions on-marked-up shutdown-backup-sessions
->   server redis-02 127.0.0.1:6381 check port 6381 check inter 2s weight 1 inter 2s downinter 5s rise 10 fall 2 backup
->   bind *:6379
->   mode tcp
->   option tcpka
->   option tcplog
->   option tcp-check
->   tcp-check send PING\r\n
->   tcp-check expect string +PONG
->   tcp-check send info\ replication\r\n
->   tcp-check expect string role:master
->   tcp-check send QUIT\r\n
->   tcp-check expect string +OK
->   balance roundrobin
+> live:
+>   ha_engine: redis
+>   ha_engine_address: redis-headless.grafana.svc.cluster.local:6379
+>   ha_engine_password: $__file{/your/redis/password/secret/mount}
 > ```
->
-> Next, point Grafana Live to Haproxy address:port.

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -207,8 +207,6 @@ To bypass these limitations, Grafana v8.1 has an experimental Live HA engine tha
 
 When the Redis engine is configured, Grafana Live keeps its state in Redis and uses Redis PUB/SUB functionality to deliver messages to all subscribers throughout all Grafana server nodes.
 
-
-
 Here is an example configuration:
 
 ```
@@ -234,6 +232,5 @@ Live currently does not support Redis Sentinel. We recommend using a Redis Clust
    ha_engine_address: redis-headless.grafana.svc.cluster.local:6379
    ha_engine_password: $__file{/your/redis/password/secret/mount}
 ```
+
 {{< /admonition >}}
-
-

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -225,7 +225,10 @@ After running:
 - Streaming from Telegraf delivers messages to all subscribers.
 - A separate unidirectional stream between Grafana and backend data source opens on different Grafana servers. Publishing data to a channel delivers messages to instance subscribers, as a result, publications from different instances on different machines do not produce duplicate data on panels.
 
-> **Note:** Live currently does not support Redis Sentinel.  We recommend using a Redis Cluster for high-availability via a k8s helm chart such as the Bitnami Redis chart which has values to provision a Redis Cluster.  Grafana Live can then be pointed to the `redis-headless` service
+{{< admonition type="note" >}}
+Live currently does not support Redis Sentinel. We recommend using a Redis Cluster for high-availability via a k8s helm chart such as the Bitnami Redis chart which has values to provision a Redis Cluster. Grafana Live can then be pointed to the `redis-headless` service.
+{{< /admonition >}}
+
 >
 > ```
 > live:

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -227,12 +227,13 @@ After running:
 
 {{< admonition type="note" >}}
 Live currently does not support Redis Sentinel. We recommend using a Redis Cluster for high-availability via a k8s helm chart such as the Bitnami Redis chart which has values to provision a Redis Cluster. Grafana Live can then be pointed to the `redis-headless` service.
+
+```
+ live:
+   ha_engine: redis
+   ha_engine_address: redis-headless.grafana.svc.cluster.local:6379
+   ha_engine_password: $__file{/your/redis/password/secret/mount}
+```
 {{< /admonition >}}
 
->
-> ```
-> live:
->   ha_engine: redis
->   ha_engine_address: redis-headless.grafana.svc.cluster.local:6379
->   ha_engine_password: $__file{/your/redis/password/secret/mount}
-> ```
+


### PR DESCRIPTION
Documentation update on Grafana Live's Redis Sentinel support and our recommended path for a highly-available Live configuration