### PR TITLE
Keepers: Fix integration tests

### DIFF
--- a/pkg/tests/apis/secret/main_test.go
+++ b/pkg/tests/apis/secret/main_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/registry/apis/secret"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -131,7 +133,7 @@ func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, user apis
 		GVR:  gvrSecureValues,
 	})
 
-	testSecureValue := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
+	testSecureValue := helper.LoadYAMLOrJSONFile("testdata/secure-value-default-generate.yaml")
 	if len(keeperName) == 1 {
 		testSecureValue.Object["spec"].(map[string]any)["keeper"] = keeperName[0]
 	}
@@ -139,6 +141,21 @@ func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, user apis
 	raw, err := secureValueClient.Resource.Create(ctx, testSecureValue, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, raw)
+
+	// Before returning, we need to wait for the outbox to process it, and the status.phase to be Succeeded.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		result, err := secureValueClient.Resource.Get(ctx, raw.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		status, ok := result.Object["status"].(map[string]any)
+		require.True(t, ok)
+		require.NotNil(t, status)
+
+		statusPhase, ok := status["phase"].(string)
+		require.True(t, ok)
+		require.Equal(t, "Succeeded", statusPhase)
+	}, 10*time.Second, 250*time.Millisecond, "expected status to be Suceeded")
 
 	t.Cleanup(func() {
 		require.NoError(t, secureValueClient.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))

--- a/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
@@ -3,8 +3,10 @@ kind: SecureValue
 metadata:
   annotations:
     xx: XXX
+    yy: YYY
   labels:
     aa: AAA
+    bb: BBB
 spec:
   description: This is a secret
   value: this is super duper secure


### PR DESCRIPTION
Initial PR addressing integration test issues.

- Properly set Keeper value coming from the DB, we need to check if it is `.Valid` before setting an empty string.

- Wait for SecureValue to be created by the Outbox on tests.

- Skip test with AWS Keeper (not implementable in OSS).

- Change Client used to Create Keepers in limited scope permissions tests