### PR TITLE
[release-12.0.1] TableNG: Filter and sort sub tables

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -56,6 +56,7 @@ import {
   getTextAlign,
   handleSort,
   MapFrameToGridOptions,
+  processNestedTableRows,
   shouldTextOverflow,
 } from './utils';
 
@@ -268,14 +269,6 @@ export function TableNG(props: TableNGProps) {
     [textWraps, columnTypes, getColumnWidths, headersLength, fieldDisplayType]
   );
 
-  const getDisplayedValue = (row: TableRow, key: string) => {
-    const field = props.data.fields.find((field) => {
-      return getDisplayName(field) === key;
-    })!;
-    const displayedValue = formattedValueToString(field.display!(row[key]));
-    return displayedValue;
-  };
-
   // Filter rows
   const filteredRows = useMemo(() => {
     const filterValues = Object.entries(filter);
@@ -284,6 +277,13 @@ export function TableNG(props: TableNGProps) {
       crossFilterOrder.current = [];
       return rows;
     }
+
+    // Helper function to get displayed value
+    const getDisplayedValue = (row: TableRow, key: string) => {
+      const field = props.data.fields.find((field) => field.name === key)!;
+      const displayedValue = formattedValueToString(field.display!(row[key]));
+      return displayedValue;
+    };
 
     // Update crossFilterOrder
     const filterKeys = new Set(filterValues.map(([key]) => key));
@@ -300,6 +300,28 @@ export function TableNG(props: TableNGProps) {
     // reset crossFilterRows
     crossFilterRows.current = {};
 
+    // For nested tables, only filter parent rows and keep their children
+    if (isNestedTable) {
+      return processNestedTableRows(rows, (parents) =>
+        parents.filter((row) => {
+          for (const [key, value] of filterValues) {
+            const displayedValue = getDisplayedValue(row, key);
+            if (!value.filteredSet.has(displayedValue)) {
+              return false;
+            }
+            // collect rows for crossFilter
+            if (!crossFilterRows.current[key]) {
+              crossFilterRows.current[key] = [row];
+            } else {
+              crossFilterRows.current[key].push(row);
+            }
+          }
+          return true;
+        })
+      );
+    }
+
+    // Regular filtering for non-nested tables
     return rows.filter((row) => {
       for (const [key, value] of filterValues) {
         const displayedValue = getDisplayedValue(row, key);
@@ -315,35 +337,38 @@ export function TableNG(props: TableNGProps) {
       }
       return true;
     });
-  }, [rows, filter, props.data.fields]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rows, filter, isNestedTable, props.data.fields]);
 
   // Sort rows
   const sortedRows = useMemo(() => {
-    const comparators = sortColumns.map(({ columnKey }) => getComparator(columnTypes[columnKey]));
-    const sortDirs = sortColumns.map(({ direction }) => (direction === 'ASC' ? 1 : -1));
-
     if (sortColumns.length === 0) {
       return filteredRows;
     }
 
-    return filteredRows.slice().sort((a, b) => {
+    // Common sort comparator function
+    const compareRows = (a: TableRow, b: TableRow): number => {
       let result = 0;
-      let sortIndex = 0;
+      for (let i = 0; i < sortColumns.length; i++) {
+        const { columnKey, direction } = sortColumns[i];
+        const compare = getComparator(columnTypes[columnKey]);
+        const sortDir = direction === 'ASC' ? 1 : -1;
 
-      for (const { columnKey } of sortColumns) {
-        const compare = comparators[sortIndex];
-        result = sortDirs[sortIndex] * compare(a[columnKey], b[columnKey]);
-
+        result = sortDir * compare(a[columnKey], b[columnKey]);
         if (result !== 0) {
           break;
         }
-
-        sortIndex += 1;
       }
-
       return result;
-    });
-  }, [filteredRows, sortColumns, columnTypes]);
+    };
+
+    // Handle nested tables
+    if (isNestedTable) {
+      return processNestedTableRows(filteredRows, (parents) => [...parents].sort(compareRows));
+    }
+
+    // Regular sort for tables without nesting
+    return filteredRows.slice().sort((a, b) => compareRows(a, b));
+  }, [filteredRows, sortColumns, columnTypes, isNestedTable]);
 
   // Paginated rows
   // TODO consolidate calculations into pagination wrapper component and only use when needed


### PR DESCRIPTION
Backport 2c1851e8c851711de482f27bec2d8b0a1b2214e3 from #104327

---

## What does this PR do? 📓 

This PR is a primary fix for sorting/filtering for sub tables in TableNG. Sorting at the header parent level sorts the parent rows correctly and also correctly nests its sub table. Filtering at the header parent level sorts at the parent row level, and correctly nests its sub table.

This **does not** fix the actual sorting of the sub table rows themselves. That will be a follow-up PR.

Fixes #104012
Fixes #104295

Can test with: [Debug_ Panel Title __ 2025-01-28 17_52_52-1745344727814.json](https://github.com/user-attachments/files/19854832/Debug_.Panel.Title.__.2025-01-28.17_52_52-1745344727814.json)

#### Demo 💻 🎥 

#### Before

https://github.com/user-attachments/assets/91595582-3c94-4dd6-bb9b-a3debd0bbc8f

#### After

https://github.com/user-attachments/assets/eb07777c-3b18-4728-b290-4618055ee19e
