### PR TITLE
Git Sync: remove `grafanaAPIServerEnsureKubectlAccess` from required toggles

### DIFF
--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -80,9 +80,6 @@ The values that you enter for the `permitted_provisioning_paths` become the base
    [feature_toggles]
    provisioning = true
    kubernetesDashboards = true ; use k8s from browser
-
-   # If you want easy kubectl setup development mode
-   grafanaAPIServerEnsureKubectlAccess = true
    ```
 
 1. Locate or add a `[paths]` section. To add more than one location, use the pipe character (`|`) to separate the paths. The list should not include empty paths or trailing pipes. Add these values:

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -72,9 +72,6 @@ To enable the required feature toggles, add them to your Grafana configuration f
    [feature_toggles]
    provisioning = true
    kubernetesDashboards = true ; use k8s from browser
-
-   # If you want easy kubectl setup development mode
-   grafanaAPIServerEnsureKubectlAccess = true
    ```
 
 1. Save the changes to the file and restart Grafana.


### PR DESCRIPTION
`grafanaAPIServerEnsureKubectlAccess` is not required for git sync