### PR TITLE
[release-10.4.19] Chore: Fix Enterprise build

### DIFF
--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/grafana/grafana/pkg/build"
+	"github.com/grafana/grafana/pkg/build/cmd/util"
 	"github.com/urfave/cli/v2"
 )
 
@@ -66,7 +67,7 @@ func main() {
 			Name:      "publish-metrics",
 			Usage:     "Publish a set of metrics from stdin",
 			ArgsUsage: "<api-key>",
-			Action:    MaxArgCountWrapper(1, PublishMetrics),
+			Action:    util.MaxArgCountWrapper(1, PublishMetrics),
 		},
 		{
 			Name:   "verify-drone",
@@ -178,7 +179,7 @@ func main() {
 							Name:      "fetch",
 							Usage:     "Fetch Grafana Docker images",
 							ArgsUsage: "[version]",
-							Action:    MaxArgCountWrapper(1, FetchImages),
+							Action:    util.MaxArgCountWrapper(1, FetchImages),
 							Flags: []cli.Flag{
 								&editionFlag,
 							},

--- a/pkg/build/cmd/util/argcount_wrapper.go
+++ b/pkg/build/cmd/util/argcount_wrapper.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import "github.com/urfave/cli/v2"
 

--- a/pkg/build/cmd/util/flags.go
+++ b/pkg/build/cmd/util/flags.go
@@ -1,0 +1,8 @@
+package util
+
+import "github.com/urfave/cli/v2"
+
+var DryRunFlag = cli.BoolFlag{
+	Name:  "dry-run",
+	Usage: "Only simulate actions",
+}

--- a/pkg/kindsysreport/codegen/report.json
+++ b/pkg/kindsysreport/codegen/report.json
@@ -33,9 +33,7 @@
     },
     "alertgroupspanelcfg": {
       "category": "composable",
-      "codeowners": [
-        "grafana/alerting-frontend"
-      ],
+      "codeowners": [],
       "currentVersion": [
         0,
         0
@@ -533,7 +531,7 @@
     "elasticsearchdataquery": {
       "category": "composable",
       "codeowners": [
-        "grafana/observability-logs"
+        "grafana/aws-datasources"
       ],
       "currentVersion": [
         0,
@@ -1249,7 +1247,7 @@
     "parcadataquery": {
       "category": "composable",
       "codeowners": [
-        "grafana/observability-traces-and-profiling"
+        "grafana/oss-big-tent"
       ],
       "currentVersion": [
         0,
@@ -1420,7 +1418,7 @@
     "prometheusdataquery": {
       "category": "composable",
       "codeowners": [
-        "grafana/observability-metrics"
+        "grafana/oss-big-tent"
       ],
       "currentVersion": [
         0,


### PR DESCRIPTION
Enterprise builds were failing in Drone:
```
FAIL	github.com/grafana/grafana/pkg/build/cmd [setup failed]
# github.com/grafana/grafana/pkg/build/cmd
pkg/build/cmd/artifactspage.go:13:2: no required module provides package github.com/grafana/grafana/pkg/build/cmd/util; to add it:
	cd /drone/src/pkg/build
	go get github.com/grafana/grafana/pkg/build/cmd/util
# github.com/grafana/grafana/pkg/build/cmd
found packages main (argcount_wrapper.go) and build (artifactspage.go) in /drone/src/pkg/build/cmd
```

This change replicates what we have in `main`, adding a new `util` package.