### PR TITLE
Prometheus: Fix semver import path

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -3,7 +3,7 @@ import { defaults } from 'lodash';
 import { tz } from 'moment-timezone';
 import { lastValueFrom, Observable, throwError } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
-import semver from 'semver/preload';
+import { gte } from 'semver';
 
 import {
   AbstractQuery,
@@ -214,7 +214,7 @@ export class PrometheusDatasource
       return false;
     }
 
-    return semver.gte(this.datasourceConfigurationPrometheusVersion, targetVersion);
+    return gte(this.datasourceConfigurationPrometheusVersion, targetVersion);
   }
 
   _addTracingHeaders(httpOptions: PromQueryRequest, options: DataQueryRequest<PromQuery>) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a rogue import path in the prometheus npm package that causes builds resolving to esm files to break

```
ERROR in ../node_modules/@grafana/prometheus/dist/esm/datasource.mjs 5:0-36
Module not found: Error: Can't resolve 'semver/preload' in '/Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/dist/esm'
Did you mean 'preload.js'?
BREAKING CHANGE: The request 'semver/preload' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'semver/preload' in '/Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/dist/esm'
  Parsed request is a module
  using description file: /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/package.json (relative path: ./dist/esm)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      looking for modules in /Users/jackwestbrook/dev/grafana/metrics-drilldown/src
        /Users/jackwestbrook/dev/grafana/metrics-drilldown/src/semver doesn't exist
      /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/dist/esm/node_modules doesn't exist or is not a directory
      /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/dist/node_modules doesn't exist or is not a directory
      looking for modules in /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/node_modules
        /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/prometheus/node_modules/semver doesn't exist
      /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/@grafana/node_modules doesn't exist or is not a directory
      /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/node_modules doesn't exist or is not a directory
      looking for modules in /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules
        existing directory /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/semver
          using description file: /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/semver/package.json (relative path: .)
            using description file: /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/semver/package.json (relative path: ./preload)
              Field 'browser' doesn't contain a valid alias configuration
              /Users/jackwestbrook/dev/grafana/metrics-drilldown/node_modules/semver/preload doesn't exist
      /Users/jackwestbrook/dev/grafana/node_modules doesn't exist or is not a directory
      /Users/jackwestbrook/dev/node_modules doesn't exist or is not a directory
      /Users/jackwestbrook/node_modules doesn't exist or is not a directory
      /Users/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
 @ ../node_modules/@grafana/prometheus/dist/esm/index.mjs 36:0-80 36:0-80 36:0-80
 @ ./utils.ts 31:0-56 243:23-40 244:21-38
 @ ./App/App.tsx 6:0-59 14:11-26 18:39-54 21:29-43
 @ ./module.tsx
```

**Why do we need this feature?**

So plugins using this package can continue to be built.

**Who is this feature for?**

Grafana plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
