### PR TITLE
Chore:  Fix `import/order`ing for image imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,9 +101,16 @@ module.exports = [
       'import/order': [
         'error',
         {
+          pathGroups: [
+            {
+              pattern: 'img/**',
+              group: 'internal',
+            },
+          ],
           groups: [['builtin', 'external'], 'internal', 'parent', 'sibling', 'index'],
           'newlines-between': 'always',
           alphabetize: { order: 'asc' },
+          pathGroupsExcludedImportTypes: ['builtin'],
         },
       ],
       'no-restricted-imports': [


### PR DESCRIPTION
**What is this feature?**
Got caught in a bit of a catch-22 with https://github.com/grafana/grafana/pull/105006 so I had to split this out.
That PR adds new image imports under `img/...`, and sorts them differently in the imports. But it has failures in enterprise repo, so I fixed them, but enterprise pulls its eslint config from here, so I had to split this config change out from the other PR...

**Why do we need this feature?**
Make sure that `import foo from 'img/foo.svg'` will end up in a nicer place in ordered imports, e.g.

```
import { useState } from 'react';

import { dateTimeFormat } from '@grafana/data';
import cardBgLightSvg from 'img/foo/card-bg-light.svg';
```

rather than 

```
import { useState } from 'react';
import cardBgLightSvg from 'img/foo/card-bg-light.svg';

import { dateTimeFormat } from '@grafana/data';
```