### PR TITLE
datasources: remove empty if

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -225,9 +225,6 @@ class DataSourceWithBackend<
       if (!(config.featureToggles.queryService || config.featureToggles.grafanaAPIServerWithExperimentalAPIs)) {
         console.warn('feature toggle queryServiceFromUI also requires the queryService to be running');
       } else {
-        if (!hasExpr && dsUIDs.size === 1) {
-          // TODO? can we talk directly to the apiserver?
-        }
         url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
       }
     }


### PR DESCRIPTION
we remove an unused if-branch.

there is an if-branch in the code that does nothing, it's there to mention a possible optimalisation. we are not planning to do this optimalisation, and we are trying to make this "production ready",  so this PR removes the branch.