### PR TITLE
Chore: Update eslint configs to ignore `/spec/` files when necessary

### DIFF
--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -96,8 +96,14 @@ module.exports = [
     },
   },
   {
-    files: ['**/*.{ts,tsx}'],
-    ignores: ['**/*.{test,spec}.{ts,tsx}', '**/__mocks__/**', '**/public/test/**', '**/mocks.{ts,tsx}'],
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    ignores: [
+      '**/*.{test,spec}.{ts,tsx}',
+      '**/__mocks__/**',
+      '**/public/test/**',
+      '**/mocks.{ts,tsx}',
+      '**/spec/**/*.{ts,tsx}',
+    ],
     rules: {
       '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
     },

--- a/.betterer.results
+++ b/.betterer.results
@@ -1723,8 +1723,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./external.utils\`)", "0"]
     ],
     "public/app/features/explore/spec/helper/setup.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/state/time.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -284,6 +284,7 @@ module.exports = [
       '**/*.{test,spec}.{ts,tsx}',
       '**/__mocks__/',
       'public/test',
+      '**/spec/**/*.{ts,tsx}',
     ],
     rules: {
       '@grafana/no-untranslated-strings': 'error',

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -34,7 +34,6 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
-import { t } from 'app/core/internationalization';
 import { GrafanaRoute } from 'app/core/navigation/GrafanaRoute';
 import { Echo } from 'app/core/services/echo/Echo';
 import { setLastUsedDatasourceUID } from 'app/core/utils/explore';
@@ -295,7 +294,7 @@ export function makeDatasourceSetup({
             // eslint-disable-next-line @grafana/no-untranslated-strings
             <div>
               <input
-                aria-label={t('explore.make-datasource-setup.aria-label-query', 'query')}
+                aria-label="query"
                 defaultValue={props.query.expr}
                 onChange={(event) => {
                   props.onChange({ ...props.query, expr: event.target.value });

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -290,8 +290,6 @@ export function makeDatasourceSetup({
       components: {
         QueryEditor(props: QueryEditorProps<LokiDatasource, LokiQuery>) {
           return (
-            // don't need translations, this is a test helper
-            // eslint-disable-next-line @grafana/no-untranslated-strings
             <div>
               <input
                 aria-label="query"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4738,9 +4738,6 @@
     "logs-volumne-panel-list": {
       "body-no-logs-volume-available": "No volume information available for the current queries and time range."
     },
-    "make-datasource-setup": {
-      "aria-label-query": "query"
-    },
     "next": "Next",
     "next-prev-result": {
       "aria-label-next": "Next result button",


### PR DESCRIPTION
**What is this feature?**
ESLint rules weren't skipping files in `/spec/` directories. There was a file that had a unneeded translation and a betterer issue for type assertion
