### PR TITLE
Remote Alertmanager: Add timeouts to the HTTP client

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1578,7 +1578,7 @@ password =
 sync_interval = 5m
 
 # Timeout for the HTTP client. Default is 30 seconds.
-timeout =
+timeout = 30s
 
 #################################### Annotations #########################
 [annotations]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1577,6 +1577,9 @@ password =
 
 sync_interval = 5m
 
+# Timeout for the HTTP client. Default is 30 seconds.
+timeout =
+
 #################################### Annotations #########################
 [annotations]
 # Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -195,6 +195,7 @@ func (ng *AlertNG) init() error {
 			ExternalURL:       ng.Cfg.AppURL,
 			SmtpFrom:          ng.Cfg.Smtp.FromAddress,
 			StaticHeaders:     ng.Cfg.Smtp.StaticHeaders,
+			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
 		}
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, skipInvalid bool) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, skipInvalid)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -93,6 +93,9 @@ type AlertmanagerConfig struct {
 
 	// SyncInterval determines how often we should attempt to synchronize configuration.
 	SyncInterval time.Duration
+
+	// Timeout for the HTTP client.
+	Timeout time.Duration
 }
 
 func (cfg *AlertmanagerConfig) Validate() error {
@@ -141,6 +144,7 @@ func NewAlertmanager(ctx context.Context, cfg AlertmanagerConfig, store stateSto
 		TenantID: cfg.TenantID,
 		Password: cfg.BasicAuthPassword,
 		Logger:   logger,
+		Timeout:  cfg.Timeout,
 	}
 	amc, err := remoteClient.NewAlertmanager(amcCfg, metrics, tracer)
 	if err != nil {

--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -35,7 +35,7 @@ type Alertmanager struct {
 }
 
 func NewAlertmanager(cfg *AlertmanagerConfig, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer) (*Alertmanager, error) {
-	// First, add the authentication middleware.
+	// First, set up the http client.
 	c := &http.Client{
 		Transport: &MimirAuthRoundTripper{
 			TenantID: cfg.TenantID,

--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -24,6 +24,7 @@ type AlertmanagerConfig struct {
 	Password string
 	URL      *url.URL
 	Logger   log.Logger
+	Timeout  time.Duration
 }
 
 type Alertmanager struct {
@@ -35,11 +36,14 @@ type Alertmanager struct {
 
 func NewAlertmanager(cfg *AlertmanagerConfig, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer) (*Alertmanager, error) {
 	// First, add the authentication middleware.
-	c := &http.Client{Transport: &MimirAuthRoundTripper{
-		TenantID: cfg.TenantID,
-		Password: cfg.Password,
-		Next:     httpclient.NewHTTPTransport(),
-	}}
+	c := &http.Client{
+		Transport: &MimirAuthRoundTripper{
+			TenantID: cfg.TenantID,
+			Password: cfg.Password,
+			Next:     httpclient.NewHTTPTransport(),
+		},
+		Timeout: cfg.Timeout,
+	}
 
 	tc := client.NewTimedClient(c, metrics.RequestLatency)
 	trc := client.NewTracedClient(tc, tracer, "remote.alertmanager.client")

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -47,6 +47,7 @@ const (
 `
 	alertingDefaultInitializationTimeout    = 30 * time.Second
 	evaluatorDefaultEvaluationTimeout       = 30 * time.Second
+	remoteAlertmanagerDefaultTimeout        = 30 * time.Second
 	schedulerDefaultAdminConfigPollInterval = time.Minute
 	schedulerDefaultExecuteAlerts           = true
 	schedulerDefaultMaxAttempts             = 3
@@ -152,6 +153,7 @@ type RemoteAlertmanagerSettings struct {
 	TenantID     string
 	Password     string
 	SyncInterval time.Duration
+	Timeout      time.Duration
 }
 
 type UnifiedAlertingScreenshotSettings struct {
@@ -393,6 +395,10 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		Password: remoteAlertmanager.Key("password").MustString(""),
 	}
 	uaCfgRemoteAM.SyncInterval, err = gtime.ParseDuration(valueAsString(remoteAlertmanager, "sync_interval", (schedulerDefaultAdminConfigPollInterval).String()))
+	if err != nil {
+		return err
+	}
+	uaCfgRemoteAM.Timeout, err = gtime.ParseDuration(valueAsString(remoteAlertmanager, "timeout", (remoteAlertmanagerDefaultTimeout).String()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When sending requests to the remote Alertmanager, two operations have timeouts in place:
- The readiness check, which uses exponential backoff + a timeout
- Sending alerts, as it's done by the [Manager struct](https://github.com/grafana/grafana/blob/82f0a58490d9bc4589b7050d1221143f2892a123/pkg/services/ngalert/sender/notifier.go#L112), using a separate client

This PR adds a configurable timeout to the HTTP client used by the [remote.Alertmanager](https://github.com/grafana/grafana/blob/82f0a58490d9bc4589b7050d1221143f2892a123/pkg/services/ngalert/remote/alertmanager.go#L53-L73) struct, affecting all remaining operations.

Fixes https://github.com/grafana/alerting-squad/issues/950