### PR TITLE
Provisioning: allow history when exporting from unified storage

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -60,9 +60,5 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 		return w.legacyMigrator.Migrate(ctx, rw, *options, progress)
 	}
 
-	if options.History {
-		return errors.New("history is not yet supported in unified storage")
-	}
-
 	return w.unifiedMigrator.Migrate(ctx, rw, *options, progress)
 }

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -92,24 +92,6 @@ func TestMigrationWorker_WithHistory(t *testing.T) {
 		err := worker.Process(context.Background(), repo, job, progressRecorder)
 		require.EqualError(t, err, "history is only supported for github repositories")
 	})
-
-	t.Run("fail unified", func(t *testing.T) {
-		progressRecorder := jobs.NewMockJobProgressRecorder(t)
-		progressRecorder.On("SetTotal", mock.Anything, 10).Return()
-		progressRecorder.On("Strict").Return()
-
-		repo := repository.NewMockRepository(t)
-		repo.On("Config").Return(&provisioning.Repository{
-			Spec: provisioning.RepositorySpec{
-				Type: provisioning.GitHubRepositoryType,
-				GitHub: &provisioning.GitHubRepositoryConfig{
-					URL: "empty", // not valid
-				},
-			},
-		})
-		err := worker.Process(context.Background(), repo, job, progressRecorder)
-		require.EqualError(t, err, "history is not yet supported in unified storage")
-	})
 }
 
 func TestMigrationWorker_Process(t *testing.T) {


### PR DESCRIPTION
In unified storage, we do not keep full history; however we use the same flag to indicate if we want everything to exist in a single commit or not.  I think better to keep the flag and show user/time data even for the last value.