### PR TITLE
TestData DS: Make Random Walk queries compatible with Data Plane

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -715,7 +715,7 @@ func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int) *
 		max = *model.Max
 	}
 
-	timeVec := make([]*time.Time, 0)
+	timeVec := make([]time.Time, 0)
 	floatVec := make([]*float64, 0)
 
 	walker := startValue
@@ -737,7 +737,7 @@ func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int) *
 			// skip value
 		} else {
 			t := time.Unix(timeWalkerMs/int64(1e+3), (timeWalkerMs%int64(1e+3))*int64(1e+6))
-			timeVec = append(timeVec, &t)
+			timeVec = append(timeVec, t)
 			floatVec = append(floatVec, &nextValue)
 		}
 
@@ -903,7 +903,7 @@ func predictableSeries(timeRange backend.TimeRange, timeStep, length int64, getV
 	wavePeriod := timeStep * length
 	maxPoints := 10000 // Don't return too many points
 
-	timeVec := make([]*time.Time, 0)
+	timeVec := make([]time.Time, 0)
 	floatVec := make([]*float64, 0)
 
 	for i := 0; i < maxPoints && timeCursor < to; i++ {
@@ -913,7 +913,7 @@ func predictableSeries(timeRange backend.TimeRange, timeStep, length int64, getV
 		}
 
 		t := time.Unix(timeCursor/int64(1e+3), (timeCursor%int64(1e+3))*int64(1e+6))
-		timeVec = append(timeVec, &t)
+		timeVec = append(timeVec, t)
 		floatVec = append(floatVec, val)
 
 		timeCursor += timeStep

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -758,6 +758,7 @@ func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int) *
 			"customStat": 10,
 		},
 	})
+	frame.Meta.Type = data.FrameTypeTimeSeriesMulti
 
 	return frame
 }


### PR DESCRIPTION
**What is this feature?**

Make TestData data source Random Walk queries compatible with Dataplane:
https://grafana.com/developers/dataplane/timeseries

- Adds the Frame Type
- Make the time column non-nullable

**Why do we need this feature?**

Enables compatibility with SQL Expressions.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



**Special notes for your reviewer:**

 - I haven't set `FrameTypeVersion`, this would change the code path for other Server side expression operations, where as only setting the type for SSE will only impact the SQL operation 

I've tested this locally, and it's now working well:

![image](https://github.com/user-attachments/assets/a43c3fee-5482-4a7f-afba-0205ef1753f0)

Note: When testing, if you want to get a No-op, you have to also convert back to Multi-format at the end, for the TimeSeries Viz to accept the data and render it correctly:

![image](https://github.com/user-attachments/assets/ebf523a5-387d-4c6a-ad33-18c398237f00)


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.