### PR TITLE
Worker: Add polling interval configuration for outbox queue

### DIFF
--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -75,8 +75,9 @@ func NewSecretAPIBuilder(
 		database:                   database,
 		accessClient:               accessClient,
 		worker: worker.NewWorker(worker.Config{
-			BatchSize:      1,
-			ReceiveTimeout: 5 * time.Second,
+			BatchSize:       1,
+			ReceiveTimeout:  5 * time.Second,
+			PollingInterval: 500 * time.Millisecond,
 		},
 			database,
 			secretsOutboxQueue,

--- a/pkg/registry/apis/secret/worker/worker.go
+++ b/pkg/registry/apis/secret/worker/worker.go
@@ -26,6 +26,8 @@ type Config struct {
 	BatchSize uint
 	// How long to wait for a request to fetch messages from the outbox queue
 	ReceiveTimeout time.Duration
+	// How often to poll the outbox queue for new messages
+	PollingInterval time.Duration
 }
 
 func NewWorker(
@@ -48,6 +50,9 @@ func NewWorker(
 
 // The main method to drive the worker
 func (w *Worker) ControlLoop(ctx context.Context) error {
+	t := time.NewTicker(w.config.PollingInterval)
+	defer t.Stop()
+
 	for {
 		select {
 		// If the context was canceled
@@ -56,7 +61,11 @@ func (w *Worker) ControlLoop(ctx context.Context) error {
 			return ctx.Err()
 
 		// Otherwise try to receive messages
-		default:
+		case <-t.C:
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
 			w.receiveAndProcessMessages(ctx)
 		}
 	}

--- a/pkg/registry/apis/secret/worker/worker_test.go
+++ b/pkg/registry/apis/secret/worker/worker_test.go
@@ -74,8 +74,9 @@ func TestProcessMessage(t *testing.T) {
 
 		worker := NewWorker(Config{
 			// TODO: randomize
-			BatchSize:      10,
-			ReceiveTimeout: 1 * time.Second,
+			BatchSize:       10,
+			ReceiveTimeout:  1 * time.Second,
+			PollingInterval: time.Millisecond,
 		},
 			database,
 			outboxQueueWrapper,


### PR DESCRIPTION
Rather than polling continuously, we can do so in discrete-ish intervals