### PR TITLE
[Release 12.0.0] SchemaV2 Fix Import mapping ds #104200

### DIFF
--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -39,8 +39,8 @@ export function ImportDashboardOverviewV2() {
       ...dashboard,
       title: form.dashboard.title,
       annotations: dashboard.annotations?.map((annotation: AnnotationQueryKind) => {
-        if (annotation.spec.datasource?.type) {
-          const dsType = annotation.spec.datasource.type;
+        if (annotation.spec.query?.kind) {
+          const dsType = annotation.spec.query.kind;
           if (form[`datasource-${dsType}` as keyof typeof form]) {
             const ds = form[`datasource-${dsType}` as keyof typeof form] as { uid: string; type: string };
             return {
@@ -59,8 +59,8 @@ export function ImportDashboardOverviewV2() {
       }),
       variables: dashboard.variables?.map((variable) => {
         if (variable.kind === 'QueryVariable') {
-          if (variable.spec.datasource?.type) {
-            const dsType = variable.spec.datasource.type;
+          if (variable.spec.query?.kind) {
+            const dsType = variable.spec.query.kind;
             if (form[`datasource-${dsType}` as keyof typeof form]) {
               const ds = form[`datasource-${dsType}` as keyof typeof form] as { uid: string; type: string };
               return {


### PR DESCRIPTION
backport of #104200  - Without this fix, users cannot import datasources correctly in schema v2 when exported with the option "Export the dashboard to use in another instance".

We were relying on the "datasource" existence, instead of using the `query.kind`.

### Before

https://github.com/user-attachments/assets/91acad21-59fa-4b70-8822-156904098ee6

### After

https://github.com/user-attachments/assets/420a03da-82af-4283-95c2-3464e364fb6e



