### PR TITLE
GrafanaUI: Add primary variant to Counter

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2, locale } from '@grafana/data';
 
@@ -12,7 +12,7 @@ export interface CounterProps {
 export const Counter = ({ value, className }: CounterProps) => {
   const styles = useStyles2(getStyles);
 
-  return <span className={styles.counter, className}>{locale(value, 0).text}</span>;
+  return <span className={cx(styles.counter, className)}>{locale(value, 0).text}</span>;
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -4,10 +4,10 @@ import { GrafanaTheme2, locale } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 
-type CounterVariant = 'primary' | 'secondary'
+type CounterVariant = 'primary' | 'secondary';
 export interface CounterProps {
   value: number;
-  variant?: CounterVariant
+  variant?: CounterVariant;
 }
 
 export const Counter = ({ value, variant = 'secondary' }: CounterProps) => {
@@ -21,7 +21,7 @@ const getStyles = (theme: GrafanaTheme2, variant: CounterVariant) => ({
     label: 'counter',
     marginLeft: theme.spacing(1),
     borderRadius: theme.spacing(3),
-    backgroundColor: variant === "primary" ? theme.colors.primary.main : theme.colors.action.hover,
+    backgroundColor: variant === 'primary' ? theme.colors.primary.main : theme.colors.action.hover,
     padding: theme.spacing(0.25, 1),
     color: theme.colors.text.secondary,
     fontWeight: theme.typography.fontWeightMedium,

--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -1,26 +1,27 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 
 import { GrafanaTheme2, locale } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 
+type CounterVariant = 'primary' | 'secondary'
 export interface CounterProps {
   value: number;
-  className?: string
+  variant?: CounterVariant
 }
 
-export const Counter = ({ value, className }: CounterProps) => {
-  const styles = useStyles2(getStyles);
+export const Counter = ({ value, variant = 'secondary' }: CounterProps) => {
+  const styles = useStyles2(getStyles, variant);
 
-  return <span className={cx(styles.counter, className)}>{locale(value, 0).text}</span>;
+  return <span className={styles.counter}>{locale(value, 0).text}</span>;
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, variant: CounterVariant) => ({
   counter: css({
     label: 'counter',
     marginLeft: theme.spacing(1),
     borderRadius: theme.spacing(3),
-    backgroundColor: theme.colors.action.hover,
+    backgroundColor: variant === "primary" ? theme.colors.primary.main : theme.colors.action.hover,
     padding: theme.spacing(0.25, 1),
     color: theme.colors.text.secondary,
     fontWeight: theme.typography.fontWeightMedium,

--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -6,12 +6,13 @@ import { useStyles2 } from '../../themes';
 
 export interface CounterProps {
   value: number;
+  className: string
 }
 
-export const Counter = ({ value }: CounterProps) => {
+export const Counter = ({ value, className }: CounterProps) => {
   const styles = useStyles2(getStyles);
 
-  return <span className={styles.counter}>{locale(value, 0).text}</span>;
+  return <span className={styles.counter, className}>{locale(value, 0).text}</span>;
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -6,7 +6,7 @@ import { useStyles2 } from '../../themes';
 
 export interface CounterProps {
   value: number;
-  className: string
+  className?: string
 }
 
 export const Counter = ({ value, className }: CounterProps) => {


### PR DESCRIPTION
**What is this feature?**

~~Add a `className` property to `Counter` component.~~
Add a `variant` property to `Counter` component.

**Why do we need this feature?**

~~With the `className` property, it is more flexible while using it out of the box with custom css property passed in.~~
With the `variant` property, we are able to alter the color of the counter's background.

**Who is this feature for?**

For anyone using Grafana UI

**Special notes for your reviewer:**
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
