### PR TITLE
Rename grafana cli to grafana server cli

### DIFF
--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -11,7 +11,7 @@ labels:
   products:
     - enterprise
     - oss
-title: Grafana Server CLI
+title: Grafana server CLI
 weight: 400
 ---
 

--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -65,7 +65,7 @@ grafana cli -h
 
 ### Display Grafana server CLI version
 
-`--version` or `-v` prints the version of Grafana CLI currently running.
+`--version` or `-v` prints the version of Grafana server CLI currently running.
 
 **Example:**
 

--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - administration/cli/
-description: Guide to using grafana cli
+description: Guide to using grafana server cli
 keywords:
   - grafana
   - cli
@@ -11,15 +11,15 @@ labels:
   products:
     - enterprise
     - oss
-title: Grafana CLI
+title: Grafana Server CLI
 weight: 400
 ---
 
-# Grafana CLI
+# Grafana server CLI
 
-Grafana CLI is a small executable that's bundled with Grafana server.
+Grafana server CLI is a small executable that's bundled with Grafana server.
 You can run it on the same machine Grafana server is running on.
-Grafana CLI has `plugins` and `admin` commands, as well as global options.
+Grafana server CLI has `plugins` and `admin` commands, as well as global options.
 
 To list all commands and options:
 
@@ -27,9 +27,9 @@ To list all commands and options:
 grafana cli -h
 ```
 
-## Run Grafana CLI
+## Run Grafana server CLI
 
-To run Grafana CLI, add the path to the Grafana binaries in your `PATH` environment variable.
+To run Grafana server CLI, add the path to the Grafana binaries in your `PATH` environment variable.
 Alternately, if your current directory is the `bin` directory, run `./grafana cli`.
 Otherwise, you can specify full path to the binary.
 For example, on Linux `/usr/share/grafana/bin/grafana` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana.exe`, and run it with `grafana cli`.
@@ -41,7 +41,7 @@ If you're on Windows, run Windows PowerShell as Administrator.
 
 ## Grafana CLI command syntax
 
-The general syntax for commands in Grafana CLI is:
+The general syntax for commands in Grafana server CLI is:
 
 ```bash
 grafana cli [global options] command [command options] [arguments...]
@@ -49,11 +49,11 @@ grafana cli [global options] command [command options] [arguments...]
 
 ## Global options
 
-Grafana CLI allows you to temporarily override certain Grafana default settings. Except for `--help` and `--version`, most global options are only used by developers.
+Grafana server CLI allows you to temporarily override certain Grafana default settings. Except for `--help` and `--version`, most global options are only used by developers.
 
 Each global option applies only to the command in which it is used. For example, `--pluginsDir value` does not permanently change where Grafana saves plugins. It only changes it for command in which you apply the option.
 
-### Display Grafana CLI help
+### Display Grafana server CLI help
 
 `--help` or `-h` displays the help, including default paths and Docker configuration information.
 
@@ -63,7 +63,7 @@ Each global option applies only to the command in which it is used. For example,
 grafana cli -h
 ```
 
-### Display Grafana CLI version
+### Display Grafana server CLI version
 
 `--version` or `-v` prints the version of Grafana CLI currently running.
 


### PR DESCRIPTION
In order to accommodate the new Grafana CLI, @mjseaman requested to rename this CLI to grafana server CLI so that there are no conflicts with the pages. 

This PR adds Grafana server CLI where necessary.