### PR TITLE
CI: Use pull_request_target for PR patch check

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -3,7 +3,7 @@
 name: Dispatch check for patch conflicts
 run-name: dispatch-check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -26,7 +26,6 @@ jobs:
           # App needs Actions: Read/Write for the grafana/security-patch-actions repo
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-
       - name: "Dispatch job"
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
`pull_request_target` events should be used carefully, as these workflows do have access to secrets.

Therefore, this workflow does not run check out or run any scripts in the codebase. It does, however, need to successfully run on forks.