### PR TITLE
TableNG: Fix cell type logic

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/GeoCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/GeoCell.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/css';
+import WKT from 'ol/format/WKT';
+import { Geometry } from 'ol/geom';
+
+import { useStyles2 } from '../../../../themes';
+import { GeoCellProps } from '../types';
+
+export function GeoCell({ value, justifyContent, height }: GeoCellProps) {
+  const styles = useStyles2(getStyles);
+
+  let disp = '';
+
+  if (value instanceof Geometry) {
+    disp = new WKT().writeGeometry(value, {
+      featureProjection: 'EPSG:3857',
+      dataProjection: 'EPSG:4326',
+    });
+  } else if (value != null) {
+    disp = `${value}`;
+  }
+
+  return (
+    <div className={styles.cell} style={{ justifyContent, height }}>
+      <div className={styles.cellText} style={{ fontFamily: 'monospace' }}>
+        {disp}
+      </div>
+    </div>
+  );
+}
+
+const getStyles = () => ({
+  cell: css({
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '0 8px',
+  }),
+  cellText: css({
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }),
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -119,8 +119,7 @@ export function TableCellNG(props: TableCellNGProps) {
     default:
       // Handle auto cell type detection
       if (field.type === FieldType.geo) {
-        cell = <></>;
-        // cell = <GeoCell tableStyles={styles} cellProps={props} field={field} innerWidth={divWidth} rowIdx={rowIdx} />;
+        cell = <JSONCell {...commonProps} />;
       } else if (field.type === FieldType.frame) {
         const firstValue = field.values[0];
         if (isDataFrame(firstValue) && isTimeSeriesFrame(firstValue)) {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -135,6 +135,8 @@ export function TableCellNG(props: TableCellNGProps) {
       break;
   }
 
+  const isJSONCell = cell instanceof JSONCell;
+
   const handleMouseEnter = () => {
     setIsHovered(true);
     if (shouldTextOverflow()) {
@@ -189,10 +191,7 @@ export function TableCellNG(props: TableCellNGProps) {
               onClick={() => {
                 setContextMenuProps({
                   value: String(value ?? ''),
-                  mode:
-                    cellType === TableCellDisplayMode.JSONView
-                      ? TableCellInspectorMode.code
-                      : TableCellInspectorMode.text,
+                  mode: isJSONCell ? TableCellInspectorMode.code : TableCellInspectorMode.text,
                 });
                 setIsInspecting(true);
               }}

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/css';
+import { WKT } from 'ol/format';
+import { Geometry } from 'ol/geom';
 import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { FieldType, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';
@@ -188,12 +190,22 @@ export function TableCellNG(props: TableCellNGProps) {
               name="eye"
               tooltip={t('grafana-ui.table.cell-inspect-tooltip', 'Inspect value')}
               onClick={() => {
+                let inspectValue = value;
+                let mode = TableCellInspectorMode.text;
+
+                if (field.type === FieldType.geo && value instanceof Geometry) {
+                  inspectValue = new WKT().writeGeometry(value, {
+                    featureProjection: 'EPSG:3857',
+                    dataProjection: 'EPSG:4326',
+                  });
+                  mode = TableCellInspectorMode.code;
+                } else if (cellType === TableCellDisplayMode.JSONView) {
+                  mode = TableCellInspectorMode.code;
+                }
+
                 setContextMenuProps({
-                  value: String(value ?? ''),
-                  mode:
-                    cellType === TableCellDisplayMode.JSONView
-                      ? TableCellInspectorMode.code
-                      : TableCellInspectorMode.text,
+                  value: String(inspectValue ?? ''),
+                  mode,
                 });
                 setIsInspecting(true);
               }}

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/css';
 import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { FieldType, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';
 import { TableAutoCellOptions, TableCellDisplayMode } from '@grafana/schema';
 
 import { useStyles2 } from '../../../../themes';
 import { t } from '../../../../utils/i18n';
 import { IconButton } from '../../../IconButton/IconButton';
+// import { GeoCell } from '../../Cells/GeoCell';
 import { TableCellInspectorMode } from '../../TableCellInspector';
 import {
   CellColors,
@@ -78,52 +79,31 @@ export function TableCellNG(props: TableCellNGProps) {
     }
   }, [divWidthRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Common props for all cells
+  const commonProps = {
+    value,
+    field,
+    rowIdx,
+    justifyContent,
+  };
+
   // Get the correct cell type
   let cell: ReactNode = null;
   switch (cellType) {
     case TableCellDisplayMode.Sparkline:
-      cell = (
-        <SparklineCell
-          value={value}
-          field={field}
-          theme={theme}
-          timeRange={timeRange}
-          width={divWidth}
-          rowIdx={rowIdx}
-          justifyContent={justifyContent}
-        />
-      );
+      cell = <SparklineCell {...commonProps} theme={theme} timeRange={timeRange} width={divWidth} />;
       break;
     case TableCellDisplayMode.Gauge:
     case TableCellDisplayMode.BasicGauge:
     case TableCellDisplayMode.GradientGauge:
     case TableCellDisplayMode.LcdGauge:
-      cell = (
-        <BarGaugeCell
-          value={value}
-          field={field}
-          theme={theme}
-          timeRange={timeRange}
-          height={height}
-          width={divWidth}
-          rowIdx={rowIdx}
-        />
-      );
+      cell = <BarGaugeCell {...commonProps} theme={theme} timeRange={timeRange} height={height} width={divWidth} />;
       break;
     case TableCellDisplayMode.Image:
-      cell = (
-        <ImageCell
-          cellOptions={cellOptions}
-          field={field}
-          height={height}
-          justifyContent={justifyContent}
-          value={value}
-          rowIdx={rowIdx}
-        />
-      );
+      cell = <ImageCell {...commonProps} cellOptions={cellOptions} height={height} />;
       break;
     case TableCellDisplayMode.JSONView:
-      cell = <JSONCell value={value} justifyContent={justifyContent} field={field} rowIdx={rowIdx} />;
+      cell = <JSONCell {...commonProps} />;
       break;
     case TableCellDisplayMode.DataLinks:
       cell = <DataLinksCell field={field} rowIdx={rowIdx} />;
@@ -137,15 +117,23 @@ export function TableCellNG(props: TableCellNGProps) {
       break;
     case TableCellDisplayMode.Auto:
     default:
-      cell = (
-        <AutoCell
-          value={value}
-          field={field}
-          justifyContent={justifyContent}
-          rowIdx={rowIdx}
-          cellOptions={cellOptions}
-        />
-      );
+      // Handle auto cell type detection
+      if (field.type === FieldType.geo) {
+        cell = <></>;
+        // cell = <GeoCell tableStyles={styles} cellProps={props} field={field} innerWidth={divWidth} rowIdx={rowIdx} />;
+      } else if (field.type === FieldType.frame) {
+        const firstValue = field.values[0];
+        if (isDataFrame(firstValue) && isTimeSeriesFrame(firstValue)) {
+          cell = <SparklineCell {...commonProps} theme={theme} timeRange={timeRange} width={divWidth} />;
+        } else {
+          cell = <JSONCell {...commonProps} />;
+        }
+      } else if (field.type === FieldType.other) {
+        cell = <JSONCell {...commonProps} />;
+      } else {
+        cell = <AutoCell {...commonProps} cellOptions={cellOptions} />;
+      }
+      break;
   }
 
   const handleMouseEnter = () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -22,6 +22,7 @@ import { ActionsCell } from './ActionsCell';
 import AutoCell from './AutoCell';
 import { BarGaugeCell } from './BarGaugeCell';
 import { DataLinksCell } from './DataLinksCell';
+import { GeoCell } from './GeoCell';
 import { ImageCell } from './ImageCell';
 import { JSONCell } from './JSONCell';
 import { SparklineCell } from './SparklineCell';
@@ -119,7 +120,7 @@ export function TableCellNG(props: TableCellNGProps) {
     default:
       // Handle auto cell type detection
       if (field.type === FieldType.geo) {
-        cell = <></>;
+        cell = <GeoCell {...commonProps} height={height} />;
       } else if (field.type === FieldType.frame) {
         const firstValue = field.values[0];
         if (isDataFrame(firstValue) && isTimeSeriesFrame(firstValue)) {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -119,7 +119,7 @@ export function TableCellNG(props: TableCellNGProps) {
     default:
       // Handle auto cell type detection
       if (field.type === FieldType.geo) {
-        cell = <JSONCell {...commonProps} />;
+        cell = <></>;
       } else if (field.type === FieldType.frame) {
         const firstValue = field.values[0];
         if (isDataFrame(firstValue) && isTimeSeriesFrame(firstValue)) {
@@ -134,8 +134,6 @@ export function TableCellNG(props: TableCellNGProps) {
       }
       break;
   }
-
-  const isJSONCell = cell instanceof JSONCell;
 
   const handleMouseEnter = () => {
     setIsHovered(true);
@@ -191,7 +189,10 @@ export function TableCellNG(props: TableCellNGProps) {
               onClick={() => {
                 setContextMenuProps({
                   value: String(value ?? ''),
-                  mode: isJSONCell ? TableCellInspectorMode.code : TableCellInspectorMode.text,
+                  mode:
+                    cellType === TableCellDisplayMode.JSONView
+                      ? TableCellInspectorMode.code
+                      : TableCellInspectorMode.text,
                 });
                 setIsInspecting(true);
               }}

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -207,6 +207,12 @@ export interface DataLinksCellProps {
   rowIdx: number;
 }
 
+export interface GeoCellProps {
+  value: TableCellValue;
+  justifyContent: Property.JustifyContent;
+  height: number;
+}
+
 export interface ActionCellProps {
   actions?: ActionModel[];
 }


### PR DESCRIPTION
## What does this PR do? 📓 

TableOG has this function to check for component type based on on cell type + other logic `getCellComponent`. In TableNG, nothing is happening to check the additional logic we see in that function. So incorporate that into TableCellNG. 

This needs to be re-written in the future to be much better structured. But this will have to do for now.

This bug surfaced because an "auto" cell in a user's table was supposed to be rendering as Sparkline but wasn't. The below logic in TableOG handles that, but didn't get ported over. 

**Update:** Also fixes another reported bug for `fieldType.other`, which _should_ render JSON cells, but currently isn't. 

Relevant text block below. This is the "default" case for the switch. So work through all other explicit types first, then handle this forking logic. 

``` javascript
       // Handle auto cell type detection
      if (field.type === FieldType.geo) {
        cell = <></>;
      } else if (field.type === FieldType.frame) {
        const firstValue = field.values[0];
        if (isDataFrame(firstValue) && isTimeSeriesFrame(firstValue)) {
          cell = <SparklineCell {...commonProps} theme={theme} timeRange={timeRange} width={divWidth} />;
        } else {
          cell = <JSONCell {...commonProps} />;
        }
      } else if (field.type === FieldType.other) {
        cell = <JSONCell {...commonProps} />;
      } else {
        cell = <AutoCell {...commonProps} cellOptions={cellOptions} />;
      }
      break;
```

To test, check out this dashboard on main vs. on this branch: [Table Sparklines and more-1744385826127.json](https://github.com/user-attachments/files/19709760/Table.Sparklines.and.more-1744385826127.json)
