### PR TITLE
docs(alerting): Add a note about sequential evaluation

### DIFF
--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -38,14 +38,14 @@ When data source-managed alert rules are converted to Grafana-managed alert rule
 - All rules are given `rule_query_offset` offset value of 1m.
 - The `missing_series_evals_to_resolve` is set to 1 for the new rules.
 - The newly created rules are given unique UIDs.
-- The imported rules are evaluated sequentially within each rule group, mirroring Prometheus behavior.
-  Sequential evaluation applies only to rules imported with the migration UI or API and only while they remain read‑only in the UI (displayed as "Provisioned").
-  If you import rules with the `X-Disable-Provenance: true` header or via the regular provisioning API, they behave like regular Grafana
-  alert rules and are evaluated in parallel.
 
 {{< admonition type="note" >}}
 Plugin rules that have the label `__grafana_origin` are not included on alert rule imports.
 {{< /admonition >}}
+
+### Evaluation of imported rules
+
+The imported rules are evaluated sequentially within each rule group, mirroring Prometheus behavior. Sequential evaluation applies to rules only while they remain read‑only (displayed as "Provisioned"). If you import rules with the `X-Disable-Provenance: true` header or via the regular provisioning API, they behave like regular Grafana alert rules and are evaluated in parallel.
 
 ## Import alert rules
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -38,6 +38,10 @@ When data source-managed alert rules are converted to Grafana-managed alert rule
 - All rules are given `rule_query_offset` offset value of 1m.
 - The `missing_series_evals_to_resolve` is set to 1 for the new rules.
 - The newly created rules are given unique UIDs.
+- The imported rules are evaluated sequentially within each rule group, mirroring Prometheus behavior.
+  Sequential evaluation applies only to rules imported with the migration UI or API and only while they remain read‑only in the UI (displayed as "Provisioned").
+  If you import rules with the `X-Disable-Provenance: true` header or via the regular provisioning API, they behave like regular Grafana
+  alert rules and are evaluated in parallel.
 
 {{< admonition type="note" >}}
 Plugin rules that have the label `__grafana_origin` are not included on alert rule imports.
@@ -57,7 +61,7 @@ To convert data source-managed alert rules to Grafana managed alerts:
 
 1. In Additional settings, select a target folder or designate a new folder to import the rules into.
 
-   If you import the rules into an existing folder, don't chose a folder with existing alert rules, as they could get overwritten.
+   If you import the rules into an existing folder, don't choose a folder with existing alert rules, as they could get overwritten.
 
 1. (Optional) Select a Namespace and/or Group to determine which rules are imported.
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration/migration-api.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/migration-api.md
@@ -45,10 +45,14 @@ When data source-managed alert rules are converted to Grafana-managed alert rule
   ```
   If this value is set explicitly in a rule group, that value takes precedence over the configuration setting.
 - The `missing_series_evals_to_resolve` is set to 1 for the new rules.
+- The imported rules are evaluated sequentially within each rule group, mirroring Prometheus behavior.
+  Sequential evaluation applies only to rules imported with the migration UI or API and only while they remain read‑only in the UI (displayed as "Provisioned").
+  If you import rules with the `X-Disable-Provenance: true` header or via the regular provisioning API, they behave like regular Grafana
+  alert rules and are evaluated in parallel.
 - The newly created rules are given unique UIDs.  
   If you don't want the UID to be automatically generated, you can specify a specific UID with the `__grafana_alert_rule_uid__` label.
 
-## Import alert rules with Mimirtool or coretextool
+## Import alert rules with Mimirtool or cortextool
 
 You can use either [Mimirtool](/docs/mimir/latest/manage/tools/mimirtool/) or [`cortextool`](https://github.com/grafana/cortex-tools) (version `0.11.3` or later) to import your alert rules. For more information about Mimirtool commands, see the [Mimirtool documentation](/docs/mimir/latest/manage/tools/mimirtool/#rules).
 
@@ -58,13 +62,13 @@ To convert your alert rules, use the following command prompt substituting the y
 MIMIR_ADDRESS=https://<Grafana URL>.grafana-dev.net/api/convert/ MIMIR_AUTH_TOKEN=<your token ID> MIMIR_TENANT_ID=1
 ```
 
-For coretextool, you need to set `--backend=loki` to import Loki alert rules. For example:
+For cortextool, you need to set `--backend=loki` to import Loki alert rules. For example:
 
 ```bash
 CORTEX_ADDRESS=<grafana url>/api/convert/ CORTEX_AUTH_TOKEN=<your token> CORTEX_TENANT_ID=1 cortextool rules --backend=loki list
 ```
 
-Headers can be passed to the `mimirtool` or `coretextool` via `--extra-headers`.
+Headers can be passed to the `mimirtool` or `cortextool` via `--extra-headers`.
 
 For more information about the Rule API points and examples of Mimirtool commands, see the [Mimir HTTP API documentation](/docs/mimir/latest/references/http-api/#ruler-rules:~:text=config/v1/rules-,Get%20rule%20groups%20by%20namespace,DELETE%20%3Cprometheus%2Dhttp%2Dprefix%3E/config/v1/rules/%7Bnamespace%7D,-Delete%20tenant%20configuration) for more information about the Rule API points and examples of Mimirtool commands.
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration/migration-api.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/migration-api.md
@@ -45,10 +45,6 @@ When data source-managed alert rules are converted to Grafana-managed alert rule
   ```
   If this value is set explicitly in a rule group, that value takes precedence over the configuration setting.
 - The `missing_series_evals_to_resolve` is set to 1 for the new rules.
-- The imported rules are evaluated sequentially within each rule group, mirroring Prometheus behavior.
-  Sequential evaluation applies only to rules imported with the migration UI or API and only while they remain read‑only in the UI (displayed as "Provisioned").
-  If you import rules with the `X-Disable-Provenance: true` header or via the regular provisioning API, they behave like regular Grafana
-  alert rules and are evaluated in parallel.
 - The newly created rules are given unique UIDs.  
   If you don't want the UID to be automatically generated, you can specify a specific UID with the `__grafana_alert_rule_uid__` label.
 

--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
@@ -25,6 +25,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
+  evaluation-of-imported-ds-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/#evaluation-of-imported-rules
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/#evaluation-of-imported-rules
 ---
 
 # Alert rule evaluation
@@ -50,7 +55,7 @@ Rules in different groups can be evaluated simultaneously.
 
 - **Data source-managed** rules within the same group are evaluated sequentially, one after the other—this is useful to ensure that recording rules are evaluated before alert rules.
 
-- **Grafana-managed rules [imported from data source-managed rules](ref:import-ds-rules)** are evaluated sequentially, like data source-managed rules.
+- **Grafana-managed rules [imported from data source-managed rules](ref:import-ds-rules)** can be evaluated sequentially or in parallel, depending on how they are imported. For more information, refer to [Evaluation of imported rules](ref:evaluation-of-imported-ds-rules).
 
 ## Pending period
 


### PR DESCRIPTION
Add a note about sequential evaluation of the rule groups imported via Proemtheus-compatible API.