### PR TITLE
Alerting: Add alertingBulkActionsInUI feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1027,4 +1027,9 @@ export interface FeatureToggles {
   * @default false
   */
   alertRuleUseFiredAtForStartsAt?: boolean;
+  /**
+  * Enables the alerting bulk actions in the UI
+  * @default true
+  */
+  alertingBulkActionsInUI?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1768,6 +1768,16 @@ var (
 			Owner:       grafanaAlertingSquad,
 			Expression:  "false",
 		},
+		{
+			Name:              "alertingBulkActionsInUI",
+			Description:       "Enables the alerting bulk actions in the UI",
+			FrontendOnly:      true,
+			Stage:             FeatureStageGeneralAvailability,
+			Owner:             grafanaAlertingSquad,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+			Expression:        "true", // enabled by default
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -231,3 +231,4 @@ metricsFromProfiles,experimental,@grafana/observability-traces-and-profiling,fal
 pluginsAutoUpdate,experimental,@grafana/plugins-platform-backend,false,false,false
 alertingListViewV2PreviewToggle,privatePreview,@grafana/alerting-squad,false,false,true
 alertRuleUseFiredAtForStartsAt,experimental,@grafana/alerting-squad,false,false,false
+alertingBulkActionsInUI,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -934,4 +934,8 @@ const (
 	// FlagAlertRuleUseFiredAtForStartsAt
 	// Use FiredAt for StartsAt when sending alerts to Alertmaanger
 	FlagAlertRuleUseFiredAtForStartsAt = "alertRuleUseFiredAtForStartsAt"
+
+	// FlagAlertingBulkActionsInUI
+	// Enables the alerting bulk actions in the UI
+	FlagAlertingBulkActionsInUI = "alertingBulkActionsInUI"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -98,6 +98,25 @@
     },
     {
       "metadata": {
+        "name": "alertingBulkActionsInUI",
+        "resourceVersion": "1745504721038",
+        "creationTimestamp": "2025-04-24T14:01:56Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-04-24 14:25:21.03825 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables the alerting bulk actions in the UI",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true,
+        "hideFromDocs": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingCentralAlertHistory",
         "resourceVersion": "1745339544057",
         "creationTimestamp": "2024-05-29T15:01:38Z"


### PR DESCRIPTION
**What is this feature?**

This PR adds the new feature toggle `alertingBulkActionsInUI` for protecting a new feature : Bulk actions for alerting folders in the UI. This feature will be enabled by default.

**Why do we need this feature?**

We want to protect this new feature, as it can potentially be destructive.

**Who is this feature for?**

Alerting devs.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
