### PR TITLE
[release-12.0.0] Dashboards: Fix cleanup job

### DIFF
--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -35,7 +35,7 @@ type DashboardService interface {
 	CountInFolders(ctx context.Context, orgID int64, folderUIDs []string, user identity.Requester) (int64, error)
 	GetAllDashboards(ctx context.Context) ([]*Dashboard, error)
 	GetAllDashboardsByOrgId(ctx context.Context, orgID int64) ([]*Dashboard, error)
-	CleanUpDashboard(ctx context.Context, dashboardUID string, orgId int64) error
+	CleanUpDashboard(ctx context.Context, dashboardUID string, dashboardId int64, orgId int64) error
 	CountDashboardsInOrg(ctx context.Context, orgID int64) (int64, error)
 	SetDefaultPermissions(ctx context.Context, dto *SaveDashboardDTO, dash *Dashboard, provisioned bool)
 	UnstructuredToLegacyDashboard(ctx context.Context, item *unstructured.Unstructured, orgID int64) (*Dashboard, error)

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -48,17 +48,17 @@ func (_m *FakeDashboardService) BuildSaveDashboardCommand(ctx context.Context, d
 	return r0, r1
 }
 
-// CleanUpDashboard provides a mock function with given fields: ctx, dashboardUID, orgId
-func (_m *FakeDashboardService) CleanUpDashboard(ctx context.Context, dashboardUID string, orgId int64) error {
-	ret := _m.Called(ctx, dashboardUID, orgId)
+// CleanUpDashboard provides a mock function with given fields: ctx, dashboardUID, dashboardId, orgId
+func (_m *FakeDashboardService) CleanUpDashboard(ctx context.Context, dashboardUID string, dashboardId int64, orgId int64) error {
+	ret := _m.Called(ctx, dashboardUID, dashboardId, orgId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CleanUpDashboard")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, int64) error); ok {
-		r0 = rf(ctx, dashboardUID, orgId)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) error); ok {
+		r0 = rf(ctx, dashboardUID, dashboardId, orgId)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -344,7 +344,7 @@ func (dr *DashboardServiceImpl) processDashboardBatch(ctx context.Context, orgID
 			"deletionTimestamp", deletionTimestamp,
 			"resourceVersion", resourceVersion)
 
-		if err = dr.CleanUpDashboard(ctx, dash.UID, orgID); err != nil {
+		if err = dr.CleanUpDashboard(ctx, dash.UID, dash.ID, orgID); err != nil {
 			errs = append(errs, fmt.Errorf("failed to clean up dashboard %s: %w", dash.UID, err))
 		}
 		itemsProcessed++
@@ -1779,7 +1779,7 @@ func (dr *DashboardServiceImpl) DeleteInFolders(ctx context.Context, orgID int64
 
 func (dr *DashboardServiceImpl) Kind() string { return entity.StandardKindDashboard }
 
-func (dr *DashboardServiceImpl) CleanUpDashboard(ctx context.Context, dashboardUID string, orgId int64) error {
+func (dr *DashboardServiceImpl) CleanUpDashboard(ctx context.Context, dashboardUID string, dashboardID int64, orgId int64) error {
 	ctx, span := tracer.Start(ctx, "dashboards.service.CleanUpDashboard")
 	defer span.End()
 
@@ -1789,7 +1789,7 @@ func (dr *DashboardServiceImpl) CleanUpDashboard(ctx context.Context, dashboardU
 		return err
 	}
 
-	return dr.dashboardStore.CleanupAfterDelete(ctx, &dashboards.DeleteDashboardCommand{OrgID: orgId, UID: dashboardUID})
+	return dr.dashboardStore.CleanupAfterDelete(ctx, &dashboards.DeleteDashboardCommand{OrgID: orgId, UID: dashboardUID, ID: dashboardID})
 }
 
 // -----------------------------------------------------------------------------------------

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2577,6 +2577,7 @@ func TestCleanUpDashboard(t *testing.T) {
 
 			ctx := context.Background()
 			dashboardUID := "dash-uid"
+			dashboardID := int64(1)
 			orgID := int64(1)
 
 			// Setup mocks
@@ -2586,11 +2587,12 @@ func TestCleanUpDashboard(t *testing.T) {
 				fakeStore.On("CleanupAfterDelete", mock.Anything, &dashboards.DeleteDashboardCommand{
 					OrgID: orgID,
 					UID:   dashboardUID,
+					ID:    dashboardID,
 				}).Return(tc.cleanupError).Maybe()
 			}
 
 			// Execute
-			err := service.CleanUpDashboard(ctx, dashboardUID, orgID)
+			err := service.CleanUpDashboard(ctx, dashboardUID, dashboardID, orgID)
 
 			// Assert
 			if tc.expectedError != nil {


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/104822 - this is needed so instances that used to have dashboardRestore enabled don't have annotations deleted that are not associated with dashboards