### PR TITLE
docs(alerting): replace outdated alert state diagram with updated image

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-state.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state.md
@@ -61,7 +61,7 @@ refs:
 
 An alert rule and its corresponding alert instances can transition through distinct states during the alert rule evaluation.
 
-{{< figure src="/media/docs/alerting/alert-instance-states-v3.png" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
+{{< figure src="/media/docs/alerting/alert-state-diagram2.png" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
 
 There are three key components that helps us understand the behavior of our alerts:
 


### PR DESCRIPTION


Continuation of https://github.com/grafana/grafana/pull/103412

This PR replaces an outdated alert state diagram with the same image updated in the previous PR. 