### PR TITLE
SQL Expressions: Reduce memory consumption when converting from TimeSeries (Multi)

### DIFF
--- a/pkg/expr/convert_to_full_long_ts_test.go
+++ b/pkg/expr/convert_to_full_long_ts_test.go
@@ -371,3 +371,38 @@ func TestConvertTimeSeriesMultiToFullLongWithDisplayName(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkConvertToFullLong(b *testing.B) {
+	// Create time-series data with 5,000 rows
+	times := make([]time.Time, 5000)
+	for i := range times {
+		times[i] = time.Unix(int64(i), 0)
+	}
+	values := make([]float64, 5000)
+	for i := range values {
+		values[i] = float64(i)
+	}
+
+	// Create a second series with 5,000 rows
+	times2 := make([]time.Time, 5000)
+	for i := range times2 {
+		times2[i] = time.Unix(int64(i), 0)
+	}
+	values2 := make([]float64, 5000)
+	for i := range values2 {
+		values2[i] = float64(i)
+	}
+
+	// Create a frame with the times
+	frame := data.NewFrame("cpu", data.NewField("time", nil, times), data.NewField("cpu", nil, values))
+	frame.Meta = &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}
+
+	// Create a second frame with the times
+	frame2 := data.NewFrame("cpu", data.NewField("time", nil, times2), data.NewField("cpu", nil, values2))
+	frame2.Meta = &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}
+
+	// Run the conversion
+	for b.Loop() {
+		ConvertToFullLong(data.Frames{frame, frame2})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

I'll put more details in here soon. But I think this is a BIG saving in memory consumption when converting from TimeSeries (Multi) into full-long format. We weren't initialising the array before, so there was a lot of garbage collection as the array had to be dynamically resized every time we added more rows to exceed its size.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
