### PR TITLE
improve decrypt logging

### DIFF
--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -50,7 +50,6 @@ type decryptStorage struct {
 func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv0alpha1.ExposedSecureValue, decryptErr error) {
 	var decrypterIdentity string
 	// TEMPORARY: While we evaluate all of our auditing needs, provide one for decrypt operations.
-	logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_request", "namespace", namespace, "secret_name", name)
 	defer func() {
 		if decryptErr == nil {
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_success", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity)

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -47,7 +47,18 @@ type decryptStorage struct {
 }
 
 // Decrypt decrypts a secure value from the keeper.
-func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv0alpha1.ExposedSecureValue, decryptErr error) {
+	var decrypterIdentity string
+	// TEMPORARY: While we evaluate all of our auditing needs, provide one for decrypt operations.
+	logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_request", "namespace", namespace, "secret_name", name)
+	defer func() {
+		if decryptErr == nil {
+			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_success", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity)
+		} else {
+			logging.FromContext(ctx).Error("Audit log:", "operation", "decrypt_secret_error", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity, "error", decryptErr)
+		}
+	}()
+
 	// Basic authn check before reading a secure value metadata, it is here on purpose.
 	if _, ok := claims.AuthInfoFrom(ctx); !ok {
 		return "", contracts.ErrDecryptNotAuthorized
@@ -61,7 +72,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		return "", contracts.ErrDecryptNotFound
 	}
 
-	identity, authorized := s.decryptAuthorizer.Authorize(ctx, sv.Decrypters)
+	decrypterIdentity, authorized := s.decryptAuthorizer.Authorize(ctx, sv.Decrypters)
 	if !authorized {
 		return "", contracts.ErrDecryptNotAuthorized
 	}
@@ -80,9 +91,6 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 	if err != nil {
 		return "", contracts.ErrDecryptFailed
 	}
-
-	// TEMPORARY: While we evaluate all of our auditing needs, provide one for decrypt operations.
-	logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret", "namespace", namespace, "secret_name", name, "decrypter_identity", identity)
 
 	return exposedValue, nil
 }

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -55,7 +55,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		if decryptErr == nil {
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_success", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity)
 		} else {
-			logging.FromContext(ctx).Error("Audit log:", "operation", "decrypt_secret_error", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity, "error", decryptErr)
+			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_error", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity, "error", decryptErr)
 		}
 	}()
 


### PR DESCRIPTION
**What is this feature?**

Improves audit logging around secret decryption. Previously we were only logging successful decrypts, but we should be logging all decrypt requests and the results.

**Why do we need this feature?**

We need a complete audit log of all decryption attempts, so that if a user's secret leaks, we can confidently say our service isn't what leaked it. 

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1286


