### PR TITLE
Plugins repo: Ensure normalized versions are used to select compatible plugin versions

### DIFF
--- a/pkg/plugins/repo/version.go
+++ b/pkg/plugins/repo/version.go
@@ -44,7 +44,7 @@ func SelectSystemCompatibleVersion(log log.PrettyLogger, versions []Version, plu
 		}, nil
 	}
 	for _, v := range versions {
-		if v.Version == version {
+		if normalizeVersion(v.Version) == version {
 			ver = v
 			break
 		}

--- a/pkg/plugins/repo/version_test.go
+++ b/pkg/plugins/repo/version_test.go
@@ -73,4 +73,12 @@ func TestSelectSystemCompatibleVersion(t *testing.T) {
 		)
 		require.ErrorContains(t, err, "not compatible")
 	})
+
+	t.Run("Should handle v prefix correctly", func(t *testing.T) {
+		_, err := SelectSystemCompatibleVersion(logger,
+			createPluginVersions(versionArg{version: "v2.0.0"}),
+			"test", "2.0.0", fakeCompatOpts(),
+		)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug where Grafana is unable to install a plugin from the catalog if it has a `v` prefix.

An example is the `grafana-irm-app` (cloud-only), which for example has a version value of `v0.31.1-dev.5+ga6b24d9bb` (rather than `0.31.1-dev.5+ga6b24d9bb`).

This is accepted by the GCOM API, but when trying to install the plugin via `grafana cli`, it fails with this error

```
Error: ✗ [plugin.versionNotFound] grafana-irm-app v0.31.1-dev.5+ga6b24d9bb either does not exist or is not supported on your system linux-amd64
```

This is because `normalizeVersion` (which strips the `v` prefix) is called on the parameter, but it's not called on the data returned by the GCOM API.

See https://github.com/grafana/deployment_tools/pull/259159 for more information.

Reason why the `v` prefix is required for IRM plugin: https://github.com/grafana/irm/blob/a6b24d9bb0b983c1287508d78900c66c94b1f63e/.github/actions/build-and-publish-plugin-artifact/action.yml#L69-L70

**Why do we need this feature?**

Bugfix.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
