### PR TITLE
Scenes: add support for sourcemaps when linking

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -24,8 +24,6 @@ const esbuildOptions = {
 };
 
 const fs = require('fs');
-const { get } = require('jquery');
-const { isConstructorDeclaration } = require('typescript');
 
 // To speed up webpack and prevent unnecessary rebuilds we ignore decoupled packages
 function getDecoupledPlugins() {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -72,7 +72,7 @@ module.exports = (env = {}) => {
         //  local version of @grafana/scenes
         'react-router-dom': path.resolve('./node_modules/react-router-dom'),
         '@grafana/scenes': scenesModule(),
-      }
+      },
     },
 
     module: {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -4,6 +4,7 @@ const browserslist = require('browserslist');
 const { resolveToEsbuildTarget } = require('esbuild-plugin-browserslist');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const fs = require('fs');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 const { DefinePlugin, EnvironmentPlugin } = require('webpack');
@@ -11,7 +12,6 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const LiveReloadPlugin = require('webpack-livereload-plugin');
 const { merge } = require('webpack-merge');
 const WebpackBar = require('webpackbar');
-const fs = require('fs');
 
 const getEnvConfig = require('./env-util.js');
 const common = require('./webpack.common.js');

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -11,6 +11,7 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const LiveReloadPlugin = require('webpack-livereload-plugin');
 const { merge } = require('webpack-merge');
 const WebpackBar = require('webpackbar');
+const fs = require('fs');
 
 const getEnvConfig = require('./env-util.js');
 const common = require('./webpack.common.js');
@@ -23,8 +24,6 @@ const esbuildOptions = {
   jsx: 'automatic',
 };
 
-const fs = require('fs');
-
 // To speed up webpack and prevent unnecessary rebuilds we ignore decoupled packages
 function getDecoupledPlugins() {
   const { packages } = getPackagesSync(process.cwd());
@@ -33,11 +32,10 @@ function getDecoupledPlugins() {
 
 // When linking scenes for development, resolve the path to the src directory for sourcemaps
 function scenesModule() {
-  const relativeScenesPath = './node_modules/@grafana/scenes'
-  const scenesPath = path.resolve(relativeScenesPath);
+  const scenesPath = path.resolve('./node_modules/@grafana/scenes');
   try {
-    const stats = fs.lstatSync(scenesPath);
-    if (stats.isSymbolicLink()) {
+    const status = fs.lstatSync(scenesPath);
+    if (status.isSymbolicLink()) {
       console.log(`scenes is linked to local scenes repo`);
       return path.resolve(scenesPath + '/src');
     }


### PR DESCRIPTION
In local dev mode linking scenes to grafana, using the dev script in scenes, sourcemaps are not working.  This will check if scenes is linked and point to the src files, enabling sourcemaps.

Before
![image](https://github.com/user-attachments/assets/6bbe3c4e-ac82-438e-8101-57a0aea20ad0)

After
![image](https://github.com/user-attachments/assets/2049fb1e-c0e8-4392-927e-140a5ef4d399)

Attempted some [changes in scenes](https://github.com/grafana/scenes/pull/1105) ( closing that ) both approaches required changing the webpack.dev
