### PR TITLE
CI: use push event instead of pull_request_target in pr-patch-check.yml

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -47,7 +47,7 @@ jobs:
                 owner: 'grafana',
                 repo: 'security-patch-actions',
                 workflow_id: 'test-patches-event.yml',
-                ref: 'km/patch-check-vault',
+                ref: 'main',
                 inputs: {
                   src_repo: REPO,
                   src_ref: 'main',

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -22,7 +22,7 @@ jobs:
       REPO: ${{ github.repository }}
       SENDER: ${{ github.event.sender.login }}
       SHA: ${{ github.sha }}
-      PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_COMMIT_SHA: ${{ github.event.push.head.sha }}
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
     steps:

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -1,22 +1,15 @@
-# Owned by grafana-delivery-squad
-# Intended to be dropped into the base repo Ex: grafana/grafana
 name: Dispatch check for patch conflicts
 run-name: dispatch-check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-    branches:
-      - "main"
-      - "v*.*.*"
-      - "release-*"
+  push:
+    branches-ignore:
+      - main
+      - release-*.*.*
+    tags-ignore:
+      - *
 
 permissions: {}
 
-# Since this is run on a pull request, we want to apply the patches intended for the
-# target branch onto the source branch, to verify compatibility before merging.
 jobs:
   dispatch-job:
     permissions:
@@ -31,6 +24,7 @@ jobs:
       SHA: ${{ github.sha }}
       PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
     steps:
       - name: "Get vault secrets"
         id: vault-secrets

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -1,12 +1,12 @@
 name: Dispatch check for patch conflicts
-run-name: dispatch-check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
+run-name: dispatch-check-patch-conflicts-${{ github.head_ref }}
 on:
   push:
     branches-ignore:
-      - main
-      - release-*.*.*
+      - "main"
+      - "release-*.*.*"
     tags-ignore:
-      - *
+      - "*"
 
 permissions: {}
 
@@ -17,12 +17,9 @@ jobs:
       contents: read
       actions: write
     env:
-      HEAD_REF: ${{ github.head_ref }}
-      BASE_REF: ${{ github.base_ref }}
       REPO: ${{ github.repository }}
       SENDER: ${{ github.event.sender.login }}
       SHA: ${{ github.sha }}
-      PR_COMMIT_SHA: ${{ github.event.push.head.sha }}
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
     steps:
@@ -45,7 +42,7 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            const {HEAD_REF, BASE_REF, REPO, SENDER, SHA, PR_COMMIT_SHA} = process.env;
+            const {REPO, SENDER, SHA} = process.env;
 
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',
@@ -54,11 +51,11 @@ jobs:
                 ref: 'main',
                 inputs: {
                   src_repo: REPO,
-                  src_ref: HEAD_REF,
+                  src_ref: 'main',
                   src_merge_sha: SHA,
-                  src_pr_commit_sha: PR_COMMIT_SHA,
+                  src_pr_commit_sha: SHA,
                   patch_repo: REPO + '-security-patches',
-                  patch_ref: BASE_REF,
+                  patch_ref: 'main',
                   triggering_github_handle: SENDER
                 }
             })

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -1,5 +1,4 @@
 name: Dispatch check for patch conflicts
-run-name: dispatch-check-patch-conflicts-${{ github.head_ref }}
 on:
   push:
     branches-ignore:
@@ -48,7 +47,7 @@ jobs:
                 owner: 'grafana',
                 repo: 'security-patch-actions',
                 workflow_id: 'test-patches-event.yml',
-                ref: 'main',
+                ref: 'km/patch-check-vault',
                 inputs: {
                   src_repo: REPO,
                   src_ref: 'main',


### PR DESCRIPTION
* Doesn't run on `main` / `release-` branches.
* Only runs in `grafana/grafana` repository.
* Should still show up in checks that are on pull requests, so we can make it required.