### PR TITLE
Actions(ephemeral-instances): Clone the ephemeral repo

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -41,8 +41,17 @@ jobs:
           app_id: ${{ env.APP_ID }}
           private_key: ${{ env.APP_PEM }}
 
+      - name: Checkout ephemeral instances repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: grafana/ephemeral-grafana-instances-github-action
+          token: ${{ steps.generate_token.outputs.token }}
+          ref: main
+          path: ephemeral
+          persist-credentials: false
+
       - name: build and deploy ephemeral instance
-        uses: grafana/ephemeral-grafana-instances-github-action@main
+        uses: ./ephemeral
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           gcom-host: ${{ env.GCOM_HOST }}


### PR DESCRIPTION
Due to our org settings, we can't use private repository workflows in public repositories. To get around this, clone the ephemeral instances repository to use the action.