### PR TITLE
Transformations: For matrix transform, default empty value to zero if the value type is number

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -1,7 +1,7 @@
 import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
-import { DataFrame, Field } from '../../types/dataFrame';
+import { DataFrame, Field, FieldType } from '../../types/dataFrame';
 import {
   SpecialValue,
   DataTransformerInfo,
@@ -68,7 +68,6 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
         const columnFieldMatch = options.columnField || DEFAULT_COLUMN_FIELD;
         const rowFieldMatch = options.rowField || DEFAULT_ROW_FIELD;
         const valueFieldMatch = options.valueField || DEFAULT_VALUE_FIELD;
-        const emptyValue = options.emptyValue || DEFAULT_EMPTY_VALUE;
 
         // Accept only single queries
         if (data.length !== 1) {
@@ -80,6 +79,9 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
         const keyRowField = findKeyField(frame, rowFieldMatch);
         const valueField = findKeyField(frame, valueFieldMatch);
         const rowColumnField = `${rowFieldMatch}\\${columnFieldMatch}`;
+
+        const emptyValue =
+          options.emptyValue || valueField?.type === FieldType.number ? SpecialValue.Zero : DEFAULT_EMPTY_VALUE;
 
         if (!keyColumnField || !keyRowField || !valueField) {
           return data;


### PR DESCRIPTION
Draft PR while we figure out if this is the direction we want to take... 

**What is this feature?**

For the matrix transform, the default empty value is a string. If this data is later reduced, a string in the values will result in values being concatenated instead of added. This logic defaults the empty value to a number if the field type is number.

**Which issue(s) does this PR fix?**:

Example dashboard on issue ticket.

Fixes #96993

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
