### PR TITLE
Devenv: Avoid explicit uid for testdata in dashboards

### DIFF
--- a/devenv/dev-dashboards/annotations/annotation-filtering.json
+++ b/devenv/dev-dashboards/annotations/annotation-filtering.json
@@ -101,10 +101,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -179,10 +176,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -257,10 +251,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -335,10 +326,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/feature-templating/templating-repeating-panels.json
+++ b/devenv/dev-dashboards/feature-templating/templating-repeating-panels.json
@@ -42,10 +42,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -159,10 +156,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/feature-templating/templating-repeating-rows.json
+++ b/devenv/dev-dashboards/feature-templating/templating-repeating-rows.json
@@ -69,10 +69,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/home.json
+++ b/devenv/dev-dashboards/home.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 26,
         "w": 6,
@@ -56,10 +53,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -87,10 +81,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -120,10 +111,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 26,
         "w": 6,
@@ -153,10 +141,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -186,10 +171,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 13,
         "w": 6,

--- a/devenv/dev-dashboards/migrations/migrations.json
+++ b/devenv/dev-dashboards/migrations/migrations.json
@@ -195,10 +195,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "unit": "short"
@@ -291,10 +288,7 @@
       }
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,
@@ -329,10 +323,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "unit": "short"
@@ -429,10 +420,7 @@
       }
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,
@@ -568,10 +556,7 @@
       }
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,
@@ -606,10 +591,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "unit": "short"
@@ -704,10 +686,7 @@
       }
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,
@@ -739,10 +718,7 @@
     },
     {
       "columns": [],
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -816,10 +792,7 @@
       "type": "table-old"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 10,
         "w": 8,
@@ -857,10 +830,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "format": "areaF2",
       "gauge": {
         "maxValue": 100,
@@ -930,10 +900,7 @@
       "valueName": "avg"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1002,10 +969,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1036,10 +1000,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 10,
         "w": 16,
@@ -1089,10 +1050,7 @@
       "type": "grafana-piechart-panel"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 10,
         "w": 8,
@@ -1267,10 +1225,7 @@
       "valueName": "total"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 10,
         "w": 8,

--- a/devenv/dev-dashboards/panel-barchart/barchart-thresholds-mappings.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-thresholds-mappings.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -124,10 +121,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -244,10 +238,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -328,10 +319,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -413,10 +401,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -542,10 +527,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -684,10 +666,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -805,10 +784,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -948,10 +924,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1035,10 +1008,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1122,10 +1092,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1209,10 +1176,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-barchart/barchart-tooltips-legends.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-tooltips-legends.json
@@ -358,10 +358,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -465,10 +462,7 @@
       "type": "barchart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-bargauge/panel_tests_bar_gauge.json
+++ b/devenv/dev-dashboards/panel-bargauge/panel_tests_bar_gauge.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -125,10 +122,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -238,10 +232,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -351,10 +342,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -464,10 +452,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -577,10 +562,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -690,10 +672,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -845,10 +824,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1023,10 +999,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1096,10 +1069,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1169,10 +1139,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1242,10 +1209,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1320,10 +1284,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-candlestick/candlestick.json
+++ b/devenv/dev-dashboards/panel-candlestick/candlestick.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -177,10 +174,7 @@
       "type": "candlestick"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,10 +260,7 @@
       "type": "candlestick"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -355,10 +346,7 @@
       "type": "candlestick"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-canvas/canvas-connection-examples.json
+++ b/devenv/dev-dashboards/panel-canvas/canvas-connection-examples.json
@@ -2225,10 +2225,7 @@
       "type": "canvas"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2857,10 +2854,7 @@
       "type": "canvas"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-canvas/canvas-examples.json
+++ b/devenv/dev-dashboards/panel-canvas/canvas-examples.json
@@ -50,10 +50,7 @@
       },
       "type": "canvas",
       "title": "Wind Energy",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "pluginVersion": "9.4.0-pre",
       "fieldConfig": {
         "defaults": {
@@ -1144,10 +1141,7 @@
       ]
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 15,
         "w": 6,
@@ -1182,10 +1176,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3330,10 +3321,7 @@
       "type": "canvas"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 18,
         "w": 6,
@@ -3368,10 +3356,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3608,10 +3593,7 @@
       "type": "canvas"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 15,
         "w": 6,
@@ -3633,10 +3615,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3824,10 +3803,7 @@
       "type": "canvas"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 15,
         "w": 6,

--- a/devenv/dev-dashboards/panel-common/shared_queries.json
+++ b/devenv/dev-dashboards/panel-common/shared_queries.json
@@ -22,10 +22,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-datagrid/datagrid_metric_values.json
+++ b/devenv/dev-dashboards/panel-datagrid/datagrid_metric_values.json
@@ -22,10 +22,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 8,
         "w": 12,

--- a/devenv/dev-dashboards/panel-flamegraph/panel_tests_flame_graph.json
+++ b/devenv/dev-dashboards/panel-flamegraph/panel_tests_flame_graph.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 14,
         "w": 24,

--- a/devenv/dev-dashboards/panel-geomap/geomap-color-field.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-color-field.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-geomap/geomap-photo-layer.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-photo-layer.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-geomap/geomap-route-layer.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-route-layer.json
@@ -92,10 +92,7 @@
           "csvContent": "lat,lon,alt\n45,0,0\n40,5,5\n35,10,10\n30,15, 15\n25,20,20"
         }
       ],
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "options": {
         "view": {
           "allLayers": true,

--- a/devenv/dev-dashboards/panel-geomap/geomap-spatial-operations-transformer.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-spatial-operations-transformer.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-geomap/geomap-v91.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap-v91.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -129,10 +126,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -215,10 +209,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-geomap/geomap_multi-layers.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap_multi-layers.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -322,10 +319,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-geomap/panel-geomap.json
+++ b/devenv/dev-dashboards/panel-geomap/panel-geomap.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -130,10 +127,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -236,10 +230,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -334,10 +325,7 @@
       "type": "geomap"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-heatmap/heatmap-calculate-log.json
+++ b/devenv/dev-dashboards/panel-heatmap/heatmap-calculate-log.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-heatmap/heatmap-legacy.json
+++ b/devenv/dev-dashboards/panel-heatmap/heatmap-legacy.json
@@ -40,10 +40,7 @@
         "mode": "opacity"
       },
       "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 7,
@@ -96,10 +93,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 9,
@@ -157,10 +151,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,
@@ -213,10 +204,7 @@
         "mode": "opacity"
       },
       "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 7,
@@ -327,10 +315,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 11,
         "w": 8,

--- a/devenv/dev-dashboards/panel-histogram/histogram_tests.json
+++ b/devenv/dev-dashboards/panel-histogram/histogram_tests.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -168,10 +165,7 @@
       "type": "histogram"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -251,10 +245,7 @@
       "type": "histogram"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -334,10 +325,7 @@
       "type": "histogram"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -429,10 +417,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -516,10 +501,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -601,10 +583,7 @@
       "type": "histogram"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -686,10 +665,7 @@
       "type": "histogram"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-table/table_sparkline_cell.json
+++ b/devenv/dev-dashboards/panel-table/table_sparkline_cell.json
@@ -22,10 +22,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-table/table_tests_new.json
+++ b/devenv/dev-dashboards/panel-table/table_tests_new.json
@@ -182,10 +182,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -332,10 +329,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -472,10 +466,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-text/text-options.json
+++ b/devenv/dev-dashboards/panel-text/text-options.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -64,10 +61,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -99,10 +93,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -134,10 +125,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 9,
         "w": 12,

--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -131,10 +128,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -237,10 +231,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "Should show gaps",
       "fieldConfig": {
         "defaults": {
@@ -343,10 +334,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -211,10 +208,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -288,10 +282,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -96,10 +93,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -171,10 +165,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -246,10 +237,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -345,10 +333,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -453,10 +438,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -574,10 +556,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -641,10 +620,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-formats.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-formats.json
@@ -803,10 +803,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 8,
         "w": 5,
@@ -828,10 +825,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-nulls.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-nulls.json
@@ -1385,10 +1385,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1476,10 +1473,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1571,10 +1565,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1664,10 +1655,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1757,10 +1745,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1850,10 +1835,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1943,10 +1925,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2036,10 +2015,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2237,10 +2213,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2332,10 +2305,7 @@
       "type": "trend"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-stacking2.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-stacking2.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -308,10 +305,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -612,10 +606,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -942,10 +933,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1498,10 +1486,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1848,10 +1833,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2065,10 +2047,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2177,10 +2156,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2498,10 +2474,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2634,10 +2607,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2770,10 +2740,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2906,10 +2873,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3145,10 +3109,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3384,10 +3345,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-yaxis-ticks.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-yaxis-ticks.json
@@ -39,10 +39,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -133,10 +130,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -227,10 +221,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -321,10 +312,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -415,10 +403,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -509,10 +494,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -603,10 +585,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -698,10 +677,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -793,10 +769,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -887,10 +860,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -977,10 +947,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1067,10 +1034,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1158,10 +1122,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1250,10 +1211,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-trend/trend_example.json
+++ b/devenv/dev-dashboards/panel-trend/trend_example.json
@@ -22,10 +22,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-xychart/xychart-migrations.json
+++ b/devenv/dev-dashboards/panel-xychart/xychart-migrations.json
@@ -28,10 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -111,10 +108,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -261,10 +255,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -459,10 +450,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "gridPos": {
         "h": 7,
         "w": 3,
@@ -483,10 +471,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -584,10 +569,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -741,10 +723,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1832,10 +1811,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1933,10 +1909,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2034,10 +2007,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/panel-xychart/xychart-tooltip-color-test.json
+++ b/devenv/dev-dashboards/panel-xychart/xychart-tooltip-color-test.json
@@ -577,10 +577,7 @@
       "type": "xychart"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/transforms/join-by-field.json
+++ b/devenv/dev-dashboards/transforms/join-by-field.json
@@ -42,10 +42,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -274,10 +271,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/devenv/dev-dashboards/transforms/join-by-labels.json
+++ b/devenv/dev-dashboards/transforms/join-by-labels.json
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "testdata",
-        "uid": "PD8C576611E62080A"
-      },
+      "datasource": { "type": "testdata" },
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
With https://github.com/grafana/grafana/pull/101495 and https://github.com/grafana/grafana/pull/104308 -- a DataSourceRef only needs to include the type, and it will pick the first matching value

For testdata, this should be easy because there are no special configs