### PR TITLE
[release-12.0.1] Provisioning: Remove warning logs for valid usage (#104555)

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -743,7 +743,7 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 	var userID int64
 	if id, err := identity.UserIdentifier(dto.User.GetID()); err == nil {
 		userID = id
-	} else {
+	} else if !identity.IsServiceIdentity(ctx) {
 		dr.log.Debug("User does not belong to a user or service account namespace, using 0 as user ID", "id", dto.User.GetID())
 	}
 

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -768,7 +768,7 @@ func (s *Service) CreateLegacy(ctx context.Context, cmd *folder.CreateFolderComm
 	var userID int64
 	if id, err := identity.UserIdentifier(cmd.SignedInUser.GetID()); err == nil {
 		userID = id
-	} else {
+	} else if !identity.IsServiceIdentity(ctx) {
 		s.log.Warn("User does not belong to a user or service account namespace, using 0 as user ID", "id", cmd.SignedInUser.GetID())
 	}
 
@@ -918,7 +918,7 @@ func (s *Service) legacyUpdate(ctx context.Context, cmd *folder.UpdateFolderComm
 	var userID int64
 	if id, err := identity.UserIdentifier(cmd.SignedInUser.GetID()); err == nil {
 		userID = id
-	} else {
+	} else if !identity.IsServiceIdentity(ctx) {
 		s.log.Warn("User does not belong to a user or service account namespace, using 0 as user ID", "id", cmd.SignedInUser.GetID())
 	}
 
@@ -1441,7 +1441,7 @@ func (s *Service) buildSaveDashboardCommand(ctx context.Context, dto *dashboards
 	var userID int64
 	if id, err := identity.UserIdentifier(dto.User.GetID()); err == nil {
 		userID = id
-	} else {
+	} else if !identity.IsServiceIdentity(ctx) {
 		s.log.Warn("User does not belong to a user or service account namespace, using 0 as user ID", "id", dto.User.GetID())
 	}
 


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104555 - These logs can really spam an instance, and can be concerning to users when there is nothing wrong.

This PR cleans up incorrect warning logs, where during provisioning, we were logging warnings [here](https://github.com/grafana/grafana/blob/06343fcda9320cafeb226887312d1112dce6ac04/pkg/services/folder/folderimpl/folder.go#L772) and [here](https://github.com/grafana/grafana/blob/06343fcda9320cafeb226887312d1112dce6ac04/pkg/services/dashboards/service/dashboard_service.go#L755) if debug logs were on, like:

WARN [folder-service] User does not belong to a user or service account namespace, using 0 as user ID id=access-policy:0 

But that is valid [here](https://github.com/grafana/grafana/blob/06343fcda9320cafeb226887312d1112dce6ac04/pkg/services/provisioning/dashboards/file_reader.go#L151).