### PR TITLE
Alerting: Make receiver optional in routing preview and handle fallback case

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -79,7 +79,7 @@ function NotificationPreviewByAlertManager({
               route={route}
               // If we can't find a receiver, it might just be because the user doesn't have access
               receiver={receiver ? receiver : undefined}
-              receiverName={route?.receiver ? route.receiver : undefined}
+              receiverNameFromRoute={route?.receiver ? route.receiver : undefined}
               key={routeId}
               routesByIdMap={routesByIdMap}
               alertManagerSourceName={alertManagerSource.name}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -79,6 +79,7 @@ function NotificationPreviewByAlertManager({
               route={route}
               // If we can't find a receiver, it might just be because the user doesn't have access
               receiver={receiver ? receiver : undefined}
+              receiverName={route?.receiver ? route.receiver : undefined}
               key={routeId}
               routesByIdMap={routesByIdMap}
               alertManagerSourceName={alertManagerSource.name}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -73,14 +73,12 @@ function NotificationPreviewByAlertManager({
           if (!route) {
             return null;
           }
-          if (!receiver) {
-            throw new Error('Receiver not found');
-          }
           return (
             <NotificationRoute
               instanceMatches={instanceMatches}
               route={route}
-              receiver={receiver}
+              // If we can't find a receiver, it might just be because the user doesn't have access
+              receiver={receiver ? receiver : undefined}
               key={routeId}
               routesByIdMap={routesByIdMap}
               alertManagerSourceName={alertManagerSource.name}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
@@ -21,25 +21,31 @@ import { NotificationRouteDetailsModal } from './NotificationRouteDetailsModal';
 import UnknownContactPointDetails from './UnknownContactPointDetails';
 import { RouteWithPath } from './route';
 
-function NotificationRouteHeader({
-  route,
-  receiver,
-  receiverName,
-  routesByIdMap,
-  instancesCount,
-  alertManagerSourceName,
-  expandRoute,
-  onExpandRouteClick,
-}: {
+export interface ReceiverNameProps {
+  /** Receiver name taken from route definition. Used as a fallback when full receiver details cannot be found (in case of RBAC restrictions) */
+  receiverNameFromRoute?: string;
+}
+
+interface NotificationRouteHeaderProps extends ReceiverNameProps {
   route: RouteWithPath;
   receiver?: Receiver;
-  receiverName?: string;
   routesByIdMap: Map<string, RouteWithPath>;
   instancesCount: number;
   alertManagerSourceName: string;
   expandRoute: boolean;
   onExpandRouteClick: (expand: boolean) => void;
-}) {
+}
+
+function NotificationRouteHeader({
+  route,
+  receiver,
+  receiverNameFromRoute,
+  routesByIdMap,
+  instancesCount,
+  alertManagerSourceName,
+  expandRoute,
+  onExpandRouteClick,
+}: NotificationRouteHeaderProps) {
   const styles = useStyles2(getStyles);
   const [showDetails, setShowDetails] = useState(false);
 
@@ -79,7 +85,7 @@ function NotificationRouteHeader({
               <span className={styles.textMuted}>
                 <Trans i18nKey="alerting.notification-route-header.delivered-to">@ Delivered to</Trans>
               </span>{' '}
-              {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverName} />}
+              {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverNameFromRoute} />}
             </div>
 
             <div className={styles.verticalBar} />
@@ -95,7 +101,7 @@ function NotificationRouteHeader({
           onClose={() => setShowDetails(false)}
           route={route}
           receiver={receiver}
-          receiverName={receiverName}
+          receiverNameFromRoute={receiverNameFromRoute}
           routesByIdMap={routesByIdMap}
           alertManagerSourceName={alertManagerSourceName}
         />
@@ -104,10 +110,9 @@ function NotificationRouteHeader({
   );
 }
 
-interface NotificationRouteProps {
+interface NotificationRouteProps extends ReceiverNameProps {
   route: RouteWithPath;
   receiver?: Receiver;
-  receiverName?: string;
   instanceMatches: AlertInstanceMatch[];
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;
@@ -117,7 +122,7 @@ export function NotificationRoute({
   route,
   instanceMatches,
   receiver,
-  receiverName,
+  receiverNameFromRoute,
   routesByIdMap,
   alertManagerSourceName,
 }: NotificationRouteProps) {
@@ -132,7 +137,7 @@ export function NotificationRoute({
       <NotificationRouteHeader
         route={route}
         receiver={receiver}
-        receiverName={receiverName}
+        receiverNameFromRoute={receiverNameFromRoute}
         routesByIdMap={routesByIdMap}
         instancesCount={instanceMatches.length}
         alertManagerSourceName={alertManagerSourceName}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
@@ -24,6 +24,7 @@ import { RouteWithPath } from './route';
 function NotificationRouteHeader({
   route,
   receiver,
+  receiverName,
   routesByIdMap,
   instancesCount,
   alertManagerSourceName,
@@ -32,6 +33,7 @@ function NotificationRouteHeader({
 }: {
   route: RouteWithPath;
   receiver?: Receiver;
+  receiverName?: string;
   routesByIdMap: Map<string, RouteWithPath>;
   instancesCount: number;
   alertManagerSourceName: string;
@@ -77,7 +79,7 @@ function NotificationRouteHeader({
               <span className={styles.textMuted}>
                 <Trans i18nKey="alerting.notification-route-header.delivered-to">@ Delivered to</Trans>
               </span>{' '}
-              {receiver ? receiver.name : <UnknownContactPointDetails />}
+              {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverName} />}
             </div>
 
             <div className={styles.verticalBar} />
@@ -93,6 +95,7 @@ function NotificationRouteHeader({
           onClose={() => setShowDetails(false)}
           route={route}
           receiver={receiver}
+          receiverName={receiverName}
           routesByIdMap={routesByIdMap}
           alertManagerSourceName={alertManagerSourceName}
         />
@@ -104,6 +107,7 @@ function NotificationRouteHeader({
 interface NotificationRouteProps {
   route: RouteWithPath;
   receiver?: Receiver;
+  receiverName?: string;
   instanceMatches: AlertInstanceMatch[];
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;
@@ -113,6 +117,7 @@ export function NotificationRoute({
   route,
   instanceMatches,
   receiver,
+  receiverName,
   routesByIdMap,
   alertManagerSourceName,
 }: NotificationRouteProps) {
@@ -127,6 +132,7 @@ export function NotificationRoute({
       <NotificationRouteHeader
         route={route}
         receiver={receiver}
+        receiverName={receiverName}
         routesByIdMap={routesByIdMap}
         instancesCount={instanceMatches.length}
         alertManagerSourceName={alertManagerSourceName}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
@@ -18,6 +18,7 @@ import { Spacer } from '../../Spacer';
 
 import { NotificationPolicyMatchers } from './NotificationPolicyMatchers';
 import { NotificationRouteDetailsModal } from './NotificationRouteDetailsModal';
+import UnknownContactPointDetails from './UnknownContactPointDetails';
 import { RouteWithPath } from './route';
 
 function NotificationRouteHeader({
@@ -30,7 +31,7 @@ function NotificationRouteHeader({
   onExpandRouteClick,
 }: {
   route: RouteWithPath;
-  receiver: Receiver;
+  receiver?: Receiver;
   routesByIdMap: Map<string, RouteWithPath>;
   instancesCount: number;
   alertManagerSourceName: string;
@@ -76,7 +77,7 @@ function NotificationRouteHeader({
               <span className={styles.textMuted}>
                 <Trans i18nKey="alerting.notification-route-header.delivered-to">@ Delivered to</Trans>
               </span>{' '}
-              {receiver.name}
+              {receiver ? receiver.name : <UnknownContactPointDetails />}
             </div>
 
             <div className={styles.verticalBar} />
@@ -102,7 +103,7 @@ function NotificationRouteHeader({
 
 interface NotificationRouteProps {
   route: RouteWithPath;
-  receiver: Receiver;
+  receiver?: Receiver;
   instanceMatches: AlertInstanceMatch[];
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
@@ -14,6 +14,7 @@ import { createContactPointSearchLink } from '../../../utils/misc';
 import { Authorize } from '../../Authorize';
 import { Matchers } from '../../notification-policies/Matchers';
 
+import { ReceiverNameProps } from './NotificationRoute';
 import UnknownContactPointDetails from './UnknownContactPointDetails';
 import { RouteWithPath, hasEmptyMatchers, isDefaultPolicy } from './route';
 
@@ -52,11 +53,10 @@ function PolicyPath({ route, routesByIdMap, matcherFormatter }: Props) {
   );
 }
 
-interface NotificationRouteDetailsModalProps {
+interface NotificationRouteDetailsModalProps extends ReceiverNameProps {
   onClose: () => void;
   route: RouteWithPath;
   receiver?: Receiver;
-  receiverName?: string;
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;
 }
@@ -65,7 +65,7 @@ export function NotificationRouteDetailsModal({
   onClose,
   route,
   receiver,
-  receiverName,
+  receiverNameFromRoute,
   routesByIdMap,
   alertManagerSourceName,
 }: NotificationRouteDetailsModalProps) {
@@ -111,7 +111,7 @@ export function NotificationRouteDetailsModal({
               <Trans i18nKey="alerting.notification-route-details-modal.contact-point">Contact point</Trans>
 
               <span className={styles.textMuted}>
-                {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverName} />}
+                {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverNameFromRoute} />}
               </span>
             </Stack>
             <Authorize actions={[AlertmanagerAction.UpdateContactPoint]}>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
@@ -14,6 +14,7 @@ import { createContactPointSearchLink } from '../../../utils/misc';
 import { Authorize } from '../../Authorize';
 import { Matchers } from '../../notification-policies/Matchers';
 
+import UnknownContactPointDetails from './UnknownContactPointDetails';
 import { RouteWithPath, hasEmptyMatchers, isDefaultPolicy } from './route';
 
 interface Props {
@@ -54,7 +55,7 @@ function PolicyPath({ route, routesByIdMap, matcherFormatter }: Props) {
 interface NotificationRouteDetailsModalProps {
   onClose: () => void;
   route: RouteWithPath;
-  receiver: Receiver;
+  receiver?: Receiver;
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;
 }
@@ -107,13 +108,15 @@ export function NotificationRouteDetailsModal({
             <Stack gap={1} direction="column">
               <Trans i18nKey="alerting.notification-route-details-modal.contact-point">Contact point</Trans>
 
-              <span className={styles.textMuted}>{receiver.name}</span>
+              <span className={styles.textMuted}>{receiver ? receiver.name : <UnknownContactPointDetails />}</span>
             </Stack>
             <Authorize actions={[AlertmanagerAction.UpdateContactPoint]}>
               <Stack gap={1} direction="row" alignItems="center">
-                <TextLink href={createContactPointSearchLink(receiver.name, alertManagerSourceName)} external>
-                  <Trans i18nKey="alerting.notification-route-details-modal.see-details-link">See details</Trans>
-                </TextLink>
+                {receiver ? (
+                  <TextLink href={createContactPointSearchLink(receiver.name, alertManagerSourceName)} external>
+                    <Trans i18nKey="alerting.notification-route-details-modal.see-details-link">See details</Trans>
+                  </TextLink>
+                ) : null}
               </Stack>
             </Authorize>
           </div>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
@@ -56,6 +56,7 @@ interface NotificationRouteDetailsModalProps {
   onClose: () => void;
   route: RouteWithPath;
   receiver?: Receiver;
+  receiverName?: string;
   routesByIdMap: Map<string, RouteWithPath>;
   alertManagerSourceName: string;
 }
@@ -64,6 +65,7 @@ export function NotificationRouteDetailsModal({
   onClose,
   route,
   receiver,
+  receiverName,
   routesByIdMap,
   alertManagerSourceName,
 }: NotificationRouteDetailsModalProps) {
@@ -108,7 +110,9 @@ export function NotificationRouteDetailsModal({
             <Stack gap={1} direction="column">
               <Trans i18nKey="alerting.notification-route-details-modal.contact-point">Contact point</Trans>
 
-              <span className={styles.textMuted}>{receiver ? receiver.name : <UnknownContactPointDetails />}</span>
+              <span className={styles.textMuted}>
+                {receiver ? receiver.name : <UnknownContactPointDetails receiverName={receiverName} />}
+              </span>
             </Stack>
             <Authorize actions={[AlertmanagerAction.UpdateContactPoint]}>
               <Stack gap={1} direction="row" alignItems="center">

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/UnknownContactPointDetails.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/UnknownContactPointDetails.tsx
@@ -1,0 +1,19 @@
+import { Tooltip } from '@grafana/ui';
+import { Trans, t } from 'app/core/internationalization';
+
+const UnknownContactPointDetails = () => (
+  <span style={{ cursor: 'help' }}>
+    <Tooltip
+      content={t(
+        'alerting.unknown-contact-point-details.unknown-contact-point-tooltip',
+        'Details could not be found. This may be because you do not have access to the contact point'
+      )}
+    >
+      <span>
+        <Trans i18nKey="alerting.unknown-contact-point-details.unknown-contact-point">Unknown contact point</Trans>
+      </span>
+    </Tooltip>
+  </span>
+);
+
+export default UnknownContactPointDetails;

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/UnknownContactPointDetails.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/UnknownContactPointDetails.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
-const UnknownContactPointDetails = () => (
+const UnknownContactPointDetails = ({ receiverName }: { receiverName?: string }) => (
   <span style={{ cursor: 'help' }}>
     <Tooltip
       content={t(
@@ -10,7 +10,11 @@ const UnknownContactPointDetails = () => (
       )}
     >
       <span>
-        <Trans i18nKey="alerting.unknown-contact-point-details.unknown-contact-point">Unknown contact point</Trans>
+        {receiverName ? (
+          receiverName
+        ) : (
+          <Trans i18nKey="alerting.unknown-contact-point-details.unknown-contact-point">Unknown contact point</Trans>
+        )}
       </span>
     </Tooltip>
   </span>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2350,6 +2350,10 @@
     "type-selector-button": {
       "add-expression": "Add expression"
     },
+    "unknown-contact-point-details": {
+      "unknown-contact-point": "Unknown contact point",
+      "unknown-contact-point-tooltip": "Details could not be found. This may be because you do not have access to the contact point"
+    },
     "unknown-rule-list-item": {
       "title-unknown-rule-type": "Unknown rule type"
     },


### PR DESCRIPTION
**What is this feature?**
Handles the case where contact point details may not be available to a user when using routing previews on the alert rule edit form.
This is most likely to happen due to RBAC permissions preventing the user from seeing the contact point in question.

In this scenario, we show a different message describing that this is an unknown contact point

**Why do we need this feature?**
So we can handle RBAC/granular contact point permissions correctly 