### PR TITLE
Grafana UI: Add `ref` to `DatePickerWithInput`

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
@@ -1,5 +1,14 @@
 import { css } from '@emotion/css';
-import { autoUpdate, flip, shift, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
+import {
+  autoUpdate,
+  flip,
+  ReferenceElement,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+} from '@floating-ui/react';
 import { ChangeEvent, forwardRef, useImperativeHandle, useState } from 'react';
 
 import { GrafanaTheme2, dateTime } from '@grafana/data';
@@ -27,7 +36,7 @@ export interface DatePickerWithInputProps extends Omit<InputProps, 'value' | 'on
 }
 
 /** @public */
-export const DatePickerWithInput = forwardRef<HTMLInputElement, DatePickerWithInputProps>(
+export const DatePickerWithInput = forwardRef<ReferenceElement, DatePickerWithInputProps>(
   ({ value, minDate, maxDate, onChange, closeOnSelect, placeholder = 'Date', ...rest }, ref) => {
     const [open, setOpen] = useState(false);
     const styles = useStyles2(getStyles);
@@ -43,7 +52,7 @@ export const DatePickerWithInput = forwardRef<HTMLInputElement, DatePickerWithIn
       shift(),
     ];
 
-    const { context, refs, floatingStyles } = useFloating({
+    const { context, refs, floatingStyles } = useFloating<ReferenceElement>({
       open,
       placement: 'bottom-start',
       onOpenChange: setOpen,
@@ -56,7 +65,7 @@ export const DatePickerWithInput = forwardRef<HTMLInputElement, DatePickerWithIn
     const dismiss = useDismiss(context);
     const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, click]);
 
-    useImperativeHandle(ref, () => refs.reference.current as HTMLInputElement, [refs.reference]);
+    useImperativeHandle(ref, () => refs.reference.current!, [refs.reference]);
 
     return (
       <div className={styles.container}>

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
@@ -1,14 +1,5 @@
 import { css } from '@emotion/css';
-import {
-  autoUpdate,
-  flip,
-  ReferenceElement,
-  shift,
-  useClick,
-  useDismiss,
-  useFloating,
-  useInteractions,
-} from '@floating-ui/react';
+import { autoUpdate, flip, shift, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
 import { ChangeEvent, forwardRef, useImperativeHandle, useState } from 'react';
 
 import { GrafanaTheme2, dateTime } from '@grafana/data';
@@ -36,7 +27,7 @@ export interface DatePickerWithInputProps extends Omit<InputProps, 'value' | 'on
 }
 
 /** @public */
-export const DatePickerWithInput = forwardRef<ReferenceElement, DatePickerWithInputProps>(
+export const DatePickerWithInput = forwardRef<HTMLInputElement, DatePickerWithInputProps>(
   ({ value, minDate, maxDate, onChange, closeOnSelect, placeholder = 'Date', ...rest }, ref) => {
     const [open, setOpen] = useState(false);
     const styles = useStyles2(getStyles);
@@ -52,7 +43,7 @@ export const DatePickerWithInput = forwardRef<ReferenceElement, DatePickerWithIn
       shift(),
     ];
 
-    const { context, refs, floatingStyles } = useFloating<ReferenceElement>({
+    const { context, refs, floatingStyles } = useFloating<HTMLInputElement>({
       open,
       placement: 'bottom-start',
       onOpenChange: setOpen,
@@ -65,7 +56,9 @@ export const DatePickerWithInput = forwardRef<ReferenceElement, DatePickerWithIn
     const dismiss = useDismiss(context);
     const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, click]);
 
-    useImperativeHandle(ref, () => refs.reference.current!, [refs.reference]);
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(ref, () => refs.domReference.current, [
+      refs.domReference,
+    ]);
 
     return (
       <div className={styles.container}>

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { autoUpdate, flip, shift, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, forwardRef, useImperativeHandle, useState } from 'react';
 
 import { GrafanaTheme2, dateTime } from '@grafana/data';
 
@@ -11,7 +11,7 @@ import { DatePicker } from '../DatePicker/DatePicker';
 export const formatDate = (date: Date | string) => dateTime(date).format('L');
 
 /** @public */
-export interface DatePickerWithInputProps extends Omit<InputProps, 'ref' | 'value' | 'onChange'> {
+export interface DatePickerWithInputProps extends Omit<InputProps, 'value' | 'onChange'> {
   /** Value selected by the DatePicker */
   value?: Date | string;
   /** The minimum date the value can be set to */
@@ -27,78 +27,76 @@ export interface DatePickerWithInputProps extends Omit<InputProps, 'ref' | 'valu
 }
 
 /** @public */
-export const DatePickerWithInput = ({
-  value,
-  minDate,
-  maxDate,
-  onChange,
-  closeOnSelect,
-  placeholder = 'Date',
-  ...rest
-}: DatePickerWithInputProps) => {
-  const [open, setOpen] = useState(false);
-  const styles = useStyles2(getStyles);
+export const DatePickerWithInput = forwardRef<HTMLInputElement, DatePickerWithInputProps>(
+  ({ value, minDate, maxDate, onChange, closeOnSelect, placeholder = 'Date', ...rest }, ref) => {
+    const [open, setOpen] = useState(false);
+    const styles = useStyles2(getStyles);
 
-  // the order of middleware is important!
-  // see https://floating-ui.com/docs/arrow#order
-  const middleware = [
-    flip({
-      // see https://floating-ui.com/docs/flip#combining-with-shift
-      crossAxis: false,
-      boundary: document.body,
-    }),
-    shift(),
-  ];
+    // the order of middleware is important!
+    // see https://floating-ui.com/docs/arrow#order
+    const middleware = [
+      flip({
+        // see https://floating-ui.com/docs/flip#combining-with-shift
+        crossAxis: false,
+        boundary: document.body,
+      }),
+      shift(),
+    ];
 
-  const { context, refs, floatingStyles } = useFloating({
-    open,
-    placement: 'bottom-start',
-    onOpenChange: setOpen,
-    middleware,
-    whileElementsMounted: autoUpdate,
-    strategy: 'fixed',
-  });
+    const { context, refs, floatingStyles } = useFloating({
+      open,
+      placement: 'bottom-start',
+      onOpenChange: setOpen,
+      middleware,
+      whileElementsMounted: autoUpdate,
+      strategy: 'fixed',
+    });
 
-  const click = useClick(context);
-  const dismiss = useDismiss(context);
-  const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, click]);
+    const click = useClick(context);
+    const dismiss = useDismiss(context);
+    const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, click]);
 
-  return (
-    <div className={styles.container}>
-      <Input
-        ref={refs.setReference}
-        type="text"
-        autoComplete={'off'}
-        placeholder={placeholder}
-        value={value ? formatDate(value) : value}
-        onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-          // Allow resetting the date
-          if (ev.target.value === '') {
-            onChange('');
-          }
-        }}
-        className={styles.input}
-        {...rest}
-        {...getReferenceProps()}
-      />
-      <div className={styles.popover} ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-        <DatePicker
-          isOpen={open}
-          value={value && typeof value !== 'string' ? value : dateTime().toDate()}
-          minDate={minDate}
-          maxDate={maxDate}
-          onChange={(ev) => {
-            onChange(ev);
-            if (closeOnSelect) {
-              setOpen(false);
+    useImperativeHandle(ref, () => refs.reference.current as HTMLInputElement, [refs.reference]);
+
+    return (
+      <div className={styles.container}>
+        <Input
+          ref={refs.setReference}
+          type="text"
+          autoComplete={'off'}
+          placeholder={placeholder}
+          value={value ? formatDate(value) : value}
+          onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+            // Allow resetting the date
+            if (ev.target.value === '') {
+              onChange('');
             }
           }}
-          onClose={() => setOpen(false)}
+          className={styles.input}
+          {...rest}
+          {...getReferenceProps()}
         />
+        <div className={styles.popover} ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+          <DatePicker
+            isOpen={open}
+            value={value && typeof value !== 'string' ? value : dateTime().toDate()}
+            minDate={minDate}
+            maxDate={maxDate}
+            onChange={(ev) => {
+              onChange(ev);
+              if (closeOnSelect) {
+                setOpen(false);
+              }
+            }}
+            onClose={() => setOpen(false)}
+          />
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
+
+DatePickerWithInput.displayName = 'DatePickerWithInput';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- It adds forwardRef to the component so it can be managed by any parent component that renders it

**Why do we need this feature?**

- Enhancement, better native behavior. We need it to specifically focus and show an error in a form

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/104345

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
