### PR TITLE
FEMT: Basic frontend-service implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,6 +138,7 @@
 /pkg/services/dashboardversion/ @grafana/grafana-backend-group
 /pkg/services/encryption/ @grafana/grafana-operator-experience-squad
 /pkg/services/folder/ @grafana/grafana-search-and-storage
+/pkg/services/frontend/ @grafana/grafana-frontend-platform
 /pkg/services/apiserver @grafana/grafana-app-platform-squad
 /pkg/services/hooks/ @grafana/grafana-backend-group
 /pkg/services/kmsproviders/ @grafana/grafana-operator-experience-squad

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -83,6 +83,16 @@
       "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },
     {
+      "name": "Run Frontend Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
+      "cwd": "${workspaceFolder}",
+      "env": { "GF_DEFAULT_TARGET": "frontend-server", "GF_SERVER_HTTP_PORT": "3003" },
+      "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    },
+    {
       "name": "Attach to Chrome",
       "port": 9222,
       "request": "attach",

--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -9,6 +9,7 @@ const (
 	StorageServer         string = "storage-server"
 	ZanzanaServer         string = "zanzana-server"
 	InstrumentationServer string = "instrumentation-server"
+	FrontendServer        string = "frontend-server"
 )
 
 var dependencyMap = map[string][]string{
@@ -17,4 +18,5 @@ var dependencyMap = map[string][]string{
 	ZanzanaServer:    {InstrumentationServer},
 	Core:             {},
 	All:              {Core},
+	FrontendServer:   {},
 }

--- a/pkg/server/frontend_server.go
+++ b/pkg/server/frontend_server.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type frontendServer struct {
+	*services.BasicService
+	cfg      *setting.Cfg
+	httpServ *http.Server
+	log      log.Logger
+	errChan  chan error
+}
+
+func NewFrontendServer(cfg *setting.Cfg) (*frontendServer, error) {
+	s := &frontendServer{
+		cfg: cfg,
+		log: log.New("frontend-server"),
+	}
+	s.BasicService = services.NewBasicService(s.start, s.running, s.stop)
+	return s, nil
+}
+
+func (s *frontendServer) start(ctx context.Context) error {
+	s.httpServ = s.newFrontendServer(ctx)
+	s.errChan = make(chan error)
+	go func() {
+		s.errChan <- s.httpServ.ListenAndServe()
+	}()
+	return nil
+}
+
+func (s *frontendServer) running(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-s.errChan:
+		return err
+	}
+}
+
+func (s *frontendServer) stop(failureReason error) error {
+	s.log.Info("stopping frontend server", "reason", failureReason)
+	if err := s.httpServ.Shutdown(context.Background()); err != nil {
+		s.log.Error("failed to shutdown frontend server", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (s *frontendServer) newFrontendServer(ctx context.Context) *http.Server {
+	s.log.Info("starting frontend server", "addr", ":"+s.cfg.HTTPPort)
+
+	router := http.NewServeMux()
+	router.HandleFunc("/", s.handleRequest)
+
+	server := &http.Server{
+		// 5s timeout for header reads to avoid Slowloris attacks (https://thetooth.io/blog/slowloris-attack/)
+		ReadHeaderTimeout: 5 * time.Second,
+		Addr:              ":" + s.cfg.HTTPPort,
+		Handler:           router,
+		BaseContext:       func(_ net.Listener) context.Context { return ctx },
+	}
+
+	return server
+}
+
+func (s *frontendServer) handleRequest(writer http.ResponseWriter, request *http.Request) {
+	s.log.Info("handling request", "method", request.Method, "url", request.URL.String())
+	htmlContent := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Grafana Frontend Server</title>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <h1>Grafana Frontend Server</h1>
+    <p>This is a simple static HTML page served by the Grafana frontend server module.</p>
+</body>
+</html>`
+
+	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	writer.Write([]byte(htmlContent))
+}

--- a/pkg/server/frontend_server.go
+++ b/pkg/server/frontend_server.go
@@ -78,6 +78,12 @@ func (s *frontendServer) newFrontendServer(ctx context.Context) *http.Server {
 }
 
 func (s *frontendServer) handleRequest(writer http.ResponseWriter, request *http.Request) {
+	// This should:
+	// - call http://slug/api/bootdata
+	// - render index.html with the bootdata
+	// - something-something-something frontend assets
+	// - return it to the user!
+
 	s.log.Info("handling request", "method", request.Method, "url", request.URL.String())
 	htmlContent := `<!DOCTYPE html>
 <html>

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -120,7 +120,7 @@ func (s *ModuleServer) Run() error {
 
 	// only run the instrumentation server module if were not running a module that already contains an http server
 	m.RegisterInvisibleModule(modules.InstrumentationServer, func() (services.Service, error) {
-		if m.IsModuleEnabled(modules.All) || m.IsModuleEnabled(modules.Core) {
+		if m.IsModuleEnabled(modules.All) || m.IsModuleEnabled(modules.Core) || m.IsModuleEnabled(modules.FrontendServer) {
 			return services.NewBasicService(nil, nil, nil).WithName(modules.InstrumentationServer), nil
 		}
 		return NewInstrumentationService(s.log, s.cfg, s.promGatherer)
@@ -149,6 +149,10 @@ func (s *ModuleServer) Run() error {
 
 	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {
 		return authz.ProvideZanzanaService(s.cfg, s.features)
+	})
+
+	m.RegisterModule(modules.FrontendServer, func() (services.Service, error) {
+		return NewFrontendServer(s.cfg)
 	})
 
 	m.RegisterModule(modules.All, nil)

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -152,7 +152,7 @@ func (s *ModuleServer) Run() error {
 	})
 
 	m.RegisterModule(modules.FrontendServer, func() (services.Service, error) {
-		return NewFrontendServer(s.cfg)
+		return NewFrontendServer(s.cfg, s.promGatherer)
 	})
 
 	m.RegisterModule(modules.All, nil)

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/services/authz"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/frontend"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
@@ -152,7 +153,7 @@ func (s *ModuleServer) Run() error {
 	})
 
 	m.RegisterModule(modules.FrontendServer, func() (services.Service, error) {
-		return NewFrontendServer(s.cfg, s.promGatherer)
+		return frontend.ProvideFrontendService(s.cfg, s.promGatherer)
 	})
 
 	m.RegisterModule(modules.All, nil)

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -102,5 +102,8 @@ func (s *frontendService) handleRequest(writer http.ResponseWriter, request *htt
 </html>`
 
 	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-	writer.Write([]byte(htmlContent))
+	_, err := writer.Write([]byte(htmlContent))
+	if err != nil {
+		s.log.Error("could not write to response", "err", err)
+	}
 }

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -79,10 +79,10 @@ func (s *frontendService) newFrontendServer(ctx context.Context) *http.Server {
 
 func (s *frontendService) handleRequest(writer http.ResponseWriter, request *http.Request) {
 	// This should:
-	// - call http://slug/api/bootdata
-	// - render index.html with the bootdata
-	// - something-something-something frontend assets
-	// - return it to the user!
+	// - get correct asset urls from fs or cdn
+	// - generate a nonce
+	// - render them into the index.html
+	// - and return it to the user!
 
 	s.log.Info("handling request", "method", request.Method, "url", request.URL.String())
 	htmlContent := `<!DOCTYPE html>


### PR DESCRIPTION
This PR adds a basic implementation for the new frontend-service. This will eventually evolve into what renders and returns the index.html to the user, but how now it is just an extremely basic 'Hello, world!" stub so we can set up deployments to dev first.

I'm not sure if this is the right approach - I kind of muddled my way through setting this up with the help of Cursor, so I would appreciate a check to make sure this is the right approach to scaffold this out.

The development experience for this isn't _super_ great at the moment. The most basic way to run this locally is to:

1. Add this server config in your ini:
  ```ini
  app_mode = development
  target = "frontend-server"
  ```
2. Use VSCode Run and Debug with the "Run Frontend Server" option.

For a auto-rebuild-like experience, I've temporarily just been using [air](https://github.com/air-verse/air) by installing it locally and running this command:

```sh
air -build.cmd="make gen-go; make GO_BUILD_DEV=1 build-backend" -build.bin="./bin/grafana" -build.args_bin="server target --homepath . --packaging dev" -b
uild.include_ext="go" -build.include_dir="pkg,apps" -build.exclude_file="pkg/server/wire_gen.go"
```

Part of https://github.com/grafana/grafana/issues/104503