### PR TITLE
Remove role support from ext jwt client

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -73,9 +73,6 @@ type FetchPermissionsParams struct {
 	RestrictedActions []string
 	// AllowedActions will be added to the identity permissions
 	AllowedActions []string
-	// Note: Kept for backwards compatibility, use AllowedActions instead
-	// Roles permissions will be directly added to the identity permissions
-	Roles []string
 }
 
 type (

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -167,10 +167,6 @@ func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Req
 		span.SetAttributes(attribute.StringSlice("identity.ClientParams.FetchPermissionsParams.RestrictedActions", identity.ClientParams.FetchPermissionsParams.RestrictedActions))
 	}
 
-	if len(identity.ClientParams.FetchPermissionsParams.Roles) > 0 {
-		span.SetAttributes(attribute.StringSlice("identity.ClientParams.FetchPermissionsParams.Roles", identity.ClientParams.FetchPermissionsParams.Roles))
-	}
-
 	if len(identity.ClientParams.FetchPermissionsParams.AllowedActions) > 0 {
 		span.SetAttributes(attribute.StringSlice("identity.ClientParams.FetchPermissionsParams.AllowedActions", identity.ClientParams.FetchPermissionsParams.AllowedActions))
 	}

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -62,9 +62,6 @@ func TestService_Authenticate(t *testing.T) {
 									"datasources:read",
 									"datasources:query",
 								},
-								Roles: []string{
-									"fixed:datasources:reader",
-								},
 							},
 						},
 					},
@@ -78,9 +75,6 @@ func TestService_Authenticate(t *testing.T) {
 						RestrictedActions: []string{
 							"datasources:read",
 							"datasources:query",
-						},
-						Roles: []string{
-							"fixed:datasources:reader",
 						},
 					},
 				},
@@ -103,9 +97,6 @@ func TestService_Authenticate(t *testing.T) {
 								AllowedActions: []string{
 									"datasources:write",
 								},
-								Roles: []string{
-									"fixed:datasources:writer",
-								},
 							},
 						},
 					},
@@ -122,9 +113,6 @@ func TestService_Authenticate(t *testing.T) {
 						},
 						AllowedActions: []string{
 							"datasources:write",
-						},
-						Roles: []string{
-							"fixed:datasources:writer",
 						},
 					},
 				},
@@ -237,10 +225,6 @@ func TestService_Authenticate(t *testing.T) {
 					case "identity.ClientParams.FetchPermissionsParams.AllowedActions":
 						if len(tt.expectedIdentity.ClientParams.FetchPermissionsParams.AllowedActions) > 0 {
 							assert.Equal(t, tt.expectedIdentity.ClientParams.FetchPermissionsParams.AllowedActions, attr.Value.AsStringSlice())
-						}
-					case "identity.ClientParams.FetchPermissionsParams.Roles":
-						if len(tt.expectedIdentity.ClientParams.FetchPermissionsParams.Roles) > 0 {
-							assert.Equal(t, tt.expectedIdentity.ClientParams.FetchPermissionsParams.Roles, attr.Value.AsStringSlice())
 						}
 					}
 				}

--- a/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
@@ -83,10 +83,8 @@ func TestRBACSync_FetchPermissions(t *testing.T) {
 			identity: &authn.Identity{
 				ID: "2", Type: claims.TypeUser, OrgID: 1,
 				ClientParams: authn.ClientParams{
-					SyncPermissions: true,
-					FetchPermissionsParams: authn.FetchPermissionsParams{
-						Roles: []string{"fixed:teams:reader"},
-					},
+					SyncPermissions:        true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{},
 				},
 			},
 			expectedPermissions: map[string][]string{accesscontrol.ActionTeamsRead: {accesscontrol.ScopeTeamsAll}},
@@ -96,10 +94,8 @@ func TestRBACSync_FetchPermissions(t *testing.T) {
 			identity: &authn.Identity{
 				ID: "2", Type: claims.TypeUser, OrgID: 1,
 				ClientParams: authn.ClientParams{
-					SyncPermissions: true,
-					FetchPermissionsParams: authn.FetchPermissionsParams{
-						Roles: []string{"fixed:teams:reader", "fixed:unknown:role"},
-					},
+					SyncPermissions:        true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{},
 				},
 			},
 			expectedPermissions: map[string][]string{accesscontrol.ActionTeamsRead: {accesscontrol.ScopeTeamsAll}},
@@ -152,7 +148,6 @@ func TestRBACSync_FetchPermissions(t *testing.T) {
 					FetchPermissionsParams: authn.FetchPermissionsParams{
 						RestrictedActions: []string{accesscontrol.ActionUsersWrite, accesscontrol.ActionTeamsWrite, "dashboards:read"},
 						AllowedActions:    []string{"dashboards:read"},
-						Roles:             []string{"fixed:teams:reader", "fixed:teams:writer"},
 					},
 				},
 			},

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -165,15 +165,7 @@ func (s *ExtendedJWT) authenticateAsService(accessTokenClaims authlib.Claims[aut
 	permissions := accessTokenClaims.Rest.Permissions
 	fetchPermissionsParams := authn.FetchPermissionsParams{}
 	if len(permissions) > 0 {
-		fetchPermissionsParams.Roles = make([]string, 0, len(permissions))
-		fetchPermissionsParams.AllowedActions = make([]string, 0, len(permissions))
-		for i := range permissions {
-			if strings.HasPrefix(permissions[i], "fixed:") {
-				fetchPermissionsParams.Roles = append(fetchPermissionsParams.Roles, permissions[i])
-			} else {
-				fetchPermissionsParams.AllowedActions = append(fetchPermissionsParams.AllowedActions, permissions[i])
-			}
-		}
+		fetchPermissionsParams.AllowedActions = append(fetchPermissionsParams.AllowedActions, permissions...)
 	}
 
 	return &authn.Identity{

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -36,7 +36,7 @@ var (
 		Rest: authnlib.AccessTokenClaims{
 			Scopes:               []string{"profile", "groups"},
 			DelegatedPermissions: []string{"dashboards:create", "folders:read", "datasources:explore", "datasources.insights:read"},
-			Permissions:          []string{"fixed:folders:reader", "folders:read"},
+			Permissions:          []string{"folders:read"},
 			Namespace:            "default", // org ID of 1 is special and translates to default
 		},
 	}
@@ -238,7 +238,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				AuthID:            "access-policy:this-uid",
 				ClientParams: authn.ClientParams{
 					SyncPermissions:        true,
-					FetchPermissionsParams: authn.FetchPermissionsParams{Roles: []string{"fixed:folders:reader"}, AllowedActions: []string{"folders:read"}}},
+					FetchPermissionsParams: authn.FetchPermissionsParams{AllowedActions: []string{"folders:read"}}},
 			},
 		},
 		{
@@ -469,7 +469,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 					IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
 				},
 				Rest: authnlib.AccessTokenClaims{
-					Permissions: []string{"fixed:folders:reader"},
+					Permissions: []string{"folders:reader"},
 					Namespace:   "default",
 				},
 			},


### PR DESCRIPTION
This PR removes role support which is no longer (using access token action list instead).