### PR TITLE
CloudMigrations: Make table sort case insensitive

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -434,7 +434,7 @@ func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string
 		if errorsOnly {
 			sess.Where("status = ?", cloudmigration.ItemStatusError)
 		}
-		return sess.OrderBy(fmt.Sprintf("%s %s", col, dir)).Find(&resources, &cloudmigration.CloudMigrationResource{
+		return sess.OrderBy(fmt.Sprintf("lower(%s) %s", col, dir)).Find(&resources, &cloudmigration.CloudMigrationResource{
 			SnapshotUID: snapshotUid,
 		})
 	})

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -437,8 +437,8 @@ func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string
 		}
 		// TODO: It would be better if the query builder supported a case-insensitive flag for the .OrderBy() method
 		orderByClause := fmt.Sprintf("lower(%s) %s", col, dir)
-		if ss.db.GetDBType() == migrator.Postgres {
-			// Postgres does not support lower() in ORDER BY -- sorts by case-insensitive by default
+		if ss.db.GetDBType() == migrator.Postgres || // Postgres does not support lower() in ORDER BY -- sorts by case-insensitive by default
+			params.SortColumn == cloudmigration.SortColumnID { // Don't apply a string sort to a numeric column
 			orderByClause = fmt.Sprintf("%s %s", col, dir)
 		}
 		return sess.OrderBy(orderByClause).Find(&resources, &cloudmigration.CloudMigrationResource{

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -437,6 +437,7 @@ func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string
 		}
 		orderByClause := fmt.Sprintf("lower(%s) %s", col, dir)
 		if ss.db.GetDBType() == migrator.Postgres {
+			// Postgres does not support lower() in ORDER BY -- sorts by case-insensitive by default
 			orderByClause = fmt.Sprintf("%s %s", col, dir)
 		}
 		return sess.OrderBy(orderByClause).Find(&resources, &cloudmigration.CloudMigrationResource{

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -435,6 +435,7 @@ func (ss *sqlStore) getSnapshotResources(ctx context.Context, snapshotUid string
 		if errorsOnly {
 			sess.Where("status = ?", cloudmigration.ItemStatusError)
 		}
+		// TODO: It would be better if the query builder supported a case-insensitive flag for the .OrderBy() method
 		orderByClause := fmt.Sprintf("lower(%s) %s", col, dir)
 		if ss.db.GetDBType() == migrator.Postgres {
 			// Postgres does not support lower() in ORDER BY -- sorts by case-insensitive by default

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -357,48 +357,77 @@ func Test_SnapshotResources(t *testing.T) {
 			assert.Equal(t, "2", results[0].UID)
 		})
 	})
+}
 
-	t.Run("test case-insensitive sorting", func(t *testing.T) {
-		// Create test data with mixed case names
-		resources := []cloudmigration.CloudMigrationResource{
-			{UID: "1", SnapshotUID: "abc123", Name: "B", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
-			{UID: "2", SnapshotUID: "abc123", Name: "aa", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
-			{UID: "3", SnapshotUID: "abc123", Name: "ba", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
-			{UID: "4", SnapshotUID: "abc123", Name: "A", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
-		}
+func Test_SnapshotResourceCaseInsensitiveSorting(t *testing.T) {
+	t.Parallel()
 
-		err := s.db.WithDbSession(ctx, func(sess *db.Session) error {
-			_, err := sess.Insert(resources)
-			return err
-		})
-		require.NoError(t, err)
+	_, s := setUpTest(t)
+	ctx := context.Background()
 
-		// Test ascending sort
-		results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-			ResultPage:  1,
-			ResultLimit: 100,
-			SortColumn:  cloudmigration.SortColumnName,
-			SortOrder:   cloudmigration.SortOrderAsc,
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "A", results[0].Name)
-		assert.Equal(t, "aa", results[1].Name)
-		assert.Equal(t, "B", results[2].Name)
-		assert.Equal(t, "ba", results[3].Name)
+	// Create test data with mixed case names
+	resources := []cloudmigration.CloudMigrationResource{
+		{UID: "1", SnapshotUID: "abc123", Name: "B", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
+		{UID: "2", SnapshotUID: "abc123", Name: "aa", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
+		{UID: "3", SnapshotUID: "abc123", Name: "ba", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
+		{UID: "4", SnapshotUID: "abc123", Name: "A", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
+	}
 
-		// Test descending sort
-		results, err = s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
-			ResultPage:  1,
-			ResultLimit: 100,
-			SortColumn:  cloudmigration.SortColumnName,
-			SortOrder:   cloudmigration.SortOrderDesc,
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "ba", results[0].Name)
-		assert.Equal(t, "B", results[1].Name)
-		assert.Equal(t, "aa", results[2].Name)
-		assert.Equal(t, "A", results[3].Name)
+	err := s.db.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Insert(resources)
+		return err
 	})
+	require.NoError(t, err)
+
+	// Test ascending sort
+	results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+		ResultPage:  1,
+		ResultLimit: 100,
+		SortColumn:  cloudmigration.SortColumnName,
+		SortOrder:   cloudmigration.SortOrderAsc,
+	})
+	require.NoError(t, err)
+	assert.True(t, testNameComesBefore(t, results, "A", "aa"))
+	assert.True(t, testNameComesBefore(t, results, "B", "ba"))
+	assert.True(t, testNameComesBefore(t, results, "A", "B"))
+	assert.True(t, testNameComesBefore(t, results, "aa", "B"))
+	assert.True(t, testNameComesBefore(t, results, "aa", "ba"))
+	assert.True(t, testNameComesBefore(t, results, "A", "ba"))
+	assert.True(t, testNameComesBefore(t, results, "A", "B"))
+
+	// Test descending sort
+	results, err = s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+		ResultPage:  1,
+		ResultLimit: 100,
+		SortColumn:  cloudmigration.SortColumnName,
+		SortOrder:   cloudmigration.SortOrderDesc,
+	})
+	require.NoError(t, err)
+	assert.True(t, testNameComesBefore(t, results, "ba", "B"))
+	assert.True(t, testNameComesBefore(t, results, "aa", "A"))
+	assert.True(t, testNameComesBefore(t, results, "ba", "B"))
+	assert.True(t, testNameComesBefore(t, results, "aa", "A"))
+	assert.True(t, testNameComesBefore(t, results, "ba", "B"))
+	assert.True(t, testNameComesBefore(t, results, "aa", "A"))
+}
+
+func testNameComesBefore(t *testing.T, input []cloudmigration.CloudMigrationResource, first string, second string) bool {
+	t.Helper()
+
+	foundFirst, foundSecond := false, false
+	for _, r := range input {
+		if r.Name == second {
+			foundSecond = true
+			continue
+		}
+		if r.Name == first {
+			if foundSecond {
+				return false
+			}
+			foundFirst = true
+		}
+	}
+	return foundFirst && foundSecond
 }
 
 func TestGetSnapshotList(t *testing.T) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -357,6 +357,48 @@ func Test_SnapshotResources(t *testing.T) {
 			assert.Equal(t, "2", results[0].UID)
 		})
 	})
+
+	t.Run("test case-insensitive sorting", func(t *testing.T) {
+		// Create test data with mixed case names
+		resources := []cloudmigration.CloudMigrationResource{
+			{UID: "1", SnapshotUID: "abc123", Name: "B", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
+			{UID: "2", SnapshotUID: "abc123", Name: "aa", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
+			{UID: "3", SnapshotUID: "abc123", Name: "ba", Type: cloudmigration.DashboardDataType, Status: cloudmigration.ItemStatusOK},
+			{UID: "4", SnapshotUID: "abc123", Name: "A", Type: cloudmigration.AlertRuleType, Status: cloudmigration.ItemStatusOK},
+		}
+
+		err := s.db.WithDbSession(ctx, func(sess *db.Session) error {
+			_, err := sess.Insert(resources)
+			return err
+		})
+		require.NoError(t, err)
+
+		// Test ascending sort
+		results, err := s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnName,
+			SortOrder:   cloudmigration.SortOrderAsc,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "A", results[0].Name)
+		assert.Equal(t, "aa", results[1].Name)
+		assert.Equal(t, "B", results[2].Name)
+		assert.Equal(t, "ba", results[3].Name)
+
+		// Test descending sort
+		results, err = s.getSnapshotResources(ctx, "abc123", cloudmigration.SnapshotResultQueryParams{
+			ResultPage:  1,
+			ResultLimit: 100,
+			SortColumn:  cloudmigration.SortColumnName,
+			SortOrder:   cloudmigration.SortOrderDesc,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ba", results[0].Name)
+		assert.Equal(t, "B", results[1].Name)
+		assert.Equal(t, "aa", results[2].Name)
+		assert.Equal(t, "A", results[3].Name)
+	})
 }
 
 func TestGetSnapshotList(t *testing.T) {


### PR DESCRIPTION
**Context**

Addressing a small nit pointed out by Daniel. Postgres has case-insensitive sorting by default. MySQL and SQLite require it in the query.

Tested in SQLite, MySQL, and Postgres.