### PR TITLE
(grafana-ui): Fix Select input not being cleared

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -282,7 +282,13 @@ export function SelectBase<T, Rest = {}>({
     renderControl,
     showAllSelectedWhenOpen,
     tabSelectsValue,
-    value: isMulti ? selectedValue : selectedValue?.[0],
+    // When the selectedValue is undefined, set it to null instead
+    // This forces react-select to show the placeholder
+    value: isMulti
+      ? selectedValue
+      : selectedValue === undefined || (Array.isArray(selectedValue) && selectedValue.length === 0)
+        ? null
+        : selectedValue?.[0],
     noMultiValueWrap,
   };
 
@@ -346,6 +352,10 @@ export function SelectBase<T, Rest = {}>({
           Option: SelectMenuOptions,
           ClearIndicator(props: ClearIndicatorProps) {
             const { clearValue } = props;
+            // Don't render clear indicator if selectedValue is undefined/empty
+            if (selectedValue === undefined || (Array.isArray(selectedValue) && selectedValue.length === 0)) {
+              return null;
+            }
             return (
               <Icon
                 name="times"
@@ -378,6 +388,12 @@ export function SelectBase<T, Rest = {}>({
           },
           DropdownIndicator: DropdownIndicator,
           SingleValue(props: Props<T>) {
+            // Only render SingleValue if we actually have a value
+            // This fixes the issue when clearing programmatically but react-select
+            // component still has stale cached value data
+            if (selectedValue === undefined || (Array.isArray(selectedValue) && selectedValue.length === 0)) {
+              return null;
+            }
             return <SingleValue {...props} isDisabled={disabled} />;
           },
           SelectContainer,


### PR DESCRIPTION
**What is this feature?**
This PR addresses an edge case in the react-select integration where programmatic clearing of the input value (undefined) does not fully reset the internal state of the component. This caused stale UI states where the selected option would still appear visually, or the clear button remained visible despite no value being present.


📚 Background
In most usage patterns, react-select behaves predictably:
- A user selects an option.
- The input reflects the selection.
- The user can clear it using the clear button or another manual interaction.

However, in db-o11y, we encountered a sync issue in a specific flow:

1. A user groups data by schema
![group](https://github.com/user-attachments/assets/4903beec-f261-45af-99ee-75a33070b8af)


2. Then clicks a label in a chart tooltip to add a new filter
<img width="357" alt="click" src="https://github.com/user-attachments/assets/ac781d77-12ba-4f8d-92da-4528db4e4845" />


3. At this point, the selected [groupBy value](https://github.com/grafana/scenes/blob/6ed48bfb7bdc89d7a694976930dc37f04a77007a/packages/scenes/src/variables/groupby/GroupByVariable.tsx#L320) should be cleared to allow a new filter context
![expected-behaviour](https://github.com/user-attachments/assets/ae92d57b-33d2-472f-99e1-3118184739d9)

**But internally, the Select still holds onto the stale selection due to how it handles undefined values.**

**Solution**
Complete component reset: when React sees a different key prop, it completely unmounts and remounts the component, clearing any stale internal state

**Before**

https://github.com/user-attachments/assets/0d588e1f-cb79-424a-ab0f-2280b6776636


**After**

https://github.com/user-attachments/assets/b7974ecf-f688-43ba-babe-bdb5c0a7d1d8


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
