### PR TITLE
Scopes: Fix highlighting of current active dashboard.

### DIFF
--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom-v5-compat';
+
+import { ScopesNavigationTreeLink } from './ScopesNavigationTreeLink';
+
+// Mock react-router-dom's useLocation
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useLocation: jest.fn(),
+}));
+
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+};
+
+describe('ScopesNavigationTreeLink', () => {
+  const mockUseLocation = useLocation as jest.Mock;
+
+  beforeEach(() => {
+    mockUseLocation.mockReturnValue({ pathname: '/current-path' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders link with correct props', () => {
+    renderWithRouter(<ScopesNavigationTreeLink to="/test-path" title="Test Link" id="test-id" />);
+
+    const link = screen.getByTestId('scopes-dashboards-test-id');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/test-path');
+    expect(link).toHaveAttribute('role', 'treeitem');
+    expect(link).toHaveTextContent('Test Link');
+  });
+
+  it('sets aria-current when path matches', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/test-path' });
+
+    renderWithRouter(<ScopesNavigationTreeLink to="/test-path" title="Test Link" id="test-id" />);
+
+    const link = screen.getByTestId('scopes-dashboards-test-id');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not set aria-current when path does not match', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/different-path' });
+
+    renderWithRouter(<ScopesNavigationTreeLink to="/test-path" title="Test Link" id="test-id" />);
+
+    const link = screen.getByTestId('scopes-dashboards-test-id');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('handles dashboard paths correctly', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/d/dashboard1/some-details' });
+
+    renderWithRouter(<ScopesNavigationTreeLink to="/d/dashboard1" title="Dashboard Link" id="dashboard-id" />);
+
+    const link = screen.getByTestId('scopes-dashboards-dashboard-id');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not match when path is just the start of another path', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/test-path/extra' });
+
+    renderWithRouter(<ScopesNavigationTreeLink to="/test-path" title="Test Link" id="test-id" />);
+
+    const link = screen.getByTestId('scopes-dashboards-test-id');
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('only highlights the matching link when multiple links are present', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/test-path' });
+
+    renderWithRouter(
+      <>
+        <ScopesNavigationTreeLink to="/test-path" title="Matching Link" id="matching-id" />
+        <ScopesNavigationTreeLink to="/test-path-extra" title="Other Link" id="other-id" />
+      </>
+    );
+
+    const matchingLink = screen.getByTestId('scopes-dashboards-matching-id');
+    const otherLink = screen.getByTestId('scopes-dashboards-other-id');
+
+    expect(matchingLink).toHaveAttribute('aria-current', 'page');
+    expect(otherLink).not.toHaveAttribute('aria-current');
+  });
+});

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
@@ -86,4 +86,23 @@ describe('ScopesNavigationTreeLink', () => {
     expect(matchingLink).toHaveAttribute('aria-current', 'page');
     expect(otherLink).not.toHaveAttribute('aria-current');
   });
+
+  it('matches path correctly when current location has query parameters', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/test-path',
+    });
+
+    renderWithRouter(
+      <>
+        <ScopesNavigationTreeLink to="/test-path?param1=value1&param2=value2" title="Matching Link" id="matching-id" />
+        <ScopesNavigationTreeLink to="/test-path-other" title="Other Link" id="other-id" />
+      </>
+    );
+
+    const matchingLink = screen.getByTestId('scopes-dashboards-matching-id');
+    const otherLink = screen.getByTestId('scopes-dashboards-other-id');
+
+    expect(matchingLink).toHaveAttribute('aria-current', 'page');
+    expect(otherLink).not.toHaveAttribute('aria-current');
+  });
 });

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
@@ -19,7 +19,8 @@ export function ScopesNavigationTreeLink({ to, title, id }: ScopesNavigationTree
   // For dashboards, the title is appended to the path. We need to diregard this
   const currentPath = isDashboard ? useLocation().pathname.split('/').slice(0, 3).join('/') : useLocation().pathname;
 
-  const isCurrent = to === currentPath;
+  // Ignore query params
+  const isCurrent = to.split('?')[0] === currentPath;
 
   return (
     <Link

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
@@ -24,7 +24,7 @@ export function ScopesNavigationTreeLink({ to, title, id }: ScopesNavigationTree
   const isDashboard = to.startsWith('/d/');
   const locPathname = useLocation().pathname;
 
-  // For dashboards, the title is appended to the path. We need to diregard this
+  // For dashboards, the title is appended to the path when we navigate to just the dashboard id, hence we need to disregard this
   const currentPath = isDashboard ? getDashboardPathForComparison(locPathname) : locPathname;
 
   // Ignore query params

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
@@ -19,11 +19,12 @@ export function ScopesNavigationTreeLink({ to, title, id }: ScopesNavigationTree
   // For dashboards, the title is appended to the path. We need to diregard this
   const currentPath = isDashboard ? useLocation().pathname.split('/').slice(0, 3).join('/') : useLocation().pathname;
 
-  const isCurrent = to.startsWith(currentPath);
+  const isCurrent = to === currentPath;
 
   return (
     <Link
       to={to}
+      aria-current={isCurrent ? 'page' : undefined}
       className={cx(styles.container, isCurrent && styles.current)}
       data-testid={`scopes-dashboards-${id}`}
       role="treeitem"

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
@@ -11,13 +11,21 @@ export interface ScopesNavigationTreeLinkProps {
   id: string;
 }
 
+// Helper function to get the base path for a dashboard URL for comparison purposes.
+// e.g., /d/dashboardId/slug -> /d/dashboardId
+//       /d/dashboardId      -> /d/dashboardId
+function getDashboardPathForComparison(pathname: string): string {
+  return pathname.split('/').slice(0, 3).join('/');
+}
+
 export function ScopesNavigationTreeLink({ to, title, id }: ScopesNavigationTreeLinkProps) {
   const styles = useStyles2(getStyles);
   const linkIcon = useMemo(() => getLinkIcon(to), [to]);
   const isDashboard = to.startsWith('/d/');
+  const locPathname = useLocation().pathname;
 
   // For dashboards, the title is appended to the path. We need to diregard this
-  const currentPath = isDashboard ? useLocation().pathname.split('/').slice(0, 3).join('/') : useLocation().pathname;
+  const currentPath = isDashboard ? getDashboardPathForComparison(locPathname) : locPathname;
 
   // Ignore query params
   const isCurrent = to.split('?')[0] === currentPath;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Improves path matching for current active dashboard/link:
- Removes startsWith
- Removes queryparams for comparison
- Adds `aria-current` for a11y and testing 
- Adds test suite for the link component


**Why do we need this feature?**

So it behaves properly


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hyperion-planning/issues/231

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
