### PR TITLE
TimeZonePicker: Replace underscores with space

### DIFF
--- a/e2e/old-arch/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e/old-arch/dashboards-suite/dashboard-time-zone.spec.ts
@@ -198,7 +198,7 @@ describe('Dashboard time zone support', () => {
     e2e.flows.setTimeRange({
       from: 'now-6h',
       to: 'now',
-      zone: 'America/Los_Angeles',
+      zone: 'America/Los Angeles',
     });
     // Need to wait for 2 calls as there's 2 panels
     cy.wait(['@dataQuery', '@dataQuery']);

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -100,7 +100,7 @@ const useTimeZones = (includeInternal: boolean | InternalTimeZones[]): Selectabl
         options.push({
           label: name,
           value: info.zone,
-          searchIndex: getSearchIndex(info, now),
+          searchIndex: getSearchIndex(name, info, now),
         });
 
         return options;
@@ -164,12 +164,16 @@ const useFilterBySearchIndex = () => {
   }, []);
 };
 
-const getSearchIndex = (info: TimeZoneInfo, timestamp: number): string => {
+const getSearchIndex = (label: string, info: TimeZoneInfo, timestamp: number): string => {
   const parts: string[] = [
-    toLower(info.name),
+    toLower(info.zone),
     toLower(info.abbreviation),
     toLower(formatUtcOffset(timestamp, info.zone)),
   ];
+
+  if (label !== info.zone) {
+    parts.push(toLower(label));
+  }
 
   for (const country of info.countries) {
     parts.push(toLower(country.name));

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -86,28 +86,33 @@ interface SelectableZoneGroup extends SelectableValue<string> {
 const useTimeZones = (includeInternal: boolean | InternalTimeZones[]): SelectableZoneGroup[] => {
   const now = Date.now();
 
-  const timeZoneGroups = getTimeZoneGroups(includeInternal).map((group: GroupedTimeZones) => {
-    const options = group.zones.reduce((options: SelectableZone[], zone) => {
-      const info = getTimeZoneInfo(zone, now);
+  const timeZoneGroups = useMemo(() => {
+    return getTimeZoneGroups(includeInternal).map((group: GroupedTimeZones) => {
+      const options = group.zones.reduce((options: SelectableZone[], zone) => {
+        const info = getTimeZoneInfo(zone, now);
 
-      if (!info) {
+        if (!info) {
+          return options;
+        }
+
+        const name = info.name.replace(/_/g, ' ');
+
+        options.push({
+          label: name,
+          value: info.zone,
+          searchIndex: getSearchIndex(info, now),
+        });
+
         return options;
-      }
+      }, []);
 
-      options.push({
-        label: info.name,
-        value: info.zone,
-        searchIndex: getSearchIndex(info, now),
-      });
+      return {
+        label: group.name,
+        options,
+      };
+    });
+  }, [includeInternal, now]);
 
-      return options;
-    }, []);
-
-    return {
-      label: group.name,
-      options,
-    };
-  });
   return timeZoneGroups;
 };
 


### PR DESCRIPTION
This PR makes the option labels in the TimeZonePicker slightly easier on the eyes by replacing underscores with spaces.

![image](https://github.com/user-attachments/assets/820dd266-cc1f-4099-b3a4-84933f43e8cc)


