### PR TITLE
Database: use sqlx transaction rather than xorm

### DIFF
--- a/pkg/registry/apis/secret/contracts/database.go
+++ b/pkg/registry/apis/secret/contracts/database.go
@@ -3,10 +3,12 @@ package contracts
 import (
 	"context"
 	"database/sql"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 )
 
 type Database interface {
-	Transaction(ctx context.Context, f func(context.Context) error) error
+	Transaction(ctx context.Context, f func(*session.SessionTx) error) error
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...any) (Rows, error)
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -19,6 +19,7 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
+	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 )
 
 var (
@@ -133,7 +134,7 @@ func (s *SecureValueRest) Create(
 	// Assigned inside the transaction callback
 	var object runtime.Object
 
-	if err := s.database.Transaction(ctx, func(ctx context.Context) error {
+	if err := s.database.Transaction(ctx, func(*session.SessionTx) error {
 		// TODO: return err when secret already exists
 		createdSecureValue, err := s.secureValueMetadataStorage.Create(ctx, sv)
 		if err != nil {

--- a/pkg/registry/apis/secret/worker/worker.go
+++ b/pkg/registry/apis/secret/worker/worker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
@@ -67,7 +68,7 @@ func (w *Worker) ControlLoop(ctx context.Context) error {
 
 // TODO: don't rollback every message when a single error happens
 func (w *Worker) receiveAndProcessMessages(ctx context.Context) {
-	if err := w.database.Transaction(ctx, func(ctx context.Context) error {
+	if err := w.database.Transaction(ctx, func(sess *session.SessionTx) error {
 		timeoutCtx, cancel := context.WithTimeout(ctx, w.config.ReceiveTimeout)
 		messages, err := w.outboxQueue.ReceiveN(timeoutCtx, w.config.BatchSize)
 		cancel()

--- a/pkg/storage/secret/database/database.go
+++ b/pkg/storage/secret/database/database.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 )
 
 // Implements contracts.Database
@@ -13,12 +14,14 @@ type Database struct {
 	db db.DB
 }
 
+var _ contracts.Database = &Database{}
+
 func New(db db.DB) *Database {
 	return &Database{db: db}
 }
 
-func (db *Database) Transaction(ctx context.Context, f func(context.Context) error) error {
-	return db.db.InTransaction(ctx, f)
+func (db *Database) Transaction(ctx context.Context, f func(*session.SessionTx) error) error {
+	return db.db.GetSqlxSession().WithTransaction(ctx, f)
 }
 
 func (db *Database) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	claims "github.com/grafana/authlib/types"
@@ -109,11 +108,7 @@ func (s *keeperMetadataStorage) Read(ctx context.Context, namespace xkube.Namesp
 	return keeper, nil
 }
 
-type dbQuerier interface {
-	Query(ctx context.Context, query string, args ...any) (*sql.Rows, error)
-}
-
-func (s *keeperMetadataStorage) read(ctx context.Context, dbQuerier dbQuerier, namespace, name string, forUpdate sqlForUpdate) (*keeperDB, error) {
+func (s *keeperMetadataStorage) read(ctx context.Context, dbQuerier session.SessionQuerier, namespace, name string, forUpdate sqlForUpdate) (*keeperDB, error) {
 	req := &readKeeper{
 		SQLTemplate: sqltemplate.New(s.dialect),
 		Namespace:   namespace,


### PR DESCRIPTION
Swaps `xorm` transactions with `sqlx`. This "mixing" was causing `database is locked` issues in SQLite.