### PR TITLE
docs(alerting): specify sequential evaluation for imported DS rules

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
@@ -20,6 +20,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/
+  import-ds-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/
 ---
 
 # Alert rule evaluation
@@ -33,17 +38,19 @@ The criteria determining when an alert rule fires are based on two settings:
 
 ## Evaluation group
 
-Every alert rule is assigned to an evaluation group. You can assign the alert rule to an existing evaluation group or create a new one.
+Every alert rule and recording rule is assigned to an evaluation group. You can assign the rule to an existing evaluation group or create a new one.
 
-Each evaluation group contains an **evaluation interval** that determines how frequently the alert rule is checked. For instance, the evaluation may occur every `10s`, `30s`, `1m`, `10m`, etc.
+Each evaluation group contains an **evaluation interval** that determines how frequently the rule is checked. For instance, the evaluation may occur every `10s`, `30s`, `1m`, `10m`, etc.
 
 **Evaluation strategies**
 
-Alert rules in different groups can be evaluated simultaneously.
+Rules in different groups can be evaluated simultaneously.
 
-- **Grafana-managed** alert rules within the same group are evaluated concurrently—they are evaluated at different times over the same evaluation interval but display the same evaluation timestamp.
+- **Grafana-managed** rules within the same group are evaluated concurrently—they are evaluated at different times over the same evaluation interval but display the same evaluation timestamp.
 
-- **Data-source managed** alert rules within the same group are evaluated sequentially, one after the other—this is useful to ensure that recording rules are evaluated before alert rules.
+- **Data source-managed** rules within the same group are evaluated sequentially, one after the other—this is useful to ensure that recording rules are evaluated before alert rules.
+
+- **Grafana-managed rules [imported from data source-managed rules](ref:import-ds-rules)** are evaluated sequentially, like data source-managed rules.
 
 ## Pending period
 


### PR DESCRIPTION
Adding minor docs for https://github.com/grafana/grafana/pull/98829


⭐  [Preview](https://deploy-preview-grafana-104234-zb444pucvq-vp.a.run.app/docs/grafana/latest//alerting/fundamentals/alert-rule-evaluation/)