### PR TITLE
Alerting: Fix wrong conditional showing errors all the time

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -49,7 +49,7 @@ export function RuleListErrors(): ReactElement {
         </>
       );
     }
-    if (true) {
+    if (grafanaRulerError) {
       result.push(
         <>
           <Trans i18nKey="alerting.rule-list-errors.failed-to-load-grafana-rules-config">


### PR DESCRIPTION
**What is this feature?**

This PR fixes a wrong conditional (checking if true).
This error was introducex in this [PR](https://github.com/grafana/grafana/pull/104103/files#diff-fe6d1a424b83054dd4f64564dd4e83b505b4c5ba47714e19387235483a75c56aR52-R60)
**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
