### PR TITLE
[release-12.0.1] Add landing page for Obs as Code doc

### DIFF
--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -14,6 +14,42 @@ labels:
     - oss
 title: Observability as Code
 weight: 100
+<<<<<<< HEAD
+=======
+cards:
+  items:
+    - title: Get started
+      height: 24
+      href: ./get-started/
+      description: Learn about how you can use Observability as Code.
+    - title: Grafana CLI
+      height: 24
+      href: ./grafana-cli/
+      description: Grafana CLI (`grafanactl`) is a command-line tool designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through Grafana’s REST API, all from the terminal.
+    - title: JSON schema v2
+      height: 24
+      href: ./schema-v2/
+      description: Grafana dashboards are represented as JSON objects that store metadata, panels, variables, and settings. Observability as Code works with all versions of the JSON model, and it's fully compatible with version 2.
+    - title: Foundation SDK
+      height: 24
+      href: ./foundation-sdk/
+      description: The Grafana Foundation SDK is a set of tools, types, and libraries that let you define Grafana dashboards and resources using strongly typed code.
+    - title: Git Sync (experimental)
+      height: 24
+      href: ./provision-resources/intro-git-sync/
+      description: Git Sync is an experimental feature that lets you store your dashboard files in a GitHub repository and synchronize those changes with your Grafana instance.
+    - title: File provisioning (experimental)
+      height: 24
+      href: ./provision-resources/
+      description: File provisioning in Grafana lets you include resources, including folders and dashboard JSON files, that are stored in a local file system.
+  title_class: pt-0 lh-1
+hero:
+  title: Observability as Code
+  description: Using Observability as Code, you can version, automate, and scale Grafana configurations, including dashboards and observability workflows.
+  height: 110
+  level: 1
+  width: 110
+>>>>>>> 02042c1ac0b (Add landing page for Obs as Code doc (#105015))
 ---
 
 # Observability as Code
@@ -24,10 +60,10 @@ By representing Grafana resources as code, you can integrate them into existing 
 
 Observability as Code provides more control over configuration. Instead of manually configuring dashboards or settings through the Grafana UI, you can:
 
-- **Write configurations in code:** Define dashboards in JSON or other supported formats.
-- **Sync your Grafana setup to GitHub:** Track changes, collaborate, and roll back updates using Git and GitHub, or other remote sources.
-- **Automate with CI/CD:** Integrate Grafana directly into your development and deployment pipelines.
-- **Standardize workflows:** Ensure consistency across your teams by using repeatable, codified processes for managing Grafana resources.
+- Write configurations in code: Define dashboards in JSON or other supported formats.
+- Sync your Grafana setup to GitHub: Track changes, collaborate, and roll back updates using Git and GitHub, or other remote sources.
+- Automate with CI/CD: Integrate Grafana directly into your development and deployment pipelines.
+- Standardize workflows: Ensure consistency across your teams by using repeatable, codified processes for managing Grafana resources.
 
 {{< section depth=5 >}}
 

--- a/docs/sources/observability-as-code/_index.md
+++ b/docs/sources/observability-as-code/_index.md
@@ -14,8 +14,6 @@ labels:
     - oss
 title: Observability as Code
 weight: 100
-<<<<<<< HEAD
-=======
 cards:
   items:
     - title: Get started
@@ -49,7 +47,6 @@ hero:
   height: 110
   level: 1
   width: 110
->>>>>>> 02042c1ac0b (Add landing page for Obs as Code doc (#105015))
 ---
 
 # Observability as Code

--- a/docs/sources/observability-as-code/foundation-sdk/_index.md
+++ b/docs/sources/observability-as-code/foundation-sdk/_index.md
@@ -14,7 +14,7 @@ weight: 250
 
 # Get started with the Grafana Foundation SDK
 
-The [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk) is a set of tools, types, and libraries that enable you to define Grafana dashboards and resources using strongly typed code. By writing your dashboards as code, you can:
+The [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk) is a set of tools, types, and libraries that let you define Grafana dashboards and resources using strongly typed code. By writing your dashboards as code, you can:
 
 - **Leverage strong typing:** Catch errors at compile time, ensuring more reliable configurations.
 - **Enhance version control:** Track changes seamlessly using standard version control systems like Git.

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -21,10 +21,6 @@ weight: 300
 Provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. This feature isn't available in Grafana Cloud.
 {{< /admonition >}}
 
-{{< section depth="5" >}}
-
-<hr />
-
 Using Provisioning, you can configure how to store your dashboard JSON files in either GitHub repositories using Git Sync or a local path.
 
 Of the two experimental options, Git Sync is the recommended method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards to your configured GitHub repository.

--- a/docs/sources/observability-as-code/schema-v2/_index.md
+++ b/docs/sources/observability-as-code/schema-v2/_index.md
@@ -18,9 +18,9 @@ weight: 200
 
 # Dashboard JSON schema v2
 
-Grafana dashboards are represented as JSON objects that store metadata, panels, variables, and settings.
-
 {{< docs/experimental product="Dashboard JSON schema v2" featureFlag="`dashboardNewLayouts`" >}}
+
+Grafana dashboards are represented as JSON objects that store metadata, panels, variables, and settings.
 
 Observability as Code works with all versions of the JSON model, and it's fully compatible with version 2.
 


### PR DESCRIPTION
Backport 02042c1ac0b885f9cec172768f5dc7cea77eeddc from #105015

---

**Why do we need this feature?**

Update the landing page for Observability as Code with sections for other features. 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
