### PR TITLE
Prometheus: Remove series endpoint call from Metrics Explorer

### DIFF
--- a/packages/grafana-prometheus/src/metric_find_query.test.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.test.ts
@@ -147,15 +147,11 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     // <LegacyPrometheus>
-    it('label_values(metric, resource) should generate series query with correct time', async () => {
+    it('label_values(metric, resource) should generate label/__name__/values query with correct time', async () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
       const results = await query.process(raw);
@@ -164,24 +160,19 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/uid/ABCDEF/resources/api/v1/series?match${encodeURIComponent(
+        url: `/api/datasources/uid/ABCDEF/resources/api/v1/label/resource/values?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });
 
-    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate series query with correct time', async () => {
+    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate label/__name__/values? query with correct time', async () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric{label1="foo", label2="bar", label3="baz"}, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
       const results = await query.process(raw);
@@ -190,9 +181,8 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: '/api/datasources/uid/ABCDEF/resources/api/v1/series?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C%20label2%3D%22bar%22%2C%20label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
+        url: '/api/datasources/uid/ABCDEF/resources/api/v1/label/resource/values?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C%20label2%3D%22bar%22%2C%20label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });
@@ -201,11 +191,7 @@ describe('PrometheusMetricFindQuery', () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: '' },
-          ],
+          data: ['value1', 'value2'],
         },
       });
       const results = await query.process(raw);
@@ -216,11 +202,10 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/uid/ABCDEF/resources/api/v1/series?match${encodeURIComponent(
+        url: `/api/datasources/uid/ABCDEF/resources/api/v1/label/resource/values?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });

--- a/packages/grafana-prometheus/src/metric_find_query.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.ts
@@ -86,8 +86,9 @@ export class PrometheusMetricFindQuery {
       escapedLabel = escapeForUtf8Support(label);
     }
 
+    const url = `/api/v1/label/${escapedLabel}/values`;
+
     if (!metric || this.datasource.hasLabelsMatchAPISupport()) {
-      const url = `/api/v1/label/${escapedLabel}/values`;
 
       return this.datasource.metadataRequest(url, params).then((result) => {
         return _map(result.data.data, (value) => {
@@ -95,14 +96,8 @@ export class PrometheusMetricFindQuery {
         });
       });
     } else {
-      const url = `/api/v1/series`;
-
       return this.datasource.metadataRequest(url, params).then((result) => {
-        const _labels = _map(result.data.data, (metric) => {
-          return metric[label] || '';
-        }).filter((label) => {
-          return label !== '';
-        });
+        const _labels = _map(result.data.data, (metric) => metric);
 
         return uniq(_labels).map((metric) => {
           return {

--- a/packages/grafana-prometheus/src/metric_find_query.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.ts
@@ -89,7 +89,6 @@ export class PrometheusMetricFindQuery {
     const url = `/api/v1/label/${escapedLabel}/values`;
 
     if (!metric || this.datasource.hasLabelsMatchAPISupport()) {
-
       return this.datasource.metadataRequest(url, params).then((result) => {
         return _map(result.data.data, (value) => {
           return { text: value };


### PR DESCRIPTION
**What is this feature?**

This is part of https://github.com/grafana/grafana/issues/70777 and https://github.com/grafana/grafana/issues/100376

With this PR we replaced `/series` endpoint usage in Metrics Explorer with label values call.

**Why do we need this feature?**

To be able to use less costly endpoint instead of expensive one. 

**Who is this feature for?**

Prometheus users who use Metrics Explorer and regex match and also have high cardinality metrics.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
