### PR TITLE
SecretsManager: remove not needed validation from queries

### DIFF
--- a/pkg/storage/secret/encryption/data/data_key_delete.sql
+++ b/pkg/storage/secret/encryption/data/data_key_delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM {{ .Ident "secret_data_key" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "uid" }}      = {{ .Arg .UID }}
 ;

--- a/pkg/storage/secret/encryption/data/data_key_disable.sql
+++ b/pkg/storage/secret/encryption/data/data_key_disable.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   {{ .Ident "active" }} = false,
   {{ .Ident "updated" }} = {{ .Arg .Updated }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "active" }} = true
 ;

--- a/pkg/storage/secret/encryption/data/data_key_list.sql
+++ b/pkg/storage/secret/encryption/data/data_key_list.sql
@@ -9,6 +9,5 @@ SELECT
   {{ .Ident "updated" }}
 FROM
   {{ .Ident "secret_data_key" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 ;

--- a/pkg/storage/secret/encryption/data/data_key_read.sql
+++ b/pkg/storage/secret/encryption/data/data_key_read.sql
@@ -9,7 +9,6 @@ SELECT
   {{ .Ident "updated" }}
 FROM
   {{ .Ident "secret_data_key" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "uid" }} = {{ .Arg .UID }}
 ;

--- a/pkg/storage/secret/encryption/data/data_key_read_current.sql
+++ b/pkg/storage/secret/encryption/data/data_key_read_current.sql
@@ -9,8 +9,7 @@ SELECT
   {{ .Ident "updated" }}
 FROM
   {{ .Ident "secret_data_key" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "label" }} = {{ .Arg .Label }} AND
   {{ .Ident "active" }} = true
 ;

--- a/pkg/storage/secret/encryption/data/encrypted_value_delete.sql
+++ b/pkg/storage/secret/encryption/data/encrypted_value_delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM {{ .Ident "secret_encrypted_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "uid" }}      = {{ .Arg .UID }}
 ;

--- a/pkg/storage/secret/encryption/data/encrypted_value_read.sql
+++ b/pkg/storage/secret/encryption/data/encrypted_value_read.sql
@@ -6,7 +6,6 @@ SELECT
   {{ .Ident "updated" }}
 FROM
   {{ .Ident "secret_encrypted_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "uid" }} = {{ .Arg .UID }}
 ;

--- a/pkg/storage/secret/encryption/data/encrypted_value_update.sql
+++ b/pkg/storage/secret/encryption/data/encrypted_value_update.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   {{ .Ident "encrypted_data" }} = {{ .Arg .EncryptedData }},
   {{ .Ident "updated" }} = {{ .Arg .Updated }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "uid" }} = {{ .Arg .UID }}
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_delete-delete-no-uid.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_delete-delete-no-uid.sql
@@ -1,5 +1,4 @@
 DELETE FROM `secret_data_key`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid`      = ''
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM `secret_data_key`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid`      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_disable-disable.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_disable-disable.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   `active` = false,
   `updated` = '2025-01-01 00:00:00 +0000 UTC'
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `active` = true
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_list-list.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_list-list.sql
@@ -9,6 +9,5 @@ SELECT
   `updated`
 FROM
   `secret_data_key`
-WHERE 1 = 1 AND
-  `namespace` = 'ns'
+WHERE `namespace` = 'ns'
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_read-read.sql
@@ -9,7 +9,6 @@ SELECT
   `updated`
 FROM
   `secret_data_key`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid` = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--data_key_read_current-read_current.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--data_key_read_current-read_current.sql
@@ -9,8 +9,7 @@ SELECT
   `updated`
 FROM
   `secret_data_key`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `label` = 'label' AND
   `active` = true
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM `secret_encrypted_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid`      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_read-read.sql
@@ -6,7 +6,6 @@ SELECT
   `updated`
 FROM
   `secret_encrypted_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid` = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_update-update.sql
+++ b/pkg/storage/secret/encryption/testdata/mysql--encrypted_value_update-update.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   `encrypted_data` = '[115 101 99 114 101 116]',
   `updated` = 5679
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `uid` = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_delete-delete-no-uid.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_delete-delete-no-uid.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = ''
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_disable-disable.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_disable-disable.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   "active" = false,
   "updated" = '2025-01-01 00:00:00 +0000 UTC'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "active" = true
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_list-list.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_list-list.sql
@@ -9,6 +9,5 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_read-read.sql
@@ -9,7 +9,6 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--data_key_read_current-read_current.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--data_key_read_current-read_current.sql
@@ -9,8 +9,7 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "label" = 'label' AND
   "active" = true
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_encrypted_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_read-read.sql
@@ -6,7 +6,6 @@ SELECT
   "updated"
 FROM
   "secret_encrypted_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_update-update.sql
+++ b/pkg/storage/secret/encryption/testdata/postgres--encrypted_value_update-update.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   "encrypted_data" = '[115 101 99 114 101 116]',
   "updated" = 5679
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_delete-delete-no-uid.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_delete-delete-no-uid.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = ''
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_disable-disable.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_disable-disable.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   "active" = false,
   "updated" = '2025-01-01 00:00:00 +0000 UTC'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "active" = true
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_list-list.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_list-list.sql
@@ -9,6 +9,5 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_read-read.sql
@@ -9,7 +9,6 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--data_key_read_current-read_current.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--data_key_read_current-read_current.sql
@@ -9,8 +9,7 @@ SELECT
   "updated"
 FROM
   "secret_data_key"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "label" = 'label' AND
   "active" = true
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_delete-delete.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_encrypted_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid"      = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_read-read.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_read-read.sql
@@ -6,7 +6,6 @@ SELECT
   "updated"
 FROM
   "secret_encrypted_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_update-update.sql
+++ b/pkg/storage/secret/encryption/testdata/sqlite--encrypted_value_update-update.sql
@@ -3,7 +3,6 @@ UPDATE
 SET
   "encrypted_data" = '[115 101 99 114 101 116]',
   "updated" = 5679
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "uid" = 'abc123'
 ;

--- a/pkg/storage/secret/metadata/data/keeper_delete.sql
+++ b/pkg/storage/secret/metadata/data/keeper_delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM {{ .Ident "secret_keeper" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }}      = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/data/keeper_list.sql
+++ b/pkg/storage/secret/metadata/data/keeper_list.sql
@@ -13,7 +13,6 @@ SELECT
   {{ .Ident "payload" }}
 FROM
   {{ .Ident "secret_keeper" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 ORDER BY {{ .Ident "updated" }} DESC
 ;

--- a/pkg/storage/secret/metadata/data/keeper_listByName.sql
+++ b/pkg/storage/secret/metadata/data/keeper_listByName.sql
@@ -4,8 +4,7 @@ SELECT
   {{ .Ident "name" }}
 FROM
   {{ .Ident "secret_keeper" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} IN ({{ .ArgList .KeeperNames }})
 {{ .SelectFor "UPDATE" }}
 ;

--- a/pkg/storage/secret/metadata/data/keeper_read.sql
+++ b/pkg/storage/secret/metadata/data/keeper_read.sql
@@ -13,8 +13,7 @@ SELECT
   {{ .Ident "payload" }}
 FROM
   {{ .Ident "secret_keeper" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 {{ if .IsForUpdate }}
 {{ .SelectFor "UPDATE" }}

--- a/pkg/storage/secret/metadata/data/keeper_update.sql
+++ b/pkg/storage/secret/metadata/data/keeper_update.sql
@@ -13,7 +13,6 @@ SET
   {{ .Ident "description" }} = {{ .Arg .Row.Description }},
   {{ .Ident "type" }} = {{ .Arg .Row.Type }},
   {{ .Ident "payload" }} = {{ .Arg .Row.Payload }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Row.Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Row.Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Row.Name }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_delete.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM {{ .Ident "secret_secure_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }}      = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_list.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_list.sql
@@ -17,7 +17,6 @@ SELECT
   {{ .Ident "external_id" }}
 FROM
   {{ .Ident "secret_secure_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 ORDER BY {{ .Ident "updated" }} DESC
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_listByName.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_listByName.sql
@@ -5,8 +5,7 @@ SELECT
   {{ .Ident "keeper" }}
 FROM
   {{ .Ident "secret_secure_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} IN ({{ .ArgList .UsedSecureValues }})
 {{ .SelectFor "UPDATE" }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_read.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_read.sql
@@ -17,7 +17,6 @@ SELECT
   {{ .Ident "external_id" }}
 FROM
   {{ .Ident "secret_secure_value" }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_update.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_update.sql
@@ -25,7 +25,6 @@ SET
   {{ .Ident "ref" }} = {{ .Arg .Row.Ref.String }},
   {{ end }}
   {{ .Ident "external_id" }} = {{ .Arg .Row.ExternalID }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Row.Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Row.Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Row.Name }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_updateExternalId.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_updateExternalId.sql
@@ -2,7 +2,6 @@ UPDATE
   {{ .Ident "secret_secure_value" }}
 SET
   {{ .Ident "external_id" }} = {{ .Arg .ExternalID }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_updateStatus.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_updateStatus.sql
@@ -2,7 +2,6 @@ UPDATE
   {{ .Ident "secret_secure_value" }}
 SET
   {{ .Ident "status_phase" }} = {{ .Arg .Phase }}
-WHERE 1 = 1 AND
-  {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM `secret_keeper`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE  `namespace` = 'ns' AND
   `name`      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_list-list.sql
@@ -13,7 +13,6 @@ SELECT
   `payload`
 FROM
   `secret_keeper`
-WHERE 1 = 1 AND
-  `namespace` = 'ns'
+WHERE `namespace` = 'ns'
 ORDER BY `updated` DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_listByName-list.sql
@@ -2,8 +2,7 @@ SELECT
   `name`
 FROM
   `secret_keeper`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` IN ('a', 'b')
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read-for-update.sql
@@ -13,8 +13,7 @@ SELECT
   `payload`
 FROM
   `secret_keeper`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_read-read.sql
@@ -13,7 +13,6 @@ SELECT
   `payload`
 FROM
   `secret_keeper`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--keeper_update-update.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--keeper_update-update.sql
@@ -13,7 +13,6 @@ SET
   `description` = 'description',
   `type` = 'sql',
   `payload` = ''
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM `secret_secure_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name`      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_list-list.sql
@@ -17,7 +17,6 @@ SELECT
   `external_id`
 FROM
   `secret_secure_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns'
+WHERE `namespace` = 'ns'
 ORDER BY `updated` DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_listByName-list.sql
@@ -3,8 +3,7 @@ SELECT
   `keeper`
 FROM
   `secret_secure_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE  `namespace` = 'ns' AND
   `name` IN ('a', 'b')
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_read-read.sql
@@ -17,7 +17,6 @@ SELECT
   `external_id`
 FROM
   `secret_secure_value`
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_update-update-not-null.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_update-update-not-null.sql
@@ -17,7 +17,6 @@ SET
   `decrypters` = 'decrypters_test',
   `ref` = 'ref_test',
   `external_id` = 'extId'
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_update-update-null.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_update-update-null.sql
@@ -13,7 +13,6 @@ SET
   `status_phase` = 'creating',
   `description` = 'description',
   `external_id` = 'extId'
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateExternalId-updateExternalId.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateExternalId-updateExternalId.sql
@@ -2,7 +2,6 @@ UPDATE
   `secret_secure_value`
 SET
   `external_id` = 'extId'
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateStatus-updateStatus.sql
@@ -2,7 +2,6 @@ UPDATE
   `secret_secure_value`
 SET
   `status_phase` = 'Succeeded'
-WHERE 1 = 1 AND
-  `namespace` = 'ns' AND
+WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE  "namespace" = 'ns' AND
   "name"      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_list-list.sql
@@ -13,7 +13,6 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ORDER BY "updated" DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_listByName-list.sql
@@ -2,8 +2,7 @@ SELECT
   "name"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" IN ('a', 'b')
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read-for-update.sql
@@ -13,8 +13,7 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_read-read.sql
@@ -13,7 +13,6 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--keeper_update-update.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--keeper_update-update.sql
@@ -13,7 +13,6 @@ SET
   "description" = 'description',
   "type" = 'sql',
   "payload" = ''
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name"      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_list-list.sql
@@ -17,7 +17,6 @@ SELECT
   "external_id"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ORDER BY "updated" DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_listByName-list.sql
@@ -3,8 +3,7 @@ SELECT
   "keeper"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE  "namespace" = 'ns' AND
   "name" IN ('a', 'b')
 FOR UPDATE
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_read-read.sql
@@ -17,7 +17,6 @@ SELECT
   "external_id"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_update-update-not-null.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_update-update-not-null.sql
@@ -17,7 +17,6 @@ SET
   "decrypters" = 'decrypters_test',
   "ref" = 'ref_test',
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_update-update-null.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_update-update-null.sql
@@ -13,7 +13,6 @@ SET
   "status_phase" = 'creating',
   "description" = 'description',
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateExternalId-updateExternalId.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateExternalId-updateExternalId.sql
@@ -2,7 +2,6 @@ UPDATE
   "secret_secure_value"
 SET
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateStatus-updateStatus.sql
@@ -2,7 +2,6 @@ UPDATE
   "secret_secure_value"
 SET
   "status_phase" = 'Succeeded'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE  "namespace" = 'ns' AND
   "name"      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_list-list.sql
@@ -13,7 +13,6 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ORDER BY "updated" DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_listByName-list.sql
@@ -2,7 +2,6 @@ SELECT
   "name"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" IN ('a', 'b')
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read-for-update.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read-for-update.sql
@@ -13,7 +13,6 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_read-read.sql
@@ -13,7 +13,6 @@ SELECT
   "payload"
 FROM
   "secret_keeper"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--keeper_update-update.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--keeper_update-update.sql
@@ -13,7 +13,6 @@ SET
   "description" = 'description',
   "type" = 'sql',
   "payload" = ''
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_delete-delete.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_delete-delete.sql
@@ -1,5 +1,4 @@
 DELETE FROM "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name"      = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_list-list.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_list-list.sql
@@ -17,7 +17,6 @@ SELECT
   "external_id"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns'
+WHERE "namespace" = 'ns'
 ORDER BY "updated" DESC
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_listByName-list.sql
@@ -3,7 +3,6 @@ SELECT
   "keeper"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE  "namespace" = 'ns' AND
   "name" IN ('a', 'b')
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_read-read.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_read-read.sql
@@ -17,7 +17,6 @@ SELECT
   "external_id"
 FROM
   "secret_secure_value"
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_update-update-not-null.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_update-update-not-null.sql
@@ -17,7 +17,6 @@ SET
   "decrypters" = 'decrypters_test',
   "ref" = 'ref_test',
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_update-update-null.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_update-update-null.sql
@@ -13,7 +13,6 @@ SET
   "status_phase" = 'creating',
   "description" = 'description',
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateExternalId-updateExternalId.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateExternalId-updateExternalId.sql
@@ -2,7 +2,6 @@ UPDATE
   "secret_secure_value"
 SET
   "external_id" = 'extId'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateStatus-updateStatus.sql
@@ -2,7 +2,6 @@ UPDATE
   "secret_secure_value"
 SET
   "status_phase" = 'Succeeded'
-WHERE 1 = 1 AND
-  "namespace" = 'ns' AND
+WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/tests/apis/secret/main_test.go
+++ b/pkg/tests/apis/secret/main_test.go
@@ -155,7 +155,7 @@ func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, user apis
 		statusPhase, ok := status["phase"].(string)
 		require.True(t, ok)
 		require.Equal(t, "Succeeded", statusPhase)
-	}, 10*time.Second, 250*time.Millisecond, "expected status to be Suceeded")
+	}, 10*time.Second, 250*time.Millisecond, "expected status to be Succeeded")
 
 	t.Cleanup(func() {
 		require.NoError(t, secureValueClient.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))


### PR DESCRIPTION
Removes "1 = 1" assertion from a lot of queries, where it is not needed. 
Updates tests