### PR TITLE
Alerting: Add recovering state to the grafana_alerting_alerts metric

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -52,6 +52,7 @@ func (c *cache) RegisterMetrics(r prometheus.Registerer) {
 	r.MustRegister(newAlertCountByState(eval.Pending))
 	r.MustRegister(newAlertCountByState(eval.Error))
 	r.MustRegister(newAlertCountByState(eval.NoData))
+	r.MustRegister(newAlertCountByState(eval.Recovering))
 }
 
 func (c *cache) countAlertsBy(state eval.State) float64 {


### PR DESCRIPTION
**What is this feature?**

Support for `keep_firing_for` was added in https://github.com/grafana/grafana/pull/100750 and introduced a new alert state: `recovering`. This PR adds the new state to the `grafana_alerting_alerts` metric that shows how many alerts per state are registered in the scheduler:

```
# HELP grafana_alerting_alerts How many alerts by state are in the scheduler.
# TYPE grafana_alerting_alerts gauge
grafana_alerting_alerts{state="alerting"} 1
grafana_alerting_alerts{state="recovering"} 1
...
```