### PR TITLE
fix: make data syncer run configurable on mode (2->3) change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -455,7 +455,7 @@ require (
 	github.com/mithrandie/ternary v1.1.1 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect	
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect

--- a/go.mod
+++ b/go.mod
@@ -455,7 +455,7 @@ require (
 	github.com/mithrandie/ternary v1.1.1 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -164,6 +164,10 @@ func SetDualWritingMode(
 			return Mode0, errDualWriterSetCurrentMode
 		}
 	case cfg.Mode >= Mode3 && currentMode < Mode3:
+		if cfg.DisableMigration {
+			return currentMode, nil
+		}
+
 		// Transitioning to Mode3 or higher requires data synchronization.
 		cfgModeTmp := cfg.Mode
 		// Before running the sync, set the syncer config to the current mode, as we have to run the syncer

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -164,7 +164,7 @@ func SetDualWritingMode(
 			return Mode0, errDualWriterSetCurrentMode
 		}
 	case cfg.Mode >= Mode3 && currentMode < Mode3:
-		if cfg.DisableMigration {
+		if cfg.SkipDataSync {
 			return currentMode, nil
 		}
 

--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -36,6 +36,7 @@ type SyncerConfig struct {
 	LegacyStorage     Storage
 	Storage           Storage
 	ServerLockService ServerLockService
+	DisableMigration  bool
 
 	DataSyncerInterval     time.Duration
 	DataSyncerRecordsLimit int

--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -36,7 +36,7 @@ type SyncerConfig struct {
 	LegacyStorage     Storage
 	Storage           Storage
 	ServerLockService ServerLockService
-	DisableMigration  bool
+	SkipDataSync      bool
 
 	DataSyncerInterval     time.Duration
 	DataSyncerRecordsLimit int

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestSetDualWritingMode(t *testing.T) {
 	type testCase struct {
-		name             string
-		kvStore          *fakeNamespacedKV
-		desiredMode      DualWriterMode
-		expectedMode     DualWriterMode
-		disableMigration bool
-		serverLockError  error
+		name            string
+		kvStore         *fakeNamespacedKV
+		desiredMode     DualWriterMode
+		expectedMode    DualWriterMode
+		skipDataSync    bool
+		serverLockError error
 	}
 	tests :=
 		[]testCase{
@@ -63,11 +63,11 @@ func TestSetDualWritingMode(t *testing.T) {
 				serverLockError: fmt.Errorf("lock already exists"),
 			},
 			{
-				name:             "should keep mode2 when trying to go from mode2 to mode3 and migration is disabled",
-				kvStore:          &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
-				desiredMode:      Mode3,
-				expectedMode:     Mode2,
-				disableMigration: true,
+				name:         "should keep mode2 when trying to go from mode2 to mode3 and migration is disabled",
+				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
+				desiredMode:  Mode3,
+				expectedMode: Mode2,
+				skipDataSync: true,
 			},
 		}
 
@@ -94,7 +94,7 @@ func TestSetDualWritingMode(t *testing.T) {
 			Storage:           us,
 			Kind:              "playlist.grafana.app/playlists",
 			Mode:              tt.desiredMode,
-			DisableMigration:  tt.disableMigration,
+			SkipDataSync:      tt.skipDataSync,
 			ServerLockService: serverLockSvc,
 			RequestInfo:       &request.RequestInfo{},
 			Reg:               p,

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -345,7 +345,7 @@ func InstallAPIs(
 				Kind:                   key,
 				RequestInfo:            requestInfo,
 				Mode:                   mode,
-				DisableMigration:       dualWriterMigrationDataSyncDisabled,
+				SkipDataSync:           dualWriterMigrationDataSyncDisabled,
 				LegacyStorage:          legacy,
 				Storage:                storage,
 				ServerLockService:      serverLock,

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -315,6 +315,7 @@ func InstallAPIs(
 
 			var (
 				dualWriterPeriodicDataSyncJobEnabled bool
+				dualWriterMigrationDataSyncDisabled  bool
 				dataSyncerInterval                   = time.Hour
 				dataSyncerRecordsLimit               = 1000
 			)
@@ -323,6 +324,7 @@ func InstallAPIs(
 			if resourceExists {
 				mode = resourceConfig.DualWriterMode
 				dualWriterPeriodicDataSyncJobEnabled = resourceConfig.DualWriterPeriodicDataSyncJobEnabled
+				dualWriterMigrationDataSyncDisabled = resourceConfig.DualWriterMigrationDataSyncDisabled
 				dataSyncerInterval = resourceConfig.DataSyncerInterval
 				dataSyncerRecordsLimit = resourceConfig.DataSyncerRecordsLimit
 			}
@@ -343,6 +345,7 @@ func InstallAPIs(
 				Kind:                   key,
 				RequestInfo:            requestInfo,
 				Mode:                   mode,
+				DisableMigration:       dualWriterMigrationDataSyncDisabled,
 				LegacyStorage:          legacy,
 				Storage:                storage,
 				ServerLockService:      serverLock,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -556,6 +556,7 @@ type Cfg struct {
 type UnifiedStorageConfig struct {
 	DualWriterMode                       rest.DualWriterMode
 	DualWriterPeriodicDataSyncJobEnabled bool
+	DualWriterMigrationDataSyncDisabled  bool
 	// DataSyncerInterval defines how often the data syncer should run for a resource on the grafana instance.
 	DataSyncerInterval time.Duration
 	// DataSyncerRecordsLimit defines how many records will be processed at max during a sync invocation.

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -30,6 +30,9 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		// parse dualWriter periodic data syncer config
 		dualWriterPeriodicDataSyncJobEnabled := section.Key("dualWriterPeriodicDataSyncJobEnabled").MustBool(false)
 
+		// parse dualWriter migration data sync disabled from resource section
+		dualWriterMigrationDataSyncDisabled := section.Key("dualWriterMigrationDataSyncDisabled").MustBool(false)
+
 		// parse dataSyncerRecordsLimit from resource section
 		dataSyncerRecordsLimit := section.Key("dataSyncerRecordsLimit").MustInt(1000)
 
@@ -39,6 +42,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		storageConfig[resourceName] = UnifiedStorageConfig{
 			DualWriterMode:                       rest.DualWriterMode(dualWriterMode),
 			DualWriterPeriodicDataSyncJobEnabled: dualWriterPeriodicDataSyncJobEnabled,
+			DualWriterMigrationDataSyncDisabled:  dualWriterMigrationDataSyncDisabled,
 			DataSyncerRecordsLimit:               dataSyncerRecordsLimit,
 			DataSyncerInterval:                   dataSyncerInterval,
 		}


### PR DESCRIPTION
Dual writer mode change from 2 -> 3 triggers the data syncer run. This PR makes this behavior configurable so that we can test the [migration controller](https://github.com/grafana/unistore-migration-controller) in dev.

- We will skip the automatic triggering of the data syncer, as we want migration controller to do the job.
- This capability will reside in the unified storage section (per resource) already present in `config.ini`.
- This will be a temporary config value, helping us test in the dev environment. We plan on removing the data syncer completely from the migration flow once we reach a stable status in dev.