### PR TITLE
SecretsManager: Add field validation on spec for some fields

### DIFF
--- a/pkg/apis/secret/go.mod
+++ b/pkg/apis/secret/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apimachinery v0.32.3
 	k8s.io/apiserver v0.32.3
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 )
 
 require (
@@ -94,7 +95,6 @@ require (
 	k8s.io/client-go v0.32.3 // indirect
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/apis/secret/v0alpha1/keeper.go
+++ b/pkg/apis/secret/v0alpha1/keeper.go
@@ -16,7 +16,7 @@ type Keeper struct {
 	// This is the actual keeper schema.
 	// +patchStrategy=replace
 	// +patchMergeKey=name
-	Spec KeeperSpec `json:"spec,omitempty" patchStrategy:"replace" patchMergeKey:"name"`
+	Spec KeeperSpec `json:"spec" patchStrategy:"replace" patchMergeKey:"name"`
 }
 
 func (k *Keeper) IsSqlKeeper() bool {
@@ -29,13 +29,33 @@ type KeeperConfig interface {
 
 type KeeperSpec struct {
 	// Human friendly name for the keeper.
+	// +k8s:validation:minLength=1
+	// +k8s:validation:maxLength=253
 	Title string `json:"title"`
 
-	// You can only chose one of the following.
-	SQL       *SQLKeeperConfig       `json:"sql,omitempty"`
-	AWS       *AWSKeeperConfig       `json:"aws,omitempty"`
-	Azure     *AzureKeeperConfig     `json:"azurekeyvault,omitempty"`
-	GCP       *GCPKeeperConfig       `json:"gcp,omitempty"`
+	// SQL Keeper Configuration.
+	// +structType=atomic
+	// +optional
+	SQL *SQLKeeperConfig `json:"sql,omitempty"`
+
+	// AWS Keeper Configuration.
+	// +structType=atomic
+	// +optional
+	AWS *AWSKeeperConfig `json:"aws,omitempty"`
+
+	// Azure Keeper Configuration.
+	// +structType=atomic
+	// +optional
+	Azure *AzureKeeperConfig `json:"azurekeyvault,omitempty"`
+
+	// GCP Keeper Configuration.
+	// +structType=atomic
+	// +optional
+	GCP *GCPKeeperConfig `json:"gcp,omitempty"`
+
+	// HashiCorp Vault Keeper Configuration.
+	// +structType=atomic
+	// +optional
 	HashiCorp *HashiCorpKeeperConfig `json:"hashivault,omitempty"`
 }
 
@@ -99,15 +119,19 @@ type HashiCorpCredentials struct {
 type Envelope struct{}
 
 // Holds the way credentials are obtained.
+// +union
 type CredentialValue struct {
 	// The name of the secure value that holds the actual value.
+	// +optional
 	SecureValueName string `json:"secureValueName,omitempty"`
 
 	// The value is taken from the environment variable.
+	// +optional
 	ValueFromEnv string `json:"valueFromEnv,omitempty"`
 
 	// The value is taken from the Grafana config file.
 	// TODO: how do we explain that this is a path to the config file?
+	// +optional
 	ValueFromConfig string `json:"valueFromConfig,omitempty"`
 }
 

--- a/pkg/apis/secret/v0alpha1/secure_value.go
+++ b/pkg/apis/secret/v0alpha1/secure_value.go
@@ -14,11 +14,11 @@ type SecureValue struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// This is the actual secure value schema.
-	Spec SecureValueSpec `json:"spec,omitempty"`
+	Spec SecureValueSpec `json:"spec"`
 
 	// Read-only observed status of the `SecureValue`.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	Status SecureValueStatus `json:"status"`
+	Status SecureValueStatus `json:"status,omitempty"`
 }
 
 // +enum
@@ -50,30 +50,33 @@ type SecureValueStatus struct {
 
 type SecureValueSpec struct {
 	// Human friendly name for the secure value.
+	// +k8s:validation:minLength=1
+	// +k8s:validation:maxLength=253
 	Title string `json:"title"`
 
 	// The raw value is only valid for write. Read/List will always be empty.
 	// There is no support for mixing `value` and `ref`, you can't create a secret in a third-party keeper with a specified `ref`.
+	// +k8s:validation:minLength=1
 	Value ExposedSecureValue `json:"value,omitempty"`
 
-	// When using a remote Key manager, the ref is used to reference a value inside the remote storage.
+	// When using a third-party keeper, the `ref` is used to reference a value inside the remote storage.
 	// This should not contain sensitive information.
+	// +k8s:validation:minLength=1
+	// +k8s:validation:maxLength=1024
+	// +optional
 	Ref string `json:"ref,omitempty"`
 
 	// Name of the keeper, being the actual storage of the secure value.
 	// If not specified, the default keeper for the namespace will be used.
+	// +k8s:validation:minLength=1
+	// +k8s:validation:maxLength=253
 	// +optional
 	Keeper *string `json:"keeper,omitempty"`
 
 	// The Decrypters that are allowed to decrypt this secret.
 	// An empty list means no service can decrypt it.
-	// Support and behavior is still TBD, but could likely look like:
-	// * testdata.grafana.app/{name1}
-	// * testdata.grafana.app/{name2}
-	// * runner.k6.grafana.app/*  -- allow any k6 test runner
-	// Rather than a string pattern, we may want a more explicit object:
-	// [{ group:"testdata.grafana.app", name="name1"},
-	//  { group:"runner.k6.grafana.app"}]
+	// +k8s:validation:maxItems=64
+	// +k8s:validation:uniqueItems=true
 	// +listType=atomic
 	// +optional
 	Decrypters []string `json:"decrypters"`

--- a/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
@@ -10,6 +10,7 @@ package v0alpha1
 import (
 	common "k8s.io/kube-openapi/pkg/common"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
+	ptr "k8s.io/utils/ptr"
 )
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
@@ -214,6 +215,19 @@ func schema_pkg_apis_secret_v0alpha1_CredentialValue(ref common.ReferenceCallbac
 							Description: "The value is taken from the Grafana config file.",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-unions": []interface{}{
+						map[string]interface{}{
+							"fields-to-discriminateBy": map[string]interface{}{
+								"secureValueName": "SecureValueName",
+								"valueFromConfig": "ValueFromConfig",
+								"valueFromEnv":    "ValueFromEnv",
+							},
 						},
 					},
 				},
@@ -424,6 +438,7 @@ func schema_pkg_apis_secret_v0alpha1_Keeper(ref common.ReferenceCallback) common
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -490,34 +505,65 @@ func schema_pkg_apis_secret_v0alpha1_KeeperSpec(ref common.ReferenceCallback) co
 						SchemaProps: spec.SchemaProps{
 							Description: "Human friendly name for the keeper.",
 							Default:     "",
+							MinLength:   ptr.To[int64](1),
+							MaxLength:   ptr.To[int64](253),
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"sql": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Description: "You can only chose one of the following.",
+							Description: "SQL Keeper Configuration.",
 							Ref:         ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.SQLKeeperConfig"),
 						},
 					},
 					"aws": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.AWSKeeperConfig"),
+							Description: "AWS Keeper Configuration.",
+							Ref:         ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.AWSKeeperConfig"),
 						},
 					},
 					"azurekeyvault": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.AzureKeeperConfig"),
+							Description: "Azure Keeper Configuration.",
+							Ref:         ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.AzureKeeperConfig"),
 						},
 					},
 					"gcp": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.GCPKeeperConfig"),
+							Description: "GCP Keeper Configuration.",
+							Ref:         ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.GCPKeeperConfig"),
 						},
 					},
 					"hashivault": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.HashiCorpKeeperConfig"),
+							Description: "HashiCorp Vault Keeper Configuration.",
+							Ref:         ref("github.com/grafana/grafana/pkg/apis/secret/v0alpha1.HashiCorpKeeperConfig"),
 						},
 					},
 				},
@@ -591,7 +637,7 @@ func schema_pkg_apis_secret_v0alpha1_SecureValue(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"status"},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -658,6 +704,8 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "Human friendly name for the secure value.",
 							Default:     "",
+							MinLength:   ptr.To[int64](1),
+							MaxLength:   ptr.To[int64](253),
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -665,13 +713,16 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The raw value is only valid for write. Read/List will always be empty. There is no support for mixing `value` and `ref`, you can't create a secret in a third-party keeper with a specified `ref`.",
+							MinLength:   ptr.To[int64](1),
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"ref": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When using a remote Key manager, the ref is used to reference a value inside the remote storage. This should not contain sensitive information.",
+							Description: "When using a third-party keeper, the `ref` is used to reference a value inside the remote storage. This should not contain sensitive information.",
+							MinLength:   ptr.To[int64](1),
+							MaxLength:   ptr.To[int64](1024),
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -679,6 +730,8 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 					"keeper": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the keeper, being the actual storage of the secure value. If not specified, the default keeper for the namespace will be used.",
+							MinLength:   ptr.To[int64](1),
+							MaxLength:   ptr.To[int64](253),
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -690,7 +743,9 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "The Decrypters that are allowed to decrypt this secret. An empty list means no service can decrypt it. Support and behavior is still TBD, but could likely look like: * testdata.grafana.app/{name1} * testdata.grafana.app/{name2} * runner.k6.grafana.app/*  -- allow any k6 test runner Rather than a string pattern, we may want a more explicit object: [{ group:\"testdata.grafana.app\", name=\"name1\"},\n { group:\"runner.k6.grafana.app\"}]",
+							Description: "The Decrypters that are allowed to decrypt this secret. An empty list means no service can decrypt it.",
+							MaxItems:    ptr.To[int64](64),
+							UniqueItems: true,
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -364,6 +364,17 @@ func validateSecureValueUpdate(sv, oldSv *secretv0alpha1.SecureValue) field.Erro
 func validateDecrypters(decrypters []string, decryptersAllowList map[string]struct{}) field.ErrorList {
 	errs := make(field.ErrorList, 0)
 
+	// Limit the number of decrypters to 64 to not have it unbounded.
+	// The number was chosen arbitrarily and should be enough.
+	if len(decrypters) > 64 {
+		errs = append(
+			errs,
+			field.TooMany(field.NewPath("spec", "decrypters"), len(decrypters), 64),
+		)
+
+		return errs
+	}
+
 	decrypterNames := make(map[string]struct{}, 0)
 
 	for i, decrypter := range decrypters {

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -262,4 +262,23 @@ func TestValidateSecureValue(t *testing.T) {
 			require.Empty(t, errs)
 		})
 	})
+
+	t.Run("`decrypters` cannot have more than 64 items", func(t *testing.T) {
+		decrypters := make([]string, 0, 64+1)
+		for i := 0; i < 64+1; i++ {
+			decrypters = append(decrypters, fmt.Sprintf("actor_app%d", i))
+		}
+
+		sv := &secretv0alpha1.SecureValue{
+			Spec: secretv0alpha1.SecureValueSpec{
+				Title: "title", Ref: "ref",
+
+				Decrypters: decrypters,
+			},
+		}
+
+		errs := ValidateSecureValue(sv, nil, admission.Create, nil)
+		require.Len(t, errs, 1)
+		require.Equal(t, "spec.decrypters", errs[0].Field)
+	})
 }

--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -52,10 +52,10 @@ func initSecretStore(mg *migrator.Migrator) string {
 			{Name: "status_message", Type: migrator.DB_Text, Nullable: true},
 
 			// Spec
-			{Name: "title", Type: migrator.DB_Text, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Chosen arbitrarily, but should be enough for a human friendly name.
 			{Name: "keeper", Type: migrator.DB_NVarchar, Length: 253, Nullable: true}, // Keeper name, if not set, use default keeper.
 			{Name: "decrypters", Type: migrator.DB_Text, Nullable: true},
-			{Name: "ref", Type: migrator.DB_Text, Nullable: true}, // Reference to third-party storage secret path.
+			{Name: "ref", Type: migrator.DB_NVarchar, Length: 1024, Nullable: true}, // Reference to third-party storage secret path.Chosen arbitrarily, but should be enough.
 			{Name: "external_id", Type: migrator.DB_Text, Nullable: false},
 		},
 		Indices: []*migrator.Index{
@@ -78,7 +78,7 @@ func initSecretStore(mg *migrator.Migrator) string {
 			{Name: "updated_by", Type: migrator.DB_Text, Nullable: false},
 
 			// Spec
-			{Name: "title", Type: migrator.DB_Text, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Chosen arbitrarily, but should be enough for a human friendly name.
 			{Name: "type", Type: migrator.DB_Text, Nullable: false},
 			// Each keeper has a different payload so we store the whole thing as a blob.
 			{Name: "payload", Type: migrator.DB_Text, Nullable: true},


### PR DESCRIPTION
Adds a limit of 253 characters to the `title` for both SecureValue and Keeper. Why this value? Same one K8s enforces for `name` and `namespace`...

Adds a limit of 1024 characters to the `ref`. Why? Nice and round number, should be more than enough for anyone!

Also a limit of 64 decrypters in the list. I don't think we'll ever reach that, unless we support specific decrypters by name. But even then.