### PR TITLE
MetricsDrilldown: Restore link to Metrics Drilldown from Explore

### DIFF
--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -18,7 +18,12 @@ type Props = {
   extensionsToShow: 'queryless' | 'basic';
 };
 
-const QUERYLESS_APPS = ['grafana-pyroscope-app', 'grafana-lokiexplore-app', 'grafana-exploretraces-app'];
+const QUERYLESS_APPS = [
+  'grafana-pyroscope-app',
+  'grafana-lokiexplore-app',
+  'grafana-exploretraces-app',
+  'grafana-metricsdrilldown-app',
+];
 
 export function ToolbarExtensionPoint(props: Props): ReactElement | null {
   const { exploreId, extensionsToShow } = props;


### PR DESCRIPTION
## What is this change?

A backport of https://github.com/grafana/grafana/pull/104069 to `12.0.1`, to fix an important bug related to Grafana Metrics Drilldown.

## Related issue

This PR supports https://github.com/grafana/grafana/issues/104066.