### PR TITLE
Alerting: Use value of ha_redis_cluster_mode_enabled in redisPeer config

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -179,15 +179,16 @@ func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
 	// Redis setup.
 	if cfg.UnifiedAlerting.HARedisAddr != "" {
 		redisPeer, err := newRedisPeer(redisConfig{
-			addr:       cfg.UnifiedAlerting.HARedisAddr,
-			name:       cfg.UnifiedAlerting.HARedisPeerName,
-			prefix:     cfg.UnifiedAlerting.HARedisPrefix,
-			password:   cfg.UnifiedAlerting.HARedisPassword,
-			username:   cfg.UnifiedAlerting.HARedisUsername,
-			db:         cfg.UnifiedAlerting.HARedisDB,
-			maxConns:   cfg.UnifiedAlerting.HARedisMaxConns,
-			tlsEnabled: cfg.UnifiedAlerting.HARedisTLSEnabled,
-			tls:        cfg.UnifiedAlerting.HARedisTLSConfig,
+			addr:        cfg.UnifiedAlerting.HARedisAddr,
+			name:        cfg.UnifiedAlerting.HARedisPeerName,
+			prefix:      cfg.UnifiedAlerting.HARedisPrefix,
+			password:    cfg.UnifiedAlerting.HARedisPassword,
+			username:    cfg.UnifiedAlerting.HARedisUsername,
+			db:          cfg.UnifiedAlerting.HARedisDB,
+			maxConns:    cfg.UnifiedAlerting.HARedisMaxConns,
+			tlsEnabled:  cfg.UnifiedAlerting.HARedisTLSEnabled,
+			tls:         cfg.UnifiedAlerting.HARedisTLSConfig,
+			clusterMode: cfg.UnifiedAlerting.HARedisClusterModeEnabled,
 		}, clusterLogger, moa.metrics.Registerer, cfg.UnifiedAlerting.HAPushPullInterval)
 		if err != nil {
 			return fmt.Errorf("unable to initialize redis: %w", err)


### PR DESCRIPTION
The value of `ha_redis_cluster_mode_enabled` was not actually being used in the config during the creation of the `redisPeer` - this PR fixes that

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
