### PR TITLE
datasources: query-service url fix

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -226,7 +226,7 @@ class DataSourceWithBackend<
         if (!hasExpr && dsUIDs.size === 1) {
           // TODO? can we talk directly to the apiserver?
         }
-        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=' + this.type`;
+        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
       }
     }
 


### PR DESCRIPTION
the way we construct the datasource-query-url was incorrect, and this caused the `?ds_type=...` part to become garbled. the PR fixes this.