### PR TITLE
fix(plugins/azuremonitor): placeholder for client secret

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AppRegistrationCredentials.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AppRegistrationCredentials.tsx
@@ -136,7 +136,7 @@ export const AppRegistrationCredentials = (props: AppRegistrationCredentialsProp
             <Input
               className="width-30"
               aria-label="Client Secret"
-              placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+              placeholder="aVeryLongRandomStringOfLettersNumbersAndSymbols"
               value={credentials.clientSecret || ''}
               onChange={onClientSecretChange}
               id="client-secret"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changing the placeholder for Azure Monitor Client secret field so it doesn't resemble a UUID which confuses that it might be the ID instead of the client secret value required.

**Why do we need this feature?**

It confuses people.

**Who is this feature for?**

Azure Monitor plugin users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
