### PR TITLE
CI: Remove bad caching from integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -23,22 +23,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Restore GOCACHE
-        uses: actions/cache/restore@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-sqlite
-          restore-keys: |
-            go-test-cache-${{ github.base_ref }}-sqlite
-            go-test-cache-main-sqlite
-          path: /home/runner/.cache/go-build
       - run: |
           make gen-go
           go test -tags=sqlite -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
-      - name: Save GOCACHE
-        uses: actions/cache/save@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-sqlite
-          path: /home/runner/.cache/go-build
   mysql:
     name: MySQL
     runs-on: ubuntu-latest-8-cores
@@ -64,24 +51,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Restore GOCACHE
-        uses: actions/cache/restore@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-mysql
-          restore-keys: |
-            go-test-cache-${{ github.base_ref }}-mysql
-            go-test-cache-main-mysql
-          path: /home/runner/.cache/go-build
       - run: |
           sudo apt-get update -yq && sudo apt-get install mariadb-client
           cat devenv/docker/blocks/mysql_tests/setup.sql | mariadb -h 127.0.0.1 -P 3306 -u root -prootpass --disable-ssl-verify-server-cert
           make gen-go
           go test -tags=mysql -p=1 -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
-      - name: Save GOCACHE
-        uses: actions/cache/save@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-mysql
-          path: /home/runner/.cache/go-build
   postgres:
     name: Postgres
     runs-on: ubuntu-latest-8-cores
@@ -102,14 +76,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Restore GOCACHE
-        uses: actions/cache/restore@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-postgres
-          restore-keys: |
-            go-test-cache-${{ github.base_ref }}-postgres
-            go-test-cache-main-postgres
-          path: /home/runner/.cache/go-build
       - env:
           GRAFANA_TEST_DB: postgres
           PGPASSWORD: grafanatest
@@ -119,8 +85,3 @@ jobs:
           psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
           make gen-go
           go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
-      - name: Save GOCACHE
-        uses: actions/cache/save@v4
-        with:
-          key: go-test-cache-${{ github.ref_name }}-postgres
-          path: /home/runner/.cache/go-build


### PR DESCRIPTION
This caching strategy didn't work out unfortunately.