### PR TITLE
SecretService: Use own sql template for secure value read for decrypt

### DIFF
--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -33,5 +33,5 @@ type SecureValueMetadataStorage interface {
 	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.SecureValue, error)
 	SetStatusSucceeded(ctx context.Context, namespace xkube.Namespace, name string) error
 	SetExternalID(ctx context.Context, namespace xkube.Namespace, name string, externalID ExternalID) error
-	ReadForDecrypt(ctx context.Context, namespace xkube.Namespace, name string, opts ReadOpts) (*DecryptSecureValue, error)
+	ReadForDecrypt(ctx context.Context, namespace xkube.Namespace, name string) (*DecryptSecureValue, error)
 }

--- a/pkg/registry/apis/secret/worker/worker_test.go
+++ b/pkg/registry/apis/secret/worker/worker_test.go
@@ -379,8 +379,8 @@ func (wrapper *secureValueMetadataStorageWrapper) SetExternalID(ctx context.Cont
 	}
 	return nil
 }
-func (wrapper *secureValueMetadataStorageWrapper) ReadForDecrypt(ctx context.Context, namespace xkube.Namespace, name string, opts contracts.ReadOpts) (*contracts.DecryptSecureValue, error) {
-	return wrapper.impl.ReadForDecrypt(ctx, namespace, name, opts)
+func (wrapper *secureValueMetadataStorageWrapper) ReadForDecrypt(ctx context.Context, namespace xkube.Namespace, name string) (*contracts.DecryptSecureValue, error) {
+	return wrapper.impl.ReadForDecrypt(ctx, namespace, name)
 }
 
 type keeperServiceWrapper struct {

--- a/pkg/storage/secret/metadata/data/secure_value_read_for_decrypt.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_read_for_decrypt.sql
@@ -1,0 +1,10 @@
+SELECT
+  {{ .Ident "keeper" }},
+  {{ .Ident "decrypters" }},
+  {{ .Ident "ref" }},
+  {{ .Ident "external_id" }}
+FROM
+  {{ .Ident "secret_secure_value" }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
+  {{ .Ident "name" }} = {{ .Arg .Name }}
+;

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -66,7 +66,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 	// The auth token will not necessarily have the permission to read the secure value metadata,
 	// but we still need to do it to inspect the `decrypters` field, hence the actual `authorize`
 	// function call happens after this.
-	sv, err := s.secureValueMetadataStorage.ReadForDecrypt(ctx, namespace, name, contracts.ReadOpts{})
+	sv, err := s.secureValueMetadataStorage.ReadForDecrypt(ctx, namespace, name)
 	if err != nil {
 		return "", contracts.ErrDecryptNotFound
 	}

--- a/pkg/storage/secret/metadata/query.go
+++ b/pkg/storage/secret/metadata/query.go
@@ -31,6 +31,7 @@ var (
 	sqlSecureValueUpdate           = mustTemplate("secure_value_update.sql")
 	sqlSecureValueUpdateExternalId = mustTemplate("secure_value_updateExternalId.sql")
 	sqlSecureValueUpdateStatus     = mustTemplate("secure_value_updateStatus.sql")
+	sqlSecureValueReadForDecrypt   = mustTemplate("secure_value_read_for_decrypt.sql")
 
 	sqlSecureValueOutboxAppend   = mustTemplate("secure_value_outbox_append.sql")
 	sqlSecureValueOutboxReceiveN = mustTemplate("secure_value_outbox_receiveN.sql")
@@ -216,6 +217,14 @@ type updateStatusSecureValue struct {
 func (r updateStatusSecureValue) Validate() error {
 	return nil // TODO
 }
+
+type readSecureValueForDecrypt struct {
+	sqltemplate.SQLTemplate
+	Namespace string
+	Name      string
+}
+
+func (r readSecureValueForDecrypt) Validate() error { return nil }
 
 /*************************************/
 /**-- Secure Value Outbox Queries --**/

--- a/pkg/storage/secret/metadata/query_test.go
+++ b/pkg/storage/secret/metadata/query_test.go
@@ -287,6 +287,16 @@ func TestSecureValueQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlSecureValueReadForDecrypt: {
+				{
+					Name: "read-for-decrypt",
+					Data: &readSecureValueForDecrypt{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Name:        "name",
+						Namespace:   "ns",
+					},
+				},
+			},
 		},
 	})
 }

--- a/pkg/storage/secret/metadata/secure_value_model.go
+++ b/pkg/storage/secret/metadata/secure_value_model.go
@@ -227,8 +227,16 @@ func toRow(sv *secretv0alpha1.SecureValue, externalID string) (*secureValueDB, e
 	}, nil
 }
 
+// DTO for `secureValueForDecrypt` query result, only what we need.
+type secureValueForDecrypt struct {
+	Keeper     sql.NullString
+	Decrypters sql.NullString
+	Ref        sql.NullString
+	ExternalID string
+}
+
 // to Decrypt maps a DB row into a DecryptSecureValue object needed for decryption.
-func (sv *secureValueDB) toDecrypt() (*contracts.DecryptSecureValue, error) {
+func (sv *secureValueForDecrypt) toDecrypt() (*contracts.DecryptSecureValue, error) {
 	decrypters := make([]string, 0)
 	if sv.Decrypters.Valid && sv.Decrypters.String != "" {
 		if err := json.Unmarshal([]byte(sv.Decrypters.String), &decrypters); err != nil {

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_read_for_decrypt-read-for-decrypt.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_read_for_decrypt-read-for-decrypt.sql
@@ -1,0 +1,10 @@
+SELECT
+  `keeper`,
+  `decrypters`,
+  `ref`,
+  `external_id`
+FROM
+  `secret_secure_value`
+WHERE `namespace` = 'ns' AND
+  `name` = 'name'
+;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_read_for_decrypt-read-for-decrypt.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_read_for_decrypt-read-for-decrypt.sql
@@ -1,0 +1,10 @@
+SELECT
+  "keeper",
+  "decrypters",
+  "ref",
+  "external_id"
+FROM
+  "secret_secure_value"
+WHERE "namespace" = 'ns' AND
+  "name" = 'name'
+;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_read_for_decrypt-read-for-decrypt.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_read_for_decrypt-read-for-decrypt.sql
@@ -1,0 +1,10 @@
+SELECT
+  "keeper",
+  "decrypters",
+  "ref",
+  "external_id"
+FROM
+  "secret_secure_value"
+WHERE "namespace" = 'ns' AND
+  "name" = 'name'
+;


### PR DESCRIPTION
**What is this feature?**

Use own sql template for secure value read for decrypt since the migration for secure value has been completed and the method needs only certain columns to be selected.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1376

