### PR TITLE
TeamMember: Treat null permission as member

### DIFF
--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -259,13 +259,23 @@ func (s *legacySQLStore) ListUserTeams(ctx context.Context, ns claims.NamespaceI
 	var lastID int64
 	for rows.Next() {
 		t := UserTeam{}
-		err := rows.Scan(&t.ID, &t.UID, &t.Name, &t.Permission)
+
+		// regression: team_member.permission has been nulled in some instances
+		var nullablePermission *int64
+		err := rows.Scan(&t.ID, &t.UID, &t.Name, &nullablePermission)
 		if err != nil {
 			return nil, err
 		}
 
-		lastID = t.ID
+		// ignore null permissions
+		if nullablePermission != nil {
+			t.Permission = team.PermissionType(*nullablePermission)
+		} else {
+			t.Permission = team.PermissionType(0)
+		}
+
 		res.Items = append(res.Items, t)
+		lastID = t.ID
 		if len(res.Items) > int(query.Pagination.Limit)-1 {
 			res.Continue = lastID
 			res.Items = res.Items[0 : len(res.Items)-1]

--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -261,16 +261,17 @@ func (s *legacySQLStore) ListUserTeams(ctx context.Context, ns claims.NamespaceI
 		t := UserTeam{}
 
 		// regression: team_member.permission has been nulled in some instances
+		// Team memberships created before the permission column was added will have a NULL value
 		var nullablePermission *int64
 		err := rows.Scan(&t.ID, &t.UID, &t.Name, &nullablePermission)
 		if err != nil {
 			return nil, err
 		}
 
-		// ignore null permissions
 		if nullablePermission != nil {
 			t.Permission = team.PermissionType(*nullablePermission)
 		} else {
+			// treat NULL as member permission
 			t.Permission = team.PermissionType(0)
 		}
 


### PR DESCRIPTION
This pull request addresses a regression in the `ListUserTeams` method of the `legacySQLStore` implementation by handling null values for team member permissions. The most important change ensures that null permissions are ignored to prevent errors during processing.

I wanted to add a log so we can identify instances with this issue but seems no legacy store implements logs. Therefore I'd like confirmation before creating a logger there