### PR TITLE
SecretsService: Move interfaces from DataKey store to contracts

### DIFF
--- a/pkg/registry/apis/secret/contracts/data_key.go
+++ b/pkg/registry/apis/secret/contracts/data_key.go
@@ -1,0 +1,37 @@
+package contracts
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
+)
+
+var (
+	ErrDataKeyNotFound = errors.New("data key not found")
+)
+
+// SecretDataKey does not have a mirrored K8s resource
+type SecretDataKey struct {
+	UID           string
+	Active        bool
+	Namespace     string
+	Label         string
+	Provider      encryption.ProviderID
+	EncryptedData []byte
+	Created       time.Time
+	Updated       time.Time
+}
+
+// DataKeyStorage is the interface for wiring and dependency injection.
+type DataKeyStorage interface {
+	CreateDataKey(ctx context.Context, dataKey *SecretDataKey) error
+	GetDataKey(ctx context.Context, namespace, uid string) (*SecretDataKey, error)
+	GetCurrentDataKey(ctx context.Context, namespace, label string) (*SecretDataKey, error)
+	GetAllDataKeys(ctx context.Context, namespace string) ([]*SecretDataKey, error)
+	DisableDataKeys(ctx context.Context, namespace string) error
+	DeleteDataKey(ctx context.Context, namespace, uid string) error
+
+	ReEncryptDataKeys(ctx context.Context, namespace string, providers encryption.ProviderMap, currProvider encryption.ProviderID) error
+}

--- a/pkg/registry/apis/secret/encryption/manager/manager_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager_test.go
@@ -85,7 +85,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 	ctx := context.Background()
 	namespace := "test-namespace"
 
-	dataKey := &encryptionstorage.SecretDataKey{
+	dataKey := &contracts.SecretDataKey{
 		UID:           util.GenerateShortUID(),
 		Label:         "test1",
 		Active:        true,
@@ -96,7 +96,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 
 	t.Run("querying for a DEK that does not exist", func(t *testing.T) {
 		res, err := store.GetDataKey(ctx, namespace, dataKey.UID)
-		assert.ErrorIs(t, encryptionstorage.ErrDataKeyNotFound, err)
+		assert.ErrorIs(t, contracts.ErrDataKeyNotFound, err)
 		assert.Nil(t, res)
 	})
 
@@ -122,7 +122,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 	})
 
 	t.Run("creating an inactive DEK", func(t *testing.T) {
-		k := &encryptionstorage.SecretDataKey{
+		k := &contracts.SecretDataKey{
 			UID:           util.GenerateShortUID(),
 			Namespace:     namespace,
 			Active:        false,
@@ -135,7 +135,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 		require.Error(t, err)
 
 		res, err := store.GetDataKey(ctx, namespace, k.UID)
-		assert.Equal(t, encryptionstorage.ErrDataKeyNotFound, err)
+		assert.Equal(t, contracts.ErrDataKeyNotFound, err)
 		assert.Nil(t, res)
 	})
 
@@ -155,7 +155,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 		require.NoError(t, err)
 
 		res, err := store.GetDataKey(ctx, namespace, dataKey.UID)
-		assert.Equal(t, encryptionstorage.ErrDataKeyNotFound, err)
+		assert.Equal(t, contracts.ErrDataKeyNotFound, err)
 		assert.Nil(t, res)
 	})
 }

--- a/pkg/storage/secret/encryption/data_key_store_test.go
+++ b/pkg/storage/secret/encryption/data_key_store_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -34,7 +35,7 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	ctx := context.Background()
 
 	// Define a data key whose lifecycle we will test
-	dataKey := &SecretDataKey{
+	dataKey := &contracts.SecretDataKey{
 		UID:           "test-uid",
 		Namespace:     "test-namespace",
 		Label:         "test-label",
@@ -44,7 +45,7 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	}
 
 	// Define a second data key in a different namespace that should remain undisturbed
-	unchangingDataKey := &SecretDataKey{
+	unchangingDataKey := &contracts.SecretDataKey{
 		UID:           "static-uid",
 		Namespace:     "static-namespace",
 		Label:         "static-label",
@@ -110,7 +111,7 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	// Verify that the data key is deleted
 	_, err = store.GetDataKey(ctx, "test-namespace", "test-uid")
 	require.Error(t, err)
-	require.Equal(t, ErrDataKeyNotFound, err)
+	require.Equal(t, contracts.ErrDataKeyNotFound, err)
 
 	// Verify that the unchanging data key still exists and is active
 	staticKey, err := store.GetDataKey(ctx, "static-namespace", "static-uid")

--- a/pkg/storage/secret/encryption/query.go
+++ b/pkg/storage/secret/encryption/query.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
@@ -95,7 +96,7 @@ func (r deleteEncryptedValue) Validate() error {
 /*************************************/
 type createDataKey struct {
 	sqltemplate.SQLTemplate
-	Row *SecretDataKey
+	Row *contracts.SecretDataKey
 }
 
 func (r createDataKey) Validate() error { return nil }

--- a/pkg/storage/secret/encryption/query_test.go
+++ b/pkg/storage/secret/encryption/query_test.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
 )
 
@@ -72,7 +73,7 @@ func TestDataKeyQueries(t *testing.T) {
 					Name: "create",
 					Data: &createDataKey{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
-						Row: &SecretDataKey{
+						Row: &contracts.SecretDataKey{
 							UID:           "abc123",
 							Active:        true,
 							Namespace:     "ns",
@@ -86,7 +87,7 @@ func TestDataKeyQueries(t *testing.T) {
 					Name: "create-not-active",
 					Data: &createDataKey{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
-						Row: &SecretDataKey{
+						Row: &contracts.SecretDataKey{
 							UID:           "abc123",
 							Active:        false,
 							Namespace:     "ns",


### PR DESCRIPTION
**What is this feature?**

Move interfaces from DataKey store to contracts.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1373