### PR TITLE
[DOC] Add landing page and focus for Obs as Code docs

### DIFF
--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -1,7 +1,4 @@
 ---
-_build:
-  list: false
-noindex: true
 cascade:
   noindex: true
 description: Overview of Observability as Code including description, key features, and explanation of benefits.

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -65,8 +65,6 @@ Observability as Code provides more control over configuration. Instead of manua
 
 {{< card-grid key="cards" type="simple" >}}
 
-
-
 <!-- Hiding this part of the doc because the rest of the docs aren't released yet
 
 ## Key features

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -1,4 +1,7 @@
 ---
+_build:
+  list: false
+noindex: true
 cascade:
   noindex: true
 description: Overview of Observability as Code including description, key features, and explanation of benefits.

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -32,7 +32,7 @@ cards:
     - title: Git Sync
       height: 24
       href: ./provision-resources/intro-git-sync/
-      description: Git Sync is an experimental feature that lets you store your dashboard files in a Git Hub repository and synchrize those changes with your Grafana instance.
+      description: Git Sync is an experimental feature that lets you store your dashboard files in a GitHub repository and synchronize those changes with your Grafana instance.
   title_class: pt-0 lh-1
 hero:
   title: Observability as Code

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -37,9 +37,6 @@ hero:
   height: 110
   level: 1
   width: 110
-title: Introduction to Grafana CLI
-menuTitle: Grafana CLI
-weight: 130
 ---
 
 {{< docs/hero-simple key="hero" >}}

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -19,12 +19,39 @@ labels:
     - oss
 title: Observability as Code
 weight: 100
+cards:
+  items:
+    - title: Get started
+      height: 24
+      href: ./get-started/
+      description: Learn about how you can use Observability as Code.
+    - title: Grafana CLI
+      height: 24
+      href: ./grafana-cli/
+      description: Grafana CLI (`grafanactl`) is a command-line tool designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through Grafana’s REST API, all from the terminal.
+    - title: Git Sync
+      height: 24
+      href: ./provision-resources/intro-git-sync/
+      description: Git Sync is an experimental feature that lets you store your dashboard files in a Git Hub repository and synchrize those changes with your Grafana instance.
+  title_class: pt-0 lh-1
+hero:
+  title: Observability as Code
+  description: Using Observability as Code, you can version, automate, and scale Grafana configurations, including dashboards and observability workflows.
+  height: 110
+  level: 1
+  width: 110
+title: Introduction to Grafana CLI
+menuTitle: Grafana CLI
+weight: 130
 ---
 
-# Observability as Code
+{{< docs/hero-simple key="hero" >}}
+
+---
+
+## Overview
 
 Observability as Code lets you apply code management best practices to your observability resources.
-Using Observability as Code, you can version, automate, and scale Grafana configurations, including dashboards and observability workflows.
 By representing Grafana resources as code, you can integrate them into existing infrastructure-as-code workflows and apply standard development practices.
 
 Observability as Code provides more control over configuration. Instead of manually configuring dashboards or settings through the Grafana UI, you can:
@@ -34,7 +61,11 @@ Observability as Code provides more control over configuration. Instead of manua
 - **Automate with CI/CD:** Integrate Grafana directly into your development and deployment pipelines.
 - **Standardize workflows:** Ensure consistency across your teams by using repeatable, codified processes for managing Grafana resources.
 
-{{< section depth=5 >}}
+## Explore
+
+{{< card-grid key="cards" type="simple" >}}
+
+
 
 <!-- Hiding this part of the doc because the rest of the docs aren't released yet
 

--- a/docs/sources/observability-as-code/get-started.md
+++ b/docs/sources/observability-as-code/get-started.md
@@ -34,22 +34,23 @@ Observability as Code lets you manage dashboards, resources, and configurations 
 
    - Learn about a toolkit for programmatically creating and managing Grafana dashboards and resources with reusable components and streamlined workflows.
 -->
+
 1. [Grafana CLI (`grafanactl`)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/grafana-cli)
 
-      - Use a command-line tool for simplifying the management of Grafana resources.
-      - Grafana CLI Works across environments (OSS, Enterprise, Cloud), and provides solutions for many as-code situations.
-      - It provides the flexibility many advanced users and existing pipelines require: CI/CD, pull/push from remotes, and more.
+   - Use a command-line tool for simplifying the management of Grafana resources.
+   - Grafana CLI Works across environments (OSS, Enterprise, Cloud), and provides solutions for many as-code situations.
+   - It provides the flexibility many advanced users and existing pipelines require: CI/CD, pull/push from remotes, and more.
 
 1. [Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/)
 
-    - Configure Git repositories to store your dashboard JSON files.
-    - Understand best practices for version control, including collaboration through pull requests and rollbacks.
-    - Edit your JSON files in GitHub and then sync with Grafana.
+   - Configure Git repositories to store your dashboard JSON files.
+   - Understand best practices for version control, including collaboration through pull requests and rollbacks.
+   - Edit your JSON files in GitHub and then sync with Grafana.
 
 1. [Manage dashboard deployments from GitHub](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
-    - Integrate dashboards into CI/CD pipelines using tools like GitHub Actions.
-    - Leverage provisioning features in Grafana to automate updates and deployment of dashboards.
+   - Integrate dashboards into CI/CD pipelines using tools like GitHub Actions.
+   - Leverage provisioning features in Grafana to automate updates and deployment of dashboards.
 
 ## Additional Observability as Code tools
 
@@ -57,20 +58,19 @@ Explore these additional tools and libraries for working with Observability as C
 
 - [Terraform](../infrastructure-as-code/terraform/)
 
-   - Use the Grafana Terraform provider to manage dashboards, alerts, and more.
-   - Understand how to define and deploy resources using HCL/JSON configurations.
+  - Use the Grafana Terraform provider to manage dashboards, alerts, and more.
+  - Understand how to define and deploy resources using HCL/JSON configurations.
 
 - [Ansible](../infrastructure-as-code/ansible/)
 
-   - Learn to use the Grafana Ansible collection to manage Grafana Cloud resources, including folders and cloud stacks.
-   - Write playbooks to automate resource provisioning through the Grafana API.
+  - Learn to use the Grafana Ansible collection to manage Grafana Cloud resources, including folders and cloud stacks.
+  - Write playbooks to automate resource provisioning through the Grafana API.
 
 - [Grafana Operator](../infrastructure-as-code/grafana-operator/)
 
   - Utilize Kubernetes-native management with the Grafana Operator.
   - Manage dashboards, folders, and data sources via Kubernetes Custom Resources.
   - Integrate with GitOps workflows for seamless version control and deployment.
-
 
 - [Crossplane](https://github.com/grafana/crossplane-provider-grafana) lets you manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
 - [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically. It is currently in the process of being deprecated.

--- a/docs/sources/observability-as-code/get-started.md
+++ b/docs/sources/observability-as-code/get-started.md
@@ -17,44 +17,55 @@ weight: 100
 
 # Get started with Observability as Code
 
-Simply put, with Observability as Code, you can manage Grafana resources.
-You can write code that describes what you want the dashboard to do, rather than manipulate it via the UI.
+Grafana provides a suite of tools for **Observability as Code** to help you manage your Grafana resources programmatically and at scale. This approach lets you define dashboards, data sources, and other configurations in code, enabling version control, automated testing, and reliable deployments through CI/CD pipelines.
 
-Observability as Code lets you manage dashboards, resources, and configurations programmatically, leveraging powerful tools for automation and standardization.
+Historically, managing Grafana as code involved various community and Grafana Labs tools, but lacked a single, cohesive story. Grafana 12 introduces foundational improvements, including new versioned APIs and official tooling, to provide a clearer path forward.
 
-## Get started with Observability as Code
+## Grafana CLI (`grafanactl`)
 
-<!--
-1. [**Understand the Dashboard Schemas**](json-models/)
+Use the official command-line tool, `grafanactl`, to interact with your Grafana instances and manage resources via the new APIs.
 
-   - Learn about the Dashboard JSON models, which introduces clearer separation of properties, improved layouts, and metadata management.
-   - Review examples of JSON definitions for dashboards to get familiar with the structure and fields.
+- It's the recommended tool for automation and direct API interaction, suitable for CI/CD pipelines and local development or ad-hoc tasks. It supports pulling/pushing configurations from remote instances, validating configs, and more.
+- `grafanactl` works across all environments for Grafana OSS, Enterprise, and Cloud.
 
-1. [**Understand the Foundation SDK**](foundation-sdk)
+Refer to the [Grafana CLI (`grafanactl`)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/grafana-cli) documentation for more information.
 
-   - Learn about a toolkit for programmatically creating and managing Grafana dashboards and resources with reusable components and streamlined workflows.
--->
+## Git Sync
 
-1. [Grafana CLI (`grafanactl`)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/grafana-cli)
+For an integrated, UI-driven Git workflow focused on dashboards, explore Git Sync.
 
-   - Use a command-line tool for simplifying the management of Grafana resources.
-   - Grafana CLI Works across environments (OSS, Enterprise, Cloud), and provides solutions for many as-code situations.
-   - It provides the flexibility many advanced users and existing pipelines require: CI/CD, pull/push from remotes, and more.
+- Connect folders or entire Grafana instances directly to a GitHub repository to synchronize dashboard definitions, enabling version control, branching, and pull requests directly from Grafana.
+- Git Sync offers a simple, out-of-the-box approach for managing dashboards as code.
+  {{< admonition type="note" >}}
+  Git Sync is an **experimental feature** in Grafana 12, available in Grafana OSS and Enterprise [nightly releases](https://grafana.com/grafana/download/nightly). It is not yet available in Grafana Cloud.
+  {{< /admonition >}}
 
-1. [Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/)
+Refer to the [Git Sync documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/) to learn more.
 
-   - Configure Git repositories to store your dashboard JSON files.
-   - Understand best practices for version control, including collaboration through pull requests and rollbacks.
-   - Edit your JSON files in GitHub and then sync with Grafana.
+## Direct API usage
 
-1. [Manage dashboard deployments from GitHub](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
+For maximum flexibility, advanced use cases, or building custom tooling, you can interact directly with the underlying versioned APIs.
 
-   - Integrate dashboards into CI/CD pipelines using tools like GitHub Actions.
-   - Leverage provisioning features in Grafana to automate updates and deployment of dashboards.
+- This approach requires handling HTTP requests and responses but provides complete control over resource management.
+- `grafanactl`, Git Sync, and the Foundation SDK are all built on top of these APIs.
+- To understand Dashboard Schemas accepted by the APIs, refer to the [JSON models documentation](json-models/).
+
+Refer to the [Grafana APIs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/apis/) documentation for more information.
+
+## Foundation SDK
+
+To programmatically define your Grafana resources (like dashboards or alerts) using familiar programming languages, use Foundation SDK.
+
+- Define resources using strongly typed builders in languages like Go, TypeScript, Python, Java, and PHP.
+- Avoid crafting complex JSON manually and integrate resource generation into your existing development workflows.
+- Catch errors at compile time and easily integrate resource generation into your CI/CD pipelines.
+- Use in conjunction with `grafanactl` to push your programmatically generated resources.
+
+Refer to the [Foundation SDK](../foundation-sdk) documentation for more information.
 
 ## Additional Observability as Code tools
 
-Explore these additional tools and libraries for working with Observability as Code.
+If you're already using established Infrastructure as Code or other configuration management tools, Grafana offers integrations to manage resources within your existing workflows.
 
 - [Terraform](../infrastructure-as-code/terraform/)
 

--- a/docs/sources/observability-as-code/get-started.md
+++ b/docs/sources/observability-as-code/get-started.md
@@ -25,7 +25,7 @@ Historically, managing Grafana as code involved various community and Grafana La
 
 Use the official command-line tool, `grafanactl`, to interact with your Grafana instances and manage resources via the new APIs.
 
-- It's the recommended tool for automation and direct API interaction, suitable for CI/CD pipelines and local development or ad-hoc tasks. It supports pulling/pushing configurations from remote instances, validating configs, and more.
+- It's the recommended tool for automation and direct API interaction, suitable for CI/CD pipelines and local development or free-form tasks. It supports pulling/pushing configurations from remote instances, validating configurations, and more.
 - `grafanactl` works across all environments for Grafana OSS, Enterprise, and Cloud.
 
 Refer to the [Grafana CLI (`grafanactl`)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/grafana-cli) documentation for more information.

--- a/docs/sources/observability-as-code/get-started.md
+++ b/docs/sources/observability-as-code/get-started.md
@@ -34,45 +34,44 @@ Observability as Code lets you manage dashboards, resources, and configurations 
 
    - Learn about a toolkit for programmatically creating and managing Grafana dashboards and resources with reusable components and streamlined workflows.
 -->
+1. [Grafana CLI (`grafanactl`)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/grafana-cli)
 
-1.  [**Set up Git Sync**](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/)
+      - Use a command-line tool for simplifying the management of Grafana resources.
+      - Grafana CLI Works across environments (OSS, Enterprise, Cloud), and provides solutions for many as-code situations.
+      - It provides the flexibility many advanced users and existing pipelines require: CI/CD, pull/push from remotes, and more.
+
+1. [Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/)
 
     - Configure Git repositories to store your dashboard JSON files.
     - Understand best practices for version control, including collaboration through pull requests and rollbacks.
     - Edit your JSON files in GitHub and then sync with Grafana.
 
-1.  [**Manage dashboard deployments from GitHub**](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
+1. [Manage dashboard deployments from GitHub](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/)
 
     - Integrate dashboards into CI/CD pipelines using tools like GitHub Actions.
     - Leverage provisioning features in Grafana to automate updates and deployment of dashboards.
-    <!--
 
-1.  **Explore additional tools and libraries for working with Observability as Code**
+## Additional Observability as Code tools
 
-    - [**Grafanactl**](grafanactl)
+Explore these additional tools and libraries for working with Observability as Code.
 
-      - Use a command-line tool for simplifying the management of Grafana resources.
+- [Terraform](../infrastructure-as-code/terraform/)
 
-    - [**Terraform**](infrastructure-as-code/terraform/)
+   - Use the Grafana Terraform provider to manage dashboards, alerts, and more.
+   - Understand how to define and deploy resources using HCL/JSON configurations.
 
-      - Use the Grafana Terraform provider to manage dashboards, alerts, and more.
-      - Understand how to define and deploy resources using HCL/JSON configurations.
+- [Ansible](../infrastructure-as-code/ansible/)
 
-    - [**Ansible**](infrastructure-as-code/ansible/)
+   - Learn to use the Grafana Ansible collection to manage Grafana Cloud resources, including folders and cloud stacks.
+   - Write playbooks to automate resource provisioning through the Grafana API.
 
-      - Learn to use the Grafana Ansible collection to manage Grafana Cloud resources, including folders and cloud stacks.
-      - Write playbooks to automate resource provisioning through the Grafana API.
+- [Grafana Operator](../infrastructure-as-code/grafana-operator/)
 
-    - [**Grafana Operator**](./infrastructure-as-code/grafana-operator/_index.md)
+  - Utilize Kubernetes-native management with the Grafana Operator.
+  - Manage dashboards, folders, and data sources via Kubernetes Custom Resources.
+  - Integrate with GitOps workflows for seamless version control and deployment.
 
-           - Utilize Kubernetes-native management with the Grafana Operator.
-           - Manage dashboards, folders, and data sources via Kubernetes Custom Resources.
-           - Integrate with GitOps workflows for seamless version control and deployment.
 
-      -->
-
-## Explore additional Observability as Code tools
-
-- [**Crossplane:**](https://github.com/grafana/crossplane-provider-grafana) Manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
-- [**Grafonnet:**](https://github.com/grafana/grafonnet) Grafonnet is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically. It is currently in the process of being deprecated.
-- [**Grizzly:**](https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/grizzly/dashboards-folders-datasources/) Grizzly is a command-line tool that simplifies managing Grafana resources using Kubernetes-inspired YAML syntax. It is currently in the process of being deprecated.
+- [Crossplane](https://github.com/grafana/crossplane-provider-grafana) lets you manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
+- [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically. It is currently in the process of being deprecated.
+- [Grizzly](https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/grizzly/dashboards-folders-datasources/) is a deprecated command-line tool that simplifies managing Grafana resources using Kubernetes-inspired YAML syntax.


### PR DESCRIPTION
**What is this feature?**

Updates: 
* Adds a landing page layout for the Observability as Code docs. 
* Updates the get started page to include and focus on Grafana CLI. 
* Makes the OaC main page live. (related to https://github.com/grafana/grafana/pull/104843)
![image](https://github.com/user-attachments/assets/41110710-3886-4b86-9703-d9fd9f76e07a)


Fixes #

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
