### PR TITLE
feat(unified-storage): return guid, group and resource on read/list

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	context "context"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -71,6 +71,8 @@ type BackendReadResponse struct {
 	Key    *ResourceKey
 	Folder string
 
+	// GUID that is used internally
+	GUID string
 	// The new resource version
 	ResourceVersion int64
 	// The properties

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
@@ -593,9 +594,12 @@ type listIter struct {
 	err error
 
 	// The row
+	guid      string
 	rv        int64
 	value     []byte
 	namespace string
+	resource  string
+	group     string
 	name      string
 	folder    string
 }
@@ -639,7 +643,7 @@ func (l *listIter) Value() []byte {
 func (l *listIter) Next() bool {
 	if l.rows.Next() {
 		l.offset++
-		l.err = l.rows.Scan(&l.rv, &l.namespace, &l.name, &l.folder, &l.value)
+		l.err = l.rows.Scan(&l.guid, &l.rv, &l.namespace, &l.resource, &l.group, &l.name, &l.folder, &l.value)
 		return true
 	}
 	return false

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -7,16 +7,17 @@ import (
 	"fmt"
 	"testing"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/mattn/go-sqlite3"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/test"
 	"github.com/grafana/grafana/pkg/util/testutil"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var (
@@ -401,6 +402,7 @@ func TestBackend_delete(t *testing.T) {
 }
 
 type readHistoryRow struct {
+	guid             string
 	namespace        string
 	group            string
 	resource         string
@@ -418,6 +420,7 @@ func TestBackend_ReadResource(t *testing.T) {
 		b, ctx := setupBackendTest(t)
 
 		expectedReadRow := readHistoryRow{
+			guid:             "guid",
 			namespace:        "ns",
 			group:            "gr",
 			resource:         "rs",
@@ -426,11 +429,12 @@ func TestBackend_ReadResource(t *testing.T) {
 			resource_version: "300",
 			value:            "rv-300",
 		}
-		readResource := []string{"namespace", "group", "resource", "name", "folder", "resource_version", "value"}
+		readResource := []string{"guid", "namespace", "group", "resource", "name", "folder", "resource_version", "value"}
 		b.SQLMock.ExpectBegin()
 		b.SQLMock.ExpectQuery("SELECT .* FROM resource").
 			WillReturnRows(sqlmock.NewRows(readResource).
 				AddRow(
+					expectedReadRow.guid,
 					expectedReadRow.namespace,
 					expectedReadRow.group,
 					expectedReadRow.resource,
@@ -473,6 +477,7 @@ func TestBackend_ReadResource(t *testing.T) {
 		b, ctx := setupBackendTest(t)
 
 		expectedReadRow := readHistoryRow{
+			guid:             "guid",
 			namespace:        "ns",
 			group:            "gr",
 			resource:         "rs",
@@ -482,11 +487,12 @@ func TestBackend_ReadResource(t *testing.T) {
 			value:            "rv-300",
 		}
 
-		readHistoryColumns := []string{"namespace", "group", "resource", "name", "folder", "resource_version", "value"}
+		readHistoryColumns := []string{"guid", "namespace", "group", "resource", "name", "folder", "resource_version", "value"}
 		b.SQLMock.ExpectBegin()
 		b.SQLMock.ExpectQuery("SELECT .* FROM resource_history").
 			WillReturnRows(sqlmock.NewRows(readHistoryColumns).
 				AddRow(
+					expectedReadRow.guid,
 					expectedReadRow.namespace,
 					expectedReadRow.group,
 					expectedReadRow.resource,
@@ -534,7 +540,7 @@ func TestBackend_getHistory(t *testing.T) {
 		Name:      "nm",
 	}
 	rv1, rv2, rv3 := int64(100), int64(200), int64(300)
-	cols := []string{"resource_version", "namespace", "name", "folder", "value"}
+	cols := []string{"guid", "resource_version", "namespace", "group", "resource", "name", "folder", "value"}
 
 	tests := []struct {
 		name                          string
@@ -657,8 +663,11 @@ func TestBackend_getHistory(t *testing.T) {
 				historyRows := sqlmock.NewRows(cols)
 				for _, rv := range tc.expectedVersions {
 					historyRows.AddRow(
+						"guid",                           // guid
 						rv,                               // resource_version
 						"ns",                             // namespace
+						"gr",                             // group
+						"rs",                             // resource
 						"nm",                             // name
 						"folder",                         // folder
 						[]byte(fmt.Sprintf("rv-%d", rv)), // value
@@ -829,12 +838,15 @@ func setupHistoryTest(b testBackend, resourceVersions []int64, latestRV int64, e
 	}
 
 	// Create the mock rows for the history items
-	cols := []string{"resource_version", "namespace", "name", "folder", "value"}
+	cols := []string{"guid", "resource_version", "namespace", "group", "resource", "name", "folder", "value"}
 	historyRows := sqlmock.NewRows(cols)
 	for _, rv := range resourceVersions {
 		historyRows.AddRow(
+			"guid",                           // guid
 			rv,                               // resource_version
 			"ns",                             // namespace
+			"gr",                             // group
+			"rs",                             // resource
 			"nm",                             // name
 			"folder",                         // folder
 			[]byte(fmt.Sprintf("rv-%d", rv)), // value

--- a/pkg/storage/unified/sql/data/resource_history_get.sql
+++ b/pkg/storage/unified/sql/data/resource_history_get.sql
@@ -1,6 +1,9 @@
 SELECT
+  {{ .Ident "guid" }},
   {{ .Ident "resource_version" }},
   {{ .Ident "namespace" }},
+  {{ .Ident "group" }},
+  {{ .Ident "resource" }},
   {{ .Ident "name" }},
   {{ .Ident "folder" }},
   {{ .Ident "value" }}

--- a/pkg/storage/unified/sql/data/resource_history_list.sql
+++ b/pkg/storage/unified/sql/data/resource_history_list.sql
@@ -1,10 +1,13 @@
 SELECT
+    kv.{{ .Ident "guid" }},
     kv.{{ .Ident "resource_version" }},
     kv.{{ .Ident "namespace" }},
+    kv.{{ .Ident "group" }},
+    kv.{{ .Ident "resource" }},
     kv.{{ .Ident "name" }},
     kv.{{ .Ident "folder" }},
     kv.{{ .Ident "value" }}
-    FROM {{ .Ident "resource_history" }} as kv 
+    FROM {{ .Ident "resource_history" }} as kv
     INNER JOIN  (
         SELECT {{ .Ident "namespace" }}, {{ .Ident "group" }}, {{ .Ident "resource" }}, {{ .Ident "name" }},  max({{ .Ident "resource_version" }}) AS {{ .Ident "resource_version" }}
         FROM {{ .Ident "resource_history" }} AS mkv
@@ -24,7 +27,7 @@ SELECT
                 AND {{ .Ident "name" }}      = {{ .Arg .Request.Options.Key.Name }}
                 {{ end }}
             {{ end }}
-        GROUP BY mkv.{{ .Ident "namespace" }}, mkv.{{ .Ident "group" }}, mkv.{{ .Ident "resource" }}, mkv.{{ .Ident "name" }} 
+        GROUP BY mkv.{{ .Ident "namespace" }}, mkv.{{ .Ident "group" }}, mkv.{{ .Ident "resource" }}, mkv.{{ .Ident "name" }}
     ) AS maxkv
     ON
         maxkv.{{ .Ident "resource_version" }}  = kv.{{ .Ident "resource_version" }}
@@ -32,7 +35,7 @@ SELECT
         AND maxkv.{{ .Ident "group" }}         = kv.{{ .Ident "group" }}
         AND maxkv.{{ .Ident "resource" }}      = kv.{{ .Ident "resource" }}
         AND maxkv.{{ .Ident "name" }}          = kv.{{ .Ident "name" }}
-    WHERE kv.{{ .Ident "action" }}  != 3 
+    WHERE kv.{{ .Ident "action" }}  != 3
     {{ if and .Request.Options .Request.Options.Key }}
         {{ if .Request.Options.Key.Namespace }}
         AND kv.{{ .Ident "namespace" }} = {{ .Arg .Request.Options.Key.Namespace }}

--- a/pkg/storage/unified/sql/data/resource_history_poll.sql
+++ b/pkg/storage/unified/sql/data/resource_history_poll.sql
@@ -1,4 +1,5 @@
 SELECT
+    {{ .Ident "guid" | .Into .Response.GUID }},
     {{ .Ident "resource_version" | .Into .Response.ResourceVersion }},
     {{ .Ident "namespace" | .Into .Response.Key.Namespace }},
     {{ .Ident "group" | .Into .Response.Key.Group }},

--- a/pkg/storage/unified/sql/data/resource_history_read.sql
+++ b/pkg/storage/unified/sql/data/resource_history_read.sql
@@ -1,4 +1,5 @@
 SELECT
+    {{ .Ident "guid" | .Into .Response.GUID }},
     {{ .Ident "namespace" | .Into .Response.Key.Namespace }},
     {{ .Ident "group" | .Into .Response.Key.Group }},
     {{ .Ident "resource" | .Into .Response.Key.Resource }},

--- a/pkg/storage/unified/sql/data/resource_list.sql
+++ b/pkg/storage/unified/sql/data/resource_list.sql
@@ -2,8 +2,8 @@ SELECT
     {{ .Ident "guid" }},
     {{ .Ident "resource_version" }},
     {{ .Ident "namespace" }},
-    {{ .Ident "resource" }},
     {{ .Ident "group" }},
+    {{ .Ident "resource" }},
     {{ .Ident "name" }},
     {{ .Ident "folder" }},
     {{ .Ident "value" }}

--- a/pkg/storage/unified/sql/data/resource_list.sql
+++ b/pkg/storage/unified/sql/data/resource_list.sql
@@ -1,6 +1,9 @@
 SELECT
+    {{ .Ident "guid" }},
     {{ .Ident "resource_version" }},
     {{ .Ident "namespace" }},
+    {{ .Ident "resource" }},
+    {{ .Ident "group" }},
     {{ .Ident "name" }},
     {{ .Ident "folder" }},
     {{ .Ident "value" }}

--- a/pkg/storage/unified/sql/data/resource_read.sql
+++ b/pkg/storage/unified/sql/data/resource_read.sql
@@ -1,4 +1,5 @@
 SELECT
+    {{ .Ident "guid" | .Into .Response.GUID }},
     {{ .Ident "namespace" | .Into .Response.Key.Namespace }},
     {{ .Ident "group" | .Into .Response.Key.Group }},
     {{ .Ident "resource" | .Into .Response.Key.Resource }},

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -116,6 +116,7 @@ func (r sqlStatsRequest) Validate() error {
 
 type historyPollResponse struct {
 	Key             resource.ResourceKey
+	GUID            string
 	ResourceVersion int64
 	PreviousRV      *int64
 	Value           []byte

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read object history.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read object history.sql
@@ -1,6 +1,9 @@
 SELECT
+  `guid`,
   `resource_version`,
   `namespace`,
+  `group`,
+  `resource`,
   `name`,
   `folder`,
   `value`

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read trash second page.sql
@@ -1,6 +1,9 @@
 SELECT
+  `guid`,
   `resource_version`,
   `namespace`,
+  `group`,
+  `resource`,
   `name`,
   `folder`,
   `value`

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_get-read trash.sql
@@ -1,6 +1,9 @@
 SELECT
+  `guid`,
   `resource_version`,
   `namespace`,
+  `group`,
+  `resource`,
   `name`,
   `folder`,
   `value`

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_list-single path.sql
@@ -1,17 +1,20 @@
 SELECT
+    kv.`guid`,
     kv.`resource_version`,
     kv.`namespace`,
+    kv.`group`,
+    kv.`resource`,
     kv.`name`,
     kv.`folder`,
     kv.`value`
-    FROM `resource_history` as kv 
+    FROM `resource_history` as kv
     INNER JOIN  (
         SELECT `namespace`, `group`, `resource`, `name`,  max(`resource_version`) AS `resource_version`
         FROM `resource_history` AS mkv
         WHERE 1 = 1
             AND `resource_version` <=  0
                 AND `namespace` = 'ns'
-        GROUP BY mkv.`namespace`, mkv.`group`, mkv.`resource`, mkv.`name` 
+        GROUP BY mkv.`namespace`, mkv.`group`, mkv.`resource`, mkv.`name`
     ) AS maxkv
     ON
         maxkv.`resource_version`  = kv.`resource_version`
@@ -19,7 +22,7 @@ SELECT
         AND maxkv.`group`         = kv.`group`
         AND maxkv.`resource`      = kv.`resource`
         AND maxkv.`name`          = kv.`name`
-    WHERE kv.`action`  != 3 
+    WHERE kv.`action`  != 3
         AND kv.`namespace` = 'ns'
     ORDER BY kv.`namespace` ASC, kv.`name` ASC
     LIMIT 10 OFFSET 0

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_poll-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_poll-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    `guid`,
     `resource_version`,
     `namespace`,
     `group`,

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_read-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_read-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    `guid`,
     `namespace`,
     `group`,
     `resource`,

--- a/pkg/storage/unified/sql/testdata/mysql--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_list-filter_on_namespace.sql
@@ -2,8 +2,8 @@ SELECT
     `guid`,
     `resource_version`,
     `namespace`,
-    `resource`,
     `group`,
+    `resource`,
     `name`,
     `folder`,
     `value`

--- a/pkg/storage/unified/sql/testdata/mysql--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_list-filter_on_namespace.sql
@@ -1,6 +1,9 @@
 SELECT
+    `guid`,
     `resource_version`,
     `namespace`,
+    `resource`,
+    `group`,
     `name`,
     `folder`,
     `value`

--- a/pkg/storage/unified/sql/testdata/mysql--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_read-without_resource_version.sql
@@ -1,4 +1,5 @@
 SELECT
+    `guid`,
     `namespace`,
     `group`,
     `resource`,

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read object history.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read object history.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read trash second page.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_get-read trash.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_list-single path.sql
@@ -1,17 +1,20 @@
 SELECT
+    kv."guid",
     kv."resource_version",
     kv."namespace",
+    kv."group",
+    kv."resource",
     kv."name",
     kv."folder",
     kv."value"
-    FROM "resource_history" as kv 
+    FROM "resource_history" as kv
     INNER JOIN  (
         SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
         FROM "resource_history" AS mkv
         WHERE 1 = 1
             AND "resource_version" <=  0
                 AND "namespace" = 'ns'
-        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
+        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name"
     ) AS maxkv
     ON
         maxkv."resource_version"  = kv."resource_version"
@@ -19,7 +22,7 @@ SELECT
         AND maxkv."group"         = kv."group"
         AND maxkv."resource"      = kv."resource"
         AND maxkv."name"          = kv."name"
-    WHERE kv."action"  != 3 
+    WHERE kv."action"  != 3
         AND kv."namespace" = 'ns'
     ORDER BY kv."namespace" ASC, kv."name" ASC
     LIMIT 10 OFFSET 0

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_poll-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_poll-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "resource_version",
     "namespace",
     "group",

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_read-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_read-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "namespace",
     "group",
     "resource",

--- a/pkg/storage/unified/sql/testdata/postgres--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_list-filter_on_namespace.sql
@@ -2,8 +2,8 @@ SELECT
     "guid",
     "resource_version",
     "namespace",
-    "resource",
     "group",
+    "resource",
     "name",
     "folder",
     "value"

--- a/pkg/storage/unified/sql/testdata/postgres--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_list-filter_on_namespace.sql
@@ -1,6 +1,9 @@
 SELECT
+    "guid",
     "resource_version",
     "namespace",
+    "resource",
+    "group",
     "name",
     "folder",
     "value"

--- a/pkg/storage/unified/sql/testdata/postgres--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_read-without_resource_version.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "namespace",
     "group",
     "resource",

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read object history.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read object history.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read trash second page.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_get-read trash.sql
@@ -1,6 +1,9 @@
 SELECT
+  "guid",
   "resource_version",
   "namespace",
+  "group",
+  "resource",
   "name",
   "folder",
   "value"

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_list-single path.sql
@@ -1,17 +1,20 @@
 SELECT
+    kv."guid",
     kv."resource_version",
     kv."namespace",
+    kv."group",
+    kv."resource",
     kv."name",
     kv."folder",
     kv."value"
-    FROM "resource_history" as kv 
+    FROM "resource_history" as kv
     INNER JOIN  (
         SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
         FROM "resource_history" AS mkv
         WHERE 1 = 1
             AND "resource_version" <=  0
                 AND "namespace" = 'ns'
-        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
+        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name"
     ) AS maxkv
     ON
         maxkv."resource_version"  = kv."resource_version"
@@ -19,7 +22,7 @@ SELECT
         AND maxkv."group"         = kv."group"
         AND maxkv."resource"      = kv."resource"
         AND maxkv."name"          = kv."name"
-    WHERE kv."action"  != 3 
+    WHERE kv."action"  != 3
         AND kv."namespace" = 'ns'
     ORDER BY kv."namespace" ASC, kv."name" ASC
     LIMIT 10 OFFSET 0

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_poll-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_poll-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "resource_version",
     "namespace",
     "group",

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_read-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_read-single path.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "namespace",
     "group",
     "resource",

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_list-filter_on_namespace.sql
@@ -2,8 +2,8 @@ SELECT
     "guid",
     "resource_version",
     "namespace",
-    "resource",
     "group",
+    "resource",
     "name",
     "folder",
     "value"

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_list-filter_on_namespace.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_list-filter_on_namespace.sql
@@ -1,6 +1,9 @@
 SELECT
+    "guid",
     "resource_version",
     "namespace",
+    "resource",
+    "group",
     "name",
     "folder",
     "value"

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_read-without_resource_version.sql
@@ -1,4 +1,5 @@
 SELECT
+    "guid",
     "namespace",
     "group",
     "resource",


### PR DESCRIPTION
This PR adds the GUID to any Read response that comes from the SQL backend. It's also adding the GUID, Resource and Group to the list iterator for internal use.

This will enable us the always use the GUID and resource "path" for caching and other mechanics around unified storage.