### PR TITLE
Update custom branding

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
@@ -32,7 +32,7 @@ With custom branding, you have the ability to modify the following elements:
 - Side menu top logo
 - Footer and help menu links
 - Fav icon (shown in browser tab)
-- Login title (will not appear if a login logo is set)
+- Login title
 - Login subtitle (will not appear if a login logo is set)
 - Login box background
 - Loading logo


### PR DESCRIPTION
Docs change. Now we keep the title on login page even with a defined logo (see any Grafana Cloud login page or contact me to get an example of custom logo + title)

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
