### PR TITLE
Transformations: Prevent auto-naming of fields with alias in Calculate field

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -267,12 +267,18 @@ export const calculateFieldTransformer: DataTransformerInfo<CalculateFieldTransf
             return frame;
           }
 
-          const field = {
+          const field: Field = {
             name: getNameFromOptions(options),
             type: FieldType.number,
             config: {},
             values,
           };
+
+          if (options.alias?.length) {
+            // this prevents downstream auto-renames when there is an explicit alias
+            field.config.displayName = options.alias;
+          }
+
           let fields: Field[] = [];
 
           // Replace all fields with the single field


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/104852

in https://github.com/grafana/grafana/pull/93602 we began auto-joining only when needed. unfortunately this affects our very complex automatic field naming, where there is different behavior between one or multiple frames.

when a user explicitly defines an alias, however, we should respect this and not try to auto-name.