### PR TITLE
Show micro and nano seconds in logs

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -95,14 +95,18 @@ export const LogRow = ({
   const logLineRef = useRef<HTMLTableRowElement | null>(null);
   const theme = useTheme2();
 
-  const timestamp = useMemo(
-    () =>
+  const timestamp = useMemo(() => {
+    let microAndNanoSeconds = row.timeEpochNs.slice(-6);
+    if (parseInt(microAndNanoSeconds, 10) === 0) {
+      microAndNanoSeconds = '000000';
+    }
+    return (
       dateTimeFormat(row.timeEpochMs, {
         timeZone: timeZone,
         defaultWithMS: true,
-      }),
-    [row.timeEpochMs, timeZone]
-  );
+      }) + microAndNanoSeconds
+    );
+  }, [row.timeEpochMs, row.timeEpochNs, timeZone]);
   const levelStyles = useMemo(() => getLogLevelStyles(theme, row.logLevel), [row.logLevel, theme]);
   const processedRow = useMemo(
     () =>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We would like to see the micro and nano second of log timestamp:

![image](https://github.com/user-attachments/assets/9a0230bb-7283-4ebf-ba8f-3f26b226fa4e)

**Why do we need this feature?**

We have some time sensitive logs in ElasticSearch where we wish to see the entire timestamp, including the nano seconds.

**Who is this feature for?**

DataScience Engineers 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I can imagine you might want to have this configurable. If so, please let me know how that could be done.

MomentJS doesn't support nano seconds. [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date)doesn't have it. [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) would, be that won't ship anytime soon. Anyway, because that is missing, I took a shortcut and just 6 the last 6 characters of the total nano seconds.
Would be okay to revisit this if you known another way.

Most important question: can we have this in principle?
If so, happy to address anything that needs tweaking.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
