### PR TITLE
Actions: Add a workflow to add pr/external labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -790,6 +790,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-codeql-analysis-javascript.yml @DanCech
 /.github/workflows/pr-codeql-analysis-python.yml @DanCech
 /.github/workflows/pr-commands.yml @tolzhabayev
+/.github/workflows/pr-external-labelling.yml @Proximyst
 /.github/workflows/pr-patch-check-event.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/pr-test-integration.yml @grafana/grafana-backend-group
 /.github/workflows/reject-gh-secrets.yml @grafana/grafana-operator-experience-squad

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1194,5 +1194,13 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/699"
     }
+  },
+  {
+    "type": "label",
+    "name": "type/docs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
+    }
   }
 ]

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -254,38 +254,6 @@
     "addLabel": "area/alerting"
   },
   {
-    "type": "label",
-    "name": "area/alerting",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/52"
-    }
-  },
-  {
-    "type": "author",
-    "name": "pr/external",
-    "notMemberOf": {
-      "org": "grafana"
-    },
-    "ignoreList": [
-      "renovate[bot]",
-      "dependabot[bot]",
-      "grafana-delivery-bot[bot]",
-      "grafanabot",
-      "alerting-team[bot]"
-    ],
-    "action": "updateLabel",
-    "addLabel": "pr/external"
-  },
-  {
-    "type": "label",
-    "name": "type/docs",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/69"
-    }
-  },
-  {
     "type": "changedfiles",
     "matches": [
       "public/app/plugins/panel/candlestick/**/*"

--- a/.github/workflows/pr-external-labelling.yml
+++ b/.github/workflows/pr-external-labelling.yml
@@ -2,7 +2,7 @@ name: External PR labelling
 
 on:
   # We need "write" permissions on the PR to be able to add a label.
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] We need this to have labelling permissions. There are no user inputs here, so we should be fine.
     types:
       - opened
 

--- a/.github/workflows/pr-external-labelling.yml
+++ b/.github/workflows/pr-external-labelling.yml
@@ -1,0 +1,25 @@
+name: External PR labelling
+
+on:
+  # We need "write" permissions on the PR to be able to add a label.
+  pull_request_target:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  label-if-external:
+    name: Add 'pr/external' label if the PR is external
+    if: github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'OWNER'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to write the label
+
+    steps:
+      - name: Add the 'pr/external' label
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Adding 'pr/external' label to the PR"
+          gh pr edit "$PR_NUMBER" --add-label pr/external


### PR DESCRIPTION
We currently can't read the org members in the pr-commands workflow, and we want it to be run on `pull_request_target`. As such, we need a new workflow with very, very limited access to make this work.

I don't particularly care who owns this workflow. If someone else wants it, please.