### PR TITLE
Prometheus: Add example field for setting the scrape interval in provisioning docs

### DIFF
--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -258,6 +258,7 @@ After you have provisioned a data source you cannot edit it.
           prometheusVersion: 3.3.0
           cacheLevel: 'High'
           disableRecordingRules: false
+          timeInterval: 10s   # Prometheus scrape interval
           incrementalQueryOverlapWindow: 10m
           exemplarTraceIdDestinations:
             # Field with internal link pointing to data source in Grafana.


### PR DESCRIPTION
When using Prometheus as a datasource Grafana can optionally know the scrape interval of Prometheus. In the GUI it is easy to spot, however when provisioning the datasource the example was lacking this information.

This commit adds this missing field to the provisioning example.