### PR TITLE
Log Controls: Add dividers and increase max height of the panel

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1253,7 +1253,7 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
     scrollableLogRows: css({
       overflowY: 'scroll',
       width: '100%',
-      maxHeight: '75vh',
+      maxHeight: '80vh',
     }),
     logRows: css({
       overflowX: `${wrapLogMessage ? 'unset' : 'scroll'}`,

--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -184,7 +184,7 @@ const styles = {
   scrollableLogRows: css({
     overflowY: 'auto',
     width: '100%',
-    maxHeight: '75vh',
+    maxHeight: '80vh',
   }),
   forwardedScrollableLogRows: css({
     overflowY: 'auto',

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -233,6 +233,7 @@ export const LogListControls = ({ eventBus, visualisationType = 'logs' }: Props)
           />
           {visualisationType === 'logs' && (
             <>
+              <div className={styles.divider} />
               <Dropdown overlay={deduplicationMenu} placement="auto-end">
                 <IconButton
                   name={'filter'}
@@ -253,6 +254,7 @@ export const LogListControls = ({ eventBus, visualisationType = 'logs' }: Props)
                   size="lg"
                 />
               </Dropdown>
+              <div className={styles.divider} />
               <IconButton
                 name="clock-nine"
                 aria-pressed={showTime}


### PR DESCRIPTION
Small follow up to https://github.com/grafana/grafana/pull/103401 , increasing the max height a bit, and adding more dividers to the controls, so that we have:

```
Scroll bottom
Sort order
---------------
Filters (level and dedup)
---------------
Timestamp
Unique labels
Wrap
Prettify
Escape newlines
---------------
Download
```

![Controls](https://github.com/user-attachments/assets/21d88630-b64d-48e9-842d-a9eaae4e965a)

