### PR TITLE
getLogRowStyles: fix typo

### DIFF
--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -206,7 +206,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
     logDetailsLabel: css({
       label: 'logs-row-details__label',
       maxWidth: '30em',
-      minMidth: '20em',
+      minWidth: '20em',
       padding: theme.spacing(0, 1),
       overflowWrap: 'break-word',
     }),


### PR DESCRIPTION
Fixing a typo introduced in https://github.com/grafana/grafana/pull/94989

Fixes #103865