### PR TITLE
InfluxDB: Fix nested variable interpolation

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, extend, has, isString, map as _map, omit, pick, reduce } from 'lodash';
+import { map as _map, cloneDeep, extend, has, isString, omit, pick, reduce } from 'lodash';
 import { lastValueFrom, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
@@ -359,7 +359,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // If matches are found this regex is evaluated to check if the variable is contained in the regex /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
-    if (!query) {
+
+    // We need to validate the type of the query as some legacy cases can pass a query value with a different type
+    if (!query || typeof query !== 'string') {
       return value;
     }
 


### PR DESCRIPTION
Fixes a bug introduced in #100762.

Legacy (pre-scenes) template variables use [this](https://github.com/grafana/grafana/blob/df2e6d5eeeebfc7ff0bbb47269f512b8cc4da574/public/app/features/templating/formatVariableValue.ts#L26) function which can lead to a variable that is not a string being passed to our `interpolateQueryExpr` function.

The previous implementation ran `regex.test` against the query which would return `false` if the regex did not match. This would also be the case if the query variable was not a string.

I've updated the implementation to just validate that the query is a string, otherwise the variable value will be returned unmodified.

This is only reproducible by setting the following feature toggle values:

```
dashboardScene = false
dashboardSceneForViewers = false
dashboardSceneSolo = false
```