### PR TITLE
chore(unified-storage): remove debug logging for poller

### DIFF
--- a/pkg/storage/unified/sql/notifier_sql.go
+++ b/pkg/storage/unified/sql/notifier_sql.go
@@ -150,11 +150,6 @@ func (p *pollingNotifier) poller(ctx context.Context, since groupResourceRV, str
 
 					// We don't need to poll if the RV hasn't changed.
 					if since[group][resource] >= latestRV {
-						p.log.Debug("polling for resource skipped",
-							"group", group,
-							"resource", resource,
-							"latestKnownRV", since[group][resource],
-							"latestFetchedRV", latestRV)
 						continue
 					}
 


### PR DESCRIPTION
**Example logs in debug mode:**
```
t=2025-05-02T13:36:02.91981+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:02.919789+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:02.923771+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:02.923758+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.030808+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.030787+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.030808+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.030787+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.143757+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.143734+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.143757+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.143733+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.254263+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.254245+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.259691+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.259676+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.366536+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.366506+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.366594+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.366576+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.476509+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.476496+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.476518+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.476496+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.587575+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.587538+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.587575+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.587538+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.709006+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.70898+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.709007+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.708981+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.823383+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.823359+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.823383+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.823369+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.937301+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.937279+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:03.9373+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:03.93728+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:04.049461+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:04.049441+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
t=2025-05-02T13:36:04.049554+02:00 level=debug caller=logger.go:204 time=2025-05-02T13:36:04.049518+02:00 msg="polling for resource skipped" logger=sql-resource-server group=dashboard.grafana.app resource=dashboards latestKnownRV=1746013879469752 latestFetchedRV=1746013879469752
```