### PR TITLE
Dashboard: Improve diffing by handling the Infinity value

### DIFF
--- a/public/app/core/utils/object.test.ts
+++ b/public/app/core/utils/object.test.ts
@@ -19,6 +19,22 @@ describe('objects', () => {
       world: {
         deeper: 10,
         arr: [null, 1, 'hello'],
+        value: -Infinity,
+      },
+      simple: 'A',
+    });
+    expect(value.hello).toBeNull();
+    expect(value.world.foo).toBeNull();
+    expect(value.bar).toBeUndefined();
+  });
+
+  it('returns a clean copy with Infinity converted to 0', () => {
+    const copy = sortedDeepCloneWithoutNulls(value, true);
+    expect(copy).toMatchObject({
+      world: {
+        deeper: 10,
+        arr: [null, 1, 'hello'],
+        value: 0,
       },
       simple: 'A',
     });

--- a/public/app/core/utils/object.ts
+++ b/public/app/core/utils/object.ts
@@ -1,19 +1,29 @@
 ﻿import { isArray, isPlainObject } from 'lodash';
 
-/** @returns a deep clone of the object, but with any null value removed */
-export function sortedDeepCloneWithoutNulls<T>(value: T): T {
+/**
+ * @returns A deep clone of the object, but with any null value removed.
+ * @param value - The object to be cloned and cleaned.
+ * @param convertInfinity - If true, -Infinity or Infinity is converted to 0.
+ * This is because Infinity is not a valid JSON value, and sometimes we want to convert it to 0 instead of default null.
+ */
+export function sortedDeepCloneWithoutNulls<T>(value: T, convertInfinity?: boolean): T {
   if (isArray(value)) {
-    return value.map(sortedDeepCloneWithoutNulls) as unknown as T;
+    return value.map((item) => sortedDeepCloneWithoutNulls(item, convertInfinity)) as unknown as T;
   }
   if (isPlainObject(value)) {
     return Object.keys(value as { [key: string]: any })
       .sort()
       .reduce((acc: any, key) => {
         const v = (value as any)[key];
-        // Remove null values and also -Infinity which is not a valid JSON value
-        if (v != null && v !== -Infinity) {
-          acc[key] = sortedDeepCloneWithoutNulls(v);
+        // Remove null values
+        if (v != null) {
+          acc[key] = sortedDeepCloneWithoutNulls(v, convertInfinity);
         }
+
+        if (convertInfinity && (v === Infinity || v === -Infinity)) {
+          acc[key] = 0;
+        }
+
         return acc;
       }, {});
   }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -146,7 +146,7 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
     scopeMeta: state.scopeMeta,
   };
 
-  return sortedDeepCloneWithoutNulls(dashboard);
+  return sortedDeepCloneWithoutNulls(dashboard, true);
 }
 
 export function gridItemToPanel(gridItem: DashboardGridItem, isSnapshot = false): Panel {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -117,7 +117,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
   try {
     // validateDashboardSchemaV2 will throw an error if the dashboard is not valid
     if (validateDashboardSchemaV2(dashboardSchemaV2)) {
-      return sortedDeepCloneWithoutNulls(dashboardSchemaV2);
+      return sortedDeepCloneWithoutNulls(dashboardSchemaV2, true);
     }
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);


### PR DESCRIPTION
This PR addresses the issue with Infinity value, where we would remove any field containing that value, because Infinity is not a valid JSON and when if not removed, it defaults to `null` when converted to JSON. 

This approach doesn't work for some fields like `color.value` in `thresholds.steps` array because the first item in this array will be assigned `value: -Infinity` during runtime, so that the first item is always the base color. However, the backend will assign `value: 0` because this field is mandatory in the schema. We've discussed making this field optional, which would fix the issue, but making it optional makes some unexpected behaviors, like when just passing this when creating a dashboard:

```
{
  "thresholds": {
    "mode": "absolute",
    "steps": [
      {
        "color": "green"
      },
      {
        "color": "orange"
      },
      {
        "color": "red"
      }
    ]
  }
}
```

This will only show the first color in the array (the base one), while the other ones will not be displayed, like this:
![Screenshot 2025-05-06 at 2 50 52 PM](https://github.com/user-attachments/assets/a3fb4ca6-501d-42a7-b0fd-9908b107dbdc)



But if we keep it as mandatory, then all fields will be set to 0, and user will see this:

![Screenshot 2025-05-06 at 2 41 53 PM](https://github.com/user-attachments/assets/65aa38d1-593a-411b-849d-313bd6729d0c)

In the `sortedDeepCloneWithoutNulls` I've made this conversion from Infinity optional, but both v1 and v2 scene to schema transformers use it. I just wanted to make this a bit more explicit so it's more obvious that we are converting Infinity to 0.

Please check that:
- [ ] It works as expected from a user's perspective.
