### PR TITLE
Add width to select components to not span the whole width

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -147,6 +147,7 @@ const SearchField = ({
       <Stack gap={0} width="auto">
         {!hideScope && (
           <Select
+            width="auto"
             className={styles.dropdown}
             inputId={`${filter.id}-scope`}
             options={addVariablesToOptions ? withTemplateVariableOptions(scopeOptions) : scopeOptions}
@@ -158,6 +159,7 @@ const SearchField = ({
         )}
         {!hideTag && (
           <Select
+            width="auto"
             className={styles.dropdown}
             inputId={`${filter.id}-tag`}
             isLoading={isTagsLoading}
@@ -197,6 +199,7 @@ const SearchField = ({
              * For example the number of span names being returned can easily reach 10s of thousands,
              * which is enough to cause a user's web browser to seize up
              */
+            width="auto"
             virtualized
             className={styles.dropdown}
             inputId={`${filter.id}-value`}

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
@@ -187,6 +187,7 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
           >
             <Stack gap={0}>
               <Select
+                width="auto"
                 options={[
                   { label: 'span', value: 'span' },
                   { label: 'trace', value: 'trace' },


### PR DESCRIPTION
**What is this feature?**

Avoid select inputs to span the whole width.

**Why do we need this feature?**

The Select component was taking all the available space, when we actually just want it to take the normal width of a select component.

**Who is this feature for?**

Users of:
- Explore traces
- App o11y

Before:
<img width="1470" alt="Screenshot 2025-05-13 at 13 36 02" src="https://github.com/user-attachments/assets/748d6992-15e5-4905-a301-8976e2382695" />
After:

https://github.com/user-attachments/assets/21095ca3-2d43-4c98-9602-a4e144ea570e

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
