### PR TITLE
Alerting: Add support for unknown rule state

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/StateBadges.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/StateBadges.tsx
@@ -48,6 +48,10 @@ export const StateBadge = ({ state, health }: StateBadgeProps) => {
       color = 'warning';
       stateLabel = 'Recovering';
       break;
+    case PromAlertingRuleState.Unknown:
+      color = 'info';
+      stateLabel = 'Unknown';
+      break;
   }
 
   // if the rule is in "error" health we don't really care about the state
@@ -65,7 +69,7 @@ export const StateBadge = ({ state, health }: StateBadgeProps) => {
 };
 
 // the generic badge component
-type BadgeColor = 'success' | 'error' | 'warning';
+type BadgeColor = 'success' | 'error' | 'warning' | 'info';
 
 interface BadgeProps {
   color: BadgeColor;

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -36,6 +36,7 @@ export const RuleListStateView = ({ namespaces }: Props) => {
       [PromAlertingRuleState.Pending, []],
       [PromAlertingRuleState.Recovering, []],
       [PromAlertingRuleState.Inactive, []],
+      [PromAlertingRuleState.Unknown, []],
     ]);
 
     namespaces.forEach((namespace) =>
@@ -75,6 +76,7 @@ const STATE_TITLES: Record<PromAlertingRuleState, string> = {
   [PromAlertingRuleState.Pending]: 'Pending',
   [PromAlertingRuleState.Inactive]: 'Normal',
   [PromAlertingRuleState.Recovering]: 'Recovering',
+  [PromAlertingRuleState.Unknown]: 'Unknown',
 };
 
 const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: CombinedRule[] }) => {

--- a/public/app/features/alerting/unified/rule-list/StateView.tsx
+++ b/public/app/features/alerting/unified/rule-list/StateView.tsx
@@ -34,6 +34,7 @@ export const StateView = ({ namespaces }: Props) => {
       [PromAlertingRuleState.Pending, []],
       [PromAlertingRuleState.Recovering, []],
       [PromAlertingRuleState.Inactive, []],
+      [PromAlertingRuleState.Unknown, []],
     ]);
 
     namespaces.forEach((namespace) =>
@@ -70,6 +71,7 @@ const STATE_TITLES: Record<PromAlertingRuleState, string> = {
   [PromAlertingRuleState.Pending]: 'Pending',
   [PromAlertingRuleState.Inactive]: 'Normal',
   [PromAlertingRuleState.Recovering]: 'Recovering',
+  [PromAlertingRuleState.Unknown]: 'Unknown',
 };
 
 const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: CombinedRule[] }) => {

--- a/public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx
@@ -29,13 +29,15 @@ const icons: Record<PromAlertingRuleState, IconName> = {
   [PromAlertingRuleState.Pending]: 'circle',
   [PromAlertingRuleState.Recovering]: 'exclamation-circle',
   [PromAlertingRuleState.Firing]: 'exclamation-circle',
+  [PromAlertingRuleState.Unknown]: 'question-circle',
 };
 
-const color: Record<PromAlertingRuleState, 'success' | 'error' | 'warning'> = {
+const color: Record<PromAlertingRuleState, 'success' | 'error' | 'warning' | 'info'> = {
   [PromAlertingRuleState.Inactive]: 'success',
   [PromAlertingRuleState.Pending]: 'warning',
   [PromAlertingRuleState.Recovering]: 'warning',
   [PromAlertingRuleState.Firing]: 'error',
+  [PromAlertingRuleState.Unknown]: 'info',
 };
 
 const stateNames: Record<PromAlertingRuleState, string> = {
@@ -43,6 +45,7 @@ const stateNames: Record<PromAlertingRuleState, string> = {
   [PromAlertingRuleState.Pending]: 'Pending',
   [PromAlertingRuleState.Firing]: 'Firing',
   [PromAlertingRuleState.Recovering]: 'Recovering',
+  [PromAlertingRuleState.Unknown]: 'Unknown',
 };
 
 const operationIcons: Record<RuleOperation, IconName> = {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -222,6 +222,7 @@ const alertStateSortScore = {
   [PromAlertingRuleState.Inactive]: 2,
   [GrafanaAlertState.NoData]: 3,
   [GrafanaAlertState.Normal]: 4,
+  [PromAlertingRuleState.Unknown]: 5,
 };
 
 export function sortAlerts(sortOrder: SortOrder, alerts: Alert[]): Alert[] {

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -13,6 +13,7 @@ export enum PromAlertingRuleState {
   Inactive = 'inactive',
   Pending = 'pending',
   Recovering = 'recovering',
+  Unknown = 'unknown',
 }
 
 export enum GrafanaAlertState {


### PR DESCRIPTION
**What is this feature?**
This PR adds frontend support for the recently introduced `unknown` state for GMA rules

The unknown state typically occurs right after a new rule is created and hasn't been evaluated yet.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/1727eee6-ce53-4dc9-ade3-917438b07ece" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
