### PR TITLE
Alerting: Allow clearing namespace and group filter

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx
@@ -59,7 +59,7 @@ export const NamespaceAndGroupFilter = ({ rulesSourceName }: Props) => {
               {...field}
               onChange={(value) => {
                 setValue('ruleGroup', ''); //reset if namespace changes
-                onChange(value.value);
+                onChange(value?.value);
               }}
               id="namespace-picker"
               placeholder={t('alerting.namespace-and-group-filter.select-namespace', 'Select namespace')}
@@ -67,6 +67,7 @@ export const NamespaceAndGroupFilter = ({ rulesSourceName }: Props) => {
               width={42}
               loading={isLoading}
               disabled={isLoading || !rulesSourceName}
+              isClearable
             />
           )}
           name="namespace"
@@ -88,12 +89,13 @@ export const NamespaceAndGroupFilter = ({ rulesSourceName }: Props) => {
               options={groupOptions}
               width={42}
               onChange={(value) => {
-                setValue('ruleGroup', value.value ?? '');
+                setValue('ruleGroup', value?.value ?? '');
               }}
               id="group-picker"
               placeholder={t('alerting.namespace-and-group-filter.select-group', 'Select group')}
               loading={isLoading}
               disabled={isLoading || !namespace || !rulesSourceName}
+              isClearable
             />
           )}
           name="ruleGroup"


### PR DESCRIPTION
**What is this feature?**

This pr allows clearing namespace and group filters.

**Why do we need this feature?**

Allow users to clear these filters, otherwise we should reload the page.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
