### PR TITLE
Dashboard: Fixes outline for repeated rows

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -1,11 +1,12 @@
 import { useSessionStorage } from 'react-use';
 
 import { BusEventWithPayload } from '@grafana/data';
-import { SceneGridRow, SceneObject, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { LocalValueVariable, SceneGridRow, SceneObject, SceneVariableSet, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
 import { EditableDashboardElement, isEditableDashboardElement } from '../scene/types/EditableDashboardElement';
+import { LocalVariableEditableElement } from '../settings/variables/LocalVariableEditableElement';
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
@@ -40,6 +41,10 @@ export function getEditableElementFor(sceneObj: SceneObject | undefined): Editab
 
   if (sceneObj instanceof SceneVariableSet) {
     return new VariableSetEditableElement(sceneObj);
+  }
+
+  if (sceneObj instanceof LocalValueVariable) {
+    return new LocalVariableEditableElement(sceneObj);
   }
 
   if (isSceneVariable(sceneObj)) {

--- a/public/app/features/dashboard-scene/settings/variables/LocalVariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/LocalVariableEditableElement.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+import { LocalValueVariable } from '@grafana/scenes';
+import { Box, Stack } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+
+import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
+
+export class LocalVariableEditableElement implements EditableDashboardElement {
+  public readonly isEditableDashboardElement = true;
+
+  public constructor(public variable: LocalValueVariable) {}
+
+  public getEditableElementInfo(): EditableDashboardElementInfo {
+    return {
+      typeName: t('dashboard.edit-pane.elements.local-variable', 'Local variable'),
+      icon: 'dollar-alt',
+      instanceName: ` $${this.variable.state.name} = ${this.variable.getValueText!()}`,
+      isHidden: true,
+    };
+  }
+
+  public useEditPaneOptions(): OptionsPaneCategoryDescriptor[] {
+    const variable = this.variable;
+
+    return useMemo(() => {
+      const category = new OptionsPaneCategoryDescriptor({
+        title: '',
+        id: 'local-variable-options',
+      });
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: '',
+          skipField: true,
+          render: () => {
+            return (
+              <Box paddingBottom={1}>
+                <Stack>
+                  <Stack>
+                    <span>${variable.state.name}</span>
+                    <span>=</span>
+                    <span>{variable.getValueText()}</span>
+                  </Stack>
+                </Stack>
+              </Box>
+            );
+          },
+        })
+      );
+
+      return [category];
+    }, [variable]);
+  }
+}

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -10,6 +10,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
+import { DashboardScene } from '../../scene/DashboardScene';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
 import { getDashboardSceneFor } from '../../utils/utils';
 
@@ -51,6 +52,7 @@ function VariableList({ set }: { set: SceneVariableSet }) {
   const { variables } = set.useState();
   const styles = useStyles2(getStyles);
   const [isAdding, setIsAdding] = useToggle(false);
+  const canAdd = set.parent instanceof DashboardScene;
 
   const onEditVariable = (variable: SceneVariable) => {
     const { editPane } = getDashboardSceneFor(set).state;
@@ -83,11 +85,13 @@ function VariableList({ set }: { set: SceneVariableSet }) {
           </Stack>
         </div>
       ))}
-      <Box paddingBottom={1} display={'flex'}>
-        <Button fullWidth icon="plus" size="sm" variant="secondary" onClick={setIsAdding}>
-          <Trans i18nKey="dashboard.edit-pane.variables.add-variable">Add variable</Trans>
-        </Button>
-      </Box>
+      {canAdd && (
+        <Box paddingBottom={1} display={'flex'}>
+          <Button fullWidth icon="plus" size="sm" variant="secondary" onClick={setIsAdding}>
+            <Trans i18nKey="dashboard.edit-pane.variables.add-variable">Add variable</Trans>
+          </Button>
+        </Box>
+      )}
     </Stack>
   );
 }

--- a/public/app/features/dashboard-scene/settings/variables/editors/SystemVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SystemVariableEditor.tsx
@@ -1,0 +1,28 @@
+import { SceneVariable, LocalValueVariable } from '@grafana/scenes';
+import { Stack } from '@grafana/ui';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+
+export function getSystemVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
+  if (!(variable instanceof LocalValueVariable)) {
+    return [];
+  }
+
+  return [
+    new OptionsPaneItemDescriptor({
+      title: '',
+      render: () => {
+        return (
+          <Stack direction="column">
+            <Stack>
+              <Stack>
+                <span>${variable.state.name}</span>
+                <span>=</span>
+                <span>${variable.getValueText()}</span>
+              </Stack>
+            </Stack>
+          </Stack>
+        );
+      },
+    }),
+  ];
+}

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -31,6 +31,7 @@ import { DataSourceVariableEditor } from './editors/DataSourceVariableEditor';
 import { GroupByVariableEditor } from './editors/GroupByVariableEditor';
 import { IntervalVariableEditor } from './editors/IntervalVariableEditor';
 import { QueryVariableEditor } from './editors/QueryVariableEditor';
+import { getSystemVariableOptions } from './editors/SystemVariableEditor';
 import { TextBoxVariableEditor } from './editors/TextBoxVariableEditor';
 
 interface EditableVariableConfig {

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -31,7 +31,6 @@ import { DataSourceVariableEditor } from './editors/DataSourceVariableEditor';
 import { GroupByVariableEditor } from './editors/GroupByVariableEditor';
 import { IntervalVariableEditor } from './editors/IntervalVariableEditor';
 import { QueryVariableEditor } from './editors/QueryVariableEditor';
-import { getSystemVariableOptions } from './editors/SystemVariableEditor';
 import { TextBoxVariableEditor } from './editors/TextBoxVariableEditor';
 
 interface EditableVariableConfig {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3174,6 +3174,7 @@
     "edit-pane": {
       "elements": {
         "dashboard": "Dashboard",
+        "local-variable": "Local variable",
         "multiple-elements": "Multiple elements",
         "multiple-elements-delete-text": "Are you sure you want to delete these elements?",
         "multiple-panels": "Multiple panels",


### PR DESCRIPTION

1) Fixes crashing dashboard when selecting a variables node under a repeated row (new old old row) 
2) Now cannot add variables to local variable sets under repeated rows
3) Render local variable values in outline but cannot be edited or deleted  


![Screenshot 2025-04-22 at 13 46 30](https://github.com/user-attachments/assets/625b4e29-6b20-4379-95fd-7e225c07d941)
