### PR TITLE
DataSourceSrv: include alias in type filter

### DIFF
--- a/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -110,10 +107,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "Should be smaller given the longer value",
       "fieldConfig": {
         "defaults": {
@@ -193,10 +187,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -274,10 +265,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -436,10 +424,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -518,10 +503,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -259,8 +259,14 @@ export class DatasourceSrv implements DataSourceService {
       if (filters.filter && !filters.filter(x)) {
         return false;
       }
-      if (filters.type && (Array.isArray(filters.type) ? !filters.type.includes(x.type) : filters.type !== x.type)) {
-        return false;
+      if (filters.type) {
+        if (Array.isArray(filters.type)) {
+          if (!filters.type.includes(x.type)) {
+            return false;
+          }
+        } else if (x.type !== filters.type || !x.meta.aliasIDs?.includes(filters.type!)) {
+          return false;
+        }
       }
       if (
         !filters.all &&

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -264,7 +264,7 @@ export class DatasourceSrv implements DataSourceService {
           if (!filters.type.includes(x.type)) {
             return false;
           }
-        } else if (x.type !== filters.type || !x.meta.aliasIDs?.includes(filters.type!)) {
+        } else if (!(x.type === filters.type || x.meta.aliasIDs?.includes(filters.type!))) {
           return false;
         }
       }


### PR DESCRIPTION
See: http://localhost:3000/d/WFlOM-jM1/barchart-panel-tests-value-sizing

This allows us to pick datasources by type -- this was previously failing for testdata/gdev dashboards!


I think this is worth backporting to 12.0