### PR TITLE
MetricsDrilldown: Restore link to Metrics Drilldown from Explore

### DIFF
--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -18,7 +18,12 @@ type Props = {
   extensionsToShow: 'queryless' | 'basic';
 };
 
-const QUERYLESS_APPS = ['grafana-pyroscope-app', 'grafana-lokiexplore-app', 'grafana-exploretraces-app'];
+const QUERYLESS_APPS = [
+  'grafana-pyroscope-app',
+  'grafana-lokiexplore-app',
+  'grafana-exploretraces-app',
+  'grafana-metricsdrilldown-app',
+];
 
 export function ToolbarExtensionPoint(props: Props): ReactElement | null {
   const { exploreId, extensionsToShow } = props;


### PR DESCRIPTION
## Related issue

This PR fixes #104066.

## What is this change?

A one-liner, to add [`grafana-metricsdrilldown-app`](https://grafana.com/grafana/plugins/grafana-metricsdrilldown-app) to the list of queryless apps that we create the **Go queryless** extensions for. This fixes 

## Demo

### Before

![Image](https://github.com/user-attachments/assets/90156a66-d9cd-4efd-8a29-b2337d9f7ede)

### After

https://github.com/user-attachments/assets/5746fdaf-ed1c-4ce2-8269-ba8d4de32084
