### PR TITLE
Combobox: Fix an issue where custom values would accumulate as typed

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -65,10 +65,12 @@ export function useOptions<T extends string | number>(rawOptions: AsyncOptions<T
     (opts: Array<ComboboxOption<T>>) => {
       let currentOptions: Array<ComboboxOption<T>> = opts;
       if (createCustomValue && userTypedSearch) {
-        //Since the label of a normal option does not have to match its value and a custom option has the same value and label,
-        //we just focus on the value to check if the option already exists
+        // Since the label of a normal option does not have to match its value and a custom option has the same value and label,
+        // we just focus on the value to check if the option already exists
         const customValueExists = opts.some((opt) => opt.value === userTypedSearch);
         if (!customValueExists) {
+          // Make sure to clone the array first to avoid mutating the original array!
+          currentOptions = currentOptions.slice();
           currentOptions.unshift({
             label: userTypedSearch,
             value: userTypedSearch as T,


### PR DESCRIPTION
If you had custom values turned on with async options, the 'custom values' would accumulate as you type. This is because when we added custom options to the list, we were mutating the original options array.

This PR fixes it by cloning the array first.

Fixes https://github.com/grafana/grafana/issues/103859

I tried to write a test for this but was having trouble having it fail with the bug.