### PR TITLE
[release-12.0.1] Dashboard: Fix Panel Explore link subpath duplication  (#104952)

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -353,7 +353,6 @@ describe('getPanelMenu()', () => {
   });
 
   describe('onNavigateToExplore', () => {
-    const testSubUrl = '/testSubUrl';
     const testUrl = '/testUrl';
     const windowOpen = jest.fn();
     let event: any;
@@ -387,15 +386,16 @@ describe('getPanelMenu()', () => {
       expect(windowOpen).toHaveBeenLastCalledWith(testUrl);
     });
 
-    it('should navigate to url with subUrl', () => {
-      config.appSubUrl = testSubUrl;
+    it('should navigate to url without subUrl even if appSubUrl is set', () => {
+      const exploreUrl = '/explore?param1=a&param2=b';
+      config.appSubUrl = 'grafana';
       explore.onClick!(event);
 
       const openInNewWindow = navigateSpy.mock.calls[0][1].openInNewWindow;
 
-      openInNewWindow(testUrl);
-
-      expect(windowOpen).toHaveBeenLastCalledWith(`${testSubUrl}${testUrl}`);
+      openInNewWindow(`${exploreUrl}`);
+      // When opening in a new window, onNavigateToExplore should not include the subUrl, as getExploreUrl already handles it.
+      expect(windowOpen).toHaveBeenLastCalledWith(`${exploreUrl}`);
     });
   });
 

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,6 +1,5 @@
 import { PanelMenuItem, urlUtil, PluginExtensionLink } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import config from 'app/core/config';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { t } from 'app/core/internationalization';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -88,8 +87,7 @@ export function getPanelMenu(
 
   const onNavigateToExplore = (event: React.MouseEvent) => {
     event.preventDefault();
-    const openInNewWindow =
-      event.ctrlKey || event.metaKey ? (url: string) => window.open(`${config.appSubUrl}${url}`) : undefined;
+    const openInNewWindow = event.ctrlKey || event.metaKey ? (url: string) => window.open(url) : undefined;
     store.dispatch(
       navigateToExplore(panel, {
         timeRange: getTimeSrv().timeRange(),

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -2,7 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { AnyAction } from 'redux';
 
-import { SplitOpenOptions, TimeRange, EventBusSrv } from '@grafana/data';
+import { SplitOpenOptions, TimeRange, EventBusSrv, locationUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { generateExploreId, GetExploreUrlArguments } from 'app/core/utils/explore';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -151,7 +151,7 @@ export const navigateToExplore = (
       return;
     }
 
-    locationService.push(path!);
+    locationService.push(locationUtil.stripBaseFromUrl(path!));
   };
 };
 


### PR DESCRIPTION
Backport from #104952 

* Stop appending subpath in onNavigateToExplore function old-arch
* we are using assureBaseUrl inside getExploreUrl function

* adjust test to ensure subPath is not added to the url

* fix linting

(cherry picked from commit c594faa64e50cac47f6bf6c9cbc0df8af5c63bd5)
