### PR TITLE
Dashboards: Remove numeric folder id from annotation metadata

### DIFF
--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -70,8 +70,6 @@ export const AnnoKeyDashboardGnetId = 'grafana.app/dashboard-gnet-id';
 /** @deprecated NOT A REAL annotation -- this is just a shim */
 export const AnnoKeyFolderTitle = 'grafana.app/folderTitle';
 /** @deprecated NOT A REAL annotation -- this is just a shim */
-export const AnnoKeyFolderId = 'grafana.app/folderId';
-/** @deprecated NOT A REAL annotation -- this is just a shim */
 export const AnnoKeyFolderUrl = 'grafana.app/folderUrl';
 
 // labels
@@ -98,8 +96,6 @@ type GrafanaClientAnnotations = {
   [AnnoKeySlug]?: string;
   [AnnoKeyFolderTitle]?: string;
   [AnnoKeyFolderUrl]?: string;
-  [AnnoKeyFolderId]?: number;
-  [AnnoKeyFolderId]?: number;
   [AnnoKeySavedFromUI]?: string;
   [AnnoKeyDashboardIsSnapshot]?: boolean;
   [AnnoKeyDashboardSnapshotOriginalUrl]?: string;

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -5,7 +5,6 @@ import {
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
   AnnoKeyFolder,
-  AnnoKeyFolderId,
   AnnoKeyFolderTitle,
   AnnoKeyFolderUrl,
   AnnoKeyMessage,
@@ -106,7 +105,6 @@ describe('v2 dashboard API', () => {
     // parameter convertToV1, we need to cast the result to DashboardWithAccessInfo<DashboardV2Spec> to be able to
     // access
     const result = (await api.getDashboardDTO('test')) as DashboardWithAccessInfo<DashboardV2Spec>;
-    expect(result.metadata.annotations![AnnoKeyFolderId]).toBe(1);
     expect(result.metadata.annotations![AnnoKeyFolderTitle]).toBe('New Folder');
     expect(result.metadata.annotations![AnnoKeyFolderUrl]).toBe('/folder/url');
     expect(result.metadata.annotations![AnnoKeyFolder]).toBe('new-folder');
@@ -199,7 +197,6 @@ describe('v2 dashboard API', () => {
           annotations: {
             [AnnoKeyFolder]: 'folderUidXyz',
             [AnnoKeyFolderUrl]: 'url folder used in the client',
-            [AnnoKeyFolderId]: 42,
             [AnnoKeyFolderTitle]: 'title folder used in the client',
           },
         },

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -6,7 +6,6 @@ import kbn from 'app/core/utils/kbn';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import {
   AnnoKeyFolder,
-  AnnoKeyFolderId,
   AnnoKeyFolderTitle,
   AnnoKeyFolderUrl,
   AnnoKeyMessage,
@@ -58,7 +57,6 @@ export class K8sDashboardV2API
           const folder = await backendSrv.getFolderByUid(dashboard.metadata.annotations[AnnoKeyFolder]);
           dashboard.metadata.annotations[AnnoKeyFolderTitle] = folder.title;
           dashboard.metadata.annotations[AnnoKeyFolderUrl] = folder.url;
-          dashboard.metadata.annotations[AnnoKeyFolderId] = folder.id;
         } catch (e) {
           throw new Error('Failed to load folder');
         }
@@ -121,7 +119,6 @@ export class K8sDashboardV2API
       // remove frontend folder annotations
       delete obj.metadata.annotations?.[AnnoKeyFolderTitle];
       delete obj.metadata.annotations?.[AnnoKeyFolderUrl];
-      delete obj.metadata.annotations?.[AnnoKeyFolderId];
 
       obj.metadata.annotations = {
         ...obj.metadata.annotations,


### PR DESCRIPTION
Using numeric folder id is no longer necessary *and* it is an invalid property in metdata annotations (they must all be strings)

This PR removes the property, it is not used anyway