### PR TITLE
Authorization: Fix filtered role display

### DIFF
--- a/public/app/core/components/RolePicker/utils.ts
+++ b/public/app/core/components/RolePicker/utils.ts
@@ -7,14 +7,15 @@ export const isNotDelegatable = (role: Role) => {
 // addDisplayNameForFixedRole provides a fallback name for fixed roles
 // this is "incase" a fixed role is introduced but without a displayname set
 // example: currently this would give:
-// fixed:datasources:name -> datasources name
+// fixed:datasources:name       -> datasources name
 // fixed:datasources:admin      -> datasources admin
+// fixed:support.bundles:writer -> support bundles writer
 export const addDisplayNameForFixedRole = (role: Role) => {
   const fixedRolePrefix = 'fixed:';
   if (!role.displayName && role.name.startsWith(fixedRolePrefix)) {
     let newRoleName = '';
     let rNameWithoutFixedPrefix = role.name.replace(fixedRolePrefix, '');
-    newRoleName = rNameWithoutFixedPrefix.replace(/:/g, ' ');
+    newRoleName = rNameWithoutFixedPrefix.replace(/[:\\.]/g, ' ');
     role.displayName = newRoleName;
   }
   return role;

--- a/public/app/core/components/RolePicker/utils.ts
+++ b/public/app/core/components/RolePicker/utils.ts
@@ -21,7 +21,10 @@ export const addDisplayNameForFixedRole = (role: Role) => {
 };
 
 // Adds a display name for use when the list of roles is filtered
+// If either group or displayName are undefined, we fall back (see RoleMenuOption.tsx)
 export const addFilteredDisplayName = (role: Role) => {
-  role.filteredDisplayName = role.group + ':' + role.displayName;
+  if (role.group && role.displayName) {
+    role.filteredDisplayName = role.group + ':' + role.displayName;
+  }
   return role;
 };


### PR DESCRIPTION
**What is this feature?**
If roles are created without a `group`  or `displayName`, filtering the role list will result in broken names being shown

**Which issue(s) does this PR fix?**:

Fixes #16121
