### PR TITLE
Prometheus library: Replace data-test-id with data-testid

### DIFF
--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -67,7 +67,7 @@ describe('Prometheus query editor', () => {
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
     cy.get(`[data-test-id="prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-test-id="prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -67,7 +67,7 @@ describe.skip('Prometheus query editor', () => {
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
     cy.get(`[data-test-id="prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-test-id="prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -112,7 +112,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
                 <EditorSwitch
                   value={query.exemplar || false}
                   onChange={onExemplarChange}
-                  data-test-id="prometheus-exemplars"
+                  data-testid={selectors.components.DataSource.Prometheus.queryEditor.exemplars}
                 />
               </EditorField>
             )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Prompted by this: https://github.com/grafana/grafana-amazonprometheus-datasource/issues/306
It seems like there used to be a [reason](https://github.com/grafana/grafana/pull/93736#discussion_r1775110801) there was `data-test-id` instead of `data-testid` here, but adding it now it seems like it passes the prop ok? 
<img width="234" alt="Screenshot 2025-05-12 at 13 34 23" src="https://github.com/user-attachments/assets/07a8eaff-0bb6-4b3a-8e8e-db775910ab59" />

**Why do we need this feature?**

Fix some tech debt

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
