### PR TITLE
K8s: App Plugins: Fix dashboard updater

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -139,6 +139,7 @@ func (du *DashboardUpdater) syncPluginDashboards(ctx context.Context, plugin plu
 
 func (du *DashboardUpdater) handlePluginStateChanged(ctx context.Context, event *pluginsettings.PluginStateChangedEvent) error {
 	du.logger.Info("Plugin state changed", "pluginId", event.PluginId, "enabled", event.Enabled)
+	ctx, _ = identity.WithServiceIdentity(ctx, event.OrgId)
 
 	if event.Enabled {
 		p, exists := du.pluginStore.Plugin(ctx, event.PluginId)


### PR DESCRIPTION
**What is this feature?**

This PR adds a service identity to the background plugin updater, which is needed now that dashboards are going through the k8s flow, it will look for the identity in the context.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/grafana/issues/104514
