### PR TITLE
Dashboard - edit pane textbox variable

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/TextBoxVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/TextBoxVariableForm.tsx
@@ -16,7 +16,7 @@ interface TextBoxVariableFormProps {
 export function TextBoxVariableForm({ defaultValue, value, onChange, onBlur, inline }: TextBoxVariableFormProps) {
   return (
     <>
-      { !inline && (
+      {!inline && (
         <VariableLegend>
           <Trans i18nKey="dashboard-scene.text-box-variable-form.text-options">Text options</Trans>
         </VariableLegend>
@@ -25,7 +25,7 @@ export function TextBoxVariableForm({ defaultValue, value, onChange, onBlur, inl
       <VariableTextField
         value={value}
         defaultValue={defaultValue}
-        name={inline ? undefined : "Default value"}
+        name={inline ? undefined : 'Default value'}
         placeholder={t('dashboard-scene.text-box-variable-form.placeholder-default-value-if-any', '(optional)')}
         onChange={onChange}
         onBlur={onBlur}

--- a/public/app/features/dashboard-scene/settings/variables/components/TextBoxVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/TextBoxVariableForm.tsx
@@ -10,18 +10,22 @@ interface TextBoxVariableFormProps {
   defaultValue?: string;
   onChange?: (event: FormEvent<HTMLInputElement>) => void;
   onBlur?: (event: FormEvent<HTMLInputElement>) => void;
+  inline?: boolean;
 }
 
-export function TextBoxVariableForm({ defaultValue, value, onChange, onBlur }: TextBoxVariableFormProps) {
+export function TextBoxVariableForm({ defaultValue, value, onChange, onBlur, inline }: TextBoxVariableFormProps) {
   return (
     <>
-      <VariableLegend>
-        <Trans i18nKey="dashboard-scene.text-box-variable-form.text-options">Text options</Trans>
-      </VariableLegend>
+      { !inline && (
+        <VariableLegend>
+          <Trans i18nKey="dashboard-scene.text-box-variable-form.text-options">Text options</Trans>
+        </VariableLegend>
+      )}
+
       <VariableTextField
         value={value}
         defaultValue={defaultValue}
-        name="Default value"
+        name={inline ? undefined : "Default value"}
         placeholder={t('dashboard-scene.text-box-variable-form.placeholder-default-value-if-any', '(optional)')}
         onChange={onChange}
         onBlur={onBlur}

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx
@@ -7,7 +7,7 @@ import { Field, Input } from '@grafana/ui';
 interface VariableTextFieldProps {
   value?: string;
   defaultValue?: string;
-  name: string;
+  name?: string;
   placeholder?: string;
   onChange?: (event: FormEvent<HTMLInputElement>) => void;
   testId?: string;

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -39,6 +39,15 @@ describe('TextBoxVariableEditor', () => {
     await userEvent.tab();
     expect(textBoxVar.state.value).toBe(newValue);
   });
+
+  it('renders inline', () => {
+    const onChange = jest.fn();
+    render(<TextBoxVariableEditor variable={textBoxVar} onChange={onChange} inline={true}/>);
+  
+    const input = screen.getByRole('textbox', { name: undefined });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('initial value test');
+  });
 });
 
 async function buildTestScene() {

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -42,17 +42,11 @@ describe('TextBoxVariableEditor', () => {
 
   it('renders inline', () => {
     const onChange = jest.fn();
-    const variable = new TextBoxVariable({
-      name: 'textBoxVar',
-      label: 'textBoxVar',
-      type: 'textbox',
-      value: 'initial value test',
-    });
-    render(<TextBoxVariableEditor variable={variable} onChange={onChange} inline={true} />);
+    render(<TextBoxVariableEditor variable={textBoxVar} onChange={onChange} inline={true} />);
 
-    const input = screen.getByDisplayValue(variable.state.value);
+    const input = screen.getByDisplayValue(textBoxVar.state.value);
     expect(input).toBeInTheDocument();
-    expect(input).toHaveValue(variable.state.value);
+    expect(input).toHaveValue(textBoxVar.state.value);
 
     const legend = screen.queryByText('Text options');
     expect(legend).not.toBeInTheDocument();

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { VariableType } from '@grafana/data';
 import { TextBoxVariable } from '@grafana/scenes';
 
 import { TextBoxVariableEditor } from './TextBoxVariableEditor';

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { VariableType } from '@grafana/data';
 import { TextBoxVariable } from '@grafana/scenes';
 
 import { TextBoxVariableEditor } from './TextBoxVariableEditor';
-import { VariableType } from '@grafana/data';
 
 describe('TextBoxVariableEditor', () => {
   let textBoxVar: TextBoxVariable;
@@ -49,8 +49,8 @@ describe('TextBoxVariableEditor', () => {
       type: 'textbox',
       value: 'initial value test',
     });
-    render(<TextBoxVariableEditor variable={variable} onChange={onChange} inline={true}/>);
-  
+    render(<TextBoxVariableEditor variable={variable} onChange={onChange} inline={true} />);
+
     const input = screen.getByDisplayValue(variable.state.value);
     expect(input).toBeInTheDocument();
     expect(input).toHaveValue(variable.state.value);

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -47,6 +47,9 @@ describe('TextBoxVariableEditor', () => {
     const input = screen.getByRole('textbox', { name: undefined });
     expect(input).toBeInTheDocument();
     expect(input).toHaveValue('initial value test');
+
+    const legend = screen.queryByText('Text options');
+    expect(legend).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { TextBoxVariable } from '@grafana/scenes';
 
 import { TextBoxVariableEditor } from './TextBoxVariableEditor';
+import { VariableType } from '@grafana/data';
 
 describe('TextBoxVariableEditor', () => {
   let textBoxVar: TextBoxVariable;
@@ -42,11 +43,17 @@ describe('TextBoxVariableEditor', () => {
 
   it('renders inline', () => {
     const onChange = jest.fn();
-    render(<TextBoxVariableEditor variable={textBoxVar} onChange={onChange} inline={true}/>);
+    const variable = new TextBoxVariable({
+      name: 'textBoxVar',
+      label: 'textBoxVar',
+      type: 'textbox',
+      value: 'initial value test',
+    });
+    render(<TextBoxVariableEditor variable={variable} onChange={onChange} inline={true}/>);
   
-    const input = screen.getByRole('textbox', { name: undefined });
+    const input = screen.getByDisplayValue(variable.state.value);
     expect(input).toBeInTheDocument();
-    expect(input).toHaveValue('initial value test');
+    expect(input).toHaveValue(variable.state.value);
 
     const legend = screen.queryByText('Text options');
     expect(legend).not.toBeInTheDocument();

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,11 +1,11 @@
+import { noop } from 'lodash';
 import { FormEvent } from 'react';
 
 import { SceneVariable, TextBoxVariable } from '@grafana/scenes';
+import { t } from 'app/core/internationalization';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
-import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-import { t } from 'i18next';
-import { noop } from 'lodash';
 
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -10,17 +10,17 @@ import { noop } from 'lodash';
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
   onChange: (variable: TextBoxVariable) => void;
-  hideLabel?: boolean;
+  inline?: boolean;
 }
 
-export function TextBoxVariableEditor({ variable, hideLabel }: TextBoxVariableEditorProps) {
+export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEditorProps) {
   const { value } = variable.useState();
 
   const onTextValueChange = (e: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: e.currentTarget.value });
   };
 
-  return <TextBoxVariableForm defaultValue={value} onBlur={onTextValueChange} inline={true} />;
+  return <TextBoxVariableForm defaultValue={value} onBlur={onTextValueChange} inline={inline} />;
 }
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
@@ -32,7 +32,7 @@ export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneI
   return [
     new OptionsPaneItemDescriptor({
       title: t('dashboard-scene.textbox-variable-form.label-value', 'Value'),
-      render: () => <TextBoxVariableEditor onChange={noop} variable={variable} hideLabel={true} />,
+      render: () => <TextBoxVariableEditor onChange={noop} variable={variable} inline={true} />,
     }),
   ];
 }

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,20 +1,38 @@
 import { FormEvent } from 'react';
 
-import { TextBoxVariable } from '@grafana/scenes';
+import { SceneVariable, TextBoxVariable } from '@grafana/scenes';
 
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { t } from 'i18next';
+import { noop } from 'lodash';
 
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
   onChange: (variable: TextBoxVariable) => void;
+  hideLabel?: boolean;
 }
 
-export function TextBoxVariableEditor({ variable }: TextBoxVariableEditorProps) {
+export function TextBoxVariableEditor({ variable, hideLabel }: TextBoxVariableEditorProps) {
   const { value } = variable.useState();
 
   const onTextValueChange = (e: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: e.currentTarget.value });
   };
 
-  return <TextBoxVariableForm defaultValue={value} onBlur={onTextValueChange} />;
+  return <TextBoxVariableForm defaultValue={value} onBlur={onTextValueChange} inline={true} />;
+}
+
+export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
+  if (!(variable instanceof TextBoxVariable)) {
+    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    return [];
+  }
+
+  return [
+    new OptionsPaneItemDescriptor({
+      title: t('dashboard-scene.textbox-variable-form.label-value', 'Value'),
+      render: () => <TextBoxVariableEditor onChange={noop} variable={variable} hideLabel={true} />,
+    }),
+  ];
 }

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -31,7 +31,7 @@ import { DataSourceVariableEditor } from './editors/DataSourceVariableEditor';
 import { GroupByVariableEditor } from './editors/GroupByVariableEditor';
 import { IntervalVariableEditor } from './editors/IntervalVariableEditor';
 import { QueryVariableEditor } from './editors/QueryVariableEditor';
-import { TextBoxVariableEditor } from './editors/TextBoxVariableEditor';
+import { TextBoxVariableEditor, getTextBoxVariableOptions } from './editors/TextBoxVariableEditor';
 
 interface EditableVariableConfig {
   name: string;
@@ -89,6 +89,7 @@ export const EDITABLE_VARIABLES: Record<EditableVariableType, EditableVariableCo
     name: 'Textbox',
     description: 'Users can enter any arbitrary strings in a textbox',
     editor: TextBoxVariableEditor,
+    getOptions: getTextBoxVariableOptions,
   },
 };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4203,6 +4203,9 @@
       "placeholder-default-value-if-any": "(optional)",
       "text-options": "Text options"
     },
+    "textbox-variable-form": {
+      "label-value": "Value"
+    },
     "title-field-label": {
       "title": "Title"
     },


### PR DESCRIPTION
Adds the Textbox Variable editor to the edit pane.

Fixes https://github.com/grafana/grafana-org/issues/497

![image](https://github.com/user-attachments/assets/87baba3a-8164-47d5-8a1a-c50c33e529ae)
