### PR TITLE
MSSQL: Add support for specifying SPN and support strict mode

### DIFF
--- a/pkg/tsdb/mssql/kerberos/kerberos.go
+++ b/pkg/tsdb/mssql/kerberos/kerberos.go
@@ -26,6 +26,7 @@ type KerberosAuth struct {
 	ConfigFilePath            string
 	UDPConnectionLimit        int
 	EnableDNSLookupKDC        string
+	ServerSPN                 string
 }
 
 func GetKerberosSettings(settings backend.DataSourceInstanceSettings) (kerberosAuth KerberosAuth, err error) {
@@ -36,6 +37,7 @@ func GetKerberosSettings(settings backend.DataSourceInstanceSettings) (kerberosA
 		ConfigFilePath:            "",
 		UDPConnectionLimit:        1,
 		EnableDNSLookupKDC:        "",
+		ServerSPN:                 "",
 	}
 
 	err = json.Unmarshal(settings.JSONData, &kerberosAuth)
@@ -98,6 +100,10 @@ func Krb5ParseAuthCredentials(host string, port string, db string, user string, 
 
 	if kerberosAuth.EnableDNSLookupKDC != "" {
 		krb5DriverParams += "krb5-dnslookupkdc=" + kerberosAuth.EnableDNSLookupKDC + ";"
+	}
+
+	if kerberosAuth.ServerSPN != "" {
+		krb5DriverParams += "serverSpn=" + kerberosAuth.ServerSPN + ";"
 	}
 
 	return krb5DriverParams

--- a/pkg/tsdb/mssql/kerberos/kerberos_test.go
+++ b/pkg/tsdb/mssql/kerberos/kerberos_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetKerberosSettings(t *testing.T) {
 	t.Run("Should correctly parse settings", func(t *testing.T) {
 		settings := backend.DataSourceInstanceSettings{
-			JSONData: []byte(`{"keytabFilePath":"keytab","credentialCache":"cache","credentialCacheLookupFile":"lookup","configFilePath":"config","UDPConnectionLimit":1,"enableDNSLookupKDC":"dns"}`),
+			JSONData: []byte(`{"keytabFilePath":"keytab","credentialCache":"cache","credentialCacheLookupFile":"lookup","configFilePath":"config","UDPConnectionLimit":1,"enableDNSLookupKDC":"dns","serverSPN":"testSpn"}`),
 		}
 
 		kerberosSettings, err := GetKerberosSettings(settings)
@@ -22,6 +22,7 @@ func TestGetKerberosSettings(t *testing.T) {
 		require.Equal(t, "config", kerberosSettings.ConfigFilePath)
 		require.Equal(t, 1, kerberosSettings.UDPConnectionLimit)
 		require.Equal(t, "dns", kerberosSettings.EnableDNSLookupKDC)
+		require.Equal(t, "testSpn", kerberosSettings.ServerSPN)
 	})
 
 	t.Run("Should correctly parse legacy UDPConnectionLimit", func(t *testing.T) {
@@ -49,6 +50,7 @@ func TestGetKerberosSettings(t *testing.T) {
 		require.Equal(t, "", kerberosSettings.ConfigFilePath)
 		require.Equal(t, 1, kerberosSettings.UDPConnectionLimit)
 		require.Equal(t, "", kerberosSettings.EnableDNSLookupKDC)
+		require.Equal(t, "", kerberosSettings.ServerSPN)
 	})
 
 	t.Run("Will error if legacy UDPConnectionLimit can't be converted to number", func(t *testing.T) {

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -294,6 +294,7 @@ func generateConnectionString(dsInfo sqleng.DataSourceInfo, azureManagedIdentity
 	}
 	switch encrypt {
 	case "true":
+	case "strict":
 		connStr += fmt.Sprintf("encrypt=%s;TrustServerCertificate=%t;", encrypt, tlsSkipVerify)
 		if hostNameInCertificate != "" {
 			connStr += fmt.Sprintf("hostNameInCertificate=%s;", hostNameInCertificate)

--- a/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
@@ -122,6 +122,7 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
     { value: MSSQLEncryptOptions.disable, label: 'disable' },
     { value: MSSQLEncryptOptions.false, label: 'false' },
     { value: MSSQLEncryptOptions.true, label: 'true' },
+    { value: MSSQLEncryptOptions.strict, label: 'strict' },
   ];
 
   return (
@@ -180,6 +181,13 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
                 </li>
                 <li>
                   <i>true</i> - Data sent between client and server is encrypted.
+                </li>
+                <li>
+                  <i>strict</i> - Data sent between client and server is encrypted using{' '}
+                  <a href="https://learn.microsoft.com/en-us/sql/relational-databases/security/networking/tds-8">
+                    TDS8
+                  </a>
+                  .
                 </li>
               </ul>
               If you&apos;re using an older version of Microsoft SQL Server like 2008 and 2008R2 you may need to disable

--- a/public/app/plugins/datasource/mssql/configuration/Kerberos.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/Kerberos.tsx
@@ -135,6 +135,10 @@ export const KerberosAdvancedSettings = (props: DataSourcePluginOptionsEditorPro
     updateDatasourcePluginJsonDataOption(props, 'configFilePath', event.currentTarget.value);
   };
 
+  const onServerSpnChanged = (event: SyntheticEvent<HTMLInputElement>) => {
+    updateDatasourcePluginJsonDataOption(props, 'serverSpn', event.currentTarget.value);
+  };
+
   return (
     <>
       <ConfigSubSection title="Windows AD: Advanced Settings">
@@ -195,6 +199,17 @@ export const KerberosAdvancedSettings = (props: DataSourcePluginOptionsEditorPro
               required
               value={configFilePath || '/etc/krb5.conf'}
             />
+          </Field>
+          <Field
+            label="Server SPN"
+            description={
+              <span>
+                The Kerberos SPN (Service Principal Name) for the server. This may need to be specified when attempting
+                to connect to a SQL Server that has Extended Protection enabled.
+              </span>
+            }
+          >
+            <Input type="text" width={LONG_WIDTH} onChange={onServerSpnChanged} value={jsonData.serverSpn} />
           </Field>
         </FieldSet>
       </ConfigSubSection>

--- a/public/app/plugins/datasource/mssql/types.ts
+++ b/public/app/plugins/datasource/mssql/types.ts
@@ -16,6 +16,7 @@ export enum MSSQLEncryptOptions {
   disable = 'disable',
   false = 'false',
   true = 'true',
+  strict = 'strict',
 }
 export interface MssqlOptions extends SQLOptions {
   authenticationType?: MSSQLAuthenticationType;
@@ -30,6 +31,7 @@ export interface MssqlOptions extends SQLOptions {
   configFilePath?: string;
   UDPConnectionLimit?: number;
   enableDNSLookupKDC?: string;
+  serverSpn?: string;
 }
 
 export interface MssqlSecureOptions {


### PR DESCRIPTION
Adding support for specifying the server SPN and also adding support for `strict` encryption mode. Both of these connection parameters may be required when connecting to a SQL Server that has extended protection enabled.

Specifying `strict` as the encryption mode will ensure that data sent between Grafana and the server is encrypted using [TDS8](https://learn.microsoft.com/en-us/sql/relational-databases/security/networking/tds-8?view=sql-server-ver16).

Specifying the server SPN will ensure it's added to the connection string, therefore supporting [service binding](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/connect-to-the-database-engine-using-extended-protection?view=sql-server-ver16#channel-binding).