### PR TITLE
Units: dBm should not be scaled with SI prefixes

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -246,7 +246,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Volt (V)', id: 'volt', fn: SIPrefix('V') },
       { name: 'Kilovolt (kV)', id: 'kvolt', fn: SIPrefix('V', 1) },
       { name: 'Millivolt (mV)', id: 'mvolt', fn: SIPrefix('V', -1) },
-      { name: 'Decibel-milliwatt (dBm)', id: 'dBm', fn: SIPrefix('dBm') },
+      { name: 'Decibel-milliwatt (dBm)', id: 'dBm', fn: toFixedUnit('dBm') },
       { name: 'Milliohm (mΩ)', id: 'mohm', fn: SIPrefix('Ω', -1) },
       { name: 'Ohm (Ω)', id: 'ohm', fn: SIPrefix('Ω') },
       { name: 'Kiloohm (kΩ)', id: 'kohm', fn: SIPrefix('Ω', 1) },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Measurements in dBm are no longer scaled with SI prefixes.

**Why do we need this feature?**

Measurements in dBm are logarithmic and should not be scaled with SI prefixes. A measurement of 0.9 dBm should be displayed as such, not as 900 mdBm.

**Who is this feature for?**

Anyone working with signal measurements, for example fiber optics and wireless.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #105060

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
