### PR TITLE
docs: recorded queries depreciation

### DIFF
--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -15,7 +15,11 @@ title: Recorded queries
 weight: 300
 ---
 
-# Recorded queries
+# DEPRECIATED Recorded queries
+
+{{% admonition type="warning" %}}
+Recorded queries are deprecated.  Please use the new [Grafana Cloud Alerting and Recording Rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
+{{% /admonition %}}
 
 Recorded queries allow you to see trends over time by taking a snapshot of a data point on a set interval. This can give you insight into historic trends.
 

--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -18,7 +18,7 @@ weight: 300
 # DEPRECIATED Recorded queries
 
 {{% admonition type="warning" %}}
-Recorded queries are deprecated.  Please use the new [Grafana Cloud Alerting and Recording Rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
+Recorded queries are deprecated.  Please use the new [Grafana Cloud alerting and recording rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
 {{% /admonition %}}
 
 Recorded queries allow you to see trends over time by taking a snapshot of a data point on a set interval. This can give you insight into historic trends.

--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -18,7 +18,7 @@ weight: 300
 # DEPRECIATED Recorded queries
 
 {{% admonition type="warning" %}}
-Recorded queries are deprecated.  Please use the new [Grafana Cloud alerting and recording rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
+Recorded queries are deprecated. Please use the new [Grafana Cloud alerting and recording rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
 {{% /admonition %}}
 
 Recorded queries allow you to see trends over time by taking a snapshot of a data point on a set interval. This can give you insight into historic trends.

--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -18,7 +18,7 @@ weight: 300
 # DEPRECIATED Recorded queries
 
 {{% admonition type="warning" %}}
-Recorded queries are deprecated. Please use the new [Grafana Cloud alerting and recording rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
+Recorded queries are deprecated. Please use the new [Grafana Managed Recording Rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
 {{% /admonition %}}
 
 Recorded queries allow you to see trends over time by taking a snapshot of a data point on a set interval. This can give you insight into historic trends.


### PR DESCRIPTION
added a depreciation warning and a link to the alerting docs

from slack originally:
The GR 12 team are introducing grafana managed recording rules and deprecating and migrating recorded queries.  I asked Ryan Kehoe and he confirmed that all that is required is a deprecation notice on the recorded queries information (this page: https://grafana.com/docs/grafana/latest/administration/recorded-queries/)  and a link to the new page (already in place):  https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/.  And then add a link to the GMRR page on the deprecation notice / on the recorded queries page.
