### PR TITLE
NavTree: Group APM and Infra plugins under "Observability" section

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -203,6 +203,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/library-panels/", reqSignedIn, hs.Index)
 	r.Get("/monitoring/", reqSignedIn, hs.Index)
 	r.Get("/monitoring/*", reqSignedIn, hs.Index)
+	r.Get("/observability/", reqSignedIn, hs.Index)
+	r.Get("/observability/*", reqSignedIn, hs.Index)
 	r.Get("/alerts-and-incidents", reqSignedIn, hs.Index)
 	r.Get("/alerts-and-incidents/*", reqSignedIn, hs.Index)
 

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -21,7 +21,7 @@ const (
 	WeightAlertsAndIncidents
 	WeightAIAndML
 	WeightTestingAndSynthetics
-	WeightMonitoring
+	WeightObservability
 	WeightCloudServiceProviders
 	WeightInfrastructure
 	WeightApplication
@@ -44,7 +44,7 @@ const (
 	NavIDAlertsAndIncidents   = "alerts-and-incidents"
 	NavIDTestingAndSynthetics = "testing-and-synthetics"
 	NavIDAlerting             = "alerting"
-	NavIDMonitoring           = "monitoring"
+	NavIDObservability        = "observability"
 	NavIDInfrastructure       = "infrastructure"
 	NavIDFrontend             = "frontend"
 	NavIDReporting            = "reports"

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -231,7 +231,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				Icon:       "heart-rate",
 				SortWeight: navtree.WeightObservability,
 				Children:   []*navtree.NavLink{appLink},
-				Url:        s.cfg.AppSubURL + "/monitoring",
+				Url:        s.cfg.AppSubURL + "/observability",
 			})
 		case navtree.NavIDInfrastructure:
 			treeRoot.AddSection(&navtree.NavLink{

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -223,13 +223,13 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				SortWeight: navtree.WeightApps,
 				Url:        s.cfg.AppSubURL + "/apps",
 			})
-		case navtree.NavIDMonitoring:
+		case navtree.NavIDObservability:
 			treeRoot.AddSection(&navtree.NavLink{
 				Text:       "Observability",
-				Id:         navtree.NavIDMonitoring,
+				Id:         navtree.NavIDObservability,
 				SubTitle:   "Observability and infrastructure apps",
 				Icon:       "heart-rate",
-				SortWeight: navtree.WeightMonitoring,
+				SortWeight: navtree.WeightObservability,
 				Children:   []*navtree.NavLink{appLink},
 				Url:        s.cfg.AppSubURL + "/monitoring",
 			})
@@ -305,14 +305,16 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 
 func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
-		"grafana-k8s-app":                  {SectionID: navtree.NavIDInfrastructure, SortWeight: 1, Text: "Kubernetes"},
-		"grafana-dbo11y-app":               {SectionID: navtree.NavIDInfrastructure, SortWeight: 2, Text: "Databases"},
-		"grafana-app-observability-app":    {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightApplication, Text: "Application", Icon: "graph-bar"},
+		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 1, Icon: "asserts"},
+		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 2, Text: "Application"},
+		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 3, Icon: "cloud-provider"},
+		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Kubernetes"},
+		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Databases"},
+		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Frontend"},
 		"grafana-metricsdrilldown-app":     {SectionID: navtree.NavIDDrilldown, SortWeight: 1, Text: "Metrics"},
 		"grafana-lokiexplore-app":          {SectionID: navtree.NavIDDrilldown, SortWeight: 2, Text: "Logs"},
 		"grafana-exploretraces-app":        {SectionID: navtree.NavIDDrilldown, SortWeight: 3, Text: "Traces"},
 		"grafana-pyroscope-app":            {SectionID: navtree.NavIDDrilldown, SortWeight: 4, Text: "Profiles"},
-		"grafana-kowalski-app":             {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightFrontend, Text: "Frontend", Icon: "frontend-observability"},
 		"grafana-synthetic-monitoring-app": {SectionID: navtree.NavIDTestingAndSynthetics, SortWeight: 2, Text: "Synthetics"},
 		"grafana-irm-app":                  {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 3, Text: "IRM"},
 		"grafana-oncall-app":               {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 4, Text: "OnCall"},
@@ -328,8 +330,6 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-logvolumeexplorer-app":    {SectionID: navtree.NavIDCfg, Text: "Log Volume Explorer"},
 		"grafana-easystart-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightApps + 1, Text: "Connections", Icon: "adjust-circle"},
 		"k6-app":                           {SectionID: navtree.NavIDTestingAndSynthetics, SortWeight: 1, Text: "Performance"},
-		"grafana-asserts-app":              {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAsserts, Icon: "asserts"},
-		"grafana-csp-app":                  {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightCloudServiceProviders, Icon: "cloud-provider"},
 	}
 
 	if s.features.IsEnabledGlobally(featuremgmt.FlagGrafanaAdvisor) {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -207,21 +207,21 @@ func TestAddAppLinks(t *testing.T) {
 	t.Run("Should only add an 'Observability' section if a plugin exists that wants to live there", func(t *testing.T) {
 		service.navigationAppConfig = map[string]NavigationAppConfig{}
 
-		// Check if the Monitoring section is not there if no apps try to register to it
+		// Check if the Observability section is not there if no apps try to register to it
 		treeRoot := navtree.NavTreeRoot{}
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
-		monitoringNode := treeRoot.FindById(navtree.NavIDMonitoring)
+		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 		require.Nil(t, monitoringNode)
 
 		// It should appear and once an app tries to register to it
 		treeRoot = navtree.NavTreeRoot{}
 		service.navigationAppConfig = map[string]NavigationAppConfig{
-			"test-app1": {SectionID: navtree.NavIDMonitoring},
+			"test-app1": {SectionID: navtree.NavIDObservability},
 		}
 		err = service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
-		monitoringNode = treeRoot.FindById(navtree.NavIDMonitoring)
+		monitoringNode = treeRoot.FindById(navtree.NavIDObservability)
 		require.NotNil(t, monitoringNode)
 		require.Len(t, monitoringNode.Children, 1)
 		require.Equal(t, "Test app1 name", monitoringNode.Children[0].Text)
@@ -277,15 +277,15 @@ func TestAddAppLinks(t *testing.T) {
 
 	t.Run("Should be able to control app sort order with SortWeight (smaller SortWeight displayed first)", func(t *testing.T) {
 		service.navigationAppConfig = map[string]NavigationAppConfig{
-			"test-app2": {SectionID: navtree.NavIDMonitoring, SortWeight: 2},
-			"test-app1": {SectionID: navtree.NavIDMonitoring, SortWeight: 3},
-			"test-app3": {SectionID: navtree.NavIDMonitoring, SortWeight: 1},
+			"test-app2": {SectionID: navtree.NavIDObservability, SortWeight: 2},
+			"test-app1": {SectionID: navtree.NavIDObservability, SortWeight: 3},
+			"test-app3": {SectionID: navtree.NavIDObservability, SortWeight: 1},
 		}
 
 		treeRoot := navtree.NavTreeRoot{}
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		treeRoot.Sort()
-		monitoringNode := treeRoot.FindById(navtree.NavIDMonitoring)
+		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 
 		require.NoError(t, err)
 		require.Equal(t, "Test app3 name", monitoringNode.Children[0].Text)

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -367,7 +367,7 @@ func TestReadingNavigationSettings(t *testing.T) {
 		_, _ = service.cfg.Raw.NewSection("navigation.app_sections")
 		service.readNavigationSettings()
 
-		require.Equal(t, "infrastructure", service.navigationAppConfig["grafana-k8s-app"].SectionID)
+		require.Equal(t, "observability", service.navigationAppConfig["grafana-k8s-app"].SectionID)
 	})
 
 	t.Run("Can add additional overrides via ini system", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestReadingNavigationSettings(t *testing.T) {
 		require.Equal(t, "dashboards", service.navigationAppConfig["grafana-k8s-app"].SectionID)
 		require.Equal(t, "admin", service.navigationAppConfig["other-app"].SectionID)
 
-		require.Equal(t, int64(1), service.navigationAppConfig["grafana-k8s-app"].SortWeight)
+		require.Equal(t, int64(4), service.navigationAppConfig["grafana-k8s-app"].SortWeight)
 		require.Equal(t, int64(12), service.navigationAppConfig["other-app"].SortWeight)
 
 		require.Equal(t, "admin", service.navigationAppPathConfig["/a/grafana-k8s-app/foo"].SectionID)

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -188,7 +188,11 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/monitoring',
-      component: () => <NavLandingPage navId="monitoring" />,
+      component: () => <Navigate replace to="/observability" />,
+    },
+    {
+      path: '/observability',
+      component: () => <NavLandingPage navId="observability" />,
     },
     {
       path: '/infrastructure',


### PR DESCRIPTION
[Navigation tree testing](https://docs.google.com/presentation/d/19LDfEWQGFECxvBwZ08cZXY3gLtl4d4gDFX44sY2dbak/edit?slide=id.g2971971a0d4_0_42#slide=id.g2971971a0d4_0_42) has concluded that Grafana's new observability navigation will be structured with "Observability" as a top-level navigation item, containing all O11y products listed within it.

This PR reintroduces "Observability" section to nav tree and puts asserts, k8s, csp, db o11y, app o11y frontend o11y plugins under it.

Also see [O11y Information architecture release plan](https://docs.google.com/document/d/1oYGJ5NxBxirpaQ_j9Eh6QzOEbjSVZkg83H1_w5zKyrY/edit?tab=t.0)

fixes https://github.com/grafana/asserts-app-plugin/issues/1094

![image](https://github.com/user-attachments/assets/9fca029d-e648-4afb-ade9-ff35565928e2)

