### PR TITLE
Alerting: Update grafana/alerting from de176b4a0309 to 83b6de6b0a35

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/googleapis/go-sql-spanner v1.11.1 // @grafana/grafana-search-and-storage
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.3 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20250429131604-de176b4a0309 // @grafana/alerting-backend
+	github.com/grafana/alerting v0.0.0-20250508220812-83b6de6b0a35 // @grafana/alerting-backend
 	github.com/grafana/authlib v0.0.0-20250422131730-e8482efe6b8a // @grafana/identity-access-team
 	github.com/grafana/authlib/types v0.0.0-20250325095148-d6da9c164a7d // @grafana/identity-access-team
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics

--- a/go.sum
+++ b/go.sum
@@ -1565,8 +1565,8 @@ github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7Fsg
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/alerting v0.0.0-20250429131604-de176b4a0309 h1:H2p3XKDHnTBGkMXLCgXiqb2dFnHbQ4zPDXOwKK4Ne3Y=
-github.com/grafana/alerting v0.0.0-20250429131604-de176b4a0309/go.mod h1:pMfhRxL2LZ3Pm8iy7VcVsb9CLYuBtjFYbf1oxgx7yFA=
+github.com/grafana/alerting v0.0.0-20250508220812-83b6de6b0a35 h1:/FvrKg5ZtJ09oWOt91lIPpeWtWGcNqXv/9UOQaRDyQE=
+github.com/grafana/alerting v0.0.0-20250508220812-83b6de6b0a35/go.mod h1:pMfhRxL2LZ3Pm8iy7VcVsb9CLYuBtjFYbf1oxgx7yFA=
 github.com/grafana/authlib v0.0.0-20250422131730-e8482efe6b8a h1:irEH0Abl6mKbkPx/xtmB5Wai4ipzEB6hGPNsLya/p9Y=
 github.com/grafana/authlib v0.0.0-20250422131730-e8482efe6b8a/go.mod h1:PBtQaXwkFu4BAt2aXsR7w8p8NVpdjV5aJYhqRDei9Us=
 github.com/grafana/authlib/types v0.0.0-20250325095148-d6da9c164a7d h1:34E6btDAhdDOiSEyrMaYaHwnJpM8w9QKzVQZIBzLNmM=

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	alertingHttp "github.com/grafana/alerting/http"
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers"
 	alertingTemplates "github.com/grafana/alerting/templates"
@@ -380,7 +379,6 @@ func (am *alertmanager) buildReceiverIntegrations(receiver *alertingNotify.APIRe
 		tmpl,
 		img,
 		LoggerFactory,
-		alertingHttp.DefaultClientConfiguration,
 		func(n receivers.Metadata) (receivers.EmailSender, error) {
 			return s, nil
 		},

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -373,7 +373,7 @@ func (am *alertmanager) buildReceiverIntegrations(receiver *alertingNotify.APIRe
 	if err != nil {
 		return nil, err
 	}
-	s := &sender{am.NotificationService}
+	s := &emailSender{am.NotificationService}
 	img := newImageProvider(am.Store, log.New("ngalert.notifier.image-provider"))
 	integrations, err := alertingNotify.BuildReceiverIntegrations(
 		receiverCfg,

--- a/pkg/services/ngalert/notifier/email_test.go
+++ b/pkg/services/ngalert/notifier/email_test.go
@@ -206,43 +206,11 @@ func createSut(t *testing.T, messageTmpl string, subjectTmpl string, emailTmpl *
 func getSingleSentMessage(t *testing.T, ns *emailSender) *notifications.Message {
 	t.Helper()
 
-	mailer := ns.ns.GetMailer().(*notifications.FakeMailer)
+	mailer := ns.ns.(*notifications.NotificationService).GetMailer().(*notifications.FakeMailer)
 	require.Len(t, mailer.Sent, 1)
 	sent := mailer.Sent[0]
 	mailer.Sent = []*notifications.Message{}
 	return sent
-}
-
-type emailSender struct {
-	ns *notifications.NotificationService
-}
-
-func (e emailSender) SendWebhook(ctx context.Context, cmd *receivers.SendWebhookSettings) error {
-	panic("not implemented")
-}
-
-func (e emailSender) SendEmail(ctx context.Context, cmd *receivers.SendEmailSettings) error {
-	sendEmailCommand := notifications.SendEmailCommand{
-		To:            cmd.To,
-		SingleEmail:   cmd.SingleEmail,
-		Template:      cmd.Template,
-		Subject:       cmd.Subject,
-		Data:          cmd.Data,
-		ReplyTo:       cmd.ReplyTo,
-		EmbeddedFiles: cmd.EmbeddedFiles,
-	}
-	if len(cmd.EmbeddedContents) > 0 {
-		sendEmailCommand.EmbeddedContents = make([]notifications.EmbeddedContent, len(cmd.EmbeddedContents))
-		for i, ec := range cmd.EmbeddedContents {
-			sendEmailCommand.EmbeddedContents[i] = notifications.EmbeddedContent{
-				Name:    ec.Name,
-				Content: ec.Content,
-			}
-		}
-	}
-	return e.ns.SendEmailCommandHandlerSync(ctx, &notifications.SendEmailCommandSync{
-		SendEmailCommand: sendEmailCommand,
-	})
 }
 
 func createEmailSender(t *testing.T) *emailSender {

--- a/pkg/services/ngalert/notifier/sender.go
+++ b/pkg/services/ngalert/notifier/sender.go
@@ -8,25 +8,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/notifications"
 )
 
-type sender struct {
+type emailSender struct {
 	ns notifications.Service
 }
 
-func (s sender) SendWebhook(ctx context.Context, cmd *receivers.SendWebhookSettings) error {
-	return s.ns.SendWebhookSync(ctx, &notifications.SendWebhookSync{
-		Url:         cmd.URL,
-		User:        cmd.User,
-		Password:    cmd.Password,
-		Body:        cmd.Body,
-		HttpMethod:  cmd.HTTPMethod,
-		HttpHeader:  cmd.HTTPHeader,
-		ContentType: cmd.ContentType,
-		Validation:  cmd.Validation,
-		TLSConfig:   cmd.TLSConfig,
-	})
-}
-
-func (s sender) SendEmail(ctx context.Context, cmd *receivers.SendEmailSettings) error {
+func (s emailSender) SendEmail(ctx context.Context, cmd *receivers.SendEmailSettings) error {
 	sendEmailCommand := notifications.SendEmailCommand{
 		To:            cmd.To,
 		SingleEmail:   cmd.SingleEmail,

--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
-
-	alertingHTTP "github.com/grafana/alerting/http"
+	"time"
 
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -71,7 +71,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 		request.Header.Set(k, v)
 	}
 
-	resp, err := alertingHTTP.NewTLSClient(webhook.TLSConfig).Do(request)
+	resp, err := NewTLSClient(webhook.TLSConfig).Do(request)
 	if err != nil {
 		return redactURL(err)
 	}
@@ -110,4 +110,27 @@ func redactURL(err error) error {
 	}
 	e.URL = "<redacted>"
 	return e
+}
+
+// NewTLSClient creates a new HTTP client with the provided TLS configuration or with default settings.
+func NewTLSClient(tlsConfig *tls.Config) *http.Client {
+	nc := func(tlsConfig *tls.Config) *http.Client {
+		return &http.Client{
+			Timeout: time.Second * 30,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+				Proxy:           http.ProxyFromEnvironment,
+				Dial: (&net.Dialer{
+					Timeout: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout: 5 * time.Second,
+			},
+		}
+	}
+
+	if tlsConfig == nil {
+		return nc(&tls.Config{Renegotiation: tls.RenegotiateFreelyAsClient})
+	}
+
+	return nc(tlsConfig)
 }


### PR DESCRIPTION
[Update grafana alerting from grafana/alerting@de176b4a0309 to grafana/alerting@83b6de6b0a35

Includes:
- https://github.com/grafana/alerting/pull/319
- https://github.com/grafana/alerting/pull/317


Small cleanup included:

`grafana/alerting` hasn't used the grafana webhook sender for a while now, so this method is no longer used anywhere.

- Removed `SendWebhook` from the `sender` struct and rename it to `emailSender` so that its use is clearer.
- Also, for similar reasons, the `Webhook` method on Grafana's webhook sender `sendWebRequestSync` should not call `grafana/alerting` code for `NewTLSClient`. The previous `grafana/alerting` function is vendored into grafana to decouple them.