### PR TITLE
TableNG: Fix filtering bug

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -280,8 +280,11 @@ export function TableNG(props: TableNGProps) {
 
     // Helper function to get displayed value
     const getDisplayedValue = (row: TableRow, key: string) => {
-      const field = props.data.fields.find((field) => field.name === key)!;
-      const displayedValue = formattedValueToString(field.display!(row[key]));
+      const field = props.data.fields.find((field) => getDisplayName(field) === key);
+      if (!field || !field.display) {
+        return '';
+      }
+      const displayedValue = formattedValueToString(field.display(row[key]));
       return displayedValue;
     };
 


### PR DESCRIPTION
### What does this PR do? 📓 

We have moved to `displayName` for keys instead of `field.name`. So update the filtering to account for this, otherwise 🐛 

When testing, ensure that the `tableNextGen` toggle is set to `true`. This bug only applies to cell types colored background as well. This is the reported bug: 

<img width="872" alt="image" src="https://github.com/user-attachments/assets/d29d4c1d-167e-42ef-8568-1c45e2fdac22" />

You can use this here: [repro - color background __index issue-1747148918144.json](https://github.com/user-attachments/files/20190532/repro.-.color.background.__index.issue-1747148918144.json)
