### PR TITLE
DashboardReload: Do not preserve or restore URL state if dashboard version invalid

### DIFF
--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
@@ -29,6 +29,17 @@ describe('dashboardSessionState', () => {
       expect(window.sessionStorage.getItem(PRESERVED_SCENE_STATE_KEY)).toBeNull();
     });
 
+    it('should do nothing if dashboard version is 0', () => {
+      const scene = buildTestScene();
+      scene.setState({ version: 0 });
+
+      const deactivate = scene.activate();
+      expect(window.sessionStorage.getItem(PRESERVED_SCENE_STATE_KEY)).toBeNull();
+
+      deactivate();
+      expect(window.sessionStorage.getItem(PRESERVED_SCENE_STATE_KEY)).toBeNull();
+    });
+
     it('should capture dashboard scene state and save it to session storage on deactivation', () => {
       const scene = buildTestScene();
 
@@ -79,6 +90,19 @@ describe('dashboardSessionState', () => {
 
       window.sessionStorage.setItem(PRESERVED_SCENE_STATE_KEY, '?var-customVar=b&from=now-5m&to=now&timezone=browser');
       const scene = buildTestScene();
+
+      restoreDashboardStateFromLocalStorage(scene);
+
+      expect(locationService.getLocation().search).toBe('?var-customVar=b&from=now-6h&to=now&timezone=browser');
+    });
+
+    it('should not restore state if dashboard version is 0', () => {
+      window.sessionStorage.setItem(
+        PRESERVED_SCENE_STATE_KEY,
+        '?var-customVarNotOnDB=b&from=now-5m&to=now&timezone=browser'
+      );
+      const scene = buildTestScene();
+      scene.setState({ version: 0 });
 
       restoreDashboardStateFromLocalStorage(scene);
 

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
@@ -7,6 +7,10 @@ import { DashboardScene } from '../scene/DashboardScene';
 export const PRESERVED_SCENE_STATE_KEY = `grafana.dashboard.preservedUrlFiltersState`;
 
 export function restoreDashboardStateFromLocalStorage(dashboard: DashboardScene) {
+  if (!dashboard.state.version) {
+    return;
+  }
+
   const preservedUrlState = window.sessionStorage.getItem(PRESERVED_SCENE_STATE_KEY);
 
   if (preservedUrlState) {
@@ -49,7 +53,7 @@ export function preserveDashboardSceneStateInLocalStorage(scene: DashboardScene)
 
   return () => {
     // Skipping saving state for default home dashboard
-    if (!scene.state.uid) {
+    if (!scene.state.uid || !scene.state.version) {
       return;
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a check on preserve and restore so that if the version is zero we do neither on navigation. This fixes an issue where we would navigate to another dashboard which might have an invalid version and, for example, no variables, and it would trigger a storage save of this invalid state. On reload it would then restore this invalid state even though variables would be populated and the version would be valid, but since we already preserved the invalid state it will overwrite the new state with this preserved state.

The restore part also works similar but in an opposite direction: if we have a valid URL state and the current dashboard would be invalid with an invalid version and no variables, the preserved valid URL state would not persist because that invalid dashboard has no variables and thus they would be dropped due to https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/utils/dashboardSessionState.ts#L30. After this, on the next URL state preservation we would save the invalid state described in the above paragraph which completes the cycle and leaves us with a broken state.

**Why do we need this feature?**

Fixes the issue

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
