### PR TITLE
[release-12.0.1] Docs: removed backslashes in SQL code in SQL expressions doc

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -111,15 +111,15 @@ Use the following workflow to create a SQL expression:
    **Inspect inputs**. Start with simple test queries to understand the shape of your input frames.
 
    ```sql
-   SELECT \* FROM A LIMIT 10\.
+   SELECT * FROM A LIMIT 10.
    ```
 
-   This lets you see the available columns and sample rows from `query A`. Repeat this for each input query you want to use (e.g., SELECT \* FROM B LIMIT 10).
+   This lets you see the available columns and sample rows from `query A`. Repeat this for each input query you want to use (e.g., `SELECT * FROM B LIMIT 10`).
 
 1. **Inspect your data**. Repeat this for each input query to understand the column structure and data types you're working with.
 
    ```sql
-   SELECT \* FROM \<B, C, D, etc\> LIMIT 10
+   SELECT * FROM <B, C, D, etc> LIMIT 10
    ```
 
 1. **Construct the SQL expression.** Once you understand your data, you can write your SQL expression to join, filter, or otherwise transform the data.
@@ -139,7 +139,7 @@ For data to be used in SQL expressions, it must be in a **tabular format**, spec
 
 ## SQL conversion rules
 
-When a RefID is referenced within a SQL statement (e.g., SELECT \* FROM A), the system invokes a distinct SQL conversion process.
+When a RefID is referenced within a SQL statement (e.g., `SELECT * FROM A`), the system invokes a distinct SQL conversion process.
 
 The SQL conversion path:
 
@@ -201,6 +201,6 @@ During conversion:
 
    ![Example using a Prometheus query](/media/docs/sql-expressions/sql-expressions-prom-query-example.png)
 
-2. Add the SQL expression **SELECT \* from A**. After you add a SQL expression that selects from RefID A, Grafana converts it to a table response:
+2. Add the SQL expression `SELECT * from A`. After you add a SQL expression that selects from RefID A, Grafana converts it to a table response:
 
    ![Add the SQL expression](/media/docs/sql-expressions/add-the-sql-expression.png)


### PR DESCRIPTION
Backport 59cb0176bc327d0da4c874a262b20523db27d877 from #105009

---

Removed backslashes in SQL code.

**Special notes for your reviewer:**

REVIEWERS:  Please ensure backports are correct.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
