### PR TITLE
K8s: Dashboards: Fix error handling

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -270,7 +270,7 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 	// Validate folder existence if specified
 	if !a.IsDryRun() && accessor.GetFolder() != "" {
 		if err := b.validateFolderExists(ctx, accessor.GetFolder(), id.GetOrgID()); err != nil {
-			return apierrors.NewBadRequest(err.Error())
+			return apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), accessor.GetFolder())
 		}
 	}
 
@@ -330,7 +330,7 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 	// Validate folder existence if specified and changed
 	if !a.IsDryRun() && newAccessor.GetFolder() != "" && newAccessor.GetFolder() != oldAccessor.GetFolder() {
 		if err := b.validateFolderExists(ctx, newAccessor.GetFolder(), nsInfo.OrgID); err != nil {
-			return apierrors.NewBadRequest(err.Error())
+			return apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), newAccessor.GetFolder())
 		}
 	}
 

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -254,12 +254,12 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 
 	// Basic validations
 	if err := b.dashboardService.ValidateBasicDashboardProperties(title, accessor.GetName(), accessor.GetMessage()); err != nil {
-		return err
+		return apierrors.NewBadRequest(err.Error())
 	}
 
 	// Validate refresh interval
 	if err := b.dashboardService.ValidateDashboardRefreshInterval(b.cfg.MinRefreshInterval, refresh); err != nil {
-		return err
+		return apierrors.NewBadRequest(err.Error())
 	}
 
 	id, err := identity.GetRequester(ctx)
@@ -270,7 +270,7 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 	// Validate folder existence if specified
 	if !a.IsDryRun() && accessor.GetFolder() != "" {
 		if err := b.validateFolderExists(ctx, accessor.GetFolder(), id.GetOrgID()); err != nil {
-			return err
+			return apierrors.NewBadRequest(err.Error())
 		}
 	}
 
@@ -288,7 +288,7 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 			return err
 		}
 		if quotaReached {
-			return dashboards.ErrQuotaReached
+			return apierrors.NewForbidden(dashv1.DashboardResourceInfo.GroupResource(), a.GetName(), dashboards.ErrQuotaReached)
 		}
 	}
 
@@ -324,19 +324,19 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 
 	// Basic validations
 	if err := b.dashboardService.ValidateBasicDashboardProperties(title, newAccessor.GetName(), newAccessor.GetMessage()); err != nil {
-		return err
+		return apierrors.NewBadRequest(err.Error())
 	}
 
 	// Validate folder existence if specified and changed
 	if !a.IsDryRun() && newAccessor.GetFolder() != "" && newAccessor.GetFolder() != oldAccessor.GetFolder() {
 		if err := b.validateFolderExists(ctx, newAccessor.GetFolder(), nsInfo.OrgID); err != nil {
-			return err
+			return apierrors.NewBadRequest(err.Error())
 		}
 	}
 
 	// Validate refresh interval
 	if err := b.dashboardService.ValidateDashboardRefreshInterval(b.cfg.MinRefreshInterval, refresh); err != nil {
-		return err
+		return apierrors.NewBadRequest(err.Error())
 	}
 
 	allowOverwrite := false // TODO: Add support for overwrite flag
@@ -345,7 +345,7 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 		if allowOverwrite {
 			newAccessor.SetGeneration(oldAccessor.GetGeneration())
 		} else {
-			return dashboards.ErrDashboardVersionMismatch
+			return apierrors.NewBadRequest(dashboards.ErrDashboardVersionMismatch.Error())
 		}
 	}
 

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -212,7 +212,7 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 		t.Run("reject dashboard with non-existent folder UID", func(t *testing.T) {
 			nonExistentFolderUID := "non-existent-folder-uid"
 			_, err := createDashboard(t, adminClient, "Dashboard in Non-existent Folder", &nonExistentFolderUID, nil)
-			ctx.Helper.EnsureStatusError(err, http.StatusNotFound, "folder not found")
+			ctx.Helper.EnsureStatusError(err, http.StatusNotFound, "folders.folder.grafana.app \"non-existent-folder-uid\" not found")
 		})
 	})
 


### PR DESCRIPTION
**What is this feature?**

This PR makes sure that we return api errors in validation hooks so that we get the correct error response code in /apis


**For example:**
Before:
```
curl -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer <>' localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards/tests -d '{"spec": {"title": "testing", "refresh": "1ns"}, "metadata": {"name": "tests"}}'
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Dashboard refresh interval is too low",
  "code": 500
}%
```

After:
```
curl -X PUT -H 'Content-Type: application/json' -H 'Authorization:
Bearer <>' localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards/tests -d '{"spec": {"title": "testing", "refresh": "1ns"}, "metadata": {"name": "tests"}}'
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Dashboard refresh interval is too low",
  "reason": "BadRequest",
  "code": 400
}%
```

Closes https://github.com/grafana/app-platform-wg/issues/266