### PR TITLE
Chore: Add snowflake xorm tag

### DIFF
--- a/pkg/util/xorm/core/core.go
+++ b/pkg/util/xorm/core/core.go
@@ -34,6 +34,7 @@ type Column struct {
 	Indexes         map[string]int
 	IsPrimaryKey    bool
 	IsAutoIncrement bool
+	IsSnowflakeID   bool
 	IsCreated       bool
 	IsUpdated       bool
 	IsDeleted       bool

--- a/pkg/util/xorm/core/core.go
+++ b/pkg/util/xorm/core/core.go
@@ -34,7 +34,7 @@ type Column struct {
 	Indexes         map[string]int
 	IsPrimaryKey    bool
 	IsAutoIncrement bool
-	IsSnowflakeID   bool
+	IsRandomID      bool
 	IsCreated       bool
 	IsUpdated       bool
 	IsDeleted       bool
@@ -1581,7 +1581,7 @@ type Table struct {
 	Indexes       map[string]*Index
 	PrimaryKeys   []string
 	AutoIncrement string
-	Snowflake     string
+	RandomID      string
 	Created       map[string]bool
 	Updated       string
 	Deleted       string
@@ -1697,8 +1697,8 @@ func (table *Table) AddColumn(col *Column) {
 	if col.IsAutoIncrement {
 		table.AutoIncrement = col.Name
 	}
-	if col.IsSnowflakeID {
-		table.Snowflake = col.Name
+	if col.IsRandomID {
+		table.RandomID = col.Name
 	}
 	if col.IsCreated {
 		table.Created[col.Name] = true

--- a/pkg/util/xorm/core/core.go
+++ b/pkg/util/xorm/core/core.go
@@ -1581,6 +1581,7 @@ type Table struct {
 	Indexes       map[string]*Index
 	PrimaryKeys   []string
 	AutoIncrement string
+	Snowflake     string
 	Created       map[string]bool
 	Updated       string
 	Deleted       string
@@ -1695,6 +1696,9 @@ func (table *Table) AddColumn(col *Column) {
 	}
 	if col.IsAutoIncrement {
 		table.AutoIncrement = col.Name
+	}
+	if col.IsSnowflakeID {
+		table.Snowflake = col.Name
 	}
 	if col.IsCreated {
 		table.Created[col.Name] = true

--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -44,7 +44,7 @@ type Engine struct {
 
 	defaultContext    context.Context
 	sequenceGenerator SequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
-	snowflake         func() int64
+	randomIDGen       func() int64
 }
 
 // CondDeleted returns the conditions whether a record is soft deleted.

--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -44,7 +44,7 @@ type Engine struct {
 
 	defaultContext    context.Context
 	sequenceGenerator SequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
-	snowflake         *snowflake
+	snowflake         func() int64
 }
 
 // CondDeleted returns the conditions whether a record is soft deleted.

--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -44,6 +44,7 @@ type Engine struct {
 
 	defaultContext    context.Context
 	sequenceGenerator SequenceGenerator // If not nil, this generator is used to generate auto-increment values for inserts.
+	snowflake         *snowflake
 }
 
 // CondDeleted returns the conditions whether a record is soft deleted.

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -319,16 +319,16 @@ func (session *Session) innerInsert(bean any) (int64, error) {
 			colNames = append(colNames, table.AutoIncrement)
 			args = append(args, seq)
 		}
-	} else if len(table.Snowflake) > 0 {
-		found := slices.Contains(colNames, table.Snowflake)
+	} else if len(table.RandomID) > 0 {
+		found := slices.Contains(colNames, table.RandomID)
 		if !found {
-			id := session.engine.snowflake()
-			colNames = append(colNames, table.Snowflake)
+			id := session.engine.randomIDGen()
+			colNames = append(colNames, table.RandomID)
 			args = append(args, id)
-			// Set snowflakeID back to the bean.
-			col := table.GetColumn(table.Snowflake)
+			// Set random ID back to the bean.
+			col := table.GetColumn(table.RandomID)
 			if col == nil {
-				return 0, fmt.Errorf("column %s not found in table %s", table.Snowflake, table.Name)
+				return 0, fmt.Errorf("column %s not found in table %s", table.RandomID, table.Name)
 			}
 			idValue, err := col.ValueOf(bean)
 			if err != nil {
@@ -604,7 +604,7 @@ func (session *Session) genInsertColumns(bean any) ([]string, []any, error) {
 		}
 		fieldValue := *fieldValuePtr
 
-		if col.IsAutoIncrement || col.IsSnowflakeID {
+		if col.IsAutoIncrement || col.IsRandomID {
 			switch fieldValue.Type().Kind() {
 			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int, reflect.Int64:
 				if fieldValue.Int() == 0 {

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -7,7 +7,6 @@ package xorm
 import (
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 	"slices"
 	"sort"
@@ -321,13 +320,11 @@ func (session *Session) innerInsert(bean any) (int64, error) {
 			args = append(args, seq)
 		}
 	} else if len(table.Snowflake) > 0 {
-		found := slices.Contains(colNames, table.AutoIncrement)
-		log.Println("found", found)
+		found := slices.Contains(colNames, table.Snowflake)
 		if !found {
-			id := session.engine.snowflake.Generate()
+			id := session.engine.snowflake()
 			colNames = append(colNames, table.Snowflake)
 			args = append(args, id)
-			log.Println("found", id, args, colNames)
 			// Set snowflakeID back to the bean.
 			col := table.GetColumn(table.Snowflake)
 			if col == nil {
@@ -607,7 +604,7 @@ func (session *Session) genInsertColumns(bean any) ([]string, []any, error) {
 		}
 		fieldValue := *fieldValuePtr
 
-		if col.IsAutoIncrement {
+		if col.IsAutoIncrement || col.IsSnowflakeID {
 			switch fieldValue.Type().Kind() {
 			case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int, reflect.Int64:
 				if fieldValue.Int() == 0 {

--- a/pkg/util/xorm/session_insert.go
+++ b/pkg/util/xorm/session_insert.go
@@ -820,7 +820,7 @@ func (s *snowflake) Generate() int64 {
 	defer s.mu.Unlock()
 	currentTime := time.Since(s.epoch).Milliseconds()
 	if currentTime == s.lastTime {
-		s.sequence = (s.sequence + 1) & 4095
+		s.sequence = (s.sequence + 1) & 0xfff
 		if s.sequence == 0 {
 			// wait for next millisecond, we are not using time.Sleep() here due to its low resolution (often >4ms)
 			for currentTime <= s.lastTime {

--- a/pkg/util/xorm/tag.go
+++ b/pkg/util/xorm/tag.go
@@ -34,22 +34,22 @@ type tagHandler func(ctx *tagContext) error
 var (
 	// defaultTagHandlers enumerates all the default tag handler
 	defaultTagHandlers = map[string]tagHandler{
-		"PK":        PKTagHandler,
-		"NULL":      NULLTagHandler,
-		"NOT":       IgnoreTagHandler,
-		"AUTOINCR":  AutoIncrTagHandler,
-		"SNOWFLAKE": SnowflakeIDTagHandler,
-		"DEFAULT":   DefaultTagHandler,
-		"CREATED":   CreatedTagHandler,
-		"UPDATED":   UpdatedTagHandler,
-		"DELETED":   DeletedTagHandler,
-		"VERSION":   VersionTagHandler,
-		"UTC":       UTCTagHandler,
-		"LOCAL":     LocalTagHandler,
-		"NOTNULL":   NotNullTagHandler,
-		"INDEX":     IndexTagHandler,
-		"UNIQUE":    UniqueTagHandler,
-		"COMMENT":   CommentTagHandler,
+		"PK":       PKTagHandler,
+		"NULL":     NULLTagHandler,
+		"NOT":      IgnoreTagHandler,
+		"AUTOINCR": AutoIncrTagHandler,
+		"RANDOMID": RandomIDTagHandler,
+		"DEFAULT":  DefaultTagHandler,
+		"CREATED":  CreatedTagHandler,
+		"UPDATED":  UpdatedTagHandler,
+		"DELETED":  DeletedTagHandler,
+		"VERSION":  VersionTagHandler,
+		"UTC":      UTCTagHandler,
+		"LOCAL":    LocalTagHandler,
+		"NOTNULL":  NotNullTagHandler,
+		"INDEX":    IndexTagHandler,
+		"UNIQUE":   UniqueTagHandler,
+		"COMMENT":  CommentTagHandler,
 	}
 )
 
@@ -89,9 +89,9 @@ func AutoIncrTagHandler(ctx *tagContext) error {
 	return nil
 }
 
-// SnowflakeIDTagHandler describes snowflake id tag handler
-func SnowflakeIDTagHandler(ctx *tagContext) error {
-	ctx.col.IsSnowflakeID = true
+// RandomIDTagHandler describes snowflake id tag handler
+func RandomIDTagHandler(ctx *tagContext) error {
+	ctx.col.IsRandomID = true
 	return nil
 }
 

--- a/pkg/util/xorm/tag.go
+++ b/pkg/util/xorm/tag.go
@@ -34,21 +34,22 @@ type tagHandler func(ctx *tagContext) error
 var (
 	// defaultTagHandlers enumerates all the default tag handler
 	defaultTagHandlers = map[string]tagHandler{
-		"PK":       PKTagHandler,
-		"NULL":     NULLTagHandler,
-		"NOT":      IgnoreTagHandler,
-		"AUTOINCR": AutoIncrTagHandler,
-		"DEFAULT":  DefaultTagHandler,
-		"CREATED":  CreatedTagHandler,
-		"UPDATED":  UpdatedTagHandler,
-		"DELETED":  DeletedTagHandler,
-		"VERSION":  VersionTagHandler,
-		"UTC":      UTCTagHandler,
-		"LOCAL":    LocalTagHandler,
-		"NOTNULL":  NotNullTagHandler,
-		"INDEX":    IndexTagHandler,
-		"UNIQUE":   UniqueTagHandler,
-		"COMMENT":  CommentTagHandler,
+		"PK":        PKTagHandler,
+		"NULL":      NULLTagHandler,
+		"NOT":       IgnoreTagHandler,
+		"AUTOINCR":  AutoIncrTagHandler,
+		"SNOWFLAKE": SnowflakeIDTagHandler,
+		"DEFAULT":   DefaultTagHandler,
+		"CREATED":   CreatedTagHandler,
+		"UPDATED":   UpdatedTagHandler,
+		"DELETED":   DeletedTagHandler,
+		"VERSION":   VersionTagHandler,
+		"UTC":       UTCTagHandler,
+		"LOCAL":     LocalTagHandler,
+		"NOTNULL":   NotNullTagHandler,
+		"INDEX":     IndexTagHandler,
+		"UNIQUE":    UniqueTagHandler,
+		"COMMENT":   CommentTagHandler,
 	}
 )
 
@@ -85,6 +86,12 @@ func NotNullTagHandler(ctx *tagContext) error {
 // AutoIncrTagHandler describes autoincr tag handler
 func AutoIncrTagHandler(ctx *tagContext) error {
 	ctx.col.IsAutoIncrement = true
+	return nil
+}
+
+// SnowflakeIDTagHandler describes snowflake id tag handler
+func SnowflakeIDTagHandler(ctx *tagContext) error {
+	ctx.col.IsSnowflakeID = true
 	return nil
 }
 

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -96,7 +96,7 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 		tagHandlers:     defaultTagHandlers,
 		defaultContext:  context.Background(),
 		timestampFormat: "2006-01-02 15:04:05",
-		snowflake:       newSnowflake(rand.Int64N(1024)).Generate,
+		randomIDGen:     newSnowflake(rand.Int64N(1024)).Generate,
 	}
 
 	switch uri.DbType {

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"reflect"
 	"runtime"

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -96,7 +96,7 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 		tagHandlers:     defaultTagHandlers,
 		defaultContext:  context.Background(),
 		timestampFormat: "2006-01-02 15:04:05",
-		snowflake:       newSnowflake(rand.Int63n(1024)).Generate,
+		snowflake:       newSnowflake(rand.Int64N(1024)).Generate,
 	}
 
 	switch uri.DbType {

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -96,7 +96,7 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 		tagHandlers:     defaultTagHandlers,
 		defaultContext:  context.Background(),
 		timestampFormat: "2006-01-02 15:04:05",
-		snowflake:       newSnowflake(rand.Int63n(1024)),
+		snowflake:       newSnowflake(rand.Int63n(1024)).Generate,
 	}
 
 	switch uri.DbType {

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"os"
 	"reflect"
 	"runtime"
@@ -95,6 +96,7 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 		tagHandlers:     defaultTagHandlers,
 		defaultContext:  context.Background(),
 		timestampFormat: "2006-01-02 15:04:05",
+		snowflake:       newSnowflake(rand.Int63n(1024)),
 	}
 
 	switch uri.DbType {

--- a/pkg/util/xorm/xorm_test.go
+++ b/pkg/util/xorm/xorm_test.go
@@ -48,3 +48,25 @@ type TestStruct struct {
 	Comment string
 	Json    json.RawMessage
 }
+
+func TestSnowflakeID(t *testing.T) {
+	type StructWithSnowflake struct {
+		ID      int64 `xorm:"'id' snowflake"`
+		Comment string
+	}
+	eng, err := NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, eng)
+
+	_, err = eng.Exec("CREATE TABLE struct_with_snowflake(id int primary key, comment text)")
+	require.NoError(t, err)
+
+	sess := eng.NewSession()
+	defer sess.Close()
+
+	obj := &StructWithSnowflake{Comment: "test comment"}
+	_, err = sess.Insert(obj)
+	require.NoError(t, err)
+	t.Fatal(obj.ID)
+	require.Equal(t, int64(1), obj.ID)
+}

--- a/pkg/util/xorm/xorm_test.go
+++ b/pkg/util/xorm/xorm_test.go
@@ -49,15 +49,15 @@ type TestStruct struct {
 	Json    json.RawMessage
 }
 
-func TestSnowflakeID(t *testing.T) {
-	type SnowflakeRecord struct {
-		ID      int64 `xorm:"'id' pk snowflake"`
+func TestRandomID(t *testing.T) {
+	type RandomIDRecord struct {
+		ID      int64 `xorm:"'id' pk randomid"`
 		Comment string
 	}
 
 	eng, err := NewEngine("sqlite3", ":memory:")
 	require.NoError(t, err)
-	require.NoError(t, eng.Sync(new(SnowflakeRecord)))
+	require.NoError(t, eng.Sync(new(RandomIDRecord)))
 
 	// Test sequence of different snowflake values
 	testCases := []struct {
@@ -72,15 +72,15 @@ func TestSnowflakeID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			eng.snowflake = func() int64 { return tc.id }
+			eng.randomIDGen = func() int64 { return tc.id }
 
-			obj := &SnowflakeRecord{Comment: tc.comment}
+			obj := &RandomIDRecord{Comment: tc.comment}
 			_, err := eng.Insert(obj)
 			require.NoError(t, err)
 			require.Equal(t, tc.id, obj.ID, "ID should match current snowflake value")
 
 			// Verify database entry
-			var retrieved SnowflakeRecord
+			var retrieved RandomIDRecord
 			has, err := eng.ID(tc.id).Get(&retrieved)
 			require.NoError(t, err)
 			require.True(t, has)


### PR DESCRIPTION
This PR introduces new xorm tag, `snowflake`, which might replace `autoincr` in some cases where SnowflakeID is more desirable than auto-incremented sequential numeric IDs.

It seems to behave much like autoincrement tag, modifying the original field in the "bean" on inserts.

Next step would be to try it on some tables/models.