### PR TITLE
Secrets: Replace logger with grafana-app-sdk one

### DIFF
--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana-app-sdk/logging"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/reststorage"
@@ -45,7 +45,6 @@ var (
 
 type SecretAPIBuilder struct {
 	tracer                     tracing.Tracer
-	log                        *log.ConcreteLogger
 	secretService              *service.SecretService
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage
 	keeperMetadataStorage      contracts.KeeperMetadataStorage
@@ -69,7 +68,6 @@ func NewSecretAPIBuilder(
 ) (*SecretAPIBuilder, error) {
 	return &SecretAPIBuilder{
 		tracer:                     tracer,
-		log:                        log.New("secret.SecretAPIBuilder"),
 		secretService:              secretService,
 		secureValueMetadataStorage: secureValueMetadataStorage,
 		keeperMetadataStorage:      keeperMetadataStorage,
@@ -80,7 +78,6 @@ func NewSecretAPIBuilder(
 			BatchSize:      1,
 			ReceiveTimeout: 5 * time.Second,
 		},
-			log.New("secret.worker"),
 			database,
 			secretsOutboxQueue,
 			secureValueMetadataStorage,
@@ -686,7 +683,7 @@ func (b *SecretAPIBuilder) GetPostStartHooks() (map[string]genericapiserver.Post
 		"start-outbox-queue-worker": func(hookCtx genericapiserver.PostStartHookContext) error {
 			if err := b.worker.ControlLoop(hookCtx.Context); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					b.log.Error("secrets outbox worker exited control loop with error, secrets won't be created/updated/deleted/etc while the worker is not running: %+v", err)
+					logging.FromContext(hookCtx).Error("secrets outbox worker exited control loop with error, secrets won't be created/updated/deleted/etc while the worker is not running: %+v", err)
 					return err
 				}
 			}

--- a/pkg/registry/apis/secret/worker/worker.go
+++ b/pkg/registry/apis/secret/worker/worker.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
@@ -14,7 +14,6 @@ import (
 // Consumes and processes messages from the secure value outbox queue
 type Worker struct {
 	config                     Config
-	log                        *log.ConcreteLogger
 	database                   contracts.Database
 	outboxQueue                contracts.OutboxQueue
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage
@@ -31,7 +30,6 @@ type Config struct {
 
 func NewWorker(
 	config Config,
-	log *log.ConcreteLogger,
 	database contracts.Database,
 	outboxQueue contracts.OutboxQueue,
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage,
@@ -40,7 +38,6 @@ func NewWorker(
 ) *Worker {
 	return &Worker{
 		config:                     config,
-		log:                        log,
 		database:                   database,
 		outboxQueue:                outboxQueue,
 		secureValueMetadataStorage: secureValueMetadataStorage,
@@ -82,7 +79,7 @@ func (w *Worker) receiveAndProcessMessages(ctx context.Context) {
 		}
 		return nil
 	}); err != nil {
-		w.log.Error("receiving outbox messages", "err", err.Error())
+		logging.FromContext(ctx).Error("receiving outbox messages", "err", err.Error())
 	}
 }
 


### PR DESCRIPTION
Rather than using `pkg/infra/log`, we use the App SDK one, which is based on `slog`.