### PR TITLE
[release-12.0.1] Dashboards: Fix moving to general folder

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -332,7 +332,7 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 	}
 
 	// Validate folder existence if specified and changed
-	if !a.IsDryRun() && newAccessor.GetFolder() != oldAccessor.GetFolder() {
+	if !a.IsDryRun() && newAccessor.GetFolder() != oldAccessor.GetFolder() && newAccessor.GetFolder() != "" {
 		id, err := identity.GetRequester(ctx)
 		if err != nil {
 			return fmt.Errorf("error getting requester: %w", err)

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -246,6 +246,20 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			_, err := createDashboard(t, adminClient, "Dashboard in Non-existent Folder", &nonExistentFolderUID, nil)
 			ctx.Helper.EnsureStatusError(err, http.StatusNotFound, "folders.folder.grafana.app \"non-existent-folder-uid\" not found")
 		})
+
+		t.Run("allow moving folder to general folder", func(t *testing.T) {
+			folder1 := createFolderObject(t, "folder1", "default", "")
+			folder1UID := folder1.GetName()
+			dash, err := createDashboard(t, adminClient, "Dashboard in a Folder", &folder1UID, nil)
+			require.NoError(t, err)
+
+			generalFolderUID := ""
+			_, err = updateDashboard(t, adminClient, dash, "Move dashboard into the General Folder", &generalFolderUID)
+			require.NoError(t, err)
+
+			err = adminClient.Resource.Delete(context.Background(), dash.GetName(), v1.DeleteOptions{})
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("Dashboard schema validations", func(t *testing.T) {
@@ -942,7 +956,7 @@ func createDashboard(t *testing.T, client *apis.K8sResourceClient, title string,
 	t.Helper()
 
 	var folderUIDStr string
-	if folderUID != nil && *folderUID != "" {
+	if folderUID != nil {
 		folderUIDStr = *folderUID
 	}
 


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104655 - this is required to allow dashboards to be moved from a folder to the general folder