### PR TITLE
Chore: Better builtin variable check during parsing the code

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -39,13 +39,12 @@ import {
 import { QueryBuilderLabelFilter, QueryBuilderOperation } from './shared/types';
 import { PromVisualQuery, PromVisualQueryBinary } from './types';
 
+
 /**
  * Parses a PromQL query into a visual query model.
  *
- * It traverses the tree and uses sort of state machine to update the query model. The query model is modified
- * during the traversal and sent to each handler as context.
- *
- * @param expr
+ * It traverses the tree and uses sort of state machine to update the query model.
+ * The query model is modified during the traversal and sent to each handler as context.
  */
 export function buildVisualQueryFromString(expr: string): Context {
   const replacedExpr = replaceVariables(expr);

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -41,7 +41,6 @@ import {
 import { QueryBuilderLabelFilter, QueryBuilderOperation } from './shared/types';
 import { PromVisualQuery, PromVisualQueryBinary } from './types';
 
-
 /**
  * Parses a PromQL query into a visual query model.
  *

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
@@ -67,6 +67,40 @@ describe('replaceBuiltInVariables', () => {
       expected:
         'histogram_quantile(0.95, sum(rate(process_max_fds[7999799979997999])) by (le)) + rate(process_max_fds[711_999_999])',
     },
+    {
+      expr: 'rate(http_requests_total{job="api-server"}[$__interval_ms] offset $__interval_ms)',
+      expected: 'rate(http_requests_total{job="api-server"}[79_999_999_999] offset 79_999_999_999)',
+    },
+    {
+      expr: 'max_over_time(node_memory_usage[$__range_s])',
+      expected: 'max_over_time(node_memory_usage[79_299_999])',
+    },
+    {
+      expr: 'avg_over_time(cpu_usage{env="prod"}[$__range])',
+      expected: 'avg_over_time(cpu_usage{env="prod"}[799_999])',
+    },
+    {
+      expr: 'rate(requests[$__interval]) / rate(requests[$__interval] offset $__interval)',
+      expected: 'rate(requests[711_999_999]) / rate(requests[711_999_999] offset 711_999_999)',
+    },
+    {
+      expr: 'sum(rate(http_requests_total{status=~"5.."}[$__rate_interval])) / sum(rate(http_requests_total[$__rate_interval])) or vector($__range_ms / $__interval_ms)',
+      expected:
+        'sum(rate(http_requests_total{status=~"5.."}[7999799979997999])) / sum(rate(http_requests_total[7999799979997999])) or vector(722_999_999 / 79_999_999_999)',
+    },
+    {
+      expr: 'sum(rate(http_requests_total{job="api"}[5m]))',
+      expected: 'sum(rate(http_requests_total{job="api"}[5m]))',
+    },
+    {
+      expr: 'max_over_time(rate(cpu{instance="server-01"}[$__interval])[$__range_s:$__interval])',
+      expected: 'max_over_time(rate(cpu{instance="server-01"}[711_999_999])[79_299_999:711_999_999])',
+    },
+    {
+      expr: 'rate(cpu[$__interval]) + rate(memory[$__interval_ms]) + rate(disk[$__rate_interval]) + rate(network[$__range]) + rate(io[$__range_s]) + rate(gpu[$__range_ms])',
+      expected:
+        'rate(cpu[711_999_999]) + rate(memory[79_999_999_999]) + rate(disk[7999799979997999]) + rate(network[799_999]) + rate(io[79_299_999]) + rate(gpu[722_999_999])',
+    },
   ];
 
   testCases.forEach((testCase) => {

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
@@ -4,9 +4,9 @@ import { parser } from '@prometheus-io/lezer-promql';
 import {
   getLeftMostChild,
   getString,
-  replaceBuiltInVariables,
+  replaceBuiltInVariable,
   replaceVariables,
-  returnBuiltInVariables,
+  returnBuiltInVariable,
 } from './parsingUtils';
 
 describe('getLeftMostChild', () => {
@@ -52,29 +52,29 @@ describe('replaceBuiltInVariables', () => {
   const testCases = [
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__interval])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[1_999_999y])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[1_999_999])',
     },
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__rate_interval])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[3_999_999y])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[3_999_999])',
     },
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__range_ms])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[4_999_999y])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[4_999_999])',
     },
     {
       expr: 'histogram_quantile(0.95, sum(rate(process_max_fds[$__rate_interval])) by (le)) + rate(process_max_fds[$__interval])',
       expected:
-        'histogram_quantile(0.95, sum(rate(process_max_fds[3_999_999y])) by (le)) + rate(process_max_fds[1_999_999y])',
+        'histogram_quantile(0.95, sum(rate(process_max_fds[3_999_999])) by (le)) + rate(process_max_fds[1_999_999])',
     },
   ];
 
   testCases.forEach((testCase) => {
     it(testCase.expr, () => {
-      const actual1 = replaceBuiltInVariables(testCase.expr);
+      const actual1 = replaceBuiltInVariable(testCase.expr);
       expect(actual1).toBe(testCase.expected);
 
-      const actual2 = returnBuiltInVariables(actual1);
+      const actual2 = returnBuiltInVariable(actual1);
       expect(actual2).toBe(testCase.expr);
     });
   });

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
@@ -52,20 +52,20 @@ describe('replaceBuiltInVariables', () => {
   const testCases = [
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__interval])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[1_999_999])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[711_999_999])',
     },
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__rate_interval])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[3_999_999])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[7999799979997999])',
     },
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__range_ms])',
-      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[4_999_999])',
+      expected: 'sum_over_time([[metric_var]]{bar="${app}"}[722_999_999])',
     },
     {
       expr: 'histogram_quantile(0.95, sum(rate(process_max_fds[$__rate_interval])) by (le)) + rate(process_max_fds[$__interval])',
       expected:
-        'histogram_quantile(0.95, sum(rate(process_max_fds[3_999_999])) by (le)) + rate(process_max_fds[1_999_999])',
+        'histogram_quantile(0.95, sum(rate(process_max_fds[7999799979997999])) by (le)) + rate(process_max_fds[711_999_999])',
     },
   ];
 

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.test.ts
@@ -48,7 +48,7 @@ describe('getString', () => {
   });
 });
 
-describe('replaceBuiltInVariables', () => {
+describe('builtInTimeVariables', () => {
   const testCases = [
     {
       expr: 'sum_over_time([[metric_var]]{bar="${app}"}[$__interval])',

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
@@ -174,10 +174,10 @@ const replacementToVariable = BUILT_IN_VARIABLES.reduce(
 );
 
 // Pre-compiled regular expressions for efficient search/replace
-const builtInVariablePattern = BUILT_IN_VARIABLES.map(({variable}) => variable.replace(/\$/g, '\\$')).join('|');
+const builtInVariablePattern = BUILT_IN_VARIABLES.map(({ variable }) => variable.replace(/\$/g, '\\$')).join('|');
 const builtInVariableRegex = new RegExp(builtInVariablePattern, 'g');
 
-const builtInReplacementPattern = BUILT_IN_VARIABLES.map(({replacement}) => replacement).join('|');
+const builtInReplacementPattern = BUILT_IN_VARIABLES.map(({ replacement }) => replacement).join('|');
 const builtInReplacementRegex = new RegExp(builtInReplacementPattern, 'g');
 
 /**

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
@@ -32,9 +32,8 @@ export function makeError(expr: string, node: SyntaxNode) {
 const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
 
 /**
- * As variables with $ are creating parsing errors, we first replace them with magic string that is parsable and at
- * the same time we can get the variable and its format back from it.
- * @param expr
+ * As variables with $ are creating parsing errors, we first replace them with magic string that is
+ * parsable and at the same time we can get the variable and its format back from it.
  */
 export function replaceVariables(expr: string) {
   return expr.replace(variableRegex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
@@ -138,3 +137,21 @@ export const regexifyLabelValuesQueryString = (query: string) => {
   const queryArray = query.split(' ');
   return queryArray.map((query) => `${query}.*`).join('');
 };
+
+const builtInVariables = ['$__interval', '$__interval_ms', '$__rate_interval', '$__range_ms', '$__range_s', '$__range'];
+
+export function replaceBuiltInVariables(expr: string): string {
+  builtInVariables.forEach((variable, idx) => {
+    expr = expr.replace(new RegExp(`\\${variable}`, 'g'), `${idx + 1}_999_999y`);
+  });
+
+  return expr;
+}
+
+export function returnBuiltInVariables(expr: string): string {
+  builtInVariables.forEach((variable, idx) => {
+    expr = expr.replace(new RegExp(`${idx + 1}_999_999y`, 'g'), variable);
+  });
+
+  return expr;
+}

--- a/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsingUtils.ts
@@ -157,21 +157,15 @@ const BUILT_IN_VARIABLES = [
 ];
 
 // Derived maps for efficient lookups
-const variableToReplacement = BUILT_IN_VARIABLES.reduce(
-  (map, { variable, replacement }) => {
-    map[variable] = replacement;
-    return map;
-  },
-  {} as Record<string, string>
-);
+const variableToReplacement = BUILT_IN_VARIABLES.reduce<Record<string, string>>((map, { variable, replacement }) => {
+  map[variable] = replacement;
+  return map;
+}, {});
 
-const replacementToVariable = BUILT_IN_VARIABLES.reduce(
-  (map, { variable, replacement }) => {
-    map[replacement] = variable;
-    return map;
-  },
-  {} as Record<string, string>
-);
+const replacementToVariable = BUILT_IN_VARIABLES.reduce<Record<string, string>>((map, { variable, replacement }) => {
+  map[replacement] = variable;
+  return map;
+}, {});
 
 // Pre-compiled regular expressions for efficient search/replace
 const builtInVariablePattern = BUILT_IN_VARIABLES.map(({ variable }) => variable.replace(/\$/g, '\\$')).join('|');


### PR DESCRIPTION
**What is this feature?**

In the current implementation we had to parse twice the same expression just to confirm there is no issues with the builtin variables. This isn't efficient. I introduce a replacement map so we could only parse once. 

**Why do we need this feature?**

For efficient query parsing

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/87687

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
