### PR TITLE
SQL Language: Replace language definition ID from `flightsql` to `sql`

### DIFF
--- a/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
@@ -34,7 +34,7 @@ export class FlightSQLDatasource extends SqlDatasource {
       getMeta: (identifier?: TableIdentifier) => this.fetchMeta(identifier),
     };
     this.sqlLanguageDefinition = {
-      id: 'flightsql',
+      id: 'sql',
       completionProvider: getSqlCompletionProvider(args),
       formatter: formatSQL,
     };


### PR DESCRIPTION
# SQL Language: Replace language definition ID from 'flightsql' to 'sql'

## What is this feature?
This PR updates the language definition ID from 'flightsql' to 'sql' in the SQL language definition configuration for InfluxDB Core SQL.

## Why do we need this feature?
Monaco editor doesn't recognize "flightsql" as a valid language, which causes errors in the browser console:
```
SQLEditor.js:96 Uncaught (in promise) Error: Unknown Monaco language flightsql
    at vn (SQLEditor.js:96:13)
    at St (SQLEditor.js:106:30)
    at onEditorDidMount (SQLEditor.js:85:9)
    ...
```

Using the standard 'sql' language definition ID resolves this error and ensures proper syntax highlighting, code formatting, and autocompletion when working with SQL queries in the InfluxDB Core SQL interface.

## Who is this feature for?
This change benefits users of InfluxDB Core SQL in Grafana, providing them with a functional SQL editor without console errors.

## Which issue(s) does this PR fix?:
Fixes #104796

## Special notes for your reviewer:
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [[notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new)](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [[What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/)](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

This is a simple but important fix that resolves the Monaco editor error by using the standard 'sql' language identifier instead of 'flightsql'. I've verified that this change resolves the console errors when using the InfluxDB Core SQL editor.