### PR TITLE
CI: manually `git clone` for backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone
-      - run: git clone --depth=1 "https://github.com/grafana/grafana.git"
+        run: git clone --depth=1 "https://github.com/grafana/grafana.git"
       - run: git config --local user.name "github-actions[bot]"
       - run: git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - run: git config --local --add --bool push.autoSetupRemote true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,12 +14,8 @@ jobs:
     if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4 # 4.2.2
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-          fetch-tags: false
+      - name: Clone
+      - run: git clone --depth=1 "https://github.com/grafana/grafana.git"
       - run: git config --local user.name "github-actions[bot]"
       - run: git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - run: git config --local --add --bool push.autoSetupRemote true


### PR DESCRIPTION
This gives us more control over the backport's shallow clone