### PR TITLE
Frontend: Update TimePicker immediately when time zone is changed without page reload

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -73,10 +73,10 @@ export const TimeRangeContent = (props: Props) => {
 
   // Synchronize internal state with external value
   useEffect(() => {
-    const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
+    const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone,fiscalYearStartMonth);
     setFrom(fromValue);
     setTo(toValue);
-  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);  // fiscalYearStartMonth is included here because valueToState depends on it
+  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]); // fiscalYearStartMonth is included here because valueToState depends on it
 
   const onOpen = useCallback(
     (event: FormEvent<HTMLElement>) => {
@@ -244,7 +244,7 @@ export const TimeRangeContent = (props: Props) => {
 
 function isRangeInvalid(from: string, to: string, timezone?: string): boolean {
   const raw: RawTimeRange = { from, to };
-  const timeRange = rangeUtil.convertRawToRange(raw, timezone);
+  const timeRange = rangeUtil.convertRawToRange(raw, timezone, fiscalYearStartMonth); 
   const valid = timeRange.from.isSame(timeRange.to) || timeRange.from.isBefore(timeRange.to);
 
   return !valid;
@@ -259,8 +259,8 @@ function valueToState(
   const toValue = valueAsString(rawTo, timeZone);
   const fromInvalid = !isValid(fromValue, false, timeZone);
   const toInvalid = !isValid(toValue, true, timeZone);
-  // If "To" is invalid, we should not check the range anyways
-  const rangeInvalid = isRangeInvalid(fromValue, toValue, timeZone) && !toInvalid;
+  // If "To" is invalid, we should not check the range anyways, fiscalYearStartMonth passed into rangeInvalid calculation
+  const rangeInvalid = isRangeInvalid(fromValue, toValue, timeZone, fiscalYearStartMonth)) && !toInvalid;
 
   return [
     {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -76,7 +76,7 @@ export const TimeRangeContent = (props: Props) => {
     const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
     setFrom(fromValue);
     setTo(toValue);
-  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);
+  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);  // fiscalYearStartMonth is included here because valueToState depends on it
 
   const onOpen = useCallback(
     (event: FormEvent<HTMLElement>) => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -135,7 +135,9 @@ export const TimeRangeContent = (props: Props) => {
     setTo(toValue);
   };
 
-  const fiscalYear = rangeUtil.convertRawToRange({ from: 'now/fy', to: 'now/fy' }, timeZone, fiscalYearStartMonth);
+  const fiscalYear = useMemo(() => {
+    return rangeUtil.convertRawToRange({ from: 'now/fy', to: 'now/fy' }, timeZone, fiscalYearStartMonth);
+  }, [fiscalYearStartMonth, timeZone]);
 
   const fyTooltip = (
     <div className={style.tooltip}>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -76,7 +76,7 @@ export const TimeRangeContent = (props: Props) => {
     const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
     setFrom(fromValue);
     setTo(toValue);
-  }, [value.raw.from, value.raw.to, timeZone]);
+  }, [value.raw.from, value.raw.to, timeZone], fiscalYearStartMonth);
 
   const onOpen = useCallback(
     (event: FormEvent<HTMLElement>) => {
@@ -137,8 +137,12 @@ export const TimeRangeContent = (props: Props) => {
   const fiscalYearMessage = t('time-picker.range-content.fiscal-year', 'Fiscal year');
   
   const fiscalYear = useMemo(() => {
-    return rangeUtil.convertRawToRange({ from: 'now/fy', to: 'now/fy' }, timeZone, fiscalYearStartMonth);
-  }, [fiscalYearStartMonth, timeZone]);
+    return rangeUtil.convertRawToRange(
+      { from: value.raw.from, to: value.raw.to },
+      timeZone,
+       fiscalYearStartMonth
+      );
+  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);
 
   const fyTooltip = (
     <div className={style.tooltip}>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -73,7 +73,7 @@ export const TimeRangeContent = (props: Props) => {
 
   // Synchronize internal state with external value
   useEffect(() => {
-    const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone,fiscalYearStartMonth);
+    const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth);
     setFrom(fromValue);
     setTo(toValue);
   }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]); // fiscalYearStartMonth is included here because valueToState depends on it

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -140,7 +140,7 @@ export const TimeRangeContent = (props: Props) => {
     return rangeUtil.convertRawToRange(
       { from: value.raw.from, to: value.raw.to },
       timeZone,
-       fiscalYearStartMonth
+      fiscalYearStartMonth
       );
   }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -99,11 +99,11 @@ export const TimeRangeContent = (props: Props) => {
 
   const onChange = useCallback(
     (from: DateTime | string, to: DateTime | string) => {
-      const [fromValue, toValue] = valueToState(from, to, timeZone);
+      const [fromValue, toValue] = valueToState(from, to, timeZone, fiscalYearStartMonth);
       setFrom(fromValue);
       setTo(toValue);
     },
-    [timeZone]
+    [timeZone, fiscalYearStartMonth]
   );
 
   const submitOnEnter = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -130,7 +130,7 @@ export const TimeRangeContent = (props: Props) => {
       return;
     }
 
-    const [fromValue, toValue] = valueToState(range.from, range.to, timeZone);
+    const [fromValue, toValue] = valueToState(range.from, range.to, timeZone, fiscalYearStartMonth);
     setFrom(fromValue);
     setTo(toValue);
   };
@@ -242,7 +242,7 @@ export const TimeRangeContent = (props: Props) => {
   );
 };
 
-function isRangeInvalid(from: string, to: string, timezone?: string): boolean {
+function isRangeInvalid(from: string, to: string, timezone?: string, fiscalYearStartMonth?: number): boolean {
   const raw: RawTimeRange = { from, to };
   const timeRange = rangeUtil.convertRawToRange(raw, timezone, fiscalYearStartMonth); 
   const valid = timeRange.from.isSame(timeRange.to) || timeRange.from.isBefore(timeRange.to);
@@ -253,14 +253,15 @@ function isRangeInvalid(from: string, to: string, timezone?: string): boolean {
 function valueToState(
   rawFrom: DateTime | string,
   rawTo: DateTime | string,
-  timeZone?: TimeZone
+  timeZone?: TimeZone,
+  fiscalYearStartMonth?: number
 ): [InputState, InputState] {
   const fromValue = valueAsString(rawFrom, timeZone);
   const toValue = valueAsString(rawTo, timeZone);
   const fromInvalid = !isValid(fromValue, false, timeZone);
   const toInvalid = !isValid(toValue, true, timeZone);
   // If "To" is invalid, we should not check the range anyways, fiscalYearStartMonth passed into rangeInvalid calculation
-  const rangeInvalid = isRangeInvalid(fromValue, toValue, timeZone, fiscalYearStartMonth)) && !toInvalid;
+  const rangeInvalid = isRangeInvalid(fromValue, toValue, timeZone, fiscalYearStartMonth) && !toInvalid;
 
   return [
     {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { FormEvent, useCallback, useEffect, useId, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useId, useState, useMemo } from 'react';
 import * as React from 'react';
 
 import {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -76,7 +76,7 @@ export const TimeRangeContent = (props: Props) => {
     const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
     setFrom(fromValue);
     setTo(toValue);
-  }, [value.raw.from, value.raw.to, timeZone], fiscalYearStartMonth);
+  }, [value.raw.from, value.raw.to, timeZone, fiscalYearStartMonth]);
 
   const onOpen = useCallback(
     (event: FormEvent<HTMLElement>) => {
@@ -146,7 +146,7 @@ export const TimeRangeContent = (props: Props) => {
 
   const fyTooltip = (
     <div className={style.tooltip}>
-      {rangeUtil.isFiscal(value) ? (
+      {rangeUtil.isFiscal(value, timeZone, fiscalYearStartMonth) ? (
         <Tooltip
           content={t('time-picker.range-content.fiscal-year', 'Fiscal year: {{from}} - {{to}}', {
             from: fiscalYear.from.format('MMM-DD'),

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -134,7 +134,8 @@ export const TimeRangeContent = (props: Props) => {
     setFrom(fromValue);
     setTo(toValue);
   };
-
+  const fiscalYearMessage = t('time-picker.range-content.fiscal-year', 'Fiscal year');
+  
   const fiscalYear = useMemo(() => {
     return rangeUtil.convertRawToRange({ from: 'now/fy', to: 'now/fy' }, timeZone, fiscalYearStartMonth);
   }, [fiscalYearStartMonth, timeZone]);


### PR DESCRIPTION
**What is this feature?**

Previously, the TimePicker did not update according to the new time zone selection unless the page was reloaded, causing confusion for users when switching between time zones.

**Who is this feature for?**

All users interacting with time-based data who need real-time feedback when changing their time zone settings.

Which issue(s) does this PR fix?:

Fixes #99071

