### PR TITLE
[release-12.0.0] App Plugins: Fix dashboard updater (#104583)

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -139,6 +139,7 @@ func (du *DashboardUpdater) syncPluginDashboards(ctx context.Context, plugin plu
 
 func (du *DashboardUpdater) handlePluginStateChanged(ctx context.Context, event *pluginsettings.PluginStateChangedEvent) error {
 	du.logger.Info("Plugin state changed", "pluginId", event.PluginId, "enabled", event.Enabled)
+	ctx, _ = identity.WithServiceIdentity(ctx, event.OrgId)
 
 	if event.Enabled {
 		p, exists := du.pluginStore.Plugin(ctx, event.PluginId)


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104583 - Needed to ensure app plugin dashboards stay up to date