### PR TITLE
docs(alerting): clarify transition to Recovering state when using recovery thresholds

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -137,7 +137,7 @@ If the threshold is set as the alert condition, the alert fires when the thresho
 
 ### Recovery threshold
 
-To reduce the noise from flapping alerts, you can set a recovery threshold so that the alert returns to the `Normal` state only after the recovery threshold is crossed.
+To reduce the noise from flapping alerts, you can set a recovery threshold so that the alert returns to the `Normal` or `Recovering` state only after the recovery threshold is crossed.
 
 Flapping alerts occur when the query value repeatedly crosses above and below the alert threshold, causing frequent state changes. This results in a series of firing-resolved-firing notifications and a noisy alert state history.
 
@@ -149,8 +149,8 @@ For example, if you have an alert for latency with a threshold of 1000ms and the
 
 To prevent this, you can set a recovery threshold to define two thresholds instead of one:
 
-1. An alert transitions to the `Pending` or `Alerting` state when the alert threshold is crossed.
-1. An alert transitions back to `Normal` state only after the recovery threshold is crossed.
+1. An alert transitions to the `Pending` or `Alerting` state when it crosses the alert threshold.
+1. It then transitions to the `Recovering` or `Normal` state only when it crosses the recovery threshold.
 
 In the previous example, setting the recovery threshold to 900ms means the alert only resolves when the latency falls below 900ms:
 


### PR DESCRIPTION
This PR updates the recovery thresholds docs detailing the possible transition to the Recovering state. 

Continuation of: 
- https://github.com/grafana/grafana/pull/103412 Docs: new `keep_firing_for` 
- https://github.com/grafana/grafana/pull/102780 Docs: clarify pending state when using recovery thresholds
- https://github.com/grafana/grafana/pull/102788: related UI changes 

⭐ [Preview](https://deploy-preview-grafana-104381-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#recovery-threshold)


