### PR TITLE
FilterByValueTransformer: Suggest variable regex formatter

### DIFF
--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.test.tsx
@@ -3,14 +3,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { FieldType } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
-import { regexMatcherEditor } from './RegexMatcherEditor';
+import { basicMatcherEditor } from './BasicMatcherEditor';
 
 jest.mock('@grafana/runtime', () => ({
   getTemplateSrv: jest.fn(),
 }));
 
-describe('RegexMatcherEditor', () => {
-  it('adds :regex suffix to variable suggestions', async () => {
+describe('BasicMatcherEditor', () => {
+  it('shows variable suggestions', async () => {
     // Mock template service variables
     const mockVariables = [
       { name: 'var1', label: 'Variable 1', value: '$var1' },
@@ -30,7 +30,7 @@ describe('RegexMatcherEditor', () => {
       values: [],
     };
 
-    const Editor = regexMatcherEditor({ validator: () => true });
+    const Editor = basicMatcherEditor({ validator: () => true });
     render(<Editor options={options} onChange={onChangeMock} field={field} />);
 
     // Focus the input and press $ to trigger suggestions
@@ -41,15 +41,12 @@ describe('RegexMatcherEditor', () => {
     // Wait for suggestions to appear and verify
     await waitFor(() => {
       const suggestions = screen.getAllByRole('menuitem');
-      // Verify exact number of suggestions (each variable has both regular and regex versions)
-      expect(suggestions).toHaveLength(mockVariables.length * 2);
+      // Verify exact number of suggestions
+      expect(suggestions).toHaveLength(mockVariables.length);
 
       mockVariables.forEach((variable) => {
-        const regularSuggestion = suggestions.find((s) => s.textContent?.includes(variable.label));
-        const regexSuggestion = suggestions.find((s) => s.textContent?.includes(`${variable.label}:regex`));
-
-        expect(regularSuggestion).toBeInTheDocument();
-        expect(regexSuggestion).toBeInTheDocument();
+        const suggestion = suggestions.find((s) => s.textContent?.includes(variable.label));
+        expect(suggestion).toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-import { FieldType } from '@grafana/data';
+import { FieldType, TypedVariableModel } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { basicMatcherEditor } from './BasicMatcherEditor';
@@ -12,14 +12,19 @@ jest.mock('@grafana/runtime', () => ({
 describe('BasicMatcherEditor', () => {
   it('shows variable suggestions', async () => {
     // Mock template service variables
-    const mockVariables = [
-      { name: 'var1', label: 'Variable 1', value: '$var1' },
-      { name: 'var2', label: 'Variable 2', value: '$var2' },
+    const mockVariables: TypedVariableModel[] = [
+      { name: 'var1', label: 'Variable 1', type: 'custom' } as TypedVariableModel,
+      { name: 'var2', label: 'Variable 2', type: 'custom' } as TypedVariableModel,
     ];
 
-    (getTemplateSrv as jest.Mock).mockReturnValue({
+    const mockTemplateSrv = {
       getVariables: () => mockVariables,
-    });
+      replace: jest.fn(),
+      containsTemplate: jest.fn(),
+      updateTimeRange: jest.fn(),
+    };
+
+    jest.mocked(getTemplateSrv).mockReturnValue(mockTemplateSrv);
 
     const onChangeMock = jest.fn();
     const options = { value: '' };
@@ -45,7 +50,7 @@ describe('BasicMatcherEditor', () => {
       expect(suggestions).toHaveLength(mockVariables.length);
 
       mockVariables.forEach((variable) => {
-        const suggestion = suggestions.find((s) => s.textContent?.includes(variable.label));
+        const suggestion = suggestions.find((s) => s.textContent?.includes(variable.label as string));
         expect(suggestion).toBeInTheDocument();
       });
     });

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/NoopMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/NoopMatcherEditor.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import { NoopMatcherEditor } from './NoopMatcherEditor';
+
+describe('NoopMatcherEditor', () => {
+  it('renders nothing', () => {
+    const { container } = render(<NoopMatcherEditor />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { FieldType } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+
+import { rangeMatcherEditor } from './RangeMatcherEditor';
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: jest.fn(),
+}));
+
+describe('RangeMatcherEditor', () => {
+  it('shows variable suggestions for both from and to inputs', async () => {
+    // Mock template service variables
+    const mockVariables = [
+      { name: 'var1', label: 'Variable 1', value: '$var1' },
+      { name: 'var2', label: 'Variable 2', value: '$var2' },
+    ];
+
+    (getTemplateSrv as jest.Mock).mockReturnValue({
+      getVariables: () => mockVariables,
+    });
+
+    const onChangeMock = jest.fn();
+    const options = { from: '', to: '' };
+    const field = {
+      name: 'test',
+      type: FieldType.string,
+      config: {},
+      values: [],
+    };
+
+    const Editor = rangeMatcherEditor({ validator: () => true });
+    render(<Editor options={options} onChange={onChangeMock} field={field} />);
+
+    // Test "from" input
+    const fromInput = screen.getByPlaceholderText('From');
+    fireEvent.focus(fromInput);
+    fireEvent.keyDown(fromInput, { key: '$' });
+
+    // Wait for suggestions to appear and verify for "from" input
+    await waitFor(() => {
+      const menus = screen.getAllByRole('menu');
+      const fromMenu = menus[0]; // First menu is for the "from" input
+      const fromSuggestions = fromMenu.querySelectorAll('[role="menuitem"]');
+      // Verify exact number of suggestions for "from" input
+      expect(fromSuggestions).toHaveLength(mockVariables.length);
+
+      mockVariables.forEach((variable) => {
+        const suggestion = Array.from(fromSuggestions).find((s) => s.textContent?.includes(variable.label));
+        expect(suggestion).toBeInTheDocument();
+      });
+    });
+
+    // Clear suggestions
+    fireEvent.blur(fromInput);
+
+    // Test "to" input
+    const toInput = screen.getByPlaceholderText('To');
+    fireEvent.focus(toInput);
+    fireEvent.keyDown(toInput, { key: '$' });
+
+    // Wait for suggestions to appear and verify for "to" input
+    await waitFor(() => {
+      const menus = screen.getAllByRole('menu');
+      const toMenu = menus[1];
+      const toSuggestions = toMenu.querySelectorAll('[role="menuitem"]');
+      // Verify exact number of suggestions for "to" input
+      expect(toSuggestions).toHaveLength(mockVariables.length);
+
+      mockVariables.forEach((variable) => {
+        const suggestion = Array.from(toSuggestions).find((s) => s.textContent?.includes(variable.label));
+        expect(suggestion).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-import { FieldType } from '@grafana/data';
+import { FieldType, TypedVariableModel } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { rangeMatcherEditor } from './RangeMatcherEditor';
@@ -12,14 +12,19 @@ jest.mock('@grafana/runtime', () => ({
 describe('RangeMatcherEditor', () => {
   it('shows variable suggestions for both from and to inputs', async () => {
     // Mock template service variables
-    const mockVariables = [
-      { name: 'var1', label: 'Variable 1', value: '$var1' },
-      { name: 'var2', label: 'Variable 2', value: '$var2' },
+    const mockVariables: TypedVariableModel[] = [
+      { name: 'var1', label: 'Variable 1', type: 'custom' } as TypedVariableModel,
+      { name: 'var2', label: 'Variable 2', type: 'custom' } as TypedVariableModel,
     ];
 
-    (getTemplateSrv as jest.Mock).mockReturnValue({
+    const mockTemplateSrv = {
       getVariables: () => mockVariables,
-    });
+      replace: jest.fn(),
+      containsTemplate: jest.fn(),
+      updateTimeRange: jest.fn(),
+    };
+
+    jest.mocked(getTemplateSrv).mockReturnValue(mockTemplateSrv);
 
     const onChangeMock = jest.fn();
     const options = { from: '', to: '' };
@@ -47,7 +52,7 @@ describe('RangeMatcherEditor', () => {
       expect(fromSuggestions).toHaveLength(mockVariables.length);
 
       mockVariables.forEach((variable) => {
-        const suggestion = Array.from(fromSuggestions).find((s) => s.textContent?.includes(variable.label));
+        const suggestion = Array.from(fromSuggestions).find((s) => s.textContent?.includes(variable.label as string));
         expect(suggestion).toBeInTheDocument();
       });
     });
@@ -69,7 +74,7 @@ describe('RangeMatcherEditor', () => {
       expect(toSuggestions).toHaveLength(mockVariables.length);
 
       mockVariables.forEach((variable) => {
-        const suggestion = Array.from(toSuggestions).find((s) => s.textContent?.includes(variable.label));
+        const suggestion = Array.from(toSuggestions).find((s) => s.textContent?.includes(variable.label as string));
         expect(suggestion).toBeInTheDocument();
       });
     });

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { FieldType } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+
+import { regexMatcherEditor } from './RegexMatcherEditor';
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: jest.fn(),
+}));
+
+describe('RegexMatcherEditor', () => {
+  it('adds :regex suffix to variable suggestions', async () => {
+    // Mock template service variables
+    const mockVariables = [
+      { name: 'var1', label: 'Variable 1', value: '$var1' },
+      { name: 'var2', label: 'Variable 2', value: '$var2' },
+    ];
+
+    (getTemplateSrv as jest.Mock).mockReturnValue({
+      getVariables: () => mockVariables,
+    });
+
+    const onChangeMock = jest.fn();
+    const options = { value: '' };
+    const field = {
+      name: 'test',
+      type: FieldType.string,
+      config: {},
+      values: [],
+    };
+
+    const Editor = regexMatcherEditor({ validator: () => true });
+    render(<Editor options={options} onChange={onChangeMock} field={field} />);
+
+    // Focus the input and press $ to trigger suggestions
+    const input = screen.getByPlaceholderText('Value or variable');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: '$' });
+
+    // Wait for suggestions to appear and verify
+    await waitFor(() => {
+      const suggestions = screen.getAllByRole('menuitem');
+      mockVariables.forEach((variable) => {
+        const regularSuggestion = suggestions.find((s) => s.textContent?.includes(variable.label));
+        const regexSuggestion = suggestions.find((s) => s.textContent?.includes(`${variable.label}:regex`));
+
+        expect(regularSuggestion).toBeInTheDocument();
+        expect(regexSuggestion).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-import { FieldType } from '@grafana/data';
+import { FieldType, TypedVariableModel } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { regexMatcherEditor } from './RegexMatcherEditor';
@@ -12,14 +12,19 @@ jest.mock('@grafana/runtime', () => ({
 describe('RegexMatcherEditor', () => {
   it('adds :regex suffix to variable suggestions', async () => {
     // Mock template service variables
-    const mockVariables = [
-      { name: 'var1', label: 'Variable 1', value: '$var1' },
-      { name: 'var2', label: 'Variable 2', value: '$var2' },
+    const mockVariables: TypedVariableModel[] = [
+      { name: 'var1', label: 'Variable 1', type: 'custom' } as TypedVariableModel,
+      { name: 'var2', label: 'Variable 2', type: 'custom' } as TypedVariableModel,
     ];
 
-    (getTemplateSrv as jest.Mock).mockReturnValue({
+    const mockTemplateSrv = {
       getVariables: () => mockVariables,
-    });
+      replace: jest.fn(),
+      containsTemplate: jest.fn(),
+      updateTimeRange: jest.fn(),
+    };
+
+    jest.mocked(getTemplateSrv).mockReturnValue(mockTemplateSrv);
 
     const onChangeMock = jest.fn();
     const options = { value: '' };
@@ -45,8 +50,8 @@ describe('RegexMatcherEditor', () => {
       expect(suggestions).toHaveLength(mockVariables.length * 2);
 
       mockVariables.forEach((variable) => {
-        const regularSuggestion = suggestions.find((s) => s.textContent?.includes(variable.label));
-        const regexSuggestion = suggestions.find((s) => s.textContent?.includes(`${variable.label}:regex`));
+        const regularSuggestion = suggestions.find((s) => s.textContent?.includes(variable.label as string));
+        const regexSuggestion = suggestions.find((s) => s.textContent?.includes(`${variable.label as string}:regex`));
 
         expect(regularSuggestion).toBeInTheDocument();
         expect(regexSuggestion).toBeInTheDocument();

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.tsx
@@ -16,7 +16,7 @@ export function regexMatcherEditor(
     const { validator } = config;
     const { value } = options;
     const [isInvalid, setInvalid] = useState(!validator(value));
-    const variableSuggestions = getVariableSuggestions().reduce<Array<VariableSuggestion>>((acc, v) => {
+    const variableSuggestions = getVariableSuggestions().reduce<VariableSuggestion[]>((acc, v) => {
       acc.push(v);
       acc.push({
         ...v,

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RegexMatcherEditor.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import * as React from 'react';
 
-import { ValueMatcherID, BasicValueMatcherOptions } from '@grafana/data';
+import { ValueMatcherID, BasicValueMatcherOptions, VariableSuggestion } from '@grafana/data';
 import { t } from 'app/core/internationalization';
 
 import { SuggestionsInput } from '../../suggestionsInput/SuggestionsInput';
@@ -16,6 +16,19 @@ export function regexMatcherEditor(
     const { validator } = config;
     const { value } = options;
     const [isInvalid, setInvalid] = useState(!validator(value));
+    const variableSuggestions = getVariableSuggestions().reduce<Array<VariableSuggestion>>((acc, v) => {
+      acc.push(v);
+      acc.push({
+        ...v,
+        documentation: t(
+          'transformers.regex-matcher-editor.variable-regex-documentation',
+          'Formats multi-value variable into a regex string'
+        ),
+        label: v.label.concat(':regex'),
+        value: v.value.concat(':regex'),
+      });
+      return acc;
+    }, []);
 
     const onChangeVariableValue = useCallback(
       (value: string) => {
@@ -34,7 +47,7 @@ export function regexMatcherEditor(
         value={value}
         onChange={onChangeVariableValue}
         placeholder={t('transformers.regex-matcher-editor.placeholder-value-or-variable', 'Value or variable')}
-        suggestions={getVariableSuggestions()}
+        suggestions={variableSuggestions}
       />
     );
   };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9022,7 +9022,8 @@
       "placeholder-choose-stat": "Choose stat"
     },
     "regex-matcher-editor": {
-      "placeholder-value-or-variable": "Value or variable"
+      "placeholder-value-or-variable": "Value or variable",
+      "variable-regex-documentation": "Formats multi-value variable into a regex string"
     },
     "regression-transformer-editor": {
       "label-degree": "Degree",


### PR DESCRIPTION
**Changes**
- If the matcher is a regex, the suggestion dropdown will include regex-formatted variables in the transformer's filter by value editor

![image](https://github.com/user-attachments/assets/fd3daa12-28de-4994-8774-bb5074bb703c)


 **UI/UX Improvements**
- Users can now select either regular variables or their regex counterparts
- Added helpful documentation explaining that regex variants "Formats multi-value variable into a regex string"
- Maintained existing placeholder text "Value or variable"

This enhancement improves the user experience when working with regex patterns in transformers by providing a more intuitive way to handle multi-value variables.

**Epic**

Part of https://github.com/grafana/grafana-org/issues/524