### PR TITLE
Canvas pan + zoom: Unique key for canvas panel elements

### DIFF
--- a/public/app/features/canvas/runtime/root.tsx
+++ b/public/app/features/canvas/runtime/root.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { CanvasFrameOptions } from '../frame';
 
 import { FrameState } from './frame';
@@ -49,7 +51,9 @@ export class RootElement extends FrameState {
         ref={this.setRootRef}
         style={{ ...this.sizeStyle, ...this.dataStyle }}
       >
-        {this.elements.map((v) => v.render())}
+        {this.elements.map((v) => (
+          <Fragment key={v.UID}>{v.render()}</Fragment>
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
## What does this PR do? 📓 

Fixes this error in `CanvasPanel` 

``` console
Warning: Each child in a list should have a unique "key" prop. in this file
```

Fixes #104683

You can test with this, or any canvas panel, adding new elements: [canvas test-1746043663800.json](https://github.com/user-attachments/files/19983707/canvas.test-1746043663800.json)

Note: There are other instances of this error that pop up in the console when using canvas, but they're related to the dashboard panel options and should be considered out of scope for this PR.
