### PR TITLE
[release-11.6.1] [IAM] Prepend AppSubURL to redirectURI before validating it

### DIFF
--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -89,11 +89,11 @@ func (hs *HTTPServer) RotateUserAuthTokenRedirect(c *contextmodel.ReqContext) re
 		return response.Redirect(hs.GetRedirectURL(c))
 	}
 
-	redirectTo := c.Query("redirectTo")
+	redirectTo := hs.Cfg.AppSubURL + c.Query("redirectTo")
 	if err := hs.ValidateRedirectTo(redirectTo); err != nil {
 		return response.Redirect(hs.Cfg.AppSubURL + "/")
 	}
-	return response.Redirect(hs.Cfg.AppSubURL + redirectTo)
+	return response.Redirect(redirectTo)
 }
 
 // swagger:route POST /user/auth-tokens/rotate

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -283,7 +283,7 @@ func handleLogin(r *http.Request, w http.ResponseWriter, cfg *setting.Cfg, ident
 			scopedRedirectToCookie, err := r.Cookie(redirectToCookieName)
 			if err == nil {
 				redirectTo, _ := url.QueryUnescape(scopedRedirectToCookie.Value)
-				if redirectTo != "" && validator(redirectTo) == nil {
+				if redirectTo != "" && validator(cfg.AppSubURL+redirectTo) == nil {
 					redirectURL = cfg.AppSubURL + redirectTo
 				}
 				cookies.DeleteCookie(w, redirectToCookieName, cookieOptions(cfg))


### PR DESCRIPTION
Backport 5053aa576d521b81ad561ccd0ef9f2c4d5fffe1a from #103475

---

Closes https://github.com/grafana/grafana/issues/102462

The issue is explained very well in https://github.com/grafana/grafana/issues/102130. I've aimed at keeping the redirectUrl validation as it is, meaning that it still checks that the redirectUrl starts with the AppSubURL. To make validation pass, this PR passes the full redirectUri (AppSubURL + redirectTo) to the validation function instead of just redirectTo.

I've tested it locally quite a lot and didn't notice anything breaking with this change. To replicate the issue, I set the config
```ini
[auth]
token_rotation_interval_minutes = 1
```
then logged into Grafana to get the session cookie. After that, I closed any Grafana tabs to make sure that the token is not rotated in the background, waited 1 minute so that next time we go to Grafana the token needs to be rotated, and then opened a dashboard link. That should redirect to the dashboard page after rotating the token.
