### PR TITLE
[release-12.0.0] Dashboard API: Update dashboard version docs

### DIFF
--- a/docs/sources/developers/http_api/dashboard_versions.md
+++ b/docs/sources/developers/http_api/dashboard_versions.md
@@ -47,30 +47,33 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
 Content-Length: 428
 
-[
-  {
-    "id": 2,
-    "dashboardId": 1,
-    "uid": "QA7wKklGz",
-    "parentVersion": 1,
-    "restoredFrom": 0,
-    "version": 2,
-    "created": "2017-06-08T17:24:33-04:00",
-    "createdBy": "admin",
-    "message": "Updated panel title"
-  },
-  {
-    "id": 1,
-    "dashboardId": 1,
-    "uid": "QA7wKklGz",
-    "parentVersion": 0,
-    "restoredFrom": 0,
-    "version": 1,
-    "created": "2017-06-08T17:23:33-04:00",
-    "createdBy": "admin",
-    "message": "Initial save"
-  }
-]
+{
+  "continueToken": "",
+  "versions": [
+    {
+      "id": 2,
+      "dashboardId": 1,
+      "uid": "QA7wKklGz",
+      "parentVersion": 1,
+      "restoredFrom": 0,
+      "version": 2,
+      "created": "2017-06-08T17:24:33-04:00",
+      "createdBy": "admin",
+      "message": "Updated panel title"
+    },
+    {
+      "id": 1,
+      "dashboardId": 1,
+      "uid": "QA7wKklGz",
+      "parentVersion": 0,
+      "restoredFrom": 0,
+      "version": 1,
+      "created": "2017-06-08T17:23:33-04:00",
+      "createdBy": "admin",
+      "message": "Initial save"
+    }
+  ]
+}
 ```
 
 Status Codes:
@@ -89,7 +92,7 @@ Get the dashboard version with the given version, for the dashboard with the giv
 **Example request for getting a dashboard version**:
 
 ```http
-GET /api/dashboards/id/1/versions/1 HTTP/1.1
+GET /api/dashboards/uid/QA7wKklGz/versions/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104565 - makes sure our dashboard versioning api docs are up to date