### PR TITLE
Grafana-UI: Fix storybook icons

### DIFF
--- a/packages/grafana-ui/.storybook/copyAssets.ts
+++ b/packages/grafana-ui/.storybook/copyAssets.ts
@@ -18,7 +18,7 @@ const iconPaths = Object.keys(availableIconsIndex)
     const subDir = getIconSubDir(iconName as IconName, 'default');
     return {
       from: `../../../public/img/icons/${subDir}/${iconName}.svg`,
-      to: `./static/public/img/icons/${subDir}/${iconName}.svg`,
+      to: `./static/public/build/img/icons/${subDir}/${iconName}.svg`,
     };
   });
 


### PR DESCRIPTION
**What is this feature?**
I broke the icons in storybook in https://github.com/grafana/grafana/pull/105006/files#diff-627c85fa3a54c87a661c6ccf49d8550bd3ad0b226e09c1fc7c080a93bf4f0665

**Why do we need this feature?**
So storybook icons are working!