### PR TITLE
CI: Fix Skye and E2E GHA workflows

### DIFF
--- a/.github/workflows/run-e2e-suite.yml
+++ b/.github/workflows/run-e2e-suite.yml
@@ -27,6 +27,7 @@ jobs:
           args: go run ./pkg/build/e2e --package=grafana.tar.gz --suite=${{ inputs.suite }}
       - name: Set suite name
         id: set-suite-name
+        if: ${{ always() && inputs.old-arch != true }}
         env:
           SUITE: ${{ inputs.suite }}
         run: |

--- a/.github/workflows/run-e2e-suite.yml
+++ b/.github/workflows/run-e2e-suite.yml
@@ -21,19 +21,18 @@ jobs:
         with:
           name: ${{ inputs.package }}
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
-        if: inputs.old-arch == false
         with:
           verb: run
           args: go run ./pkg/build/e2e --package=grafana.tar.gz --suite=${{ inputs.suite }}
       - name: Set suite name
         id: set-suite-name
-        if: ${{ always() && inputs.old-arch != true }}
+        if: always()
         env:
           SUITE: ${{ inputs.suite }}
         run: |
           echo "suite=$(echo $SUITE | sed 's/\//-/g')" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
-        if: ${{ always() && inputs.old-arch != true }}
+        if: always()
         with:
           name: e2e-${{ steps.set-suite-name.outputs.suite }}-${{github.run_number}}
           path: videos

--- a/.github/workflows/skye-add-to-project.yml
+++ b/.github/workflows/skye-add-to-project.yml
@@ -33,11 +33,11 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
         with:
           # Vault secret paths:
-          # - ci/repo/grafana/grafana/plugins_platform_issue_commands_github_bot
+          # - ci/repo/grafana/grafana/grafana_pr_automation_app
           # - ci/repo/grafana/grafana/frontend_platform_skye_usernames (comma separated list of usernames)
           repo_secrets: |
-            GH_APP_ID=plugins_platform_issue_commands_github_bot:app_id
-            GH_APP_PEM=plugins_platform_issue_commands_github_bot:app_pem
+            GH_APP_ID=grafana_pr_automation_app:app_id
+            GH_APP_PEM=grafana_pr_automation_app:app_pem
             ALLOWED_USERS=frontend_platform_skye_usernames:allowed_users
 
       - name: Generate token


### PR DESCRIPTION
Fixes the Skye issues GHA workflow to use the PR automation app credentials.

Fixes the e2e workflow to properly name artifacts from the different suites - the step to make the suite name filename friendly wasn't ran. Previously this overwrote the environment variable so it wasn't detected.