### PR TITLE
UnifiedStorage: enable unifiedStorageHistoryPruner by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -958,6 +958,7 @@ export interface FeatureToggles {
   alertingMigrationUI?: boolean;
   /**
   * Enables the unified storage history pruner
+  * @default true
   */
   unifiedStorageHistoryPruner?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1646,10 +1646,11 @@ var (
 		{
 			Name:              "unifiedStorageHistoryPruner",
 			Description:       "Enables the unified storage history pruner",
-			Stage:             FeatureStageExperimental,
+			Stage:             FeatureStageGeneralAvailability,
 			Owner:             grafanaSearchAndStorageSquad,
 			HideFromAdminPage: true,
 			HideFromDocs:      true,
+			Expression:        "true", // will be removed soon
 		},
 		{
 			Name:        "azureMonitorLogsBuilderEditor",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -215,7 +215,7 @@ grafanaManagedRecordingRulesDatasources,experimental,@grafana/alerting-squad,fal
 infinityRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 inviteUserExperimental,experimental,@grafana/sharing-squad,false,false,true
 alertingMigrationUI,experimental,@grafana/alerting-squad,false,false,true
-unifiedStorageHistoryPruner,experimental,@grafana/search-and-storage,false,false,false
+unifiedStorageHistoryPruner,GA,@grafana/search-and-storage,false,false,false
 azureMonitorLogsBuilderEditor,preview,@grafana/partner-datasources,false,false,false
 localeFormatPreference,experimental,@grafana/grafana-frontend-platform,false,false,false
 unifiedStorageGrpcConnectionPool,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2963,15 +2963,19 @@
     {
       "metadata": {
         "name": "unifiedStorageHistoryPruner",
-        "resourceVersion": "1745339544057",
-        "creationTimestamp": "2025-03-17T10:36:38Z"
+        "resourceVersion": "1745478115689",
+        "creationTimestamp": "2025-03-17T10:36:38Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-04-24 07:01:55.689179 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the unified storage history pruner",
-        "stage": "experimental",
+        "stage": "GA",
         "codeowner": "@grafana/search-and-storage",
         "hideFromAdminPage": true,
-        "hideFromDocs": true
+        "hideFromDocs": true,
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
`unifiedStorageHistoryPruner` has been running in cloud for more than a month -- lets make it the default.

With controllers (provisioning/gitsync!) the history can grow very fast!