### PR TITLE
GitHub Actions: Explicitly pass github username and commit sha

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -40,7 +40,9 @@ jobs:
                 inputs: {
                   src_repo: "${{ github.repository }}",
                   src_ref: "${{ github.head_ref }}",
+                  src_sha: "${{ github.sha }}",
                   patch_repo: "${{ github.repository }}-security-patches",
-                  patch_ref: "${{ github.base_ref }}"
+                  patch_ref: "${{ github.base_ref }}",
+                  triggering_github_handle: "${{ github.event.sender.login }}"
                 }
             })

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -34,8 +34,9 @@ jobs:
                 workflow_id: 'mirror-branch-and-apply-patches-event.yml',
                 ref: 'main',
                 inputs: {
-                  ref: "${{ github.ref_name }}",
+                  src_ref: "${{ github.ref_name }}",
                   src_repo: "${{ github.repository }}",
+                  src_sha: "${{ github.sha }}",
                   dest_repo: "${{ github.repository }}-security-mirror",
                   patch_repo: "${{ github.repository }}-security-patches"
                 }


### PR DESCRIPTION
Due to the dispatch, we're actually assuming the identity of the bot. Also, we need the actual SHA so we can report back the status as we lose some magic when the handler is invoked with a dispatch instead of the actual event.