### PR TITLE
Azure Prometheus: Add Azure prom to Azure forward auth setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1064,8 +1064,8 @@ user_identity_federated_credential_audience =
 username_assertion =
 
 # Set the plugins that will receive Azure settings for each request (via plugin context)
-# By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
-forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql
+# By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL, Azure Prometheus).
+forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql, grafana-azureprometheus-datasource
 
 # Specifies whether Entra password auth can be used for the MSSQL data source
 # Disabled by default, needs to be explicitly enabled

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1048,7 +1048,7 @@
 
 # Set the plugins that will receive Azure settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
-;forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql
+;forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql, grafana-azureprometheus-datasourc
 
 # Specifies whether Entra password auth can be used for the MSSQL data source
 # Disabled by default, needs to be explicitly enabled

--- a/pkg/services/pluginsintegration/pluginconfig/request_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/request_test.go
@@ -311,7 +311,7 @@ func TestRequestConfigProvider_PluginRequestConfig_azure(t *testing.T) {
 			UsernameAssertion:           true,
 		},
 		UserIdentityFallbackCredentialsEnabled: true,
-		ForwardSettingsPlugins:                 []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql"},
+		ForwardSettingsPlugins:                 []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql", "grafana-azureprometheus-datasource"},
 		AzureEntraPasswordCredentialsEnabled:   true,
 	}
 


### PR DESCRIPTION
Add `grafana-azureprometheus-datasource`  to `forward_settings_to_plugins`. Azure prom will not be able to authenticate without forwarding Azure settings to it.