### PR TITLE
search: add index batching

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -454,7 +454,6 @@ func (s *searchSupport) dispatchEvent(ctx context.Context, evt *WrittenEvent) {
 	default:
 		s.log.Info("ignoring watch event", "type", evt.Type)
 		span.AddEvent("ignoring watch event", trace.WithAttributes(attribute.String("type", evt.Type.String())))
-
 	}
 
 	nsr := NamespacedResource{

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -435,6 +435,7 @@ func (s *searchSupport) init(ctx context.Context) error {
 			}
 			if evt.Err != nil {
 				s.log.Error("error indexing watch event", "error", evt.Err)
+				continue
 			}
 			// record latency from when event was created to when it was indexed
 			span.AddEvent("index latency", trace.WithAttributes(attribute.Float64("latency_seconds", evt.Latency.Seconds())))

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -551,8 +551,8 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 			},
 		}, func(iter ListIterator) error {
 			// Collect all documents in a single bulk request
-			// TODO: update to either use the index queue processor or use multiple smaller bulk requests
 			items := make([]*BulkIndexItem, 0)
+
 			for iter.Next() {
 				if err = iter.Error(); err != nil {
 					return err

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -746,7 +746,7 @@ func (s *searchSupport) getOrCreateIndexQueueProcessor(index ResourceIndex, nsr 
 		s.log.Error("error getting document builder", "error", err)
 		return nil, err
 	}
-	indexQueueProcessor := NewIndexQueueProcessor(index, nsr, maxBatchSize, builder, s.indexEventsChan)
+	indexQueueProcessor := newIndexQueueProcessor(index, nsr, maxBatchSize, builder, s.indexEventsChan)
 	s.indexQueueProcessors[key] = indexQueueProcessor
 	return indexQueueProcessor, nil
 }

--- a/pkg/storage/unified/resource/search_queue.go
+++ b/pkg/storage/unified/resource/search_queue.go
@@ -1,0 +1,142 @@
+package resource
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// IndexQueueProcessor manages queue-based operations for a specific index
+// It is responsible for ingesting events for a single index
+// It will batch events and send them to the index in a single bulk request
+type IndexQueueProcessor struct {
+	index     ResourceIndex
+	nsr       NamespacedResource
+	queue     chan *indexEvent
+	batchSize int
+	cancel    context.CancelFunc
+	builder   DocumentBuilder
+
+	mu      sync.Mutex
+	running bool
+}
+
+type indexEvent struct {
+	ev   *WrittenEvent
+	done chan *IndexResult
+}
+
+type IndexResult struct {
+	doc *IndexableDocument
+	err error
+}
+
+// NewIndexQueueProcessor creates a new IndexQueueProcessor for the given index
+func NewIndexQueueProcessor(index ResourceIndex, nsr NamespacedResource, batchSize int, builder DocumentBuilder) *IndexQueueProcessor {
+	return &IndexQueueProcessor{
+		index:     index,
+		nsr:       nsr,
+		queue:     make(chan *indexEvent, 1000), // Buffer size of 1000 events
+		batchSize: batchSize,
+		builder:   builder,
+		running:   false,
+	}
+}
+
+// Add adds an event to the queue and ensures the background processor is running
+// Returns a channel that will receive the indexed document when processing is complete
+func (b *IndexQueueProcessor) Add(evt *WrittenEvent) <-chan *IndexResult {
+	done := make(chan *IndexResult, 1)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.running {
+		b.running = true
+		b.startProcessor()
+	}
+	b.queue <- &indexEvent{ev: evt, done: done}
+	return done
+}
+
+// startProcessor starts the background goroutine if it's not already running
+func (b *IndexQueueProcessor) startProcessor() {
+	// No need for lock here since running is already set
+	go func() {
+		defer func() {
+			b.mu.Lock()
+			b.running = false
+			b.mu.Unlock()
+		}()
+
+		for {
+			batch := make([]*indexEvent, 0, b.batchSize)
+			select {
+			case evt := <-b.queue:
+				batch = append(batch, evt)
+			default:
+				// No need for stop() method, just return and let defer handle it
+				return
+			}
+
+		prepare:
+			for len(batch) < b.batchSize {
+				select {
+				case evt := <-b.queue:
+					batch = append(batch, evt)
+				default:
+					break prepare
+				}
+			}
+
+			b.process(batch)
+		}
+	}()
+}
+
+// process handles a batch of events
+func (b *IndexQueueProcessor) process(batch []*indexEvent) {
+	if len(batch) == 0 {
+		return
+	}
+
+	// Create bulk request
+	req := &BulkIndexRequest{
+		Items: make([]*BulkIndexItem, 0, len(batch)),
+	}
+	resp := make([]*IndexResult, 0, len(batch))
+
+	for _, i := range batch {
+		result := &IndexResult{}
+		resp = append(resp, result)
+
+		evt := i.ev
+		item := &BulkIndexItem{}
+		if evt.Type == WatchEvent_DELETED {
+			item.Action = BulkActionDelete
+			item.Key = evt.Key
+		} else {
+			item.Action = BulkActionIndex
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			doc, err := b.builder.BuildDocument(ctx, evt.Key, evt.ResourceVersion, evt.Value)
+			if err != nil {
+				result.err = err
+			} else {
+				item.Doc = doc
+				result.doc = doc
+			}
+		}
+		req.Items = append(req.Items, item)
+	}
+
+	err := b.index.BulkIndex(req)
+	if err != nil {
+		for _, r := range resp {
+			r.err = err
+		}
+	}
+
+	// Send results to the channel
+	for idx, i := range batch {
+		i.done <- resp[idx]
+	}
+}

--- a/pkg/storage/unified/resource/search_queue.go
+++ b/pkg/storage/unified/resource/search_queue.go
@@ -31,8 +31,8 @@ type IndexEvent struct {
 	Err               error
 }
 
-// NewIndexQueueProcessor creates a new IndexQueueProcessor for the given index
-func NewIndexQueueProcessor(index ResourceIndex, nsr NamespacedResource, batchSize int, builder DocumentBuilder, resChan chan *IndexEvent) *indexQueueProcessor {
+// newIndexQueueProcessor creates a new IndexQueueProcessor for the given index
+func newIndexQueueProcessor(index ResourceIndex, nsr NamespacedResource, batchSize int, builder DocumentBuilder, resChan chan *IndexEvent) *indexQueueProcessor {
 	return &indexQueueProcessor{
 		index:     index,
 		nsr:       nsr,

--- a/pkg/storage/unified/resource/search_queue_test.go
+++ b/pkg/storage/unified/resource/search_queue_test.go
@@ -1,0 +1,158 @@
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewIndexQueueProcessor(t *testing.T) {
+	mockIndex := &MockResourceIndex{}
+	mockBuilder := &MockDocumentBuilder{}
+	nsr := NamespacedResource{Resource: "test"}
+
+	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder)
+
+	assert.NotNil(t, processor)
+	assert.Equal(t, 10, processor.batchSize)
+	assert.NotNil(t, processor.queue)
+}
+
+func TestIndexQueueProcessor_SingleEvent(t *testing.T) {
+	mockIndex := &MockResourceIndex{}
+	mockBuilder := &MockDocumentBuilder{}
+	// mockObserver := &MockIndexLatencyObserver{}
+	nsr := NamespacedResource{Resource: "test"}
+
+	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder)
+
+	// Test data
+	key := ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"}
+	evt := &WrittenEvent{
+		Key:             &key,
+		ResourceVersion: time.Now().UnixMicro(),
+		Type:            WatchEvent_ADDED,
+		Value:           []byte(`{"test": "data"}`),
+	}
+
+	// Setup expectations
+	mockBuilder.On("BuildDocument", mock.Anything, &key, evt.ResourceVersion, evt.Value).Return(&IndexableDocument{Key: &key}, nil)
+	mockIndex.On("BulkIndex", mock.MatchedBy(func(req *BulkIndexRequest) bool {
+		return len(req.Items) == 1 && req.Items[0].Action == BulkActionIndex
+	})).Return(nil)
+
+	// Start processor and wait for the document to be indexed
+	resp := <-processor.Add(evt)
+	assert.NotNil(t, resp)
+	assert.Nil(t, resp.err)
+	assert.Equal(t, &key, resp.doc.Key)
+
+	mockBuilder.AssertExpectations(t)
+	mockIndex.AssertExpectations(t)
+}
+
+func TestIndexQueueProcessor_BatchProcessing(t *testing.T) {
+	mockIndex := &MockResourceIndex{}
+	mockBuilder := &MockDocumentBuilder{}
+	nsr := NamespacedResource{Namespace: "default", Resource: "test"}
+
+	processor := NewIndexQueueProcessor(mockIndex, nsr, 2, mockBuilder)
+
+	// Test data for two events
+	events := []*WrittenEvent{
+		{
+			Key:             &ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"},
+			ResourceVersion: time.Now().UnixMicro(),
+			Type:            WatchEvent_ADDED,
+			Value:           []byte(`{"test": "data1"}`),
+		},
+		{
+			Key:             &ResourceKey{Resource: "test", Name: "obj2", Namespace: "default"},
+			ResourceVersion: time.Now().UnixMicro(),
+			Type:            WatchEvent_DELETED,
+		},
+	}
+
+	// Setup expectations
+	mockBuilder.On("BuildDocument", mock.Anything, events[0].Key, events[0].ResourceVersion, events[0].Value).
+		Return(&IndexableDocument{Key: events[0].Key}, nil)
+	mockIndex.On("BulkIndex", mock.MatchedBy(func(req *BulkIndexRequest) bool {
+		return len(req.Items) == 2 &&
+			req.Items[0].Action == BulkActionIndex &&
+			req.Items[1].Action == BulkActionDelete
+	})).Return(nil)
+
+	// Start processor and add events
+	d0 := processor.Add(events[0])
+	d1 := processor.Add(events[1])
+
+	r0 := <-d0
+	r1 := <-d1
+
+	assert.Nil(t, r0.err)
+	assert.Nil(t, r1.err)
+	assert.Equal(t, events[0].Key, r0.doc.Key)
+	assert.Nil(t, r1.doc) // deleted event
+
+	mockBuilder.AssertExpectations(t)
+	mockIndex.AssertExpectations(t)
+}
+
+func TestIndexQueueProcessor_BuildDocumentError(t *testing.T) {
+	mockIndex := &MockResourceIndex{}
+	mockBuilder := &MockDocumentBuilder{}
+	nsr := NamespacedResource{Resource: "test"}
+
+	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder)
+
+	evt := &WrittenEvent{
+		Key:             &ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"},
+		ResourceVersion: time.Now().UnixMicro(),
+		Type:            WatchEvent_ADDED,
+		Value:           []byte(`invalid json`),
+	}
+
+	// Setup expectations for error case
+	mockBuilder.On("BuildDocument", mock.Anything, evt.Key, evt.ResourceVersion, evt.Value).
+		Return(nil, assert.AnError)
+
+	// The bulk index should not be called since document building failed
+	mockIndex.On("BulkIndex", mock.Anything).Return(nil).Maybe()
+
+	resp := <-processor.Add(evt)
+	assert.NotNil(t, resp)
+	assert.Error(t, resp.err)
+	assert.Nil(t, resp.doc)
+
+	mockBuilder.AssertExpectations(t)
+	mockIndex.AssertExpectations(t)
+}
+
+func TestIndexQueueProcessor_BulkIndexError(t *testing.T) {
+	mockIndex := &MockResourceIndex{}
+	mockBuilder := &MockDocumentBuilder{}
+	nsr := NamespacedResource{Resource: "test"}
+
+	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder)
+
+	evt := &WrittenEvent{
+		Key:             &ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"},
+		ResourceVersion: time.Now().UnixMicro(),
+		Type:            WatchEvent_ADDED,
+		Value:           []byte(`{"test": "data"}`),
+	}
+
+	// Setup expectations
+	mockBuilder.On("BuildDocument", mock.Anything, evt.Key, evt.ResourceVersion, evt.Value).
+		Return(&IndexableDocument{Key: evt.Key}, nil)
+	mockIndex.On("BulkIndex", mock.Anything).Return(assert.AnError)
+
+	resp := <-processor.Add(evt)
+	assert.NotNil(t, resp)
+	assert.Error(t, resp.err)
+
+	mockBuilder.AssertExpectations(t)
+	mockIndex.AssertExpectations(t)
+}

--- a/pkg/storage/unified/resource/search_queue_test.go
+++ b/pkg/storage/unified/resource/search_queue_test.go
@@ -15,7 +15,7 @@ func TestNewIndexQueueProcessor(t *testing.T) {
 
 	resChan := make(chan *IndexEvent)
 
-	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
+	processor := newIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
 
 	assert.NotNil(t, processor)
 	assert.Equal(t, 10, processor.batchSize)
@@ -29,7 +29,7 @@ func TestIndexQueueProcessor_SingleEvent(t *testing.T) {
 
 	resChan := make(chan *IndexEvent)
 
-	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
+	processor := newIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
 
 	// Test data
 	key := ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"}
@@ -65,7 +65,7 @@ func TestIndexQueueProcessor_BatchProcessing(t *testing.T) {
 
 	resChan := make(chan *IndexEvent)
 
-	processor := NewIndexQueueProcessor(mockIndex, nsr, 2, mockBuilder, resChan)
+	processor := newIndexQueueProcessor(mockIndex, nsr, 2, mockBuilder, resChan)
 
 	// Test data for two events
 	events := []*WrittenEvent{
@@ -114,7 +114,7 @@ func TestIndexQueueProcessor_BuildDocumentError(t *testing.T) {
 
 	resChan := make(chan *IndexEvent)
 
-	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
+	processor := newIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
 
 	evt := &WrittenEvent{
 		Key:             &ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"},
@@ -148,7 +148,7 @@ func TestIndexQueueProcessor_BulkIndexError(t *testing.T) {
 
 	resChan := make(chan *IndexEvent)
 
-	processor := NewIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
+	processor := newIndexQueueProcessor(mockIndex, nsr, 10, mockBuilder, resChan)
 
 	evt := &WrittenEvent{
 		Key:             &ResourceKey{Resource: "test", Name: "obj1", Namespace: "default"},

--- a/pkg/storage/unified/resource/search_queue_test.go
+++ b/pkg/storage/unified/resource/search_queue_test.go
@@ -25,7 +25,6 @@ func TestNewIndexQueueProcessor(t *testing.T) {
 func TestIndexQueueProcessor_SingleEvent(t *testing.T) {
 	mockIndex := &MockResourceIndex{}
 	mockBuilder := &MockDocumentBuilder{}
-	// mockObserver := &MockIndexLatencyObserver{}
 	nsr := NamespacedResource{Resource: "test"}
 
 	resChan := make(chan *IndexEvent)

--- a/pkg/storage/unified/resource/search_queue_test.go
+++ b/pkg/storage/unified/resource/search_queue_test.go
@@ -44,7 +44,7 @@ func TestIndexQueueProcessor_SingleEvent(t *testing.T) {
 	// Setup expectations
 	mockBuilder.On("BuildDocument", mock.Anything, &key, evt.ResourceVersion, evt.Value).Return(&IndexableDocument{Key: &key}, nil)
 	mockIndex.On("BulkIndex", mock.MatchedBy(func(req *BulkIndexRequest) bool {
-		return len(req.Items) == 1 && req.Items[0].Action == BulkActionIndex
+		return len(req.Items) == 1 && req.Items[0].Action == ActionIndex
 	})).Return(nil)
 
 	// Start processor and wait for the document to be indexed

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1,0 +1,54 @@
+package resource
+
+import (
+	"context"
+
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ ResourceIndex = &MockResourceIndex{}
+
+// Mock implementations
+type MockResourceIndex struct {
+	mock.Mock
+}
+
+func (m *MockResourceIndex) BulkIndex(req *BulkIndexRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}
+
+func (m *MockResourceIndex) Search(ctx context.Context, access types.AccessClient, req *ResourceSearchRequest, federate []ResourceIndex) (*ResourceSearchResponse, error) {
+	args := m.Called(ctx, access, req, federate)
+	return args.Get(0).(*ResourceSearchResponse), args.Error(1)
+}
+
+func (m *MockResourceIndex) CountManagedObjects(ctx context.Context) ([]*CountManagedObjectsResponse_ResourceCount, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*CountManagedObjectsResponse_ResourceCount), args.Error(1)
+}
+
+func (m *MockResourceIndex) DocCount(ctx context.Context, folder string) (int64, error) {
+	args := m.Called(ctx, folder)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockResourceIndex) ListManagedObjects(ctx context.Context, req *ListManagedObjectsRequest) (*ListManagedObjectsResponse, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(*ListManagedObjectsResponse), args.Error(1)
+}
+
+var _ DocumentBuilder = &MockDocumentBuilder{}
+
+type MockDocumentBuilder struct {
+	mock.Mock
+}
+
+func (m *MockDocumentBuilder) BuildDocument(ctx context.Context, key *ResourceKey, resourceVersion int64, value []byte) (*IndexableDocument, error) {
+	args := m.Called(ctx, key, resourceVersion, value)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*IndexableDocument), nil
+}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -165,8 +165,8 @@ type SearchOptions struct {
 	// Skip building index on startup for small indexes
 	InitMinCount int
 
-	// Observer for index latency metrics
-	IndexLatencyObserver IndexLatencyObserver
+	// Channel to watch for index events (for testing)
+	IndexEventsChan chan *IndexEvent
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -145,6 +145,12 @@ type BlobConfig struct {
 	Backend BlobSupport
 }
 
+// IndexLatencyObserver is an interface for observing index latency metrics
+// This is used for testing
+type IndexLatencyObserver interface {
+	Observe(evt *WrittenEvent, doc *IndexableDocument, latency float64)
+}
+
 // Passed as input to the constructor
 type SearchOptions struct {
 	// The raw index backend (eg, bleve, frames, parquet, etc)
@@ -158,6 +164,9 @@ type SearchOptions struct {
 
 	// Skip building index on startup for small indexes
 	InitMinCount int
+
+	// Observer for index latency metrics
+	IndexLatencyObserver IndexLatencyObserver
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -145,12 +145,6 @@ type BlobConfig struct {
 	Backend BlobSupport
 }
 
-// IndexLatencyObserver is an interface for observing index latency metrics
-// This is used for testing
-type IndexLatencyObserver interface {
-	Observe(evt *WrittenEvent, latency float64)
-}
-
 // Passed as input to the constructor
 type SearchOptions struct {
 	// The raw index backend (eg, bleve, frames, parquet, etc)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -148,7 +148,7 @@ type BlobConfig struct {
 // IndexLatencyObserver is an interface for observing index latency metrics
 // This is used for testing
 type IndexLatencyObserver interface {
-	Observe(evt *WrittenEvent, doc *IndexableDocument, latency float64)
+	Observe(evt *WrittenEvent, latency float64)
 }
 
 // Passed as input to the constructor

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -225,14 +225,12 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 
 	// Batch all the changes
 	idx := &bleveIndex{
-		key:       key,
-		index:     index,
-		batch:     index.NewBatch(),
-		batchSize: b.opts.BatchSize,
-		fields:    fields,
-		standard:  resource.StandardSearchFields(),
-		features:  b.features,
-		tracing:   b.tracer,
+		key:      key,
+		index:    index,
+		fields:   fields,
+		standard: resource.StandardSearchFields(),
+		features: b.features,
+		tracing:  b.tracer,
 	}
 
 	idx.allFields, err = getAllFields(idx.standard, fields)
@@ -242,12 +240,6 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 
 	if build {
 		_, err = builder(idx)
-		if err != nil {
-			return nil, err
-		}
-
-		// Flush the batch
-		err = idx.Flush()
 		if err != nil {
 			return nil, err
 		}
@@ -318,51 +310,33 @@ type bleveIndex struct {
 
 	// The values returned with all
 	allFields []*resource.ResourceTableColumnDefinition
-
-	// only valid in single thread
-	batch     *bleve.Batch
-	batchSize int // ??? not totally sure the units here
-
-	features featuremgmt.FeatureToggles
-	tracing  trace.Tracer
+	features  featuremgmt.FeatureToggles
+	tracing   trace.Tracer
 }
 
-// Write implements resource.DocumentIndex.
-func (b *bleveIndex) Write(v *resource.IndexableDocument) error {
-	v = v.UpdateCopyFields()
+// BulkIndex implements resource.ResourceIndex.
+func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
+	if len(req.Items) == 0 {
+		return nil
+	}
 
-	// remove references (for now!)
-	v.References = nil
-	if b.batch != nil {
-		err := b.batch.Index(v.Key.SearchID(), v)
-		if err != nil {
-			return err
+	batch := b.index.NewBatch()
+	for _, item := range req.Items {
+		switch item.Action {
+		case resource.BulkActionIndex:
+			doc := item.Doc.UpdateCopyFields()
+			doc.References = nil // remove references (for now!)
+
+			err := batch.Index(doc.Key.SearchID(), doc)
+			if err != nil {
+				return err
+			}
+		case resource.BulkActionDelete:
+			batch.Delete(item.Key.SearchID())
 		}
-		if b.batch.Size() > b.batchSize {
-			err = b.index.Batch(b.batch)
-			b.batch.Reset() // clear the batch
-		}
-		return err // nil
 	}
-	return b.index.Index(v.Key.SearchID(), v)
-}
 
-// Delete implements resource.DocumentIndex.
-func (b *bleveIndex) Delete(key *resource.ResourceKey) error {
-	if b.batch != nil {
-		return fmt.Errorf("unexpected delete while building batch")
-	}
-	return b.index.Delete(key.SearchID())
-}
-
-// Flush implements resource.DocumentIndex.
-func (b *bleveIndex) Flush() (err error) {
-	if b.batch != nil {
-		err = b.index.Batch(b.batch)
-		b.batch.Reset()
-		b.batch = nil
-	}
-	return err
+	return b.index.Batch(batch)
 }
 
 func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resource.ListManagedObjectsRequest) (*resource.ListManagedObjectsResponse, error) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -323,7 +323,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 	batch := b.index.NewBatch()
 	for _, item := range req.Items {
 		switch item.Action {
-		case resource.BulkActionIndex:
+		case resource.ActionIndex:
 			doc := item.Doc.UpdateCopyFields()
 			doc.References = nil // remove references (for now!)
 
@@ -331,7 +331,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 			if err != nil {
 				return err
 			}
-		case resource.BulkActionDelete:
+		case resource.ActionDelete:
 			batch.Delete(item.Key.SearchID())
 		}
 	}

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -34,3 +34,23 @@ func TestBleveSearchBackend(t *testing.T) {
 		NSPrefix: "bleve-test",
 	})
 }
+
+func TestSearchBackendBenchmark(t *testing.T) {
+	opts := &unitest.BenchmarkOptions{
+		NumResources:     10000,
+		Concurrency:      1, // For now we only want to test the write throughput
+		NumNamespaces:    1,
+		NumGroups:        1,
+		NumResourceTypes: 1,
+	}
+	tempDir := t.TempDir()
+
+	// Create a new bleve backend
+	backend, err := NewBleveBackend(BleveOptions{
+		Root: tempDir,
+	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchPermissionFiltering), nil)
+	require.NoError(t, err)
+	require.NotNil(t, backend)
+
+	unitest.BenchmarkSearchBackend(t, backend, opts)
+}

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -1,0 +1,36 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
+)
+
+func TestBleveSearchBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Run the search backend test suite
+	unitest.RunSearchBackendTest(t, func(ctx context.Context) resource.SearchBackend {
+		tempDir := t.TempDir()
+
+		// Create a new bleve backend
+		backend, err := NewBleveBackend(BleveOptions{
+			Root:          tempDir,
+			FileThreshold: 5,
+		}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchPermissionFiltering), nil)
+		require.NoError(t, err)
+		require.NotNil(t, backend)
+
+		return backend
+	}, &unitest.TestOptions{
+		NSPrefix: "bleve-test",
+	})
+}

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -101,7 +101,7 @@ func newTestWriter(size int, batchSize int) IndexWriter {
 		for i := 0; i < size; i++ {
 			name := fmt.Sprintf("name%d", i)
 			item := &resource.BulkIndexItem{
-				Action: resource.BulkActionIndex,
+				Action: resource.ActionIndex,
 				Doc: &resource.IndexableDocument{
 					RV:   int64(i),
 					Name: name,

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -33,7 +33,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -47,7 +47,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name2",
@@ -77,7 +77,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -91,7 +91,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name2",
@@ -121,7 +121,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -135,7 +135,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name2",
@@ -164,7 +164,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -178,7 +178,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name2",
@@ -208,7 +208,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -249,7 +249,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -263,7 +263,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   2,
 						Name: "name2",
@@ -296,7 +296,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -361,7 +361,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -375,7 +375,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name2",
@@ -389,7 +389,7 @@ func TestCanSearchByTitle(t *testing.T) {
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name3",
@@ -430,7 +430,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						RV:   1,
 						Name: "name1",
@@ -451,7 +451,7 @@ func TestCanSearchByTitle(t *testing.T) {
 			err = index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV:   int64(i),
 							Name: fmt.Sprintf("name%d", i),

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -30,28 +30,37 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("when query is empty, sort documents by title instead of search score", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "name1",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "name1",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "bbb",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "aaa",
+					},
+				},
 			},
-			Title: "bbb",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "aaa",
 		})
 		require.NoError(t, err)
 
@@ -65,28 +74,37 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("will boost phrase match query over match query results", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "name1",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "name1",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "I want to say a hello",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "we want hello",
+					},
+				},
 			},
-			Title: "I want to say a hello",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "we want hello",
 		})
 		require.NoError(t, err)
 
@@ -100,28 +118,37 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("will prioritize matches", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "name1",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "name1",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "Asserts Dashboards",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "New dashboard 10",
+					},
+				},
 			},
-			Title: "Asserts Dashboards",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "New dashboard 10",
 		})
 		require.NoError(t, err)
 
@@ -134,28 +161,37 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("will boost exact match query over match phrase query results", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "name1",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "name1",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "we want hello pls",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "we want hello",
+					},
+				},
 			},
-			Title: "we want hello pls",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "we want hello",
 		})
 		require.NoError(t, err)
 
@@ -169,16 +205,23 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("title with numbers will match document", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "aaa",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "aaa",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "A123456",
+					},
+				},
 			},
-			Title: "A123456",
 		})
 		require.NoError(t, err)
 
@@ -203,29 +246,37 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("title will match escaped characters", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "aaa",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "aaa",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "what\"s up",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   2,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "what\"s that",
+					},
+				},
 			},
-			Title: "what\"s up",
-		})
-		require.NoError(t, err)
-
-		err = index.Write(&resource.IndexableDocument{
-			RV:   2,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "what\"s that",
 		})
 		require.NoError(t, err)
 
@@ -242,16 +293,23 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("title search will match document", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "aaa",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "aaa",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "I want to say a wonderfully Hello to the WORLD! Hello-world",
+					},
+				},
 			},
-			Title: "I want to say a wonderfully Hello to the WORLD! Hello-world",
 		})
 		require.NoError(t, err)
 
@@ -300,40 +358,51 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("title search will NOT match documents", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "name1",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "name1",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "I want to say a wonderful Hello to the WORLD! Hello-world",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name2",
+						Key: &resource.ResourceKey{
+							Name:      "name2",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "A0456",
+					},
+				},
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name3",
+						Key: &resource.ResourceKey{
+							Name:      "name3",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "mash-A02382-10",
+					},
+				},
 			},
-			Title: "I want to say a wonderful Hello to the WORLD! Hello-world",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name2",
-			Key: &resource.ResourceKey{
-				Name:      "name2",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "A0456",
-		})
-		require.NoError(t, err)
-		err = index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name3",
-			Key: &resource.ResourceKey{
-				Name:      "name3",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
-			},
-			Title: "mash-A02382-10",
 		})
 		require.NoError(t, err)
 
@@ -358,35 +427,47 @@ func TestCanSearchByTitle(t *testing.T) {
 
 	t.Run("title search with character will match one document", func(t *testing.T) {
 		index, _ := newTestDashboardsIndex(t, threshold, 2, 2, noop)
-		err := index.Write(&resource.IndexableDocument{
-			RV:   1,
-			Name: "name1",
-			Key: &resource.ResourceKey{
-				Name:      "aaa",
-				Namespace: key.Namespace,
-				Group:     key.Group,
-				Resource:  key.Resource,
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.BulkActionIndex,
+					Doc: &resource.IndexableDocument{
+						RV:   1,
+						Name: "name1",
+						Key: &resource.ResourceKey{
+							Name:      "aaa",
+							Namespace: key.Namespace,
+							Group:     key.Group,
+							Resource:  key.Resource,
+						},
+						Title: "foo",
+					},
+				},
 			},
-			Title: "foo",
 		})
 		require.NoError(t, err)
 
 		for i, v := range search.TermCharacters {
-			err = index.Write(&resource.IndexableDocument{
-				RV:   int64(i),
-				Name: fmt.Sprintf("name%d", i),
-				Key: &resource.ResourceKey{
-					Name:      fmt.Sprintf("name%d", i),
-					Namespace: key.Namespace,
-					Group:     key.Group,
-					Resource:  key.Resource,
+			err = index.BulkIndex(&resource.BulkIndexRequest{
+				Items: []*resource.BulkIndexItem{
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV:   int64(i),
+							Name: fmt.Sprintf("name%d", i),
+							Key: &resource.ResourceKey{
+								Name:      fmt.Sprintf("name%d", i),
+								Namespace: key.Namespace,
+								Group:     key.Group,
+								Resource:  key.Resource,
+							},
+							Title: fmt.Sprintf(`test foo%d%sbar`, i, v),
+						},
+					},
 				},
-				Title: fmt.Sprintf(`test foo%d%sbar`, i, v),
 			})
 			require.NoError(t, err)
-		}
 
-		for i, v := range search.TermCharacters {
 			title := fmt.Sprintf(`test foo%d%sbar`, i, v)
 			query := newQueryByTitle(title)
 			res, err := index.Search(context.Background(), nil, query, nil)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -68,7 +68,7 @@ func TestBleveBackend(t *testing.T) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV:   1,
 							Name: "aaa",
@@ -101,7 +101,7 @@ func TestBleveBackend(t *testing.T) {
 						},
 					},
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV:   2,
 							Name: "bbb",
@@ -135,7 +135,7 @@ func TestBleveBackend(t *testing.T) {
 						},
 					},
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV: 3,
 							Key: &resource.ResourceKey{
@@ -349,7 +349,7 @@ func TestBleveBackend(t *testing.T) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV: 1,
 							Key: &resource.ResourceKey{
@@ -374,7 +374,7 @@ func TestBleveBackend(t *testing.T) {
 						},
 					},
 					{
-						Action: resource.BulkActionIndex,
+						Action: resource.ActionIndex,
 						Doc: &resource.IndexableDocument{
 							RV: 2,
 							Key: &resource.ResourceKey{

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -65,91 +65,107 @@ func TestBleveBackend(t *testing.T) {
 			Group:     key.Group,
 			Resource:  key.Resource,
 		}, 2, rv, info.Fields, func(index resource.ResourceIndex) (int64, error) {
-			_ = index.Write(&resource.IndexableDocument{
-				RV:   1,
-				Name: "aaa",
-				Key: &resource.ResourceKey{
-					Name:      "aaa",
-					Namespace: "ns",
-					Group:     "dashboard.grafana.app",
-					Resource:  "dashboards",
-				},
-				Title:  "aaa (dash)",
-				Folder: "xxx",
-				Fields: map[string]any{
-					DASHBOARD_PANEL_TYPES:       []string{"timeseries", "table"},
-					DASHBOARD_ERRORS_TODAY:      25,
-					DASHBOARD_VIEWS_LAST_1_DAYS: 50,
-				},
-				Labels: map[string]string{
-					utils.LabelKeyDeprecatedInternalID: "10", // nolint:staticcheck
-				},
-				Tags: []string{"aa", "bb"},
-				Manager: &utils.ManagerProperties{
-					Kind:     utils.ManagerKindRepo,
-					Identity: "repo-1",
-				},
-				Source: &utils.SourceProperties{
-					Path:            "path/to/aaa.json",
-					Checksum:        "xyz",
-					TimestampMillis: 1609462800000, // 2021
+			err := index.BulkIndex(&resource.BulkIndexRequest{
+				Items: []*resource.BulkIndexItem{
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV:   1,
+							Name: "aaa",
+							Key: &resource.ResourceKey{
+								Name:      "aaa",
+								Namespace: "ns",
+								Group:     "dashboard.grafana.app",
+								Resource:  "dashboards",
+							},
+							Title:  "aaa (dash)",
+							Folder: "xxx",
+							Fields: map[string]any{
+								DASHBOARD_PANEL_TYPES:       []string{"timeseries", "table"},
+								DASHBOARD_ERRORS_TODAY:      25,
+								DASHBOARD_VIEWS_LAST_1_DAYS: 50,
+							},
+							Labels: map[string]string{
+								utils.LabelKeyDeprecatedInternalID: "10", // nolint:staticcheck
+							},
+							Tags: []string{"aa", "bb"},
+							Manager: &utils.ManagerProperties{
+								Kind:     utils.ManagerKindRepo,
+								Identity: "repo-1",
+							},
+							Source: &utils.SourceProperties{
+								Path:            "path/to/aaa.json",
+								Checksum:        "xyz",
+								TimestampMillis: 1609462800000, // 2021
+							},
+						},
+					},
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV:   2,
+							Name: "bbb",
+							Key: &resource.ResourceKey{
+								Name:      "bbb",
+								Namespace: "ns",
+								Group:     "dashboard.grafana.app",
+								Resource:  "dashboards",
+							},
+							Title:  "bbb (dash)",
+							Folder: "xxx",
+							Fields: map[string]any{
+								DASHBOARD_PANEL_TYPES:       []string{"timeseries"},
+								DASHBOARD_ERRORS_TODAY:      40,
+								DASHBOARD_VIEWS_LAST_1_DAYS: 100,
+							},
+							Tags: []string{"aa"},
+							Labels: map[string]string{
+								"region":                           "east",
+								utils.LabelKeyDeprecatedInternalID: "11", // nolint:staticcheck
+							},
+							Manager: &utils.ManagerProperties{
+								Kind:     utils.ManagerKindRepo,
+								Identity: "repo-1",
+							},
+							Source: &utils.SourceProperties{
+								Path:            "path/to/bbb.json",
+								Checksum:        "hijk",
+								TimestampMillis: 1640998800000, // 2022
+							},
+						},
+					},
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV: 3,
+							Key: &resource.ResourceKey{
+								Name:      "ccc",
+								Namespace: "ns",
+								Group:     "dashboard.grafana.app",
+								Resource:  "dashboards",
+							},
+							Name:   "ccc",
+							Title:  "ccc (dash)",
+							Folder: "zzz",
+							Manager: &utils.ManagerProperties{
+								Kind:     utils.ManagerKindRepo,
+								Identity: "repo2",
+							},
+							Source: &utils.SourceProperties{
+								Path: "path/in/repo2.yaml",
+							},
+							Fields: map[string]any{},
+							Tags:   []string{"aa"},
+							Labels: map[string]string{
+								"region": "west",
+							},
+						},
+					},
 				},
 			})
-			_ = index.Write(&resource.IndexableDocument{
-				RV:   2,
-				Name: "bbb",
-				Key: &resource.ResourceKey{
-					Name:      "bbb",
-					Namespace: "ns",
-					Group:     "dashboard.grafana.app",
-					Resource:  "dashboards",
-				},
-				Title:  "bbb (dash)",
-				Folder: "xxx",
-				Fields: map[string]any{
-					DASHBOARD_PANEL_TYPES:       []string{"timeseries"},
-					DASHBOARD_ERRORS_TODAY:      40,
-					DASHBOARD_VIEWS_LAST_1_DAYS: 100,
-				},
-				Tags: []string{"aa"},
-				Labels: map[string]string{
-					"region":                           "east",
-					utils.LabelKeyDeprecatedInternalID: "11", // nolint:staticcheck
-				},
-				Manager: &utils.ManagerProperties{
-					Kind:     utils.ManagerKindRepo,
-					Identity: "repo-1",
-				},
-				Source: &utils.SourceProperties{
-					Path:            "path/to/bbb.json",
-					Checksum:        "hijk",
-					TimestampMillis: 1640998800000, // 2022
-				},
-			})
-			_ = index.Write(&resource.IndexableDocument{
-				RV: 3,
-				Key: &resource.ResourceKey{
-					Name:      "ccc",
-					Namespace: "ns",
-					Group:     "dashboard.grafana.app",
-					Resource:  "dashboards",
-				},
-				Name:   "ccc",
-				Title:  "ccc (dash)",
-				Folder: "zzz",
-				Manager: &utils.ManagerProperties{
-					Kind:     utils.ManagerKindRepo,
-					Identity: "repo2",
-				},
-				Source: &utils.SourceProperties{
-					Path: "path/in/repo2.yaml",
-				},
-				Fields: map[string]any{},
-				Tags:   []string{"aa"},
-				Labels: map[string]string{
-					"region": "west",
-				},
-			})
+			if err != nil {
+				return 0, err
+			}
 			return rv, nil
 		})
 		require.NoError(t, err)
@@ -330,42 +346,55 @@ func TestBleveBackend(t *testing.T) {
 			Group:     key.Group,
 			Resource:  key.Resource,
 		}, 2, rv, fields, func(index resource.ResourceIndex) (int64, error) {
-			_ = index.Write(&resource.IndexableDocument{
-				RV: 1,
-				Key: &resource.ResourceKey{
-					Name:      "zzz",
-					Namespace: "ns",
-					Group:     "folder.grafana.app",
-					Resource:  "folders",
-				},
-				Title: "zzz (folder)",
-				Manager: &utils.ManagerProperties{
-					Kind:     utils.ManagerKindRepo,
-					Identity: "repo-1",
-				},
-				Source: &utils.SourceProperties{
-					Path:            "path/to/folder.json",
-					Checksum:        "xxxx",
-					TimestampMillis: 300,
-				},
-				Labels: map[string]string{
-					utils.LabelKeyDeprecatedInternalID: "123",
+			err := index.BulkIndex(&resource.BulkIndexRequest{
+				Items: []*resource.BulkIndexItem{
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV: 1,
+							Key: &resource.ResourceKey{
+								Name:      "zzz",
+								Namespace: "ns",
+								Group:     "folder.grafana.app",
+								Resource:  "folders",
+							},
+							Title: "zzz (folder)",
+							Manager: &utils.ManagerProperties{
+								Kind:     utils.ManagerKindRepo,
+								Identity: "repo-1",
+							},
+							Source: &utils.SourceProperties{
+								Path:            "path/to/folder.json",
+								Checksum:        "xxxx",
+								TimestampMillis: 300,
+							},
+							Labels: map[string]string{
+								utils.LabelKeyDeprecatedInternalID: "123",
+							},
+						},
+					},
+					{
+						Action: resource.BulkActionIndex,
+						Doc: &resource.IndexableDocument{
+							RV: 2,
+							Key: &resource.ResourceKey{
+								Name:      "yyy",
+								Namespace: "ns",
+								Group:     "folder.grafana.app",
+								Resource:  "folders",
+							},
+							Title: "yyy (folder)",
+							Labels: map[string]string{
+								"region":                           "west",
+								utils.LabelKeyDeprecatedInternalID: "321",
+							},
+						},
+					},
 				},
 			})
-			_ = index.Write(&resource.IndexableDocument{
-				RV: 2,
-				Key: &resource.ResourceKey{
-					Name:      "yyy",
-					Namespace: "ns",
-					Group:     "folder.grafana.app",
-					Resource:  "folders",
-				},
-				Title: "yyy (folder)",
-				Labels: map[string]string{
-					"region":                           "west",
-					utils.LabelKeyDeprecatedInternalID: "321",
-				},
-			})
+			if err != nil {
+				return 0, err
+			}
 			return rv, nil
 		})
 		require.NoError(t, err)

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -20,7 +19,7 @@ import (
 )
 
 func newTestBackend(b testing.TB) resource.StorageBackend {
-	dbstore := infraDB.InitTestDB(b)
+	dbstore := db.InitTestDB(b)
 	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 	require.NoError(b, err)
 	require.NotNil(b, eDB)
@@ -41,11 +40,11 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if infraDB.IsTestDBSpanner() {
+	if db.IsTestDBSpanner() {
 		t.Skip("Skipping benchmark on Spanner")
 	}
 	opts := test.DefaultBenchmarkOptions()
-	if infraDB.IsTestDbSQLite() {
+	if db.IsTestDbSQLite() {
 		opts.Concurrency = 1 // to avoid SQLite database is locked error
 	}
 	test.BenchmarkStorageBackend(t, newTestBackend(t), opts)
@@ -55,7 +54,7 @@ func TestIntegrationBenchmarkResourceServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if infraDB.IsTestDBSpanner() {
+	if db.IsTestDBSpanner() {
 		t.Skip("Skipping benchmark on Spanner")
 	}
 

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -85,7 +85,7 @@ func TestIntegrationBenchmarkResourceServer(t *testing.T) {
 
 	storage, err := sql.NewBackend(sql.BackendOptions{
 		DBProvider: eDB,
-		IsHA:       true,
+		IsHA:       false,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, storage)

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -68,7 +68,7 @@ func TestIntegrationBenchmarkResourceServer(t *testing.T) {
 	}
 	tempDir := t.TempDir()
 	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 	// Create a new bleve backend
 	search, err := search.NewBleveBackend(search.BleveOptions{

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -5,16 +5,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	test "github.com/grafana/grafana/pkg/storage/unified/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestBackend(b *testing.B) resource.StorageBackend {
+func newTestBackend(b testing.TB) resource.StorageBackend {
 	dbstore := infraDB.InitTestDB(b)
 	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 	require.NoError(b, err)
@@ -32,10 +36,58 @@ func newTestBackend(b *testing.B) resource.StorageBackend {
 	return backend
 }
 
-func BenchmarkSQLStorageBackend(b *testing.B) {
+func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if infraDB.IsTestDBSpanner() {
+		t.Skip("Skipping benchmark on Spanner")
+	}
 	opts := test.DefaultBenchmarkOptions()
 	if infraDB.IsTestDbSQLite() {
 		opts.Concurrency = 1 // to avoid SQLite database is locked error
 	}
-	test.BenchmarkStorageBackend(b, newTestBackend(b), opts)
+	test.BenchmarkStorageBackend(t, newTestBackend(t), opts)
+}
+
+func TestIntegrationBenchmarkResourceServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if infraDB.IsTestDBSpanner() {
+		t.Skip("Skipping benchmark on Spanner")
+	}
+	opts := &test.BenchmarkOptions{
+		NumResources:     1000,
+		Concurrency:      1, // For now we only want to test the write throughput
+		NumNamespaces:    1,
+		NumGroups:        1,
+		NumResourceTypes: 1,
+	}
+	tempDir := t.TempDir()
+
+	// Create a new bleve backend
+	search, err := search.NewBleveBackend(search.BleveOptions{
+		Root: tempDir,
+	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchPermissionFiltering), nil)
+	require.NoError(t, err)
+	require.NotNil(t, search)
+
+	// Create a new resource backend
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, eDB)
+
+	storage, err := sql.NewBackend(sql.BackendOptions{
+		DBProvider: eDB,
+		IsHA:       true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, storage)
+
+	err = storage.Init(context.Background())
+	require.NoError(t, err)
+
+	test.BenchmarkIndexServer(t, storage, search, opts)
 }

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -60,8 +60,8 @@ func TestIntegrationBenchmarkResourceServer(t *testing.T) {
 
 	ctx := context.Background()
 	opts := &test.BenchmarkOptions{
-		NumResources:     100,
-		Concurrency:      1,
+		NumResources:     1000,
+		Concurrency:      10,
 		NumNamespaces:    1,
 		NumGroups:        1,
 		NumResourceTypes: 1,

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -445,7 +445,7 @@ func (o *testIndexLatencyObserver) Len() int {
 	return len(o.latencies)
 }
 
-func (o *testIndexLatencyObserver) Observe(evt *resource.WrittenEvent, doc *resource.IndexableDocument, latency float64) {
+func (o *testIndexLatencyObserver) Observe(evt *resource.WrittenEvent, latency float64) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.latencies = append(o.latencies, latency)

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -175,13 +175,10 @@ func BenchmarkStorageBackend(b testing.TB, backend resource.StorageBackend, opts
 }
 
 // runSearchBackendBenchmarkWriteThroughput runs a write throughput benchmark for search backend
+// This is a simple benchmark that writes a single resource/group/namespace because indices are per-tenant/group/resource.
 func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resource.SearchBackend, opts *BenchmarkOptions) (*BenchmarkResult, error) {
 	if opts == nil {
 		opts = DefaultBenchmarkOptions()
-	}
-
-	if opts.NumResources > 0 || opts.NumGroups > 0 || opts.NumResourceTypes > 0 {
-		return nil, fmt.Errorf("NumResources, NumGroups, and NumResourceTypes must be 0 because indices are per-tenant")
 	}
 
 	// Create channels for workers

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -147,16 +147,19 @@ func runStorageBackendBenchmark(ctx context.Context, backend resource.StorageBac
 }
 
 // BenchmarkStorageBackend runs a benchmark test for a storage backend implementation
-func BenchmarkStorageBackend(b *testing.B, backend resource.StorageBackend, opts *BenchmarkOptions) {
+func BenchmarkStorageBackend(b testing.TB, backend resource.StorageBackend, opts *BenchmarkOptions) {
 	ctx := context.Background()
 
 	result, err := runStorageBackendBenchmark(ctx, backend, opts)
 	require.NoError(b, err)
 
-	b.ReportMetric(result.Throughput, "writes/sec")
-	b.ReportMetric(float64(result.P50Latency.Milliseconds()), "p50-latency-ms")
-	b.ReportMetric(float64(result.P90Latency.Milliseconds()), "p90-latency-ms")
-	b.ReportMetric(float64(result.P99Latency.Milliseconds()), "p99-latency-ms")
+	// Only report metrics if we're running a benchmark
+	if bb, ok := b.(*testing.B); ok {
+		bb.ReportMetric(result.Throughput, "writes/sec")
+		bb.ReportMetric(float64(result.P50Latency.Milliseconds()), "p50-latency-ms")
+		bb.ReportMetric(float64(result.P90Latency.Milliseconds()), "p90-latency-ms")
+		bb.ReportMetric(float64(result.P99Latency.Milliseconds()), "p99-latency-ms")
+	}
 
 	// Also log the results for better visibility
 	b.Logf("Benchmark Configuration: Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d", opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes)
@@ -168,4 +171,152 @@ func BenchmarkStorageBackend(b *testing.B, backend resource.StorageBackend, opts
 	b.Logf("P50 Latency: %v", result.P50Latency)
 	b.Logf("P90 Latency: %v", result.P90Latency)
 	b.Logf("P99 Latency: %v", result.P99Latency)
+}
+
+// runSearchBackendBenchmarkWriteThroughput runs a write throughput benchmark for search backend
+func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resource.SearchBackend, opts *BenchmarkOptions) (*BenchmarkResult, error) {
+	if opts == nil {
+		opts = DefaultBenchmarkOptions()
+	}
+
+	if opts.NumResources > 0 || opts.NumGroups > 0 || opts.NumResourceTypes > 0 {
+		return nil, fmt.Errorf("NumResources, NumGroups, and NumResourceTypes must be 0 because indices are per-tenant")
+	}
+
+	// Create channels for workers
+	jobs := make(chan int, opts.NumResources)
+	results := make(chan time.Duration, opts.NumResources)
+	errors := make(chan error, opts.NumResources)
+
+	// Fill the jobs channel
+	for i := 0; i < opts.NumResources; i++ {
+		jobs <- i
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+
+	// Initialize namespace and resource type
+	nr := resource.NamespacedResource{
+		Namespace: "ns-init",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	// Build initial index
+	size := int64(10000) // force the index to be on disk
+	index, err := backend.BuildIndex(ctx, nr, size, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+		return 0, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize backend: %w", err)
+	}
+
+	// Start workers
+	startTime := time.Now()
+	for workerID := 0; workerID < opts.Concurrency; workerID++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for jobID := range jobs {
+
+				doc := &resource.IndexableDocument{
+					Key: &resource.ResourceKey{
+						Namespace: nr.Namespace,
+						Group:     nr.Group,
+						Resource:  nr.Resource,
+						Name:      fmt.Sprintf("item-%d", jobID),
+					},
+					Title: fmt.Sprintf("Document %d", jobID),
+					Tags:  []string{"tag1", "tag2"},
+					Fields: map[string]interface{}{
+						"field1": jobID,
+						"field2": fmt.Sprintf("value-%d", jobID),
+					},
+				}
+
+				writeStart := time.Now()
+				err := index.Write(doc)
+				if err != nil {
+					errors <- err
+					return
+				}
+
+				results <- time.Since(writeStart)
+			}
+		}()
+	}
+
+	// Wait for all workers to complete
+	wg.Wait()
+	close(results)
+	close(errors)
+
+	// Check for errors
+	if len(errors) > 0 {
+		return nil, <-errors // Return the first error encountered
+	}
+
+	// Collect all latencies
+	latencies := make([]time.Duration, 0, opts.NumResources)
+	for latency := range results {
+		latencies = append(latencies, latency)
+	}
+
+	// Sort latencies for percentile calculation
+	sort.Slice(latencies, func(i, j int) bool {
+		return latencies[i] < latencies[j]
+	})
+
+	totalDuration := time.Since(startTime)
+	throughput := float64(opts.NumResources) / totalDuration.Seconds()
+
+	return &BenchmarkResult{
+		TotalDuration: totalDuration,
+		WriteCount:    opts.NumResources,
+		Throughput:    throughput,
+		P50Latency:    latencies[len(latencies)*50/100],
+		P90Latency:    latencies[len(latencies)*90/100],
+		P99Latency:    latencies[len(latencies)*99/100],
+	}, nil
+}
+
+// BenchmarkSearchBackend runs a benchmark test for a search backend implementation
+func BenchmarkSearchBackend(tb testing.TB, backend resource.SearchBackend, opts *BenchmarkOptions) {
+	ctx := context.Background()
+
+	result, err := runSearchBackendBenchmarkWriteThroughput(ctx, backend, opts)
+	require.NoError(tb, err)
+
+	if b, ok := tb.(*testing.B); ok {
+		b.ReportMetric(result.Throughput, "writes/sec")
+		b.ReportMetric(float64(result.P50Latency.Milliseconds()), "p50-latency-ms")
+		b.ReportMetric(float64(result.P90Latency.Milliseconds()), "p90-latency-ms")
+		b.ReportMetric(float64(result.P99Latency.Milliseconds()), "p99-latency-ms")
+	}
+
+	// Also log the results for better visibility
+	tb.Logf("Benchmark Configuration: Workers=%d, Resources=%d, Namespaces=%d, Groups=%d, Resource Types=%d", opts.Concurrency, opts.NumResources, opts.NumNamespaces, opts.NumGroups, opts.NumResourceTypes)
+	tb.Logf("")
+	tb.Logf("Benchmark Results:")
+	tb.Logf("Total Duration: %v", result.TotalDuration)
+	tb.Logf("Write Count: %d", result.WriteCount)
+	tb.Logf("Throughput: %.2f writes/sec", result.Throughput)
+	tb.Logf("P50 Latency: %v", result.P50Latency)
+	tb.Logf("P90 Latency: %v", result.P90Latency)
+	tb.Logf("P99 Latency: %v", result.P99Latency)
+}
+
+func BenchmarkIndexServer(tb testing.TB, backend resource.StorageBackend, searchBackend resource.SearchBackend, opts *BenchmarkOptions) {
+	server, err := resource.NewResourceServer(resource.ResourceServerOptions{
+		Backend: backend,
+		Search: resource.SearchOptions{
+			Backend: searchBackend,
+		},
+	})
+	require.NoError(tb, err)
+	require.NotNil(tb, server)
+
+	// TODO: Implement
+
 }

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -217,7 +217,6 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 		go func() {
 			defer wg.Done()
 			for jobID := range jobs {
-
 				doc := &resource.IndexableDocument{
 					Key: &resource.ResourceKey{
 						Namespace: nr.Namespace,

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -72,7 +72,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						Key: &resource.ResourceKey{
 							Namespace: ns.Namespace,
@@ -118,7 +118,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						Key: &resource.ResourceKey{
 							Namespace: ns.Namespace,
@@ -135,7 +135,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 					},
 				},
 				{
-					Action: resource.BulkActionIndex,
+					Action: resource.ActionIndex,
 					Doc: &resource.IndexableDocument{
 						Key: &resource.ResourceKey{
 							Namespace: ns.Namespace,

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -1,0 +1,217 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// Test names for the search backend test suite
+const (
+	TestBuildIndex    = "build index"
+	TestTotalDocs     = "total docs"
+	TestResourceIndex = "resource index"
+)
+
+// NewSearchBackendFunc is a function that creates a new SearchBackend instance
+type NewSearchBackendFunc func(ctx context.Context) resource.SearchBackend
+
+// RunSearchBackendTest runs the search backend test suite
+func RunSearchBackendTest(t *testing.T, newBackend NewSearchBackendFunc, opts *TestOptions) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	if opts == nil {
+		opts = &TestOptions{}
+	}
+
+	if opts.NSPrefix == "" {
+		opts.NSPrefix = "test-" + time.Now().Format("20060102150405")
+	}
+
+	t.Logf("Running tests with namespace prefix: %s", opts.NSPrefix)
+
+	cases := []struct {
+		name string
+		fn   func(*testing.T, resource.SearchBackend, string)
+	}{
+		{TestBuildIndex, runTestSearchBackendBuildIndex},
+		{TestTotalDocs, runTestSearchBackendTotalDocs},
+		{TestResourceIndex, runTestResourceIndex},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fn(t, newBackend(context.Background()), opts.NSPrefix)
+		})
+	}
+}
+
+func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend, nsPrefix string) {
+	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
+	ns := resource.NamespacedResource{
+		Namespace: nsPrefix + "-ns1",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	// Get the index should return nil if the index does not exist
+	index, err := backend.GetIndex(ctx, ns)
+	require.NoError(t, err)
+	require.Nil(t, index)
+
+	// Build the index
+	index, err = backend.BuildIndex(ctx, ns, 0, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+		// Write a test document
+		doc := &resource.IndexableDocument{
+			Key: &resource.ResourceKey{
+				Namespace: ns.Namespace,
+				Group:     ns.Group,
+				Resource:  ns.Resource,
+				Name:      "doc1",
+			},
+			Title: "Document 1",
+		}
+		err := index.Write(doc)
+		if err != nil {
+			return 0, err
+		}
+		return 1, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, index)
+
+	// Get the index should now return the index
+	index, err = backend.GetIndex(ctx, ns)
+	require.NoError(t, err)
+	require.NotNil(t, index)
+}
+
+func runTestSearchBackendTotalDocs(t *testing.T, backend resource.SearchBackend, nsPrefix string) {
+	// Get total document count
+	count := backend.TotalDocs()
+	require.GreaterOrEqual(t, count, int64(0))
+}
+
+func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix string) {
+	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
+	ns := resource.NamespacedResource{
+		Namespace: nsPrefix + "-ns1",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	// Build initial index with some test documents
+	index, err := backend.BuildIndex(ctx, ns, 3, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+		// Write initial test documents
+		docs := []*resource.IndexableDocument{
+			{
+				Key: &resource.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+					Name:      "doc1",
+				},
+				Title: "Document 1",
+				Tags:  []string{"tag1", "tag2"},
+				Fields: map[string]interface{}{
+					"field1": 1,
+					"field2": "value1",
+				},
+			},
+			{
+				Key: &resource.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+					Name:      "doc2",
+				},
+				Title: "Document 2",
+				Tags:  []string{"tag2", "tag3"},
+				Fields: map[string]interface{}{
+					"field1": 2,
+					"field2": "value2",
+				},
+			},
+		}
+
+		for _, doc := range docs {
+			err := index.Write(doc)
+			if err != nil {
+				return 0, err
+			}
+		}
+		return int64(len(docs)), nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, index)
+
+	err = index.Flush()
+	require.NoError(t, err)
+
+	t.Run("Write", func(t *testing.T) {
+		// Write a new document
+		doc := &resource.IndexableDocument{
+			Key: &resource.ResourceKey{
+				Namespace: ns.Namespace,
+				Group:     ns.Group,
+				Resource:  ns.Resource,
+				Name:      "doc3",
+			},
+			Title: "Document 3",
+			Tags:  []string{"tag3", "tag4"},
+			Fields: map[string]interface{}{
+				"field1": 3,
+				"field2": "value3",
+			},
+		}
+		err := index.Write(doc)
+		require.NoError(t, err)
+
+		// Verify document count
+		count, err := index.DocCount(ctx, "")
+		require.NoError(t, err)
+		require.Equal(t, int64(3), count)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		// Delete a document
+		err := index.Delete(&resource.ResourceKey{
+			Namespace: ns.Namespace,
+			Group:     ns.Group,
+			Resource:  ns.Resource,
+			Name:      "doc2",
+		})
+		require.NoError(t, err)
+
+		// Verify document count
+		count, err := index.DocCount(ctx, "")
+		require.NoError(t, err)
+		require.Equal(t, int64(2), count)
+	})
+
+	t.Run("Search", func(t *testing.T) {
+		req := &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Fields: []string{"title", "folder", "tags"},
+			Query:  "tag3",
+			Limit:  10,
+		}
+		resp, err := index.Search(ctx, nil, req, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(1), resp.TotalHits) // Only doc3 should have tag3 now
+	})
+}


### PR DESCRIPTION
Increase indexing throughput by batching events per index.

This PR introduces a per index batch processor. Everytime a new event is ingested:
- the event is dispatched to a queue, one queue per index.
- Within each queue, events are indexed in small batch. The Write/Delete methods have been replaced with a single BatchIndex operation.
- Processor are concurrent with one-another: events in different indices can be processed concurrently

Add a few integration tests for indexing:
- A couple simple tests to verify the implementation for the SearchBackend. This really aims to be a starting point to verify the implementation is correct
- Add a performance test for the Search Backend and the Search server


## Benchmark

Here are 3 run of TestIntegrationBenchmarkResourceServer showing before/after. As you can see, throughput went from ~35 events/s to ~2k per index (x65)
```
## Before with 100 resources
=== RUN   TestIntegrationBenchmarkResourceServer
    Benchmark Configuration: Workers=1, Resources=100, Namespaces=1, Groups=1, Resource Types=1
    Storage Benchmark Results:
    Total Duration: 39.488875ms
    
    Storage Write Count: 100
    Storage Write Throughput: 2532.36 writes/sec
    P50 Write Latency: 326.125µs
    P90 Write Latency: 349.542µs
    P99 Write Latency: 6.472458ms
    
    Index Latency Results:
    Indexing Throughput: 35.48 events/sec
    P50 Index Latency: 1.473s
    P90 Index Latency: 2.573s
    P99 Index Latency: 2.779s

## After with 100 resources
=== RUN   TestIntegrationBenchmarkResourceServer
    Benchmark Configuration: Workers=1, Resources=100, Namespaces=1, Groups=1, Resource Types=1
        
    Storage Benchmark Results:
    Total Duration: 44.591334ms
    Storage Write Count: 100
    Storage Write Throughput: 2242.59 writes/sec
    P50 Write Latency: 322.25µs
    P90 Write Latency: 399.709µs
    P99 Write Latency: 9.143542ms
    
    Index Latency Results:
    Indexing Throughput: 1163.41 events/sec
    P50 Index Latency: 0.041s
    P90 Index Latency: 0.053s
    P99 Index Latency: 0.059s

## After with 10k resources  
=== RUN   TestIntegrationBenchmarkResourceServer
 Benchmark Configuration: Workers=1, Resources=10000, Namespaces=1, Groups=1, Resource Types=1

 Storage Benchmark Results:
 Total Duration: 4.628090541s
 Storage Write Count: 10000
 Storage Write Throughput: 2160.72 writes/sec
 P50 Write Latency: 351.667µs
 P90 Write Latency: 423.166µs
 P99 Write Latency: 4.134375ms

 Index Latency Results:
 Indexing Throughput: 2144.91 events/sec
 P50 Index Latency: 0.042s
 P90 Index Latency: 0.054s
 P99 Index Latency: 0.065s
--- PASS: TestIntegrationBenchmarkResourceServer (4.87s)
```