### PR TITLE
SQLTemplates: Add helper to ensure all templates have a test-case

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/queries_test.go
+++ b/pkg/registry/apis/dashboard/legacy/queries_test.go
@@ -30,7 +30,8 @@ func TestDashboardQueries(t *testing.T) {
 	}
 
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
-		RootDir: "testdata",
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
 		Templates: map[*template.Template][]mocks.TemplateTestCase{
 			sqlQueryDashboards: {
 				{

--- a/pkg/registry/apis/iam/legacy/service_account.go
+++ b/pkg/registry/apis/iam/legacy/service_account.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	claims "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
@@ -229,6 +230,10 @@ type listServiceAccountTokensQuery struct {
 	UserTable    string
 	TokenTable   string
 	OrgUserTable string
+}
+
+func (listServiceAccountTokensQuery) Validate() error {
+	return nil // TODO
 }
 
 func (s *legacySQLStore) ListServiceAccountTokens(ctx context.Context, ns claims.NamespaceInfo, query ListServiceAccountTokenQuery) (*ListServiceAccountTokenResult, error) {

--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -54,8 +54,21 @@ func TestIdentityQueries(t *testing.T) {
 		return &v
 	}
 
+	listServiceAccounts := func(q *ListServiceAccountsQuery) sqltemplate.SQLTemplate {
+		v := newListServiceAccounts(nodb, q)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	listServiceAccountTokens := func(q *ListServiceAccountTokenQuery) sqltemplate.SQLTemplate {
+		v := newListServiceAccountTokens(nodb, q)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
-		RootDir: "testdata",
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
 		Templates: map[*template.Template][]mocks.TemplateTestCase{
 			sqlQueryTeamsTemplate: {
 				{
@@ -189,6 +202,101 @@ func TestIdentityQueries(t *testing.T) {
 						UserUID:    "user-1",
 						OrgID:      1,
 						Pagination: common.Pagination{Limit: 1, Continue: 2},
+					}),
+				},
+			},
+			sqlQueryUserInternalIDTemplate: {
+				{
+					Name: "user_internal_id",
+					Data: &getUserInternalIDQuery{
+						SQLTemplate:  mocks.NewTestingSQLTemplate(),
+						UserTable:    nodb.Table("user"),
+						OrgUserTable: nodb.Table("org_user"),
+						Query: &GetUserInternalIDQuery{
+							UID:   "user-1",
+							OrgID: 1,
+						},
+					},
+				},
+			},
+			sqlQueryTeamInternalIDTemplate: {
+				{
+					Name: "team_internal_id",
+					Data: &getTeamInternalIDQuery{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						TeamTable:   nodb.Table("team"),
+						Query: &GetTeamInternalIDQuery{
+							UID:   "team-1",
+							OrgID: 1,
+						},
+					},
+				},
+			},
+			sqlQueryServiceAccountInternalIDTemplate: {
+				{
+					Name: "basic",
+					Data: &getServiceAccountInternalIDQuery{
+						SQLTemplate:  mocks.NewTestingSQLTemplate(),
+						UserTable:    nodb.Table("user"),
+						OrgUserTable: nodb.Table("org_user"),
+						Query: &GetServiceAccountInternalIDQuery{
+							OrgID: 1,
+							UID:   "sa-1",
+						},
+					},
+				},
+			},
+			sqlQueryServiceAccountsTemplate: {
+				{
+					Name: "service_accounts",
+					Data: listServiceAccounts(&ListServiceAccountsQuery{
+						UID:        "sa-1",
+						OrgID:      1,
+						Pagination: common.Pagination{Limit: 1},
+					}),
+				},
+				{
+					Name: "service_accounts_page_1",
+					Data: listServiceAccounts(&ListServiceAccountsQuery{
+						OrgID:      1,
+						Pagination: common.Pagination{Limit: 5},
+					}),
+				},
+				{
+					Name: "service_accounts_page_2",
+					Data: listServiceAccounts(&ListServiceAccountsQuery{
+						OrgID: 1,
+						Pagination: common.Pagination{
+							Limit:    1,
+							Continue: 2,
+						},
+					}),
+				},
+			},
+			sqlQueryServiceAccountTokensTemplate: {
+				{
+					Name: "service_account_tokens",
+					Data: listServiceAccountTokens(&ListServiceAccountTokenQuery{
+						UID:        "sa-1",
+						OrgID:      1,
+						Pagination: common.Pagination{Limit: 1},
+					}),
+				},
+				{
+					Name: "service_account_tokens_page_1",
+					Data: listServiceAccountTokens(&ListServiceAccountTokenQuery{
+						OrgID:      1,
+						Pagination: common.Pagination{Limit: 5},
+					}),
+				},
+				{
+					Name: "service_accounts_tokens_page_2",
+					Data: listServiceAccountTokens(&ListServiceAccountTokenQuery{
+						OrgID: 1,
+						Pagination: common.Pagination{
+							Limit:    1,
+							Continue: 2,
+						},
 					}),
 				},
 			},

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_internal_id-basic.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_internal_id-basic.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM `grafana`.`user` as u
+INNER JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'sa-1'
+AND u.is_service_account
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_account_tokens.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM `grafana`.`api_key` as t
+  INNER JOIN `grafana`.`user` as u ON t.service_account_id = u.id
+  INNER JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_account_tokens_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_account_tokens_page_1.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM `grafana`.`api_key` as t
+  INNER JOIN `grafana`.`user` as u ON t.service_account_id = u.id
+  INNER JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+ ORDER BY t.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_accounts_tokens_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_account_tokens_query-service_accounts_tokens_page_2.sql
@@ -1,0 +1,17 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM `grafana`.`api_key` as t
+  INNER JOIN `grafana`.`user` as u ON t.service_account_id = u.id
+  INNER JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+   AND t.id >= 2
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts_page_1.sql
@@ -1,0 +1,12 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--service_accounts_query-service_accounts_page_2.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.id >= 2
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--team_internal_id-team_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--team_internal_id-team_internal_id.sql
@@ -1,0 +1,5 @@
+SELECT t.id
+FROM `grafana`.`team` as t
+WHERE t.org_id = 1
+AND t.uid = 'team-1'
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--user_internal_id-user_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--user_internal_id-user_internal_id.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM `grafana`.`user` as u
+INNER JOIN `grafana`.`org_user` as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'user-1'
+AND NOT u.is_service_account
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_internal_id-basic.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_internal_id-basic.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'sa-1'
+AND u.is_service_account
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_account_tokens.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_account_tokens_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_account_tokens_page_1.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+ ORDER BY t.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_accounts_tokens_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_account_tokens_query-service_accounts_tokens_page_2.sql
@@ -1,0 +1,17 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+   AND t.id >= 2
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts_page_1.sql
@@ -1,0 +1,12 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--service_accounts_query-service_accounts_page_2.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.id >= 2
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--team_internal_id-team_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--team_internal_id-team_internal_id.sql
@@ -1,0 +1,5 @@
+SELECT t.id
+FROM "grafana"."team" as t
+WHERE t.org_id = 1
+AND t.uid = 'team-1'
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--user_internal_id-user_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--user_internal_id-user_internal_id.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'user-1'
+AND NOT u.is_service_account
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_internal_id-basic.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_internal_id-basic.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'sa-1'
+AND u.is_service_account
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_account_tokens.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_account_tokens_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_account_tokens_page_1.sql
@@ -1,0 +1,16 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+ ORDER BY t.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_accounts_tokens_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_account_tokens_query-service_accounts_tokens_page_2.sql
@@ -1,0 +1,17 @@
+SELECT
+  t.id,
+  t.name,
+  t.is_revoked,
+  t.last_used_at,
+  t.expires,
+  t.created,
+  t.updated
+  FROM "grafana"."api_key" as t
+  INNER JOIN "grafana"."user" as u ON t.service_account_id = u.id
+  INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = ''
+   AND t.id >= 2
+ ORDER BY t.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.uid = 'sa-1'
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts_page_1.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts_page_1.sql
@@ -1,0 +1,12 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+ ORDER BY u.id asc
+ LIMIT 5

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts_page_2.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--service_accounts_query-service_accounts_page_2.sql
@@ -1,0 +1,13 @@
+SELECT
+  u.id,
+  u.uid,
+  u.name,
+  u.is_disabled,
+  u.created,
+  u.updated
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
+ WHERE o.org_id = 1
+   AND u.is_service_account
+   AND u.id >= 2
+ ORDER BY u.id asc
+ LIMIT 1

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--team_internal_id-team_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--team_internal_id-team_internal_id.sql
@@ -1,0 +1,5 @@
+SELECT t.id
+FROM "grafana"."team" as t
+WHERE t.org_id = 1
+AND t.uid = 'team-1'
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--user_internal_id-user_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--user_internal_id-user_internal_id.sql
@@ -1,0 +1,7 @@
+SELECT u.id
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as o ON u.id = o.user_id
+WHERE o.org_id = 1
+AND u.uid = 'user-1'
+AND NOT u.is_service_account
+LIMIT 1;

--- a/pkg/services/authz/rbac/store/sql_test.go
+++ b/pkg/services/authz/rbac/store/sql_test.go
@@ -42,7 +42,8 @@ func TestIdentityQueries(t *testing.T) {
 	}
 
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
-		RootDir: "testdata",
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
 		Templates: map[*template.Template][]mocks.TemplateTestCase{
 			sqlUserIdentifiers: {
 				{

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestUnifiedStorageQueries(t *testing.T) {
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
-		RootDir: "testdata",
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
 		Templates: map[*template.Template][]mocks.TemplateTestCase{
 			sqlResourceDelete: {
 				{
@@ -331,6 +332,16 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Data: &sqlResourceVersionUpsertRequest{
 						SQLTemplate:     mocks.NewTestingSQLTemplate(),
 						ResourceVersion: int64(12354),
+					},
+				},
+			},
+
+			sqlResourceVersionList: {
+				{
+					Name: "single path",
+					Data: &sqlResourceVersionListRequest{
+						SQLTemplate:          mocks.NewTestingSQLTemplate(),
+						groupResourceVersion: new(groupResourceVersion),
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_list-single path.sql
@@ -1,0 +1,6 @@
+SELECT
+    `resource_version`,
+    `group`,
+    `resource`
+    FROM `resource_version`
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_list-single path.sql
@@ -1,0 +1,6 @@
+SELECT
+    "resource_version",
+    "group",
+    "resource"
+    FROM "resource_version"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_list-single path.sql
@@ -1,0 +1,6 @@
+SELECT
+    "resource_version",
+    "group",
+    "resource"
+    FROM "resource_version"
+;


### PR DESCRIPTION
**What is this feature?**

Adds an extra check in `mocks.CheckQuerySnapshots` to make sure that all `.sql` templates have a test case.

It is only executed if `SQLTemplatesFS` is passed (non-nil) in `mocks.TemplateTestSetup` struct.

I took the opportunity in this PR to add this extra check to all storages that are using SQL templates, and add test cases for missing templates.

**Why do we need this feature?**

Improve test coverage of template-generated SQL queries.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
