### PR TITLE
[release-12.0.0] Dashboards and Folders: cleanup timestamps and error codes

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -434,7 +435,7 @@ func (a *dashboardSqlAccess) SaveDashboard(ctx context.Context, orgId int64, das
 		return nil, created, err
 	}
 	if failOnExisting && !created {
-		return nil, created, dashboards.ErrDashboardWithSameUIDExists
+		return nil, created, apierrors.NewConflict(dashboardV1.DashboardResourceInfo.GroupResource(), dash.Name, dashboards.ErrDashboardWithSameUIDExists)
 	}
 
 	out, err := a.dashStore.SaveDashboard(ctx, *cmd)

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -273,7 +273,7 @@ func (s *legacyStorage) Update(ctx context.Context,
 			NewParentUID: newParent,
 		})
 		if err != nil {
-			return nil, created, fmt.Errorf("error changing parent folder spec")
+			return nil, created, err
 		}
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -2257,7 +2257,9 @@ func (dr *DashboardServiceImpl) unstructuredToLegacyDashboardWithUsers(item *uns
 	out.Created = obj.GetCreationTimestamp().Time
 	updated, err := obj.GetUpdatedTimestamp()
 	if err == nil && updated != nil {
-		out.Updated = *updated
+		// old apis return in local time, created is already doing that
+		localTime := updated.Local()
+		out.Updated = localTime
 	} else {
 		// by default, set updated to created
 		out.Updated = out.Created

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -36,12 +36,12 @@ func parseUnstructuredToLegacyFolder(item *unstructured.Unstructured) (*folder.F
 		url = dashboards.GetFolderURL(uid, slug)
 	}
 
-	created := meta.GetCreationTimestamp().UTC()
+	created := meta.GetCreationTimestamp().Local()
 	updated, _ := meta.GetUpdatedTimestamp()
 	if updated == nil {
 		updated = &created
 	} else {
-		tmp := updated.UTC()
+		tmp := updated.Local()
 		updated = &tmp
 	}
 

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -45,7 +45,7 @@ func TestFolderConversions(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := time.Parse(time.RFC3339, "2022-12-02T02:02:02Z")
-	created = created.UTC()
+	created = created.Local()
 	require.NoError(t, err)
 
 	fake := usertest.NewUserServiceFake()
@@ -232,7 +232,7 @@ func TestFolderListConversions(t *testing.T) {
 	require.NoError(t, err)
 
 	created, err := time.Parse(time.RFC3339, "2022-12-02T02:02:02Z")
-	created = created.UTC()
+	created = created.Local()
 	require.NoError(t, err)
 
 	fake := usertest.NewUserServiceFake()

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -54,6 +54,24 @@ func (r rcp) GetRestConfig(ctx context.Context) (*clientrest.Config, error) {
 	}, nil
 }
 
+func compareFoldersNormalizeTime(t *testing.T, expected, actual *folder.Folder) {
+	require.Equal(t, expected.Title, actual.Title)
+	require.Equal(t, expected.UID, actual.UID)
+	require.Equal(t, expected.OrgID, actual.OrgID)
+	require.Equal(t, expected.URL, actual.URL)
+	require.Equal(t, expected.Fullpath, actual.Fullpath)
+	require.Equal(t, expected.FullpathUIDs, actual.FullpathUIDs)
+	require.Equal(t, expected.CreatedByUID, actual.CreatedByUID)
+	require.Equal(t, expected.UpdatedByUID, actual.UpdatedByUID)
+	require.Equal(t, expected.ParentUID, actual.ParentUID)
+	require.Equal(t, expected.Description, actual.Description)
+	require.Equal(t, expected.HasACL, actual.HasACL)
+	require.Equal(t, expected.Version, actual.Version)
+	require.Equal(t, expected.ManagedBy, actual.ManagedBy)
+	require.Equal(t, expected.Created.Local(), actual.Created.Local())
+	require.Equal(t, expected.Updated.Local(), actual.Updated.Local())
+}
+
 func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -313,7 +331,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 					SignedInUser: usr,
 				})
 				require.NoError(t, err)
-				require.Equal(t, f, actualFolder)
+				compareFoldersNormalizeTime(t, f, actualFolder)
 			})
 
 			t.Run("When creating folder should return error if uid is general", func(t *testing.T) {
@@ -403,8 +421,8 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 					OrgID:        fooFolder.OrgID,
 					SignedInUser: usr,
 				})
-				require.Equal(t, fooFolder, actual)
 				require.NoError(t, err)
+				compareFoldersNormalizeTime(t, fooFolder, actual)
 			})
 
 			t.Run("When get folder by uid and uid is general should return the root folder object", func(t *testing.T) {
@@ -437,8 +455,8 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				}
 
 				actual, err := folderService.Get(context.Background(), query)
-				require.Equal(t, fooFolder, actual)
 				require.NoError(t, err)
+				compareFoldersNormalizeTime(t, fooFolder, actual)
 			})
 
 			t.Run("When get folder by non existing ID should return not found error", func(t *testing.T) {
@@ -471,8 +489,8 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				}
 
 				actual, err := folderService.Get(context.Background(), query)
-				require.Equal(t, fooFolder, actual)
 				require.NoError(t, err)
+				compareFoldersNormalizeTime(t, fooFolder, actual)
 			})
 
 			t.Run("When get folder by non existing Title should return not found error", func(t *testing.T) {
@@ -847,7 +865,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 			CreatedByUID: ":0",
 			UpdatedByUID: ":0",
 		}
-		require.Equal(t, expectedResult, result)
+		compareFoldersNormalizeTime(t, expectedResult, result)
 		fakeK8sClient.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104665 - this is needed as some automation relies on the error codes, and returning a 500 instead of a 404 will cause issues (for example, a similar bug broke the SLO app)