### PR TITLE
[release-11.5.5] Dashboard: Support TemplateSrv.containsTemplate in scenes context

### DIFF
--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -22,7 +22,8 @@ describe('Loki Query Editor', () => {
     e2e.flows.revertAllChanges();
   });
 
-  it('Autocomplete features should work as expected.', () => {
+  // flaky test
+  it.skip('Autocomplete features should work as expected.', () => {
     addDataSource();
 
     cy.intercept(/labels?/, (req) => {

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -905,6 +905,29 @@ describe('templateSrv', () => {
       expect(podVar.current.text).toEqual(['podA', 'podB']);
     });
 
+    it('Can use containsTemplate to check if a variable exists', () => {
+      window.__grafanaSceneContext = new EmbeddedScene({
+        $variables: new SceneVariableSet({
+          variables: [
+            new QueryVariable({ name: 'server', value: 'serverA', text: 'Server A', query: { refId: 'A' } }),
+            new QueryVariable({ name: 'pods', value: ['pA', 'pB'], text: ['podA', 'podB'], query: { refId: 'A' } }),
+            new DataSourceVariable({ name: 'ds', value: 'dsA', text: 'dsA', pluginId: 'prometheus' }),
+            new CustomVariable({ name: 'custom', value: 'A', text: 'A', query: 'A, B, C' }),
+            new IntervalVariable({ name: 'interval', value: '1m', intervals: ['1m', '2m'] }),
+          ],
+        }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      window.__grafanaSceneContext.activate();
+
+      expect(_templateSrv.containsTemplate('${server}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${pods}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${ds}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${custom}')).toBe(true);
+      expect(_templateSrv.containsTemplate('${interval}')).toBe(true);
+    });
+
     it('Should return timeRange from scenes context', () => {
       window.__grafanaSceneContext = new EmbeddedScene({
         body: new SceneCanvasText({ text: 'hello' }),

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -200,6 +200,15 @@ export class TemplateSrv implements BaseTemplateSrv {
     if (!target) {
       return false;
     }
+
+    // Scenes compatability
+    if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
+      // We are just checking that this is a valid variable reference, and we are not looking up the variable
+      this.regex.lastIndex = 0;
+      const match = this.regex.exec(target);
+      return !!match;
+    }
+
     const name = this.getVariableName(target);
     const variable = name && this.getVariableAtIndex(name);
     return variable !== null && variable !== undefined;

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -201,7 +201,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       return false;
     }
 
-    // Scenes compatability
+    // Scenes compatibility
     if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
       // We are just checking that this is a valid variable reference, and we are not looking up the variable
       this.regex.lastIndex = 0;


### PR DESCRIPTION
Backport 82184686dc5b6f5f4b0844c4235687fe3282df08 from #104072

---

**What is this feature?**

Enables statistic field to work with a template variable in scenes. This didn't work when scenes are enabled because the dashboard scene doesn't rely on or update legacy redux state, and `TemplateSrv.containsTemplate` relies on `targets.keys` from redux store.

Fixes https://github.com/grafana/grafana/issues/102872
Fixes https://github.com/grafana/support-escalations/issues/15409


**Special notes for your reviewer:**

I've skipped the loki-editor e2e test for this version - see (https://github.com/grafana/grafana/pull/104182#discussion_r2051040180) 

Please check that:
- [ ] It works as expected from a user's perspective.
