### PR TITLE
i18n: Fix incorrect interpolation in query group options

### DIFF
--- a/public/app/features/query/components/QueryGroup.test.tsx
+++ b/public/app/features/query/components/QueryGroup.test.tsx
@@ -121,6 +121,12 @@ describe('QueryGroup', () => {
     const addExpressionButton = screen.queryByTestId('query-tab-add-expression');
     expect(addExpressionButton).not.toBeInTheDocument();
   });
+
+  it('correctly renders query options', async () => {
+    renderScenario({});
+    expect(await screen.findByText('MD = 100')).toBeInTheDocument();
+    expect(await screen.findByText('Interval = 1m')).toBeInTheDocument();
+  });
 });
 
 function renderScenario(overrides: Partial<Props>) {
@@ -132,6 +138,8 @@ function renderScenario(overrides: Partial<Props>) {
       getTransformations: jest.fn(),
     }),
     options: {
+      maxDataPoints: 100,
+      minInterval: '1m',
       queries: [
         {
           datasource: mockDS,

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -310,12 +310,12 @@ export const QueryGroupOptionsEditor = React.memo(({ options, dataSource, data, 
       <>
         {
           <span className={styles.collapsedText}>
-            <Trans i18nKey="query.query-group-options-editor.collapsed-max-data-points">MD = {mdDesc}</Trans>
+            <Trans i18nKey="query.query-group-options-editor.collapsed-max-data-points">MD = {{ mdDesc }}</Trans>
           </span>
         }
         {
           <span className={styles.collapsedText}>
-            <Trans i18nKey="query.query-group-options-editor.collapsed-interval">Interval = {intervalDesc}</Trans>
+            <Trans i18nKey="query.query-group-options-editor.collapsed-interval">Interval = {{ intervalDesc }}</Trans>
           </span>
         }
       </>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7830,8 +7830,8 @@
       "title-data-source-help": "Data source help"
     },
     "query-group-options-editor": {
-      "collapsed-interval": "Interval = {intervalDesc}",
-      "collapsed-max-data-points": "MD = {mdDesc}",
+      "collapsed-interval": "Interval = {{intervalDesc}}",
+      "collapsed-max-data-points": "MD = {{mdDesc}}",
       "hide-time-info": "Hide time info",
       "Query options-title-query-options": "Query options",
       "relative-time": "Relative time",


### PR DESCRIPTION
**What is this feature?**
Fixes incorrect translation interpolation in query options.

Before:
![image](https://github.com/user-attachments/assets/8cc7d865-3e8f-4ce4-9328-6a4c067f3ca2)

After:
![image](https://github.com/user-attachments/assets/59dd5fff-f4ac-4746-b441-8ecbe6ac5a3c)
