### PR TITLE
Chore: Integration test sharding

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -37,9 +37,14 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
     env:
       GRAFANA_TEST_DB: mysql
       MYSQL_HOST: 127.0.0.1
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_COUNT: 4
     services:
       mysql:
         image: mysql:8.0.32
@@ -65,7 +70,11 @@ jobs:
           sudo apt-get update -yq && sudo apt-get install mariadb-client
           cat devenv/docker/blocks/mysql_tests/setup.sql | mariadb -h 127.0.0.1 -P 3306 -u root -prootpass --disable-ssl-verify-server-cert
           make gen-go
-          go test -tags=mysql -p=1 -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
+          ALL_TESTS=$(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
+          echo "Running tests in shard $SHARD_INDEX of $SHARD_COUNT"
+          SHARD_TESTS=$(echo "$ALL_TESTS" | awk -v shard="$SHARD_INDEX" -v count="$SHARD_COUNT" 'NR % count == shard')
+          echo "Running tests in shard $SHARD_INDEX of $SHARD_COUNT: $SHARD_TESTS"
+          go test -tags=mysql -p=1 -timeout=5m -run '^TestIntegration' $SHARD_TESTS
   postgres:
     name: Postgres
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -80,6 +80,9 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
     services:
       postgres:
         image: postgres:12.3-alpine
@@ -87,6 +90,8 @@ jobs:
           POSTGRES_USER: grafanatest
           POSTGRES_PASSWORD: grafanatest
           POSTGRES_DB: grafanatest
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_COUNT: 4
         ports:
           - 5432:5432
     steps:
@@ -107,4 +112,8 @@ jobs:
           sudo apt-get update -yq && sudo apt-get install postgresql-client
           psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
           make gen-go
-          go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
+          ALL_TESTS=$(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
+          echo "Running tests in shard $SHARD_INDEX of $SHARD_COUNT"
+          SHARD_TESTS=$(echo "$ALL_TESTS" | awk -v shard="$SHARD_INDEX" -v count="$SHARD_COUNT" 'NR % count == shard')
+          echo "Running tests in shard $SHARD_INDEX of $SHARD_COUNT: $SHARD_TESTS"
+          go test -tags=postgres -p=1 -timeout=5m -run '^TestIntegration' $SHARD_TESTS

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -90,8 +90,6 @@ jobs:
           POSTGRES_USER: grafanatest
           POSTGRES_PASSWORD: grafanatest
           POSTGRES_DB: grafanatest
-          SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_COUNT: 4
         ports:
           - 5432:5432
     steps:
@@ -108,6 +106,8 @@ jobs:
           GRAFANA_TEST_DB: postgres
           PGPASSWORD: grafanatest
           POSTGRES_HOST: 127.0.0.1
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_COUNT: 4
         run: |
           sudo apt-get update -yq && sudo apt-get install postgresql-client
           psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql


### PR DESCRIPTION
This PR splits integration tests (MySQL+Postgres) into N shards on package basis and each job then runs a subset of tests. This should improve waiting times for most Go PRs.