### PR TITLE
ElasticSearch: Improve index pattern error messaging and docs

### DIFF
--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -127,7 +127,7 @@ Additional settings are optional settings that can be configured for more contro
 
 The following settings are specific to the Elasticsearch data source.
 
-- **Index name** - Use the index settings to specify a default for the `time field` and your Elasticsearch index's name. You can use a time pattern, such as `YYYY.MM.DD`, or a wildcard for the index name.
+- **Index name** - Use the index settings to specify a default for the `time field` and your Elasticsearch index's name. You can use a time pattern, for example `[logstash-]YYYY.MM.DD`, or a wildcard for the index name. When specifying a time pattern, the fixed part(s) of the pattern should be wrapped in square brackets.
 
 - **Pattern** - Select the matching pattern if using one in your index name. Options include:
 
@@ -137,6 +137,8 @@ The following settings are specific to the Elasticsearch data source.
   - weekly
   - monthly
   - yearly
+
+Only select a pattern option if you have specified a time pattern in the Index name field.
 
 - **Time field name** - Name of the time field. The default value is @timestamp. You can enter a different name.
 

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -162,7 +162,11 @@ func (c *baseClientImpl) executeRequest(method, uriPath, uriQuery string, body [
 
 func (c *baseClientImpl) ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearchResponse, error) {
 	var err error
-	multiRequests := c.createMultiSearchRequests(r.Requests)
+	multiRequests, err := c.createMultiSearchRequests(r.Requests)
+	if err != nil {
+		return nil, err
+	}
+
 	queryParams := c.getMultiSearchQueryParameters()
 	_, span := tracing.DefaultTracer().Start(c.ctx, "datasource.elasticsearch.queryData.executeMultisearch", trace.WithAttributes(
 		attribute.String("queryParams", queryParams),
@@ -429,14 +433,14 @@ func skipUnknownField(dec *json.Decoder) error {
 	}
 }
 
-func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchRequest) []*multiRequest {
+func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchRequest) ([]*multiRequest, error) {
 	multiRequests := []*multiRequest{}
 
 	for _, searchReq := range searchRequests {
 		indices, err := c.indexPattern.GetIndices(searchReq.TimeRange)
 		if err != nil {
-			c.logger.Error("Failed to get indices from index pattern", "error", err)
-			continue
+			err := fmt.Errorf("failed to get indices from index pattern. %s", err)
+			return nil, backend.DownstreamError(err)
 		}
 		mr := multiRequest{
 			header: map[string]any{
@@ -451,7 +455,7 @@ func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchReque
 		multiRequests = append(multiRequests, &mr)
 	}
 
-	return multiRequests
+	return multiRequests, nil
 }
 
 func (c *baseClientImpl) getMultiSearchQueryParameters() string {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -183,6 +183,21 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		require.Contains(t, bodyString, "metrics-2018.05.17")
 	})
 
+	t.Run("Should return DownstreamError when index is invalid", func(t *testing.T) {
+		ds := &DatasourceInfo{
+			URL:      "test",
+			Database: "index-with-no-pattern",
+			Interval: intervalMonthly,
+		}
+
+		c, err := NewClient(context.Background(), ds, log.NewNullLogger())
+		require.NoError(t, err)
+
+		_, err = c.ExecuteMultisearch(&MultiSearchRequest{Requests: []*SearchRequest{{}}})
+		assert.Equal(t, "failed to get indices from index pattern. invalid index pattern index-with-no-pattern. Specify an index with a pattern or select 'No pattern'", err.Error())
+		require.True(t, backend.IsDownstreamError(err))
+	})
+
 	t.Run("Should return DownstreamError when decoding response fails", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			rw.Header().Set("Content-Type", "application/x-ndjson")

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -194,7 +194,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = c.ExecuteMultisearch(&MultiSearchRequest{Requests: []*SearchRequest{{}}})
-		assert.Equal(t, "failed to get indices from index pattern. invalid index pattern index-with-no-pattern. Specify an index with a pattern or select 'No pattern'", err.Error())
+		assert.Equal(t, "failed to get indices from index pattern. invalid index pattern index-with-no-pattern. Specify an index with a time pattern or select 'No pattern'", err.Error())
 		require.True(t, backend.IsDownstreamError(err))
 	})
 

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -136,7 +136,12 @@ func (ip *dynamicIndexPattern) GetIndices(timeRange backend.TimeRange) ([]string
 	indices := make([]string, 0)
 
 	for _, t := range intervals {
-		indices = append(indices, formatDate(t, ip.pattern))
+		index, err := formatDate(t, ip.pattern)
+		if err != nil {
+			return []string{}, err
+		} else {
+			indices = append(indices, index)
+		}
 	}
 
 	return indices, nil
@@ -251,13 +256,16 @@ func (i *yearlyInterval) Generate(from, to time.Time) []time.Time {
 	return intervals
 }
 
-func formatDate(t time.Time, pattern string) string {
+func formatDate(t time.Time, pattern string) (string, error) {
 	var formattedDatePatterns []string
 	var bases []string
 	base := ""
 	isBaseFirst := false
 
 	baseStart := strings.Index(pattern, "[")
+	if baseStart == -1 {
+		return "", fmt.Errorf("invalid index pattern %s. Specify an index with a time pattern or select 'No pattern'", pattern)
+	}
 	for baseStart != -1 {
 		var datePattern string
 
@@ -344,7 +352,7 @@ func formatDate(t time.Time, pattern string) string {
 		fullPattern = append(fullPattern, bases...)
 	}
 
-	return strings.Join(fullPattern, "")
+	return strings.Join(fullPattern, ""), nil
 }
 
 func patternToLayout(pattern string) string {

--- a/pkg/tsdb/elasticsearch/client/index_pattern_test.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern_test.go
@@ -121,7 +121,7 @@ func TestIndexPattern(t *testing.T) {
 		indices, err := ip.GetIndices(timeRange)
 		assert.Equal(t, indices, []string{})
 		require.Error(t, err)
-		assert.Equal(t, err.Error(), "invalid index pattern kibana-sample-data-logs. Specify an index with a pattern or select 'No pattern'")
+		assert.Equal(t, err.Error(), "invalid index pattern kibana-sample-data-logs. Specify an index with a time pattern or select 'No pattern'")
 	})
 
 	t.Run("Hourly interval", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/client/index_pattern_test.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,6 +107,21 @@ func TestIndexPattern(t *testing.T) {
 				require.Equal(t, indices[0], "data-2018.03")
 			})
 		})
+	})
+
+	t.Run("Dynamic index pattern with error", func(t *testing.T) {
+		from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
+		to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
+		timeRange := backend.TimeRange{
+			From: from,
+			To:   to,
+		}
+		ip, err := NewIndexPattern(intervalHourly, "kibana-sample-data-logs")
+		require.NoError(t, err)
+		indices, err := ip.GetIndices(timeRange)
+		assert.Equal(t, indices, []string{})
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid index pattern kibana-sample-data-logs. Specify an index with a pattern or select 'No pattern'")
 	})
 
 	t.Run("Hourly interval", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/healthcheck.go
+++ b/pkg/tsdb/elasticsearch/healthcheck.go
@@ -160,6 +160,10 @@ func validateIndex(ctx context.Context, ds *es.DatasourceInfo) (message string, 
 		return fmt.Sprintf("Failed to get index pattern: %s", err), "error"
 	}
 
+	if len(indices) == 0 && ds.Interval != "" {
+		return "Unable to find pattern in index name. Either add an index pattern or specify 'No pattern", "error"
+	}
+
 	indexList := strings.Join(indices, ",")
 
 	validateUrl := fmt.Sprintf("%s/%s/_field_caps?fields=%s", ds.URL, indexList, ds.ConfiguredFields.TimeField)

--- a/pkg/tsdb/elasticsearch/healthcheck.go
+++ b/pkg/tsdb/elasticsearch/healthcheck.go
@@ -160,10 +160,6 @@ func validateIndex(ctx context.Context, ds *es.DatasourceInfo) (message string, 
 		return fmt.Sprintf("Failed to get index pattern: %s", err), "error"
 	}
 
-	if len(indices) == 0 && ds.Interval != "" {
-		return "Unable to find pattern in index name. Either add an index pattern or specify 'No pattern", "error"
-	}
-
 	indexList := strings.Join(indices, ",")
 
 	validateUrl := fmt.Sprintf("%s/%s/_field_caps?fields=%s", ds.URL, indexList, ds.ConfiguredFields.TimeField)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We got a couple of bug reports before where the users were specifying an index without a time pattern, i.e. `kibana-logs` and at the same time selecting a Pattern. This caused us to build the dynamic index name wrong. This adds some validation of the healthcheck and the API calls to _multisearch. They will now return a "invalid pattern" error before sending a request to ElasticSearch. 
<img width="700" alt="Screenshot 2025-04-11 at 16 17 27" src="https://github.com/user-attachments/assets/6916ba10-f0b3-4c98-adc3-d5ce8046b970" />

This PR also updates the docs to make it more clear that pattern should only be specified if there's a dynamic time pattern index specified

**Why do we need this feature?**

Improve user experience and prevent downstream errors

**Who is this feature for?**

ElasticSearch users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
