### PR TITLE
datasources: querier: refactor: rename client to clientSupplier

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -241,7 +241,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 		return &backend.QueryDataResponse{}, nil
 	}
 
-	client, err := b.client.GetDataSourceClient(
+	client, err := b.clientSupplier.GetDataSourceClient(
 		ctx,
 		v0alpha1.DataSourceRef{
 			Type: req.PluginId,

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestQueryRestConnectHandler(t *testing.T) {
 	b := &QueryAPIBuilder{
-		client: mockClient{
+		clientSupplier: mockClient{
 			lastCalledWithHeaders: &map[string]string{},
 		},
 		tracer: tracing.InitializeTracerForTest(),
@@ -80,7 +80,7 @@ func TestQueryRestConnectHandler(t *testing.T) {
 		"X-Rule-Type":              "type-1",
 		"X-Rule-Version":           "version-1",
 		"X-Grafana-Org-Id":         "1",
-	}, *b.client.(mockClient).lastCalledWithHeaders)
+	}, *b.clientSupplier.(mockClient).lastCalledWithHeaders)
 }
 
 func TestInstantQueryFromAlerting(t *testing.T) {

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -43,17 +43,17 @@ type QueryAPIBuilder struct {
 
 	authorizer authorizer.Authorizer
 
-	tracer     tracing.Tracer
-	metrics    *metrics.ExprMetrics
-	parser     *queryParser
-	client     clientapi.DataSourceClientSupplier
-	registry   query.DataSourceApiServerRegistry
-	converter  *expr.ResultConverter
-	queryTypes *query.QueryTypeDefinitionList
+	tracer         tracing.Tracer
+	metrics        *metrics.ExprMetrics
+	parser         *queryParser
+	clientSupplier clientapi.DataSourceClientSupplier
+	registry       query.DataSourceApiServerRegistry
+	converter      *expr.ResultConverter
+	queryTypes     *query.QueryTypeDefinitionList
 }
 
 func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
-	client clientapi.DataSourceClientSupplier,
+	clientSupplier clientapi.DataSourceClientSupplier,
 	ar authorizer.Authorizer,
 	registry query.DataSourceApiServerRegistry,
 	legacy service.LegacyDataSourceLookup,
@@ -80,7 +80,7 @@ func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
 	return &QueryAPIBuilder{
 		concurrentQueryLimit: 4,
 		log:                  log.New("query_apiserver"),
-		client:               client,
+		clientSupplier:       clientSupplier,
 		authorizer:           ar,
 		registry:             registry,
 		parser:               newQueryParser(reader, legacy, tracer, log.New("query_parser")),


### PR DESCRIPTION
i renamed some variables named `client` to `clientSupplier`.

this is how the querier works:
- it parses the incoming requests, identifies which data sources (`type` and `uid`) will be needed to handle the request
- it asks it's `ClientSupplier` to get a `Client` that is suitable for the given data source `type` and `uid`
- it calls the `Client`'s `QueryData`

but the naming is confusing. in the `QueryAPIBuilder` structure, the field is named `client`, but contains a `ClientSupplier`. i adjusted this name to be `clientSupplier`, to be consistent.

no functional changes.