### PR TITLE
Klog: Reduce verbosity and set as default

### DIFF
--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -24,10 +24,15 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	}
 
 	if cfg.Env == setting.Dev {
-		defaultLogLevel = 10
 		port = 6443
 		ip = net.ParseIP("0.0.0.0")
 		apiURL = fmt.Sprintf("https://%s:%d", ip, port)
+	}
+
+	// if grafana log level is set to debug, also increase the api server log level to 7,
+	// which will log the request headers & more details about the request
+	if cfg.Raw.Section("log").Key("level").MustString("info") == "debug" {
+		defaultLogLevel = 7
 	}
 
 	host := net.JoinHostPort(cfg.HTTPAddr, strconv.Itoa(port))

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -48,8 +48,15 @@ func (o *ExtraOptions) ApplyTo(c *genericapiserver.RecommendedConfig) error {
 	}); err != nil {
 		return err
 	}
-	// TODO: klog isn't working as expected, investigate - it logs some of the time
+	// if verbosity is 8+, response bodies will be logged. versboity of 7 should then be the max
+	if o.Verbosity > 7 {
+		o.Verbosity = 7
+	}
 	klog.SetSlogLogger(logger)
+	// at this point, the slog will be the background logger. set it as the default logger, as setting solely slog above
+	// won't update the verbosity because it is set as a contextual logger, and that function says "such a logger cannot
+	// rely on verbosity checking in klog"
+	klog.SetLogger(klog.Background())
 	if _, err := logs.GlogSetter(strconv.Itoa(o.Verbosity)); err != nil {
 		logger.Error("failed to set log level", "error", err)
 	}


### PR DESCRIPTION
**What is this feature?**

This PR reduces the verbosity of klog, so that:
- Response bodies cannot be logged, even when in debug mode
- We only do verbose logging _if_ the grafana instance is set to debug logging or set a specific verbosity level for the api server. Not just if they are running locally

In order to do that, this PR also had to update the klog default logger to take into account the verbosity we set. See:
- https://github.com/kubernetes/klog/blob/e7125f792ea66a85818cfb45261c9e1acc585344/contextual_slog.go#L29
- https://github.com/kubernetes/klog/blob/e7125f792ea66a85818cfb45261c9e1acc585344/contextual.go#L84
- https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/staging/src/k8s.io/client-go/rest/request.go#L1456

Before (locally):
```
INFO [04-18|08:02:32] GET https://[::1]:6443/apis/dashboard.grafana.app/v1alpha1/namespaces/default/dashboards/ebb9c778-2d6e-41e6-a420-04ed41b53789 logger=grafana-apiserver
INFO [04-18|08:02:32] Request Headers:                         logger=grafana-apiserver
INFO [04-18|08:02:32]     User-Agent: grafana/v0.0.0 (darwin/arm64) kubernetes/$Format logger=grafana-apiserver
INFO [04-18|08:02:32]     Accept: application/json             logger=grafana-apiserver
INFO [04-18|08:02:32]    Authorization: Bearer <masked>       logger=grafana-apiserver
DEBUG[04-18|08:02:32] Response Body                            logger=grafana-apiserver body="{\"kind\":\"Dashboard\",\"apiVersion\":\"dashboard.grafana.app/v1alpha1\",\"metadata\":{\"name\":\"e7c29343-6d1e-4167-9c13-803fe5be8c46\",\"namespace\":\"default\",\"uid\":\"oCYoRXGd1Xbk64LRQ2w89P7PZsm9nvU9pWPooItNdngX\",\"resourceVersion\":\"1\",\"generation\":1,\"creationTimestamp\":\"2025-04-11T14:07:36Z\",\"labels\":{\"grafana.app/deprecatedInternalID\":\"8\"},\"annotations\":{\"grafana.app/createdBy\":\"provisioning:\",\"grafana.app/updatedBy\":\"provisioning:\",\"grafana.app/updatedTimestamp\":\"2025-04-11T14:07:36Z\"}},\"spec\":{\"annotations\":{\"list\":[{\"builtIn\":1,\"datasource\":{\"type\":\"grafana\",\"uid\":\"-- Grafana --\"},\"enable\":true,\"hide\":true,\"iconColor\":\"rgba(0, 211, 255, 1)\",\"name\":\"Annotations \\u0026 Alerts\",\"type\":\"dashboard\"}]},\"editable\":true,\"fiscalYearStartMonth\":0,\"graphTooltip\":0,\"links\":[],\"liveNow\":false,\"panels\":[{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"gridPos\":{\"h\":3,\"w\":24,\"x\":0,\"y\":0},\"id\":8,\"options\":{\"code\":{\"language\":\"plaintext\",\"showLineNumbers\":false,\"showMiniMap\":false},\"content\":\"* `__all_variables`=${__all_variables}\\n* `__url_time_range`=${__url_time_range}\",\"mode\":\"markdown\"},\"pluginVersion\":\"9.5.0-pre\",\"title\":\"Panel Title\",\"type\":\"text\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"custom\":{\"align\":\"auto\",\"cellOptions\":{\"type\":\"auto\"},\"inspect\":false},\"links\":[{\"targetBlank\":true,\"title\":\"value=${__value.raw}\\u0026time=${__value.time}\\u0026__value:percentencode=${__value:percentencode}\\u0026text=${__value.text}\",\"url\":\"value=${__value.raw}\\u0026time=${__value.time}justvalue=${__value:percentencode}\\u0026text=${__value.text}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]},\"unit\":\"percent\"},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":0,\"y\":3},\"id\":2,\"options\":{\"cellHeight\":\"sm\",\"footer\":{\"countRows\":false,\"fields\":\"\",\"reducer\":[\"sum\"],\"show\":false},\"showHeader\":true,\"showRowNums\":false},\"pluginVersion\":\"9.5.0-pre\",\"title\":\"DataLink: with __value.raw=\\u0026__value.time=\\u0026__value:percentencode=\",\"type\":\"table\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"links\":[{\"targetBlank\":true,\"title\":\"Value link\",\"url\":\"value=${__value.raw}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":12,\"y\":3},\"id\":3,\"options\":{\"colorMode\":\"value\",\"graphMode\":\"area\",\"justifyMode\":\"auto\",\"orientation\":\"auto\",\"reduceOptions\":{\"calcs\":[\"lastNotNull\"],\"fields\":\"\",\"values\":false},\"textMode\":\"auto\"},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"random_walk\",\"seriesCount\":5}],\"title\":\"Stat panel with __value.raw \",\"type\":\"stat\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"continuous-GrYlRd\"},\"links\":[{\"title\":\"${__value.raw}\",\"url\":\"${__value.raw}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":0,\"y\":10},\"id\":6,\"options\":{\"displayMode\":\"basic\",\"minVizHeight\":10,\"minVizWidth\":0,\"orientation\":\"horizontal\",\"reduceOptions\":{\"calcs\":[],\"fields\":\"\",\"values\":true},\"showUnfilled\":true,\"valueMode\":\"color\"},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"csvFileName\":\"browser_marketshare.csv\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"csv_file\"}],\"title\":\"data link __value.raw\",\"transformations\":[{\"id\":\"limit\",\"options\":{\"limitField\":5}}],\"type\":\"bargauge\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"description\":\"Since this is using getFrameDisplayName it works kind badly (especially with testdata) and only returns the  `Series (refId)`. \\n\\nSo this should show:\\n* Series (Query1)\\n* Series (Query2)\",\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"displayName\":\"${__series.name}\",\"links\":[{\"targetBlank\":true,\"title\":\"Value link\",\"url\":\"value=${__calc}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":12,\"y\":10},\"id\":12,\"options\":{\"colorMode\":\"value\",\"graphMode\":\"area\",\"justifyMode\":\"auto\",\"orientation\":\"auto\",\"reduceOptions\":{\"calcs\":[\"lastNotNull\"],\"fields\":\"\",\"values\":false},\"textMode\":\"auto\"},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"alias\":\"\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"Query1\",\"scenarioId\":\"random_walk\",\"seriesCount\":1},{\"alias\":\"\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"hide\":false,\"refId\":\"Query2\",\"scenarioId\":\"random_walk\",\"seriesCount\":1}],\"title\":\"${series.name} in display name\",\"type\":\"stat\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"custom\":{\"align\":\"auto\",\"cellOptions\":{\"type\":\"auto\"},\"inspect\":false},\"links\":[{\"title\":\"__data.refId=${__data.refId}\\u0026__data.fields[0]=${__data.fields[0]}\\u0026cluster=${__field.labels.cluster}\",\"url\":\"refId=${__data.refId}\\u0026__data.fields[0]=${__data.fields[0]}\\u0026cluster=${__field.labels.cluster}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]},\"unit\":\"percent\"},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":0,\"y\":17},\"id\":11,\"options\":{\"cellHeight\":\"sm\",\"footer\":{\"countRows\":false,\"fields\":\"\",\"reducer\":[\"sum\"],\"show\":false},\"showHeader\":true,\"showRowNums\":false},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"labels\":\"cluster=US\",\"refId\":\"A\",\"scenarioId\":\"random_walk\"}],\"title\":\"DataLink: refId=${__data.refId}\\u0026__data.fields[0]=${__data.fields[0]}\\u0026cluster=${__field.labels.cluster}\",\"type\":\"table\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"palette-classic\"},\"custom\":{\"axisCenteredZero\":false,\"axisColorMode\":\"text\",\"axisLabel\":\"\",\"axisPlacement\":\"auto\",\"barAlignment\":0,\"drawStyle\":\"line\",\"fillOpacity\":0,\"gradientMode\":\"none\",\"hideFrom\":{\"legend\":false,\"tooltip\":false,\"viz\":false},\"lineInterpolation\":\"linear\",\"lineWidth\":1,\"pointSize\":5,\"scaleDistribution\":{\"type\":\"linear\"},\"showPoints\":\"auto\",\"spanNulls\":false,\"stacking\":{\"group\":\"A\",\"mode\":\"none\"},\"thresholdsStyle\":{\"mode\":\"off\"}},\"links\":[{\"title\":\"${__value.raw}\",\"url\":\"${__value.raw}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":12,\"y\":17},\"id\":10,\"options\":{\"legend\":{\"calcs\":[],\"displayMode\":\"list\",\"placement\":\"bottom\",\"showLegend\":true},\"tooltip\":{\"mode\":\"single\",\"sort\":\"none\"}},\"targets\":[{\"alias\":\"10,20,30,40\",\"csvContent\":\"Time, value, test\\n\\\"2023-03-24T17:12:12.347Z\\\", 10,hello\\n\\\"2023-03-24T17:22:12.347Z\\\", 20,asd\\n\\\"2023-03-24T17:32:12.347Z\\\", 30,asd2\\n\\\"2023-03-24T17:42:12.347Z\\\", 40,as34\\n\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"csv_content\"},{\"alias\":\"5,6,7\",\"csvContent\":\"Time, value, test\\n\\\"2023-03-24T17:12:12.347Z\\\", 5,hello\\n\\\"2023-03-24T17:22:12.347Z\\\", 6,asd\\n\\\"2023-03-24T17:42:12.347Z\\\", 7,as34\\n\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"B\",\"scenarioId\":\"csv_content\"}],\"title\":\"Data links with ${__value.raw}\",\"transformations\":[{\"id\":\"joinByField\",\"options\":{}}],\"type\":\"timeseries\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"custom\":{\"align\":\"auto\",\"cellOptions\":{\"type\":\"auto\"},\"inspect\":false},\"links\":[{\"title\":\"__field.name=${__field.name}\\u0026__field.labels.cluster=${__field.labels.cluster}\",\"url\":\"__field.name=${__field.name}\\u0026__field.labels.cluster=${__field.labels.cluster}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]},\"unit\":\"percent\"},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":0,\"y\":24},\"id\":13,\"options\":{\"cellHeight\":\"sm\",\"footer\":{\"countRows\":false,\"fields\":\"\",\"reducer\":[\"sum\"],\"show\":false},\"showHeader\":true,\"showRowNums\":false},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"labels\":\"cluster=US\",\"refId\":\"A\",\"scenarioId\":\"random_walk\"}],\"title\":\"DataLink: __field.name=\\u0026__field.labels.cluster\",\"type\":\"table\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"description\":\"The stat display names should be \\n*  Stockholm = Bad\\n* New York = Good \\n\",\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"displayName\":\"$__cell_0 = $__cell_2\",\"links\":[],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":12,\"y\":24},\"id\":14,\"options\":{\"colorMode\":\"value\",\"graphMode\":\"area\",\"justifyMode\":\"auto\",\"orientation\":\"auto\",\"reduceOptions\":{\"calcs\":[\"lastNotNull\"],\"fields\":\"\",\"values\":true},\"textMode\":\"auto\"},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"alias\":\"\",\"csvContent\":\"name, value, name2\\nStockholm, 10, Good\\nNew York, 15, Bad\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"csv_content\"}],\"title\":\"DisplayName with __cell_0 = __cell_2\",\"type\":\"stat\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"description\":\"The stat display names should be \\n*  Stockholm = Bad\\n* New York = Good \\n\",\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"custom\":{\"align\":\"auto\",\"cellOptions\":{\"type\":\"auto\"},\"inspect\":false},\"displayName\":\"${__field.name}\",\"links\":[{\"targetBlank\":true,\"title\":\"Value link\",\"url\":\"value=${__calc}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":0,\"y\":31},\"id\":15,\"options\":{\"cellHeight\":\"sm\",\"footer\":{\"countRows\":false,\"fields\":\"\",\"reducer\":[\"sum\"],\"show\":false},\"showHeader\":true,\"showRowNums\":false},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"alias\":\"\",\"csvContent\":\"name, value, name2\\nStockholm, 10, Good\\nNew York, 15, Bad\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"csv_content\"}],\"title\":\"DisplayName: __field.name\",\"type\":\"table\"},{\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"description\":\"The stat display names should be \\n*  Stockholm = Bad\\n* New York = Good \\n\",\"fieldConfig\":{\"defaults\":{\"color\":{\"mode\":\"thresholds\"},\"displayName\":\"${__data.fields[0]} = ${__data.fields[2]}\",\"links\":[{\"targetBlank\":true,\"title\":\"__data.fields[0] = ${__data.fields[0]} = __value.raw = ${__value.raw}\",\"url\":\"__data.fields[0] = ${__data.fields[0]} = __value.raw = ${__value.raw}\"}],\"mappings\":[],\"thresholds\":{\"mode\":\"absolute\",\"steps\":[{\"color\":\"green\"},{\"color\":\"red\",\"value\":80}]}},\"overrides\":[]},\"gridPos\":{\"h\":7,\"w\":12,\"x\":12,\"y\":31},\"id\":16,\"options\":{\"colorMode\":\"value\",\"graphMode\":\"area\",\"justifyMode\":\"auto\",\"orientation\":\"auto\",\"reduceOptions\":{\"calcs\":[\"lastNotNull\"],\"fields\":\"\",\"values\":true},\"textMode\":\"auto\"},\"pluginVersion\":\"9.5.0-pre\",\"targets\":[{\"alias\":\"\",\"csvContent\":\"name, value, name2\\nStockholm, 10, Good\\nNew York, 15, Bad\",\"datasource\":{\"type\":\"testdata\",\"uid\":\"PD8C576611E62080A\"},\"refId\":\"A\",\"scenarioId\":\"csv_content\"}],\"title\":\"$__data.fields[0] = $__data.fields[2] with datalinks\",\"type\":\"stat\"}],\"refresh\":\"\",\"schemaVersion\":41,\"tags\":[\"gdev\",\"templating\"],\"templating\":{\"list\":[{\"current\":{\"selected\":false,\"text\":\"A\",\"value\":\"A\"},\"hide\":0,\"includeAll\":false,\"multi\":false,\"name\":\"customVar\",\"options\":[{\"selected\":true,\"text\":\"A\",\"value\":\"A\"},{\"selected\":false,\"text\":\"B\",\"value\":\"B\"},{\"selected\":false,\"text\":\"C\",\"value\":\"C\"}],\"query\":\"A,B,C\",\"queryValue\":\"\",\"skipUrlSync\":false,\"type\":\"custom\"}]},\"time\":{\"from\":\"2023-03-24T17:12:12.347Z\",\"to\":\"2023-03-24T17:42:12.347Z\"},\"timepicker\":{},\"timezone\":\"\",\"title\":\"Templating - Macros\",\"weekStart\":\"\"},\"status\":{}}\n"
INFO [04-18|08:02:32] Response Status: 200 OK in 7 milliseconds logger=grafana-apiserver
```

After:
```
INFO [04-18|08:04:15] GET https://[::1]:6443/apis/dashboard.grafana.app/v1alpha1/namespaces/default/dashboards/ebb9c778-2d6e-41e6-a420-04ed41b53789 logger=grafana-apiserver
INFO [04-18|08:04:15] Request Headers:                         logger=grafana-apiserver
INFO [04-18|08:04:15]     User-Agent: grafana/v0.0.0 (darwin/arm64) kubernetes/$Format logger=grafana-apiserver
INFO [04-18|08:04:15]     Accept: application/json             logger=grafana-apiserver
INFO [04-18|08:04:15]     Authorization: Bearer <masked>       logger=grafana-apiserver
DEBUG[04-18|08:04:15] grafana-apiserver: GET "/apis/dashboard.grafana.app/v1alpha1/namespaces/default/dashboards/ebb9c778-2d6e-41e6-a420-04ed41b53789" satisfied by gorestful with webservice /apis/dashboard.grafana.app/v1alpha1 logger=grafana-apiserver
INFO [04-18|08:04:15] Response Status: 200 OK in 2 milliseconds logger=grafana-apiserver
```
