### PR TITLE
Admin: Rename White labeling to Custom branding

### DIFF
--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -175,7 +175,7 @@ Enterprise plugins might stop working.
 
 #### Custom branding
 
-The Custom branding feature is turned off, meaning that any custom branding options will not have any effect.
+The custom branding feature is turned off, meaning that any custom branding options will not have any effect.
 
 #### Usage insights
 

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -173,9 +173,9 @@ SAML authentication is not affected by an expired license.
 
 Enterprise plugins might stop working.
 
-#### White labeling
+#### Custom branding
 
-The white labeling feature is turned off, meaning that any white labeling options will not have any effect.
+The Custom branding feature is turned off, meaning that any custom branding options will not have any effect.
 
 #### Usage insights
 

--- a/public/app/features/admin/UpgradePage.tsx
+++ b/public/app/features/admin/UpgradePage.tsx
@@ -174,7 +174,7 @@ const FeatureListing = () => {
       <Item title={t('admin.feature-listing.title-team-sync', 'Team Sync')}>
         <Trans i18nKey="admin.get-enterprise.team-sync-details">LDAP, GitHub OAuth, Auth Proxy, Okta</Trans>
       </Item>
-      <Item title={t('admin.feature-listing.title-white-labeling', 'White labeling')} />
+      <Item title={t('admin.feature-listing.title-custom-branding', 'Custom branding')} />
       <Item title={t('admin.feature-listing.title-auditing', 'Auditing')} />
       <Item title={t('admin.feature-listing.title-settings-updates-at-runtime', 'Settings updates at runtime')} />
       <Item title={t('admin.feature-listing.title-grafana-usage-insights', 'Grafana usage insights')}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -103,6 +103,7 @@
     },
     "feature-listing": {
       "title-auditing": "Auditing",
+      "title-custom-branding": "Custom branding",
       "title-dashboard-presence-indicators": "Dashboard presence indicators",
       "title-dashboard-usage-stats-drawer": "Dashboard usage stats drawer",
       "title-data-source-permissions": "Data source permissions",
@@ -114,8 +115,7 @@
       "title-saml-authentication": "SAML authentication",
       "title-settings-updates-at-runtime": "Settings updates at runtime",
       "title-sort-dashboards-by-popularity-in-search": "Sort dashboards by popularity in search",
-      "title-team-sync": "Team Sync",
-      "title-white-labeling": "White labeling"
+      "title-team-sync": "Team Sync"
     },
     "feature-toggles": {
       "restart-pending": "A restart is pending for your Grafana instance to apply the latest feature toggle changes",


### PR DESCRIPTION
White labeling feature is referred to as 'Custom branding' in the docs https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/configure-custom-branding/, so updating the UpgradePage (and one docs page) to match this.