### PR TITLE
Alerting: Set folder permissions to "view" for nested folder selectors

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportFromDSRules.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportFromDSRules.tsx
@@ -151,6 +151,7 @@ const ImportFromDSRules = () => {
                         render={({ field: { onChange, ref, ...field } }) => (
                           <Stack width={42}>
                             <NestedFolderPicker
+                              permission="view"
                               showRootFolder={false}
                               invalid={!!errors.targetFolder?.message}
                               {...field}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx
@@ -50,6 +50,7 @@ export function FolderSelector() {
               render={({ field: { ref, ...field } }) => (
                 <div style={{ width: 420 }}>
                   <NestedFolderPicker
+                    permission="view"
                     showRootFolder={false}
                     invalid={!!errors.folder?.message}
                     {...field}


### PR DESCRIPTION
Alerts are allowed to be created in folders where the user only has the "read" permission, "write" permissions is not required and is only used to allow creating new folders.