### PR TITLE
[release-12.0.1] docs(alerting): `No Data/Error` state enhancements

### DIFF
--- a/docs/sources/alerting/learn/missing-data.md
+++ b/docs/sources/alerting/learn/missing-data.md
@@ -173,7 +173,7 @@ If an alert instance becomes stale, you’ll find in the [alert history](ref:ale
 
 ###
 
-### Why doesn’t MissingSeries match No Data behaviour?
+### Why doesn’t MissingSeries match No Data behavior?
 
 In dynamic environments — autoscaling groups, ephemeral pods, spot instances — series naturally come and go. **MissingSeries** normally signals infrastructure or deployment changes.
 


### PR DESCRIPTION
Backport 8c8cc31746f79d4ad38b897dba3a7c6cf923a55f from #105100

---

- Include specific **No Data** and **Error** state sections
- Detail briefly about the  error-retry logic and configuration options
- Link new guides for handling error and missing data scenarios


⭐ Preview
