### PR TITLE
[release-12.0.1] Alerting: Fix link in the migration docs

### DIFF
--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -12,6 +12,8 @@ refs:
   import-ds-rules-api:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/alerting-migration/migration-api/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/migration-api/
 ---
 
 # Import data source-managed alert rules


### PR DESCRIPTION
Backport e965b85e1900a7e316e77817362fd644546a5426 from #105295  ---  Fix the link added in https://github.com/grafana/grafana/pull/105234 for the [Cloud](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/) docs (added a new pattern similar to [this](https://github.com/grafana/grafana/blob/54f6c4ffba46d61e18084c295923cb1b2b15d3ae/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md?plain=1#L28)).
