### PR TITLE
allow setting multiple feature toggles in  run-suite

### DIFF
--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -46,10 +46,7 @@ Cypress.on('uncaught:exception', (err) => {
 //
 
 // TODO: read from toggles_gen.csv?
-const featureToggles = [
-  'kubernetesDashboards',
-  'dashboardNewLayouts',
-]
+const featureToggles = ['kubernetesDashboards', 'dashboardNewLayouts'];
 
 beforeEach(() => {
   let toggles = [];

--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -45,14 +45,29 @@ Cypress.on('uncaught:exception', (err) => {
 // });
 //
 
+const featureToggles = [
+  'kubernetesDashboards',
+  'dashboardNewLayouts',
+]
+
 beforeEach(() => {
+  let toggles = [];
+
   if (Cypress.env('DISABLE_SCENES')) {
     cy.logToConsole('disabling dashboardScene feature toggle in localstorage');
-    cy.setLocalStorage('grafana.featureToggles', 'dashboardScene=false');
+    toggles.push('dashboardScene=false');
   }
 
-  if (Cypress.env('kubernetesDashboards')) {
-    cy.logToConsole('enabling kubernetes dashboards API in localstorage');
-    cy.setLocalStorage('grafana.featureToggles', 'kubernetesDashboards=true');
+  for (const toggle of featureToggles) {
+    const toggleValue = Cypress.env(toggle);
+    if (toggleValue !== undefined) {
+      cy.logToConsole(`setting ${toggle} to ${toggleValue} in localstorage`);
+      toggles.push(`${toggle}=${toggleValue}`);
+    }
+  }
+
+  if (toggles.length > 0) {
+    cy.logToConsole('setting feature toggles in localstorage');
+    cy.setLocalStorage('grafana.featureToggles', toggles.join(','));
   }
 });

--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -45,6 +45,7 @@ Cypress.on('uncaught:exception', (err) => {
 // });
 //
 
+// TODO: read from toggles_gen.csv?
 const featureToggles = [
   'kubernetesDashboards',
   'dashboardNewLayouts',


### PR DESCRIPTION
The cypress e2e setup allows defining env variables ( feature toggles ) in the run-suite.  For example:
```
      env[kubernetesDashboards]=true
```
However currently it only allows one feature toggle.  This change will now allow multiple feature toggles.  This is needed for some new tests we are adding.
```
      env[kubernetesDashboards]=true
      env[dashboardNewLayouts]=true
```