### PR TITLE
chore(unified-storage): add dual writer metric to track instance modes

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -361,12 +361,7 @@ func InstallAPIs(
 				return nil, err
 			}
 
-			metrics.recordDualWriterMode(
-				gr.Resource,
-				gr.Group,
-				int(mode),
-				int(currentMode),
-			)
+			metrics.recordDualWriterModes(gr.Resource, gr.Group, mode, currentMode)
 
 			switch currentMode {
 			case grafanarest.Mode0:

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -298,6 +298,7 @@ func InstallAPIs(
 	// this is needed to support setting a default RESTOptionsGetter for new APIs that don't
 	// support the legacy storage type.
 	var dualWrite grafanarest.DualWriteBuilder
+	metrics := newBuilderMetrics(reg)
 
 	// nolint:staticcheck
 	if storageOpts.StorageType != options.StorageTypeLegacy {
@@ -359,6 +360,14 @@ func InstallAPIs(
 			if err != nil {
 				return nil, err
 			}
+
+			metrics.recordDualWriterMode(
+				gr.Resource,
+				gr.Group,
+				int(mode),
+				int(currentMode),
+			)
+
 			switch currentMode {
 			case grafanarest.Mode0:
 				return legacy, nil
@@ -366,6 +375,7 @@ func InstallAPIs(
 				return storage, nil
 			default:
 			}
+
 			if dualWriterPeriodicDataSyncJobEnabled {
 				// The mode might have changed in SetDualWritingMode, so apply current mode first.
 				syncerCfg.Mode = currentMode

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -14,13 +14,13 @@ type builderMetrics struct {
 func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
 	metrics := &builderMetrics{
 		dualWriterTargetMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "dual_writer_target_mode",
-			Help:        "Dual writer target mode",
+			Name:        "unified_storage_dual_writer_target_mode",
+			Help:        "Unified Storage dual writer target mode",
 			ConstLabels: prometheus.Labels{"component": "builder"},
 		}, []string{"resource", "group"}),
 		dualWriterCurrentMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "dual_writer_current_mode",
-			Help:        "Dual writer current mode",
+			Name:        "unified_storage_dual_writer_current_mode",
+			Help:        "Unified storage dual writer current mode",
 			ConstLabels: prometheus.Labels{"component": "builder"},
 		}, []string{"resource", "group"}),
 	}

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -1,0 +1,34 @@
+package builder
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type builderMetrics struct {
+	dualWriterMode *prometheus.CounterVec
+}
+
+func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
+	return &builderMetrics{
+		dualWriterMode: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dual_writer_mode",
+				Help: "Dual writer mode",
+			},
+			[]string{"resource", "group", "targetMode", "currentMode"},
+		),
+	}
+}
+
+func (m *builderMetrics) recordDualWriterMode(resource, group string, targetMode, currentMode int) {
+	labels := prometheus.Labels{
+		"resource":    resource,
+		"group":       group,
+		"targetMode":  strconv.Itoa(targetMode),
+		"currentMode": strconv.Itoa(currentMode),
+	}
+	m.dualWriterMode.With(labels).Inc()
+}

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type builderMetrics struct {
@@ -12,8 +11,8 @@ type builderMetrics struct {
 }
 
 func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
-	return &builderMetrics{
-		dualWriterMode: promauto.With(reg).NewCounterVec(
+	metrics := &builderMetrics{
+		dualWriterMode: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "dual_writer_mode",
 				Help: "Dual writer mode",
@@ -21,6 +20,8 @@ func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
 			[]string{"resource", "group", "targetMode", "currentMode"},
 		),
 	}
+	reg.MustRegister(metrics.dualWriterMode)
+	return metrics
 }
 
 func (m *builderMetrics) recordDualWriterMode(resource, group string, targetMode, currentMode int) {

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -1,35 +1,40 @@
 package builder
 
 import (
-	"strconv"
-
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/unknwon/log"
 )
 
 type builderMetrics struct {
-	dualWriterMode *prometheus.CounterVec
+	dualWriterTargetMode  *prometheus.GaugeVec
+	dualWriterCurrentMode *prometheus.GaugeVec
 }
 
 func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
 	metrics := &builderMetrics{
-		dualWriterMode: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "dual_writer_mode",
-				Help: "Dual writer mode",
-			},
-			[]string{"resource", "group", "targetMode", "currentMode"},
-		),
+		dualWriterTargetMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "dual_writer_target_mode",
+			Help:        "Dual writer target mode",
+			ConstLabels: prometheus.Labels{"component": "builder"},
+		}, []string{"resource", "group"}),
+		dualWriterCurrentMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "dual_writer_current_mode",
+			Help:        "Dual writer current mode",
+			ConstLabels: prometheus.Labels{"component": "builder"},
+		}, []string{"resource", "group"}),
 	}
-	reg.MustRegister(metrics.dualWriterMode)
+
+	if err := reg.Register(metrics.dualWriterTargetMode); err != nil {
+		log.Info("builder metrics already registered")
+	}
+	if err := reg.Register(metrics.dualWriterCurrentMode); err != nil {
+		log.Info("builder metrics already registered")
+	}
 	return metrics
 }
 
-func (m *builderMetrics) recordDualWriterMode(resource, group string, targetMode, currentMode int) {
-	labels := prometheus.Labels{
-		"resource":    resource,
-		"group":       group,
-		"targetMode":  strconv.Itoa(targetMode),
-		"currentMode": strconv.Itoa(currentMode),
-	}
-	m.dualWriterMode.With(labels).Inc()
+func (m *builderMetrics) recordDualWriterModes(resource, group string, targetMode, currentMode grafanarest.DualWriterMode) {
+	m.dualWriterTargetMode.WithLabelValues(resource, group).Set(float64(targetMode))
+	m.dualWriterCurrentMode.WithLabelValues(resource, group).Set(float64(currentMode))
 }

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -3,7 +3,7 @@ package builder
 import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog/v2"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type builderMetrics struct {
@@ -12,25 +12,16 @@ type builderMetrics struct {
 }
 
 func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
-	log := klog.NewKlogr()
-	metrics := &builderMetrics{
-		dualWriterTargetMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	return &builderMetrics{
+		dualWriterTargetMode: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "unified_storage_dual_writer_target_mode",
 			Help: "Unified Storage dual writer target mode",
 		}, []string{"resource", "group"}),
-		dualWriterCurrentMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		dualWriterCurrentMode: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "unified_storage_dual_writer_current_mode",
 			Help: "Unified storage dual writer current mode",
 		}, []string{"resource", "group"}),
 	}
-
-	if err := reg.Register(metrics.dualWriterTargetMode); err != nil {
-		log.Info("builder metrics already registered")
-	}
-	if err := reg.Register(metrics.dualWriterCurrentMode); err != nil {
-		log.Info("builder metrics already registered")
-	}
-	return metrics
 }
 
 func (m *builderMetrics) recordDualWriterModes(resource, group string, targetMode, currentMode grafanarest.DualWriterMode) {

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -3,7 +3,7 @@ package builder
 import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/unknwon/log"
+	"k8s.io/klog/v2"
 )
 
 type builderMetrics struct {
@@ -12,16 +12,15 @@ type builderMetrics struct {
 }
 
 func newBuilderMetrics(reg prometheus.Registerer) *builderMetrics {
+	log := klog.NewKlogr()
 	metrics := &builderMetrics{
 		dualWriterTargetMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "unified_storage_dual_writer_target_mode",
-			Help:        "Unified Storage dual writer target mode",
-			ConstLabels: prometheus.Labels{"component": "builder"},
+			Name: "unified_storage_dual_writer_target_mode",
+			Help: "Unified Storage dual writer target mode",
 		}, []string{"resource", "group"}),
 		dualWriterCurrentMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:        "unified_storage_dual_writer_current_mode",
-			Help:        "Unified storage dual writer current mode",
-			ConstLabels: prometheus.Labels{"component": "builder"},
+			Name: "unified_storage_dual_writer_current_mode",
+			Help: "Unified storage dual writer current mode",
 		}, []string{"resource", "group"}),
 	}
 

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/middleware"
@@ -122,6 +121,7 @@ func ProvideService(
 	restConfigProvider RestConfigProvider,
 	buildHandlerChainFuncFromBuilders builder.BuildHandlerChainFuncFromBuilders,
 	eventualRestConfigProvider *eventualRestConfigProvider,
+	reg prometheus.Registerer,
 ) (*service, error) {
 	scheme := builder.ProvideScheme()
 	codecs := builder.ProvideCodecFactory(scheme)
@@ -137,7 +137,7 @@ func ProvideService(
 		authorizer:                        authorizer.NewGrafanaAuthorizer(cfg),
 		tracing:                           tracing,
 		db:                                db, // For Unified storage
-		metrics:                           metrics.ProvideRegisterer(),
+		metrics:                           reg,
 		kvStore:                           kvStore,
 		pluginClient:                      pluginClient,
 		datasources:                       datasources,


### PR DESCRIPTION
2 new metrics are added (`unified_storage_dual_writer_current_mode` and `unified_storage_dual_writer_target_mode`) in order to track the actual dual writer mode - both the current and the target.

Related: https://github.com/grafana/search-and-storage-team/issues/238