### PR TITLE
Alerting: Fix flaky TestIntegrationPrometheusRules test

### DIFF
--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
-
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -25,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // Declare respModel at the function level
@@ -194,6 +194,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 									}`),
 							},
 						},
+						IsPaused: util.Pointer(true),
 					},
 				},
 			},


### PR DESCRIPTION
The test if flaky: [1](https://github.com/grafana/grafana/actions/runs/14307553202/job/40094775346?pr=103518), [2](https://github.com/grafana/grafana/actions/runs/14327333877/job/40155258305?pr=103537), [3](https://github.com/grafana/grafana/actions/runs/14375162490/job/40305752494?pr=103537). 

The test creates an alert rule, and then fetches it from the `/api/prometheus/grafana/api/v1/rules` endpoint. Sometimes by the time it makes the GET request, the rule has already been evaluated once, so the response contains updated information, for example `lastEvaluation` time, alert instances, etc. The test doesn't expect this, so I updated the rule to be paused. With this, it's returned in the `inactive` as expected.