### PR TITLE
Frontend instrumentation: Fix bug, where allInstrumentationsEnabled=false resulted in all instrumentation being active

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -2,7 +2,8 @@ import { BuildInfo } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { Faro, Instrumentation } from '@grafana/faro-core';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
-import { BrowserConfig, FetchTransport } from '@grafana/faro-web-sdk';
+import { BrowserConfig, FetchTransport, SessionInstrumentation } from '@grafana/faro-web-sdk';
+import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
 import {
@@ -32,7 +33,7 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
       error: jest.fn(),
     };
 
-    initializeFaroMock = jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
+    initializeFaroMock = jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValue({
       ...faroWebSdkModule.faro,
       api: {
         ...faroWebSdkModule.faro.api,
@@ -128,6 +129,27 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
     TRACKING_URLS.some((u) => u && longString.match(u) !== null);
     const end = performance.now();
     expect(end - start).toBeLessThanOrEqual(maxExecutionTime);
+  });
+
+  it('correctly set instrumentation based on options', async () => {
+    let opts = {
+      ...options,
+      allInstrumentationsEnabled: false,
+      errorInstrumentalizationEnabled: false,
+      consoleInstrumentalizationEnabled: false,
+      webVitalsInstrumentalizationEnabled: false,
+      tracingInstrumentalizationEnabled: false,
+    };
+    new GrafanaJavascriptAgentBackend(opts);
+    expect(initializeFaroMock.mock.calls[0][0].instrumentations?.length).toEqual(1);
+    expect(initializeFaroMock.mock.calls[0][0].instrumentations?.[0]).toBeInstanceOf(SessionInstrumentation);
+
+    opts.tracingInstrumentalizationEnabled = true;
+
+    new GrafanaJavascriptAgentBackend(opts);
+    expect(initializeFaroMock.mock.calls[1][0].instrumentations?.length).toEqual(2);
+    expect(initializeFaroMock.mock.calls[1][0].instrumentations?.[0]).toBeInstanceOf(TracingInstrumentation);
+    expect(initializeFaroMock.mock.calls[1][0].instrumentations?.[1]).toBeInstanceOf(SessionInstrumentation);
   });
 
   //@FIXME - make integration test work

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -99,8 +99,8 @@ export class GrafanaJavascriptAgentBackend
         environment: options.buildInfo.env,
       },
       instrumentations: options.allInstrumentationsEnabled
-        ? instrumentations
-        : [...getWebInstrumentations(), new TracingInstrumentation()],
+        ? [...getWebInstrumentations(), new TracingInstrumentation()]
+        : instrumentations,
       consoleInstrumentation: consoleInstrumentationOptions,
       trackWebVitalsAttribution: options.webVitalsInstrumentalizationEnabled || options.allInstrumentationsEnabled,
       transports,


### PR DESCRIPTION
The condition for `allInstrumentationsEnabled` config flag was flipped, resulting in always using the full set of instrumention.