### PR TITLE
[release-12.0.1] [DOC] Make Obs as Code docs public

### DIFF
--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -1,0 +1,74 @@
+---
+description: Overview of Observability as Code including description, key features, and explanation of benefits.
+keywords:
+  - observability
+  - configuration
+  - as code
+  - dashboards
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Observability as Code
+weight: 100
+---
+
+# Observability as Code
+
+Observability as Code lets you apply code management best practices to your observability resources.
+Using Observability as Code, you can version, automate, and scale Grafana configurations, including dashboards and observability workflows.
+By representing Grafana resources as code, you can integrate them into existing infrastructure-as-code workflows and apply standard development practices.
+
+Observability as Code provides more control over configuration. Instead of manually configuring dashboards or settings through the Grafana UI, you can:
+
+- **Write configurations in code:** Define dashboards in JSON or other supported formats.
+- **Sync your Grafana setup to GitHub:** Track changes, collaborate, and roll back updates using Git and GitHub, or other remote sources.
+- **Automate with CI/CD:** Integrate Grafana directly into your development and deployment pipelines.
+- **Standardize workflows:** Ensure consistency across your teams by using repeatable, codified processes for managing Grafana resources.
+
+{{< section depth=5 >}}
+
+<!-- Hiding this part of the doc because the rest of the docs aren't released yet
+
+## Key features
+
+At this time, Observability as Code lets you configure dashboards in static files rather than using the UI.
+The number of resources covered by this approach will expand over time.
+
+### App Platform: A unified foundation
+
+The [App Platform](https://github.com/grafana/grafana-app-sdk) is the backbone of Observability as Code. It provides consistent APIs for managing Grafana resources like dashboards, data sources, and service-level objectives (SLOs). With the App Platform, you gain:
+
+- A stable and predictable API for integrating Grafana into your systems.
+- Support for cloud-native workflows, making it easier to build and scale observability solutions.
+- The ability to manage Grafana resources programmatically.
+- Backwards compatibility with earlier versions of Grafana APIs, so older applications still work.
+
+### Git integration
+
+Version control is at the heart of Observability as Code. By integrating Grafana with Git, you can:
+
+- Store your dashboards in a Git repository.
+- Automatically deploy changes through CI/CD pipelines.
+- Track who made changes, when they were made, and why.
+
+### Enhanced dashboard management
+
+Dashboards are central to Grafana’s value, and Observability as Code introduces improvements to make them easier to work with:
+
+- **Ready for Schema v2:** An experimental dashboard schema that simplifies dashboards definition, separating properties for better clarity and making configurations more intuitive.
+- **New layout options:** Flexible layouts, including a new responsive grid layout that allow for more dynamic and responsive panel layouts.
+- **Improved metadata management:** Add descriptions, tags, and other metadata to better organize and understand your dashboards.
+
+### Tooling and integrations
+
+Observability as Code comes with tools to make your workflows seamless:
+
+- Examples and best practices for integrating Grafana with tools like Terraform, Kubernetes, and GitHub Actions.
+- The Foundation SDK provides a set of libraries for getting started quickly configuring and manipulating Grafana resources.
+- A command line tool for configuring your dashboards programmatically.
+- Documentation, videos, and SDKs to help you get started quickly.
+-->

--- a/docs/sources/observability-as-code/grafana-cli/_index.md
+++ b/docs/sources/observability-as-code/grafana-cli/_index.md
@@ -1,0 +1,49 @@
+---
+cascade:
+  noindex: true
+description: Overview of Grafana CLI, a command line tool for managing Grafana resources as code.
+keywords:
+  - observability
+  - configuration
+  - as code
+  - as-code
+  - dashboards
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+cards:
+  items:
+    - description: Learn how to install Grafana CLI
+      height: 24
+      href: ./install-grafana-cli/
+      title: Install Grafana CLI
+    - description: Set up Grafana CLI
+      height: 24
+      href: ./set-up-grafana-cli/
+      title: Set up your Grafana CLI
+    - description: Learn how to manage resources with Grafana CLI
+      height: 24
+      href: ./grafanacli-workflows
+      title: Manage resources with Grafana CLI
+  title_class: pt-0 lh-1
+hero:
+  description: Grafana CLI (`grafanactl`) is a command-line tool designed to simplify interaction with Grafana instances. It enables users to authenticate, manage multiple environments, and perform administrative tasks through Grafana’s REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, Grafana CLI provides a flexible and scriptable way to manage your Grafana setup efficiently.
+  height: 110
+  level: 1
+  title: Grafana CLI
+  width: 110
+title: Introduction to Grafana CLI
+menuTitle: Grafana CLI
+weight: 130
+---
+
+{{< docs/hero-simple key="hero" >}}
+
+## Explore
+
+{{< card-grid key="cards" type="simple" >}}

--- a/docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md
+++ b/docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md
@@ -1,0 +1,223 @@
+---
+cascade:
+  noindex: true
+description: Learn more about the supported workflows and use cases for Grafana CLI
+keywords:
+  - workflows
+  - Grafana CLI
+  - CLI
+  - command line
+  - grafanactl
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Manage resources with Grafana CLI
+weight: 300
+---
+
+# Manage resources with Grafana CLI
+
+{{< admonition type="note" >}}
+`grafanactl` is under active development. Command-line flags and subcommands described here may change. This document outlines the target workflows the tool is expected to support.
+{{< /admonition >}}
+
+## Migrate resources between environments
+
+Using the `config` and `resources` options, you can migrate Grafana resources from one environment to another, for example, from a development to production environment.
+The `config` option lets you define the configuration context.
+Using `resources` with `pull`, `push`, and `serve` lets you pull a defined resource from one instance, and push that resource to another instance. `Serve` allows you to preview changes locally before pushing.
+
+Use these steps to migrate resources between environments:
+
+{{< admonition type="note" >}}
+Currently, the `serve` command only works with dashboards.
+{{< /admonition >}}
+
+Use these steps to migrate resources between environments:
+
+{{< admonition type="note" >}}
+Resources are pulled and pushed from the `./resources` directory by default.
+This directory can be configured with the `--directory`/`-d` flags.
+{{< /admonition >}}
+
+1. Make changes to dashboards and other resources using the Grafana UI in your **development instance**.
+1. Pull those resources from the development environment to your local machine:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl resources pull -d ./resources/ -o yaml  # or json
+   ```
+
+1. (Optional) Preview the resources locally before pushing:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl resources serve -d ./resources/
+   ```
+
+1. Switch to the **production instance** and push the resources:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl resources push -d ./resources/
+   ```
+
+## Back up Grafana resources
+
+This workflow helps you back up all Grafana resources from one instance and later restore them. This is useful to replicate a configuration or perform disaster recovery.
+
+1. Use `grafanactl` to pull all resources from your target environment:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl resources pull -d ./resources/ -o yaml  # or json
+   ```
+
+1. Save the exported resources to version control or cloud storage.
+
+## Restore Grafana resources
+
+1. (Optional) Preview the backup locally:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl resources serve -d ./resources/
+   ```
+
+1. To restore the resources later or restore them on another instance, push the saved resources:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl resources push -d ./resources/
+   ```
+
+## Manage dashboards as code
+
+With this workflow, you can define and manage dashboards as code, saving them to a version control system like Git. This is useful for teams that want to maintain a history of changes, collaborate on dashboard design, and ensure consistency across environments.
+
+1. Use a dashboard generation script (for example, with the [Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)). You can find an example implementation in the Grafana as code [hands-on lab repository](https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang).
+
+1. Serve and preview the output of the dashboard generator locally:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl resources serve --script 'go run scripts/generate-dashboard.go' --watch './scripts'
+   ```
+
+1. When the output looks correct, generate dashboard manifest files:
+
+   ```bash
+   go run scripts/generate-dashboard.go --generate-resource-manifests --output './resources'
+   ```
+
+1. Push the generated resources to your Grafana instance:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl resources push -d ./resources/
+   ```
+
+## Explore and modify resources from the terminal
+
+This section describes how to use the Grafana CLI to interact with Grafana resources directly from your terminal. These commands allow you to browse, inspect, update, and delete resources without using the Grafana UI. This approach is useful for advanced users who want to manage resources more efficiently or integrate Grafana operations into automated workflows.
+
+### Find and delete dashboards using invalid data sources
+
+Use this workflow to identify dashboards that reference incorrect or outdated data sources, and remove them if necessary.
+
+1. Set the context to the appropriate environment:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   ```
+
+1. Find dashboards using specific data sources:
+
+   ```bash
+   grafanactl resources get dashboards -ojson | jq '.items | map({ uid: .metadata.name, datasources: .spec.panels | map(.datasource.uid)  })'
+   [
+      {
+         "uid": "important-production-dashboard",
+         "datasources": [
+            "mimir-prod"
+         ]
+      },
+      {
+         "uid": "test-dashboard-from-dev",
+         "datasources": [
+            "mimir-prod",
+            "mimir-dev"
+         ]
+      },
+      {
+         "uid": "test-dashboard-from-stg",
+         "datasources": [
+            "mimir-prod",
+            "mimir-stg",
+            "mimir-dev"
+         ]
+      }
+   ]
+   ```
+
+   This command lists dashboard UIDs along with the data source UIDs used in their panels. You can then identify the dashboards that are using invalid or unexpected data sources.
+
+1. Delete the identified dashboards directly:
+
+   ```bash
+   grafanactl resources delete dashboards/test-dashboard-from-stg,test-dashboard-from-dev
+   ✔ 2 resources deleted, 0 errors
+   ```
+
+### Find and deprecate dashboards using the old API version
+
+Use this workflow to locate dashboards using a deprecated API version and mark them accordingly.
+
+1. Set the context to the appropriate environment:
+
+   ```bash
+   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   ```
+
+1. List all available resources types and versions:
+
+   ```bash
+   grafanactl resources list
+   ```
+
+   This command returns a list of resources, including their versions, types, and quantities:
+
+   ```bash
+   GROUP                               VERSION   KIND
+   folder.grafana.app                  v1        folder
+   dashboard.grafana.app               v1        dashboard
+   dashboard.grafana.app               v1        librarypanel
+   dashboard.grafana.app               v2        dashboard
+   dashboard.grafana.app               v2        librarypanel
+   playlist.grafana.app                v1        playlist
+   ```
+
+1. Find dashboards that are still using an old API version:
+
+   ```bash
+   grafanactl resources get dashboards.v1.dashboard.grafana.app
+   ```
+
+   This command returns a table displaying the resource type, resource name, and associated namespace:
+
+   ```bash
+   KIND         NAME                                   NAMESPACE
+   dashboards   really-old-dashboard                   default
+   ```
+
+1. Edit each of these dashboards to add a `deprecated` tag:
+
+   ```bash
+   grafanactl resources edit dashboards.v1.dashboard.grafana.app/really-old-dashboard -p '{"spec":{"tags":["deprecated"]}}'
+   ```
+
+{{< admonition type="tip" >}}
+You can get help by using the `grafanactl --help` command.
+{{< /admonition >}}

--- a/docs/sources/observability-as-code/grafana-cli/install-grafana-cli.md
+++ b/docs/sources/observability-as-code/grafana-cli/install-grafana-cli.md
@@ -1,0 +1,48 @@
+---
+cascade:
+  noindex: true
+description: Installation guide for Grafana CLI, a command line tool for managing Grafana Observability as Code
+keywords:
+  - configuration
+  - Grafana CLI
+  - CLI
+  - command line
+  - grafanactl
+  - installation
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Install Grafana CLI
+weight: 100
+---
+
+# Install Grafana CLI
+
+You can install the project using one of the following supported methods:
+
+## 1. Download a pre-built binary
+
+Download the latest binary for your platform from the [Releases page](https://github.com/grafana/grafanactl/releases).
+
+Prebuilt binaries are available for a variety of operating systems and architectures. Visit the latest release page, and scroll down to the Assets section.
+
+To install the binary, follow the instructions below:
+
+1. Download the archive for the desired operating system and architecture
+1. Extract the archive
+1. Move the executable to the desired directory
+1. Ensure this directory is included in the PATH environment variable
+1. Verify that you have execute permission on the file
+
+## 2. Build from source
+
+To build `grafanactl` from source you must:
+
+- Have `git` installed
+- Have `go` v1.24 (or greater) installed
+
+```bash
+go install github.com/grafana/grafanactl/cmd@latest
+```

--- a/docs/sources/observability-as-code/grafana-cli/set-up-grafana-cli.md
+++ b/docs/sources/observability-as-code/grafana-cli/set-up-grafana-cli.md
@@ -1,6 +1,4 @@
 ---
-cascade:
-  noindex: true
 description: Configuration guide for Grafana CLI, a command line tool for managing Grafana resources as code.
 keywords:
   - configuration

--- a/docs/sources/observability-as-code/grafana-cli/set-up-grafana-cli.md
+++ b/docs/sources/observability-as-code/grafana-cli/set-up-grafana-cli.md
@@ -1,0 +1,119 @@
+---
+cascade:
+  noindex: true
+description: Configuration guide for Grafana CLI, a command line tool for managing Grafana resources as code.
+keywords:
+  - configuration
+  - Grafana CLI
+  - CLI
+  - command line
+  - grafanactl
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Set up Grafana CLI
+weight: 200
+---
+
+# Set up Grafana CLI
+
+You can configure Grafana CLI in two ways: using environment variables or through a configuration file.
+
+- **Environment variables** are ideal for CI environments and support a single context.
+- **Configuration files** can manage multiple contexts, making it easier to switch between different Grafana instances.
+
+## Use environment variables
+
+Grafana CLI communicates with Grafana via its REST API, which requires authentication credentials.
+
+At a minimum, set the URL of your Grafana instance and the organization ID:
+
+```bash
+GRAFANA_SERVER='http://localhost:3000' GRAFANA_ORG_ID='1' grafanactl config check
+```
+
+Depending on your authentication method, you may also need to set:
+
+- A [token](https://github.com/grafana/grafanactl/blob/main/docs/reference/environment-variables/index.md#grafana_token) for a [Grafana service account](https://grafana.com/docs/grafana/latest/administration/service-accounts/) (recommended)
+- A [username](https://github.com/grafana/grafanactl/blob/main/docs/reference/environment-variables/index.md#grafana_user) and [password](https://github.com/grafana/grafanactl/blob/main/docs/reference/environment-variables/index.md#grafana_password) for basic authentication
+
+To persist your configuration, consider [creating a context](#defining-contexts).
+
+A full list of supported environment variables is available in the [reference documentation](https://github.com/grafana/grafanactl/blob/main/docs/reference/environment-variables/index.md#environment-variables-reference).
+
+## Define contexts
+
+Contexts allow you to easily switch between multiple Grafana instances. By default, the CLI uses a context named `default`.
+
+To configure the `default` context:
+
+```bash
+grafanactl config set contexts.default.grafana.server http://localhost:3000
+grafanactl config set contexts.default.grafana.org-id 1
+
+# Authenticate with a service account token
+grafanactl config set contexts.default.grafana.token service-account-token
+
+# Or use basic authentication
+grafanactl config set contexts.default.grafana.user admin
+grafanactl config set contexts.default.grafana.password admin
+```
+
+You can define additional contexts in the same way:
+
+```bash
+grafanactl config set contexts.staging.grafana.server https://staging.grafana.example
+grafanactl config set contexts.staging.grafana.org-id 1
+```
+
+{{< admonition type="note" >}}
+In these examples, `default` and `staging` are the names of the contexts.
+{{< /admonition >}}
+
+## Configuration file
+
+Grafana CLI stores its configuration in a YAML file. The CLI determines the configuration file location in the following order:
+
+1. If the `--config` flag is provided, the specified file is used.
+2. If `$XDG_CONFIG_HOME` is set:
+   `$XDG_CONFIG_HOME/grafanactl/config.yaml`
+3. If `$HOME` is set:
+   `$HOME/.config/grafanactl/config.yaml`
+4. If `$XDG_CONFIG_DIRS` is set:
+   `$XDG_CONFIG_DIRS/grafanactl/config.yaml`
+
+{{< admonition type="note" >}}
+Use `grafanactl config check` to display the configuration file currently in use.
+{{< /admonition >}}
+
+## Useful commands
+
+Check the current configuration:
+
+```bash
+grafanactl config check
+```
+
+{{< admonition type="note" >}}
+This command is useful to troubleshoot your configuration.
+{{< /admonition >}}
+
+List all available contexts:
+
+```bash
+grafanactl config list-contexts
+```
+
+Switch to a specific context:
+
+```bash
+grafanactl config use-context staging
+```
+
+View the full configuration:
+
+```bash
+grafanactl config view
+```

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -1,0 +1,77 @@
+---
+description: Learn about how to provision resource using Git Sync and local file provisioning administration.
+keywords:
+  - observability
+  - configuration
+  - as code
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Provision resources and sync dashboards
+weight: 300
+---
+
+# Provision resources and sync dashboards
+
+{{< admonition type="caution" >}}
+Provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. This feature isn't available in Grafana Cloud.
+{{< /admonition >}}
+
+{{< section depth="5" >}}
+
+<hr />
+
+Using Provisioning, you can configure how to store your dashboard JSON files in either GitHub repositories using Git Sync or a local path.
+
+Of the two experimental options, Git Sync is the recommended method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards to your configured GitHub repository.
+If you push a change in the repository, those changes are mirrored in your Grafana instance.
+For more information on configuring Git Sync, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup).
+
+Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) to learn more about the version of local file provisioning in Grafana 12.
+
+## Provisioned folders and connections
+
+Dashboards and folders saved to the local path are referred to as "provisioned" resources and are labeled as such in the Grafana UI.
+
+Dashboards saved in your GitHub repository or local folder configured appear in a provisioned folder in Grafana.
+
+You can set a single folder, or multiple folders to a different repository, with up to 10 connections. Alternatively, your entire Grafana instance can be the provisioned folder.
+
+## How it works
+
+A user decides to update a provisioned dashboard that is either stored within a GitHub repository (Git Sync workflow) or in a local file (local file workflow).
+
+### Git Sync workflow
+
+Resources provisioned with Git Sync can be modified from within the Grafana UI or within the GitHub repository.
+Changes made in either the repository or the Grafana UI are bidirectional.
+
+For example, when a user updates dashboards within the Grafana UI, they choose **Save** to preserve the changes.
+Grafana notifies them that the dashboard is provisioned in a GitHub repository.
+They choose how to preserve their changes: either saved directly to a branch or pushed to a new branch using a pull request in GitHub.
+If they chose a new branch, then they open the pull request and follow their normal workflow.
+
+Grafana polls GitHub at a regular interval.
+The connection is established using a personal access token for authorization.
+With the webhooks feature enabled, repository notifications appear almost immediately.
+Without webhooks, Grafana polls for changes at the specified interval.
+The default polling interval is 60 seconds.
+
+Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database.
+The Grafana UI reads the database and updates the UI to reflect these changes.
+
+### Local file workflow
+
+In the local file workflow, all provisioned resources are changed in the local files.
+The user can't use the Grafana UI to edit or delete provisioned resources.
+
+Any changes made in the provisioned files are reflected in the Grafana database.
+The Grafana UI reads the database and updates the UI to reflect these changes.
+
+## Explore provisioning
+
+{{< section withDescriptions="true" depth="5" >}}

--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -1,0 +1,153 @@
+---
+description: Instructions for setting up file provisioning with a local path.
+keywords:
+  - as code
+  - as-code
+  - file provisioning
+  - local path
+labels:
+  products:
+    - enterprise
+    - oss
+title: Set up file provisioning
+weight: 200
+---
+
+# Set up file provisioning
+
+{{< admonition type="note" >}}
+Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature isn't available in Grafana Cloud.
+{{< /admonition >}}
+
+File provisioning in Grafana lets you include resources, including folders and dashboard JSON files, that are stored in a local file system.
+
+This page explains how to set up local file provisioning.
+
+The local path mount is referred to as a repository.
+
+Using the local path lets you also use it with a tool like `fuse`, allowing you to mount S3 buckets as local paths. You can also use tools like `restic` to automatically back up your dashboards to your preferred backup storage solution.
+
+To set up file sync with local with local files, you need to:
+
+1. Enable feature toggles and paths in Grafana configuration file (first time set up).
+1. Set the local path.
+1. Choose what content to sync with Grafana.
+
+## New file provisioning capabilities
+
+Local file provisioning using **Administration** > **Provisioning** will eventually replace the traditional methods Grafana has used for referencing local file systems for dashboard files.
+
+{{< admonition type="note" >}}
+For production system, we recommend using the `folderFromFilesStructure` capability instead of **Administration** > **Provisioning** to include dashboards from a local file system in your Grafana instance.
+Refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#provision-folders-structure-from-filesystem-to-grafana) for more information.
+{{< /admonition >}}
+
+### Limitations
+
+- A provisioned dashboard can't be deleted from within Grafana UI. The dashboard has to be deleted at the local file system and those changes synced to Grafana.
+- Changes from the local file system are one way: you can't save changes from
+
+## Before you begin
+
+To set up file provisioning, you need:
+
+- Administration rights in your Grafana organization.
+- A local directory where your dashboards will be stored.
+  - If you want to use a GitHub repository, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
+- To update the `permitted_provisioning_paths` section of `custom.ini`.
+- To enable the required feature toggles in your Grafana instance.
+
+## Enable required feature toggles and configure permitted paths
+
+To activate local file provisioning in Grafana, you need to enable the `provisioning` and `kubernetesDashboards` feature toggles.
+For additional information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles).
+
+The local setting must be a relative path and its relative path must be configured in the `permitted_provisioned_paths` configuration option.
+The configuration option is relative to your working directory, i.e. where you are running Grafana from; this is usually `/usr/share/grafana` or similar.
+
+Local file paths can point to any directory that is permitted by the configuration.
+The default paths is `devenv/dev-dashboards` and `conf/provisioning` in your `grafana` installation directory.
+
+The path must behave as a standard file directory on the system of choice.
+Any subdirectories are automatically included.
+
+The values that you enter for the `permitted_provisioning_paths` become the base paths for those entered when you enter a local path in the **Connect to local storage** wizard.
+
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
+1. Locate or add a `[feature_toggles]` section. Add these values:
+
+   ```ini
+   [feature_toggles]
+   provisioning = true
+   kubernetesDashboards = true ; use k8s from browser
+
+   # If you want easy kubectl setup development mode
+   grafanaAPIServerEnsureKubectlAccess = true
+   ```
+
+1. Locate or add a `[paths]` section. To add more than one location, use the pipe character (`|`) to separate the paths. The list should not include empty paths or trailing pipes. Add these values:
+
+   ```ini
+   [paths]
+   ; This is devenv/dev-dashboards and conf/provisioning by default.
+   permitted_provisioning_paths = grafana/ | /etc/grafana/provisioning/
+   ```
+
+1. Save the changes to the file and start Grafana.
+
+## Set up file-based provisioning
+
+To use file-based provisioning, you need the file path to the `grafana` folder where your dashboards are stored in the repository.
+
+To start setting up file-based provisioning:
+
+1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+1. Select **Administration** in the left-side menu and then **Provisioning**.
+1. Select [Configure file provisioning](#set-up-file-based-provisioning).
+
+### Connect to local storage
+
+The local path can point to any directory that is permitted by the configuration.
+Refer to [Enabled required feature toggles and paths](#enable-required-feature-toggles-and-configure-permitted-paths) for information.
+
+The starting path is always your working `grafana` directory.
+The prefix that must be entered is determined by the locations configured in `permitted_provisioning_paths`.
+The default paths are `devenv/dev-dashboards` and `conf/provisioning` in your `grafana` installation directory.
+The value you enter in the Grafana UI must _begin_ with any of the configured values. For example, `conf/provisioning/test` is valid, but `conf/test` is not.
+
+1. Enter the **Local path**, for example `grafana/`. This must begin with any of the configured `permitted_provisioned_paths`.
+1. Select **Choose what to synchronize**.
+
+The set up process verifies the path and provides an error message if a problem occurs.
+
+### Choose what to synchronize
+
+In this section, you determine the actions taken with the storage you selected.
+
+1. Select how resources should be handled in Grafana.
+
+- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. You can only have one provisioned connection with this selection.
+- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 folders. - Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
+<!--  - Select **Migrate instance to repository** to migrate the Grafana instance to the repository. This option is not available during the first time you set up remote provisioning. -->
+
+1. Select **Synchronize** to continue.
+
+### Synchronize with external storage
+
+After this one time step, all future updates are automatically saved to the local file path and provisioned back to the instance.
+
+During the initial synchronization, your dashboards will be temporarily unavailable. No data or configurations will be lost.
+How long the process takes depends upon the number of resources involved.
+
+Select **Begin synchronization** to start the process.
+
+### Choose additional settings
+
+If you wish, you can make any files synchronized as as **Read only** so no changes can be made to the resources through Grafana.
+Any resources made outside of Grafana and saved to the local repository will be reflected in Grafana.
+
+Select **Finish**.
+
+## Verify your dashboards in Grafana
+
+To verify that your dashboards are available at the location that you specified, click **Dashboards**. The name of the dashboard is listed in the **Name** column.

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -1,0 +1,229 @@
+---
+description: Instructions for setting up Git Sync, so you can provision GitHub repositories for use with Grafana.
+keywords:
+  - set up
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Set up Git Sync
+weight: 100
+---
+
+# Set up Git Sync
+
+{{< admonition type="note" >}}
+Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. Git Sync isn't available in Grafana Cloud.
+{{< /admonition >}}
+
+Git Sync lets you manage Grafana dashboards as code by storing dashboards JSON files and folders in a remote GitHub repository.
+Alternatively, you can configure a local file system instead of using GitHub.
+Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) for information.
+
+This page explains how to use Git Sync with a GitHub repository.
+
+To set up Git Sync, you need to:
+
+1. Enable feature toggles in Grafana (first time set up).
+1. Configure a connection to your GitHub repository.
+1. Choose what content to sync with Grafana.
+1. Optional: Extend Git Sync by enabling pull request notifications and image previews of dashboard changes.
+
+| Capability                                            | Benefit                                                                         | Requires                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------- |
+| Adds a table summarizing changes to your pull request | Provides a convenient way to save changes back to GitHub.                       | Webhooks configured                           |
+| Add a dashboard preview image to a PR                 | View a snapshot of dashboard changes to a pull request without opening Grafana. | Image renderer plugin and webhooks configured |
+
+## Performance impacts of enabling Git Sync
+
+Git Sync is an experimental feature and is under continuous development.
+
+We recommend evaluating the performance impact, if any, in a non-production environment.
+
+When Git Sync is enabled, the database load might increase, especially for instances with a lot of folders and nested folders.
+Reporting any issues you encounter can help us improve Git Sync.
+
+## Before you begin
+
+To set up Git Sync, you need:
+
+- Administration rights in your Grafana organization.
+- Enable the required feature toggles in your Grafana instance. Refer to [Enable required feature toggles](#enable-required-feature-toggles) for instructions.
+- A GitHub repository to store your dashboards in.
+  - If you want to use a local file path, refer to [the local file path guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
+- A GitHub access token. The Grafana UI will also explain this to you as you set it up.
+- Optional: A public Grafana instance.
+- Optional: Image Renderer plugin to save image previews with your PRs.
+
+## Enable required feature toggles
+
+To activate Git Sync in Grafana, you need to enable the `provisioning` and `kubernetesDashboards` feature toggles.
+For additional information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles).
+
+To enable the required feature toggles, add them to your Grafana configuration file:
+
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
+1. Locate or add a `[feature_toggles]` section. Add these values:
+
+   ```ini
+   [feature_toggles]
+   provisioning = true
+   kubernetesDashboards = true ; use k8s from browser
+
+   # If you want easy kubectl setup development mode
+   grafanaAPIServerEnsureKubectlAccess = true
+   ```
+
+1. Save the changes to the file and restart Grafana.
+
+## Create a GitHub access token
+
+Whenever you connect to a GitHub repository, you need to create a GitHub access token with specific repository permissions.
+This token needs to be added to your Git Sync configuration to enable read and write permissions between Grafana and GitHub repository.
+
+1. Create a new token using [Create new fine-grained personal access token](https://github.com/settings/personal-access-tokens/new). Refer to [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for instructions.
+1. Under **Permissions**, expand **Repository permissions**.
+1. Set these permissions for Git Sync:
+
+   - **Contents**: Read and write permission
+   - **Metadata**: Read-only permission
+   - **Pull requests**: Read and write permission
+   - **Webhooks**: Read and write permission
+
+1. Select any additional options and then press **Generate token**.
+1. Verify the options and select **Generate token**.
+1. Copy the access token. Leave the browser window available with the token until you've completed configuration.
+
+GitHub Apps are not currently supported.
+
+## Set up the connection to GitHub
+
+Use **Provisioning** to guide you through setting up Git Sync to use a GitHub repository.
+
+1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+1. Select **Administration** in the left-side menu and then **Provisioning**.
+1. Select **Configure Git Sync**.
+
+### Connect to external storage
+
+To connect your GitHub repository, follow these steps:
+
+1. Paste your GitHub personal access token into **Enter your access token**. Refer to [Create a GitHub access token](#create-a-github-access-token) for instructions.
+1. Paste the **Repository URL** for your GitHub repository into the text box.
+1. Enter a branch to use. The default value is `main`.
+1. Add a **Path** to a subdirectory where your dashboards are stored. The default value is `grafana/`. If your dashboards are stored in the root of your repository, then remove the directory name.
+1. Select **Choose what to synchronize** to have the connection to your repository verified and continue setup.
+
+### Choose what to synchronize
+
+You can choose to either use one repository for an entire organization or to a new Grafana folder (up to 10 connections).
+If you choose to sync all resources with external storage, then all of your dashboards are synced to that one repository.
+You won't have the option of setting up additional repositories to connect to.
+
+You can choose to synchronize all resources with GitHub or you can sync resources to a new Grafana folder.
+The options you have depend on the status of your GitHub repository.
+For example, if you are syncing with a new or empty repository, you won't have an option to migrate dashboards.
+
+1. Select how resources should be handled in Grafana.
+
+- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. You can only have one provisioned connection with this selection.
+- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections. - Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
+<!--  - Select **Migrate instance to repository** to migrate the Grafana instance to the repository. This option is not available during the first time you set up remote provisioning. -->
+
+1. Select **Synchronize** to continue.
+
+<!-- This is only relevant if we include the "Migrate instance to repository" option above. -->
+<!-- ### Synchronize with external storage
+
+The first time you connect Grafana with a GitHub repository, you need to synchronize with external storage.
+Future updates will be automatically saved to the repository and provisioned back to the instance.
+
+{{< admonition type="note">}}
+During the synchronization process, your dashboards will be temporarily unavailable.
+No data or configuration will be lost.
+However, no one will be able to create, edit, or delete resources during this process.
+In the last step, the resources will disappear and will reappear and be managed through external storage.
+{{< /admonition >}}
+
+1. Select **History** to include commits for each historical value in the synchronized data.
+1. Select **Begin synchronization** to continue. -->
+
+### Choose additional settings
+
+Finally, you can set up how often your configured storage is polled for updates.
+
+1. For **Update instance interval (seconds)**, enter how often you want the instance to pull updates from GitHub. The default value is 60 seconds.
+1. Optional: Select **Read only** to ensure resources can't be modified in Grafana.
+<!-- No workflow option listed in the UI. 1. For **Workflows**, select the GitHub workflows that you want to allow to run in the repository. Both **Branch** and **Write** are selected by default. -->
+1. Optional: If you have the Grafana Image Renderer plugin configured, you can **Enable dashboards previews in pull requests**. If image rendering is not available, then you can't select this option. For more information, refer to [Grafana Image Renderer](https://grafana.com/grafana/plugins/grafana-image-renderer/).
+1. Select **Finish** to proceed.
+
+## Verify your dashboards in Grafana
+
+To verify that your dashboards are available at the location that you specified, click **Dashboards**. The name of the dashboard is listed in the **Name** column.
+
+Now that your dashboards have been synced from a repository, you can customize the name, change the branch, and create a pull request (PR) for it.
+Refer to [Use Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/) for more information.
+
+## Configure webhooks and image rendering
+
+You can extend Git Sync by getting instant updates and pull requests using webhooks and add dashboard previews in pull requests.
+
+### Set up webhooks for realtime notification and pull request integration
+
+When connecting to a GitHub repository, Git Sync use webhooks to enable real-time updates from GitHub public repositories or enable the pull request integration.
+Without webhooks, the polling interval is set in the final configuration screen (default is 60 seconds).
+Your Grafana instance must be exposed to the public internet.
+You can do this via port forwarding and DNS, a tool such as `ngrok`, or any other method you prefer.
+
+The permissions set in your GitHub access token provide the authorization for this communication.
+
+If you use local storage, then Git Sync only provides periodic pulling.
+
+<!-- Grafana Cloud support not available yet
+{{< admonition type="note" >}}
+Webhooks are automatically available for Grafana Cloud users.
+{{< /admonition >}}
+-->
+
+Set up webhooks with whichever service or tooling you prefer.
+For example, you can use Cloudflare Tunnels with a Cloudflare-managed domain, port-forwarding and DNS options, or a tool such as `ngrok`.
+
+After you have the public URL, you can add it to your Grafana configuration file:
+
+```yaml
+[server]
+root_url = https://PUBLIC_DOMAIN.HERE
+```
+
+You can check the configured webhooks in the **View** link for your GitHub repository from **Administration** > **Provisioning**.
+
+#### Necessary paths
+
+If your security setup does not permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.
+
+The necessary paths required to be exposed are (RegExp):
+
+- `/apis/provisioning\.grafana\.app/v0(alpha1)?/namespaces/[^/]+/repositories/[^/]+/(webhook|render/.*)$`
+<!-- TODO: Path for the blob storage for image rendering? @ryantxu would know this best. -->
+
+### Set up image rendering for dashboard previews
+
+By setting up image rendering, you can add visual previews of dashboard updates directly in pull requests.
+Image rendering also requires webhooks.
+
+You can enable this capability by installing the Grafana Image Renderer plugin in your Grafana instance.
+For more information and installation instructions, refer to [Grafana Image Renderer](https://grafana.com/grafana/plugins/grafana-image-renderer/).
+
+## Modify configurations after set up is complete
+
+To update your repository configuration after you've completed set up:
+
+1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+1. Select **Administration** in the left-side menu and then **Provisioning**.
+1. Select **Settings** for the repository you wish to modify.
+1. Use the **Configure repository** screen to update any of the settings.
+1. Select **Save** to preserve the updates.

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -1,0 +1,79 @@
+---
+description: Learn about Git Sync, the Grafana feature for storing and managing dashboards within GitHub repositories.
+keywords:
+  - dashboards
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Git Sync
+weight: 100
+---
+
+# Git Sync
+
+{{< admonition type="caution" >}}
+Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. Git Sync isn't available in Grafana Cloud.
+{{< /admonition >}}
+
+Using Git Sync, you can:
+
+- Introduce a review process for creating and modifying dashboards
+- Manage dashboard configuration outside of Grafana instances
+- Replicate dashboards across multiple instances
+
+Whenever a dashboard is modified, Grafana can commit changes to Git upon saving. Users can configure settings to either enforce PR approvals before merging or allow direct commits.
+
+Users can push changes directly to GitHub and see them in Grafana. Similarly, automated workflows can do changes that will be automatically represented in Grafana by updating Git.
+
+Because the dashboards are defined in JSON files, you can enable as-code workflows where the JSON is output from Go, TypeScript, or another coding language in the format of a dashboard schema.
+
+To learn more about creating dashboards in a coding language to provision them for Git Sync, refer to the [Foundation SDK](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/foundation-sdk) documentation.
+
+## How it works
+
+Git Sync is bidirectional and also works with changes done directly in GitHub as well as within the Grafana UI.
+Grafana periodically polls GitHub at a regular internal to synchronize any changes.
+With the webhooks feature enabled, repository notifications appear almost immediately.
+Without webhooks, Grafana polls for changes at the specified interval.
+The default polling interval is 60 seconds.
+
+Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database.
+The Grafana UI reads the database and updates the UI to reflect these changes.
+
+## Common use cases
+
+Git Sync in Grafana lets you manage dashboards as code.
+Because your dashboard JSON files are stored in GitHub, you and your team can version control, collaborate, and automate deployments efficiently.
+
+### Version control and auditing
+
+Organizations can maintain a structured, version-controlled history of Grafana dashboards.
+The version control lets you revert to previous versions when necessary, compare modifications across commits, and ensure transparency in dashboard management.
+Additionally, having a detailed history of changes enhances compliance efforts, as teams can generate audit logs that document who made changes, when they were made, and why.
+
+### Automated deployment and CI/CD integration
+
+Teams can streamline their workflow by integrating dashboard updates into their CI/CD pipelines.
+By pushing changes to GitHub, automated processes can trigger validation checks, test dashboard configurations, and deploy updates programmatically using the `grafanactl` CLI and Foundation SDK.
+This reduces the risk of human errors, ensures consistency across environments, and enables a faster, more reliable release cycle for dashboards used in production monitoring and analytics.
+
+### Collaborative dashboard development
+
+With Git Sync, multiple users can work on dashboards simultaneously without overwriting each other’s modifications.
+By leveraging pull requests and branch-based workflows, teams can submit changes for review before merging them into the main branch. This process not only improves quality control but also ensures that dashboards adhere to best practices and organizational standards. Additionally, GitHub’s built-in discussion and review tools facilitate effective collaboration, making it easier to address feedback before changes go live.
+
+### Multi-environment synchronization
+
+Enterprises managing multiple Grafana instances, such as development, staging, and production environments, can seamlessly sync dashboards across these instances.
+This ensures consistency in visualization and monitoring configurations, reducing discrepancies that might arise from manually managing dashboards in different environments.
+By using Git Sync, teams can automate deployments across environments, eliminating repetitive setup tasks and maintaining a standardized monitoring infrastructure across the organization.
+
+### Disaster recovery and backup
+
+By continuously syncing dashboards to GitHub, organizations can create an always-updated backup, ensuring dashboards are never lost due to accidental deletion or system failures.
+If an issue arises--such as a corrupted dashboard, unintended modification, or a system crash--teams can quickly restore the latest functional version from the Git repository.
+This not only minimizes downtime but also adds a layer of resilience to Grafana monitoring setups, ensuring critical dashboards remain available when needed.

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -1,0 +1,134 @@
+---
+description: Update, save, and modify provisioned resources in Grafana using Git Sync.
+keywords:
+  - dashboards
+  - provisioned files
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Work with provisioned dashboards
+weight: 300
+---
+
+# Work with provisioned dashboards
+
+{{< admonition type="note" >}}
+Git Sync and File path provisioning an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana. These features aren't available in Grafana Cloud.
+{{< /admonition >}}
+
+Using Provisioning, you can choose to store your dashboard JSON files in either GitHub repositories using Git Sync or a local file path.
+
+For more information, refer to the [Dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/) documentation.
+
+## Provisioning methods
+
+Dashboards and folders synchronized using Git Sync or a local file path are referred to as "provisioned" resources.
+
+Of the two experimental options, Git Sync is the recommended method for provisioning your dashboards.
+You can synchronize any new dashboards and changes to existing dashboards to your configured GitHub repository.
+If you push a change in the repository, those changes are mirrored in your Grafana instance.
+For more information on configuring Git Sync, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/).
+
+### Local path provisioning
+
+Using the local path provisioning makes files from a specified path available within Grafana.
+These provisioned resources can only be modified in the local files and not within Grafana.
+Any changes made in the configured local path are updated in Grafana.
+
+Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup) to learn more about the version of local file provisioning in Grafana 12.
+
+{{< admonition type="note" >}}
+The experimental local path provisioning using **Administration** > **Provisioning** will replace the file provisioning methods Grafana uses for referencing local file.
+
+For production systems, use the established methods for provisioning file systems in Grafana.
+Refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#provision-folders-structure-from-filesystem-to-grafana) for more information.
+{{< /admonition >}}
+
+## Manage dashboards provisioned with Git Sync
+
+Using Git Sync, you can manage your dashboards in the UI and synchronize them with a GitHub repository.
+
+Git Sync changes the behavior in Grafana for dashboards that are saved in Git Sync:
+
+- Dashboards saved in your repository or local folder configured with Git Sync appear in a provisioned folder in Grafana.
+- Any dashboard folders saved with Git Sync have a **Provisioned** label in the UI.
+- Any changes to a provisioned resources have to be saved to the repository by opening a pull request or committing directly to the `main` branch.
+
+You can set a single folder, or multiple folders to a different repository, with up to 10 connections.
+
+### Git workflow with dashboards
+
+By default, Git version control uses a branch-based workflow for changes. This means that you can:
+
+- Commit changes to an existing branch (such as `main`) or save them to a new branch in your GitHub repository.
+- Use pull requests to review changes to dashboards.
+- Preview the changes before merging.
+
+To learn more about Git, refer to [Getting Started - About Version Control](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) of the [Pro Git book](https://git-scm.com/book/en/v2) in the official Git documentation.
+
+### Add and save a new dashboard
+
+When you create a new dashboard in a provisioned folder associated with a GitHub repository, you follow the same process you use for any new dashboard.
+Refer to [Create a dashboard](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-dashboard/) for more information.
+
+After you create the dashboard, the steps are similar to [Save dashboard changes to GitHub](#save-dashboard-changes-to-github).
+
+1. Select **Save** to preserve the new dashboard.
+1. Enter a title for the dashboard and a description.
+1. Select the provisioned folder from the **Folder** drop-down list.
+1. In **Path**, provide the path for your repository, ending in a JSON or YAML file.
+1. For **Workflow**, select **Push to main** to make a Git commit directly to the repository or **Push to a new branch** to create a pull request.
+   - **Branch**: Specify the branch name in GitHub (for example, main). This option only appears if you select **Push to a new branch**.
+1. Select **Save**.
+
+### Save dashboard changes to GitHub
+
+When you edit a provisioned resource, you are prompted to save or discard those changes.
+Saving changes requires opening a pull request in your GitHub repository.
+
+1. Select **Edit** to update a provisioned dashboard. Make your desired changes.
+
+1. Click **Save dashboard**.
+
+1. On the **Provisioned dashboard** panel, choose the options you want to use:
+
+   - **Update default refresh value**: Check this box to make the current refresh the new default.
+   - **Update default variable values**: Check this box to make the current values the new default.
+   - **Path**: Provide the path for your repository, ending in a JSON or YAML file.
+   - **Workflow:** Select **Push to main** to make a Git commit directly to the repository or **Push to a new branch** to create a pull request.
+   - **Branch**: Specify the branch name in GitHub (for example, main). This option only appears if you select **Push to a new branch**.
+   - **Comment**: Add a comment describing your changes.
+
+1. Optional: Select the **Changes** tab to view the differences between the updates you made and the original resource.
+
+1. Select **Save**.
+
+1. If you chose **Push to a new branch**, select **Open a pull request in GitHub** to open a new PR to your repository. GitHub opens with your dashboard’s code as the contents of the PR.
+
+1. Follow your usual GitHub workflow to save and merge the PR to your repository.
+
+### Remove dashboards
+
+You can remove a provisioned dashboard by deleting the dashboard from the repository.
+
+Grafana updates when the changes from the GitHub repository sync.
+
+### Tips
+
+- Use GitHub pull requests for changes to maintain review processes.
+- Provide clear commit messages describing your changes.
+- Regularly sync your repository to keep Grafana up to date.
+- Review the **Events** tab to monitor sync status.
+
+## Manage dashboards provisioned with file provisioning
+
+To update any resources in the local path, you need to edit the files directly and then save them locally.
+These changes are synchronized to Grafana.
+However, you can't create, edit, or delete these resources using the Grafana UI.
+
+For more information, refer to [How it works](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/).
+
+Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) for configuration instructions.

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -1,0 +1,77 @@
+---
+description: Instructions for working with Git Sync to perform common tasks, such as saving dashboards to GitHub and synchronizing changes with Grafana.
+keywords:
+  - as code
+  - as-code
+  - dashboards
+  - git integration
+  - git sync
+  - github
+labels:
+  products:
+    - enterprise
+    - oss
+title: Manage provisioned repositories with Git Sync
+menuTitle: Manage repositories
+weight: 400
+---
+
+# Manage provisioned repositories with Git Sync
+
+After you have set up Git Sync, you can synchronize dashboards and changes to existing dashboards to your configured GitHub repository.
+If you push a change in the repository, those changes are mirrored in your Grafana instance.
+
+## View current status of synchronization
+
+Each repository synchronized with Git Sync has a dashboard that provides a summary of resources, health, pull status, webhook, sync jobs, resources, and files.
+Use the detailed information accessed in **View** to help troubleshoot and understand the health of your repository's connection with Grafana.
+
+To view the current status, follow these steps.
+
+1. Log in to your Grafana server with an account that has the Grafana Admin or Editor flag set.
+1. Select **Administration** in the left-side menu and then **Provisioning**.
+1. Locate the repository you are interested in.
+1. If you see a green `Up-to-date` label next to the repository name, then everything is syncing as expected.
+1. Select **View** to access detailed dashboards and reports about the synchronization history of your repository.
+
+## Synchronize changes
+
+Synchronizing resources from provisioned repositories into your Grafana instance pulls the resources into the selected folder. Existing dashboards with the same `uid` are overwritten.
+
+To sync changes from your dashboards with your Git repository:
+
+1. From the left menu, select **Administration** > **Provisioning**.
+1. Select **Pull** under the repository you want to sync.
+1. Wait for the synchronization process to complete.
+
+## Remove a repository
+
+To delete a repository, follow these steps.
+
+1. Log in to your Grafana server with an account that has the Grafana Admin or Editor flag set.
+1. Select **Administration** in the left-side menu and then **Provisioning**.
+1. Locate the repository you are interested in.
+1. Select the trashcan icon in the right side to delete the chosen entry.
+1. Select **Delete** to confirm.
+
+Refer to [Work with provisioned dashboards](../provisioned-dashboards) for information on removing provisioned files.
+
+## Troubleshoot synchronization
+
+Monitor the **View** status page for synchronization issues and status updates. Common events include:
+
+- Sync started
+- Sync completed
+- Sync failed (with error details)
+- Sync issues
+
+### Dashboard sync errors
+
+- If dashboards are not syncing, check if the repository URL is correct and accessible from the Grafana instance.
+- Ensure that the configured repository branch exists and is correctly referenced.
+- Check for conflicts in the repository that may prevent syncing.
+
+### Dashboard import errors
+
+- Validate the JSON format of the dashboard files before importing.
+- If the import fails, check Grafana logs for error messages and troubleshoot accordingly.


### PR DESCRIPTION
Backport bad3d7c2db7bb2bd18cee00b58fa8b4ae1743aea from #104843

---

**What is this feature?**

NOTE: Docs should go live on Tuesday, May 6th or late Monday. 

Makes the observability as code docs publicly available. 
Updates the page weights for the TOC under OaC content.

![image](https://github.com/user-attachments/assets/a31fcc5a-4cc7-4a2d-84a5-939af5467606)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/technical-documentation/issues/1066

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
