### PR TITLE
CI: Upload go unit test reports on pushes to main

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
-      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD}.xml" >> $GITHUB_ENV
+      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD}.xml" >> "$GITHUB_ENV"
         env:
           SHARD: ${{ matrix.shard }}
       - run: go install github.com/jstemmer/go-junit-report/v2@85bf4716ac1f025f2925510a9f5e9f5bb347c009

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
-      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD}.xml" >> "$GITHUB_ENV"
+      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD/\//_}.xml" >> "$GITHUB_ENV"
         env:
           SHARD: ${{ matrix.shard }}
       - run: go install github.com/jstemmer/go-junit-report/v2@85bf4716ac1f025f2925510a9f5e9f5bb347c009
@@ -98,7 +98,7 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
-          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > $RESULTS_FILE)
+          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > "$RESULTS_FILE)
       - name: Log in to GCS
         if: github.event_name == 'push' && github.repository == 'grafana/grafana' && (success() || failure())
         uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   grafana:
-    # Run this workflow only for PRs from forks; if it gets merged into `main` or `release-*`, 
+    # Run this workflow only for PRs from forks
     # the `pr-backend-unit-tests-enterprise` workflow will run instead
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
     strategy:
@@ -58,6 +58,7 @@ jobs:
 
   grafana-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
+    # If it gets merged into `main` or `release-*`, then a junit test result is uploaded to GCS.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     strategy:
       matrix:
@@ -85,6 +86,10 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD}.xml" >> $GITHUB_ENV
+        env:
+          SHARD: ${{ matrix.shard }}
+      - run: go install github.com/jstemmer/go-junit-report/v2@85bf4716ac1f025f2925510a9f5e9f5bb347c009
       - name: Generate Go code
         run: make gen-go
       - name: Run unit tests
@@ -92,4 +97,23 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
-          go test -short -timeout=30m "${PACKAGES[@]}"
+          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > $RESULTS_FILE)
+      - name: Log in to GCS
+        if: github.event_name == 'push' && github.repository == 'grafana/grafana' && (success() || failure())
+        uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0
+        with:
+          service_account: github-junit-uploader@grafanalabs-workload-identity.iam.gserviceaccount.com
+          bucket: grafana-test-results
+      - if: github.event_name == 'push' && github.repository == 'grafana/grafana' && (success() || failure())
+        run: echo "BUCKET_PATH=go-unit-tests/$(echo ${REF_NAME} | sed 's/\//-/g')" >> "$GITHUB_ENV"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+      - name: Upload test results
+        if: github.event_name == 'push' && github.repository == 'grafana/grafana' && (success() || failure())
+        uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.2.0
+        with:
+          bucket: grafana-test-results
+          service_account: github-junit-uploader@grafanalabs-workload-identity.iam.gserviceaccount.com
+          environment: "dev" # Can be dev/prod (defaults to dev)
+          path: ${{ env.RESULTS_FILE }}
+          bucket_path: ${{ env.BUCKET_PATH }}

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - km/upload-go-unit-test-reports
       - release-*.*.*
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - km/upload-go-unit-test-reports
       - release-*.*.*
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -98,7 +98,7 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
-          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > "$RESULTS_FILE)
+          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > "$RESULTS_FILE")
       - name: Log in to GCS
         if: github.event_name == 'push' && github.repository == 'grafana/grafana' && (success() || failure())
         uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0


### PR DESCRIPTION
On pushes to `main` and `release-` branches, this will upload a junit test report to a bucket for us to process / analyze.