### PR TITLE
Don't print an error if there is nothing to be synced

### DIFF
--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -184,8 +184,8 @@ func legacyToUnifiedStorageDataSyncer(ctx context.Context, cfg *SyncerConfig) (b
 			Limit: int64(cfg.DataSyncerRecordsLimit),
 		})
 		if err != nil {
-			if len(legacyList) == 0 {
-				log.Info("legacy storage is empty, skipping sync")
+			if len(legacyList) == 0 && len(storageList) == 0 {
+				log.Info("legacy and unified storage are empty, skipping sync")
 				return
 			}
 			log.Error(err, "unable to extract list from legacy storage")

--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -184,6 +184,10 @@ func legacyToUnifiedStorageDataSyncer(ctx context.Context, cfg *SyncerConfig) (b
 			Limit: int64(cfg.DataSyncerRecordsLimit),
 		})
 		if err != nil {
+			if len(storageList) == 0 {
+				log.Info("legacy storage is empty, skipping sync")
+				return
+			}
 			log.Error(err, "unable to extract list from legacy storage")
 			return
 		}

--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -184,7 +184,7 @@ func legacyToUnifiedStorageDataSyncer(ctx context.Context, cfg *SyncerConfig) (b
 			Limit: int64(cfg.DataSyncerRecordsLimit),
 		})
 		if err != nil {
-			if len(storageList) == 0 {
+			if len(legacyList) == 0 {
 				log.Info("legacy storage is empty, skipping sync")
 				return
 			}

--- a/pkg/apiserver/rest/dualwriter_syncer_test.go
+++ b/pkg/apiserver/rest/dualwriter_syncer_test.go
@@ -179,7 +179,7 @@ func TestLegacyToUnifiedStorage_DataSyncer(t *testing.T) {
 				expectedOutcome: true,
 			},
 			{
-				name: "no items in legacy to sync",
+				name: "no items to sync",
 				setupLegacyFn: func(m *mock.Mock) {
 					m.On("List", mock.Anything, mock.Anything).Return(empty, nil)
 				},

--- a/pkg/apiserver/rest/dualwriter_syncer_test.go
+++ b/pkg/apiserver/rest/dualwriter_syncer_test.go
@@ -47,6 +47,8 @@ var legacyListWith3itemsObj2IsDifferent = &example.PodList{TypeMeta: metav1.Type
 		*legacyObj3,
 	}}
 
+var empty = &example.PodList{}
+
 var storageListWith3items = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListMeta: metav1.ListMeta{},
 	Items: []example.Pod{
 		*storageObj1,
@@ -173,6 +175,16 @@ func TestLegacyToUnifiedStorage_DataSyncer(t *testing.T) {
 					m.On("List", mock.Anything, mock.Anything).Return(storageListWith3itemsMissingFoo2, nil)
 					m.On("Update", mock.Anything, "foo2", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 					m.On("Delete", mock.Anything, "foo4", mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				},
+				expectedOutcome: true,
+			},
+			{
+				name: "no items in legacy to sync",
+				setupLegacyFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(empty, nil)
+				},
+				setupStorageFn: func(m *mock.Mock) {
+					m.On("List", mock.Anything, mock.Anything).Return(empty, nil)
 				},
 				expectedOutcome: true,
 			},


### PR DESCRIPTION
In order to distinguish between legitimate sync errors and no resources left to sync, we should just log an info type so we don't have false positives like in [here](https://admin-ops-eu-south-0.grafana-ops.net/grafana/goto/OAzmfFbHg?orgId=1).

Loosely related with https://github.com/grafana/search-and-storage-team/issues/249

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
