### PR TITLE
Alerting: Return an empty array for contact points with no integrations

### DIFF
--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -58,7 +58,8 @@ func convertToK8sResource(
 	namespacer request.NamespaceMapper,
 ) (*model.Receiver, error) {
 	spec := model.Spec{
-		Title: receiver.Name,
+		Title:        receiver.Name,
+		Integrations: []model.Integration{},
 	}
 	for _, integration := range receiver.Integrations {
 		spec.Integrations = append(spec.Integrations, model.Integration{

--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -59,7 +59,7 @@ func convertToK8sResource(
 ) (*model.Receiver, error) {
 	spec := model.Spec{
 		Title:        receiver.Name,
-		Integrations: []model.Integration{},
+		Integrations: make([]model.Integration, 0, len(receiver.Integrations)),
 	}
 	for _, integration := range receiver.Integrations {
 		spec.Integrations = append(spec.Integrations, model.Integration{

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -75,7 +75,7 @@ func TestIntegrationResourceIdentifier(t *testing.T) {
 		},
 		Spec: v0alpha1.Spec{
 			Title:        "Test-Receiver",
-			Integrations: nil,
+			Integrations: []v0alpha1.Integration{},
 		},
 	}
 
@@ -307,7 +307,7 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 				},
 				Spec: v0alpha1.Spec{
 					Title:        "receiver-1",
-					Integrations: nil,
+					Integrations: []v0alpha1.Integration{},
 				},
 			}
 			d, err := json.Marshal(created)
@@ -573,7 +573,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 				},
 				Spec: v0alpha1.Spec{
 					Title:        fmt.Sprintf("receiver-1-%s", tc.user.Identity.GetLogin()),
-					Integrations: nil,
+					Integrations: []v0alpha1.Integration{},
 				},
 			}
 			d, err := json.Marshal(expected)
@@ -929,7 +929,7 @@ func TestIntegrationOptimisticConcurrency(t *testing.T) {
 		},
 		Spec: v0alpha1.Spec{
 			Title:        "receiver-1",
-			Integrations: nil,
+			Integrations: []v0alpha1.Integration{},
 		},
 	}
 
@@ -1271,7 +1271,7 @@ func TestIntegrationCRUD(t *testing.T) {
 			},
 			Spec: v0alpha1.Spec{
 				Title:        defaultReceiver.Spec.Title,
-				Integrations: nil,
+				Integrations: []v0alpha1.Integration{},
 			},
 		}
 		_, err := adminClient.Create(ctx, newReceiver, v1.CreateOptions{})


### PR DESCRIPTION
Prior to this PR the API would respond with `null` when fetching contact points with no integrations, which is slightly annoying to work with on the front-end.

If tests needed to be added I'd be more than happy to add them if I can get some guidance for where to start looking :)