### PR TITLE
Dashboards: Disallow List with RV filter on legacy & align RV format

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -550,7 +550,7 @@ func (a *dashboardSqlAccess) GetLibraryPanels(ctx context.Context, query Library
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              p.UID,
 				CreationTimestamp: metav1.NewTime(p.Created),
-				ResourceVersion:   strconv.FormatInt(p.Updated.UnixMilli(), 10),
+				ResourceVersion:   strconv.FormatInt(p.Updated.UnixMicro(), 10),
 			},
 			Spec: dashboard.LibraryPanelSpec{},
 		}
@@ -610,7 +610,7 @@ func (a *dashboardSqlAccess) GetLibraryPanels(ctx context.Context, query Library
 	if query.UID == "" {
 		rv, err := sqlx.GetResourceVersion(ctx, "library_element", "updated")
 		if err == nil {
-			res.ResourceVersion = strconv.FormatInt(rv, 10)
+			res.ResourceVersion = strconv.FormatInt(rv*1000, 10) // convert to microseconds
 		}
 	}
 	return res, err

--- a/pkg/registry/apis/dashboard/libary_panel.go
+++ b/pkg/registry/apis/dashboard/libary_panel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -51,6 +52,9 @@ func (s *LibraryPanelStore) ConvertToTable(ctx context.Context, object runtime.O
 }
 
 func (s *LibraryPanelStore) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	if options.ResourceVersion != "" {
+		return nil, apierrors.NewBadRequest("List with explicit resourceVersion is not supported with this storage backend")
+	}
 	ns, err := request.NamespaceInfoFrom(ctx, true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What is this feature?**
This PR standardizes the ResourceVersion format returned by the LIST operation in legacystorage to match the format used by unified storage. It also explicitly disallows providing a ResourceVersion in requests, as this operation is not supported.

**Why do we need this feature?**
The previously inconsistent ResourceVersion format could lead to issues for API consumers that use it for checkpointing. As the precision differs from that of unified storage, it will result in errors.

**Who is this feature for?**
This change benefits developers or systems that rely on storing and reusing ResourceVersions returned by the dashboard APIs.

**Which issue(s) does this PR fix?**
No issue has been filed for this change.