### PR TITLE
[release-12.0.1] Dashboard and Folders: fix version mismatch

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -352,16 +352,6 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 		return apierrors.NewBadRequest(err.Error())
 	}
 
-	allowOverwrite := false // TODO: Add support for overwrite flag
-	// check for is someone else has written in between
-	if newAccessor.GetGeneration() != oldAccessor.GetGeneration() {
-		if allowOverwrite {
-			newAccessor.SetGeneration(oldAccessor.GetGeneration())
-		} else {
-			return apierrors.NewBadRequest(dashboards.ErrDashboardVersionMismatch.Error())
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -22,6 +22,7 @@ func LegacyCreateCommandToUnstructured(cmd *folder.CreateFolderCommand) (*unstru
 			"spec": map[string]any{
 				"title":       cmd.Title,
 				"description": cmd.Description,
+				"version":     1,
 			},
 		},
 	}
@@ -52,6 +53,7 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 			ResourceVersion:   fmt.Sprintf("%d", v.Updated.UnixMilli()),
 			CreationTimestamp: metav1.NewTime(v.Created),
 			Namespace:         namespacer(v.OrgID),
+			Generation:        int64(v.Version),
 		},
 		Spec: folders.FolderSpec{
 			Title:       v.Title,

--- a/pkg/services/folder/folderimpl/conversions.go
+++ b/pkg/services/folder/folderimpl/conversions.go
@@ -88,6 +88,7 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolder(ctx context.Context
 		updaterId = creatorId
 	}
 
+	folder.Version = int(item.GetGeneration())
 	folder.CreatedBy = creatorId
 	folder.UpdatedBy = updaterId
 
@@ -124,6 +125,7 @@ func (ss *FolderUnifiedStoreImpl) UnstructuredToLegacyFolderList(ctx context.Con
 			updaterId = creatorId
 		}
 
+		folder.Version = int(item.GetGeneration())
 		folder.CreatedBy = creatorId
 		folder.UpdatedBy = updaterId
 		folders = append(folders, folder)

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -591,6 +591,8 @@ func (s *Service) updateOnApiServer(ctx context.Context, cmd *folder.UpdateFolde
 		NewTitle:       cmd.NewTitle,
 		NewDescription: cmd.NewDescription,
 		SignedInUser:   user,
+		Overwrite:      cmd.Overwrite,
+		Version:        cmd.Version,
 	})
 
 	if err != nil {

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -104,6 +104,11 @@ func (ss *FolderUnifiedStoreImpl) Update(ctx context.Context, cmd folder.UpdateF
 			return nil, err
 		}
 		meta.SetFolder(*cmd.NewParentUID)
+	} else {
+		// only compare versions if not moving the folder
+		if !cmd.Overwrite && (cmd.Version != int(obj.GetGeneration())) {
+			return nil, dashboards.ErrDashboardVersionMismatch
+		}
 	}
 
 	out, err := ss.k8sclient.Update(ctx, updated, cmd.OrgID, v1.UpdateOptions{


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/104663 - this is needed for three reasons:

1. The folders /api was missing a field version that was in the api prior to G12
2. The folders /api was no longer enforcing version mismatch / using the overwrite variable, as it should
3. The dashboard /api could no longer set overwrite & be able to use force write a dashboard if it is outdated - note: version mismatches are still being enforced in /api, we will need to enforce it on an RV level in /apis before the frontend starts using /apis directly. But for now, this fixes the main flow.

All of which are breaking