### PR TITLE
Shortcuts: Remove esc global keybinding clearing search parameter

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -87,10 +87,6 @@ export class KeybindingSrv {
     this.exit();
   }
 
-  private closeSearch() {
-    this.locationService.partial({ search: null });
-  }
-
   private openAlerting() {
     this.locationService.push('/alerting');
   }
@@ -141,10 +137,6 @@ export class KeybindingSrv {
     const { kioskMode } = this.chromeService.state.getValue();
     if (kioskMode) {
       this.chromeService.exitKioskMode();
-    }
-
-    if (search.search) {
-      this.closeSearch();
     }
   }
 


### PR DESCRIPTION
When you hit `esc` on any page, it would just remove the `?search=foo` query string. This impacts apps that use this themselves, putting them into an inconsistent state.

This was previously a part of the old search overlay functionality, but this is no longer used, so its safe to remove.