### PR TITLE
[release-11.5.4] Canvas: Fix layout calcs for scale mode

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -320,8 +320,8 @@ export class ElementState implements LayerElement {
         placement.height = height;
         break;
       case VerticalConstraint.Scale:
-        placement.top = (relativeTop / (parentContainer?.height ?? height)) * 100;
-        placement.bottom = (relativeBottom / (parentContainer?.height ?? height)) * 100;
+        placement.top = (relativeTop / (parentContainer?.height ?? height)) * 100 * transformScale;
+        placement.bottom = (relativeBottom / (parentContainer?.height ?? height)) * 100 * transformScale;
         break;
     }
 
@@ -346,8 +346,8 @@ export class ElementState implements LayerElement {
         placement.width = width;
         break;
       case HorizontalConstraint.Scale:
-        placement.left = (relativeLeft / (parentContainer?.width ?? width)) * 100;
-        placement.right = (relativeRight / (parentContainer?.width ?? width)) * 100;
+        placement.left = (relativeLeft / (parentContainer?.width ?? width)) * 100 * transformScale;
+        placement.right = (relativeRight / (parentContainer?.width ?? width)) * 100 * transformScale;
         break;
     }
 


### PR DESCRIPTION
Backport 5efb620f1bb71231c296519bfbcc3ccadcaddfc8 from #103408

---

For elements in canvas that are positioned using `Scale` mode, with `canvasPanelPanZoom` enabled, upon interacting with them (select, resize, etc...) during zoom, elements are growing unexpectedly. To mitigate this, we need to undo `transformScale` for those cases.

For an element that is placed using `Scale` mode:
![image](https://github.com/user-attachments/assets/f98baccf-530c-4e49-9ac0-6d2692329baf)

Before:
![Apr-03-2025 13-03-30](https://github.com/user-attachments/assets/dcafd8fa-1329-4679-8767-ba61048b7880)

After:
![Apr-03-2025 13-03-58](https://github.com/user-attachments/assets/83514a78-c636-46b1-a943-5b7272691bcd)

Fixes https://github.com/grafana/support-escalations/issues/15551
