### PR TITLE
Chore: Remove alignRange function from prometheus frontend as it was moved to backend

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -19,7 +19,6 @@ import {
 import { config, getBackendSrv, setBackendSrv, TemplateSrv } from '@grafana/runtime';
 
 import {
-  alignRange,
   extractRuleMappingFromGroups,
   PrometheusDatasource,
   prometheusRegularEscape,
@@ -411,46 +410,6 @@ describe('PrometheusDatasource', () => {
       expect(parseInt(quantizedRange.end, 10) - parseInt(quantizedRange.start, 10)).toBe(
         (toSeconds - fromSeconds) / 1000
       );
-    });
-  });
-
-  describe('alignRange', () => {
-    it('does not modify already aligned intervals with perfect step', () => {
-      const range = alignRange(0, 3, 3, 0);
-      expect(range.start).toEqual(0);
-      expect(range.end).toEqual(3);
-    });
-
-    it('does modify end-aligned intervals to reflect number of steps possible', () => {
-      const range = alignRange(1, 6, 3, 0);
-      expect(range.start).toEqual(0);
-      expect(range.end).toEqual(6);
-    });
-
-    it('does align intervals that are a multiple of steps', () => {
-      const range = alignRange(1, 4, 3, 0);
-      expect(range.start).toEqual(0);
-      expect(range.end).toEqual(3);
-    });
-
-    it('does align intervals that are not a multiple of steps', () => {
-      const range = alignRange(1, 5, 3, 0);
-      expect(range.start).toEqual(0);
-      expect(range.end).toEqual(3);
-    });
-
-    it('does align intervals with local midnight -UTC offset', () => {
-      //week range, location 4+ hours UTC offset, 24h step time
-      const range = alignRange(4 * 60 * 60, (7 * 24 + 4) * 60 * 60, 24 * 60 * 60, -4 * 60 * 60); //04:00 UTC, 7 day range
-      expect(range.start).toEqual(4 * 60 * 60);
-      expect(range.end).toEqual((7 * 24 + 4) * 60 * 60);
-    });
-
-    it('does align intervals with local midnight +UTC offset', () => {
-      //week range, location 4- hours UTC offset, 24h step time
-      const range = alignRange(20 * 60 * 60, (8 * 24 - 4) * 60 * 60, 24 * 60 * 60, 4 * 60 * 60); //20:00 UTC on day1, 7 days later is 20:00 on day8
-      expect(range.start).toEqual(20 * 60 * 60);
-      expect(range.end).toEqual((8 * 24 - 4) * 60 * 60);
     });
   });
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -1071,28 +1071,6 @@ export class PrometheusDatasource
   }
 }
 
-/**
- * Align query range to step.
- * Rounds start and end down to a multiple of step.
- * @param start Timestamp marking the beginning of the range.
- * @param end Timestamp marking the end of the range.
- * @param step Interval to align start and end with.
- * @param utcOffsetSec Number of seconds current timezone is offset from UTC
- */
-export function alignRange(
-  start: number,
-  end: number,
-  step: number,
-  utcOffsetSec: number
-): { end: number; start: number } {
-  const alignedEnd = Math.floor((end + utcOffsetSec) / step) * step - utcOffsetSec;
-  const alignedStart = Math.floor((start + utcOffsetSec) / step) * step - utcOffsetSec;
-  return {
-    end: alignedEnd,
-    start: alignedStart,
-  };
-}
-
 export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQueryMapping {
   return groups.reduce<RuleQueryMapping>(
     (mapping, group) =>


### PR DESCRIPTION
**What is this feature?**

The functionality was moved to backend ([see it here](https://github.com/grafana/grafana/blob/a87df0528b2199405cec27589db718b51326e465/pkg/promlib/models/query.go#L429-L438)) and we don't need this function on frontend. 


**Why do we need this feature?**

The function was unnecessary

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
