### PR TITLE
Dashboard: Support TemplateSrv.containsTemplate in scenes context

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -904,6 +904,29 @@ describe('templateSrv', () => {
       expect(podVar.current.text).toEqual(['podA', 'podB']);
     });
 
+    it('Can use containsTemplate to check if a variable exists', () => {
+      window.__grafanaSceneContext = new EmbeddedScene({
+        $variables: new SceneVariableSet({
+          variables: [
+            new QueryVariable({ name: 'server', value: 'serverA', text: 'Server A', query: { refId: 'A' } }),
+            new QueryVariable({ name: 'pods', value: ['pA', 'pB'], text: ['podA', 'podB'], query: { refId: 'A' } }),
+            new DataSourceVariable({ name: 'ds', value: 'dsA', text: 'dsA', pluginId: 'prometheus' }),
+            new CustomVariable({ name: 'custom', value: 'A', text: 'A', query: 'A, B, C' }),
+            new IntervalVariable({ name: 'interval', value: '1m', intervals: ['1m', '2m'] }),
+          ],
+        }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      window.__grafanaSceneContext.activate();
+
+      expect(_templateSrv.containsTemplate('${server}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${pods}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${ds}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${custom}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${interval}')).toBe(true);
+    });
+
     it('Should return timeRange from scenes context', () => {
       window.__grafanaSceneContext = new EmbeddedScene({
         body: new SceneCanvasText({ text: 'hello' }),

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -201,17 +201,17 @@ export class TemplateSrv implements BaseTemplateSrv {
       return false;
     }
 
+    const name = this.getVariableName(target);
+
     // Scenes compatability
     if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
-      const varName = this.getVariableName(target);
-      if (!varName) {
+      if (!name) {
         return false;
       }
 
-      return !!sceneGraph.lookupVariable(varName, window.__grafanaSceneContext);
+      return !!sceneGraph.lookupVariable(name, window.__grafanaSceneContext);
     }
 
-    const name = this.getVariableName(target);
     const variable = name && this.getVariableAtIndex(name);
     return variable !== null && variable !== undefined;
   }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -200,6 +200,16 @@ export class TemplateSrv implements BaseTemplateSrv {
     if (!target) {
       return false;
     }
+
+    if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
+      const varName = this.getVariableName(target);
+      if (!varName) {
+        return false;
+      }
+
+      return !!sceneGraph.lookupVariable(varName, window.__grafanaSceneContext);
+    }
+
     const name = this.getVariableName(target);
     const variable = name && this.getVariableAtIndex(name);
     return variable !== null && variable !== undefined;

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -201,6 +201,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       return false;
     }
 
+    // Scenes compatability
     if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
       const varName = this.getVariableName(target);
       if (!varName) {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -201,17 +201,15 @@ export class TemplateSrv implements BaseTemplateSrv {
       return false;
     }
 
-    const name = this.getVariableName(target);
-
     // Scenes compatability
     if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
-      if (!name) {
-        return false;
-      }
-
-      return !!sceneGraph.lookupVariable(name, window.__grafanaSceneContext);
+      // We are just checking that this is a valid variable reference, and we are not looking up the variable
+      this.regex.lastIndex = 0;
+      const match = this.regex.exec(target);
+      return !!match;
     }
 
+    const name = this.getVariableName(target);
     const variable = name && this.getVariableAtIndex(name);
     return variable !== null && variable !== undefined;
   }


### PR DESCRIPTION
**What is this feature?**

Enables statistic field to work with a template variable in scenes. This didn't work when scenes are enabled because the dashboard scene doesn't rely on or update legacy redux state, and `TemplateSrv.containsTemplate` relies on `targets.keys` from redux store.

Fixes https://github.com/grafana/grafana/issues/102872
Fixes https://github.com/grafana/support-escalations/issues/15409


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
