### PR TITLE
docs(alerting): admonition for webhook features that are not GA in GC

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
@@ -254,6 +254,12 @@ The Alert object represents an alert included in the notification group, as prov
 
 ## Custom Payload
 
+{{< admonition type="note" >}}
+
+Custom Payload is not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
+
+{{< /admonition >}}
+
 The `Custom Payload` option allows you to completely customize the webhook payload using templates. This gives you full control over the structure and content of the webhook request.
 
 | Option            | Description                                                                                               |

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
@@ -256,7 +256,7 @@ The Alert object represents an alert included in the notification group, as prov
 
 {{< admonition type="note" >}}
 
-Custom Payload is not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
+Custom Payload is not yet [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) in Grafana Cloud.
 
 {{< /admonition >}}
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/reference.md
@@ -271,7 +271,7 @@ You can then use `tz` to change the timezone from UTC to local time, such as `Eu
 
 {{< admonition type="note" >}}
 
-Namespaced Functions is not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
+Namespaced Functions are not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
 
 {{< /admonition >}}
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/reference.md
@@ -269,6 +269,12 @@ You can then use `tz` to change the timezone from UTC to local time, such as `Eu
 
 ## Namespaced Functions
 
+{{< admonition type="note" >}}
+
+Namespaced Functions is not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
+
+{{< /admonition >}}
+
 In addition to the top-level functions, the following namespaced functions are also available:
 
 ### Collection Functions

--- a/docs/sources/alerting/configure-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/reference.md
@@ -271,7 +271,7 @@ You can then use `tz` to change the timezone from UTC to local time, such as `Eu
 
 {{< admonition type="note" >}}
 
-Namespaced Functions are not [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) by default in Grafana Cloud.
+Namespaced Functions are not yet [generally available](https://grafana.com/docs/release-life-cycle/#general-availability) in Grafana Cloud.
 
 {{< /admonition >}}
 


### PR DESCRIPTION
Add admonition to clarify latest features are not available in GC yet.

Preview:


<img width="793" alt="Screenshot 2025-04-22 at 20 17 15" src="https://github.com/user-attachments/assets/5d35c8db-8269-48b0-b2f7-8efcd8f0cc61" />
