### PR TITLE
search: fix document missing at startup

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -324,6 +324,9 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 	for _, item := range req.Items {
 		switch item.Action {
 		case resource.ActionIndex:
+			if item.Doc == nil {
+				return fmt.Errorf("missing document")
+			}
 			doc := item.Doc.UpdateCopyFields()
 			doc.References = nil // remove references (for now!)
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/db"
-	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -33,11 +32,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationStorageServer(t *testing.T) {
-	if infraDB.IsTestDBSpanner() {
+	if db.IsTestDBSpanner() {
 		t.Skip("skipping integration test")
 	}
 	unitest.RunStorageServerTest(t, func(ctx context.Context) resource.StorageBackend {
-		dbstore := infraDB.InitTestDB(t)
+		dbstore := db.InitTestDB(t)
 		eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, eDB)
@@ -56,13 +55,13 @@ func TestIntegrationStorageServer(t *testing.T) {
 
 // TestStorageBackend is a test for the StorageBackend interface.
 func TestIntegrationSQLStorageBackend(t *testing.T) {
-	if infraDB.IsTestDBSpanner() {
+	if db.IsTestDBSpanner() {
 		t.Skip("skipping integration test")
 	}
 
 	t.Run("IsHA (polling notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			dbstore := infraDB.InitTestDB(t)
+			dbstore := db.InitTestDB(t)
 			eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 			require.NoError(t, err)
 			require.NotNil(t, eDB)
@@ -81,7 +80,7 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 
 	t.Run("NotHA (in process notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			dbstore := infraDB.InitTestDB(t)
+			dbstore := db.InitTestDB(t)
 			eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 			require.NoError(t, err)
 			require.NotNil(t, eDB)
@@ -139,15 +138,15 @@ func TestIntegrationSearchAndStorage(t *testing.T) {
 }
 
 func TestClientServer(t *testing.T) {
-	if infraDB.IsTestDbSQLite() {
+	if db.IsTestDbSQLite() {
 		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	}
-	if infraDB.IsTestDBSpanner() {
+	if db.IsTestDBSpanner() {
 		t.Skip("skipping integration test")
 	}
 
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
-	dbstore := infraDB.InitTestDB(t)
+	dbstore := db.InitTestDB(t)
 
 	cfg := setting.NewCfg()
 	cfg.GRPCServer.Address = "localhost:0" // get a free address

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -114,7 +114,8 @@ func TestIntegrationSearchAndStorage(t *testing.T) {
 	})
 	// Create a new bleve backend
 	search, err := search.NewBleveBackend(search.BleveOptions{
-		Root: tempDir,
+		FileThreshold: 0,
+		Root:          tempDir,
 	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchPermissionFiltering), nil)
 	require.NoError(t, err)
 	require.NotNil(t, search)

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -429,7 +429,7 @@ func (b *testDocumentBuilder) BuildDocument(ctx context.Context, key *resource.R
 
 	title := ""
 	tags := []string{}
-	v := ""
+	val := ""
 
 	spec, ok, _ := unstructured.NestedMap(u.Object, "spec")
 	if ok {
@@ -447,7 +447,7 @@ func (b *testDocumentBuilder) BuildDocument(ctx context.Context, key *resource.R
 			}
 		}
 		if v, ok := spec["value"]; ok {
-			v = v.(string)
+			val = v.(string)
 		}
 	}
 	return &resource.IndexableDocument{
@@ -460,7 +460,7 @@ func (b *testDocumentBuilder) BuildDocument(ctx context.Context, key *resource.R
 		Title: title,
 		Tags:  tags,
 		Fields: map[string]interface{}{
-			"value": v,
+			"value": val,
 		},
 	}, nil
 }

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -58,7 +57,7 @@ func initializeBackend(ctx context.Context, backend resource.StorageBackend, opt
 					WithNamespace(namespace),
 					WithGroup(group),
 					WithResource(resourceType),
-					WithValue([]byte("init")))
+					WithValue("init"))
 				if err != nil {
 					return fmt.Errorf("failed to initialize backend: %w", err)
 				}
@@ -109,7 +108,7 @@ func runStorageBackendBenchmark(ctx context.Context, backend resource.StorageBac
 					WithNamespace(namespace),
 					WithGroup(group),
 					WithResource(resourceType),
-					WithValue([]byte(strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 20)))) // ~1.21 KiB
+					WithValue(strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 20))) // ~1.21 KiB
 
 				if err != nil {
 					errors <- err
@@ -424,7 +423,7 @@ type testDocumentBuilder struct{}
 func (b *testDocumentBuilder) BuildDocument(ctx context.Context, key *resource.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
 	// convert value to unstructured.Unstructured
 	var u unstructured.Unstructured
-	if err := json.Unmarshal(value, &u); err != nil {
+	if err := u.UnmarshalJSON(value); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal value: %w", err)
 	}
 

--- a/pkg/storage/unified/testing/search_and_storage.go
+++ b/pkg/storage/unified/testing/search_and_storage.go
@@ -1,0 +1,246 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func RunTestSearchAndStorage(t *testing.T, ctx context.Context, backend resource.StorageBackend, searchBackend resource.SearchBackend) {
+	// Create a test user with admin permissions
+	testUser := &identity.StaticRequester{
+		Type:           claims.TypeUser,
+		Login:          "testuser",
+		UserID:         123,
+		UserUID:        "u123",
+		OrgRole:        identity.RoleAdmin,
+		IsGrafanaAdmin: true,
+	}
+	ctx = claims.WithAuthInfo(ctx, testUser)
+
+	nsPrefix := "test-ns"
+
+	var server resource.ResourceServer
+
+	t.Run("Create initial resources in storage", func(t *testing.T) {
+		initialResources := []struct {
+			name  string
+			title string
+			tags  []string
+		}{
+			{
+				name:  "initial1",
+				title: "Initial Document 1",
+				tags:  []string{"tag1", "initial"},
+			},
+			{
+				name:  "initial2",
+				title: "Initial Document 2",
+				tags:  []string{"tag2", "initial"},
+			},
+		}
+
+		for _, doc := range initialResources {
+			key := &resource.ResourceKey{
+				Group:     "test.grafana.app",
+				Resource:  "testresources",
+				Namespace: nsPrefix,
+				Name:      doc.name,
+			}
+
+			// Create document using unstructured
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "test.grafana.app/v1",
+					"kind":       "TestResource",
+					"metadata": map[string]interface{}{
+						"name":      doc.name,
+						"namespace": nsPrefix,
+					},
+					"spec": map[string]interface{}{
+						"title": doc.title,
+						"tags":  doc.tags,
+					},
+				},
+			}
+
+			meta, err := utils.MetaAccessor(obj)
+			require.NoError(t, err)
+
+			// Convert unstructured to bytes
+			value, err := obj.MarshalJSON()
+			require.NoError(t, err)
+
+			// Create document
+			rv, err := backend.WriteEvent(ctx, resource.WriteEvent{
+				Type:   resource.WatchEvent_ADDED,
+				Key:    key,
+				Value:  value,
+				Object: meta,
+			})
+			require.NoError(t, err)
+			require.Greater(t, rv, int64(0))
+		}
+	})
+
+	t.Run("Create a resource server with both backends", func(t *testing.T) {
+		// Create a resource server with both backends
+		var err error
+		server, err = resource.NewResourceServer(resource.ResourceServerOptions{
+			Backend: backend,
+			Search: resource.SearchOptions{
+				Backend: searchBackend,
+				Resources: &testDocumentBuilderSupplier{
+					groupsResources: map[string]string{
+						"test.grafana.app": "testresources",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("Search for initial resources", func(t *testing.T) {
+		// Test 1: Search for initial resources
+		searchResp, err := server.Search(ctx, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Group:     "test.grafana.app",
+					Resource:  "testresources",
+					Namespace: nsPrefix,
+				},
+			},
+			Query: "initial",
+			Limit: 10,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, searchResp)
+		require.Nil(t, searchResp.Error)
+		require.Equal(t, int64(2), searchResp.TotalHits)
+	})
+
+	t.Run("Add search documents", func(t *testing.T) {
+		testDocs := []struct {
+			name  string
+			title string
+			tags  []string
+		}{
+			{
+				name:  "doc1",
+				title: "First Test Document",
+				tags:  []string{"test", "first"},
+			},
+			{
+				name:  "doc2",
+				title: "Second Test Document",
+				tags:  []string{"test", "second"},
+			},
+			{
+				name:  "doc3",
+				title: "Third Test Document",
+				tags:  []string{"test", "third"},
+			},
+		}
+
+		for _, doc := range testDocs {
+			key := &resource.ResourceKey{
+				Group:     "test.grafana.app",
+				Resource:  "testresources",
+				Namespace: nsPrefix,
+				Name:      doc.name,
+			}
+
+			// Create document using unstructured
+			obj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "test.grafana.app/v1",
+					"kind":       "TestResource",
+					"metadata": map[string]interface{}{
+						"name":      doc.name,
+						"namespace": nsPrefix,
+					},
+					"spec": map[string]interface{}{
+						"title": doc.title,
+						"tags":  doc.tags,
+					},
+				},
+			}
+
+			// Convert unstructured to bytes
+			value, err := obj.MarshalJSON()
+			require.NoError(t, err)
+
+			// Create document
+			createResp, err := server.Create(ctx, &resource.CreateRequest{
+				Key:   key,
+				Value: value,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, createResp)
+			require.Nil(t, createResp.Error)
+		}
+	})
+
+	t.Run("Search for documents", func(t *testing.T) {
+		searchResp, err := server.Search(ctx, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Group:     "test.grafana.app",
+					Resource:  "testresources",
+					Namespace: nsPrefix,
+				},
+			},
+			Query: "Test Document",
+			Limit: 10,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, searchResp)
+		require.Nil(t, searchResp.Error)
+		require.Equal(t, int64(3), searchResp.TotalHits)
+
+	})
+
+	t.Run("Search with tags", func(t *testing.T) {
+		searchResp, err := server.Search(ctx, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Group:     "test.grafana.app",
+					Resource:  "testresources",
+					Namespace: nsPrefix,
+				},
+			},
+			Query: "first",
+			Limit: 10,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, searchResp)
+		require.Nil(t, searchResp.Error)
+		require.Equal(t, int64(1), searchResp.TotalHits)
+
+	})
+
+	t.Run("Search with specific tag", func(t *testing.T) {
+		searchResp, err := server.Search(ctx, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Group:     "test.grafana.app",
+					Resource:  "testresources",
+					Namespace: nsPrefix,
+				},
+			},
+			Query: "test",
+			Limit: 10,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, searchResp)
+		require.Nil(t, searchResp.Error)
+		require.Equal(t, int64(3), searchResp.TotalHits)
+	})
+}

--- a/pkg/storage/unified/testing/search_and_storage.go
+++ b/pkg/storage/unified/testing/search_and_storage.go
@@ -204,7 +204,6 @@ func RunTestSearchAndStorage(t *testing.T, ctx context.Context, backend resource
 		require.NotNil(t, searchResp)
 		require.Nil(t, searchResp.Error)
 		require.Equal(t, int64(3), searchResp.TotalHits)
-
 	})
 
 	t.Run("Search with tags", func(t *testing.T) {
@@ -223,7 +222,6 @@ func RunTestSearchAndStorage(t *testing.T, ctx context.Context, backend resource
 		require.NotNil(t, searchResp)
 		require.Nil(t, searchResp.Error)
 		require.Equal(t, int64(1), searchResp.TotalHits)
-
 	})
 
 	t.Run("Search with specific tag", func(t *testing.T) {

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -160,7 +160,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 	require.NotNil(t, index)
 
 	t.Run("Search", func(t *testing.T) {
-		req := &resource.ResourceSearchRequest{
+		resp, err := index.Search(ctx, nil, &resource.ResourceSearchRequest{
 			Options: &resource.ListOptions{
 				Key: &resource.ResourceKey{
 					Namespace: ns.Namespace,
@@ -171,10 +171,68 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 			Fields: []string{"title", "folder", "tags"},
 			Query:  "tag3",
 			Limit:  10,
-		}
-		resp, err := index.Search(ctx, nil, req, nil)
+		}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, int64(1), resp.TotalHits) // Only doc3 should have tag3 now
+
+		// Search for Document
+		resp, err = index.Search(ctx, nil, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Query:  "Document",
+			Fields: []string{"title", "folder", "tags"},
+			Limit:  10,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(2), resp.TotalHits) // Both doc1 and doc2 should have doc now
+	})
+
+	t.Run("Add a new document", func(t *testing.T) {
+		// Add a new document
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.ActionIndex,
+					Doc: &resource.IndexableDocument{
+						Key: &resource.ResourceKey{
+							Namespace: ns.Namespace,
+							Group:     ns.Group,
+							Resource:  ns.Resource,
+							Name:      "doc3",
+						},
+						Title: "Document 3",
+						Tags:  []string{"tag3", "tag4"},
+						Fields: map[string]interface{}{
+							"field1": 3,
+							"field2": "value3",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		// Search for Document
+		resp, err := index.Search(ctx, nil, &resource.ResourceSearchRequest{
+			Options: &resource.ListOptions{
+				Key: &resource.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Query:  "Document",
+			Fields: []string{"title", "folder", "tags"},
+			Limit:  10,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(3), resp.TotalHits) // Both doc1, doc2, and doc3 should have doc now
 	})
 }

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -144,7 +144,7 @@ func runTestIntegrationBackendHappyPath(t *testing.T, backend resource.StorageBa
 		})
 		require.Nil(t, resp.Error)
 		require.Equal(t, rv4, resp.ResourceVersion)
-		require.Equal(t, "item2 MODIFIED", string(resp.Value))
+		require.Contains(t, string(resp.Value), "item2 MODIFIED")
 		require.Equal(t, "folderuid", resp.Folder)
 	})
 
@@ -160,7 +160,7 @@ func runTestIntegrationBackendHappyPath(t *testing.T, backend resource.StorageBa
 		})
 		require.Nil(t, resp.Error)
 		require.Equal(t, rv2, resp.ResourceVersion)
-		require.Equal(t, "item2 ADDED", string(resp.Value))
+		require.Contains(t, string(resp.Value), "item2 ADDED")
 	})
 
 	t.Run("List latest", func(t *testing.T) {
@@ -176,8 +176,8 @@ func runTestIntegrationBackendHappyPath(t *testing.T, backend resource.StorageBa
 		require.NoError(t, err)
 		require.Nil(t, resp.Error)
 		require.Len(t, resp.Items, 2)
-		require.Equal(t, "item2 MODIFIED", string(resp.Items[0].Value))
-		require.Equal(t, "item3 ADDED", string(resp.Items[1].Value))
+		require.Contains(t, string(resp.Items[0].Value), "item2 MODIFIED")
+		require.Contains(t, string(resp.Items[1].Value), "item3 ADDED")
 		require.GreaterOrEqual(t, resp.ResourceVersion, rv5) // rv5 is the latest resource version
 	})
 
@@ -373,11 +373,11 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 5)
 		// should be sorted by key ASC
-		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
-		require.Equal(t, "item5 ADDED", string(res.Items[3].Value))
-		require.Equal(t, "item6 ADDED", string(res.Items[4].Value))
+		require.Contains(t, string(res.Items[0].Value), "item1 ADDED")
+		require.Contains(t, string(res.Items[1].Value), "item2 MODIFIED")
+		require.Contains(t, string(res.Items[2].Value), "item4 ADDED")
+		require.Contains(t, string(res.Items[3].Value), "item5 ADDED")
+		require.Contains(t, string(res.Items[4].Value), "item6 ADDED")
 
 		require.Empty(t, res.NextPageToken)
 	})
@@ -397,9 +397,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		require.Len(t, res.Items, 3)
 		continueToken, err := resource.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
-		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
+		require.Contains(t, string(res.Items[0].Value), "item1 ADDED")
+		require.Contains(t, string(res.Items[1].Value), "item2 MODIFIED")
+		require.Contains(t, string(res.Items[2].Value), "item4 ADDED")
 		require.GreaterOrEqual(t, continueToken.ResourceVersion, rv8)
 	})
 
@@ -416,10 +416,10 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		require.NoError(t, err)
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 4)
-		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item2 ADDED", string(res.Items[1].Value))
-		require.Equal(t, "item3 ADDED", string(res.Items[2].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[3].Value))
+		require.Contains(t, string(res.Items[0].Value), "item1 ADDED")
+		require.Contains(t, string(res.Items[1].Value), "item2 ADDED")
+		require.Contains(t, string(res.Items[2].Value), "item3 ADDED")
+		require.Contains(t, string(res.Items[3].Value), "item4 ADDED")
 		require.Empty(t, res.NextPageToken)
 	})
 
@@ -439,9 +439,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 3)
 		t.Log(res.Items)
-		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
+		require.Contains(t, string(res.Items[0].Value), "item1 ADDED")
+		require.Contains(t, string(res.Items[1].Value), "item2 MODIFIED")
+		require.Contains(t, string(res.Items[2].Value), "item4 ADDED")
 
 		continueToken, err := resource.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
@@ -468,8 +468,8 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 2)
 		t.Log(res.Items)
-		require.Equal(t, "item4 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item5 ADDED", string(res.Items[1].Value))
+		require.Contains(t, string(res.Items[0].Value), "item4 ADDED")
+		require.Contains(t, string(res.Items[1].Value), "item5 ADDED")
 
 		continueToken, err = resource.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
@@ -580,7 +580,7 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 				// Check versions and values match expectations
 				for i := 0; i < 3; i++ {
 					require.Equal(t, tc.expectedVersions[i], res.Items[i].ResourceVersion)
-					require.Equal(t, tc.expectedValues[i], string(res.Items[i].Value))
+					require.Contains(t, string(res.Items[i].Value), tc.expectedValues[i])
 				}
 
 				// Check resource version in response
@@ -628,7 +628,7 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 			expectedRVs := []int64{rvHistory3, rvHistory4, rvHistory5}
 			for i, expectedRV := range expectedRVs {
 				require.Equal(t, expectedRV, secondPageRes.Items[i].ResourceVersion)
-				require.Equal(t, "item1 MODIFIED", string(secondPageRes.Items[i].Value))
+				require.Contains(t, string(secondPageRes.Items[i].Value), "item1 MODIFIED")
 			}
 		})
 	})
@@ -656,9 +656,9 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 2)
 		t.Log(res.Items)
-		require.Equal(t, "item1 MODIFIED", string(res.Items[0].Value))
+		require.Contains(t, string(res.Items[0].Value), "item1 MODIFIED")
 		require.Equal(t, rvHistory2, res.Items[0].ResourceVersion)
-		require.Equal(t, "item1 MODIFIED", string(res.Items[1].Value))
+		require.Contains(t, string(res.Items[1].Value), "item1 MODIFIED")
 		require.Equal(t, rvHistory1, res.Items[1].ResourceVersion)
 	})
 
@@ -770,11 +770,11 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 
 		// Verify the first item is the initial ADDED event
 		require.Equal(t, initialRV, allItems[0].ResourceVersion, "First item should be the initial ADDED event")
-		require.Equal(t, "paged-item ADDED", string(allItems[0].Value))
+		require.Contains(t, string(allItems[0].Value), "paged-item ADDED")
 
 		// Verify all other items are MODIFIED events and correspond to our recorded resource versions
 		for i := 1; i < len(allItems); i++ {
-			require.Equal(t, "paged-item MODIFIED", string(allItems[i].Value))
+			require.Contains(t, string(allItems[i].Value), "paged-item MODIFIED")
 			require.Equal(t, resourceVersions[i], allItems[i].ResourceVersion)
 		}
 	})
@@ -835,9 +835,9 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 		require.NoError(t, err)
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 2)
-		require.Equal(t, "deleted-item MODIFIED", string(res.Items[0].Value))
+		require.Contains(t, string(res.Items[0].Value), "deleted-item MODIFIED")
 		require.Equal(t, rv2, res.Items[0].ResourceVersion)
-		require.Equal(t, "deleted-item ADDED", string(res.Items[1].Value))
+		require.Contains(t, string(res.Items[1].Value), "deleted-item ADDED")
 		require.Equal(t, rv1, res.Items[1].ResourceVersion)
 	})
 }
@@ -933,11 +933,11 @@ func runTestIntegrationBlobSupport(t *testing.T, backend resource.StorageBackend
 		// Check that we can still access both values
 		found, err := store.GetResourceBlob(ctx, key, &utils.BlobInfo{UID: b1.Uid}, true)
 		require.NoError(t, err)
-		require.Equal(t, []byte("hello 11111"), found.Value)
+		require.Contains(t, string(found.Value), "hello 11111")
 
 		found, err = store.GetResourceBlob(ctx, key, &utils.BlobInfo{UID: b2.Uid}, true)
 		require.NoError(t, err)
-		require.Equal(t, []byte("hello 22222"), found.Value)
+		require.Contains(t, string(found.Value), "hello 22222")
 
 		// Save a resource with annotation
 		obj := &unstructured.Unstructured{}
@@ -959,13 +959,13 @@ func runTestIntegrationBlobSupport(t *testing.T, backend resource.StorageBackend
 		res, err := server.GetBlob(ctx, &resource.GetBlobRequest{Resource: key})
 		require.NoError(t, err)
 		require.Nil(t, out.Error)
-		require.Equal(t, "hello 22222", string(res.Value))
+		require.Contains(t, string(res.Value), "hello 22222")
 
 		// But we can still get an older version with an explicit UID
 		res, err = server.GetBlob(ctx, &resource.GetBlobRequest{Resource: key, Uid: b1.Uid})
 		require.NoError(t, err)
 		require.Nil(t, out.Error)
-		require.Equal(t, "hello 11111", string(res.Value))
+		require.Contains(t, string(res.Value), "hello 11111")
 	})
 }
 


### PR DESCRIPTION
Fix issue introduced in https://github.com/grafana/grafana/pull/104163 where all the documents would reuse the same key (BuildDocument takes a pointer the the key 😢 )

Add lots of integration tests 