### PR TITLE
[release-12.0.0] K8s: Dashboards: Fix provisioned dashboard cleanup (#104504)

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -303,19 +303,15 @@ func (a *dashboardSqlAccess) scanRow(rows *sql.Rows, history bool) (*dashboardRo
 		}
 
 		if origin_name.String != "" {
-			// if the reader cannot be found, it may be an orphaned provisioned dashboard
-			resolvedPath := a.provisioning.GetDashboardProvisionerResolvedPath(origin_name.String)
-			if resolvedPath != "" {
-				meta.SetSourceProperties(utils.SourceProperties{
-					Path:            origin_path.String,
-					Checksum:        origin_hash.String,
-					TimestampMillis: origin_ts.Int64,
-				})
-				meta.SetManagerProperties(utils.ManagerProperties{
-					Kind:     utils.ManagerKindClassicFP, // nolint:staticcheck
-					Identity: origin_name.String,
-				})
-			}
+			meta.SetSourceProperties(utils.SourceProperties{
+				Path:            origin_path.String,
+				Checksum:        origin_hash.String,
+				TimestampMillis: origin_ts.Int64,
+			})
+			meta.SetManagerProperties(utils.ManagerProperties{
+				Kind:     utils.ManagerKindClassicFP, // nolint:staticcheck
+				Identity: origin_name.String,
+			})
 		} else if plugin_id.String != "" {
 			meta.SetManagerProperties(utils.ManagerProperties{
 				Kind:     utils.ManagerKindPlugin,

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1153,8 +1153,11 @@ func (dr *DashboardServiceImpl) UnprovisionDashboard(ctx context.Context, dashbo
 				UpdatedAt: time.Now(),
 				Dashboard: dash.Data,
 			}, nil, true)
+			if err != nil {
+				return err
+			}
 
-			return err
+			return dr.dashboardStore.UnprovisionDashboard(ctx, dashboardId)
 		}
 
 		return dashboards.ErrDashboardNotFound

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1118,6 +1118,7 @@ func TestUnprovisionDashboard(t *testing.T) {
 			},
 			"spec": map[string]any{},
 		}}
+		fakeStore.On("UnprovisionDashboard", mock.Anything, int64(1)).Return(nil).Once()
 		k8sCliMock.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(dash, nil)
 		dashWithoutAnnotations := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": dashboardv0.APIVERSION,
@@ -1168,6 +1169,7 @@ func TestUnprovisionDashboard(t *testing.T) {
 		err := service.UnprovisionDashboard(ctx, 1)
 		require.NoError(t, err)
 		k8sCliMock.AssertExpectations(t)
+		fakeStore.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104504 - This PR fixes two issues with dashboard provisioning cleanup:

1. Orphaned provisioned (i.e. dashboards were created via file provisioning, and then that file provisioner was deleted). Here, we are supposed to delete those dashboards. However, the manager property annotations was only being set on provisioned dashboards if the provisioner still exists, because it tries to [resolve](https://github.com/grafana/grafana/blob/7ed17cacbfb5c222e05da126abd3d22f96f82c97/pkg/services/provisioning/provisioning.go#L332) the path, but if the provisioner was deleted, then that will return an empty string, and then we do not set the annotations. Then when [cleaning up orphaned dashboards](https://github.com/grafana/grafana/blob/7ed17cacbfb5c222e05da126abd3d22f96f82c97/pkg/services/dashboards/service/dashboard_service.go#L901), we [check](https://github.com/grafana/grafana/blob/7ed17cacbfb5c222e05da126abd3d22f96f82c97/pkg/services/dashboards/service/dashboard_service.go#L2142) for the annotations, and we want to get dashboards that have those annotations but do not have a provisioner associated, so we can clean them up.
2. If disableDeletion was added to the file based provisioning, we were not deleting the data from the dashboard_provisioning table, so the table was never marked as not provisioned. It was not deleted, but still was not unprovisioned.