### PR TITLE
docs(alerting): add new guides for handling missing data and connectivity errors

### DIFF
--- a/docs/sources/alerting/learn/_index.md
+++ b/docs/sources/alerting/learn/_index.md
@@ -9,12 +9,12 @@ labels:
     - enterprise
     - oss
 menuTitle: Learn
-title: Grafana Alerting Guides & Tutorials
+title: Grafana Alerting Guides
 weight: 170
 ---
 
-# Grafana Alerting Guides & Tutorials
+# Grafana Alerting Guides
 
-This section provides a set of guides for useful alerting practices and recommendations.
+This section provides a set of guides with useful alerting practices and recommendations.
 
 {{< section >}}

--- a/docs/sources/alerting/learn/_index.md
+++ b/docs/sources/alerting/learn/_index.md
@@ -1,0 +1,20 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/learn/
+description: This section provides a set of guides for useful alerting practices and recommendations
+keywords:
+  - grafana
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Learn
+title: Grafana Alerting Guides & Tutorials
+weight: 170
+---
+
+# Grafana Alerting Guides & Tutorials
+
+This section provides a set of guides for useful alerting practices and recommendations.
+
+{{< section >}}

--- a/docs/sources/alerting/learn/connectivity-errors.md
+++ b/docs/sources/alerting/learn/connectivity-errors.md
@@ -1,10 +1,12 @@
 ---
 canonical: https://grafana.com/docs/grafana/latest/alerting/learn/connectivity-errors/
-description: Declare an incident from a firing alert
+description: Learn how to detect and handle connectivity issues in alerts using Prometheus, Grafana Alerting, or both.
 keywords:
   - grafana
-  - alert rules
-  - incident
+  - alerting
+  - guide
+  - rules
+  - create
 labels:
   products:
     - cloud

--- a/docs/sources/alerting/learn/connectivity-errors.md
+++ b/docs/sources/alerting/learn/connectivity-errors.md
@@ -187,7 +187,7 @@ You can configure this behavior depending on how critical the alert is—and whe
 - **Normal**: Ignores the query error and transitions all alert instances to the `Normal` state. This is useful if the error isn’t critical or if you already have other alerts detecting connectivity issues.
 - **Keep Last State**: Keeps the previous state until the query succeeds again. Suitable for unstable environments to avoid flapping alerts.
 
-  {{< figure src="/media/docs/alerting/alert-rule-configure-no-data-and-error-v2.png" alt="A screenshot of the `Configure no data and error handling` option in Grafana Alerting." max-width="500px" >}}
+  {{< figure src="/media/docs/alerting/alert-rule-configure-no-data-and-error-v2.png" alt="A screenshot of the `Configure error handling` option in Grafana Alerting." max-width="500px" >}}
 
 This applies even when alert rules query Prometheus itself—not just external data sources.
 

--- a/docs/sources/alerting/learn/connectivity-erros.md
+++ b/docs/sources/alerting/learn/connectivity-erros.md
@@ -1,0 +1,232 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/learn/connectivity-errors/
+description: Declare an incident from a firing alert
+keywords:
+  - grafana
+  - alert rules
+  - incident
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Handling connectivity errors
+title: Handling connectivity errors in alerts
+weight: 1010
+refs:
+  pending-period:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/
+  notifications:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/
+  no-data-and-error-alerts:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/#no-data-and-error-alerts
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/#no-data-and-error-alerts
+  configure-nodata-and-error-handling:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/#modify-the-no-data-or-error-state
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/#modify-the-no-data-or-error-state
+  missing-data-guide:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/learn/missing-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/learn/missing-data/
+---
+
+# Handling connectivity errors in alerts
+
+Connectivity issues are one of the common causes of misleading alerts or unnoticed failures.
+
+Maybe your target went offline, or Prometheus couldn't scrape it. Or maybe your alert query failed because its target timed out or the network went down. These situations might look similar, but require different considerations in your alerting setup.
+
+This guide walks through how to detect and handle these types of failures, whether you're writing alert rules in Prometheus, using Grafana Alerting, or combining both. It covers both availability monitoring and alert query failures, and outlines strategies to improve the reliability of your alerts.
+
+## Understanding connectivity issues in alerts
+
+Typically, connectivity issues fall into a few common scenarios:
+
+- Servers or containers crashed or were shut down.
+- Service overload or timeout.
+- Misconfigured authentication or incorrect permissions.
+- Network issues like DNS problems or ISP outages.
+
+When we talk about connectivity errors in alerting, we’re usually referring to one of two use cases:
+
+1. **Your target is down or unreachable.**  
+   The service crashed, the host was down, or a firewall or DNS issue blocked the connection. These are **availability problems**.
+
+1. **Your alert query failed.**  
+   The alert couldn’t evaluate its query—maybe because the data source timed out or an invalid query. These are **execution errors**.
+
+It helps to separate these cases early, because they behave differently and require different strategies.
+
+Keep in mind that most alert rules don’t hit the target directly. They query metrics from a monitoring system like Prometheus, which scrapes data from your actual infrastructure or application. That gives us two typical alerting setups where connectivity issues can show up:
+
+1. **Alert rule → Target**  
+   For example, an alert rule querying an external data source like a database.
+
+2. **Alert rule → Prometheus ← Target**  
+   More common in observability stacks. For instance, Prometheus scrapes a node or container, and the alert rule queries the metrics later.
+
+   In this second setup, you can run into connectivity issues on either side. If Prometheus fails to scrape the target, your alert rule might not fire, even though something is likely wrong.
+
+## Detecting target availability with the Prometheus `up` metric
+
+Prometheus scrapes metrics from its targets regularly, following the [`scrape_interval`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) period. The default scrape interval is 60 seconds, which is generally considered common practice.
+
+Prometheus provides a built-in metric called `up` for every scrape target, a simple method to indicate whether scraping is successful:
+
+- `up == 1`: Your target is reachable; Prometheus collected the target metrics as expected.
+
+- `up == 0`: Prometheus couldn't reach your target—indicating possible downtime or network errors.
+
+A typical PromQL expression for an alert rule to detect when a target becomes unreachable is:
+
+`up == 0`
+
+But this alert rule might result in noisy alerts as one brief hiccup (a single scrape failure) will fire the alert. To reduce noise, you should add a delay:
+
+`up == 0 for: 5m`
+
+The `for` option in Prometheus (or [pending period](ref:pending-period) in Grafana) delays the alert until the condition has been true for the full duration.
+
+In this example, waiting for 5 minutes helps skip temporary hiccups. Since Prometheus scrapes metrics every minute by default, the alert only fires after five consecutive failures.
+
+However, this kind of `up` alert has a few gotchas:
+
+- **Failures can slip between scrape intervals**: An outage that starts and ends between two evaluations go undetected. You could shorten the `for` duration, but this might lead to temporary hiccups triggering false alarms.
+- **Intermittent recoveries reset the `for` timer**: A single successful scrape resets the alert timer, masking intermittent outages.
+
+Brief connectivity drops are common in real-world environments, so expect some flakiness in `up` alerts. For example:
+
+| Scrape result (`up`) | Alert rule evaluation                                |
+| :------------------- | :--------------------------------------------------- |
+| 00:00 `up == 0`      | Timer starts                                         |
+| 01:00 `up == 0`      | Timer continues                                      |
+| 02:00 `up == 0`      | Timer continues                                      |
+| 03:00 `up == 1`      | Successful scrape resets timer                       |
+| 04:00 `up == 0`      | Timer starts again                                   |
+| 05:00 `up == 0`      | No alert yet—timer hasn’t reached the `for` duration |
+
+The longer the period, the more likely this is to happen.
+
+A single recovery resets the alert, that’s why `up == 0 for: 5m` can sometimes be unreliable. Even if the target is down most of the time, the alert didn't fire, leaving you unaware of a potential persistent issue.
+
+### Using `avg_over_time`
+
+One way to work around these issues is to smooth the signal by averaging the `up` metric over a similar or longer period:
+
+`avg_over_time(up[10m]) < 0.8`
+
+This alert rule fires when the target is unreachable for more than 20% of the last 10 minutes, rather than looking for consecutive scrape failures. With a one-minute scrape interval, three or more failed scrapes within the last 10 minutes will now trigger the alert.
+
+Since this query uses a threshold and time window to control accuracy, you can now lower the `for` duration (or [pending period](ref:pending-period) in Grafana) to something shorter—`0m` or `1m`—so the alert fires faster.
+
+This approach gives you more flexibility in detecting real crashes or network issues. As always, adjust the threshold and period based on your noise tolerance and how critical the target is.
+
+### Using synthetic checks for monitoring external availability
+
+Prometheus often runs inside the same network as the target it monitors. That means Prometheus might be able to reach the target, but doesn’t ensure it’s reachable to users on the outside.
+
+Firewalls, DNS misconfigurations, or other network issues might block public traffic while Prometheus scraping `up` successfully.
+
+This is where synthetic monitoring helps. Tools like the [Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) let you continuously verify whether a service is available and reachable from outside your network—not just internally.
+
+The Blackbox Exporter exposes the results of these checks as metrics, which Prometheus can scrape like any other target. For example, the `probe_success` metric reports whether the probe was able to reach the service. The setup looks like this:
+
+**Alert rules → Prometheus ← Blackbox Exporter (external probe) → Target**
+
+To detect when a service isn’t reachable externally, you can define an alert using the `probe_success` metric:
+
+`probe_success == 0 for: 5m`
+
+This alert fires when the probe has failed continuously for 5 minutes—indicating that the service couldn’t be reached from the outside.
+
+You can then combine internal and external checks to make the detection of connectivity errors more reliable. This alert catches when the internal scrape fails or the service is externally unreachable.
+
+`up == 0 or probe_success == 0`
+
+As with the `up` metric, you might want to smooth this out using `avg_over_time()` for more robust detection. The smooth version might look like:
+
+`avg_over_time(up[10m]) < 0.8 or avg_over_time(probe_success[10m]) < 0.8`
+
+This alert fires when Prometheus couldn't scrape the target successfully for more than 20% of the past 10 minutes, or when the external probes have been failing more than 20% of the time. This smoothing technique can be applied to any binary availability signal.
+
+## When only some hosts stop reporting
+
+In many setups, Prometheus scrapes multiple hosts under the same target — for example, a fleet of servers or containers behind a common job label. It’s common for one host to go offline while the others continue to report metrics normally.
+
+If your alert only checks the general `up` metric without breaking it down by labels (like `instance`, `host`, or `pod`), you might miss when a host stops reporting. For example, an alert that looks only at the aggregated status of all instances will likely fail to catch when individual instances go missing.
+
+This isn't a connectivity error in this context — it’s not that the alert or Prometheus can't reach anything, it’s that one or more specific targets have gone silent. These kinds of problems aren’t caught by `up == 0` alerts.
+
+For these cases, see the complementary [guide on handling missing data](ref:missing-data-guide) — it covers common scenarios where the alert queries return no data at all, or where only some targets stop reporting. These aren't full availability failures or execution errors, but they can still lead to blind spots in alert detection.
+
+## Handling query errors in Grafana Alerting
+
+Not all connectivity issues come from targets going offline. Sometimes, the alert rule fails when querying its target. These aren’t availability problems—they’re query execution errors: maybe the data source timed out, the network dropped, or the query was invalid.
+
+These errors lead to broken alerts. But they come from a different part of the stack: between the alert rule and the data source, not between the data source (e.g., Prometheus) and its target.
+
+This difference matters. Availability issues are typically handled using metrics like `up` or `probe_success` but execution errors require a different setup.
+
+Grafana Alerting has built-in handling for execution errors, regardless of the data source. That includes Prometheus, and others like Graphite, InfluxDB, PostgreSQL, etc. By default, Grafana Alerting automatically handles query errors so you don’t miss critical failures. When an alert rule fails to execute, Grafana fires a special `DatasourceError` alert.
+
+You can configure this behavior depending on how critical the alert is—and whether you already have other alerts detecting the issue. In [**Configure no data and error handling**](ref:configure-nodata-and-error-handling), click **Alert state if execution error or timeout**, and choose the desired option for the alert:
+
+- **Error (default)**: Triggers a separate `DatasourceError` alert. This default ensures alert rules always inform about query errors but can create noise.
+- **Alerting**: Treats the error as if the alert condition is firing. Grafana transitions all existing instances for that rule to the `Alerting` state.
+- **Normal**: Ignores the query error and transitions all alert instances to the `Normal` state. This is useful if the error isn’t critical or if you already have other alerts detecting connectivity issues.
+- **Keep Last State**: Keeps the previous state until the query succeeds again. Suitable for unstable environments to avoid flapping alerts.
+
+  {{< figure src="/media/docs/alerting/alert-rule-configure-no-data-and-error-v2.png" alt="A screenshot of the `Configure no data and error handling` option in Grafana Alerting." max-width="500px" >}}
+
+This applies even when alert rules query Prometheus itself—not just external data sources.
+
+### Designing alerts for connectivity errors
+
+In practice, start by deciding if you want to create explicit alert rules — for example, using `up` or `probe_success` — to detect when a target is down or having connectivity issues.
+
+Then, for each alert rule, choose the error-handling behavior based on whether you already have dedicated connectivity alerts, the stability of the target, and how critical the alert is. Prioritize alerts based on symptom severity rather than just infrastructure signals that might not impact users.
+
+### Reducing redundant error notifications
+
+A single data source error can lead to multiple alerts firing simultaneously, sometimes bombarding you with many alerts and generating too much noise.
+
+As described previously, you can control the error-handling behavior for Grafana alerts. The **Keep Last State** or **Normal** option prevents alerts from firing and helps avoid redundant alerts, especially for services already covered by `up` or `probe_success` alerts.
+
+When using the default behavior, a single connectivity error will likely trigger multiple `DatasourceError` alerts.
+
+These alerts are separate from the original alerts—they’re not just a different state of the original alert. They fire immediately, ignore the pending period, and don’t inherit all the labels. This can catch you off guard if you expect them to behave like the original alerts.
+
+Consider not treating these alerts in the same way as the original alerts, and implement dedicated strategies for their notifications:
+
+- Reduce duplicate notifications by grouping `DatasourceError` alerts. Use the `datasource_uid` label to group errors from the same data source.
+
+- Route `DatasourceError` alerts separately, sending them to different teams or channels depending on their impact and urgency.
+
+For details on how to configure grouping and routing, refer to [handling notifications](ref:notifications) and [`No Data` and `Error` alerts](ref:no-data-and-error-alerts) documentation.
+
+## Wrapping up
+
+Connectivity issues are one of the common causes of noisy or misleading alerts. This guide covered two distinct types:
+
+- **Availability issues**, where the target itself is down or unreachable (e.g., due to a crash or network failure).
+
+- **Query execution errors**, where the alert rule can't reach its data source (e.g., due to timeouts, invalid queries, or data source outages).
+
+These problems come from different parts of your stack, and require its own techniques. Prometheus and Grafana allow you to detect them, and combining distinct techniques can make your alerts more resilient.
+
+With Prometheus, avoid relying solely on `up == 0`. Smooth queries to account for intermittent failures, and use synthetic monitoring to detect reachability issues from outside your network.
+
+In Grafana Alerting, configure error handling explicitly. Not all alerts are equal or have the same urgency. Tune the error-handling behavior based on the reliability and severity of the alerts and whether you already have alerts dedicated to connectivity problems.
+
+And don’t forget the third case: **missing data**. If only one host from a fleet silently disappears, you might not get alerted. If you're dealing with individual instances that stopped reporting data, see the [Guide on handling missing data](ref:missing-data-guide) to continue exploring this topic.

--- a/docs/sources/alerting/learn/missing-data.md
+++ b/docs/sources/alerting/learn/missing-data.md
@@ -1,0 +1,51 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/learn/missing-data/
+description: Declare an incident from a firing alert
+keywords:
+  - grafana
+  - alert rules
+  - incident
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Handling missing data
+title: Handling missing data in Grafana Alerting
+weight: 1020
+refs:
+  connectivity-errors-guide:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/learn/connectivity-errors/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/learn/connectivity-errors/
+  connectivity-errors-reduce-alert-fatigue:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/learn/connectivity-errors/#reducing-notification-fatigue-from-datasourceerror-alerts
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/learn/connectivity-errors/
+  alert-history:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/monitor-status/view-alert-state-history/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/monitor-status/view-alert-state-history/
+  configure-nodata-and-error-handling:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/#modify-the-no-data-or-error-state
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/#modify-the-no-data-or-error-state
+  stale-alert-instances:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/#stale-alert-instances-missingseries
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/#stale-alert-instances-missingseries
+  no-data-and-error-alerts:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rule-evaluation/state-and-health/#no-data-and-error-alerts
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rule-evaluation/state-and-health/#no-data-and-error-alerts
+---
+
+# Handling missing data in Grafana Alerting
+
+Declare an incident from a firing alert to streamline your alert to incident workflow.

--- a/docs/sources/alerting/learn/missing-data.md
+++ b/docs/sources/alerting/learn/missing-data.md
@@ -1,10 +1,12 @@
 ---
 canonical: https://grafana.com/docs/grafana/latest/alerting/learn/missing-data/
-description: Declare an incident from a firing alert
+description: Learn how to detect missing metrics and design alerts that handle gaps in data in Prometheus and Grafana Alerting.
 keywords:
   - grafana
-  - alert rules
-  - incident
+  - alerting
+  - guide
+  - rules
+  - create
 labels:
   products:
     - cloud

--- a/docs/sources/alerting/learn/missing-data.md
+++ b/docs/sources/alerting/learn/missing-data.md
@@ -48,4 +48,159 @@ refs:
 
 # Handling missing data in Grafana Alerting
 
-Declare an incident from a firing alert to streamline your alert to incident workflow.
+Missing data, or when a target stops reporting metric data, is one of the most common issues when troubleshooting alerts. In cloud-native environments, this happens all the time — pods or nodes scale down to match demand, or an entire job quietly disappears.
+
+When this happens, alerts won’t fire, and you might not notice the system has stopped reporting.
+
+Sometimes it's just a lack of data from a few instances. Other times, it's a connectivity issue where the entire target is unreachable.
+
+This guide covers different scenarios where the underlying data is missing and how to design your alerts to act on those cases. If you're troubleshooting an unreachable host or a network failure, see [Handling connectivity errors](ref:connectivity-errors-guide) as well.
+
+## No Data vs. Missing Series
+
+There are a few common causes when an instance stops reporting data, similar to [connectivity errors](ref:connectivity-errors-guide):
+
+- Host crash: The system is down, and Prometheus stops scraping the target.
+- Temporary network failures: Intermittent scrape failures cause data gaps.
+- Deployment changes: Decommissioning, Kubernetes pod eviction, or scaling down resources.
+- Ephemeral workloads: Metrics intentionally stop reporting.
+- And more.
+
+The first thing to understand is the difference between a query failure (or connectivity error), _No Data_, and a _Missing Series_.
+
+Alert queries often return multiple time series — one per instance, pod, region, or label combination. This is known as a **multi-dimensional alert**, meaning a single alert rule can trigger multiple alert instances (alerts).
+
+For example, imagine a recorded metric, `http_request_latency_seconds`, that reports latency per second in the regions where the application is deployed. The query returns one series per region — for instance, `region1` and `region2` — and generates only two alert instances. In this scenario, you may experience:
+
+- **Connectivity Error** if the alert rule query fails.
+- **No Data** if the query runs successfully but returns no data at all.
+- **Missing Series** if one or more specific series, which previously returned data, are missing, but other series still return data.
+
+In both _No Data_ and _Missing Series_ cases, the query still technically "works", but the alert won’t fire unless you explicitly configure it to handle these situations.
+
+Let’s walk through both scenarios using the previous example, with an alert that triggers if the latency exceeds 2 seconds in any region: `avg_over_time(http_request_latency_seconds[5m]) > 2`
+
+**No Data Scenario:** The query returns no data for any series:
+
+| Time  | region1    | region2    | Alert triggered              |
+| :---- | :--------- | :--------- | :--------------------------- |
+| 00:00 | 1.5s 🟢    | 1s 🟢      | ✅ No Alert                  |
+| 01:00 | No Data ⚠️ | No Data ⚠️ | ⚠️ No Alert (Silent Failure) |
+| 02:00 | No Data ⚠️ | No Data ⚠️ | ⚠️ No Alert (Silent Failure) |
+| 03:00 | 1.4s 🟢    | 1s 🟢      | ✅ No Alert                  |
+
+**MissingSeries Scenario:** Only a specific series (`region2`) disappears:
+
+| Time  | region1 | region2           | Alert triggered              |
+| :---- | :------ | :---------------- | :--------------------------- |
+| 00:00 | 1.5s 🟢 | 1s 🟢             | ✅ No Alert                  |
+| 01:00 | 1.6s 🟢 | Missing Series ⚠️ | ⚠️ No Alert (Silent Failure) |
+| 02:00 | 1.6s 🟢 | Missing Series ⚠️ | ⚠️ No Alert (Silent Failure) |
+| 03:00 | 1.4s 🟢 | 1s 🟢             | ✅ No Alert                  |
+
+In both cases, something broke silently.
+
+## Detecting missing data in Prometheus
+
+Prometheus doesn't fire alerts when the query returns no data. It simply assumes there was nothing to report, like with query errors. Missing data won’t trigger existing alerts unless you explicitly check for it.
+
+In Prometheus, a common way to catch missing data is by using the `absent_over_time` function.
+
+`absent_over_time(http_request_latency_seconds[5m]) == 1`
+
+This triggers when all series for `http_request_latency_seconds` are absent for 5 minutes — catching the _No Data_ case when the entire metric disappears.
+
+However, `absent_over_time()` can’t detect which specific series are missing since it doesn’t preserve labels. The alert won’t tell you which series stopped reporting — only that the query returns no data.
+
+If you want to check for missing data per-region or label, you can specify the label in the alert query as follows:
+
+`absent_over_time(http_request_latency_seconds{region="region1"}[5m]) == 1`  
+`or`  
+`absent_over_time(http_request_latency_seconds{region="region2"}[5m]) == 1`
+
+But this doesn't scale well. Hardcoding queries for each label set is fragile, especially in dynamic cloud environments where instances can appear or disappear at any time.
+
+## Handling No Data in Grafana alerts
+
+While Prometheus provides functions like `absent_over_time()` to detect missing data, not all data sources — like Graphite, InfluxDB, PostgreSQL, and others — available to Grafana alerts support a similar function.
+
+To handle this, Grafana Alerting implements a built-in `No Data` state logic, so you don’t need to detect missing data with `absent_*` queries. Instead, you can configure in the alert rule settings how alerts behave when no data is returned.
+
+Similar to error handling, Grafana by default triggers a special _No data_ alert and lets you control this behavior. In [**Configure no data and error handling**](ref:configure-nodata-and-error-handling), click **Alert state if no data or all values are null**, and choose one of the following options:
+
+- **No Data (default):** Triggers a new `DatasourceNoData` alert, treating _No data_ as a specific problem.
+- **Alerting:** Transition each existing alert instance into the `Alerting` state when data disappears.
+- **Normal:** Ignores missing data and transitions all instances to the `Normal` state. Useful when receiving intermittent data, such as from experimental services, sporadic actions, or periodic reports.
+- **Keep Last State:** Leaves the alert in its previous state until the data returns. This is common in environments where brief metric gaps happen regularly, like with flaky exporters or noisy environments.
+
+  {{< figure src="/media/docs/alerting/alert-rule-configure-no-data.png" alt="A screenshot of the `Configure no data handling` option in Grafana Alerting." max-width="500px" >}}
+
+### Handling DatasourceNoData notifications
+
+When Grafana triggers a [NoData alert](ref:no-data-and-error-alerts), it creates a distinct alert instance, separate from the original alert instance. These alerts behave differently:
+
+- They use a dedicated `alertname: DatasourceNoData`.
+- They don’t inherit all the labels from the original alert instances.
+- They trigger immediately, ignoring the pending period.
+
+Because of this, `DatasourceNoData` alerts might require a dedicated setup to handle their notifications. For general recommendations, see [Reduce redundant DatasourceError alerts](ref:connectivity-errors-reduce-alert-fatigue) — similar practices can apply to _NoData_ alerts.
+
+## Evicting alert instances for missing series
+
+_MissingSeries_ occurs when only some series disappear but not all. This case is subtle — but important.
+
+Grafana marks missing series as [**stale**](ref:stale-alert-instances) after two evaluation intervals and triggers the alert instance eviction process. Here’s what happens under the hood:
+
+- Alert instances with missing data keep their last state for two evaluation intervals.
+- If still missing after that:
+  - Grafana adds the annotation `grafana_state_reason: MissingSeries`.
+  - The alert instance transitions to the `Normal` state.
+  - A **resolved notification** is sent if the alert was previously firing.
+  - The **alert instance is removed** from the Grafana UI.
+
+If an alert instance becomes stale, you’ll find in the [alert history](ref:alert-history) as `Normal (Missing Series)` before it disappears. This table shows the eviction process from the previous example:
+
+| Time  | region1               | region2                            | Alert triggered                                                                                |
+| :---- | :-------------------- | :--------------------------------- | :--------------------------------------------------------------------------------------------- |
+| 00:00 | 1.5s 🟢               | 1s 🟢                              | 🟢🟢 No Alerts                                                                                 |
+| 01:00 | 3s 🔴 <br> `Alerting` | 3s 🔴 <br> `Alerting`              | 🔴🔴 Alert instances triggered for both regions                                                |
+| 02:00 | 1.6s 🟢               | MissingSeries ⚠️ <br> `Alerting` ️ | 🟢🔴 Region2 missing, state maintained.                                                        |
+| 03:00 | 1.6s 🟢               | MissingSeries ⚠️ `Alerting`️       | 🟢🔴Region2 missing, state maintained.                                                         |
+| 04:00 | 1.4s 🟢               | —                                  | 🟢 🟢 `region2` Normal (Missing Series), resolved, and instance evicted; 📩 Notification sent. |
+| 05:00 | 1.4s 🟢               | —                                  | 🟢 No Alerts                                                                                   |
+
+###
+
+### Why doesn’t MissingSeries match No Data behaviour?
+
+In dynamic environments — autoscaling groups, ephemeral pods, spot instances — series naturally come and go. **MissingSeries** normally signals infrastructure or deployment changes.
+
+By default, **No Data** triggers an alert to indicate a potential problem.
+
+The eviction process for **MissingSeries** is designed to prevent alert flapping when a pod or instance disappears, reducing alert noise.
+
+In environments with frequent scale events, prioritize symptom-based alerts over individual infrastructure signals and use aggregate alerts unless you explicitly need to track individual instances.
+
+### Handling MissingSeries notifications
+
+A stale alert instance triggers a **resolved notification** if it transitions from a firing state (such as `Alerting`, `No Data`, or `Error`) to `Normal`.
+
+You can display the `MissingSeries` annotation in notifications to indicate the alert wasn’t resolved by recovery but evicted due to series data going missing.
+
+Review these notifications to confirm whether something broke or if the alert was unnecessary. To reduce noise:
+
+- Silence or mute alerts during planned maintenance or rollouts.
+- Adjust alert rules to avoid triggering on series you expect to come and go, and use aggregated alerts instead.
+
+## Wrapping up
+
+Missing data isn’t always a failure. It’s a common scenario in dynamic environments when certain targets stop reporting.
+
+Grafana Alerting handles distinct scenarios automatically. Here’s how to think about it:
+
+- Use Grafana’s _No Data_ handling options to define what happens when a query returns nothing.
+- Understand `DatasourceNoData` and `MissingSeries` notifications, since they don’t behave like regular alerts.
+- Use `absent()` or `absent_over_time()` in Prometheus for fine-grained detection when a metric or label disappears entirely.
+- Don’t alert on every instance by default. In dynamic environments, it’s better to aggregate and alert on symptoms — unless a missing individual instance directly impacts users.
+- If you’re getting too much noise from disappearing data, consider adjusting alerts, using `Keep Last State`, or routing those alerts differently.
+- For connectivity issues involving alert query failures, see the sibling guide: [Handling connectivity errors in Grafana Alerting](ref:connectivity-errors-guide).


### PR DESCRIPTION
![Screenshot 2025-04-30 at 12 19 45](https://github.com/user-attachments/assets/d10d396e-2edd-4dc3-8eb9-ff389f03c07d)


⭐ Preview:
- [Handling connectivity errors](https://deploy-preview-grafana-104765-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/learn/connectivity-errors/)
- [Handling missing data ](https://deploy-preview-grafana-104765-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/learn/missing-data/)