### PR TITLE
Ds-querier: update error handling for client cancelled/disconnect

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -160,7 +160,6 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		// Actually run the query
 		rsp, err := b.execute(ctx, req)
 		if err != nil {
-
 			var k8sErr *errorsK8s.StatusError
 			if errors.As(err, &k8sErr) {
 				if k8sErr.ErrStatus.Code >= 500 {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -36,7 +36,7 @@ func TestQueryRestConnectHandler(t *testing.T) {
 	}
 	qr := newQueryREST(b)
 	ctx := context.Background()
-	mr := mockResponder{}
+	mr := &mockResponder{}
 
 	handler, err := qr.Connect(ctx, "name", nil, mr)
 	require.NoError(t, err)

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -140,6 +140,7 @@ func TestInstantQueryFromAlerting(t *testing.T) {
 }
 
 func TestQueryRestConnectHandlerWithContextCancelled(t *testing.T) {
+	// Create a mock client that simulates context cancellation handling
 	mockClientInstance := &mockClient{
 		lastCalledWithHeaders:     &map[string]string{},
 		shouldReturnServerTimeout: true,
@@ -188,6 +189,14 @@ func TestQueryRestConnectHandlerWithContextCancelled(t *testing.T) {
 
 	// Verify that responder.Error was not called after context cancellation
 	require.False(t, mr.errorCalled, "responder.Error should not be called after context cancellation")
+
+	// Verify that the context is actually cancelled by checking if the Done channel is closed
+	select {
+	case <-ctx.Done():
+		// This is the expected case - context is cancelled
+	default:
+		t.Error("Context should be cancelled but it is not")
+	}
 }
 
 type mockResponder struct {
@@ -199,7 +208,7 @@ func (m mockResponder) Object(statusCode int, obj runtime.Object) {
 }
 
 // Error writes the provided error to the response. This method may only be invoked once.
-func (m mockResponder) Error(err error) {
+func (m *mockResponder) Error(err error) {
 	m.errorCalled = true
 }
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana-enterprise/issues/8036

relates to https://github.com/grafana/grafana-enterprise/pull/8356

No need to try to send a response back when the connection to a client no longer exists