### PR TITLE
docs(alerting): clarify that webhook extra headers can override the Content-Type header

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
@@ -68,17 +68,17 @@ For more details on contact points, including how to test them and enable notifi
 
 #### Optional settings
 
-| Option                            | Description                                                                                                             |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| HTTP Method                       | Specifies the HTTP method to use: `POST` or `PUT`.                                                                      |
-| Basic Authentication Username     | Username for HTTP Basic Authentication.                                                                                 |
-| Basic Authentication Password     | Password for HTTP Basic Authentication.                                                                                 |
-| Authentication Header Scheme      | Scheme for the `Authorization` Request Header. Default is `Bearer`.                                                     |
-| Authentication Header Credentials | Credentials for the `Authorization` Request header.                                                                     |
-| Extra Headers                     | Additional HTTP headers to include in the request.                                                                      |
-| Max Alerts                        | Maximum number of alerts to include in a notification. Any alerts exceeding this limit are ignored. `0` means no limit. |
-| TLS                               | TLS configuration options, including CA certificate, client certificate, and client key.                                |
-| HMAC Signature                    | HMAC signature configuration options.                                                                                   |
+| Option                            | Description                                                                                                                                                                               |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP Method                       | Specifies the HTTP method to use: `POST` or `PUT`.                                                                                                                                        |
+| Basic Authentication Username     | Username for HTTP Basic Authentication.                                                                                                                                                   |
+| Basic Authentication Password     | Password for HTTP Basic Authentication.                                                                                                                                                   |
+| Authentication Header Scheme      | Scheme for the `Authorization` Request Header. Default is `Bearer`.                                                                                                                       |
+| Authentication Header Credentials | Credentials for the `Authorization` Request header.                                                                                                                                       |
+| Extra Headers                     | Additional HTTP headers to include in the request. You can also override the default `Content-Type: application/json` header to specify a different content type for the request payload. |
+| Max Alerts                        | Maximum number of alerts to include in a notification. Any alerts exceeding this limit are ignored. `0` means no limit.                                                                   |
+| TLS                               | TLS configuration options, including CA certificate, client certificate, and client key.                                                                                                  |
+| HMAC Signature                    | HMAC signature configuration options.                                                                                                                                                     |
 
 {{< admonition type="note" >}}
 


### PR DESCRIPTION
Minor docs addition, continuation of https://github.com/grafana/grafana/pull/103818. 

As discussed with @JacobsonMT in Slack.

⭐ [Preview](https://deploy-preview-grafana-104324-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/#optional-settings)
