### PR TITLE
feat(unified-storage): build full path internally when getting folders

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -341,11 +341,13 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 		filters[uid] = struct{}{}
 	}
 
-	folderMap := make(map[string]*folder.Folder, len(folders))
-	relations := make(map[string]string, len(folders))
-	for _, folder := range folders {
-		folderMap[folder.UID] = folder
-		relations[folder.UID] = folder.ParentUID
+	folderMap := make(map[string]*folder.Folder)
+	relations := make(map[string]string)
+	if q.WithFullpath || q.WithFullpathUIDs {
+		for _, folder := range folders {
+			folderMap[folder.UID] = folder
+			relations[folder.UID] = folder.ParentUID
+		}
 	}
 
 	hits := make([]*folder.Folder, 0, len(folders))

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -337,10 +337,8 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 	}
 
 	filterUIDs := map[string]struct{}{}
-	if len(q.UIDs) > 0 {
-		for _, uid := range q.UIDs {
-			filterUIDs[uid] = struct{}{}
-		}
+	for _, uid := range q.UIDs {
+		filterUIDs[uid] = struct{}{}
 	}
 
 	hits := []*folder.Folder{}

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -346,7 +346,7 @@ func (ss *FolderUnifiedStoreImpl) GetFolders(ctx context.Context, q folder.GetFo
 	hits := []*folder.Folder{}
 	cache := map[string][]*folder.Folder{}
 	for _, f := range folders {
-		if _, ok := filterUIDs[f.UID]; !ok {
+		if shouldSkipFolder(f, filterUIDs) {
 			continue
 		}
 
@@ -490,4 +490,12 @@ func computeFullPath(parents []*folder.Folder) (string, string) {
 		fullpathUIDs[i] = p.UID
 	}
 	return strings.Join(fullpath, "/"), strings.Join(fullpathUIDs, "/")
+}
+
+func shouldSkipFolder(f *folder.Folder, filterUIDs map[string]struct{}) bool {
+	if len(filterUIDs) == 0 {
+		return false
+	}
+	_, exists := filterUIDs[f.UID]
+	return !exists
 }

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -590,6 +590,61 @@ func TestGetFolders(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "should return all folders from k8s",
+			args: args{
+				ctx: context.Background(),
+				q: folder.GetFoldersFromStoreQuery{
+					GetFoldersQuery: folder.GetFoldersQuery{
+						OrgID: orgID,
+					},
+				},
+			},
+			mock: func(mockCli *client.MockK8sHandler) {
+				mockCli.On("List", mock.Anything, orgID, metav1.ListOptions{
+					Limit:    100000,
+					TypeMeta: metav1.TypeMeta{},
+				}).Return(&unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "folder1",
+									"uid":  "folder1",
+								},
+								"spec": map[string]interface{}{
+									"title": "folder1",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "folder2",
+									"uid":  "folder2",
+								},
+								"spec": map[string]interface{}{
+									"title": "folder2",
+								},
+							},
+						},
+					},
+				}, nil).Once()
+			},
+			want: []*folder.Folder{
+				{
+					UID:   "folder1",
+					Title: "folder1",
+					OrgID: orgID,
+				},
+				{
+					UID:   "folder2",
+					Title: "folder2",
+					OrgID: orgID,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "should return folders from k8s by uid",
 			args: args{
 				ctx: context.Background(),

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
@@ -602,9 +601,9 @@ func TestGetFolders(t *testing.T) {
 				},
 			},
 			mock: func(mockCli *client.MockK8sHandler) {
-				mockCli.On("List", mock.Anything, orgID, v1.ListOptions{
+				mockCli.On("List", mock.Anything, orgID, metav1.ListOptions{
 					Limit:    100000,
-					TypeMeta: v1.TypeMeta{},
+					TypeMeta: metav1.TypeMeta{},
 				}).Return(&unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
@@ -670,9 +669,9 @@ func TestGetFolders(t *testing.T) {
 				},
 			},
 			mock: func(mockCli *client.MockK8sHandler) {
-				mockCli.On("List", mock.Anything, orgID, v1.ListOptions{
+				mockCli.On("List", mock.Anything, orgID, metav1.ListOptions{
 					Limit:         100000,
-					TypeMeta:      v1.TypeMeta{},
+					TypeMeta:      metav1.TypeMeta{},
 					LabelSelector: "grafana.app/fullpath=true",
 				}).Return(&unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
@@ -767,9 +766,9 @@ func TestGetFolders(t *testing.T) {
 				},
 			},
 			mock: func(mockCli *client.MockK8sHandler) {
-				mockCli.On("List", mock.Anything, orgID, v1.ListOptions{
+				mockCli.On("List", mock.Anything, orgID, metav1.ListOptions{
 					Limit:    100000,
-					TypeMeta: v1.TypeMeta{},
+					TypeMeta: metav1.TypeMeta{},
 				}).Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "folders.folder.grafana.app", Resource: "folder"}, "folder1")).Once()
 			},
 			want:    nil,


### PR DESCRIPTION
Within the scope of the folder service improvements ([ticket](https://github.com/grafana/search-and-storage-team/issues/238)), ~this PR introduces a local cache while `GetFolders` is called with `WithFullPath` enabled. Basically this change the number of `GetParents` calls to 1 per folder sharing the same parent folder.~
~It also adds 2 new test cases for `getParentsWithCache` and `GetFolders` methods where the new local cache logic and the `WithFullPath` logic is verified.~ we are reconstructing the `FullPath` and `FullPathUIDs` based of off the `List` request which basically returns all existing folder within the target `OrgID`, hence let us leverage this fact and rebuild the full paths accordingly without using the `GetParents` method which is firing a request for each folder that is part of the parent child relationship.
Additionally, some of the logics in relation to `UID` filter in `GetFolders` have been optimized along the road. This change only refrain us from looping through the `UIDs` that are basically not present in the input query.