### PR TITLE
GrafanaUI: Created new component - EditableText

### DIFF
--- a/packages/grafana-ui/src/components/EditableText/EditableText.mdx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.mdx
@@ -1,0 +1,26 @@
+import { Meta, ArgTypes } from '@storybook/blocks';
+import { EditableText } from './EditableText';
+
+<Meta title="MDX|EditableText" component={EditableText} />
+
+# EditableText
+
+asdfasdfasdf
+
+### Usage
+
+```jsx
+import { EditableText } from '@grafana/ui';
+
+<EditableText
+  text="something"
+  editable={false}
+  textChangeHandler={(text) => {
+    console.log('change:', text);
+  }}
+/>;
+```
+
+### Props
+
+<ArgTypes of={EditableText} />

--- a/packages/grafana-ui/src/components/EditableText/EditableText.mdx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.mdx
@@ -5,7 +5,7 @@ import { EditableText } from './EditableText';
 
 # EditableText
 
-asdfasdfasdf
+This component is for inline editing a string and can be visualized as either an Input (when editing) or as a Text component.
 
 ### Usage
 

--- a/packages/grafana-ui/src/components/EditableText/EditableText.mdx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.mdx
@@ -14,7 +14,7 @@ import { EditableText } from '@grafana/ui';
 
 <EditableText
   text="something"
-  editable={false}
+  isEditing={false}
   textChangeHandler={(text) => {
     console.log('change:', text);
   }}

--- a/packages/grafana-ui/src/components/EditableText/EditableText.story.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.story.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+
+import { Switch } from '../Switch/Switch';
+
+import { EditableText } from './EditableText';
+import mdx from './EditableText.mdx';
+
+const meta: Meta<typeof EditableText> = {
+  title: 'Forms/EditableText',
+  component: EditableText,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  args: {
+    width: 30,
+    text: 'Something Default',
+  },
+};
+
+export const Basic: StoryFn<typeof EditableText> = (args) => {
+  const handleTextChange = (text: string) => {
+    console.log('Changed text:', text);
+  };
+
+  const [editable, setEditable] = useState(false);
+
+  return (
+    <div>
+      <span>Editable: </span>
+      <Switch label="Editable" value={editable} onChange={() => setEditable(!editable)} />
+      <br />
+      <EditableText {...args} editable={editable} textChangeHandler={handleTextChange} />
+    </div>
+  );
+};
+
+export default meta;

--- a/packages/grafana-ui/src/components/EditableText/EditableText.story.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.story.tsx
@@ -1,8 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
-import { Switch } from '../Switch/Switch';
-
 import { EditableText } from './EditableText';
 import mdx from './EditableText.mdx';
 
@@ -16,25 +14,18 @@ const meta: Meta<typeof EditableText> = {
   },
   args: {
     width: 30,
-    text: 'Something Default',
+    value: 'Something Default',
   },
 };
 
 export const Basic: StoryFn<typeof EditableText> = (args) => {
-  const handleTextChange = (text: string) => {
-    console.log('Changed text:', text);
+  const [text, setText] = useState(args.value);
+  const handleTextChange = (inputEvent: React.ChangeEvent<HTMLInputElement>) => {
+    setText(inputEvent.currentTarget.value);
+    console.log('Changed text:', inputEvent.currentTarget.value);
   };
 
-  const [editable, setEditable] = useState(false);
-
-  return (
-    <div>
-      <span>Editable: </span>
-      <Switch label="Editable" value={editable} onChange={() => setEditable(!editable)} />
-      <br />
-      <EditableText {...args} editable={editable} textChangeHandler={handleTextChange} />
-    </div>
-  );
+  return <EditableText {...args} value={text} onChange={handleTextChange} />;
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/EditableText/EditableText.test.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { EditableText } from './EditableText';
+
+const mockOnChange = jest.fn();
+describe('EditableText', () => {
+  it('renders as text when editable is false', async () => {
+    render(<EditableText text="Editable Text" editable={false} textChangeHandler={mockOnChange} />);
+
+    expect(screen.getByText('Editable Text')).toBeInTheDocument();
+    expect(await screen.queryByRole('input')).not.toBeInTheDocument();
+  });
+
+  it('renders as an input when editable is true', () => {
+    render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
+
+    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
+
+    expect(input.value).toBe('Editable Text');
+  });
+
+  it('triggers the textChangeHandler when the input is changed', async () => {
+    render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
+
+    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
+
+    await fireEvent.change(input, { target: { value: 'New Text' } });
+    expect(mockOnChange).toHaveBeenCalledWith('New Text');
+  });
+
+  it('retains modified text after input change and editable is set to false', async () => {
+    const { rerender } = render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
+
+    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
+
+    await fireEvent.change(input, { target: { value: 'New Text' } });
+    rerender(<EditableText text="Editable Text" editable={false} textChangeHandler={mockOnChange} />);
+
+    expect(screen.getByText('New Text')).toBeInTheDocument();
+    expect(input).not.toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/EditableText/EditableText.test.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.test.tsx
@@ -1,42 +1,34 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { EditableText } from './EditableText';
+
+const NEW_TEXT = 'New Text';
 
 const mockOnChange = jest.fn();
 describe('EditableText', () => {
   it('renders as text when editable is false', async () => {
-    render(<EditableText text="Editable Text" editable={false} textChangeHandler={mockOnChange} />);
+    render(<EditableText value="Editable Text" isEditing={false} onChange={mockOnChange} />);
 
     expect(screen.getByText('Editable Text')).toBeInTheDocument();
     expect(await screen.queryByRole('input')).not.toBeInTheDocument();
   });
 
   it('renders as an input when editable is true', () => {
-    render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
+    render(<EditableText value="Editable Text" isEditing={true} onChange={mockOnChange} />);
 
-    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
+    const input: HTMLInputElement = screen.getByRole('textbox');
 
     expect(input.value).toBe('Editable Text');
   });
 
   it('triggers the textChangeHandler when the input is changed', async () => {
-    render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
+    render(<EditableText value="Editable Text" isEditing={true} onChange={mockOnChange} />);
 
-    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
+    const input: HTMLInputElement = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, NEW_TEXT);
 
-    await fireEvent.change(input, { target: { value: 'New Text' } });
-    expect(mockOnChange).toHaveBeenCalledWith('New Text');
-  });
-
-  it('retains modified text after input change and editable is set to false', async () => {
-    const { rerender } = render(<EditableText text="Editable Text" editable={true} textChangeHandler={mockOnChange} />);
-
-    const input: HTMLInputElement = screen.getByTestId('editable-text-input');
-
-    await fireEvent.change(input, { target: { value: 'New Text' } });
-    rerender(<EditableText text="Editable Text" editable={false} textChangeHandler={mockOnChange} />);
-
-    expect(screen.getByText('New Text')).toBeInTheDocument();
-    expect(input).not.toBeInTheDocument();
+    expect(mockOnChange).toHaveBeenCalledTimes(NEW_TEXT.length + 1);
   });
 });

--- a/packages/grafana-ui/src/components/EditableText/EditableText.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.tsx
@@ -10,7 +10,7 @@ interface BaseProps {
   text: string;
   textChangeHandler?: (text: string) => void;
 }
-// This combines the interface of this component with that of the Text and Input components
+
 export type EditableTextProps = BaseProps & Partial<TextProps> & Partial<InputProps>;
 
 export const EditableText = forwardRef<HTMLDivElement, EditableTextProps>(

--- a/packages/grafana-ui/src/components/EditableText/EditableText.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, useState, useCallback, useEffect } from 'react';
+
+import { selectors } from '@grafana/e2e-selectors';
+
+import { Input, Props as InputProps } from '../Input/Input';
+import { Text, TextProps } from '../Text/Text';
+
+interface BaseProps {
+  editable?: boolean;
+  text: string;
+  textChangeHandler?: (text: string) => void;
+}
+// This combines the interface of this component with that of the Text and Input components
+export type EditableTextProps = BaseProps & Partial<TextProps> & Partial<InputProps>;
+
+export const EditableText = forwardRef<HTMLDivElement, EditableTextProps>(
+  ({ editable = false, text, textChangeHandler, ...props }, ref) => {
+    const [currentText, setCurrentText] = useState(text);
+
+    useEffect(() => {
+      setCurrentText(text);
+    }, [text]);
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newText = e.currentTarget.value;
+        setCurrentText(newText);
+        textChangeHandler?.(newText);
+      },
+      [textChangeHandler]
+    );
+
+    return (
+      <div ref={ref} data-testid={selectors.components.EditableText.name}>
+        {editable ? (
+          <Input {...props} data-testid="editable-text-input" onChange={handleChange} value={currentText} />
+        ) : (
+          <Text {...props}>{currentText}</Text>
+        )}
+      </div>
+    );
+  }
+);
+
+EditableText.displayName = 'EditableText';

--- a/packages/grafana-ui/src/components/EditableText/EditableText.tsx
+++ b/packages/grafana-ui/src/components/EditableText/EditableText.tsx
@@ -1,7 +1,5 @@
 import { forwardRef, useState, useCallback, useEffect } from 'react';
 
-import { selectors } from '@grafana/e2e-selectors';
-
 import { Input, Props as InputProps } from '../Input/Input';
 import { Text, TextProps } from '../Text/Text';
 
@@ -31,7 +29,7 @@ export const EditableText = forwardRef<HTMLDivElement, EditableTextProps>(
     );
 
     return (
-      <div ref={ref} data-testid={selectors.components.EditableText.name}>
+      <div ref={ref} data-testid="EditableText">
         {editable ? (
           <Input {...props} data-testid="editable-text-input" onChange={handleChange} value={currentText} />
         ) : (

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -280,6 +280,7 @@ export { UserIcon, type UserIconProps } from './UsersIndicator/UserIcon';
 export { UsersIndicator, type UsersIndicatorProps } from './UsersIndicator/UsersIndicator';
 export { type UserView } from './UsersIndicator/types';
 export { Avatar } from './UsersIndicator/Avatar';
+export { EditableText } from './EditableText/EditableText';
 // Export this until we've figured out a good approach to inline form styles.
 export { InlineFormLabel } from './FormLabel/FormLabel';
 export { Divider } from './Divider/Divider';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a new component to Grafana UI: EditableText.

**Why do we need this feature?**

Right now we don't have a component to handle both displaying text (in foreseeable cases, probably headers) as well as an input when editing mode is enabled. This sort of component would be great for inline editable fields where, for example, the title should be represented by just a text element when not editing.

A specific use case is for the upcoming Query Library inline editing feature (and its title field):
![Screenshot 2025-04-14 at 12 35 40 PM](https://github.com/user-attachments/assets/210930c0-49b5-4737-9722-46e2616560c1)


**Who is this feature for?**
Folks developing forms being used both for information as well as editing

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/8786

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


(Switch is just for the story)

https://github.com/user-attachments/assets/627528ee-6629-4922-8585-30bf06caa5d6

