### PR TITLE
GitHub: Add workflows for jobs in private repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -790,9 +790,11 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-codeql-analysis-python.yml @DanCech
 /.github/workflows/pr-commands.yml @tolzhabayev
 /.github/workflows/pr-patch-check.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/pr-patch-check-event.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/pr-test-integration.yml @grafana/grafana-backend-group
 /.github/workflows/pr-backend-coverage.yml @grafana/grafana-backend-group
 /.github/workflows/sync-mirror.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/sync-mirror-event.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/publish-technical-documentation-next.yml @grafana/docs-tooling
 /.github/workflows/publish-technical-documentation-release.yml @grafana/docs-tooling
 /.github/workflows/remove-milestone.yml @grafana/grafana-developer-enablement-squad

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -1,0 +1,46 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo Ex: grafana/grafana
+name: Dispatch: Check for patch conflicts
+run-name: dispatch-check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - "main"
+      - "v*.*.*"
+      - "release-*"
+
+# Since this is run on a pull request, we want to apply the patches intended for the
+# target branch onto the source branch, to verify compatibility before merging.
+jobs:
+  dispatch-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          # App needs Actions: Read/Write for the grafana/security-patch-actions repo
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - name: "Dispatch job"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+                owner: 'grafana',
+                repo: 'security-patch-actions',
+                workflow_id: 'test-patches-event.yml',
+                ref: 'main',
+                inputs: {
+                  src_repo: "${{ github.repository }}",
+                  src_ref: "${{ github.head_ref }}",
+                  patch_repo: "${{ github.repository }}-security-patches",
+                  patch_ref: "${{ github.base_ref }}"
+                }
+            })

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -1,0 +1,42 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo, Ex: grafana/grafana
+name: Dispatch: Sync to mirror
+run-name: dispatch-sync-to-mirror-${{ github.ref_name }}
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "v*.*.*"
+      - "release-*"
+
+# This is run after the pull request has been merged, so we'll run against the target branch
+jobs:
+  dispatch-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          # App needs Actions: Read/Write for the grafana/security-patch-actions repo
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - uses: actions/github-script@v7
+        if: github.repository == 'grafana/grafana'
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+                owner: 'grafana',
+                repo: 'security-patch-actions',
+                workflow_id: 'mirror-branch-and-apply-patches-event.yml',
+                ref: 'main',
+                inputs: {
+                  ref: "${{ github.ref_name }}",
+                  src_repo: "${{ github.repository }}",
+                  dest_repo: "${{ github.repository }}-security-mirror",
+                  patch_repo: "${{ github.repository }}-security-patches"
+                }
+            })


### PR DESCRIPTION
**What is this feature?**
This PR dispatches the patch checks in our private repo.

**Why do we need this feature?**
Makes it obsolete to embed the check execution directly into this repo.

**Who is this feature for?**
grafana-delivery-squad
