### PR TITLE
K8s: GetFolders to return default limit

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -321,7 +321,9 @@ func (ss *FolderUnifiedStoreImpl) GetHeight(ctx context.Context, foldrUID string
 // The full path UIDs of B is "uid1/uid2".
 // The full path UIDs of A is "uid1".
 func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFoldersFromStoreQuery) ([]*folder.Folder, error) {
-	opts := v1.ListOptions{}
+	opts := v1.ListOptions{
+		Limit: folderSearchLimit,
+	}
 	if q.WithFullpath || q.WithFullpathUIDs {
 		// only supported in modes 0-2, to keep the alerting queries from causing tons of get folder requests
 		// to retrieve the parent for all folders in grafana


### PR DESCRIPTION
Temporary workaround for https://github.com/grafana/grafana-app-platform-squad/issues/35

In mode4, we [default to 50 folders for lists](https://github.com/grafana/grafana/blob/61a849548530b9a857d49d9796be4b1a57f86973/pkg/storage/unified/resource/server.go#L856), so services that use GetFolders (such as alerting) will break if there are more than 50 folders. This PR increases that to 100,000 for now.

Long term, we should switch to using `search`, not list, but this requires us to do some SQL work in mode0 to get the [full path query parameter ](https://github.com/grafana/grafana/blob/61a849548530b9a857d49d9796be4b1a57f86973/pkg/registry/apis/folders/legacy_storage.go#L109) respected, so that we aren't doing a ton of GetFolder calls once we search.