### PR TITLE
InfluxDB: capture more downstream errors

### DIFF
--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -3,6 +3,7 @@ package fsql
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -62,6 +63,8 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusForbidden, backend.ErrorSourceDownstream, errStr)
 				case codes.NotFound:
 					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(backend.StatusNotFound, backend.ErrorSourceDownstream, errStr)
+				case codes.Unavailable:
+					tRes.Responses[q.RefID] = backend.ErrDataResponseWithSource(http.StatusServiceUnavailable, backend.ErrorSourceDownstream, errStr)
 				default:
 					tRes.Responses[q.RefID] = backend.ErrDataResponse(backend.StatusInternal, errStr)
 				}


### PR DESCRIPTION
This adds more checks on the type of errors returned from InfluxDB fsql datasource queries. The Grpc error code `Unavailable` is mapped to a downstream error source.