### PR TITLE
i18n: Update lint rule suggested import location to `@grafana/i18n`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -119,21 +119,23 @@ module.exports = [
       'no-restricted-imports': [
         'error',
         {
+          patterns: [
+            {
+              group: ['react-i18next', 'i18next'],
+              importNames: ['t'],
+              message: 'Please import useTranslate from @grafana/i18n and use the t function instead',
+            },
+            {
+              group: ['react-i18next'],
+              importNames: ['Trans'],
+              message: 'Please import from @grafana/i18n instead',
+            },
+          ],
           paths: [
             {
               name: 'react-redux',
               importNames: ['useDispatch', 'useSelector'],
               message: 'Please import from app/types instead.',
-            },
-            {
-              name: 'react-i18next',
-              importNames: ['Trans', 't'],
-              message: 'Please import from app/core/internationalization instead',
-            },
-            {
-              name: 'i18next',
-              importNames: ['t'],
-              message: 'Please import from app/core/internationalization instead',
             },
           ],
         },

--- a/packages/grafana-eslint-rules/rules/no-untranslated-strings.cjs
+++ b/packages/grafana-eslint-rules/rules/no-untranslated-strings.cjs
@@ -82,17 +82,16 @@ const noUntranslatedStrings = createRule({
         if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
           const alternateIsString = isExpressionUntranslated(expression.alternate);
           const consequentIsString = isExpressionUntranslated(expression.consequent);
+          const untranslatedExpressions = [
+            alternateIsString ? expression.alternate : undefined,
+            consequentIsString ? expression.consequent : undefined,
+          ].filter((node) => !!node);
 
-          if (alternateIsString || consequentIsString) {
+          if (untranslatedExpressions.length) {
             const messageId =
               parentType === AST_NODE_TYPES.JSXAttribute ? 'noUntranslatedStringsProp' : 'noUntranslatedStrings';
 
-            const nodesToReport = [
-              alternateIsString ? expression.alternate : undefined,
-              consequentIsString ? expression.consequent : undefined,
-            ].filter((node) => !!node);
-
-            nodesToReport.forEach((nodeToReport) => {
+            untranslatedExpressions.forEach((nodeToReport) => {
               context.report({
                 node: nodeToReport,
                 messageId,

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -209,24 +209,26 @@ function getComponentNames(node, context) {
   return names;
 }
 
+/** Package to suggest importing translation utils from */
+const PACKAGE_IMPORT_NAME = '@grafana/i18n';
+
 /**
  * Gets the import fixer for a node
- * @param {JSXElement|JSXFragment|JSXAttribute} node
  * @param {RuleFixer} fixer The fixer
  * @param {string} importName The import name
  * @param {RuleContextWithOptions} context
  * @returns {import('@typescript-eslint/utils/ts-eslint').RuleFix|undefined} The fix
  */
-function getImportsFixer(node, fixer, importName, context) {
+function getImportsFixer(fixer, importName, context) {
   const body = context.sourceCode.ast.body;
 
   const existingAppCoreI18n = body.find(
-    (node) => node.type === AST_NODE_TYPES.ImportDeclaration && node.source.value === 'app/core/internationalization'
+    (node) => node.type === AST_NODE_TYPES.ImportDeclaration && node.source.value === PACKAGE_IMPORT_NAME
   );
 
   // If there's no existing import at all, add it
   if (!existingAppCoreI18n) {
-    return fixer.insertTextBefore(body[0], `import { ${importName} } from 'app/core/internationalization';\n`);
+    return fixer.insertTextBefore(body[0], `import { ${importName} } from '${PACKAGE_IMPORT_NAME}';\n`);
   }
 
   // To keep the typechecker happy - we have to explicitly check the type
@@ -269,7 +271,7 @@ const getTransFixers = (node, context) => (fixer) => {
     }
   });
 
-  const importsFixer = getImportsFixer(node, fixer, 'Trans', context);
+  const importsFixer = getImportsFixer(fixer, 'Trans', context);
   if (importsFixer) {
     fixes.push(importsFixer);
   }
@@ -291,7 +293,7 @@ const getTFixers = (node, context) => (fixer) => {
     fixer.replaceText(node, `${node.name.name}={t("${i18nKey}", ${wrappingQuotes}${value}${wrappingQuotes})}`)
   );
 
-  const importsFixer = getImportsFixer(node, fixer, 't', context);
+  const importsFixer = getImportsFixer(fixer, 't', context);
   if (importsFixer) {
     fixes.push(importsFixer);
   }
@@ -330,4 +332,5 @@ module.exports = {
   shouldBeFixed,
   elementIsTrans,
   isStringNonAlphanumeric,
+  PACKAGE_IMPORT_NAME,
 };

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -223,7 +223,11 @@ function getImportsFixer(fixer, importName, context) {
   const body = context.sourceCode.ast.body;
 
   const existingAppCoreI18n = body.find(
-    (node) => node.type === AST_NODE_TYPES.ImportDeclaration && node.source.value === PACKAGE_IMPORT_NAME
+    (node) =>
+      node.type === AST_NODE_TYPES.ImportDeclaration &&
+      (node.source.value === PACKAGE_IMPORT_NAME ||
+        // "legacy" imports:
+        node.source.value.endsWith('core/internationalization'))
   );
 
   // If there's no existing import at all, add it

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -232,11 +232,7 @@ function getImportsFixer(fixer, importName, context) {
   const expectedImport = importPackage[importName];
 
   const existingAppCoreI18n = body.find(
-    (node) =>
-      node.type === AST_NODE_TYPES.ImportDeclaration &&
-      (node.source.value === importPackage[importName] ||
-        // "legacy" imports:
-        node.source.value.endsWith('core/internationalization'))
+    (node) => node.type === AST_NODE_TYPES.ImportDeclaration && node.source.value === importPackage[importName]
   );
 
   // If there's no existing import at all, add it

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -79,6 +79,7 @@ function canBeFixed(node, context) {
       return [
         AST_NODE_TYPES.ArrowFunctionExpression,
         AST_NODE_TYPES.FunctionDeclaration,
+        AST_NODE_TYPES.FunctionExpression,
         AST_NODE_TYPES.ClassDeclaration,
       ].includes(anc.type);
     });
@@ -350,6 +351,8 @@ const getUseTranslateFixer = (node, fixer, context) => {
   // then we can't reliably add `useTranslate`, as this may not be a React component
   if (
     !parentMethod ||
+    (parentMethod.type === AST_NODE_TYPES.FunctionDeclaration &&
+      (!parentMethod.id || !firstCharIsUpper(parentMethod.id.name))) ||
     (parentMethod.parent.type === AST_NODE_TYPES.VariableDeclarator &&
       parentMethod.parent.id.type === AST_NODE_TYPES.Identifier &&
       !firstCharIsUpper(parentMethod.parent.id.name))

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -215,24 +215,33 @@ const PACKAGE_IMPORT_NAME = '@grafana/i18n';
 /**
  * Gets the import fixer for a node
  * @param {RuleFixer} fixer The fixer
- * @param {string} importName The import name
+ * @param {'Trans'|'t'|'useTranslate'} importName The import name
  * @param {RuleContextWithOptions} context
  * @returns {import('@typescript-eslint/utils/ts-eslint').RuleFix|undefined} The fix
  */
 function getImportsFixer(fixer, importName, context) {
   const body = context.sourceCode.ast.body;
 
+  /** Map of where we expect to import each translation util from */
+  const importPackage = {
+    Trans: '@grafana/i18n',
+    useTranslate: '@grafana/i18n',
+    t: '@grafana/i18n/internal',
+  };
+
+  const expectedImport = importPackage[importName];
+
   const existingAppCoreI18n = body.find(
     (node) =>
       node.type === AST_NODE_TYPES.ImportDeclaration &&
-      (node.source.value === PACKAGE_IMPORT_NAME ||
+      (node.source.value === importPackage[importName] ||
         // "legacy" imports:
         node.source.value.endsWith('core/internationalization'))
   );
 
   // If there's no existing import at all, add it
   if (!existingAppCoreI18n) {
-    return fixer.insertTextBefore(body[0], `import { ${importName} } from '${PACKAGE_IMPORT_NAME}';\n`);
+    return fixer.insertTextBefore(body[0], `import { ${importName} } from '${expectedImport}';\n`);
   }
 
   // To keep the typechecker happy - we have to explicitly check the type

--- a/packages/grafana-eslint-rules/rules/translation-utils.cjs
+++ b/packages/grafana-eslint-rules/rules/translation-utils.cjs
@@ -129,7 +129,7 @@ function canBeFixed(node, context) {
  * @returns {string|null} The translation prefix or null
  */
 function getTranslationPrefix(context) {
-  const filename = context.getFilename();
+  const filename = context.filename;
   const match = filename.match(/public\/app\/features\/([^/]+)/);
   if (match) {
     return match[1];
@@ -218,7 +218,8 @@ function getComponentNames(node, context) {
 }
 
 /**
- * Checks if a method has a `useTranslate` call
+ * Checks if a method has a variable declaration of `t`
+ * that came from a `useTranslate` call
  * @param {Node} method The node
  * @param {RuleContextWithOptions} context
  */
@@ -260,10 +261,10 @@ function getImportsFixer(node, fixer, importName, context) {
 
   const parentMethod = getParentMethod(node, context);
 
-  // If we're trying to import `t`,
-  // and there's already a `t` variable declaration in the parent method that came from `useTranslate`,
-  // do nothing
   if (importName === 't') {
+    // If we're trying to import `t`,
+    // and there's already a `t` variable declaration in the parent method that came from `useTranslate`,
+    // do nothing
     const declarationFromUseTranslate = parentMethod ? methodHasUseTranslate(parentMethod, context) : false;
     if (declarationFromUseTranslate) {
       return;

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -1,6 +1,7 @@
 import { RuleTester } from 'eslint';
 
 import noUntranslatedStrings from '../rules/no-untranslated-strings.cjs';
+import { PACKAGE_IMPORT_NAME } from '../rules/translation-utils.cjs';
 
 RuleTester.setDefaultConfig({
   languageOptions: {
@@ -15,6 +16,10 @@ RuleTester.setDefaultConfig({
 });
 
 const filename = 'public/app/features/some-feature/SomeFile.tsx';
+
+const TRANS_IMPORT = `import { Trans } from '${PACKAGE_IMPORT_NAME}';`;
+const T_IMPORT = `import { t } from '${PACKAGE_IMPORT_NAME}';`;
+const ALL_IMPORT = `import { Trans, t } from '${PACKAGE_IMPORT_NAME}';`;
 
 const ruleTester = new RuleTester();
 
@@ -108,7 +113,7 @@ const Foo = () => <div>Untranslated text</div>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
             },
           ],
@@ -126,7 +131,7 @@ const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untra
           suggestions: [
             {
               messageId: 'wrapWithTrans',
-              output: `import { Trans } from 'app/core/internationalization';
+              output: `${TRANS_IMPORT}
 const thing = <div><Trans i18nKey="some-feature.thing.foo">foo</Trans></div>`,
             },
           ],
@@ -146,7 +151,7 @@ const Foo = () => <div>This is a longer string that we will translate</div>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.longer-string-translate">This is a longer string that we will translate</Trans></div>`,
             },
           ],
@@ -166,7 +171,7 @@ const Foo = () => <div>lots of sho rt word s to be filt ered</div>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.lots-of-sho-rt-word-s">lots of sho rt word s to be filt ered</Trans></div>`,
             },
           ],
@@ -186,7 +191,7 @@ const foo = <>hello</>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const foo = <><Trans i18nKey="some-feature.foo.hello">hello</Trans></>`,
             },
           ],
@@ -206,7 +211,7 @@ const Foo = () => <div><TestingComponent someProp={<>Test</>} /></div>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div><TestingComponent someProp={<><Trans i18nKey="some-feature.foo.test">Test</Trans></>} /></div>`,
             },
           ],
@@ -217,7 +222,7 @@ const Foo = () => <div><TestingComponent someProp={<><Trans i18nKey="some-featur
     {
       name: 'Fixes and uses ID from attribute if exists',
       code: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div id="someid" title="foo"/>`,
       filename,
       errors: [
@@ -227,7 +232,7 @@ const Foo = () => <div id="someid" title="foo"/>`,
             {
               messageId: 'wrapWithT',
               output: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div id="someid" title={t("some-feature.foo.someid-title-foo", "foo")}/>`,
             },
           ],
@@ -238,7 +243,7 @@ const Foo = () => <div id="someid" title={t("some-feature.foo.someid-title-foo",
     {
       name: 'Fixes correctly when Trans import already exists',
       code: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div>Untranslated text</div>`,
       filename,
       errors: [
@@ -248,7 +253,7 @@ const Foo = () => <div>Untranslated text</div>`,
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
             },
           ],
@@ -259,7 +264,7 @@ const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untra
     {
       name: 'Fixes correctly when t() import already exists',
       code: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div title="foo" />`,
       filename,
       errors: [
@@ -269,7 +274,7 @@ const Foo = () => <div title="foo" />`,
             {
               messageId: 'wrapWithT',
               output: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],
@@ -280,7 +285,7 @@ const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
     {
       name: 'Fixes correctly when import exists but needs to add t()',
       code: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => <div title="foo" />`,
       filename,
       errors: [
@@ -290,7 +295,7 @@ const Foo = () => <div title="foo" />`,
             {
               messageId: 'wrapWithT',
               output: `
-import { Trans, t } from 'app/core/internationalization';
+${ALL_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],
@@ -314,7 +319,7 @@ class Foo extends React.Component {
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 class Foo extends React.Component {
   render() {
     return <div><Trans i18nKey="some-feature.foo.untranslated-text">untranslated text</Trans></div>;
@@ -338,7 +343,7 @@ const Foo = () => <div title="foo" />`,
             {
               messageId: 'wrapWithT',
               output: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],
@@ -358,7 +363,7 @@ const Foo = () => <div title={"foo"} />`,
             {
               messageId: 'wrapWithT',
               output: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],
@@ -378,7 +383,7 @@ const Foo = () => <div title='"foo"' />`,
             {
               messageId: 'wrapWithT',
               output: `
-import { t } from 'app/core/internationalization';
+${T_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", '"foo"')} />`,
             },
           ],
@@ -389,7 +394,7 @@ const Foo = () => <div title={t("some-feature.foo.title-foo", '"foo"')} />`,
     {
       name: 'Fixes case with nested functions/components',
       code: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => {
   const getSomething = () => {
     return <div>foo</div>;
@@ -406,7 +411,7 @@ const Foo = () => {
             {
               messageId: 'wrapWithTrans',
               output: `
-import { Trans } from 'app/core/internationalization';
+${TRANS_IMPORT}
 const Foo = () => {
   const getSomething = () => {
     return <div><Trans i18nKey="some-feature.foo.get-something.foo">foo</Trans></div>;

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -223,6 +223,66 @@ const Foo = () => <div><TestingComponent someProp={<><Trans i18nKey="some-featur
     },
 
     {
+      name: 'Fixes basic prop case and adds useTranslate',
+      code: `
+const Foo = () => {
+  return (
+    <div title="foo" />
+  )
+}`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStringsProp',
+          suggestions: [
+            {
+              messageId: 'wrapWithT',
+              output: `
+${USE_TRANSLATE_IMPORT}
+const Foo = () => {
+  const { t } = useTranslate();
+return (
+    <div title={t("some-feature.foo.title-foo", "foo")} />
+  )
+}`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Fixes correctly when useTranslate already exists',
+      code: `
+${USE_TRANSLATE_IMPORT}
+const Foo = () => {
+  const { t } = useTranslate();
+  return (
+    <div title="foo" />
+  )
+}`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStringsProp',
+          suggestions: [
+            {
+              messageId: 'wrapWithT',
+              output: `
+${USE_TRANSLATE_IMPORT}
+const Foo = () => {
+  const { t } = useTranslate();
+  return (
+    <div title={t("some-feature.foo.title-foo", "foo")} />
+  )
+}`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
       name: 'Fixes and uses ID from attribute if exists',
       code: `
 ${T_IMPORT}

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -18,8 +18,9 @@ RuleTester.setDefaultConfig({
 const filename = 'public/app/features/some-feature/SomeFile.tsx';
 
 const TRANS_IMPORT = `import { Trans } from '${PACKAGE_IMPORT_NAME}';`;
-const T_IMPORT = `import { t } from '${PACKAGE_IMPORT_NAME}';`;
-const ALL_IMPORT = `import { Trans, t } from '${PACKAGE_IMPORT_NAME}';`;
+const T_IMPORT = `import { t } from '${PACKAGE_IMPORT_NAME}/internal';`;
+const USE_TRANSLATE_IMPORT = `import { useTranslate } from '${PACKAGE_IMPORT_NAME}';`;
+
 const LEGACY_IMPORT = `import { Trans } from 'app/core/internationalization';`;
 const LEGACY_IMPORT_RELATIVE = `import { Trans } from '../../core/internationalization';`;
 
@@ -125,7 +126,8 @@ const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untra
 
     {
       name: 'Text inside JSXElement, not in a function',
-      code: `const thing = <div>foo</div>`,
+      code: `
+const thing = <div>foo</div>`,
       filename,
       errors: [
         {
@@ -133,7 +135,8 @@ const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untra
           suggestions: [
             {
               messageId: 'wrapWithTrans',
-              output: `${TRANS_IMPORT}
+              output: `
+${TRANS_IMPORT}
 const thing = <div><Trans i18nKey="some-feature.thing.foo">foo</Trans></div>`,
             },
           ],
@@ -339,7 +342,8 @@ const Foo = () => <div title="foo" />`,
             {
               messageId: 'wrapWithT',
               output: `
-${ALL_IMPORT}
+${T_IMPORT}
+${TRANS_IMPORT}
 const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -497,6 +497,32 @@ const Foo = () => {
     },
 
     {
+      name: 'Fixes correctly when no return statement',
+      code: `
+const Foo = () => {
+  const foo = <div title="foo" />
+}
+`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStringsProp',
+          suggestions: [
+            {
+              messageId: 'wrapWithT',
+              output: `
+${T_IMPORT}
+const Foo = () => {
+  const foo = <div title={t(\"some-feature.foo.foo.title-foo\", \"foo\")} />
+}
+`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
       name: 'Fixes correctly when import exists but needs to add t()',
       code: `
 ${TRANS_IMPORT}

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -21,9 +21,6 @@ const TRANS_IMPORT = `import { Trans } from '${PACKAGE_IMPORT_NAME}';`;
 const T_IMPORT = `import { t } from '${PACKAGE_IMPORT_NAME}/internal';`;
 const USE_TRANSLATE_IMPORT = `import { useTranslate } from '${PACKAGE_IMPORT_NAME}';`;
 
-const LEGACY_IMPORT = `import { Trans } from 'app/core/internationalization';`;
-const LEGACY_IMPORT_RELATIVE = `import { Trans } from '../../core/internationalization';`;
-
 const ruleTester = new RuleTester();
 
 ruleTester.run('eslint no-untranslated-strings', noUntranslatedStrings, {
@@ -259,48 +256,6 @@ const Foo = () => <div>Untranslated text</div>`,
               messageId: 'wrapWithTrans',
               output: `
 ${TRANS_IMPORT}
-const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
-            },
-          ],
-        },
-      ],
-    },
-
-    {
-      name: 'Fixes correctly when Trans import already exists from legacy package',
-      code: `
-${LEGACY_IMPORT}
-const Foo = () => <div>Untranslated text</div>`,
-      filename,
-      errors: [
-        {
-          messageId: 'noUntranslatedStrings',
-          suggestions: [
-            {
-              messageId: 'wrapWithTrans',
-              output: `
-${LEGACY_IMPORT}
-const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
-            },
-          ],
-        },
-      ],
-    },
-
-    {
-      name: 'Fixes correctly when Trans import already exists from (relative) legacy package',
-      code: `
-${LEGACY_IMPORT_RELATIVE}
-const Foo = () => <div>Untranslated text</div>`,
-      filename,
-      errors: [
-        {
-          messageId: 'noUntranslatedStrings',
-          suggestions: [
-            {
-              messageId: 'wrapWithTrans',
-              output: `
-${LEGACY_IMPORT_RELATIVE}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
             },
           ],

--- a/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
+++ b/packages/grafana-eslint-rules/tests/no-untranslated-strings.test.js
@@ -20,6 +20,8 @@ const filename = 'public/app/features/some-feature/SomeFile.tsx';
 const TRANS_IMPORT = `import { Trans } from '${PACKAGE_IMPORT_NAME}';`;
 const T_IMPORT = `import { t } from '${PACKAGE_IMPORT_NAME}';`;
 const ALL_IMPORT = `import { Trans, t } from '${PACKAGE_IMPORT_NAME}';`;
+const LEGACY_IMPORT = `import { Trans } from 'app/core/internationalization';`;
+const LEGACY_IMPORT_RELATIVE = `import { Trans } from '../../core/internationalization';`;
 
 const ruleTester = new RuleTester();
 
@@ -254,6 +256,48 @@ const Foo = () => <div>Untranslated text</div>`,
               messageId: 'wrapWithTrans',
               output: `
 ${TRANS_IMPORT}
+const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Fixes correctly when Trans import already exists from legacy package',
+      code: `
+${LEGACY_IMPORT}
+const Foo = () => <div>Untranslated text</div>`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithTrans',
+              output: `
+${LEGACY_IMPORT}
+const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Fixes correctly when Trans import already exists from (relative) legacy package',
+      code: `
+${LEGACY_IMPORT_RELATIVE}
+const Foo = () => <div>Untranslated text</div>`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithTrans',
+              output: `
+${LEGACY_IMPORT_RELATIVE}
 const Foo = () => <div><Trans i18nKey="some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
             },
           ],


### PR DESCRIPTION
**What is this feature?**
Updates the suggested location for imports for untranslated text to be the new package `@grafana/i18n`, instead of `app/core/internationalisation`

**Why do we need this feature?**
Consistent fixes/suggestions from the eslint rule, now that the package has been created and is being used for plugins etc

**Who is this feature for?**
All UI developers

