### PR TITLE
[release 12.0.0] Klog: Prevent response bodies from being logged (#104199)

### DIFF
--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -24,10 +24,15 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	}
 
 	if cfg.Env == setting.Dev {
-		defaultLogLevel = 10
 		port = 6443
 		ip = net.ParseIP("0.0.0.0")
 		apiURL = fmt.Sprintf("https://%s:%d", ip, port)
+	}
+
+	// if grafana log level is set to debug, also increase the api server log level to 7,
+	// which will log the request headers & more details about the request
+	if cfg.Raw.Section("log").Key("level").MustString("info") == "debug" {
+		defaultLogLevel = 7
 	}
 
 	host := net.JoinHostPort(cfg.HTTPAddr, strconv.Itoa(port))

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -48,8 +48,15 @@ func (o *ExtraOptions) ApplyTo(c *genericapiserver.RecommendedConfig) error {
 	}); err != nil {
 		return err
 	}
-	// TODO: klog isn't working as expected, investigate - it logs some of the time
+	// if verbosity is 8+, response bodies will be logged. versboity of 7 should then be the max
+	if o.Verbosity > 7 {
+		o.Verbosity = 7
+	}
 	klog.SetSlogLogger(logger)
+	// at this point, the slog will be the background logger. set it as the default logger, as setting solely slog above
+	// won't update the verbosity because it is set as a contextual logger, and that function says "such a logger cannot
+	// rely on verbosity checking in klog"
+	klog.SetLogger(klog.Background())
 	if _, err := logs.GlogSetter(strconv.Itoa(o.Verbosity)); err != nil {
 		logger.Error("failed to set log level", "error", err)
 	}


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104199 - This PR removes the logging of response bodies when grafana is in debug mode