### PR TITLE
AutoGrid: Tweak height of short row height 

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -306,7 +306,7 @@ function getNamedHeightInPixels(rowHeight: AutoGridRowHeight) {
 
   switch (rowHeight) {
     case 'short':
-      return 128;
+      return 168;
     case 'tall':
       return 512;
     case 'custom':


### PR DESCRIPTION
The height difference between short and standard was too high (almost 100%), forgot to change this before the cutoff. 

Now it feels more reasonable. Also fixes a minor spacing issue in "Variable list view". 

Before
<img width="1179" alt="Screenshot 2025-04-16 at 16 06 02" src="https://github.com/user-attachments/assets/00df85ce-1cff-41bd-bec8-51a0ae314834" />

After: 
<img width="1176" alt="Screenshot 2025-04-16 at 16 05 56" src="https://github.com/user-attachments/assets/2885e514-d2aa-46fa-b21d-010526aa5510" />
