### PR TITLE
Extension Sidebar: Add `openExtensionSidebar` helper to plugin extensions 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -299,6 +299,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "packages/grafana-data/src/types/pluginExtensions.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
     "packages/grafana-data/src/types/scopes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -811,10 +811,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/components/DynamicImports/SafeDynamicImport.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -299,9 +299,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "packages/grafana-data/src/types/pluginExtensions.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "packages/grafana-data/src/types/scopes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -809,12 +806,6 @@ exports[`better eslint`] = {
     ],
     "public/app/core/components/AccessControl/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
-    ],
-    "public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/components/DynamicImports/SafeDynamicImport.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -3957,8 +3957,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
     "public/app/types/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CoreEvents\`)", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -299,9 +299,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "packages/grafana-data/src/types/pluginExtensions.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "packages/grafana-data/src/types/scopes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -299,6 +299,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "packages/grafana-data/src/types/pluginExtensions.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
     "packages/grafana-data/src/types/scopes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -806,6 +809,15 @@ exports[`better eslint`] = {
     ],
     "public/app/core/components/AccessControl/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
+    ],
+    "public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/core/components/DynamicImports/SafeDynamicImport.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -3957,7 +3969,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
     ],
     "public/app/types/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CoreEvents\`)", "0"],

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -170,6 +170,8 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   /**
    * @internal
    * Opens the extension sidebar with the registered component.
+   * @param componentTitle The title of the component to be opened in the sidebar.
+   * @param props The props to be passed to the component.
    */
   openExtensionSidebar?: (componentTitle: string, props?: any) => void;
 };

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -173,7 +173,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
    * @param componentTitle The title of the component to be opened in the sidebar.
    * @param props The props to be passed to the component.
    */
-  openSidebar?: (componentTitle: string, props?: any) => void;
+  openSidebar: (componentTitle: string, props?: Record<string, unknown>) => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -171,7 +171,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
    * @alpha @internal
    * Opens the extension sidebar with the registered component.
    */
-  openExtensionSidebar: (componentTitle: string, context: Context) => void;
+  openExtensionSidebar?: (componentTitle: string, context: Context) => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -168,10 +168,10 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
   /**
-   * @alpha
-   * Opens the
+   * @alpha @internal
+   * Opens the extension sidebar with the registered component.
    */
-  openExtensionSidebar: (componentTitle: string, context: any) => void;
+  openExtensionSidebar: (componentTitle: string, context: Context) => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -168,10 +168,10 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
   /**
-   * @alpha @internal
+   * @internal
    * Opens the extension sidebar with the registered component.
    */
-  openExtensionSidebar?: (componentTitle: string, context: Context) => void;
+  openExtensionSidebar?: (componentTitle: string, props?: any) => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -173,7 +173,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
    * @param componentTitle The title of the component to be opened in the sidebar.
    * @param props The props to be passed to the component.
    */
-  openExtensionSidebar?: (componentTitle: string, props?: any) => void;
+  openSidebar?: (componentTitle: string, props?: any) => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -167,6 +167,11 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   context?: Readonly<Context>;
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
+  /**
+   * @alpha
+   * Opens the
+   */
+  openExtensionSidebar: (componentTitle: string, context: any) => void;
 };
 
 // Extension Points & Contexts

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -15,7 +15,7 @@ export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = 700;
 
 type ExtensionSidebarComponentProps = {
-  props?: any;
+  props?: Record<string, unknown>;
 };
 
 export function ExtensionSidebar() {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -14,10 +14,16 @@ export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = 300;
 export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = 700;
 
+type ExtensionSidebarComponentProps = {
+  context?: any;
+};
+
 export function ExtensionSidebar() {
   const styles = getStyles(useTheme2());
-  const { dockedComponentId, isEnabled } = useExtensionSidebarContext();
-  const { components, isLoading } = usePluginComponents({ extensionPointId: EXTENSION_SIDEBAR_EXTENSION_POINT_ID });
+  const { dockedComponentId, isEnabled, props } = useExtensionSidebarContext();
+  const { components, isLoading } = usePluginComponents<ExtensionSidebarComponentProps>({
+    extensionPointId: EXTENSION_SIDEBAR_EXTENSION_POINT_ID,
+  });
 
   if (isLoading || !dockedComponentId || !isEnabled) {
     return null;
@@ -39,7 +45,7 @@ export function ExtensionSidebar() {
   return (
     <div className={styles.sidebarWrapper}>
       <div className={styles.content}>
-        <ExtensionComponent />
+        <ExtensionComponent context={props} />
       </div>
     </div>
   );

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -20,7 +20,7 @@ type ExtensionSidebarComponentProps = {
 
 export function ExtensionSidebar() {
   const styles = getStyles(useTheme2());
-  const { dockedComponentId, isEnabled, props } = useExtensionSidebarContext();
+  const { dockedComponentId, isEnabled, props = {} } = useExtensionSidebarContext();
   const { components, isLoading } = usePluginComponents<ExtensionSidebarComponentProps>({
     extensionPointId: EXTENSION_SIDEBAR_EXTENSION_POINT_ID,
   });
@@ -45,7 +45,7 @@ export function ExtensionSidebar() {
   return (
     <div className={styles.sidebarWrapper}>
       <div className={styles.content}>
-        <ExtensionComponent props={props} />
+        <ExtensionComponent {...props} />
       </div>
     </div>
   );

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -15,7 +15,7 @@ export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = 700;
 
 type ExtensionSidebarComponentProps = {
-  context?: any;
+  props?: any;
 };
 
 export function ExtensionSidebar() {
@@ -45,7 +45,7 @@ export function ExtensionSidebar() {
   return (
     <div className={styles.sidebarWrapper}>
       <div className={styles.content}>
-        <ExtensionComponent context={props} />
+        <ExtensionComponent props={props} />
       </div>
     </div>
   );

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 // import { render } from 'test/test-utils';
 
-import { store } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { store, EventBusSrv, EventBus } from '@grafana/data';
+import { config, getAppEvents, setAppEvents } from '@grafana/runtime';
+import { appEvents } from 'app/core/core';
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
+import { OpenExtensionSidebarEvent } from 'app/types/events';
 
 import {
   ExtensionSidebarContextProvider,
@@ -52,10 +54,31 @@ const mockPluginMeta = {
 };
 
 describe('ExtensionSidebarProvider', () => {
+  let subscribeSpy: jest.SpyInstance;
+  let originalAppEvents: EventBus;
+  let mockEventBus: EventBusSrv;
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    originalAppEvents = getAppEvents();
+
+    mockEventBus = new EventBusSrv();
+    subscribeSpy = jest.spyOn(mockEventBus, 'subscribe');
+
+    setAppEvents(mockEventBus);
+
     (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(new Map([[mockPluginMeta.pluginId, mockPluginMeta]]));
+
     jest.replaceProperty(config.featureToggles, 'extensionSidebar', true);
+
+    (store.get as jest.Mock).mockReturnValue(undefined);
+    (store.set as jest.Mock).mockImplementation(() => {});
+    (store.delete as jest.Mock).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setAppEvents(originalAppEvents);
   });
 
   const TestComponent = () => {
@@ -198,6 +221,113 @@ describe('ExtensionSidebarProvider', () => {
     // Should only include the enabled plugin
     expect(screen.getByTestId('available-components-size')).toHaveTextContent('1');
     expect(screen.getByTestId('plugin-ids')).toHaveTextContent(permittedPluginMeta.pluginId);
+  });
+
+  it('should subscribe to OpenExtensionSidebarEvent when feature is enabled', async () => {
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(subscribeSpy).toHaveBeenCalledWith(OpenExtensionSidebarEvent, expect.any(Function));
+  });
+
+  it('should not subscribe to OpenExtensionSidebarEvent when feature is disabled', () => {
+    jest.replaceProperty(config.featureToggles, 'extensionSidebar', false);
+
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(subscribeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should set dockedComponentId and props when receiving a valid OpenExtensionSidebarEvent', () => {
+    const TestComponentWithProps = () => {
+      const context = useExtensionSidebarContext();
+      return (
+        <div>
+          <div data-testid="is-open">{context.isOpen.toString()}</div>
+          <div data-testid="docked-component-id">{context.dockedComponentId || 'undefined'}</div>
+          <div data-testid="props">{context.props ? JSON.stringify(context.props) : 'undefined'}</div>
+        </div>
+      );
+    };
+
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponentWithProps />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('props')).toHaveTextContent('undefined');
+
+    act(() => {
+      // Get the event subscriber function
+      const [[, subscriberFn]] = subscribeSpy.mock.calls;
+
+      // Call it directly with the test event
+      subscriberFn(
+        new OpenExtensionSidebarEvent({
+          pluginId: 'grafana-investigations-app',
+          componentTitle: 'Test Component',
+          props: { testProp: 'test value' },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+    expect(screen.getByTestId('props')).toHaveTextContent('{"testProp":"test value"}');
+    const expectedComponentId = JSON.stringify({
+      pluginId: 'grafana-investigations-app',
+      componentTitle: 'Test Component',
+    });
+    expect(screen.getByTestId('docked-component-id')).toHaveTextContent(expectedComponentId);
+  });
+
+  it('should not open sidebar when receiving an OpenExtensionSidebarEvent with non-permitted plugin', () => {
+    render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+
+    act(() => {
+      // Get the event subscriber function
+      const [[, subscriberFn]] = subscribeSpy.mock.calls;
+
+      // Call it directly with the test event for a non-permitted plugin
+      subscriberFn(
+        new OpenExtensionSidebarEvent({
+          pluginId: 'non-permitted-plugin',
+          componentTitle: 'Test Component',
+        })
+      );
+    });
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+  });
+
+  it('should unsubscribe from OpenExtensionSidebarEvent on unmount', () => {
+    const unsubscribeMock = jest.fn();
+    subscribeSpy.mockReturnValue({
+      unsubscribe: unsubscribeMock,
+    });
+
+    const { unmount } = render(
+      <ExtensionSidebarContextProvider>
+        <TestComponent />
+      </ExtensionSidebarContextProvider>
+    );
+
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalled();
   });
 });
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -1,9 +1,7 @@
-import { render, screen, act, waitFor } from '@testing-library/react';
-// import { render } from 'test/test-utils';
+import { render, screen, act } from '@testing-library/react';
 
 import { store, EventBusSrv, EventBus } from '@grafana/data';
 import { config, getAppEvents, setAppEvents } from '@grafana/runtime';
-import { appEvents } from 'app/core/core';
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 import { OpenExtensionSidebarEvent } from 'app/types/events';
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -264,6 +264,7 @@ describe('ExtensionSidebarProvider', () => {
     expect(screen.getByTestId('is-open')).toHaveTextContent('false');
     expect(screen.getByTestId('props')).toHaveTextContent('undefined');
 
+    expect(subscribeSpy).toHaveBeenCalledWith(OpenExtensionSidebarEvent, expect.any(Function));
     act(() => {
       // Get the event subscriber function
       const [[, subscriberFn]] = subscribeSpy.mock.calls;

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -114,23 +114,26 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
   }
   const [dockedComponentId, setDockedComponentId] = useState<string | undefined>(defaultDockedComponentId);
 
-  // Enhanced function to set the docked component ID and optionally pass props
   const setDockedComponentWithProps = useCallback(
-    (componentId: string | undefined, contextProps?: any) => {
-      propsRef.current = contextProps;
+    (componentId: string | undefined, props?: any) => {
+      propsRef.current = props;
       setDockedComponentId(componentId);
     },
     [setDockedComponentId]
   );
 
-  // Listen for open extension sidebar events
   useEffect(() => {
     if (!isEnabled) {
       return;
     }
 
+    // handler to open the extension sidebar from plugins. this is done with the `helpers.openExtensionSidebar` function
     const openExtensionSidebarHandler = (event: OpenExtensionSidebarEvent) => {
-      if (event.payload.pluginId && event.payload.componentTitle) {
+      if (
+        event.payload.pluginId &&
+        event.payload.componentTitle &&
+        PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(event.payload.pluginId)
+      ) {
         setDockedComponentWithProps(
           JSON.stringify({ pluginId: event.payload.pluginId, componentTitle: event.payload.componentTitle }),
           event.payload.props

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -124,8 +124,8 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
       return;
     }
 
-    // handler to open the extension sidebar from plugins. this is done with the `helpers.openExtensionSidebar` function
-    const openExtensionSidebarHandler = (event: OpenExtensionSidebarEvent) => {
+    // handler to open the extension sidebar from plugins. this is done with the `helpers.openSidebar` function
+    const openSidebarHandler = (event: OpenExtensionSidebarEvent) => {
       if (
         event.payload.pluginId &&
         event.payload.componentTitle &&
@@ -138,7 +138,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
       }
     };
 
-    const subscription = appEvents.subscribe(OpenExtensionSidebarEvent, openExtensionSidebarHandler);
+    const subscription = appEvents.subscribe(OpenExtensionSidebarEvent, openSidebarHandler);
     return () => {
       subscription.unsubscribe();
     };

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 
 import { store, type ExtensionInfo } from '@grafana/data';
@@ -18,10 +18,7 @@ const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   'grafana-dash-app',
 ];
 
-export interface OpenExtensionSidebarPayload {
-  componentId: string;
-  props?: any;
-}
+type Props = any;
 
 type ExtensionSidebarContextType = {
   /**
@@ -53,7 +50,7 @@ type ExtensionSidebarContextType = {
    */
   setExtensionSidebarWidth: (width: number) => void;
 
-  props?: any;
+  props?: Props;
 };
 
 export const ExtensionSidebarContext = createContext<ExtensionSidebarContextType>({
@@ -75,7 +72,7 @@ interface ExtensionSidebarContextProps {
 }
 
 export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarContextProps) => {
-  const propsRef = useRef<any>();
+  const [props, setProps] = useState<Props | undefined>(undefined);
   const storedDockedPluginId = store.get(EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY);
   const [extensionSidebarWidth, setExtensionSidebarWidth] = useLocalStorage(
     EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY,
@@ -115,8 +112,8 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
   const [dockedComponentId, setDockedComponentId] = useState<string | undefined>(defaultDockedComponentId);
 
   const setDockedComponentWithProps = useCallback(
-    (componentId: string | undefined, props?: any) => {
-      propsRef.current = props;
+    (componentId: string | undefined, props?: Props) => {
+      setProps(props);
       setDockedComponentId(componentId);
     },
     [setDockedComponentId]
@@ -166,7 +163,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
         availableComponents,
         extensionSidebarWidth: extensionSidebarWidth ?? DEFAULT_EXTENSION_SIDEBAR_WIDTH,
         setExtensionSidebarWidth,
-        props: propsRef.current,
+        props,
       }}
     >
       {children}

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -2,8 +2,7 @@ import { createContext, ReactNode, useCallback, useContext, useEffect, useState 
 import { useLocalStorage } from 'react-use';
 
 import { store, type ExtensionInfo } from '@grafana/data';
-import { config } from '@grafana/runtime';
-import { appEvents } from 'app/core/core';
+import { config, getAppEvents } from '@grafana/runtime';
 import { ExtensionPointPluginMeta, getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 import { OpenExtensionSidebarEvent } from 'app/types/events';
 
@@ -136,7 +135,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
       }
     };
 
-    const subscription = appEvents.subscribe(OpenExtensionSidebarEvent, openSidebarHandler);
+    const subscription = getAppEvents().subscribe(OpenExtensionSidebarEvent, openSidebarHandler);
     return () => {
       subscription.unsubscribe();
     };

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -18,8 +18,6 @@ const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   'grafana-dash-app',
 ];
 
-type Props = any;
-
 type ExtensionSidebarContextType = {
   /**
    * Whether the extension sidebar is enabled.
@@ -50,7 +48,7 @@ type ExtensionSidebarContextType = {
    */
   setExtensionSidebarWidth: (width: number) => void;
 
-  props?: Props;
+  props?: Record<string, unknown>;
 };
 
 export const ExtensionSidebarContext = createContext<ExtensionSidebarContextType>({
@@ -72,7 +70,7 @@ interface ExtensionSidebarContextProps {
 }
 
 export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarContextProps) => {
-  const [props, setProps] = useState<Props | undefined>(undefined);
+  const [props, setProps] = useState<Record<string, unknown> | undefined>(undefined);
   const storedDockedPluginId = store.get(EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY);
   const [extensionSidebarWidth, setExtensionSidebarWidth] = useLocalStorage(
     EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY,
@@ -112,7 +110,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
   const [dockedComponentId, setDockedComponentId] = useState<string | undefined>(defaultDockedComponentId);
 
   const setDockedComponentWithProps = useCallback(
-    (componentId: string | undefined, props?: Props) => {
+    (componentId: string | undefined, props?: Record<string, unknown>) => {
       setProps(props);
       setDockedComponentId(componentId);
     },

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { store } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { EventBusSrv, store } from '@grafana/data';
+import { config, setAppEvents } from '@grafana/runtime';
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 
 import { ExtensionSidebarContextProvider, useExtensionSidebarContext } from './ExtensionSidebarProvider';
@@ -73,6 +73,11 @@ describe('ExtensionToolbarItem', () => {
     (store.set as jest.Mock).mockClear();
     (store.delete as jest.Mock).mockClear();
     jest.replaceProperty(config.featureToggles, 'extensionSidebar', true);
+    setAppEvents(new EventBusSrv());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should not render when feature toggle is disabled', () => {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -375,7 +375,7 @@ export function getLinkExtensionOnClick(
       const helpers: PluginExtensionEventHelpers = {
         context,
         openModal: createOpenModalFunction(pluginId),
-        openExtensionSidebar: (componentTitle, context) => {
+        openSidebar: (componentTitle, context) => {
           appEvents.publish(
             new OpenExtensionSidebarEvent({
               props: context,

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -20,7 +20,7 @@ import { reportInteraction, config, AppPluginConfig } from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
-import { ShowModalReactEvent } from 'app/types/events';
+import { OpenExtensionSidebarEvent, ShowModalReactEvent } from 'app/types/events';
 
 import { ExtensionsLog, log } from './logs/log';
 import { AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
@@ -375,6 +375,15 @@ export function getLinkExtensionOnClick(
       const helpers: PluginExtensionEventHelpers = {
         context,
         openModal: createOpenModalFunction(pluginId),
+        openExtensionSidebar: (componentTitle, context) => {
+          appEvents.publish(
+            new OpenExtensionSidebarEvent({
+              props: context,
+              pluginId,
+              componentTitle,
+            })
+          );
+        },
       };
 
       log.debug(`onClick '${config.title}' at '${extensionPointId}'`);

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -29,7 +29,7 @@ export interface ShowModalReactPayload {
 }
 
 export interface OpenExtensionSidebarPayload {
-  props?: any;
+  props?: Record<string, unknown>;
   pluginId: string;
   componentTitle: string;
 }

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -28,6 +28,11 @@ export interface ShowModalReactPayload {
   props?: any;
 }
 
+export interface OpenExtensionSidebarPayload {
+  props?: any;
+  pluginId: string;
+  componentTitle: string;
+}
 export interface ShowConfirmModalPayload {
   title?: string;
   text?: string;
@@ -182,6 +187,10 @@ export class ShowConfirmModalEvent extends BusEventWithPayload<ShowConfirmModalP
 
 export class ShowModalReactEvent extends BusEventWithPayload<ShowModalReactPayload> {
   static type = 'show-react-modal';
+}
+
+export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtensionSidebarPayload> {
+  static type = 'open-extension-sidebar';
 }
 
 /**

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -33,6 +33,7 @@ export interface OpenExtensionSidebarPayload {
   pluginId: string;
   componentTitle: string;
 }
+
 export interface ShowConfirmModalPayload {
   title?: string;
   text?: string;


### PR DESCRIPTION
**What is this feature?**

After adding a Sidebar in https://github.com/grafana/grafana/pull/102626 that can render certain extensions, this PR adds a feature that lets other plugins open the extension sidebar with a `openExtensionSidebar` function, that lives in the `PluginExtensionEventHelpers`.

This is particularly helpful, if the sidebar shouldn't be just opened by the toolbar button, but also with e.g. extension links. The investigations app currently registers extension links, that will add panel menu items in the Drilldown apps. Clicking one of those links would have opened Sidecar with the given context. Since Sidecar was removed [here](https://github.com/grafana/grafana/pull/103786), this PR adds similar functionality to open the Extension sidebar with a given context.

For this to work, one of the allowed extensions need to register a component first:

```ts
plugin.addComponent({
  targets: `grafana/extension-sidebar/v0-alpha`,
  title: 'Hello World',
  description: 'Hello World',
  component: function HelloWorld(props: any) {
    return <div>{props}</div>;
  },
});
```

And then, in their `addLink` config, they can call `helpers.openExtensionSidebar`:

```ts
plugin.addLink({
  title: 'Open and Add to Investigation',
  description: 'Add to Investigation',
  targets: [
    'grafana-metricsdrilldown-app/investigation/v1',
  ],

  onClick: async (_, helpers) => {
    if (!helpers.context) {
      return;
    }

    helpers.openExtensionSidebar('Hello World', helpers.context.drillDownLabel);
  },
});
```


https://github.com/user-attachments/assets/166540be-a1f9-417c-9b91-1a19627898bb

