### PR TITLE
Alerting: Render duration in `<code>` block for better presentation for translated values

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -127,7 +127,7 @@ export function QueryPreview({
           i18nKey="alerting.query-preview.relative-time-range"
           values={{ from: rangeUtil.secondsToHms(relativeTimeRange.from) }}
         >
-          {'{{from}}'} to now
+          <code>{'{{from}}'}</code> to now
         </Trans>
       </Text>
     );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1728,7 +1728,7 @@
       "min-interval": "Min. Interval = {{minInterval}}"
     },
     "query-preview": {
-      "relative-time-range": "{{from}} to now"
+      "relative-time-range": "<0>{{from}}</0> to now"
     },
     "queryAndExpressionsStep": {
       "disableAdvancedOptions": {


### PR DESCRIPTION
**What is this feature?**
Renders the `from` part of the alert rule query preview in a code block, to make it clearer (especially when using other languages)

Before: 
![image](https://github.com/user-attachments/assets/5a651d04-8776-4e97-83a9-49adfbd88221)

After:
![image](https://github.com/user-attachments/assets/7a9aae29-5e62-491c-8c02-df537d645fb1)
