### PR TITLE
KeeperMetadata: Optionally have _for update_ in query

### DIFF
--- a/pkg/storage/secret/metadata/data/keeper_read.sql
+++ b/pkg/storage/secret/metadata/data/keeper_read.sql
@@ -17,4 +17,7 @@ WHERE 1 = 1 AND
   {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ORDER BY {{ .Ident "updated" }} DESC
+{{ if .IsForUpdate }}
+{{ .SelectFor "UPDATE" }}
+{{ end }}
 ;

--- a/pkg/storage/secret/metadata/query.go
+++ b/pkg/storage/secret/metadata/query.go
@@ -8,6 +8,14 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
+// For if the query is optionally `FOR UPDATE`.
+type sqlForUpdate bool
+
+const (
+	yesForUpdate sqlForUpdate = true
+	notForUpdate sqlForUpdate = false
+)
+
 var (
 	//go:embed data/*.sql
 	sqlTemplatesFS embed.FS
@@ -46,8 +54,9 @@ func (r createKeeper) Validate() error {
 // Read
 type readKeeper struct {
 	sqltemplate.SQLTemplate
-	Namespace string
-	Name      string
+	Namespace   string
+	Name        string
+	IsForUpdate bool
 }
 
 // Validate is only used if we use `dbutil` from `unifiedstorage`

--- a/pkg/storage/secret/metadata/query_test.go
+++ b/pkg/storage/secret/metadata/query_test.go
@@ -61,6 +61,15 @@ func TestKeeperQueries(t *testing.T) {
 						Namespace:   "ns",
 					},
 				},
+				{
+					Name: "read-for-update",
+					Data: &readKeeper{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Name:        "name",
+						Namespace:   "ns",
+						IsForUpdate: true,
+					},
+				},
 			},
 			sqlKeeperUpdate: {
 				{

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read-for-update.sql
@@ -1,0 +1,21 @@
+SELECT
+  `guid`,
+  `name`,
+  `namespace`,
+  `annotations`,
+  `labels`,
+  `created`,
+  `created_by`,
+  `updated`,
+  `updated_by`,
+  `title`,
+  `type`,
+  `payload`
+FROM
+  `secret_keeper`
+WHERE 1 = 1 AND
+  `namespace` = 'ns' AND
+  `name` = 'name'
+ORDER BY `updated` DESC
+FOR UPDATE
+;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read-for-update.sql
@@ -1,0 +1,21 @@
+SELECT
+  "guid",
+  "name",
+  "namespace",
+  "annotations",
+  "labels",
+  "created",
+  "created_by",
+  "updated",
+  "updated_by",
+  "title",
+  "type",
+  "payload"
+FROM
+  "secret_keeper"
+WHERE 1 = 1 AND
+  "namespace" = 'ns' AND
+  "name" = 'name'
+ORDER BY "updated" DESC
+FOR UPDATE
+;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read-for-update.sql
@@ -1,0 +1,20 @@
+SELECT
+  "guid",
+  "name",
+  "namespace",
+  "annotations",
+  "labels",
+  "created",
+  "created_by",
+  "updated",
+  "updated_by",
+  "title",
+  "type",
+  "payload"
+FROM
+  "secret_keeper"
+WHERE 1 = 1 AND
+  "namespace" = 'ns' AND
+  "name" = 'name'
+ORDER BY "updated" DESC
+;


### PR DESCRIPTION
Since we are reusing `read`, we can add an option to make the query `FOR UPDATE`, for example we use it inside an `Update` DB transaction, so we can have consistency.

SQLite does not have support for it (but okay since only 1 writer allowed), so the generated testdata is the same.