### PR TITLE
Fix link in Use git sync doc

### DIFF
--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -24,7 +24,7 @@ Local file provisioning is an [experimental feature](https://grafana.com/docs/re
   - [Set up Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
   - [Set up file provisioning](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/)
   - [Work with provisioned dashboards](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/provisioned-dashboards/)
-  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>observability-as-code/provision-resources/use-git-sync/)
+  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
 <hr />
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -24,7 +24,7 @@ Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycl
   - [Set up Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
   - [Set up file provisioning](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/)
   - [Work with provisioned dashboards](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/provisioned-dashboards/)
-  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>observability-as-code/provision-resources/use-git-sync/)
+  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
 <hr />
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -24,7 +24,7 @@ Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycl
   - [Set up Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
   - [Set up file provisioning](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/)
   - [Work with provisioned dashboards](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/provisioned-dashboards/)
-  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>observability-as-code/provision-resources/use-git-sync/)
+  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
 <hr />
 

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -24,7 +24,7 @@ Git Sync and File path provisioning an [experimental feature](https://grafana.co
   - [Set up Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
   - [Set up file provisioning](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/)
   - [Work with provisioned dashboards](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/provisioned-dashboards/)
-  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>observability-as-code/provision-resources/use-git-sync/)
+  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
 <hr />
 

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -23,7 +23,7 @@ weight: 400
   - [Set up Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
   - [Set up file provisioning](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/)
   - [Work with provisioned dashboards](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/provisioned-dashboards/)
-  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>observability-as-code/provision-resources/use-git-sync/)
+  - [Manage provisioned repositories with Git Sync](/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
 <hr />
 


### PR DESCRIPTION
Fix a broken link in the Use git sync links in the docs. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
