### PR TITLE
scopes: marks scopes ff as experimental

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -889,7 +889,7 @@ var (
 		{
 			Name:              "promQLScope",
 			Description:       "In-development feature that will allow injection of labels into prometheus queries.",
-			Stage:             FeatureStageGeneralAvailability,
+			Stage:             FeatureStageExperimental,
 			Owner:             grafanaOSSBigTent,
 			Expression:        "true",
 			HideFromDocs:      true,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -115,7 +115,7 @@ secretsManagementAppPlatform,experimental,@grafana/grafana-operator-experience-s
 alertingSaveStatePeriodic,privatePreview,@grafana/alerting-squad,false,false,false
 alertingSaveStateCompressed,preview,@grafana/alerting-squad,false,false,false
 scopeApi,experimental,@grafana/grafana-app-platform-squad,false,false,false
-promQLScope,GA,@grafana/oss-big-tent,false,false,false
+promQLScope,experimental,@grafana/oss-big-tent,false,false,false
 logQLScope,privatePreview,@grafana/observability-logs,false,false,false
 sqlExpressions,privatePreview,@grafana/grafana-datasources-core-services,false,false,false
 groupToNestedTableTransformation,GA,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2472,12 +2472,15 @@
     {
       "metadata": {
         "name": "promQLScope",
-        "resourceVersion": "1743693517832",
-        "creationTimestamp": "2024-01-29T20:22:17Z"
+        "resourceVersion": "1744353909472",
+        "creationTimestamp": "2024-01-29T20:22:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-04-11 06:45:09.472917 +0000 UTC"
+        }
       },
       "spec": {
         "description": "In-development feature that will allow injection of labels into prometheus queries.",
-        "stage": "GA",
+        "stage": "experimental",
         "codeowner": "@grafana/oss-big-tent",
         "hideFromAdminPage": true,
         "hideFromDocs": true,


### PR DESCRIPTION
~Somehow the scopes feature flag was marked as GA which is not true. ~

~While certain parts of the overall scopes features are stable the sum of all of them are not. ~


This feature flag has been enable for a while and is stable and should be enable by default since its used by ad-hoc queries. 

