### PR TITLE
Keepers: Move actor/auth filtering layer to rest storage

### DIFF
--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -6,7 +6,6 @@ import (
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -16,11 +15,11 @@ var (
 
 // KeeperMetadataStorage is the interface for wiring and dependency injection.
 type KeeperMetadataStorage interface {
-	Create(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
+	Create(ctx context.Context, keeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error)
 	Read(ctx context.Context, namespace xkube.Namespace, name string) (*secretv0alpha1.Keeper, error)
-	Update(ctx context.Context, keeper *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
+	Update(ctx context.Context, keeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
-	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
+	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.Keeper, error)
 	GetKeeperConfig(ctx context.Context, namespace string, name *string) (secretv0alpha1.KeeperConfig, error)
 }
 

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"strings"
 
+	claims "github.com/grafana/authlib/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
@@ -35,13 +37,14 @@ var (
 // KeeperRest is an implementation of CRUDL operations on a `keeper` backed by TODO.
 type KeeperRest struct {
 	storage        contracts.KeeperMetadataStorage
+	accessClient   claims.AccessClient
 	resource       utils.ResourceInfo
 	tableConverter rest.TableConvertor
 }
 
 // NewKeeperRest is a returns a constructed `*KeeperRest`.
-func NewKeeperRest(storage contracts.KeeperMetadataStorage, resource utils.ResourceInfo) *KeeperRest {
-	return &KeeperRest{storage, resource, resource.TableConverter()}
+func NewKeeperRest(storage contracts.KeeperMetadataStorage, accessClient claims.AccessClient, resource utils.ResourceInfo) *KeeperRest {
+	return &KeeperRest{storage, accessClient, resource, resource.TableConverter()}
 }
 
 // New returns an empty `*Keeper` that is used by the `Create` method.
@@ -79,12 +82,47 @@ func (s *KeeperRest) List(ctx context.Context, options *internalversion.ListOpti
 		return nil, fmt.Errorf("missing namespace")
 	}
 
-	keepersList, err := s.storage.List(ctx, xkube.Namespace(namespace), options)
+	user, ok := claims.AuthInfoFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing auth info in context")
+	}
+
+	hasPermissionFor, err := s.accessClient.Compile(ctx, user, claims.ListRequest{
+		Group:     secretv0alpha1.GROUP,
+		Resource:  secretv0alpha1.KeeperResourceInfo.GetName(),
+		Namespace: namespace,
+		Verb:      utils.VerbGet,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile checker: %w", err)
+	}
+
+	labelSelector := options.LabelSelector
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+
+	keepersList, err := s.storage.List(ctx, xkube.Namespace(namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list keepers: %w", err)
 	}
 
-	return keepersList, nil
+	allowedKeepers := make([]secretv0alpha1.Keeper, 0)
+
+	for _, keeper := range keepersList {
+		// Check whether the user has permission to access this specific Keeper in the namespace.
+		if !hasPermissionFor(keeper.Name, "") {
+			continue
+		}
+
+		if labelSelector.Matches(labels.Set(keeper.Labels)) {
+			allowedKeepers = append(allowedKeepers, keeper)
+		}
+	}
+
+	return &secretv0alpha1.KeeperList{
+		Items: allowedKeepers,
+	}, nil
 }
 
 // Get calls the inner `store` (persistence) and returns a `Keeper` by `name`.
@@ -117,11 +155,16 @@ func (s *KeeperRest) Create(
 		return nil, fmt.Errorf("expected Keeper for create")
 	}
 
+	user, ok := claims.AuthInfoFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing auth info in context")
+	}
+
 	if err := createValidation(ctx, obj); err != nil {
 		return nil, err
 	}
 
-	createdKeeper, err := s.storage.Create(ctx, kp)
+	createdKeeper, err := s.storage.Create(ctx, kp, user.GetUID())
 	if err != nil {
 		var kErr xkube.ErrorLister
 		if errors.As(err, &kErr) {
@@ -144,6 +187,11 @@ func (s *KeeperRest) Update(
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
+	user, ok := claims.AuthInfoFrom(ctx)
+	if !ok {
+		return nil, false, fmt.Errorf("missing auth info in context")
+	}
+
 	oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -172,7 +220,7 @@ func (s *KeeperRest) Update(
 	newKeeper.Annotations = xkube.CleanAnnotations(newKeeper.Annotations)
 
 	// Current implementation replaces everything passed in the spec, so it is not a PATCH. Do we want/need to support that?
-	updatedKeeper, err := s.storage.Update(ctx, newKeeper)
+	updatedKeeper, err := s.storage.Update(ctx, newKeeper, user.GetUID())
 	if err != nil {
 		var kErr xkube.ErrorLister
 		if errors.As(err, &kErr) {


### PR DESCRIPTION
This lets us lift the auth checks from the storage layer into the reststorage one for List, making the storage easier to reason.