### PR TITLE
DashboardEditPane: Get original panel id for repeated panel edit pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -17,7 +17,7 @@ import {
 } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
-import { isInCloneChain } from '../utils/clone';
+import { containsCloneKey, getOriginalKey, isInCloneChain } from '../utils/clone';
 import { getDashboardSceneFor } from '../utils/utils';
 
 import { DashboardOutline } from './DashboardOutline';
@@ -101,7 +101,9 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> {
       return;
     }
 
-    const obj = sceneGraph.findByKey(this, element.id);
+    const elementId = containsCloneKey(element.id) ? getOriginalKey(element.id) : element.id;
+
+    const obj = sceneGraph.findByKey(this, elementId);
     if (obj) {
       this.selectObject(obj, element.id, options);
     }


### PR DESCRIPTION
editing repeated panel would not persist changes because we were not editing the original panel