### PR TITLE
Extension Sidebar: Extend the default width from 300px -> 420px

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -10,7 +10,7 @@ import {
   useExtensionSidebarContext,
 } from './ExtensionSidebarProvider';
 
-export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = 300;
+export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = 420;
 export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = 700;
 


### PR DESCRIPTION
* the Assistant sidebar has a lot of text, this width is more comfortable for reading
* Investigations (the other use case) also benefits from a little more space
* It remains adjustable (and is sticky, so we remember the user's preference)

Before:
![image (7)](https://github.com/user-attachments/assets/78527e9a-7f45-42bf-bf9d-21cfb5aa6f53)

After:
![image (8)](https://github.com/user-attachments/assets/969f3232-a49f-4d37-81e1-d747968df9fa)
