### PR TITLE
E2E: Align on how to use feature toggles in cypress tests

### DIFF
--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -46,15 +46,10 @@ Cypress.on('uncaught:exception', (err) => {
 //
 
 // TODO: read from toggles_gen.csv?
-const featureToggles = ['kubernetesDashboards', 'dashboardNewLayouts'];
+const featureToggles = ['kubernetesDashboards', 'dashboardNewLayouts', 'dashboardScene'];
 
 beforeEach(() => {
   let toggles = [];
-
-  if (Cypress.env('DISABLE_SCENES')) {
-    cy.logToConsole('disabling dashboardScene feature toggle in localstorage');
-    toggles.push('dashboardScene=false');
-  }
 
   for (const toggle of featureToggles) {
     const toggleValue = Cypress.env(toggle);

--- a/e2e/run-suite
+++ b/e2e/run-suite
@@ -91,7 +91,7 @@ case "$1" in
     "")
         ;;
    "old-arch")
-      env[DISABLE_SCENES]=true
+      env[dashboardScene]=false
       cypressConfig[specPattern]=$rootForOldArch/*/$testFilesForSingleSuite
       cypressConfig[video]=false
         case "$2" in
@@ -111,7 +111,7 @@ case "$1" in
     "old-arch/"*)
       cypressConfig[specPattern]=./e2e/"${args[0]}"/$testFilesForSingleSuite
       cypressConfig[video]=${args[1]}
-      env[DISABLE_SCENES]=true
+      env[dashboardScene]=false
       ;;
     "dashboards-schema-v2")
       env[kubernetesDashboards]=true


### PR DESCRIPTION
adjust how we pass dashboardScene feature toggle name and value for old arch tests to align with other uses