### PR TITLE
[release-12.0.1] K8s: Dashboards: Fix transformation between v1 and v2 (#104502)

### DIFF
--- a/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
@@ -78,7 +78,7 @@ AnnotationPanelFilter: {
 	exclude?: bool | *false
 
 	// Panel IDs that should be included or excluded
-	ids: [...uint8]
+	ids: [...uint32]
 }
 
 // "Off" for no shared crosshair or tooltip (default).

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec.cue
@@ -82,7 +82,7 @@ AnnotationPanelFilter: {
 	exclude?: bool | *false
 
 	// Panel IDs that should be included or excluded
-	ids: [...uint8]
+	ids: [...uint32]
 }
 
 // "Off" for no shared crosshair or tooltip (default).

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
@@ -73,7 +73,7 @@ type DashboardAnnotationPanelFilter struct {
 	// Should the specified panels be included or excluded
 	Exclude *bool `json:"exclude,omitempty"`
 	// Panel IDs that should be included or excluded
-	Ids []uint8 `json:"ids"`
+	Ids []uint32 `json:"ids"`
 }
 
 // NewDashboardAnnotationPanelFilter creates a new DashboardAnnotationPanelFilter object.

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi.go
@@ -538,7 +538,7 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardAnnotationPanelFilter(ref commo
 									SchemaProps: spec.SchemaProps{
 										Default: 0,
 										Type:    []string{"integer"},
-										Format:  "byte",
+										Format:  "int64",
 									},
 								},
 							},

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi_violation_exceptions.list
@@ -3,6 +3,7 @@ API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardAdhocVariableSpec,BaseFilters
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardAdhocVariableSpec,DefaultKeys
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardAdhocVariableSpec,Filters
+API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardAnnotationPanelFilter,Ids
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardAutoGridLayoutSpec,Items
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardConditionalRenderingGroupSpec,Items
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1,DashboardCustomVariableSpec,Options

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
@@ -1087,6 +1087,9 @@
             "type": "string",
             "default": ""
           },
+          "origin": {
+            "type": "string"
+          },
           "value": {
             "type": "string",
             "default": ""
@@ -1212,7 +1215,7 @@
             "type": "array",
             "items": {
               "type": "integer",
-              "format": "byte",
+              "format": "int64",
               "default": 0
             }
           }

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
@@ -1087,9 +1087,6 @@
             "type": "string",
             "default": ""
           },
-          "origin": {
-            "type": "string"
-          },
           "value": {
             "type": "string",
             "default": ""


### PR DESCRIPTION
backport of https://github.com/grafana/grafana/pull/104502 - Without this fix you cannot save a v1 dashboard with annotations on specific panels to a v2 dashboard

Due to https://github.com/grafana/grafana-app-sdk/issues/765, transforming from v1 to v2 with annotations fails. While we wait for the app sdk fix, this will fix it in grafana. 