### PR TITLE
GitHub Actions: Use PR commit SHA for reporting status

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -40,7 +40,8 @@ jobs:
                 inputs: {
                   src_repo: "${{ github.repository }}",
                   src_ref: "${{ github.head_ref }}",
-                  src_sha: "${{ github.sha }}",
+                  src_merge_sha: "${{ github.sha }}",
+                  src_pr_commit_sha: "${{ github.event.pull_request.head.sha }}",
                   patch_repo: "${{ github.repository }}-security-patches",
                   patch_ref: "${{ github.base_ref }}",
                   triggering_github_handle: "${{ github.event.sender.login }}"


### PR DESCRIPTION
We currently report the status to the resulting merge commit instead of the source commit, this PR fixes that.