### PR TITLE
RowsLayout: Fixes min height issue

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -206,7 +206,6 @@ function getStyles(theme: GrafanaTheme2) {
     wrapper: css({
       display: 'flex',
       flexDirection: 'column',
-      minHeight: '100px',
     }),
     wrapperNotCollapsed: css({
       '> div:nth-child(2)': {


### PR DESCRIPTION
This min-height: 100px made it so that it was no possible to have very small rows (left empty space at the bottom).

Don't think we need this min-height. I think with the canvas buttons rows always have some height to act as drop targets (in edit mode), and in view mode if a row has no content inside it it needs no height 