### PR TITLE
Dashboard Search: Escape wildcard characters in title search

### DIFF
--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -151,14 +151,17 @@ func (b *BaseDialect) AndStr() string {
 }
 
 func (b *BaseDialect) LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string) {
-	param := pattern
-	if wildcardBefore {
-		param = "%" + param
-	}
-	if wildcardAfter {
-		param = param + "%"
-	}
-	return fmt.Sprintf("%s LIKE ?", column), param
+    param = strings.ReplaceAll(param, "_", `\_`)
+    param = strings.ReplaceAll(param, "%", `\%`)
+    
+    if wildcardBefore {
+        param = "%" + param
+    }
+    if wildcardAfter {
+        param = param + "%"
+    }
+    
+    return fmt.Sprintf("%s LIKE ?", column), param
 }
 
 func (b *BaseDialect) OrStr() string {

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -151,17 +151,18 @@ func (b *BaseDialect) AndStr() string {
 }
 
 func (b *BaseDialect) LikeOperator(column string, wildcardBefore bool, pattern string, wildcardAfter bool) (string, string) {
-    param = strings.ReplaceAll(param, "_", `\_`)
-    param = strings.ReplaceAll(param, "%", `\%`)
-    
-    if wildcardBefore {
-        param = "%" + param
-    }
-    if wildcardAfter {
-        param = param + "%"
-    }
-    
-    return fmt.Sprintf("%s LIKE ?", column), param
+	param := pattern
+	param = strings.ReplaceAll(param, "_", `\_`)
+	param = strings.ReplaceAll(param, "%", `\%`)
+
+	if wildcardBefore {
+		param = "%" + param
+	}
+	if wildcardAfter {
+		param = param + "%"
+	}
+
+	return fmt.Sprintf("%s LIKE ? ESCAPE '\\'", column), param
 }
 
 func (b *BaseDialect) OrStr() string {


### PR DESCRIPTION

**What is this feature?**
This feature adds functionality to safely handle dashboard titles containing wildcard characters (% and _) in SQL LIKE queries. It escapes these characters to ensure they are treated as literals, rather than as wildcards, allowing accurate search results.

**Why do we need this feature?**
When searching for dashboard titles that may include % or _ (e.g., in the title "User_123%" or "Sales%"), the search query could incorrectly interpret these characters as wildcards, leading to inaccurate or incomplete results. Escaping these characters ensures that the search functions correctly and matches the exact title. Say if i have dashboard names AT_Folder and gateway monitoring , searching AT_ would result in both these dashboards whereas i should only be able to see AT_Folder


**Who is this feature for?**
This feature is for users of the dashboard application who want to search for specific dashboard titles, including those that may contain special characters. It is particularly useful for developers and users involved in managing or searching dashboards within a system.

**Which issue(s) does this PR fix?**:
This PR fixes the issue where dashboard titles containing % or _ were misinterpreted by the SQL LIKE query, causing search results to be incorrect or incomplete.

**Screen recording with the Fix**
[Screencast from 06-05-25 01:02:28 AM IST.webm](https://github.com/user-attachments/assets/4e3d653a-8053-4168-ab68-c656520e93e9)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
