### PR TITLE
Alerting: Fix flaky test

### DIFF
--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -82,6 +82,7 @@ func TestProcessTicks(t *testing.T) {
 		RecordingRulesCfg: rrSet,
 		Tracer:            testTracer,
 		Log:               log.New("ngalert.scheduler"),
+		FeatureToggles:    featuremgmt.WithFeatures(),
 	}
 	managerCfg := state.ManagerCfg{
 		Metrics:       testMetrics.GetStateMetrics(),


### PR DESCRIPTION
Have seen occasional flakes in the `TestProcessTicks` test - was due to a nil interface. This PR fixes that.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
