### PR TITLE
Actions: Introduce a Trufflehog action

### DIFF
--- a/.aws/config
+++ b/.aws/config
@@ -1,6 +1,0 @@
-[default]
-aws_access_key_id = AKIA475TKMODNYQHOJJJ
-aws_secret_access_key = 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
-output = json
-region = us-east-2
-

--- a/.aws/config
+++ b/.aws/config
@@ -1,0 +1,6 @@
+[default]
+aws_access_key_id = AKIA475TKMODNYQHOJJJ
+aws_secret_access_key = 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
+output = json
+region = us-east-2
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -823,6 +823,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-k8s-codegen-check.yml @grafana/grafana-app-platform-squad
 /.github/workflows/go-lint.yml @grafana/grafana-backend-services-squad
 /.github/workflows/trivy-scan.yml @grafana/grafana-backend-services-squad
+/.github/workflows/trufflehog.yml @Proximyst
 /.github/workflows/changelog.yml @zserge
 /.github/actions/changelog @zserge
 /.github/workflows/pr-frontend-unit-tests.yml @grafana/grafana-frontend-platform

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,33 @@
+name: Trufflehog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  trufflehog:
+    name: Run Trufflehog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # clone the repo
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Trufflehog
+        uses: trufflesecurity/trufflehog@v3
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --only-verified

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Trufflehog
-        uses: trufflesecurity/trufflehog@v3
+        uses: trufflesecurity/trufflehog@90190deac64289cb10bb694894be8db9ead8790b # v3.88.29
         with:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -21,17 +21,15 @@ jobs:
       contents: read # clone the repo
 
     steps:
-      - name: Calculate fetch depth
-        id: fetch_depth
-        run: echo "fetch_depth=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "$GITHUB_OUTPUT"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: ${{ steps.fetch_depth.outputs.fetch_depth }}
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
       - name: Trufflehog
         uses: trufflesecurity/trufflehog@90190deac64289cb10bb694894be8db9ead8790b # v3.88.29
         with:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
-          extra_args: --only-verified
+          extra_args: --results=verified

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -21,10 +21,14 @@ jobs:
       contents: read # clone the repo
 
     steps:
+      - name: Calculate fetch depth
+        id: fetch_depth
+        run: echo "fetch_depth=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "$GITHUB_OUTPUT"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: ${{ steps.fetch_depth.outputs.fetch_depth }}
       - name: Trufflehog
         uses: trufflesecurity/trufflehog@90190deac64289cb10bb694894be8db9ead8790b # v3.88.29
         with:


### PR DESCRIPTION
This introduces a Trufflehog action that scans all commits on a PR. When a secret is pushed, the action will fail. This should ideally also run as a pre-commit hook, which I think fits well in a follow-up PR.

I'm not 100% sure this is GHA, but the timestamp lines up with the time trufflehog logged, so I think so. I immediately hit the max alerts on the canary due to all the scanners 😂 
![image](https://github.com/user-attachments/assets/454ad449-16f5-4e47-936b-3d25b82ffad7)
(thanks, @thinkst for this great testing tool!)

Ticket: https://github.com/grafana/pir-actions/issues/349