### PR TITLE
Check identifiers validity before cleaning up dashboards

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -663,8 +663,12 @@ func (d *dashboardStore) CleanupAfterDelete(ctx context.Context, cmd *dashboards
 			return err
 		}
 
-		if err := d.deleteResourcePermissions(sess, cmd.OrgID, ac.GetResourceScopeUID("dashboards", cmd.UID)); err != nil {
-			return err
+		if hasUID && hasOrgId {
+			if err := d.deleteResourcePermissions(sess, cmd.OrgID, ac.GetResourceScopeUID("dashboards", cmd.UID)); err != nil {
+				return err
+			}
+		} else {
+			d.log.Warn("CleanupAfterDelete: No orgId or uid provided, skipping resource permission deletion", "orgId", cmd.OrgID, "uid", cmd.UID)
 		}
 
 		return nil


### PR DESCRIPTION
**What is this feature?**
This PR introduces input verification for the dashboard cleanup process. 

**Why do we need this feature?**
We share the same tables for resources that are not directly associated with a particular dashboard, which could be unintentionally impacted if the process receives default values for the identifiers.

**Who is this feature for?**
Any resource which shares a table with the dashboards but does not follow their identifier model.

**Which issue(s) does this PR fix?**:
Deletion of annotations, for example.
