### PR TITLE
Extension Sidebar: Enable conditional rendering of component

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { EventBusSrv, store } from '@grafana/data';
-import { config, setAppEvents } from '@grafana/runtime';
+import { config, setAppEvents, usePluginLinks } from '@grafana/runtime';
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 
 import { ExtensionSidebarContextProvider, useExtensionSidebarContext } from './ExtensionSidebarProvider';
@@ -33,6 +33,15 @@ jest.mock('@grafana/runtime', () => ({
       extensionSidebar: true,
     },
   },
+  usePluginLinks: jest.fn().mockImplementation(() => ({
+    links: [
+      {
+        pluginId: mockPluginMeta.pluginId,
+        title: mockComponent.title,
+      },
+    ],
+    isLoading: false,
+  })),
 }));
 
 const mockComponent = {
@@ -120,6 +129,14 @@ describe('ExtensionToolbarItem', () => {
         { ...mockComponent, title: 'Component 2' },
       ],
     };
+
+    (usePluginLinks as jest.Mock).mockReturnValue({
+      links: [
+        { pluginId: multipleComponentsMeta.pluginId, title: multipleComponentsMeta.addedComponents[0].title },
+        { pluginId: multipleComponentsMeta.pluginId, title: multipleComponentsMeta.addedComponents[1].title },
+      ],
+      isLoading: false,
+    });
 
     (getExtensionPointPluginMeta as jest.Mock).mockReturnValue(
       new Map([[multipleComponentsMeta.pluginId, multipleComponentsMeta]])


### PR DESCRIPTION
**What is this feature?**

This PR adds a way of conditionally rendering the extension sidebar, or rather the extension's component. Since components are not actually rendered, we can not make use of the `null` check and need another way of conditionally rendering them.
Plugins which want to make use of the extension sidebar now need to register both a link and a component to it's extension point. The link's `configure` method is then used to control if the component is available or not. If the link's `configure` method returns `undefined`, the component will not be rendered.