### PR TITLE
Chore: Enable `no-floating-promises` rule in (some) test files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -282,6 +282,19 @@ module.exports = [
     },
   },
   {
+    name: 'grafana/test-overrides',
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+    files: ['public/app/features/**/*.{spec,test}.tsx'],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
     name: 'grafana/alerting-test-overrides',
     plugins: {
       'testing-library': testingLibraryPlugin,

--- a/public/app/features/alerting/unified/api/annotations.test.ts
+++ b/public/app/features/alerting/unified/api/annotations.test.ts
@@ -18,9 +18,9 @@ jest.mock('@grafana/runtime', () => ({
 describe('annotations', () => {
   beforeEach(() => get.mockClear());
 
-  it('should fetch annotation for an alertId', () => {
+  it('should fetch annotation for an alertId', async () => {
     const ALERT_ID = 'abc123';
-    fetchAnnotations(ALERT_ID);
+    await fetchAnnotations(ALERT_ID);
     expect(get).toBeCalledWith('/api/annotations', { alertUID: ALERT_ID });
   });
 });

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -309,8 +309,8 @@ describe('RuleViewer', () => {
       ]);
     });
 
-    it('should render a data source managed alert rule', () => {
-      renderRuleViewer(mockRule, mockRuleIdentifier);
+    it('should render a data source managed alert rule', async () => {
+      await renderRuleViewer(mockRule, mockRuleIdentifier);
 
       // assert on basic info to be vissible
       expect(screen.getByText('cloud test alert')).toBeInTheDocument();
@@ -330,7 +330,7 @@ describe('RuleViewer', () => {
 
       const user = userEvent.setup();
 
-      renderRuleViewer(sloRule, sloRuleIdentifier);
+      await renderRuleViewer(sloRule, sloRuleIdentifier);
 
       expect(ELEMENTS.actions.more.button.get()).toBeInTheDocument();
 
@@ -349,8 +349,7 @@ describe('RuleViewer', () => {
       );
       const assertsRuleIdentifier = ruleId.fromCombinedRule(mimir.name, assertsRule);
 
-      renderRuleViewer(assertsRule, assertsRuleIdentifier);
-
+      await renderRuleViewer(assertsRule, assertsRuleIdentifier);
       expect(ELEMENTS.actions.more.button.get()).toBeInTheDocument();
 
       await userEvent.click(ELEMENTS.actions.more.button.get());
@@ -386,7 +385,7 @@ describe('RuleViewer', () => {
     const mockRuleIdentifier = ruleId.fromCombinedRule(prometheus.name, mockRule);
 
     it('should render metadata for vanilla Prometheus alert rule', async () => {
-      renderRuleViewer(mockRule, mockRuleIdentifier, ActiveTab.Details);
+      await renderRuleViewer(mockRule, mockRuleIdentifier, ActiveTab.Details);
 
       expect(screen.getByText('prom test alert')).toBeInTheDocument();
 

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useAddRuleToRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useAddRuleToRuleGroup.test.tsx
@@ -145,7 +145,7 @@ const AddRuleTestComponent = ({ ruleGroupIdentifier, rule, interval }: AddRuleTe
   const [addRule, requestState] = useAddRuleToRuleGroup();
 
   const onClick = () => {
-    addRule.execute(ruleGroupIdentifier, rule, interval);
+    void addRule.execute(ruleGroupIdentifier, rule, interval);
   };
 
   return (

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
@@ -147,7 +147,7 @@ const DeleteTestComponent = ({ rule }: DeleteTestComponentProps) => {
   const ruleGroupID = getRuleGroupLocationFromCombinedRule(rule);
   const ruleID = fromRulerRuleAndRuleGroupIdentifier(ruleGroupID, rule.rulerRule!);
   const onClick = () => {
-    deleteRuleFromGroup.execute(ruleGroupID, ruleID);
+    void deleteRuleFromGroup.execute(ruleGroupID, ruleID);
   };
 
   return (

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleGroup.test.tsx
@@ -78,7 +78,7 @@ const DeleteTestComponent = ({ ruleGroupIdentifier }: DeleteTestComponentProps) 
   const [deleteRuleGroup, requestState] = useDeleteRuleGroup();
 
   const onClick = () => {
-    deleteRuleGroup.execute(ruleGroupIdentifier);
+    void deleteRuleGroup.execute(ruleGroupIdentifier);
   };
 
   return (

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
@@ -269,7 +269,7 @@ const MoveRuleTestComponent = ({
   const [moveRule, requestState] = useMoveRuleToRuleGroup();
 
   const onClick = () => {
-    moveRule.execute(currentRuleGroupIdentifier, targetRuleGroupIdentifier, ruleID, rule);
+    void moveRule.execute(currentRuleGroupIdentifier, targetRuleGroupIdentifier, ruleID, rule);
   };
 
   return (

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleInRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleInRuleGroup.test.tsx
@@ -296,7 +296,7 @@ const UpdateRuleTestComponent = ({
   const [updateRule, requestState] = useUpdateRuleInRuleGroup();
 
   const onClick = () => {
-    updateRule.execute(ruleGroupIdentifier, ruleID, rule, targetRuleGroupIdentifier);
+    void updateRule.execute(ruleGroupIdentifier, ruleID, rule, targetRuleGroupIdentifier);
   };
 
   return (

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -47,7 +47,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')], 'B');
+    await runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -104,7 +104,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')], 'B');
+    await runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -135,7 +135,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')], 'B');
+    await runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(2))).toEmitValuesWith((values) => {
       const [loading, data] = values;
@@ -189,7 +189,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')], 'B');
+    await runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -211,7 +211,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')], 'B');
+    await runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(lastValueFrom(data.pipe(timeout(200)))).rejects.toThrow(TimeoutError);
   });
@@ -231,7 +231,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run(
+    await runner.run(
       [
         createQuery('A', {
           model: {

--- a/public/app/features/alerting/unified/useRouteGroupsMatcher.test.tsx
+++ b/public/app/features/alerting/unified/useRouteGroupsMatcher.test.tsx
@@ -33,8 +33,8 @@ describe('useRouteGroupsMatcher', () => {
 
     expect(createWorkerMock).toHaveBeenCalledTimes(1);
     expect(wrapMock).toHaveBeenCalledTimes(0); // When loading worker failed we shouldn't call wrap
-    expect(async () => {
+    await expect(async () => {
       await result.current.getRouteGroupsMap({ id: '1' }, []);
-    }).rejects.toThrowError(Error);
+    }).rejects.toThrow(Error);
   });
 });

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { render, screen } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { FieldType, getDefaultTimeRange, LoadingState, toDataFrame } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
@@ -19,8 +19,8 @@ jest.mock('./utils.ts', () => ({
   getGithubMarkdown: () => new Uint8Array(1024 * 1024).toString(),
 }));
 
-async function setup() {
-  const { panel } = await buildTestScene();
+function setup() {
+  const { panel } = buildTestScene();
   panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
   return render(<HelpWizard panel={panel} onClose={() => {}} />);
@@ -39,7 +39,7 @@ describe('HelpWizard', () => {
     config.supportBundlesEnabled = false;
     setup();
 
-    expect(screen.queryByText('You can also retrieve a support bundle')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('You can also retrieve a support bundle')).not.toBeInTheDocument());
   });
 
   it('should show error as alert', async () => {
@@ -80,7 +80,7 @@ describe('SupportSnapshot', () => {
   });
 });
 
-async function buildTestScene() {
+function buildTestScene() {
   const menu = new VizPanelMenu({
     $behaviors: [panelMenuBehavior],
   });
@@ -125,8 +125,6 @@ async function buildTestScene() {
     },
     body: DefaultGridLayoutManager.fromVizPanels([panel]),
   });
-
-  await new Promise((r) => setTimeout(r, 1));
 
   return { scene, panel, menu };
 }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -781,7 +781,7 @@ describe('DashboardScene', () => {
       });
     });
 
-    it('should return early if historySrv does not return a valid version number', () => {
+    it('should return early if historySrv does not return a valid version number', async () => {
       jest
         .mocked(historySrv.restoreDashboard)
         .mockResolvedValueOnce({ version: null })
@@ -791,7 +791,7 @@ describe('DashboardScene', () => {
         .mockResolvedValue({ version: '10' });
 
       for (let i = 0; i < 5; i++) {
-        scene.onRestore(getVersionMock()).then((res) => {
+        await scene.onRestore(getVersionMock()).then((res) => {
           expect(res).toBe(false);
         });
       }

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
@@ -114,21 +114,21 @@ describe('AnnotationsEditView', () => {
       expect(console.error).toHaveBeenCalledWith('Default datasource does not support annotations');
     });
 
-    it('should add a new annotation and group it with the other annotations', () => {
+    it('should add a new annotation and group it with the other annotations', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
       expect(dataLayers?.state.annotationLayers.length).toBe(1);
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[1].state.name).toBe(newAnnotationName);
       expect(dataLayers?.state.annotationLayers[1].isActive).toBe(true);
     });
 
-    it('should move an annotation up one position', () => {
+    it('should move an annotation up one position', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe('test');
@@ -139,10 +139,10 @@ describe('AnnotationsEditView', () => {
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe(newAnnotationName);
     });
 
-    it('should move an annotation down one position', () => {
+    it('should move an annotation down one position', async () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
-      annotationsView.onNew();
+      await annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);
       expect(dataLayers?.state.annotationLayers[0].state.name).toBe('test');

--- a/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
@@ -54,7 +54,7 @@ describe('GenAIButton', () => {
     it('should not render anything', async () => {
       setup();
 
-      waitFor(async () => expect(await screen.findByText('Auto-generate')).not.toBeInTheDocument());
+      expect(screen.queryByText('Auto-generate')).not.toBeInTheDocument();
     });
   });
 
@@ -82,12 +82,12 @@ describe('GenAIButton', () => {
     it('should render text', async () => {
       setup();
 
-      waitFor(async () => expect(await screen.findByText('Auto-generate')).toBeInTheDocument());
+      expect(await screen.findByText('Auto-generate')).toBeInTheDocument();
     });
 
     it('should enable the button', async () => {
       setup();
-      waitFor(async () => expect(await screen.findByRole('button')).toBeEnabled());
+      expect(await screen.findByRole('button')).toBeEnabled();
     });
 
     it('should send the configured messages', async () => {
@@ -168,12 +168,12 @@ describe('GenAIButton', () => {
     it('should render loading text', async () => {
       setup();
 
-      waitFor(async () => expect(await screen.findByText('Auto-generate')).toBeInTheDocument());
+      expect(await screen.findByText('Stop generating')).toBeInTheDocument();
     });
 
     it('should enable the button', async () => {
       setup();
-      waitFor(async () => expect(await screen.findByRole('button')).toBeEnabled());
+      expect(await screen.findByRole('button')).toBeEnabled();
     });
 
     it('shows the stop button while generating', async () => {
@@ -233,12 +233,12 @@ describe('GenAIButton', () => {
     it('should render improve text ', async () => {
       setup();
 
-      waitFor(async () => expect(await screen.findByText('Improve')).toBeInTheDocument());
+      expect(await screen.findByText('Improve')).toBeInTheDocument();
     });
 
     it('should enable the button', async () => {
       setup();
-      waitFor(async () => expect(await screen.findByRole('button')).toBeEnabled());
+      expect(await screen.findByRole('button')).toBeEnabled();
     });
 
     it('should call onGenerate when the text is completed', async () => {
@@ -274,12 +274,12 @@ describe('GenAIButton', () => {
     it('should render error state text', async () => {
       setup();
 
-      waitFor(async () => expect(await screen.findByText('Retry')).toBeInTheDocument());
+      expect(await screen.findByText('Retry')).toBeInTheDocument();
     });
 
     it('should enable the button', async () => {
       setup();
-      waitFor(async () => expect(await screen.findByRole('button')).toBeEnabled());
+      expect(await screen.findByRole('button')).toBeEnabled();
     });
 
     it('should retry when clicking', async () => {

--- a/public/app/features/explore/hooks/useStateSync/index.test.tsx
+++ b/public/app/features/explore/hooks/useStateSync/index.test.tsx
@@ -545,8 +545,8 @@ describe('useStateSync', () => {
       expect(store.getState().explore.panes['one']?.datasourceInstance?.uid).toBe('loki-uid');
     });
 
-    act(() => {
-      store.dispatch(splitOpen());
+    await act(async () => {
+      await store.dispatch(splitOpen());
     });
 
     await waitFor(() => {

--- a/public/app/features/explore/spec/split.test.tsx
+++ b/public/app/features/explore/spec/split.test.tsx
@@ -183,8 +183,8 @@ describe('Handles open/close splits and related events in UI and URL', () => {
       expect(await screen.findByText(`loki Editor input: { label="value"}`)).toBeInTheDocument();
     });
 
-    act(() => {
-      store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', queries: [{ expr: 'error', refId: 'A' }] }));
+    await act(async () => {
+      await store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', queries: [{ expr: 'error', refId: 'A' }] }));
     });
 
     // Editor renders the new query

--- a/public/app/features/query/components/QueryEditorRows.test.tsx
+++ b/public/app/features/query/components/QueryEditorRows.test.tsx
@@ -113,7 +113,7 @@ describe('QueryEditorRows', () => {
 
     renderScenario({ onAddQuery, onQueryCopied });
     const queryEditorRows = await screen.findAllByTestId('query-editor-row');
-    queryEditorRows.map(async (childQuery) => {
+    queryEditorRows.map((childQuery) => {
       const duplicateQueryButton = queryByLabelText(childQuery, 'Duplicate query') as HTMLElement;
 
       expect(duplicateQueryButton).toBeInTheDocument();
@@ -131,7 +131,7 @@ describe('QueryEditorRows', () => {
     renderScenario({ onQueriesChange, onQueryRemoved });
 
     const queryEditorRows = await screen.findAllByTestId('query-editor-row');
-    queryEditorRows.map(async (childQuery) => {
+    queryEditorRows.map((childQuery) => {
       const deleteQueryButton = queryByLabelText(childQuery, 'Remove query') as HTMLElement;
 
       expect(deleteQueryButton).toBeInTheDocument();


### PR DESCRIPTION
**What is this feature?**
Enables `no-floating-promises` ESLint rule for test files. This requires type information in order to work correctly - the lint rule takes a litttttle bit longer to run on CI with this enabled. Before this, it's ~1m10s, after its ~1m35s

I've only enabled it for test files so far as there are a number of patterns in the wider codebase that violate this rule, so that needs discussion before turning on everywhere (e.g. `dispatch` calls are nearly all promises, but we aren't awaiting them. They either need moving to async methods, or use of the `void` operator). Also, the lint rule runs out of memory if we use it everywhere (see https://github.com/typescript-eslint/typescript-eslint/issues/1879)

**Why do we need this feature?**
Floating promises in tests can result in weird behaviour - if you forget to await a click event, then the test will act strangely when focused/can flake

**Which issue(s) does this PR fix?**:
Fixes #93405
