### PR TITLE
Secrets: Tie lifetime of xorm.Engine to the Database

### DIFF
--- a/pkg/storage/secret/database/database.go
+++ b/pkg/storage/secret/database/database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"github.com/grafana/grafana/pkg/util/xorm"
 )
 
 // contextSessionTxKey is the key used to store the transaction in the context.
@@ -18,12 +19,28 @@ type contextSessionTxKey struct{}
 type Database struct {
 	dbType string
 	sqlx   *sqlx.DB
+
+	// Keep the xorm.Engine instance and its references alive until the apiserver is shut down.
+	// This is only needed because the xorm.Engine calls a runtime.SetFinalizer, in a RAII-like pattern to close the DB,
+	// when the engine is garbage collected. Normally, this will only ever happen when the server shuts down.
+	// Ref: pkg/util/xorm/xorm.go:118 (it seems to be a relic from the xorm codebase that was copied over).
+	// In single tenant Grafana, there are many other services and references to the xorm.Engine, so it never gets GC'd.
+	// At some point in the future if we migrate everything away from it, we need to revisit how we set up the DB opening.
+	// However, with the multi-tenant apiserver, we are no longer using the xorm.Engine directly for our DB queries.
+	// We only use it to bootstrap the database and run migrations.
+	// Instead, we use a pointer to *sql.DB directly, and that is created from *xorm.Engine -> *core.DB (also xorm) -> *sql.DB.
+	// The GC notices that the xorm.Engine is no longer referenced, and calls the finalizer to close the DB, because we
+	// only reference the pointer to *sql.DB. Here we tie the lifetime of the xorm.Engine to the Database we use for queries.
+	engine *xorm.Engine
 }
 
 func ProvideDatabase(db db.DB) *Database {
+	engine := db.GetEngine()
+
 	return &Database{
 		dbType: string(db.GetDBType()),
-		sqlx:   sqlx.NewDb(db.GetEngine().DB().DB, db.GetDialect().DriverName()),
+		sqlx:   sqlx.NewDb(engine.DB().DB, db.GetDialect().DriverName()),
+		engine: engine,
 	}
 }
 


### PR DESCRIPTION
Keep the xorm.Engine instance and its references alive until the apiserver is shut down. This is only needed because the xorm.Engine calls a runtime.SetFinalizer, in a RAII-like pattern to close the DB, when the engine is garbage collected. Normally, this will only ever happen when the server shuts down. Ref: pkg/util/xorm/xorm.go:118 (it seems to be a relic from the xorm codebase that was copied over).

In single tenant Grafana, there are many other services and references to the xorm.Engine, so it never gets GC'd. At some point in the future if we migrate everything away from it, we need to revisit how we set up the DB opening.

However, with the multi-tenant apiserver, we are no longer using the xorm.Engine directly for our DB queries. We only use it to bootstrap the database and run migrations. Instead, we use a pointer to *sql.DB directly, and that is created from *xorm.Engine -> *core.DB (also xorm) -> *sql.DB. The GC notices that the xorm.Engine is no longer referenced, and calls the finalizer to close the DB, because we only reference the pointer to *sql.DB. Here we tie the lifetime of the xorm.Engine to the Database we use for queries.

We noticed that after migrating everything away from `xorm`, when starting the `apiserver`, at some point (usually around 2min) we were getting an unrecoverable error:
```
sql: database is closed
```

Upon investigation and debugging, we realized that the DB was being closed by the GC, because the `xorm.Engine` calls a runtime.SetFinalizer: https://github.com/grafana/grafana/blob/main/pkg/util/xorm/xorm.go#L118

When setting up our DB connection, we take a pointer to the raw `*database/sql.DB` from the `xorm.Engine`.

> [!NOTE]
> I do not think is a good long term solution, we need to revisit how we are setting up and opening the DB.
> We migrated away from xorm when running queries, but we still rely on it to set the connection up and run migrations.
> I suppose it is because of the niceties of the "orm" part since we support 4 DB drivers.