### PR TITLE
Alerting: Enable alerting eslint overrides for package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -269,7 +269,7 @@ module.exports = [
       react: reactPlugin,
       '@grafana': grafanaPlugin,
     },
-    files: ['public/app/features/alerting/**/*.{ts,tsx,js,jsx}'],
+    files: ['public/app/features/alerting/**/*.{ts,tsx,js,jsx}', 'packages/grafana-alerting/**/*.{ts,tsx,js,jsx}'],
     rules: {
       'sort-imports': ['error', { ignoreDeclarationSort: true }],
       'dot-notation': 'error',
@@ -310,7 +310,7 @@ module.exports = [
     files: [
       'public/app/features/alerting/**/__tests__/**/*.[jt]s?(x)',
       'public/app/features/alerting/**/?(*.)+(spec|test).[jt]s?(x)',
-      'packages/grafana-ui/**/*.{spec,test}.{ts,tsx}',
+      'packages/{grafana-ui,grafana-alerting}/**/*.{spec,test}.{ts,tsx}',
     ],
     rules: {
       ...testingLibraryPlugin.configs['flat/react'].rules,

--- a/packages/grafana-alerting/src/grafana/api/v0alpha1/types.ts
+++ b/packages/grafana-alerting/src/grafana/api/v0alpha1/types.ts
@@ -3,7 +3,7 @@
  */
 import { MergeDeep, MergeExclusive, OverrideProperties } from 'type-fest';
 
-import type { Receiver, Integration as ReceiverIntegration, ListReceiverApiResponse } from './api.gen';
+import type { ListReceiverApiResponse, Receiver, Integration as ReceiverIntegration } from './api.gen';
 
 type GenericIntegration = OverrideProperties<
   ReceiverIntegration,

--- a/packages/grafana-alerting/src/grafana/contactPoints/hooks/useContactPoints.tsx
+++ b/packages/grafana-alerting/src/grafana/contactPoints/hooks/useContactPoints.tsx
@@ -1,6 +1,6 @@
-import { fetchBaseQuery, TypedUseQueryHookResult } from '@reduxjs/toolkit/query/react';
+import { TypedUseQueryHookResult, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
-import { alertingAPI, type ListReceiverApiArg } from '../../api/v0alpha1/api.gen';
+import { type ListReceiverApiArg, alertingAPI } from '../../api/v0alpha1/api.gen';
 import type { EnhancedListReceiverApiResponse } from '../../api/v0alpha1/types';
 
 // this is a workaround for the fact that the generated types are not narrow enough


### PR DESCRIPTION
**What is this feature?**
Adds eslint overrides to the new alerting package, so its consistent with the other code written within `unified/alerting`

**Why do we need this feature?**
🧹  & consistency

**Who is this feature for?**
Alerting UI devs