### PR TITLE
Grafana UI: Create new `CollapsableSection` without state

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
+++ b/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
@@ -25,6 +25,78 @@ export interface Props {
   unmountContentWhenClosed?: boolean;
 }
 
+export const UncontrolledCollapsableSection = ({
+  isOpen,
+  labelId,
+  label,
+  contentClassName,
+  children,
+  contentDataTestId,
+  onToggle,
+  loading,
+  headerDataTestId,
+  className,
+  unmountContentWhenClosed,
+}: Omit<Props, 'onToggle'> & { onToggle: () => void }) => {
+  const styles = useStyles2(collapsableSectionStyles);
+
+  const { current: id } = useRef(uniqueId());
+
+  const buttonLabelId = labelId ?? `collapse-label-${id}`;
+
+  const content = (
+    <div
+      id={`collapse-content-${id}`}
+      className={cx(styles.content, contentClassName, {
+        [styles.contentHidden]: !isOpen && !unmountContentWhenClosed,
+      })}
+      data-testid={contentDataTestId}
+    >
+      {children}
+    </div>
+  );
+
+  const onClick = (e: React.MouseEvent) => {
+    if (e.target instanceof HTMLElement && e.target.tagName === 'A') {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    onToggle?.();
+  };
+
+  return (
+    <>
+      {/* disabling the a11y rules here as the button handles keyboard interactions */}
+      {/* this is just to provide a better experience for mouse users */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div onClick={onClick} className={cx(styles.header, className)}>
+        <button
+          type="button"
+          id={`collapse-button-${id}`}
+          className={styles.button}
+          onClick={onClick}
+          aria-expanded={isOpen && !loading}
+          aria-controls={`collapse-content-${id}`}
+          aria-labelledby={buttonLabelId}
+        >
+          {loading ? (
+            <Spinner className={styles.spinner} />
+          ) : (
+            <Icon name={isOpen ? 'angle-up' : 'angle-down'} className={styles.icon} />
+          )}
+        </button>
+        <div className={styles.label} id={`collapse-label-${id}`} data-testid={headerDataTestId}>
+          {label}
+        </div>
+      </div>
+      {unmountContentWhenClosed ? isOpen && content : content}
+    </>
+  );
+};
+
 export const CollapsableSection = ({
   label,
   isOpen,
@@ -39,62 +111,26 @@ export const CollapsableSection = ({
   unmountContentWhenClosed = true,
 }: Props) => {
   const [open, toggleOpen] = useState<boolean>(isOpen);
-  const styles = useStyles2(collapsableSectionStyles);
 
-  const onClick = (e: React.MouseEvent) => {
-    if (e.target instanceof HTMLElement && e.target.tagName === 'A') {
-      return;
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-
+  const onClick = () => {
     onToggle?.(!open);
     toggleOpen(!open);
   };
-  const { current: id } = useRef(uniqueId());
-
-  const buttonLabelId = labelId ?? `collapse-label-${id}`;
-
-  const content = (
-    <div
-      id={`collapse-content-${id}`}
-      className={cx(styles.content, contentClassName, {
-        [styles.contentHidden]: !open && !unmountContentWhenClosed,
-      })}
-      data-testid={contentDataTestId}
-    >
-      {children}
-    </div>
-  );
 
   return (
-    <>
-      {/* disabling the a11y rules here as the button handles keyboard interactions */}
-      {/* this is just to provide a better experience for mouse users */}
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div onClick={onClick} className={cx(styles.header, className)}>
-        <button
-          type="button"
-          id={`collapse-button-${id}`}
-          className={styles.button}
-          onClick={onClick}
-          aria-expanded={open && !loading}
-          aria-controls={`collapse-content-${id}`}
-          aria-labelledby={buttonLabelId}
-        >
-          {loading ? (
-            <Spinner className={styles.spinner} />
-          ) : (
-            <Icon name={open ? 'angle-up' : 'angle-down'} className={styles.icon} />
-          )}
-        </button>
-        <div className={styles.label} id={`collapse-label-${id}`} data-testid={headerDataTestId}>
-          {label}
-        </div>
-      </div>
-      {unmountContentWhenClosed ? open && content : content}
-    </>
+    <UncontrolledCollapsableSection
+      isOpen={open}
+      onToggle={onClick}
+      label={label}
+      labelId={labelId}
+      contentClassName={contentClassName}
+      children={children}
+      contentDataTestId={contentDataTestId}
+      headerDataTestId={headerDataTestId}
+      className={className}
+      unmountContentWhenClosed={unmountContentWhenClosed}
+      loading={loading}
+    />
   );
 };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- We need to manage the open state out of the component. This is something similar to the [Collapse](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Collapse/Collapse.tsx#L125) and [ControlledCollapse](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Collapse/Collapse.tsx#L108) components

**Why do we need this feature?**

- It gives you the control over opening/closing the section

**Who is this feature for?**

 - everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/104348

**Special notes for your reviewer:**

I don't want to break retro-compatibility, so I decided to name it `UncontrolledCollapsableSection`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
