### PR TITLE
unified-storage: setup distributor module option B

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/common"
@@ -361,6 +362,8 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		}}
 		searchRequest.Options.Fields = append(searchRequest.Options.Fields, namesFilter...)
 	}
+
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", searchRequest.Options.Key.Namespace)
 
 	result, err := s.client.Search(ctx, searchRequest)
 	if err != nil {

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/grpc/metadata"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -63,6 +64,8 @@ func (h *k8sHandler) GetNamespace(orgID int64) string {
 }
 
 func (h *k8sHandler) Get(ctx context.Context, name string, orgID int64, options v1.GetOptions, subresource ...string) (*unstructured.Unstructured, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -72,6 +75,8 @@ func (h *k8sHandler) Get(ctx context.Context, name string, orgID int64, options 
 }
 
 func (h *k8sHandler) Create(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.CreateOptions) (*unstructured.Unstructured, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -81,6 +86,8 @@ func (h *k8sHandler) Create(ctx context.Context, obj *unstructured.Unstructured,
 }
 
 func (h *k8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.UpdateOptions) (*unstructured.Unstructured, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -90,6 +97,8 @@ func (h *k8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured,
 }
 
 func (h *k8sHandler) Delete(ctx context.Context, name string, orgID int64, options v1.DeleteOptions) error {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return err
@@ -99,6 +108,8 @@ func (h *k8sHandler) Delete(ctx context.Context, name string, orgID int64, optio
 }
 
 func (h *k8sHandler) DeleteCollection(ctx context.Context, orgID int64) error {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return err
@@ -108,6 +119,8 @@ func (h *k8sHandler) DeleteCollection(ctx context.Context, orgID int64) error {
 }
 
 func (h *k8sHandler) List(ctx context.Context, orgID int64, options v1.ListOptions) (*unstructured.UnstructuredList, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	client, err := h.getClient(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -130,10 +143,14 @@ func (h *k8sHandler) Search(ctx context.Context, orgID int64, in *resource.Resou
 		}
 	}
 
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", in.Options.Key.Namespace)
+
 	return h.searcher.Search(ctx, in)
 }
 
 func (h *k8sHandler) GetStats(ctx context.Context, orgID int64) (*resource.ResourceStatsResponse, error) {
+	ctx = metadata.AppendToOutgoingContext(ctx, "namespace", h.GetNamespace(orgID))
+
 	// goes directly through grpc, so doesn't need the new context
 	return h.searcher.GetStats(ctx, &resource.ResourceStatsRequest{
 		Namespace: h.GetNamespace(orgID),

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -22,7 +22,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 
 	auth := &Authenticator{Tracer: noop.NewTracerProvider().Tracer("")}
 
-	md := encodeIdentityInMetadata(before)
+	md := encodeIdentityInMetadata(before, "")
 	after, err := auth.decodeMetadata(md)
 	require.NoError(t, err)
 	require.Equal(t, before.GetID(), after.GetID())

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -13,8 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -303,24 +301,6 @@ type server struct {
 	// init checking
 	once    sync.Once
 	initErr error
-}
-
-type RingClient struct {
-	Client ResourceClient
-	grpc_health_v1.HealthClient
-	Conn *grpc.ClientConn
-}
-
-func (c *RingClient) Close() error {
-	return c.Conn.Close()
-}
-
-func (c *RingClient) String() string {
-	return c.RemoteAddress()
-}
-
-func (c *RingClient) RemoteAddress() string {
-	return c.Conn.Target()
 }
 
 // Init implements ResourceServer.


### PR DESCRIPTION
This is an alternative implementation for https://github.com/grafana/grafana/pull/104737

* makes the distributor more generic. I'm only importing the `resource` package for the sake of registering the health service for convenience in this POC.
* we don't **have** to define all the methods manually. **But we can**, if we want to override the behaviour for a particular method

Pros of this approach:

* the distributor is able back any grpc server in grafana. If we have a new module implementation that wants this behaviour, all they need to do is declare the ring as a dependency in the module list, include the lifecycler in the service and the distributor is ready to be deployed
* if we add/remove/change any methods of the storage-api, we don't need to change here, as we only really care about data in the header: namespace (see below a small issue with this) and method name
* arguably we get better performance with this approach, in particular with list methods, as the solution in option A requires the distributor to fully receive the payload from the storage-api before sending it back to the requester, while this one streams the result right away
* there's only one implementation for the proxy here: the streaming one. We can get away with this because grpc uses streaming behind the scenes for unary RPC calls as well. Since we don't have access to the stream in option A, we need to have two proxy implementations, one for unary calls and another for streaming calls (the latter was left as a TODO for now in that PR)

Cons of this approach:

* arguably more annoying to maintain the streaming implementation, as it is lower level
* currently, we can only reliably identify the namespace for a particular request by looking at the request body (which varies from request to request, see in option A how sometimes it's [request.Options.Key.Namespace](https://github.com/grafana/grafana/pull/104737/files#diff-97008c75bb42208f6a9925d3a399187d09e9e732eab09d7728cf1ba4c7e01a98R112), [request.Namespace](https://github.com/grafana/grafana/pull/104737/files#diff-97008c75bb42208f6a9925d3a399187d09e9e732eab09d7728cf1ba4c7e01a98R112) or [request.Key.Namespace](https://github.com/grafana/grafana/pull/104737/files#diff-97008c75bb42208f6a9925d3a399187d09e9e732eab09d7728cf1ba4c7e01a98R132)). For this solution to work, we need this information in the header. This is why I spreaded [this line](https://github.com/grafana/grafana/pull/105192/files#diff-bc2b9865629cb74828a25b010b6f2adfb3657693107f52b3a58558f041401e09R67) everywhere, but ideally we can figure out a way of injecting the stack information from the configuration using a similar approach as the authentication interceptor [here](https://github.com/grafana/grafana/pull/105192/files#diff-774bc616ea1624d0ea8011903c30a68f49bbb85cf5c151232ddfcc554be40f6bR170)