### PR TITLE
Logs: Fix table panel not rendering on initial load in Explore

### DIFF
--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -86,9 +86,7 @@ export const ControlledLogRows = forwardRef<HTMLDivElement | null, ControlledLog
         {rest.visualisationType === 'logs' && (
           <LogRowsComponent ref={ref} {...rest} deduplicatedRows={deduplicatedRows} />
         )}
-        {rest.visualisationType === 'table' && rest.panelState && rest.updatePanelState && (
-          <ControlledLogsTable {...rest} />
-        )}
+        {rest.visualisationType === 'table' && rest.updatePanelState && <ControlledLogsTable {...rest} />}
       </LogListContextProvider>
     );
   }


### PR DESCRIPTION
**What is this fix?**

Fixes issue with table panel not rendering until refresh or switching back and forth between logs panel and table panel in Explore.

**Who is this fix for?**
Users of logs in Explore.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/105022

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
