### PR TITLE
Chore: expose `dashboardSrv` over InjectorService (fake angular dependency)

### DIFF
--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './dataSourceSrv';
 export * from './LocationSrv';
 export * from './EchoSrv';
 export * from './templateSrv';
+export * from './legacyAngularInjector'; // Will be removed in 12.x
 export * from './live';
 export * from './LocationService';
 export * from './appEvents';

--- a/packages/grafana-runtime/src/services/legacyAngularInjector.ts
+++ b/packages/grafana-runtime/src/services/legacyAngularInjector.ts
@@ -1,0 +1,25 @@
+let singleton: InjectorService;
+
+interface InjectorService {
+  get: (key: string) => unknown;
+}
+
+/**
+ * Used during startup by Grafana to temporarily expose a fake angular injector
+ * to pure javascript plugins using {@link getLegacyAngularInjector}.
+ *
+ * @internal
+ */
+export const setLegacyAngularInjector = (instance: InjectorService) => {
+  singleton = instance;
+};
+
+/**
+ * WARNING: this function provides a temporary way for plugins to access anything in the
+ * angular injector.  While the migration from angular to react continues, there are a few
+ * options that do not yet have good alternatives.  Note that use of this function will
+ * be removed in the future.
+ *
+ * @deprecated Will be removed in grafana 12+
+ */
+export const getLegacyAngularInjector = (): InjectorService => singleton;

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -20,6 +20,7 @@ import { LiveConnectionWarning } from './features/live/LiveConnectionWarning';
 import { ExtensionRegistriesProvider } from './features/plugins/extensions/ExtensionRegistriesContext';
 import { pluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
 import { ScopesContextProvider } from './features/scopes/ScopesContextProvider';
+import { loadAndInitAngularIfEnabled } from './legacy';
 import { RouterWrapper } from './routes/RoutesWrapper';
 
 interface AppWrapperProps {
@@ -56,6 +57,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
   }
 
   async componentDidMount() {
+    await loadAndInitAngularIfEnabled();
     this.setState({ ready: true });
     $('.preloader').remove();
 

--- a/public/app/legacy.ts
+++ b/public/app/legacy.ts
@@ -1,0 +1,19 @@
+import { deprecationWarning } from '@grafana/data';
+import { setLegacyAngularInjector } from '@grafana/runtime';
+import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+
+export async function loadAndInitAngularIfEnabled() {
+  // Temporary path to allow access to services exposed directly by the angular injector
+  setLegacyAngularInjector({
+    get: (key: string) => {
+      switch (key) {
+        case 'dashboardSrv': {
+          // we do not yet have a public interface for this
+          deprecationWarning('getLegacyAngularInjector', 'getDashboardSrv');
+          return getDashboardSrv();
+        }
+      }
+      throw 'Angular is no longer supported.  Unable to expose: ' + key;
+    },
+  });
+}


### PR DESCRIPTION
**What is this feature?**

In 11.x, a few non-angular dependencies were accessible via a fake angular injector.  This lets us keep using the dashboard service until scenes is ready to make a more public release

**Why do we need this feature?**

Twinmaker

Compare to: https://github.com/grafana/grafana/blob/v11.5.x/public/app/AppWrapper.tsx#L18