### PR TITLE
[release-11.3.7] Alerting: Ensure field validators return the proper type

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -565,7 +565,7 @@ func (alertRule *AlertRule) ValidateAlertRule(cfg setting.UnifiedAlertingSetting
 		err = validateAlertRuleFields(alertRule)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", ErrAlertRuleFailedValidation, err)
 	}
 
 	if alertRule.For < 0 {
@@ -606,10 +606,10 @@ func validateAlertRuleFields(rule *AlertRule) error {
 func validateRecordingRuleFields(rule *AlertRule) error {
 	metricName := prommodels.LabelValue(rule.Record.Metric)
 	if !metricName.IsValid() {
-		return fmt.Errorf("%w: %s", ErrAlertRuleFailedValidation, "metric name for recording rule must be a valid utf8 string")
+		return errors.New("metric name for recording rule must be a valid utf8 string")
 	}
 	if !prommodels.IsValidMetricName(metricName) {
-		return fmt.Errorf("%w: %s", ErrAlertRuleFailedValidation, "metric name for recording rule must be a valid Prometheus metric name")
+		return errors.New("metric name for recording rule must be a valid Prometheus metric name")
 	}
 
 	clearRecordingRuleIgnoredFields(rule)


### PR DESCRIPTION
Backport 820c33841434513dae2359ec4e923a2f878b3abd from #104050

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR ensures callers of rule validation receive the correct error type, which will ultimately bubble up to the API return status code.

**Why do we need this feature?**

Invalid no data and error states incorrectly return 500 status codes.

**Who is this feature for?**

Users of the alerting provisioning API

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
