### PR TITLE
Alerting: Add debug log for alert timestamps before sending to external Alertmanager

### DIFF
--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -13,7 +13,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
@@ -182,7 +181,7 @@ func (s *ExternalAlertmanager) SendAlerts(alerts apimodels.PostableAlerts) {
 		na := s.alertToNotifierAlert(a)
 		as = append(as, na)
 
-		level.Debug(s.logger).Log("msg",
+		s.logger.Debug("msg",
 			"Sending alert",
 			"alert",
 			a,

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
@@ -180,6 +181,15 @@ func (s *ExternalAlertmanager) SendAlerts(alerts apimodels.PostableAlerts) {
 	for _, a := range alerts.PostableAlerts {
 		na := s.alertToNotifierAlert(a)
 		as = append(as, na)
+
+		level.Debug(s.logger).Log("msg",
+			"Sending alert",
+			"alert",
+			a,
+			"starts_at",
+			a.StartsAt,
+			"ends_at",
+			a.EndsAt)
 	}
 
 	s.manager.Send(as...)


### PR DESCRIPTION
**What is this feature?**
Adds a small debug log with `starts_at` and `ends_at` timestamp of the alert being sent to an external Alertmanager.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
