### PR TITLE
ci: move variables to `env`

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -22,6 +22,8 @@ jobs:
       BASE_REF: ${{ github.base_ref }}
       REPO: ${{ github.repository }}
       SENDER: ${{ github.event.sender.login }}
+      SHA: ${{ github.sha }}
+      PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"
@@ -46,8 +48,8 @@ jobs:
                 inputs: {
                   src_repo: REPO,
                   src_ref: HEAD_REF,
-                  src_merge_sha: "${{ github.sha }}",
-                  src_pr_commit_sha: "${{ github.event.pull_request.head.sha }}",
+                  src_merge_sha: SHA,
+                  src_pr_commit_sha: PR_COMMIT_SHA,
                   patch_repo: REPO + '-security-patches',
                   patch_ref: BASE_REF,
                   triggering_github_handle: SENDER

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            const {HEAD_REF, BASE_REF, REPO, SENDER} = process.env;
+            const {HEAD_REF, BASE_REF, REPO, SENDER, SHA, PR_COMMIT_SHA} = process.env;
 
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -17,6 +17,11 @@ on:
 # target branch onto the source branch, to verify compatibility before merging.
 jobs:
   dispatch-job:
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+      BASE_REF: ${{ github.base_ref }}
+      REPO: ${{ github.repository }}
+      SENDER: ${{ github.event.sender.login }}
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"
@@ -31,18 +36,20 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
+            const {HEAD_REF, BASE_REF, REPO, SENDER} = process.env;
+
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',
                 repo: 'security-patch-actions',
                 workflow_id: 'test-patches-event.yml',
                 ref: 'main',
                 inputs: {
-                  src_repo: "${{ github.repository }}",
-                  src_ref: "${{ github.head_ref }}",
+                  src_repo: REPO,
+                  src_ref: HEAD_REF,
                   src_merge_sha: "${{ github.sha }}",
                   src_pr_commit_sha: "${{ github.event.pull_request.head.sha }}",
-                  patch_repo: "${{ github.repository }}-security-patches",
-                  patch_ref: "${{ github.base_ref }}",
-                  triggering_github_handle: "${{ github.event.sender.login }}"
+                  patch_repo: REPO + '-security-patches',
+                  patch_ref: BASE_REF,
+                  triggering_github_handle: SENDER
                 }
             })


### PR DESCRIPTION
**What is this feature?**

Yea, let's use `env` variables to prevent script injections.