### PR TITLE
Chore: Skip database integration tests when files are not changed

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -18,7 +18,27 @@ concurrency:
 permissions: {}
 
 jobs:
+  detect-changes:
+    name: Detect whether code changed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # required to get more history in the changed-files action
+          fetch-depth: 2
+      - name: Detect changes
+        id: detect-changes
+        uses: ./.github/actions/change-detection
+        with:
+          self: .github/workflows/pr-test-integration.yml
+
   sqlite:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     strategy:
       matrix:
         shard: [
@@ -49,6 +69,8 @@ jobs:
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
   mysql:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     strategy:
       matrix:
         shard: [
@@ -95,6 +117,8 @@ jobs:
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           CGO_ENABLED=0 go test -p=1 -tags=mysql -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
   postgres:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     strategy:
       matrix:
         shard: [


### PR DESCRIPTION
**What is this feature?**
Skip the integration tests unless relevant files have been changed.
Now uses the `detect-changes` approach that we have elsewhere

On Drone, backend tests were only run when these files were changed:
https://github.com/grafana/grafana/blob/c5760eb147c50ce31209a8aab1f5788c7fa92486/.drone.yml#L263-L274

**Why do we need this feature?**
Avoid unnecessary running of integration tests that are flakey at this time anyway
