### PR TITLE
[release-11.5.5] Docs: Fix extra whitespace in Prometheus configs on Grafana Monitoring setup

### DIFF
--- a/docs/sources/setup-grafana/set-up-grafana-monitoring.md
+++ b/docs/sources/setup-grafana/set-up-grafana-monitoring.md
@@ -73,11 +73,11 @@ These instructions assume you have already added Prometheus as a data source in 
    ```
    - job_name: 'grafana_metrics'
 
-      scrape_interval: 15s
-      scrape_timeout: 5s
+     scrape_interval: 15s
+     scrape_timeout: 5s
 
-      static_configs:
-        - targets: ['localhost:3000']
+     static_configs:
+       - targets: ['localhost:3000']
    ```
 
 1. Restart Prometheus. Your new job should appear on the Targets tab.
@@ -147,12 +147,12 @@ These instructions assume you have already added Prometheus as a data source in 
    ```
    - job_name: 'grafana_github_datasource'
 
-      scrape_interval: 15s
-      scrape_timeout: 5s
-      metrics_path: /metrics/plugins/grafana-test-datasource
+     scrape_interval: 15s
+     scrape_timeout: 5s
+     metrics_path: /metrics/plugins/grafana-test-datasource
 
-      static_configs:
-        - targets: ['localhost:3000']
+     static_configs:
+       - targets: ['localhost:3000']
    ```
 
 1. Restart Prometheus. Your new job should appear on the Targets tab.


### PR DESCRIPTION
Backport 7900a53e056861023b0bc9ab902e2023d5ab80f3 from #104916

---

**What is this feature?**

Removes extra whitespace on Prometheus scraping config examples, which have the wrong indentation, and would cause it to fail.

**Why do we need this feature?**

To fix an example!

**Who is this feature for?**

Doc readers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
