### PR TITLE
Alerting: refactor alerting package

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 
@@ -269,7 +268,7 @@ func TestValidateRuleGroupFailures(t *testing.T) {
 			name: "fail if title is too long",
 			group: func() *apimodels.PostableRuleGroupConfig {
 				g := validGroup(cfg)
-				for len(g.Name) < store.AlertRuleMaxRuleGroupNameLength {
+				for len(g.Name) < models.AlertRuleMaxRuleGroupNameLength {
 					g.Name += g.Name
 				}
 				return &g
@@ -571,7 +570,7 @@ func TestValidateRuleNodeFailures_NoUID(t *testing.T) {
 			name: "fail if title is too long",
 			rule: func() *apimodels.PostableExtendedRuleNode {
 				r := validRule()
-				for len(r.GrafanaManagedAlert.Title) < store.AlertRuleMaxTitleLength {
+				for len(r.GrafanaManagedAlert.Title) < models.AlertRuleMaxTitleLength {
 					r.GrafanaManagedAlert.Title += r.GrafanaManagedAlert.Title
 				}
 				return &r
@@ -893,7 +892,7 @@ func TestValidateRuleNodeFailures_UID(t *testing.T) {
 			name: "fail if title is too long",
 			rule: func() *apimodels.PostableExtendedRuleNode {
 				r := validRule()
-				for len(r.GrafanaManagedAlert.Title) < store.AlertRuleMaxTitleLength {
+				for len(r.GrafanaManagedAlert.Title) < models.AlertRuleMaxTitleLength {
 					r.GrafanaManagedAlert.Title += r.GrafanaManagedAlert.Title
 				}
 				return &r

--- a/pkg/services/ngalert/api/validation/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"time"
 
+	prommodels "github.com/prometheus/common/model"
+
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	. "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	prommodels "github.com/prometheus/common/model"
 )
 
 type RuleLimits struct {
@@ -59,8 +59,8 @@ func ValidateRuleNode(
 		return nil, errors.New("alert rule title cannot be empty")
 	}
 
-	if len(ruleNode.GrafanaManagedAlert.Title) > store.AlertRuleMaxTitleLength {
-		return nil, fmt.Errorf("alert rule title is too long. Max length is %d", store.AlertRuleMaxTitleLength)
+	if len(ruleNode.GrafanaManagedAlert.Title) > ngmodels.AlertRuleMaxTitleLength {
+		return nil, fmt.Errorf("alert rule title is too long. Max length is %d", ngmodels.AlertRuleMaxTitleLength)
 	}
 
 	queries := AlertQueriesFromApiAlertQueries(ruleNode.GrafanaManagedAlert.Data)
@@ -335,8 +335,8 @@ func ValidateRuleGroup(
 		return nil, errors.New("rule group name cannot be empty")
 	}
 
-	if len(ruleGroupConfig.Name) > store.AlertRuleMaxRuleGroupNameLength {
-		return nil, fmt.Errorf("rule group name is too long. Max length is %d", store.AlertRuleMaxRuleGroupNameLength)
+	if len(ruleGroupConfig.Name) > ngmodels.AlertRuleMaxRuleGroupNameLength {
+		return nil, fmt.Errorf("rule group name is too long. Max length is %d", ngmodels.AlertRuleMaxRuleGroupNameLength)
 	}
 
 	interval := time.Duration(ruleGroupConfig.Interval)

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -29,6 +29,12 @@ import (
 	"github.com/grafana/grafana/pkg/util/cmputil"
 )
 
+// AlertRuleMaxRuleGroupNameLength is the maximum length of the alert rule group name
+const AlertRuleMaxRuleGroupNameLength = 190
+
+// AlertRuleMaxTitleLength is the maximum length of the alert rule title
+const AlertRuleMaxTitleLength = 190
+
 var (
 	// ErrAlertRuleNotFound is an error for an unknown alert rule.
 	ErrAlertRuleNotFound = fmt.Errorf("could not find alert rule")

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -678,7 +678,7 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 		return historian.NewMultipleBackend(primary, secondaries...), nil
 	}
 	if backend == historian.BackendTypeAnnotations {
-		store := historian.NewAnnotationStore(ar, ds, met)
+		store := store.NewAnnotationStore(ar, ds, met)
 		annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
 		return historian.NewAnnotationBackend(annotationBackendLogger, store, rs, met, ac), nil
 	}

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -48,7 +48,7 @@ type RuleStore interface {
 
 type AnnotationStore interface {
 	Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error)
-	Save(ctx context.Context, panel *PanelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error
+	Save(ctx context.Context, panel *history_model.PanelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error
 }
 
 func NewAnnotationBackend(
@@ -73,7 +73,7 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 	logger := h.log.FromContext(ctx)
 	// Build annotations before starting goroutine, to make sure all data is copied and won't mutate underneath us.
 	annotations := buildAnnotations(rule, states, logger)
-	panel := parsePanelKey(rule, logger)
+	panel := history_model.ParsePanelKey(rule, logger)
 
 	errCh := make(chan error, 1)
 	if len(annotations) == 0 {

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -74,42 +74,6 @@ func labelFingerprint(labels data.Labels) string {
 	return fmt.Sprintf("%016x", sig)
 }
 
-// PanelKey uniquely identifies a panel.
-type PanelKey struct {
-	orgID   int64
-	dashUID string
-	panelID int64
-}
-
-func NewPanelKey(orgID int64, dashUID string, panelID int64) PanelKey {
-	return PanelKey{
-		orgID:   orgID,
-		dashUID: dashUID,
-		panelID: panelID,
-	}
-}
-
-// PanelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
-func parsePanelKey(rule history_model.RuleMeta, logger log.Logger) *PanelKey {
-	if rule.DashboardUID != "" {
-		key := NewPanelKey(rule.OrgID, rule.DashboardUID, rule.PanelID)
-		return &key
-	}
-	return nil
-}
-
-func (p PanelKey) OrgID() int64 {
-	return p.orgID
-}
-
-func (p PanelKey) DashUID() string {
-	return p.dashUID
-}
-
-func (p PanelKey) PanelID() int64 {
-	return p.panelID
-}
-
 func mergeLabels(base, into data.Labels) data.Labels {
 	for k, v := range into {
 		base[k] = v

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -8,11 +8,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	prometheus "github.com/prometheus/common/model"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 const StateHistoryWriteTimeout = time.Minute

--- a/pkg/services/ngalert/state/historian/model/panel-key.go
+++ b/pkg/services/ngalert/state/historian/model/panel-key.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// PanelKey uniquely identifies a panel.
+type PanelKey struct {
+	orgID   int64
+	dashUID string
+	panelID int64
+}
+
+func NewPanelKey(orgID int64, dashUID string, panelID int64) PanelKey {
+	return PanelKey{
+		orgID:   orgID,
+		dashUID: dashUID,
+		panelID: panelID,
+	}
+}
+
+// PanelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
+func ParsePanelKey(rule RuleMeta, logger log.Logger) *PanelKey {
+	if rule.DashboardUID != "" {
+		key := NewPanelKey(rule.OrgID, rule.DashboardUID, rule.PanelID)
+		return &key
+	}
+	return nil
+}
+
+func (p PanelKey) OrgID() int64 {
+	return p.orgID
+}
+
+func (p PanelKey) DashUID() string {
+	return p.dashUID
+}
+
+func (p PanelKey) PanelID() int64 {
+	return p.panelID
+}

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/state/historian"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
 
 func BenchmarkProcessEvalResults(b *testing.B) {
@@ -26,7 +27,7 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	as := annotations.FakeAnnotationsRepo{}
 	as.On("SaveMany", mock.Anything, mock.Anything).Return(nil)
 	metrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
-	store := historian.NewAnnotationStore(&as, nil, metrics)
+	store := store.NewAnnotationStore(&as, nil, metrics)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
 	ac := &fakes.FakeRuleService{}
 	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, metrics, ac)

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/state/historian"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests"
 	alertTestUtil "github.com/grafana/grafana/pkg/services/ngalert/testutil"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -280,7 +281,7 @@ func TestDashboardAnnotations(t *testing.T) {
 
 	fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
 	historianMetrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
-	store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, historianMetrics)
+	store := store.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, historianMetrics)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
 	ac := &acfakes.FakeRuleService{}
 	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, historianMetrics, ac)
@@ -1259,7 +1260,7 @@ func TestProcessEvalResults(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			stateMetrics := metrics.NewStateMetrics(reg)
 			m := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
-			store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, m)
+			store := store.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, m)
 			annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
 			ac := &acfakes.FakeRuleService{}
 			hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, m, ac)

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -27,12 +27,6 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// AlertRuleMaxTitleLength is the maximum length of the alert rule title
-const AlertRuleMaxTitleLength = 190
-
-// AlertRuleMaxRuleGroupNameLength is the maximum length of the alert rule group name
-const AlertRuleMaxRuleGroupNameLength = 190
-
 var (
 	ErrOptimisticLock = errors.New("version conflict while updating a record in the database with optimistic locking")
 )
@@ -525,8 +519,8 @@ func (st DBstore) preventIntermediateUniqueConstraintViolations(sess *db.Session
 
 		// Some defensive programming in case the temporary title is somehow persisted it will still be recognizable.
 		uniqueTempTitle := r.Title + u
-		if len(uniqueTempTitle) > AlertRuleMaxTitleLength {
-			uniqueTempTitle = r.Title[:AlertRuleMaxTitleLength-len(u)] + uuid.New().String()
+		if len(uniqueTempTitle) > ngmodels.AlertRuleMaxTitleLength {
+			uniqueTempTitle = r.Title[:ngmodels.AlertRuleMaxTitleLength-len(u)] + uuid.New().String()
 		}
 
 		if updated, err := sess.ID(r.ID).Cols("title").Update(&alertRule{Title: uniqueTempTitle, Version: r.Version}); err != nil || updated == 0 {
@@ -929,13 +923,13 @@ func (st DBstore) validateAlertRule(alertRule ngmodels.AlertRule) error {
 	}
 
 	// enforce max name length.
-	if len(alertRule.Title) > AlertRuleMaxTitleLength {
-		return fmt.Errorf("%w: name length should not be greater than %d", ngmodels.ErrAlertRuleFailedValidation, AlertRuleMaxTitleLength)
+	if len(alertRule.Title) > ngmodels.AlertRuleMaxTitleLength {
+		return fmt.Errorf("%w: name length should not be greater than %d", ngmodels.ErrAlertRuleFailedValidation, ngmodels.AlertRuleMaxTitleLength)
 	}
 
 	// enforce max rule group name length.
-	if len(alertRule.RuleGroup) > AlertRuleMaxRuleGroupNameLength {
-		return fmt.Errorf("%w: rule group name length should not be greater than %d", ngmodels.ErrAlertRuleFailedValidation, AlertRuleMaxRuleGroupNameLength)
+	if len(alertRule.RuleGroup) > ngmodels.AlertRuleMaxRuleGroupNameLength {
+		return fmt.Errorf("%w: rule group name length should not be greater than %d", ngmodels.ErrAlertRuleFailedValidation, ngmodels.AlertRuleMaxRuleGroupNameLength)
 	}
 
 	return nil

--- a/pkg/services/ngalert/store/annotation_store.go
+++ b/pkg/services/ngalert/store/annotation_store.go
@@ -1,4 +1,4 @@
-package historian
+package store
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 type AnnotationService interface {
@@ -29,17 +30,17 @@ func NewAnnotationStore(svc AnnotationService, dashboards dashboards.DashboardSe
 	}
 }
 
-func (s *AnnotationServiceStore) Save(ctx context.Context, panel *PanelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error {
+func (s *AnnotationServiceStore) Save(ctx context.Context, panel *model.PanelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error {
 	if panel != nil {
-		dashID, err := s.dashboards.getID(ctx, panel.orgID, panel.dashUID)
+		dashID, err := s.dashboards.getID(ctx, panel.OrgID(), panel.DashUID())
 		if err != nil {
-			logger.Error("Error getting dashboard for alert annotation", "dashboardUID", panel.dashUID, "error", err)
+			logger.Error("Error getting dashboard for alert annotation", "dashboardUID", panel.DashUID(), "error", err)
 			dashID = 0
 		}
 
 		for i := range annotations {
 			annotations[i].DashboardID = dashID
-			annotations[i].PanelID = panel.panelID
+			annotations[i].PanelID = panel.PanelID()
 		}
 	}
 

--- a/pkg/services/ngalert/store/dashboard.go
+++ b/pkg/services/ngalert/store/dashboard.go
@@ -1,4 +1,4 @@
-package historian
+package store
 
 import (
 	"context"

--- a/pkg/services/ngalert/store/dashboard_test.go
+++ b/pkg/services/ngalert/store/dashboard_test.go
@@ -1,4 +1,4 @@
-package historian
+package store
 
 import (
 	"context"

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -2974,7 +2973,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						Annotations: map[string]string{"annotation1": "val1"},
 					},
 					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
-						Title:     getLongString(t, ngstore.AlertRuleMaxTitleLength+1),
+						Title:     getLongString(t, ngmodels.AlertRuleMaxTitleLength+1),
 						Condition: "A",
 						Data: []apimodels.AlertQuery{
 							{
@@ -2996,7 +2995,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			},
 			{
 				desc:      "alert rule with too long rulegroup",
-				rulegroup: getLongString(t, ngstore.AlertRuleMaxTitleLength+1),
+				rulegroup: getLongString(t, ngmodels.AlertRuleMaxTitleLength+1),
 				rule: apimodels.PostableExtendedRuleNode{
 					ApiRuleNode: &apimodels.ApiRuleNode{
 						For:         &interval,


### PR DESCRIPTION
**What is this feature?**
This PR removes dependency on dashboards package from packages we import in cloud ruler. 

- Moves `AnnotationServiceStore` to store package
- Moves PanelKey to `state/historian/model`
- Moves constants AlertRuleMaxRuleGroupNameLength and AlertRuleMaxTitleLength to models package