### PR TITLE
Config: Update defaults.ini to increase database query_retries to 3

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -190,7 +190,7 @@ migration_locking = true
 locking_attempt_timeout_sec = 0
 
 # For "sqlite" only. How many times to retry query in case of database is locked failures. Default is 0 (disabled).
-query_retries = 0
+query_retries = 3
 
 # For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
 transaction_retries = 5


### PR DESCRIPTION
**What is this feature?**

Change the default of query_retries

**Why do we need this feature?**

Alerts sometimes return DatasourceError due to the sqlstore database being locked. Increasing the default to 3 retries should mitigate the issue for most users.
Full error:
Datasource Error retry 1: database is locked

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65115