### PR TITLE
Crypto: Use stdlib methods with FIPS-140-3 compliance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	go.uber.org/goleak v1.3.0 // @grafana/grafana-search-and-storage
 	go.uber.org/zap v1.27.0 // @grafana/identity-access-team
 	gocloud.dev v0.40.0 // @grafana/grafana-app-platform-squad
-	golang.org/x/crypto v0.37.0 // @grafana/grafana-backend-group
+	golang.org/x/crypto v0.37.0 // indirect; @grafana/grafana-backend-group
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // @grafana/alerting-backend
 	golang.org/x/mod v0.24.0 // indirect; @grafana/grafana-backend-group
 	golang.org/x/net v0.39.0 // @grafana/oss-big-tent @grafana/partner-datasources

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -2,7 +2,7 @@ package cloudmigrationimpl
 
 import (
 	"context"
-	cryptoRand "crypto/rand"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/crypto/nacl/box"
 
 	snapshot "github.com/grafana/grafana-cloud-migration-snapshot/src"
 	"github.com/grafana/grafana-cloud-migration-snapshot/src/contracts"
@@ -553,7 +552,7 @@ func (s *Service) buildSnapshot(
 		s.log.Debug(fmt.Sprintf("buildSnapshot: method completed in %d ms", time.Since(start).Milliseconds()))
 	}()
 
-	publicKey, privateKey, err := box.GenerateKey(cryptoRand.Reader)
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		return fmt.Errorf("nacl: generating public and private key: %w", err)
 	}

--- a/pkg/services/cloudmigration/gmsclient/inmemory_client.go
+++ b/pkg/services/cloudmigration/gmsclient/inmemory_client.go
@@ -2,13 +2,12 @@ package gmsclient
 
 import (
 	"context"
-	cryptoRand "crypto/rand"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
-	"golang.org/x/crypto/nacl/box"
 
 	"github.com/grafana/grafana/pkg/services/cloudmigration"
 )
@@ -31,7 +30,7 @@ func (c *memoryClientImpl) ValidateKey(ctx context.Context, cm cloudmigration.Cl
 }
 
 func (c *memoryClientImpl) StartSnapshot(_ context.Context, sess cloudmigration.CloudMigrationSession) (*cloudmigration.StartSnapshotResponse, error) {
-	publicKey, _, err := box.GenerateKey(cryptoRand.Reader)
+	publicKey, _, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		return nil, fmt.Errorf("nacl: generating public and private key: %w", err)
 	}

--- a/pkg/services/encryption/encryption.go
+++ b/pkg/services/encryption/encryption.go
@@ -2,9 +2,8 @@ package encryption
 
 import (
 	"context"
+	"crypto/pbkdf2"
 	"crypto/sha256"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -44,5 +43,5 @@ type Provider interface {
 
 // KeyToBytes key length needs to be 32 bytes
 func KeyToBytes(secret, salt string) ([]byte, error) {
-	return pbkdf2.Key([]byte(secret), []byte(salt), 10000, 32, sha256.New), nil
+	return pbkdf2.Key(sha256.New, secret, []byte(salt), 10000, 32)
 }

--- a/pkg/util/encoding.go
+++ b/pkg/util/encoding.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -9,8 +10,6 @@ import (
 	"io"
 	"mime/quotedprintable"
 	"strings"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -51,7 +50,10 @@ func GetRandomString(n int, alphabets ...byte) (string, error) {
 
 // EncodePassword encodes a password using PBKDF2.
 func EncodePassword(password string, salt string) (string, error) {
-	newPasswd := pbkdf2.Key([]byte(password), []byte(salt), 10000, 50, sha256.New)
+	newPasswd, err := pbkdf2.Key(sha256.New, password, []byte(salt), 10000, 50)
+	if err != nil {
+		return "", err
+	}
 	return hex.EncodeToString(newPasswd), nil
 }
 

--- a/pkg/util/encryption.go
+++ b/pkg/util/encryption.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -146,5 +145,5 @@ func Encrypt(payload []byte, secret string) ([]byte, error) {
 
 // Key needs to be 32bytes
 func encryptionKeyToBytes(secret, salt string) ([]byte, error) {
-	return pbkdf2.Key([]byte(secret), []byte(salt), 10000, 32, sha256.New), nil
+	return pbkdf2.Key(sha256.New, secret, []byte(salt), 10000, 32)
 }


### PR DESCRIPTION
**What is this feature?**

Removes usage of `golang.org/x/crypto` in favour of methods available in the standard library.

**Why do we need this feature?**

The methods in the standard library are built with FIPS 140-3 compliance in mind.

This is a step into this direction, but for now we still need to use BoringCrypto as a means to build FIPS 140 binaries.

**Who is this feature for?**

Users who need FIPS 140-3 compliance.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
