### PR TITLE
[release-12.0.1] Chore: Bump Go version to 1.24.3

### DIFF
--- a/.citools/bra/go.mod
+++ b/.citools/bra/go.mod
@@ -1,6 +1,6 @@
 module bra
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/unknwon/bra
 

--- a/.citools/cog/go.mod
+++ b/.citools/cog/go.mod
@@ -1,6 +1,6 @@
 module cog
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/grafana/cog/cmd/cli
 

--- a/.citools/cue/go.mod
+++ b/.citools/cue/go.mod
@@ -1,6 +1,6 @@
 module cue
 
-go 1.24.1
+go 1.24.3
 
 tool cuelang.org/go/cmd/cue
 

--- a/.citools/golangci-lint/go.mod
+++ b/.citools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module golangci-lint
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/.citools/jb/go.mod
+++ b/.citools/jb/go.mod
@@ -1,6 +1,6 @@
 module jb
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 

--- a/.citools/lefthook/go.mod
+++ b/.citools/lefthook/go.mod
@@ -1,6 +1,6 @@
 module lefthook
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/evilmartians/lefthook
 

--- a/.citools/swagger/go.mod
+++ b/.citools/swagger/go.mod
@@ -1,6 +1,6 @@
 module swagger
 
-go 1.24.1
+go 1.24.3
 
 tool github.com/go-swagger/go-swagger/cmd/swagger
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -75,7 +75,7 @@ steps:
   - go install github.com/bazelbuild/buildtools/buildifier@latest
   - buildifier --lint=warn -mode=check -r .
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: lint-starlark
 trigger:
   event:
@@ -219,7 +219,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -228,21 +228,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -251,7 +251,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend-integration
 trigger:
   event:
@@ -306,7 +306,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - echo $(/usr/bin/github-app-external-token) > /github-app/token
@@ -351,16 +351,16 @@ steps:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-openapi-spec
 trigger:
   event:
@@ -437,7 +437,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -447,7 +447,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -456,7 +456,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -494,7 +494,7 @@ steps:
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.24.2 --yarn-cache=$$YARN_CACHE_FOLDER
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.24.3 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.21.3
     --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
@@ -890,7 +890,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -904,7 +904,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -913,14 +913,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -941,7 +941,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -962,7 +962,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -978,7 +978,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -994,7 +994,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -1010,7 +1010,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -1092,7 +1092,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 trigger:
   event:
@@ -1213,7 +1213,7 @@ steps:
     && return 1; fi
   depends_on:
   - clone-enterprise
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: swagger-gen
 trigger:
   event:
@@ -1318,7 +1318,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1329,7 +1329,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1339,14 +1339,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - apk add --update build-base
@@ -1354,7 +1354,7 @@ steps:
   - go test -v -run=^$ -benchmem -timeout=1h -count=8 -bench=. ${GO_PACKAGES}
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: sqlite-benchmark-integration-tests
 - commands:
   - apk add --update build-base
@@ -1366,7 +1366,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: postgres-benchmark-integration-tests
 - commands:
   - apk add --update build-base
@@ -1377,7 +1377,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: mysql-8.0-benchmark-integration-tests
 trigger:
   event:
@@ -1449,7 +1449,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 trigger:
   branch: main
@@ -1498,7 +1498,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1507,21 +1507,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -1530,7 +1530,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend-integration
 trigger:
   branch: main
@@ -1575,22 +1575,22 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-openapi-spec
 - commands:
   - ./bin/build verify-drone
@@ -1722,7 +1722,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1732,7 +1732,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1741,7 +1741,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1778,7 +1778,7 @@ steps:
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
     -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.24.2 --yarn-cache=$$YARN_CACHE_FOLDER
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.24.3 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.21.3
     --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
     .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
@@ -2249,7 +2249,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -2263,7 +2263,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2272,14 +2272,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -2300,7 +2300,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -2321,7 +2321,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -2337,7 +2337,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2353,7 +2353,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -2369,7 +2369,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   branch: main
@@ -2637,7 +2637,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2646,21 +2646,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -2669,7 +2669,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend-integration
 trigger:
   branch:
@@ -2712,22 +2712,22 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - apk add --update make
   - make gen-go
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-modfile
 - commands:
   - apk add --update make
   - make swagger-validate
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: validate-openapi-spec
 trigger:
   branch:
@@ -2806,7 +2806,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -2820,7 +2820,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2829,14 +2829,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -2857,7 +2857,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -2878,7 +2878,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -2894,7 +2894,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2910,7 +2910,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -2926,7 +2926,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   branch:
@@ -3026,7 +3026,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3156,7 +3156,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3297,7 +3297,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --artifacts-editions=oss --tag $${DRONE_TAG} --src-bucket
@@ -3389,7 +3389,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -3489,7 +3489,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -3586,7 +3586,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss ${DRONE_TAG}
@@ -3647,7 +3647,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -3722,7 +3722,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -3839,7 +3839,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -3990,7 +3990,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3999,21 +3999,21 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - apk add --update build-base shared-mime-info shared-mime-info-lang
   - go list -f '{{.Dir}}/...' -m  | xargs go test -short -covermode=atomic -timeout=5m
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend
 - commands:
   - apk add --update build-base
@@ -4022,7 +4022,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: test-backend-integration
 trigger:
   cron:
@@ -4076,7 +4076,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4220,7 +4220,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4327,7 +4327,7 @@ steps:
   - export GITHUB_TOKEN=$(cat /github-app/token)
   - dagger run --silent /src/grafana-build artifacts -a $${ARTIFACTS} --grafana-ref=$${GRAFANA_REF}
     --enterprise-ref=$${ENTERPRISE_REF} --grafana-repo=$${GRAFANA_REPO} --version=$${VERSION}
-    --go-version=1.24.2
+    --go-version=1.24.3
   depends_on:
   - github-app-generate-token
   environment:
@@ -4348,7 +4348,7 @@ steps:
       from_secret: grafana_api_key
     GCP_KEY_BASE64:
       from_secret: gcp_key_base64
-    GO_VERSION: 1.24.2
+    GO_VERSION: 1.24.3
     GPG_PASSPHRASE:
       from_secret: packages_gpg_passphrase
     GPG_PRIVATE_KEY:
@@ -4486,7 +4486,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4495,14 +4495,14 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: verify-gen-jsonnet
 - commands:
   - apk add --update make
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: wire-install
 - commands:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -4523,7 +4523,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: postgres-integration-tests
 - commands:
   - dockerize -wait tcp://mysql80:3306 -timeout 120s
@@ -4544,7 +4544,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379 -timeout 120s
@@ -4560,7 +4560,7 @@ steps:
   - wait-for-redis
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4576,7 +4576,7 @@ steps:
   - wait-for-memcached
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: memcached-integration-tests
 - commands:
   - dockerize -wait tcp://mimir_backend:8080 -timeout 120s
@@ -4592,7 +4592,7 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.24.2-alpine
+  image: golang:1.24.3-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -4895,7 +4895,7 @@ steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM docker:27-cli
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine/git:2.40.1
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.24.2-alpine
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.24.3-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22.11.0-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22-bookworm
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
@@ -4933,7 +4933,7 @@ steps:
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL docker:27-cli
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine/git:2.40.1
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.24.2-alpine
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.24.3-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22.11.0-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22-bookworm
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
@@ -5190,6 +5190,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 4fd4d156c0e04e2332ac83ea168ce5c0237e3906e032c362cd2a62bee94ba9be
+hmac: b71a700f8def31b2c7d901e77cd34e8a6bb5b1f54e5bdd7ea0981201c33e6b8f
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=alpine:3.21
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.24.2-alpine
+ARG GO_IMAGE=golang:1.24.3-alpine
 
 # Default to building locally
 ARG GO_SRC=go-builder

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .bingo/Variables.mk
 
 GO = go
-GO_VERSION = 1.24.2
+GO_VERSION = 1.24.3
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/advisor
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/grafana-app-sdk v0.31.0

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/notifications
 
-go 1.24.2
+go 1.24.3
 
 replace github.com/grafana/grafana => ../../..
 

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashboard
 
-go 1.24.2
+go 1.24.3
 
 require (
 	cuelang.org/go v0.11.1

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/folder
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/grafana-app-sdk v0.35.1

--- a/apps/investigations/go.mod
+++ b/apps/investigations/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/investigations
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/grafana-app-sdk v0.35.1

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/playlist
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/grafana-app-sdk v0.35.1

--- a/devenv/docker/blocks/prometheus_high_card/go.mod
+++ b/devenv/docker/blocks/prometheus_high_card/go.mod
@@ -1,6 +1,6 @@
 module high-card
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/prometheus/client_golang v1.20.2

--- a/devenv/docker/blocks/prometheus_utf8/go.mod
+++ b/devenv/docker/blocks/prometheus_utf8/go.mod
@@ -1,6 +1,6 @@
 module utf8-support
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/devenv/docker/blocks/stateful_webhook/Dockerfile
+++ b/devenv/docker/blocks/stateful_webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2
+FROM golang:1.24.3
 
 ADD main.go /go/src/webhook/main.go
 

--- a/docs/sources/observability-as-code/foundation-sdk/dashboard-automation.md
+++ b/docs/sources/observability-as-code/foundation-sdk/dashboard-automation.md
@@ -164,10 +164,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Go 1.24.2
+      - name: Set up Go 1.24.3
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.2
+          go-version: 1.24.3
 
       - name: Verify Go version
         run: go version
@@ -208,7 +208,7 @@ This GitHub Action automates the deployment of a Grafana dashboard using the Fou
 The first few steps:
 
 - Check out the repository to access the project code.
-- Install Go 1.24.2 using the `actions/setup-go` action.
+- Install Go 1.24.3 using the `actions/setup-go` action.
 - Verify Go is properly installed.
 
 ### 2. Download and install `grafanactl`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.24.2
+go 1.24.3
 
 require (
 	buf.build/gen/go/parca-dev/parca/connectrpc/go v1.17.0-20240902100956-02fd72488966.1 // @grafana/observability-traces-and-profiling

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.2
+go 1.24.3
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/hack
 
-go 1.24.2
+go 1.24.3
 
 require k8s.io/code-generator v0.32.0
 

--- a/pkg/aggregator/go.mod
+++ b/pkg/aggregator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/aggregator
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/authlib v0.0.0-20250325095148-d6da9c164a7d // @grafana/identity-access-team

--- a/pkg/apis/secret/go.mod
+++ b/pkg/apis/secret/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apis/secret
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250314071911-14e2784e6979

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/build/go.mod
+++ b/pkg/build/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build
 
-go 1.24.2
+go 1.24.3
 
 // Override docker/docker to avoid:
 // go: github.com/drone-runners/drone-runner-docker@v1.8.2 requires

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/codegen/go.mod
+++ b/pkg/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/codegen
 
-go 1.24.2
+go 1.24.3
 
 require (
 	cuelang.org/go v0.11.1

--- a/pkg/plugins/codegen/go.mod
+++ b/pkg/plugins/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/codegen
 
-go 1.24.2
+go 1.24.3
 
 replace github.com/grafana/grafana/pkg/codegen => ../../codegen
 

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/promlib
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040

--- a/pkg/semconv/go.mod
+++ b/pkg/semconv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/semconv
 
-go 1.24.2
+go 1.24.3
 
 require go.opentelemetry.io/otel v1.35.0
 

--- a/pkg/storage/unified/apistore/go.mod
+++ b/pkg/storage/unified/apistore/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/apistore
 
-go 1.24.2
+go 1.24.3
 
 replace (
 	github.com/grafana/grafana => ../../../..

--- a/pkg/storage/unified/resource/go.mod
+++ b/pkg/storage/unified/resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resource
 
-go 1.24.2
+go 1.24.3
 
 replace (
 	github.com/grafana/grafana/apps/folder => ../../../../apps/folder

--- a/pkg/util/xorm/go.mod
+++ b/pkg/util/xorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/util/xorm
 
-go 1.24.2
+go 1.24.3
 
 require (
 	cloud.google.com/go/spanner v1.75.0

--- a/scripts/drone/variables.star
+++ b/scripts/drone/variables.star
@@ -3,7 +3,7 @@ global variables
 """
 
 grabpl_version = "v3.1.2"
-golang_version = "1.24.2"
+golang_version = "1.24.3"
 
 # nodejs_version should match what's in ".nvmrc", but without the v prefix.
 nodejs_version = "22.11.0"

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.24.2
+go 1.24.3
 
 require golang.org/x/mod v0.20.0

--- a/scripts/modowners/go.mod
+++ b/scripts/modowners/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/modowners
 
-go 1.24.2
+go 1.24.3
 
 require golang.org/x/mod v0.10.0


### PR DESCRIPTION
**What is this feature?**

Bumps Go version to 1.24.3 which addresses CVE-2025-22873 (which we are not affected).

**Why do we need this feature?**

Prevent a situation where contributors use `os.Root` on a vulnerable version of Go.

**Who is this feature for?**

Contributors and security scanners ;)

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
