### PR TITLE
CI: Fix e2e workflow artifact name

### DIFF
--- a/.github/workflows/run-e2e-suite.yml
+++ b/.github/workflows/run-e2e-suite.yml
@@ -27,6 +27,7 @@ jobs:
           args: go run ./pkg/build/e2e --package=grafana.tar.gz --suite=${{ inputs.suite }}
       - name: Set suite name
         id: set-suite-name
+        if: ${{ always() && inputs.old-arch != true }}
         env:
           SUITE: ${{ inputs.suite }}
         run: |

--- a/.github/workflows/run-e2e-suite.yml
+++ b/.github/workflows/run-e2e-suite.yml
@@ -21,19 +21,18 @@ jobs:
         with:
           name: ${{ inputs.package }}
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
-        if: inputs.old-arch == false
         with:
           verb: run
           args: go run ./pkg/build/e2e --package=grafana.tar.gz --suite=${{ inputs.suite }}
       - name: Set suite name
         id: set-suite-name
-        if: ${{ always() && inputs.old-arch != true }}
+        if: always()
         env:
           SUITE: ${{ inputs.suite }}
         run: |
           echo "suite=$(echo $SUITE | sed 's/\//-/g')" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
-        if: ${{ always() && inputs.old-arch != true }}
+        if: always()
         with:
           name: e2e-${{ steps.set-suite-name.outputs.suite }}-${{github.run_number}}
           path: videos


### PR DESCRIPTION
The step that sets the suite name for the artifact wasn't running if the tests failed (when we actually needed it!).

I suspect this was always the case, but when it moved to use $GITHUB_OUTPUT instead, the value just stays empty rather than the default.