### PR TITLE
[Secrets] worker passes the namespace instead of secure value name when updating a secure value / ensure only op per secret is in progress at a time / set secure value status for easier debugging

### DIFF
--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -21,7 +21,7 @@ func GetRequestId(ctx context.Context) string {
 }
 
 func ContextWithRequestID(ctx context.Context, requestId string) context.Context {
-	return context.WithValue(ctx, contextRequestIdKey, requestId)
+	return context.WithValue(ctx, contextRequestIdKey{}, requestId)
 }
 
 const (

--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -11,7 +11,7 @@ type contextRequestIdKey struct{}
 type OutboxMessageType string
 
 func GetRequestId(ctx context.Context) string {
-	v := ctx.Value(contextRequestIdKey)
+	v := ctx.Value(contextRequestIdKey{})
 	requestId, ok := v.(string)
 	if !ok {
 		return ""

--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -6,7 +6,7 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 )
 
-var contextRequestIdKey = "sv_contextRequestIdKey"
+var contextRequestIdKey = &struct{}{}
 
 type OutboxMessageType string
 

--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -6,7 +6,7 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 )
 
-var contextRequestIdKey = &struct{}{}
+type contextRequestIdKey struct{}
 
 type OutboxMessageType string
 

--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -6,7 +6,23 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 )
 
+var contextRequestIdKey = "sv_contextRequestIdKey"
+
 type OutboxMessageType string
+
+func GetRequestId(ctx context.Context) string {
+	v := ctx.Value(contextRequestIdKey)
+	requestId, ok := v.(string)
+	if !ok {
+		return ""
+	}
+
+	return requestId
+}
+
+func ContextWithRequestID(ctx context.Context, requestId string) context.Context {
+	return context.WithValue(ctx, contextRequestIdKey, requestId)
+}
 
 const (
 	CreateSecretOutboxMessage OutboxMessageType = "create"
@@ -15,6 +31,7 @@ const (
 )
 
 type AppendOutboxMessage struct {
+	RequestID       string
 	Type            OutboxMessageType
 	Name            string
 	Namespace       string
@@ -24,6 +41,7 @@ type AppendOutboxMessage struct {
 }
 
 type OutboxMessage struct {
+	RequestID       string
 	Type            OutboxMessageType
 	MessageID       string
 	Name            string

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -16,8 +16,9 @@ type DecryptSecureValue struct {
 }
 
 var (
-	ErrSecureValueNotFound      = errors.New("secure value not found")
-	ErrSecureValueAlreadyExists = errors.New("secure value already exists")
+	ErrSecureValueNotFound            = errors.New("secure value not found")
+	ErrSecureValueAlreadyExists       = errors.New("secure value already exists")
+	ErrSecureValueOperationInProgress = errors.New("an operation is already in progress for the secure value")
 )
 
 type ReadOpts struct {
@@ -31,7 +32,7 @@ type SecureValueMetadataStorage interface {
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue, actorUID string) (*secretv0alpha1.SecureValue, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
 	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.SecureValue, error)
-	SetStatusSucceeded(ctx context.Context, namespace xkube.Namespace, name string) error
+	SetStatus(ctx context.Context, namespace xkube.Namespace, name string, status secretv0alpha1.SecureValueStatus) error
 	SetExternalID(ctx context.Context, namespace xkube.Namespace, name string, externalID ExternalID) error
 	ReadForDecrypt(ctx context.Context, namespace xkube.Namespace, name string) (*DecryptSecureValue, error)
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -202,7 +202,10 @@ func (s *SecureValueRest) Update(
 	// TODO: do we need to do this here again? Probably not, but double-check!
 	newSecureValue.Annotations = xkube.CleanAnnotations(newSecureValue.Annotations)
 
-	newSecureValue.Status.Phase = secretv0alpha1.SecureValuePhasePending
+	newSecureValue.Status = secretv0alpha1.SecureValueStatus{
+		Message: "Updating secure value",
+		Phase:   secretv0alpha1.SecureValuePhasePending,
+	}
 
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok {

--- a/pkg/registry/apis/secret/service/secret.go
+++ b/pkg/registry/apis/secret/service/secret.go
@@ -33,6 +33,8 @@ func ProvideSecretService(
 }
 
 func (s *SecretService) Create(ctx context.Context, sv *secretv0alpha1.SecureValue, actorUID string) (*secretv0alpha1.SecureValue, error) {
+	sv.Status = secretv0alpha1.SecureValueStatus{Phase: secretv0alpha1.SecureValuePhasePending, Message: "Creating secure value"}
+
 	var out *secretv0alpha1.SecureValue
 
 	if err := s.database.Transaction(ctx, func(ctx context.Context) error {
@@ -43,6 +45,7 @@ func (s *SecretService) Create(ctx context.Context, sv *secretv0alpha1.SecureVal
 		out = createdSecureValue
 
 		if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
+			RequestID: contracts.GetRequestId(ctx),
 			Type:      contracts.CreateSecretOutboxMessage,
 			Name:      sv.Name,
 			Namespace: sv.Namespace,
@@ -104,6 +107,8 @@ func (s *SecretService) List(ctx context.Context, namespace xkube.Namespace) (*s
 }
 
 func (s *SecretService) Update(ctx context.Context, newSecureValue *secretv0alpha1.SecureValue, actorUID string) (*secretv0alpha1.SecureValue, bool, error) {
+	// True when the effects of an update can be seen immediately.
+	// Never true in this case since updating a secure value is async.
 	const updateIsSync = false
 
 	// TODO: if updating requires communicating with external services, the secure value metadata status must be changed to Pending
@@ -120,11 +125,12 @@ func (s *SecretService) Update(ctx context.Context, newSecureValue *secretv0alph
 
 		if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
 			Type:      contracts.UpdateSecretOutboxMessage,
-			Name:      updatedSecureValue.Name,
-			Namespace: updatedSecureValue.Namespace,
+			Name:      newSecureValue.Name,
+			Namespace: newSecureValue.Namespace,
 			// TODO: encrypt
-			EncryptedSecret: updatedSecureValue.Spec.Value,
-			KeeperName:      updatedSecureValue.Spec.Keeper,
+			EncryptedSecret: newSecureValue.Spec.Value,
+			KeeperName:      newSecureValue.Spec.Keeper,
+			ExternalID:      &updatedSecureValue.Status.ExternalID,
 		}); err != nil {
 			return fmt.Errorf("failed to append message to update secure value to outbox queue: %w", err)
 		}
@@ -138,20 +144,33 @@ func (s *SecretService) Update(ctx context.Context, newSecureValue *secretv0alph
 }
 
 func (s *SecretService) Delete(ctx context.Context, namespace xkube.Namespace, name string) error {
-	// TODO: readopts
-	sv, err := s.secureValueMetadataStorage.Read(ctx, namespace, name, contracts.ReadOpts{})
-	if err != nil {
-		return fmt.Errorf("fetching secure value: %+w", err)
-	}
+	if err := s.database.Transaction(ctx, func(ctx context.Context) error {
+		sv, err := s.secureValueMetadataStorage.Read(ctx, namespace, name, contracts.ReadOpts{ForUpdate: true})
+		if err != nil {
+			return fmt.Errorf("fetching secure value: %+w", err)
+		}
 
-	if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
-		Type:       contracts.DeleteSecretOutboxMessage,
-		Name:       name,
-		Namespace:  namespace.String(),
-		KeeperName: sv.Spec.Keeper,
-		ExternalID: &sv.Status.ExternalID,
+		if sv.Status.Phase == secretv0alpha1.SecureValuePhasePending {
+			return contracts.ErrSecureValueOperationInProgress
+		}
+
+		if err := s.secureValueMetadataStorage.SetStatus(ctx, namespace, name, secretv0alpha1.SecureValueStatus{Phase: secretv0alpha1.SecureValuePhasePending, Message: "Deleting secure value"}); err != nil {
+			return fmt.Errorf("setting secure value status phase: %+w", err)
+		}
+
+		if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
+			Type:       contracts.DeleteSecretOutboxMessage,
+			Name:       name,
+			Namespace:  namespace.String(),
+			KeeperName: sv.Spec.Keeper,
+			ExternalID: &sv.Status.ExternalID,
+		}); err != nil {
+			return fmt.Errorf("appending delete secure value message to outbox queue: %+w", err)
+		}
+
+		return nil
 	}); err != nil {
-		return fmt.Errorf("appending delete secure value message to outbox queue: %+w", err)
+		return err
 	}
 
 	return nil

--- a/pkg/registry/apis/secret/worker/worker_test.go
+++ b/pkg/registry/apis/secret/worker/worker_test.go
@@ -351,12 +351,12 @@ func (wrapper *secureValueMetadataStorageWrapper) List(ctx context.Context, name
 	return wrapper.impl.List(ctx, namespace)
 }
 
-func (wrapper *secureValueMetadataStorageWrapper) SetStatusSucceeded(ctx context.Context, namespace xkube.Namespace, name string) error {
+func (wrapper *secureValueMetadataStorageWrapper) SetStatus(ctx context.Context, namespace xkube.Namespace, name string, status secretv0alpha1.SecureValueStatus) error {
 	// Maybe return an error before calling the real implementation
 	if wrapper.rng.Float32() <= 0.2 {
 		return context.DeadlineExceeded
 	}
-	if err := wrapper.impl.SetStatusSucceeded(ctx, namespace, name); err != nil {
+	if err := wrapper.impl.SetStatus(ctx, namespace, name, status); err != nil {
 		return err
 	}
 	// Maybe return an error after calling the real implementation

--- a/pkg/storage/secret/metadata/data/secure_value_updateStatus.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_updateStatus.sql
@@ -1,7 +1,8 @@
 UPDATE
   {{ .Ident "secret_secure_value" }}
 SET
-  {{ .Ident "status_phase" }} = {{ .Arg .Phase }}
+  {{ .Ident "status_phase" }} = {{ .Arg .Phase }},
+  {{ .Ident "status_message" }} = {{ .Arg .Message }}
 WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }} AND
   {{ .Ident "name" }} = {{ .Arg .Name }}
 ;

--- a/pkg/storage/secret/metadata/outbox_store.go
+++ b/pkg/storage/secret/metadata/outbox_store.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	unifiedsql "github.com/grafana/grafana/pkg/storage/unified/sql"
+
 	"github.com/google/uuid"
 	"github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/assert"
@@ -82,6 +84,9 @@ func (s *outboxStore) Append(ctx context.Context, input contracts.AppendOutboxMe
 
 	query, err := sqltemplate.Execute(sqlSecureValueOutboxAppend, req)
 	if err != nil {
+		if unifiedsql.IsRowAlreadyExistsError(err) {
+			return "", contracts.ErrSecureValueOperationInProgress
+		}
 		return "", fmt.Errorf("execute template %q: %w", sqlSecureValueOutboxAppend.Name(), err)
 	}
 

--- a/pkg/storage/secret/metadata/query.go
+++ b/pkg/storage/secret/metadata/query.go
@@ -211,6 +211,7 @@ type updateStatusSecureValue struct {
 	Namespace string
 	Name      string
 	Phase     string
+	Message   string
 }
 
 // Validate is only used if we use `dbutil` from `unifiedstorage`

--- a/pkg/storage/secret/metadata/query_test.go
+++ b/pkg/storage/secret/metadata/query_test.go
@@ -284,6 +284,7 @@ func TestSecureValueQueries(t *testing.T) {
 						Name:        "name",
 						Namespace:   "ns",
 						Phase:       "Succeeded",
+						Message:     "message-1",
 					},
 				},
 			},

--- a/pkg/storage/secret/metadata/secure_value_model.go
+++ b/pkg/storage/secret/metadata/secure_value_model.go
@@ -88,6 +88,7 @@ func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
 	if sv.Message.Valid {
 		resource.Status.Message = sv.Message.String
 	}
+	resource.Status.Phase = secretv0alpha1.SecureValuePhase(sv.Phase)
 	resource.Status.ExternalID = sv.ExternalID
 
 	// Set all meta fields here for consistency.

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_updateStatus-updateStatus.sql
@@ -1,7 +1,8 @@
 UPDATE
   `secret_secure_value`
 SET
-  `status_phase` = 'Succeeded'
+  `status_phase` = 'Succeeded',
+  `status_message` = 'message-1'
 WHERE `namespace` = 'ns' AND
   `name` = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_updateStatus-updateStatus.sql
@@ -1,7 +1,8 @@
 UPDATE
   "secret_secure_value"
 SET
-  "status_phase" = 'Succeeded'
+  "status_phase" = 'Succeeded',
+  "status_message" = 'message-1'
 WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateStatus-updateStatus.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_updateStatus-updateStatus.sql
@@ -1,7 +1,8 @@
 UPDATE
   "secret_secure_value"
 SET
-  "status_phase" = 'Succeeded'
+  "status_phase" = 'Succeeded',
+  "status_message" = 'message-1'
 WHERE "namespace" = 'ns' AND
   "name" = 'name'
 ;

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -342,7 +342,7 @@ func (b *backend) create(ctx context.Context, event resource.WriteEvent) (int64,
 			Folder:      folder,
 			GUID:        guid,
 		}); err != nil {
-			if isRowAlreadyExistsError(err) {
+			if IsRowAlreadyExistsError(err) {
 				return guid, resource.ErrResourceAlreadyExists
 			}
 			return guid, fmt.Errorf("insert into resource: %w", err)
@@ -386,8 +386,8 @@ func (b *backend) create(ctx context.Context, event resource.WriteEvent) (int64,
 	return rv, nil
 }
 
-// isRowAlreadyExistsError checks if the error is the result of the row inserted already existing.
-func isRowAlreadyExistsError(err error) bool {
+// IsRowAlreadyExistsError checks if the error is the result of the row inserted already existing.
+func IsRowAlreadyExistsError(err error) bool {
 	var sqlite sqlite3.Error
 	if errors.As(err, &sqlite) {
 		return sqlite.ExtendedCode == sqlite3.ErrConstraintUnique


### PR DESCRIPTION
- Set status message when an operation is in progress for easier debugging

![image](https://github.com/user-attachments/assets/b378d87f-dc07-4b2c-8eb1-9ef3da6b117a)

- Outbox worker was passing the secure value name instead of the namespace to `Keeper.Update`

- Secret service and outbox store ensure there's only operation in progress for a secret at a time