### PR TITLE
[Release12.0.0]:Schema V2-Fix built-in annotationsV2 (#104313)

### DIFF
--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -15,6 +15,7 @@ import {
   GridLayoutKind,
   PanelSpec,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { AnnoKeyDashboardSnapshotOriginalUrl } from 'app/features/apiserver/types';
 import { SaveDashboardAsOptions } from 'app/features/dashboard/components/SaveDashboard/types';
 import { DASHBOARD_SCHEMA_VERSION } from 'app/features/dashboard/state/DashboardMigrator';
@@ -715,7 +716,22 @@ describe('DashboardSceneSerializer', () => {
           title: baseOptions.title,
           description: baseOptions.description,
           editable: true,
-          annotations: [],
+          annotations: [
+            {
+              kind: 'AnnotationQuery',
+              spec: {
+                builtIn: true,
+                name: 'Annotations & Alerts',
+                datasource: {
+                  uid: '-- Grafana --',
+                  type: 'grafana',
+                },
+                enable: true,
+                hide: true,
+                iconColor: DEFAULT_ANNOTATION_COLOR,
+              },
+            },
+          ],
           cursorSync: 'Off',
           liveNow: false,
           preload: false,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -206,25 +206,35 @@ describe('transformSaveModelSchemaV2ToScene', () => {
     // Annotations
     expect(scene.state.$data).toBeInstanceOf(DashboardDataLayerSet);
     const dataLayers = scene.state.$data as DashboardDataLayerSet;
+    // we should get two annotations, Grafana built-in and the custom ones
     expect(dataLayers.state.annotationLayers).toHaveLength(dash.annotations.length);
-    expect(dataLayers.state.annotationLayers[0].state.name).toBe(dash.annotations[0].spec.name);
-    expect(dataLayers.state.annotationLayers[0].state.isEnabled).toBe(dash.annotations[0].spec.enable);
-    expect(dataLayers.state.annotationLayers[0].state.isHidden).toBe(dash.annotations[0].spec.hide);
+    expect(dataLayers.state.annotationLayers).toHaveLength(5);
+
+    // Built-in
+    const builtInAnnotation = dataLayers.state.annotationLayers[0] as unknown as DashboardAnnotationsDataLayer;
+    expect(builtInAnnotation.state.name).toBe('Annotations & Alerts');
+    expect(builtInAnnotation.state.isEnabled).toBe(true);
+    expect(builtInAnnotation.state.isHidden).toBe(true);
+    expect(builtInAnnotation.state?.query.builtIn).toBe(1);
 
     // Enabled
     expect(dataLayers.state.annotationLayers[1].state.name).toBe(dash.annotations[1].spec.name);
     expect(dataLayers.state.annotationLayers[1].state.isEnabled).toBe(dash.annotations[1].spec.enable);
     expect(dataLayers.state.annotationLayers[1].state.isHidden).toBe(dash.annotations[1].spec.hide);
 
-    // Disabled
     expect(dataLayers.state.annotationLayers[2].state.name).toBe(dash.annotations[2].spec.name);
     expect(dataLayers.state.annotationLayers[2].state.isEnabled).toBe(dash.annotations[2].spec.enable);
     expect(dataLayers.state.annotationLayers[2].state.isHidden).toBe(dash.annotations[2].spec.hide);
 
-    // Hidden
+    // Disabled
     expect(dataLayers.state.annotationLayers[3].state.name).toBe(dash.annotations[3].spec.name);
     expect(dataLayers.state.annotationLayers[3].state.isEnabled).toBe(dash.annotations[3].spec.enable);
     expect(dataLayers.state.annotationLayers[3].state.isHidden).toBe(dash.annotations[3].spec.hide);
+
+    // Hidden
+    expect(dataLayers.state.annotationLayers[4].state.name).toBe(dash.annotations[4].spec.name);
+    expect(dataLayers.state.annotationLayers[4].state.isEnabled).toBe(dash.annotations[4].spec.enable);
+    expect(dataLayers.state.annotationLayers[4].state.isHidden).toBe(dash.annotations[4].spec.hide);
 
     // VizPanel
     const vizPanels = (scene.state.body as DashboardLayoutManager).getVizPanels();
@@ -757,9 +767,10 @@ describe('transformSaveModelSchemaV2ToScene', () => {
       // Get the annotation layers
       const dataLayerSet = scene.state.$data as DashboardDataLayerSet;
       expect(dataLayerSet).toBeDefined();
-      expect(dataLayerSet.state.annotationLayers.length).toBe(1);
+      // it should have two annotation layers, built-in and custom
+      expect(dataLayerSet.state.annotationLayers.length).toBe(2);
 
-      const annotationLayer = dataLayerSet.state.annotationLayers[0] as DashboardAnnotationsDataLayer;
+      const annotationLayer = dataLayerSet.state.annotationLayers[1] as DashboardAnnotationsDataLayer;
 
       // Verify that the options have been merged into the query object
       expect(annotationLayer.state.query).toMatchObject({


### PR DESCRIPTION
Backport PR for #104313 , without this fix, users can NOT manage built-in annotations in v2

Root cause: Grafana built-in annotation was not implemented for dashboard v2 creation or when reading an as-code v2 dashboard. This was causing buggy behaviour during serialization:

* Showing `0` in the annotation settings edit page
* Assigning the wrong annotaiton datasource if the dashboard has an annotation different than the built-in (like in this example: https://github.com/grafana/grafana/pull/102949#issuecomment-2791039664)

In Schema V1, we did that during the transformSaveModelToScene in the `new DashboardModel` ([code](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/state/DashboardModel.ts#L191))
