### PR TITLE
Alerting: Add ALERTS alert state metric writer

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1427,6 +1427,23 @@ rule_version_record_limit = 0
 # 0 value means that rules are deleted permanently immediately.
 deleted_rule_retention = 30d
 
+[unified_alerting.alert_state_metrics]
+# Enable the alert state metrics feature to write alert state transitions to a Prometheus-like datasource.
+# When enabled, Grafana will create alert state time series similar to Prometheus ALERTS and write it
+# to the specified remote datasource.
+# Default: false
+enabled = false
+
+# The UID of the datasource to write alert state metrics to.
+# This must be a Prometheus-compatible datasource that supports remote write.
+# Leaving this empty will result in an error if 'enabled' is set to true.
+datasource_uid =
+
+# Timeout for remote write operations. If a write operation takes longer than this duration,
+# it will be aborted. Specified as a duration (e.g., 10s, 1m).
+# Default: 10s
+timeout = 10s
+
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. You must have either installed the Grafana image rendering
 # plugin, or set up Grafana to use a remote rendering service.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1407,6 +1407,23 @@
 # 0 value means that rules are deleted permanently immediately.
 ;deleted_rule_retention = 30d
 
+[unified_alerting.alert_state_metrics]
+# Enable the alert state metrics feature to write alert state transitions to a Prometheus-like datasource.
+# When enabled, Grafana will create alert state time series similar to Prometheus ALERTS and write it
+# to the specified remote datasource.
+# Default: false
+;enabled = false
+
+# The UID of the datasource to write alert state metrics to.
+# This must be a Prometheus-compatible datasource that supports remote write.
+# Leaving this empty will result in an error if 'enabled' is set to true.
+;datasource_uid =
+
+# Timeout for remote write operations. If a write operation takes longer than this duration,
+# it will be aborted. Specified as a duration (e.g., 10s, 1m).
+# Default: 10s
+;timeout = 10s
+
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. You must have either installed the Grafana image rendering
 # plugin, or set up Grafana to use a remote rendering service.

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
+	state_metric_model "github.com/grafana/grafana/pkg/services/ngalert/state/metricwriter/model"
 )
 
 var (
@@ -50,10 +51,11 @@ type Manager struct {
 	ResendDelay       time.Duration
 	ResolvedRetention time.Duration
 
-	instanceStore InstanceStore
-	images        ImageCapturer
-	historian     Historian
-	externalURL   *url.URL
+	instanceStore           InstanceStore
+	images                  ImageCapturer
+	historian               Historian
+	externalURL             *url.URL
+	alertStateMetricsWriter AlertStateMetricsWriter
 
 	rulesPerRuleGroupLimit int64
 
@@ -72,6 +74,8 @@ type ManagerCfg struct {
 	// StatePeriodicSaveBatchSize controls the size of the alert instance batch that is saved periodically when the
 	// alertingSaveStatePeriodic feature flag is enabled.
 	StatePeriodicSaveBatchSize int
+
+	AlertStateMetricsWriter AlertStateMetricsWriter
 
 	RulesPerRuleGroupLimit int64
 
@@ -93,19 +97,20 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 	}
 
 	m := &Manager{
-		cache:                  c,
-		ResendDelay:            ResendDelay, // TODO: make this configurable
-		ResolvedRetention:      cfg.ResolvedRetention,
-		log:                    cfg.Log,
-		metrics:                cfg.Metrics,
-		instanceStore:          cfg.InstanceStore,
-		images:                 cfg.Images,
-		historian:              cfg.Historian,
-		clock:                  cfg.Clock,
-		externalURL:            cfg.ExternalURL,
-		rulesPerRuleGroupLimit: cfg.RulesPerRuleGroupLimit,
-		persister:              statePersister,
-		tracer:                 cfg.Tracer,
+		cache:                   c,
+		ResendDelay:             ResendDelay, // TODO: make this configurable
+		ResolvedRetention:       cfg.ResolvedRetention,
+		log:                     cfg.Log,
+		metrics:                 cfg.Metrics,
+		instanceStore:           cfg.InstanceStore,
+		images:                  cfg.Images,
+		historian:               cfg.Historian,
+		alertStateMetricsWriter: cfg.AlertStateMetricsWriter,
+		clock:                   cfg.Clock,
+		externalURL:             cfg.ExternalURL,
+		rulesPerRuleGroupLimit:  cfg.RulesPerRuleGroupLimit,
+		persister:               statePersister,
+		tracer:                  cfg.Tracer,
 	}
 
 	return m
@@ -288,19 +293,33 @@ func (st *Manager) ResetStateByRuleUID(ctx context.Context, rule *ngModels.Alert
 	ruleKey := rule.GetKeyWithGroup()
 	transitions := st.DeleteStateByRuleUID(ctx, ruleKey, reason)
 
-	if rule == nil || st.historian == nil || len(transitions) == 0 {
+	if rule == nil || len(transitions) == 0 {
 		return transitions
 	}
 
-	ruleMeta := history_model.NewRuleMeta(rule, st.log)
-	errCh := st.historian.Record(ctx, ruleMeta, transitions)
+	if st.historian != nil {
+		ruleMeta := history_model.NewRuleMeta(rule, st.log)
+		errCh := st.historian.Record(ctx, ruleMeta, transitions)
+		handleChannelError(ctx, st.log, errCh, "Error updating historian state reset transitions", append(ruleKey.LogContext(), "reason", reason)...)
+	}
+
+	if st.alertStateMetricsWriter != nil {
+		meta := state_metric_model.RuleMeta{
+			Title: rule.Title,
+		}
+		errCh := st.alertStateMetricsWriter.Write(ctx, meta, transitions)
+		handleChannelError(ctx, st.log, errCh, "Error writing alert state metrics", append(ruleKey.LogContext(), "reason", reason)...)
+	}
+
+	return transitions
+}
+
+func handleChannelError(ctx context.Context, logger log.Logger, errCh <-chan error, message string, args ...any) {
 	go func() {
-		err := <-errCh
-		if err != nil {
-			st.log.FromContext(ctx).Error("Error updating historian state reset transitions", append(ruleKey.LogContext(), "reason", reason, "error", err)...)
+		if err := <-errCh; err != nil {
+			logger.FromContext(ctx).Error(message, append(args, "error", err)...)
 		}
 	}()
-	return transitions
 }
 
 // ProcessEvalResults updates the current states that belong to a rule with the evaluation results.
@@ -369,7 +388,17 @@ func (st *Manager) ProcessEvalResults(
 
 	st.persister.Sync(ctx, span, alertRule.GetKeyWithGroup(), allChanges)
 	if st.historian != nil {
-		st.historian.Record(ctx, history_model.NewRuleMeta(alertRule, logger), allChanges)
+		ruleMeta := history_model.NewRuleMeta(alertRule, logger)
+		errCh := st.historian.Record(ctx, ruleMeta, allChanges)
+		handleChannelError(ctx, st.log, errCh, "Error recording rule history", alertRule.GetKeyWithGroup().LogContext()...)
+	}
+
+	if st.alertStateMetricsWriter != nil {
+		meta := state_metric_model.RuleMeta{
+			Title: alertRule.Title,
+		}
+		errCh := st.alertStateMetricsWriter.Write(ctx, meta, allChanges)
+		handleChannelError(ctx, st.log, errCh, "Error writing alert state metrics", alertRule.GetKeyWithGroup().LogContext()...)
 	}
 
 	// Optional callback intended for sending the states to an alertmanager.

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2038,6 +2038,75 @@ func TestResetStateByRuleUID(t *testing.T) {
 	}
 }
 
+func TestAlertStateMetricsWriter(t *testing.T) {
+	evaluationTime := time.Now()
+	ctx := context.Background()
+
+	rule := &models.AlertRule{
+		OrgID:           1,
+		Title:           "test_title",
+		UID:             "test_alert_rule_uid",
+		NamespaceUID:    "test_namespace_uid",
+		Annotations:     map[string]string{"annotation": "test"},
+		Labels:          map[string]string{"label": "test"},
+		IntervalSeconds: 60,
+	}
+
+	evalResults := eval.Results{
+		eval.Result{
+			Instance:    data.Labels{"test": "test", "foo": "bar"},
+			State:       eval.Alerting,
+			EvaluatedAt: evaluationTime,
+		},
+	}
+
+	expectedTransitionCount := 1
+	expectedTitle := "test_title"
+
+	t.Run("processing evaluation results writes state metrics", func(t *testing.T) {
+		fakeStateMetricsWriter := &state.FakeAlertStateMetricsWriter{}
+		cfg := state.ManagerCfg{
+			AlertStateMetricsWriter: fakeStateMetricsWriter,
+			Clock:                   clock.NewMock(),
+			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.NewNopLogger(),
+			Images:                  &state.NoopImageService{},
+		}
+		st := state.NewManager(cfg, state.NewNoopPersister())
+
+		st.ProcessEvalResults(ctx, evaluationTime, rule, evalResults, nil, nil)
+
+		require.Len(t, fakeStateMetricsWriter.Calls, 1)
+		require.Equal(t, expectedTitle, fakeStateMetricsWriter.Calls[0].RuleMeta.Title)
+		require.Len(t, fakeStateMetricsWriter.Calls[0].States, expectedTransitionCount)
+		require.Equal(t, eval.Alerting, fakeStateMetricsWriter.Calls[0].States[0].State.State)
+	})
+
+	t.Run("state reset writes state metrics", func(t *testing.T) {
+		fakeStateMetricsWriter := &state.FakeAlertStateMetricsWriter{}
+		cfg := state.ManagerCfg{
+			AlertStateMetricsWriter: fakeStateMetricsWriter,
+			Clock:                   clock.NewMock(),
+			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.NewNopLogger(),
+			Images:                  &state.NoopImageService{},
+		}
+		st := state.NewManager(cfg, state.NewNoopPersister())
+
+		// First process some results to create states
+		st.ProcessEvalResults(ctx, evaluationTime, rule, evalResults, nil, nil)
+
+		// Reset the calls to leave only the ResetStateByRuleUID
+		fakeStateMetricsWriter.Calls = nil
+
+		st.ResetStateByRuleUID(ctx, rule, "test reset")
+
+		require.Len(t, fakeStateMetricsWriter.Calls, 1)
+		require.Equal(t, expectedTitle, fakeStateMetricsWriter.Calls[0].RuleMeta.Title)
+		require.Len(t, fakeStateMetricsWriter.Calls[0].States, expectedTransitionCount)
+	})
+}
+
 func setCacheID(s *state.State) *state.State {
 	if s.CacheID != 0 {
 		return s

--- a/pkg/services/ngalert/state/metricwriter/alert_state_metrics.go
+++ b/pkg/services/ngalert/state/metricwriter/alert_state_metrics.go
@@ -1,0 +1,192 @@
+package metricwriter
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/grafana/dataplane/sdata/numeric"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	promValue "github.com/prometheus/prometheus/model/value"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/state/metricwriter/model"
+)
+
+const (
+	// AlertMetricName is the metric name for synthetic alert timeseries.
+	alertMetricName = "ALERTS"
+
+	// Label names for the alert metric.
+	alertNameLabel = "alertname"
+	// alertStateLabel is the label used to indicate the Prometheus-style alert state: firing or pending.
+	alertStateLabel = "alertstate"
+	// grafanaAlertStateLabel is the label used to indicate the Grafana-style alert state: alerting, pending, recovering.
+	grafanaAlertStateLabel = "grafana_alertstate"
+	alertRuleUIDLabel      = "rule_uid"
+)
+
+type seriesWriter interface {
+	WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
+}
+
+type Config struct {
+	DatasourceUID string
+}
+
+func (c Config) Validate() error {
+	if c.DatasourceUID == "" {
+		return errors.New("datasource UID must not be empty")
+	}
+	return nil
+}
+
+type Writer struct {
+	cfg        Config
+	promWriter seriesWriter
+	logger     log.Logger
+}
+
+func NewWriter(cfg Config, promWriter seriesWriter, logger log.Logger) (*Writer, error) {
+	logger.Info("Initializing Writer", "datasourceUID", cfg.DatasourceUID)
+
+	return &Writer{
+		cfg:        cfg,
+		promWriter: promWriter,
+		logger:     logger,
+	}, nil
+}
+
+func (w *Writer) Write(ctx context.Context, ruleMeta model.RuleMeta, transitions state.StateTransitions) <-chan error {
+	errCh := make(chan error, 1)
+
+	if len(transitions) == 0 {
+		errCh <- nil
+		close(errCh)
+		return errCh
+	}
+
+	logger := w.logger.FromContext(ctx)
+
+	frames := make(data.Frames, 0, len(transitions))
+
+	for _, t := range transitions {
+		if frame := w.frameFor(ctx, ruleMeta, t); frame != nil {
+			frames = append(frames, frame)
+		}
+	}
+
+	if len(frames) == 0 {
+		logger.Debug("No frames generated for alert state metric, nothing to write")
+		errCh <- nil
+		close(errCh)
+		return errCh
+	}
+
+	st := transitions[0]
+
+	go func() {
+		defer close(errCh)
+		var sendErr error
+
+		if err := w.promWriter.WriteDatasource(ctx, w.cfg.DatasourceUID, alertMetricName, st.LastEvaluationTime, frames, st.OrgID, nil); err != nil {
+			logger.Error("Failed to write alert state metrics batch", "error", err)
+			sendErr = err
+		}
+		errCh <- sendErr
+	}()
+
+	return errCh
+}
+
+// frameFor converts a single StateTransition to a data.Frame or returns nil if
+// the transition should not generate any metrics (e.g. Normal → Normal).
+func (w *Writer) frameFor(ctx context.Context, ruleMeta model.RuleMeta, t state.StateTransition) *data.Frame {
+	sample, ok := getSample(t)
+	if !ok {
+		return nil
+	}
+
+	logger := w.logger.FromContext(ctx)
+
+	labels := make(data.Labels, len(t.Labels)+4)
+	for k, v := range t.Labels {
+		if strings.HasPrefix(k, "__") && strings.HasSuffix(k, "__") {
+			continue // skipping internal Grafana labels
+		}
+		labels[k] = v
+	}
+
+	labels[alertRuleUIDLabel] = t.AlertRuleUID
+	labels[alertNameLabel] = ruleMeta.Title
+	labels[alertStateLabel] = sample.promState
+	labels[grafanaAlertStateLabel] = sample.grafanaState
+
+	logger.Debug("Creating metric with labels",
+		"rule_uid", t.AlertRuleUID,
+		"previous_state", t.PreviousState,
+		"current_state", t.State.State,
+		"last_evaluation_time", t.LastEvaluationTime,
+		"rule_title", ruleMeta.Title,
+		"labels", labels,
+		"value", sample.value,
+	)
+
+	field := data.NewField("", labels, []float64{sample.value})
+
+	f := data.NewFrame(alertMetricName, field)
+	f.SetMeta(&data.FrameMeta{
+		Type:        data.FrameTypeNumericMulti,
+		TypeVersion: numeric.MultiFrameVersionLatest,
+	})
+
+	return f
+}
+
+type sample struct {
+	value        float64
+	grafanaState string
+	promState    string
+}
+
+// getSample determines whether a transition should emit a sample, and if so,
+// returns its value and boolean indicating whether it should be emitted.
+func getSample(tr state.StateTransition) (*sample, bool) {
+	curr, prev := tr.State.State, tr.PreviousState
+
+	var (
+		state string
+		value float64
+	)
+
+	switch {
+	case curr == eval.Alerting || curr == eval.Recovering || curr == eval.Pending:
+		state = strings.ToLower(curr.String())
+		value = 1.0
+	case curr == eval.Normal && (prev == eval.Alerting || prev == eval.Recovering || prev == eval.Pending):
+		// If this is a transition from Alerting/Recovering/Pending to Normal,
+		// we emit a sample with the previous alerting state labels, but with a special
+		// StaleNaN value: https://prometheus.io/docs/specs/prw/remote_write_spec/#stale-markers
+		state = strings.ToLower(prev.String())
+		value = math.Float64frombits(promValue.StaleNaN)
+	}
+
+	if value == 0 {
+		return nil, false
+	}
+
+	promState := state
+	if state == "recovering" || state == "alerting" {
+		promState = "firing"
+	}
+
+	return &sample{
+		value:        value,
+		grafanaState: state,
+		promState:    promState,
+	}, true
+}

--- a/pkg/services/ngalert/state/metricwriter/alert_state_metrics_test.go
+++ b/pkg/services/ngalert/state/metricwriter/alert_state_metrics_test.go
@@ -1,0 +1,353 @@
+package metricwriter
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/dataplane/sdata/numeric"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	promValue "github.com/prometheus/prometheus/model/value"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/state/metricwriter/model"
+)
+
+type fakeRemoteWriter struct {
+	mock.Mock
+}
+
+func (f *fakeRemoteWriter) WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error {
+	args := f.Called(ctx, dsUID, name, t, frames, orgID, extraLabels)
+	return args.Error(0)
+}
+
+func TestNewWriter(t *testing.T) {
+	cfg := Config{DatasourceUID: "test-ds-uid"}
+	fakeWriter := new(fakeRemoteWriter)
+	logger := log.NewNopLogger()
+
+	metricsWriter, err := NewWriter(cfg, fakeWriter, logger)
+	require.NoError(t, err)
+
+	require.NotNil(t, metricsWriter)
+	require.Equal(t, cfg.DatasourceUID, metricsWriter.cfg.DatasourceUID)
+	require.Equal(t, fakeWriter, metricsWriter.promWriter)
+	require.Equal(t, logger, metricsWriter.logger)
+}
+
+func createExpectedFrame(t *testing.T, ruleUID, ruleName, promState, grafanaState string, instanceLabels data.Labels, value float64) *data.Frame {
+	t.Helper()
+
+	labels := instanceLabels.Copy()
+	labels[alertRuleUIDLabel] = ruleUID
+	labels[alertNameLabel] = ruleName
+	labels[alertStateLabel] = promState
+	labels[grafanaAlertStateLabel] = grafanaState
+
+	valueField := data.NewField("", labels, []float64{value})
+
+	frame := data.NewFrame(alertMetricName, valueField)
+	frame.SetMeta(&data.FrameMeta{
+		Type:        data.FrameTypeNumericMulti,
+		TypeVersion: numeric.MultiFrameVersionLatest,
+	})
+	return frame
+}
+
+func createTransition(from, to eval.State, orgID int64, now time.Time) state.StateTransition {
+	return state.StateTransition{
+		State:         &state.State{AlertRuleUID: "rule-uid", OrgID: orgID, Labels: data.Labels{"instance": "server1"}, State: to, LastEvaluationTime: now},
+		PreviousState: from,
+	}
+}
+
+func TestTransitions(t *testing.T) {
+	cfg := Config{DatasourceUID: "test-ds-uid"}
+	logger := log.NewNopLogger()
+	ctx := context.Background()
+	orgID := int64(1)
+	now := time.Now()
+	ruleMeta := model.RuleMeta{Title: "test rule"}
+
+	t.Run("transitions that emit 1", func(t *testing.T) {
+		testCases := []struct {
+			from       eval.State
+			to         eval.State
+			promState  string
+			stateValue string
+		}{
+			// To alerting
+			{from: eval.Normal, to: eval.Alerting, promState: "firing", stateValue: "alerting"},
+			{from: eval.Pending, to: eval.Alerting, promState: "firing", stateValue: "alerting"},
+			{from: eval.Recovering, to: eval.Alerting, promState: "firing", stateValue: "alerting"},
+			{from: eval.Error, to: eval.Alerting, promState: "firing", stateValue: "alerting"},
+			{from: eval.NoData, to: eval.Alerting, promState: "firing", stateValue: "alerting"},
+
+			// To pending
+			{from: eval.Normal, to: eval.Pending, promState: "pending", stateValue: "pending"},
+			{from: eval.Alerting, to: eval.Pending, promState: "pending", stateValue: "pending"},
+			{from: eval.Recovering, to: eval.Pending, promState: "pending", stateValue: "pending"},
+			{from: eval.Error, to: eval.Pending, promState: "pending", stateValue: "pending"},
+			{from: eval.NoData, to: eval.Pending, promState: "pending", stateValue: "pending"},
+
+			// To recovering
+			{from: eval.Normal, to: eval.Recovering, promState: "firing", stateValue: "recovering"},
+			{from: eval.Alerting, to: eval.Recovering, promState: "firing", stateValue: "recovering"},
+			{from: eval.Pending, to: eval.Recovering, promState: "firing", stateValue: "recovering"},
+			{from: eval.Error, to: eval.Recovering, promState: "firing", stateValue: "recovering"},
+			{from: eval.NoData, to: eval.Recovering, promState: "firing", stateValue: "recovering"},
+		}
+
+		for _, tc := range testCases {
+			fromState := tc.from.String()
+			toState := tc.to.String()
+			t.Run(fromState+" to "+toState, func(t *testing.T) {
+				fakeWriter := new(fakeRemoteWriter)
+				metricsWriter, err := NewWriter(cfg, fakeWriter, logger)
+				require.NoError(t, err)
+
+				transition := createTransition(tc.from, tc.to, orgID, now)
+
+				expectedFrames := data.Frames{
+					createExpectedFrame(t, "rule-uid", "test rule", tc.promState, tc.stateValue, data.Labels{"instance": "server1"}, 1.0),
+				}
+
+				var extraLabels map[string]string
+				fakeWriter.On(
+					"WriteDatasource", ctx, cfg.DatasourceUID, alertMetricName, now, framesEqual(expectedFrames), orgID, extraLabels,
+				).Return(nil).Once()
+
+				errCh := metricsWriter.Write(ctx, ruleMeta, state.StateTransitions{transition})
+				err, ok := <-errCh
+				require.True(t, ok)
+				require.Nil(t, err)
+
+				fakeWriter.AssertExpectations(t)
+			})
+		}
+	})
+
+	t.Run("transitions that emit StaleNan", func(t *testing.T) {
+		testCases := []struct {
+			from       eval.State
+			promState  string
+			stateValue string
+		}{
+			{from: eval.Alerting, promState: "firing", stateValue: "alerting"},
+			{from: eval.Pending, promState: "pending", stateValue: "pending"},
+			{from: eval.Recovering, promState: "firing", stateValue: "recovering"},
+		}
+
+		for _, tc := range testCases {
+			fromState := tc.from.String()
+			t.Run(fromState+"->Normal", func(t *testing.T) {
+				fakeWriter := new(fakeRemoteWriter)
+				metricsWriter, err := NewWriter(cfg, fakeWriter, logger)
+				require.NoError(t, err)
+
+				transition := createTransition(tc.from, eval.Normal, orgID, now)
+
+				expectedFrames := data.Frames{
+					createExpectedFrame(t, "rule-uid", "test rule", tc.promState, tc.stateValue, data.Labels{"instance": "server1"}, math.Float64frombits(promValue.StaleNaN)),
+				}
+
+				var extraLabels map[string]string
+				fakeWriter.On(
+					"WriteDatasource", ctx, cfg.DatasourceUID, alertMetricName, now, framesEqual(expectedFrames), orgID, extraLabels,
+				).Return(nil).Once()
+
+				errCh := metricsWriter.Write(ctx, ruleMeta, state.StateTransitions{transition})
+				err, ok := <-errCh
+				require.True(t, ok)
+				require.Nil(t, err)
+
+				fakeWriter.AssertExpectations(t)
+			})
+		}
+	})
+
+	t.Run("transitions that do not emit anything", func(t *testing.T) {
+		testCases := []struct {
+			from eval.State
+			to   eval.State
+		}{
+			{from: eval.Normal, to: eval.Error},
+			{from: eval.Normal, to: eval.NoData},
+			{from: eval.Normal, to: eval.Normal},
+			{from: eval.Error, to: eval.Normal},
+			{from: eval.Error, to: eval.NoData},
+			{from: eval.Error, to: eval.Error},
+			{from: eval.NoData, to: eval.Normal},
+			{from: eval.NoData, to: eval.Error},
+			{from: eval.NoData, to: eval.NoData},
+		}
+
+		for _, tc := range testCases {
+			fromState := tc.from.String()
+			toState := tc.to.String()
+			t.Run(fromState+" to "+toState, func(t *testing.T) {
+				fakeWriter := new(fakeRemoteWriter)
+				metricsWriter, err := NewWriter(cfg, fakeWriter, logger)
+				require.NoError(t, err)
+
+				transition := createTransition(tc.from, tc.to, orgID, now)
+
+				errCh := metricsWriter.Write(ctx, ruleMeta, state.StateTransitions{transition})
+				err, ok := <-errCh
+				require.True(t, ok)
+				require.Nil(t, err)
+
+				fakeWriter.AssertNotCalled(t, "WriteDatasource", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			})
+		}
+	})
+}
+
+func TestAlertStateMetricsWriter_Write(t *testing.T) {
+	cfg := Config{DatasourceUID: "test-ds-uid"}
+	logger := log.NewNopLogger()
+	ctx := context.Background()
+	orgID := int64(1)
+	now := time.Now()
+
+	testCases := []struct {
+		name           string
+		ruleMeta       model.RuleMeta
+		states         state.StateTransitions
+		expectedErr    error
+		expectedFrames data.Frames
+	}{
+		{
+			name:     "No states",
+			ruleMeta: model.RuleMeta{Title: "Test Rule No States"},
+			states:   state.StateTransitions{},
+		},
+		{
+			name:     "Ignored states only (Normal, Error)",
+			ruleMeta: model.RuleMeta{Title: "test rule"},
+			states: state.StateTransitions{
+				{State: &state.State{AlertRuleUID: "rule-uid-normal", OrgID: orgID, Labels: data.Labels{"label1": "value1"}, State: eval.Normal, LastEvaluationTime: now}},
+				{State: &state.State{AlertRuleUID: "rule-uid-error", OrgID: orgID, Labels: data.Labels{"label2": "value2"}, State: eval.Error, LastEvaluationTime: now}},
+			},
+		},
+		{
+			name:     "Single Alerting state",
+			ruleMeta: model.RuleMeta{Title: "test rule"},
+			states: state.StateTransitions{
+				{State: &state.State{AlertRuleUID: "rule-uid-alerting", OrgID: orgID, Labels: data.Labels{"instance": "server1"}, State: eval.Alerting, LastEvaluationTime: now}},
+			},
+			expectedFrames: data.Frames{
+				createExpectedFrame(t, "rule-uid-alerting", "test rule", "firing", "alerting", data.Labels{"instance": "server1"}, 1.0),
+			},
+		},
+		{
+			name:     "Mixed states (Normal, Pending, Recovering)",
+			ruleMeta: model.RuleMeta{Title: "test rule"},
+			states: state.StateTransitions{
+				{State: &state.State{AlertRuleUID: "rule-uid-normal", OrgID: orgID, Labels: data.Labels{"state": "normal"}, State: eval.Normal, LastEvaluationTime: now}},
+				{State: &state.State{AlertRuleUID: "rule-uid-pending", OrgID: orgID, Labels: data.Labels{"state": "pending"}, State: eval.Pending, LastEvaluationTime: now}},
+				{State: &state.State{AlertRuleUID: "rule-uid-recovering", OrgID: orgID, Labels: data.Labels{"state": "recovering"}, State: eval.Recovering, LastEvaluationTime: now}},
+			},
+			expectedFrames: data.Frames{
+				createExpectedFrame(t, "rule-uid-pending", "test rule", "pending", "pending", data.Labels{"state": "pending"}, 1.0),
+				createExpectedFrame(t, "rule-uid-recovering", "test rule", "firing", "recovering", data.Labels{"state": "recovering"}, 1.0),
+			},
+		},
+		{
+			name:     "Remote writer error",
+			ruleMeta: model.RuleMeta{Title: "test rule"},
+			states: state.StateTransitions{
+				{State: &state.State{AlertRuleUID: "rule-uid-err", OrgID: orgID, Labels: data.Labels{}, State: eval.Alerting, LastEvaluationTime: now}},
+			},
+			expectedFrames: data.Frames{
+				createExpectedFrame(t, "rule-uid-err", "test rule", "firing", "alerting", data.Labels{}, 1),
+			},
+			expectedErr: errors.New("remote write failed"),
+		},
+		{
+			name:     "Internal labels are skipped",
+			ruleMeta: model.RuleMeta{Title: "test rule"},
+			states: state.StateTransitions{
+				{
+					State: &state.State{
+						AlertRuleUID:       "rule-uid-internal",
+						OrgID:              orgID,
+						Labels:             data.Labels{models.AutogeneratedRouteLabel: "ignored", "label1": "value1", "__label2": "value2"},
+						State:              eval.Alerting,
+						LastEvaluationTime: now,
+					},
+				},
+			},
+			expectedFrames: data.Frames{
+				createExpectedFrame(t, "rule-uid-internal", "test rule", "firing", "alerting", data.Labels{"label1": "value1", "__label2": "value2"}, 1.0),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeWriter := new(fakeRemoteWriter)
+			metricsWriter, err := NewWriter(cfg, fakeWriter, logger)
+			require.NoError(t, err)
+
+			if tc.expectedFrames != nil {
+				var extraLabels map[string]string
+				fakeWriter.On(
+					"WriteDatasource", ctx, cfg.DatasourceUID, alertMetricName, now, framesEqual(tc.expectedFrames), orgID, extraLabels,
+				).Return(tc.expectedErr).Once()
+			}
+
+			errCh := metricsWriter.Write(ctx, tc.ruleMeta, tc.states)
+			err, ok := <-errCh
+			require.True(t, ok)
+
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+			} else {
+				require.Nil(t, err)
+			}
+
+			fakeWriter.AssertExpectations(t)
+			if tc.expectedFrames == nil {
+				fakeWriter.AssertNotCalled(t, "WriteDatasource", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+// Custom comparer that treats NaN values as equal
+func frameCmp(a, b *data.Frame) bool {
+	opts := []cmp.Option{
+		cmp.Comparer(func(x, y float64) bool {
+			if math.IsNaN(x) && math.IsNaN(y) {
+				return true
+			}
+			return x == y
+		}),
+		cmp.AllowUnexported(data.Frame{}, data.Field{}),
+	}
+	return cmp.Equal(a, b, opts...)
+}
+
+func framesEqual(want data.Frames) interface{} {
+	return mock.MatchedBy(func(got data.Frames) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if !frameCmp(got[i], want[i]) {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/pkg/services/ngalert/state/metricwriter/model/model.go
+++ b/pkg/services/ngalert/state/metricwriter/model/model.go
@@ -1,0 +1,6 @@
+package model
+
+type RuleMeta struct {
+	Title string
+	Group string
+}

--- a/pkg/services/ngalert/state/metricwriter/noop.go
+++ b/pkg/services/ngalert/state/metricwriter/noop.go
@@ -1,0 +1,16 @@
+package metricwriter
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/state/metricwriter/model"
+)
+
+type NoopWriter struct{}
+
+func (w NoopWriter) Write(ctx context.Context, ruleMeta model.RuleMeta, states state.StateTransitions) <-chan error {
+	errCh := make(chan error)
+	close(errCh)
+	return errCh
+}

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
+	state_metric_model "github.com/grafana/grafana/pkg/services/ngalert/state/metricwriter/model"
 )
 
 // InstanceStore represents the ability to fetch and write alert instances.
@@ -50,4 +51,8 @@ type Historian interface {
 //go:generate mockgen -destination=image_mock.go -package=state github.com/grafana/grafana/pkg/services/ngalert/state ImageCapturer
 type ImageCapturer interface {
 	NewImage(ctx context.Context, r *models.AlertRule) (*models.Image, error)
+}
+
+type AlertStateMetricsWriter interface {
+	Write(ctx context.Context, ruleMeta state_metric_model.RuleMeta, states StateTransitions) <-chan error
 }

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -114,6 +114,7 @@ type UnifiedAlertingSettings struct {
 	RemoteAlertmanager            RemoteAlertmanagerSettings
 	RecordingRules                RecordingRuleSettings
 	PrometheusConversion          UnifiedAlertingPrometheusConversionSettings
+	AlertStateMetricSettings      AlertStateMetricSettings
 
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
 	MaxStateSaveConcurrency    int
@@ -144,6 +145,12 @@ type RecordingRuleSettings struct {
 	CustomHeaders        map[string]string
 	Timeout              time.Duration
 	DefaultDatasourceUID string
+}
+
+type AlertStateMetricSettings struct {
+	Enabled       bool
+	Timeout       time.Duration
+	DatasourceUID string
 }
 
 // RemoteAlertmanagerSettings contains the configuration needed
@@ -471,6 +478,13 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	}
 
 	uaCfg.RecordingRules = uaCfgRecordingRules
+
+	uaCfgAlertStateMetric := iniFile.Section("unified_alerting.alert_state_metrics")
+	uaCfg.AlertStateMetricSettings = AlertStateMetricSettings{
+		Enabled:       uaCfgAlertStateMetric.Key("enabled").MustBool(false),
+		DatasourceUID: uaCfgAlertStateMetric.Key("datasource_uid").MustString(""),
+		Timeout:       uaCfgAlertStateMetric.Key("timeout").MustDuration(defaultRecordingRequestTimeout),
+	}
 
 	uaCfg.MaxStateSaveConcurrency = ua.Key("max_state_save_concurrency").MustInt(1)
 


### PR DESCRIPTION
**What is this feature?**

This feature adds the ability to write alert state information as a metric to a Prometheus-compatible datasource, similar to the Prometheus ALERTS metric.

**Why do we need this feature?**

This feature allows to monitor the behaviour of alert. Users can create dashboards to visualize alert state patterns and history in addition to the existing alert state history in Loki. Users can set up meta-alerting based on alert state patterns.

The metric follows Prometheus ALERTS format, and adds a few new Grafana-specific labels:

- `grafana_alertstate` - Grafana alert state. Prometheus has less states than Grafana, so if the alert is `Recovering` in Grafana, for example, the value of the `alertstate` label is `firing` and the `grafana_alertstate` is `recovering`.
- `rule_uid` - UID of the rule

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/1024

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
