### PR TITLE
Docs: Change codeowners for sql expressions page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,7 @@
 /docs/sources/developers/plugins/                                                 @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 
 /docs/sources/panels-visualizations/query-transform-data/transform-data/index.md  @imatwawana @baldm0mma
+/docs/sources/panels-visualizations/query-transform-data/sql-expressions/index.md  @lwandz13 @irenerl24
 # END Technical documentation
 
 # Backend code


### PR DESCRIPTION
Remove imatwawana as codeowner for SQL expressions page
Add Larissa and Irene as codeowners for the file
