### PR TITLE
Provisioning: Require author name

### DIFF
--- a/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
+++ b/pkg/registry/apis/provisioning/repository/go-git/wrapper.go
@@ -371,9 +371,13 @@ func (g *GoGitRepo) maybeCommit(ctx context.Context, message string) error {
 		return nil
 	}
 
-	opts := &git.CommitOptions{}
+	opts := &git.CommitOptions{
+		Author: &object.Signature{
+			Name: "grafana",
+		},
+	}
 	sig := repository.GetAuthorSignature(ctx)
-	if sig != nil {
+	if sig != nil && sig.Name != "" {
 		opts.Author = &object.Signature{
 			Name:  sig.Name,
 			Email: sig.Email,


### PR DESCRIPTION
Use "grafana" as the default name (if one was not in the context)