### PR TITLE
Remote Alertmanager: Configure SMTP From address

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -216,6 +216,7 @@ func (ng *AlertNG) init() error {
 						PromoteConfig:     true,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
 						ExternalURL:       ng.Cfg.AppURL,
+						SmtpFrom:          ng.Cfg.Smtp.FromAddress,
 						StaticHeaders:     ng.Cfg.Smtp.StaticHeaders,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
@@ -252,6 +253,7 @@ func (ng *AlertNG) init() error {
 						TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						ExternalURL:       ng.Cfg.AppURL,
+						SmtpFrom:          ng.Cfg.Smtp.FromAddress,
 						StaticHeaders:     ng.Cfg.Smtp.StaticHeaders,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
@@ -290,6 +292,7 @@ func (ng *AlertNG) init() error {
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
 						ExternalURL:       ng.Cfg.AppURL,
+						SmtpFrom:          ng.Cfg.Smtp.FromAddress,
 						StaticHeaders:     ng.Cfg.Smtp.StaticHeaders,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -86,7 +86,8 @@ type AlertmanagerConfig struct {
 	// The same flag is used for promoting state.
 	PromoteConfig bool
 
-	// StaticHeaders are used in email notifications sent by the remote Alertmanager.
+	// SmtpFrom and StaticHeaders are used in email notifications sent by the remote Alertmanager.
+	SmtpFrom      string
 	StaticHeaders map[string]string
 
 	// SyncInterval determines how often we should attempt to synchronize configuration.
@@ -126,6 +127,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, store stateStore, decryptFn Decrypt
 		URL:           u,
 		PromoteConfig: cfg.PromoteConfig,
 		ExternalURL:   cfg.ExternalURL,
+		SmtpFrom:      cfg.SmtpFrom,
 		StaticHeaders: cfg.StaticHeaders,
 	}
 	mc, err := remoteClient.New(mcCfg, metrics, tracer)

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -240,7 +240,7 @@ func TestApplyConfig(t *testing.T) {
 	require.Equal(t, 1, stateSyncs)
 
 	// Failing to add the auto-generated routes should result in an error.
-	am, err = NewAlertmanager(cfg, fstore, secretsService.Decrypt, errAutogenFn, m, tracing.InitializeTracerForTest())
+	_, err = NewAlertmanager(cfg, fstore, secretsService.Decrypt, errAutogenFn, m, tracing.InitializeTracerForTest())
 	require.ErrorIs(t, am.ApplyConfig(ctx, config), errTest)
 	require.Equal(t, 2, configSyncs)
 

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -178,6 +178,7 @@ func TestApplyConfig(t *testing.T) {
 		PromoteConfig: true,
 		SyncInterval:  1 * time.Hour,
 		ExternalURL:   "https://test.grafana.com",
+		SmtpFrom:      "test-instance@grafana.net",
 		StaticHeaders: map[string]string{"Header-1": "Value-1", "Header-2": "Value-2"},
 	}
 
@@ -209,8 +210,9 @@ func TestApplyConfig(t *testing.T) {
 	require.JSONEq(t, testGrafanaConfigWithSecret, string(amCfg))
 	require.True(t, configSent.Promoted)
 
-	// Grafana's URL and static headers should be sent alongside the configuration.
+	// Grafana's URL, email "from" address, and static headers should be sent alongside the configuration.
 	require.Equal(t, cfg.ExternalURL, configSent.ExternalURL)
+	require.Equal(t, cfg.SmtpFrom, configSent.SmtpFrom)
 	require.Equal(t, cfg.StaticHeaders, configSent.StaticHeaders)
 
 	// If we already got a 200 status code response and the sync interval hasn't elapsed,

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -22,6 +22,7 @@ type UserGrafanaConfig struct {
 	Default                   bool                          `json:"default"`
 	Promoted                  bool                          `json:"promoted"`
 	ExternalURL               string                        `json:"external_url"`
+	SmtpFrom                  string                        `json:"smtp_from"`
 	StaticHeaders             map[string]string             `json:"static_headers"`
 }
 
@@ -56,6 +57,7 @@ func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, cfg *apimo
 		Default:                   isDefault,
 		Promoted:                  mc.promoteConfig,
 		ExternalURL:               mc.externalURL,
+		SmtpFrom:                  mc.smtpFrom,
 		StaticHeaders:             mc.staticHeaders,
 	})
 	if err != nil {

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -47,6 +47,7 @@ type Mimir struct {
 	metrics       *metrics.RemoteAlertmanager
 	promoteConfig bool
 	externalURL   string
+	smtpFrom      string
 	staticHeaders map[string]string
 }
 
@@ -58,6 +59,7 @@ type Config struct {
 	Logger        log.Logger
 	PromoteConfig bool
 	ExternalURL   string
+	SmtpFrom      string
 	StaticHeaders map[string]string
 }
 
@@ -102,6 +104,7 @@ func New(cfg *Config, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer
 		metrics:       metrics,
 		promoteConfig: cfg.PromoteConfig,
 		externalURL:   cfg.ExternalURL,
+		smtpFrom:      cfg.SmtpFrom,
 		staticHeaders: cfg.StaticHeaders,
 	}, nil
 }


### PR DESCRIPTION
This PR allows Grafana to send a from address to the remote Alertmanager to be used in email notifications.

Related Mimir PR: https://github.com/grafana/mimir/pull/11309

Same as https://github.com/grafana/grafana/pull/104554