### PR TITLE
Chore: Move getOriginalMetricName to the place where it's used

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -60,7 +60,7 @@ import { getQueryHints } from './query_hints';
 import { promQueryModeller } from './querybuilder/PromQueryModeller';
 import { QueryBuilderLabelFilter, QueryEditorMode } from './querybuilder/shared/types';
 import { CacheRequestInfo, defaultPrometheusQueryOverlapWindow, QueryCache } from './querycache/QueryCache';
-import { getOriginalMetricName, transformV2 } from './result_transformer';
+import { transformV2 } from './result_transformer';
 import { trackQuery } from './tracking';
 import {
   ExemplarTraceIdDestination,
@@ -902,10 +902,6 @@ export class PrometheusDatasource
       start: getPrometheusTime(timeRange.from, false).toString(),
       end: getPrometheusTime(timeRange.to, true).toString(),
     };
-  }
-
-  getOriginalMetricName(labelData: { [key: string]: string }) {
-    return getOriginalMetricName(labelData);
   }
 
   /**

--- a/packages/grafana-prometheus/src/metric_find_query.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.ts
@@ -12,6 +12,7 @@ import {
   PrometheusMetricNamesRegex,
   PrometheusQueryResultRegex,
 } from './migrations/variableMigration';
+import { getOriginalMetricName } from './result_transformer';
 import { escapeForUtf8Support, isValidLegacyName } from './utf8_support';
 
 export class PrometheusMetricFindQuery {
@@ -182,12 +183,11 @@ export class PrometheusMetricFindQuery {
     };
 
     const url = `/api/v1/series`;
-    const self = this;
 
     return this.datasource.metadataRequest(url, params).then((result) => {
       return _map(result.data.data, (metric: { [key: string]: string }) => {
         return {
-          text: self.datasource.getOriginalMetricName(metric),
+          text: getOriginalMetricName(metric),
           expandable: true,
         };
       });


### PR DESCRIPTION
**What is this feature?**

`getOriginalMetricName` is used only in `metric_find_query.ts` and no need to expose it in `datasource.ts`

