### PR TITLE
Extension Sidebar Button: Prevent button to have stretched background

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -87,6 +87,9 @@ export function ExtensionToolbarItem() {
 function getStyles(theme: GrafanaTheme2) {
   return {
     button: css({
+      // this is needed because with certain breakpoints the button will get `width: auto`
+      // and the icon will stretch
+      aspectRatio: '1 / 1 !important',
       width: '28px',
       height: '28px',
       padding: 0,


### PR DESCRIPTION
**What is this feature?**

Noticed that there are some breakpoints where the button will get a `width: auto !important`, which will stretch the background.

<img width="126" alt="image" src="https://github.com/user-attachments/assets/96bfbe40-abf1-43ef-b6f8-17cd426a699c" />
<img width="628" alt="image" src="https://github.com/user-attachments/assets/6d09a4eb-d569-4b71-a6d1-ecedd8f0a2c3" />
