### PR TITLE
I18n: Remove 'now' translations

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
@@ -14,7 +14,6 @@ import { Field } from '../../Forms/Field';
 import { Icon } from '../../Icon/Icon';
 import { getInputStyles, Input } from '../../Input/Input';
 import { ScrollContainer } from '../../ScrollContainer/ScrollContainer';
-import { Tooltip } from '../../Tooltip/Tooltip';
 import { TimePickerTitle } from '../TimeRangePicker/TimePickerTitle';
 import { TimeRangeList } from '../TimeRangePicker/TimeRangeList';
 import { quickOptions } from '../options';
@@ -170,13 +169,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
                   <div className={styles.rightSide}>
                     <div className={styles.title}>
                       <TimePickerTitle>
-                        <Tooltip content={<TooltipContent />} placement="bottom" theme="info">
-                          <div>
-                            <Trans i18nKey="time-picker.time-range.specify">
-                              Specify time range <Icon name="info-circle" />
-                            </Trans>
-                          </div>
-                        </Tooltip>
+                        <Trans i18nKey="time-picker.time-range.specify">Specify time range</Trans>
                       </TimePickerTitle>
                     </div>
                     <Field
@@ -219,48 +212,6 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
     </div>
   );
 }
-
-const TooltipContent = () => {
-  const styles = useStyles2(toolTipStyles);
-  return (
-    <>
-      <div className={styles.supported}>
-        <Trans i18nKey="time-picker.time-range.supported-formats">
-          Supported formats: <code className={styles.tooltip}>now-[digit]s/m/h/d/w</code>
-        </Trans>
-      </div>
-      <div>
-        <Trans i18nKey="time-picker.time-range.example">
-          Example: to select a time range from 10 minutes ago to now
-        </Trans>
-      </div>
-      <code className={styles.tooltip}>
-        <Trans i18nKey="time-picker.time-range.example-details">From: now-10m To: now</Trans>
-      </code>
-      <div className={styles.link}>
-        <Trans i18nKey="time-picker.time-range.more-info">
-          For more information see{' '}
-          <a href="https://grafana.com/docs/grafana/latest/dashboards/time-range-controls/">
-            docs <Icon name="external-link-alt" />
-          </a>
-          .
-        </Trans>
-      </div>
-    </>
-  );
-};
-
-const toolTipStyles = (theme: GrafanaTheme2) => ({
-  supported: css({
-    marginBottom: theme.spacing(1),
-  }),
-  tooltip: css({
-    margin: 0,
-  }),
-  link: css({
-    marginTop: theme.spacing(1),
-  }),
-});
 
 const getStyles = (fromError?: string, toError?: string) => (theme: GrafanaTheme2) => {
   const inputStyles = getInputStyles({ theme, invalid: false });

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -202,8 +202,8 @@ export const createUrlFromRichHistory = (query: RichHistoryQuery) => {
   const exploreState: ExploreUrlState = {
     /* Default range, as we are not saving timerange in rich history */
     range: {
-      from: t('explore.rich-history-utils.default-from', 'now-1h'),
-      to: t('explore.rich-history-utils.default-to', 'now'),
+      from: 'now-1h',
+      to: 'now',
     },
     datasource: query.datasourceName,
     queries: query.queries,

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -123,7 +123,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
           label={t('dashboard-settings.time-picker.refresh-live-dashboards-label', 'Refresh live dashboards')}
           description={t(
             'dashboard-settings.time-picker.refresh-live-dashboards-description',
-            "Continuously re-draw panels where the time range references 'now'"
+            'Continuously update panels when the time range includes the current time'
           )}
         >
           <Switch id="refresh-live-dashboards-toggle" value={!!this.props.liveNow} onChange={this.onLiveNowChange} />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4288,7 +4288,7 @@
       "hide-time-picker": "Hide time picker",
       "now-delay-description": "Exclude recent data that may be incomplete.",
       "now-delay-label": "Now delay",
-      "refresh-live-dashboards-description": "Continuously re-draw panels where the time range references 'now'",
+      "refresh-live-dashboards-description": "Continuously update panels when the time range includes the current time",
       "refresh-live-dashboards-label": "Refresh live dashboards",
       "time-options-label": "Time options",
       "time-zone-label": "Time zone",
@@ -4859,8 +4859,6 @@
     "rich-history-utils": {
       "a-week-ago": "a week ago",
       "days-ago": "{{num}} days ago",
-      "default-from": "now-1h",
-      "default-to": "now",
       "today": "today",
       "two-weeks-ago": "two weeks ago",
       "yesterday": "yesterday"
@@ -8522,15 +8520,11 @@
       "apply": "Apply time range",
       "aria-role": "Time range selection",
       "default-title": "Time ranges",
-      "example": "Example: to select a time range from 10 minutes ago to now",
-      "example-details": "From: now-10m To: now",
       "example-title": "Example time ranges",
       "from-label": "From",
       "from-to": "{{timeOptionFrom}} to {{timeOptionTo}}",
-      "more-info": "For more information see <2>docs <1></1></2>.",
-      "specify": "Specify time range <1></1>",
+      "specify": "Specify time range",
       "submit-button-label": "TimePicker submit button",
-      "supported-formats": "Supported formats: <1>now-[digit]s/m/h/d/w</1>",
       "to-label": "To"
     },
     "zone": {


### PR DESCRIPTION
We have some translations where the time range token 'now' has been translated when it should have been left as it's English literal.

This PR fixes this by:
 - Removing the help tooltip from [RelativeTimeRangePicker](https://developers.grafana.com/ui/canary/index.html?path=/story/pickers-and-editors-timepickers-relativetimerangepicker--basic) - we don't do thise elsewhere, and the link to help docs can't be clicked because its in a tooltip
 - Not untranslating the default time ranges in the initial Explore state. 
 - Reword the English description of the 'Refresh live dashboards' Dashboard setting description to avoid mentioning 'now' at all. 
   - This was a weird one because I can't decide whether this is refering to the time range value, or just the concept of 'now'. I changed it to more clearly refer to the concept of "currently".