### PR TITLE
E2E: Fix failing old arch test.

### DIFF
--- a/e2e/old-arch/dashboards-suite/set-options-from-ui.spec.ts
+++ b/e2e/old-arch/dashboards-suite/set-options-from-ui.spec.ts
@@ -66,13 +66,15 @@ describe('Variables - Set options from ui', () => {
     e2e.components.NavToolbar.container().click();
 
     cy.wait('@query');
-    cy.wait('@query');
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('A + B').scrollIntoView().should('be.visible');
 
     e2e.components.LoadingIndicator.icon().should('have.length', 0);
 
-    e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('AA').should('be.visible').click();
+    e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('AA')
+      .should('be.visible')
+      .should('match', 'button')
+      .click();
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownDropDown()
       .should('be.visible')

--- a/e2e/old-arch/dashboards-suite/set-options-from-ui.spec.ts
+++ b/e2e/old-arch/dashboards-suite/set-options-from-ui.spec.ts
@@ -66,6 +66,7 @@ describe('Variables - Set options from ui', () => {
     e2e.components.NavToolbar.container().click();
 
     cy.wait('@query');
+    cy.wait('@query');
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('A + B').scrollIntoView().should('be.visible');
 


### PR DESCRIPTION
**What is this feature?**
Fixes a failing E2E test by waiting for the element to become a button before clicking it.
