### PR TITLE
CI: Update actions to use environment variables, pin actions

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -21,7 +21,7 @@ jobs:
       # Note: Github will not trigger other actions from this because it uses
       # the GITHUB_TOKEN token
       - name: Run auto-milestone
-        uses: grafana/grafana-github-actions-go/auto-milestone@main
+        uses: grafana/grafana-github-actions-go/auto-milestone@d4c452f92ed826d515dccf1f62923e537953acd8 # main
         with:
           pr: ${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           persist-credentials: false
       - name: "Generate token"
@@ -28,6 +28,6 @@ jobs:
         run: |
           git remote set-url origin "https://grafana-delivery-bot:$GIT_TOKEN@github.com/grafana/grafana.git"
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@main
+        uses: grafana/grafana-github-actions-go/backport@d4c452f92ed826d515dccf1f62923e537953acd8
         with:
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: "Generate token"
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
@@ -20,7 +22,11 @@ jobs:
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - run: git config --global user.email '132647405+grafana-delivery-bot[bot]@users.noreply.github.com'
       - run: git config --global user.name 'grafana-delivery-bot[bot]'
-      - run: git remote set-url origin "https://grafana-delivery-bot:${{ steps.generate_token.outputs.token }}@github.com/grafana/grafana.git"
+      - name: Set remote URL
+        env:
+          GIT_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          git remote set-url origin "https://grafana-delivery-bot:$GIT_TOKEN@github.com/grafana/grafana.git"
       - name: Run backport
         uses: grafana/grafana-github-actions-go/backport@main
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,6 +28,6 @@ jobs:
         run: |
           git remote set-url origin "https://grafana-delivery-bot:$GIT_TOKEN@github.com/grafana/grafana.git"
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@d4c452f92ed826d515dccf1f62923e537953acd8
+        uses: grafana/grafana-github-actions-go/backport@d4c452f92ed826d515dccf1f62923e537953acd8 # main
         with:
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Update backport.yaml and auto-milestone.yml to pin github actions and use environment variables instead of github templating.