### PR TITLE
Storage: Change timeout for flaky test

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -882,7 +882,7 @@ func runTestIntegrationBackendListHistoryErrorReporting(t *testing.T, backend re
 		},
 	}
 
-	shortContext, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+	shortContext, cancel := context.WithTimeout(ctx, 1*time.Microsecond)
 	defer cancel()
 
 	res, err := server.List(shortContext, req)
@@ -890,6 +890,7 @@ func runTestIntegrationBackendListHistoryErrorReporting(t *testing.T, backend re
 	t.Log("list error:", err)
 	if res != nil {
 		t.Log("iterator error:", res.Error)
+		t.Log("numItems:", len(res.Items))
 	}
 	require.True(t, err != nil || (res != nil && res.Error != nil))
 }


### PR DESCRIPTION
**What is this feature?**
Reduces the timeout of a test to reduce flakiness.

**Why do we need this feature?**
We're just way too efficient and hence are able to serve the entire request in less than a millisecond.

**Who is this feature for?**
Everyone who doesn't like retriggering CI.

**Which issue(s) does this PR fix?**:
