### PR TITLE
Alerting: Remove alertingApiServer flag

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -71,7 +71,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `azureMonitorPrometheusExemplars`      | Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars                                        | Yes                |
 | `pinNavItems`                          | Enables pinning of nav items                                                                                                        | Yes                |
 | `failWrongDSUID`                       | Throws an error if a data source has an invalid UIDs                                                                                | Yes                |
-| `alertingApiServer`                    | Register Alerting APIs with the K8s API server                                                                                      | Yes                |
 | `cloudWatchRoundUpEndTime`             | Round up end time for metric queries to the next minute to avoid missing data                                                       | Yes                |
 | `newFiltersUI`                         | Enables new combobox style UI for the Ad hoc filters variable in scenes architecture                                                | Yes                |
 | `alertingQueryAndExpressionsStepMode`  | Enables step mode for alerting queries and expressions                                                                              | Yes                |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -659,11 +659,6 @@ export interface FeatureToggles {
   */
   enableScopesInMetricsExplore?: boolean;
   /**
-  * Register Alerting APIs with the K8s API server
-  * @default true
-  */
-  alertingApiServer?: boolean;
-  /**
   * Round up end time for metric queries to the next minute to avoid missing data
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1137,14 +1137,6 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
-			Name:            "alertingApiServer",
-			Description:     "Register Alerting APIs with the K8s API server",
-			Stage:           FeatureStageGeneralAvailability,
-			Owner:           grafanaAlertingSquad,
-			RequiresRestart: true,
-			Expression:      "true",
-		},
-		{
 			Name:        "cloudWatchRoundUpEndTime",
 			Description: "Round up end time for metric queries to the next minute to avoid missing data",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -146,7 +146,6 @@ failWrongDSUID,GA,@grafana/plugins-platform-backend,false,false,false
 zanzana,experimental,@grafana/identity-access-team,false,false,false
 reloadDashboardsOnParamsChange,experimental,@grafana/dashboards-squad,false,false,false
 enableScopesInMetricsExplore,experimental,@grafana/dashboards-squad,false,false,false
-alertingApiServer,GA,@grafana/alerting-squad,false,true,false
 cloudWatchRoundUpEndTime,GA,@grafana/aws-datasources,false,false,false
 prometheusAzureOverrideAudience,deprecated,@grafana/partner-datasources,false,false,false
 alertingFilterV2,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -595,10 +595,6 @@ const (
 	// Enables the scopes usage in Metrics Explore
 	FlagEnableScopesInMetricsExplore = "enableScopesInMetricsExplore"
 
-	// FlagAlertingApiServer
-	// Register Alerting APIs with the K8s API server
-	FlagAlertingApiServer = "alertingApiServer"
-
 	// FlagCloudWatchRoundUpEndTime
 	// Round up end time for metric queries to the next minute to avoid missing data
 	FlagCloudWatchRoundUpEndTime = "cloudWatchRoundUpEndTime"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -114,7 +114,8 @@
       "metadata": {
         "name": "alertingApiServer",
         "resourceVersion": "1743693517832",
-        "creationTimestamp": "2024-06-20T20:52:03Z"
+        "creationTimestamp": "2024-06-20T20:52:03Z",
+        "deletionTimestamp": "2025-04-16T17:44:22Z"
       },
       "spec": {
         "description": "Register Alerting APIs with the K8s API server",


### PR DESCRIPTION
**What is this feature?**
This PR is follow up for https://github.com/grafana/grafana/pull/103819 that removes flag `alertingApiServer ` from the registry and updates comments in the front-end app.