### PR TITLE
Data Sources: Add gauge for response size

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -48,7 +48,7 @@ var (
 			Namespace: "plugins",
 			Name:      "datasource_response_size",
 			Help:      "gauge of external data source response sizes returned to Grafana in bytes",
-		}, []string{"datasource_type", "secure_socks_ds_proxy_enabled", "endpoint"},
+		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
 	)
 
 	datasourceRequestsInFlight = promauto.NewGaugeVec(

--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -43,6 +43,14 @@ var (
 		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
 	)
 
+	datasourceResponseGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "plugins",
+			Name:      "datasource_response_size",
+			Help:      "gauge of external data source response sizes returned to Grafana in bytes",
+		}, []string{"datasource_type", "secure_socks_ds_proxy_enabled", "endpoint"},
+	)
+
 	datasourceRequestsInFlight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "grafana",
@@ -102,6 +110,7 @@ func executeMiddleware(next http.RoundTripper, labels prometheus.Labels) http.Ro
 		requestHistogram := datasourceRequestHistogram.MustCurryWith(labels)
 		requestInFlight := datasourceRequestsInFlight.With(labels)
 		responseSizeHistogram := datasourceResponseHistogram.With(labels)
+		responseSizeGauge := datasourceResponseGauge.With(labels)
 
 		res, err := promhttp.InstrumentRoundTripperDuration(requestHistogram,
 			promhttp.InstrumentRoundTripperCounter(requestCounter,
@@ -114,6 +123,7 @@ func executeMiddleware(next http.RoundTripper, labels prometheus.Labels) http.Ro
 		if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
 			res.Body = sdkhttpclient.CountBytesReader(res.Body, func(bytesRead int64) {
 				responseSizeHistogram.Observe(float64(bytesRead))
+				responseSizeGauge.Set(float64(bytesRead))
 			})
 		}
 


### PR DESCRIPTION
The histogram we have for recording data source HTTP response sizes is useful but doesn't provide a great picture of the response sizes at a point in time. Adding a gauge should improve our insight here.