### PR TITLE
Alerting: Remove comment references to angular in tests

### DIFF
--- a/public/app/features/alerting/unified/rule-editor/RuleEditorCloudOnlyAllowed.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorCloudOnlyAllowed.test.tsx
@@ -29,8 +29,6 @@ jest.mock('../api/ruler', () => ({
   fetchRulerRulesNamespace: jest.fn(),
 }));
 
-// there's no angular scope in test and things go terribly wrong when trying to render the query editor row.
-// lets just skip it
 jest.mock('app/features/query/components/QueryEditorRow', () => ({
   // eslint-disable-next-line react/display-name
   QueryEditorRow: () => <p>hi</p>,

--- a/public/app/features/alerting/unified/rule-editor/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorRecordingRule.test.tsx
@@ -39,8 +39,6 @@ jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
   AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div>{actions}</div>,
 }));
 
-// there's no angular scope in test and things go terribly wrong when trying to render the query editor row.
-// lets just skip it
 jest.mock('app/features/query/components/QueryEditorRow', () => ({
   // eslint-disable-next-line react/display-name
   QueryEditorRow: () => <p>hi</p>,


### PR DESCRIPTION
**What is this feature?**
Angular has been removed from the codebase - we had two comments referencing this, but the reason for mocking QueryEditor is more complex than just angular. These mocks can stay in place, but removing the comments just so there's no confusion about this being due to angular

Fixes #103869