### PR TITLE
Kinds: check for entries length

### DIFF
--- a/kinds/gen.go
+++ b/kinds/gen.go
@@ -173,6 +173,9 @@ func loadCueFiles(ctx *cue.Context, dirs []os.DirEntry) ([]codegen.SchemaForGen,
 			os.Exit(1)
 		}
 
+		if len(entries) == 0 {
+			continue
+		}
 		// It's assuming that we only have one file in each folder
 		entry := filepath.Join(dir.Name(), entries[0].Name())
 		cueFile, err := os.ReadFile(entry)


### PR DESCRIPTION
While trying to update types, I've been running into:

```
generate code from .cue files
go generate ./kinds/gen.go
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.loadCueFiles(0x14000146e58, {0x140001c7b00?, 0x101704c90?, 0x1?})
	/.../grafana/kinds/gen.go:176 +0x474
main.main()
	/.../grafana/kinds/gen.go:70 +0x54c
exit status 2
kinds/gen.go:4: running "go": exit status 1
make: *** [gen-cue] Error 1
```

Not sure if this is the right fix, but at least this allows a successful execution.