### PR TITLE
prometheus: use getSeriesValues in metrics selector

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.mock.ts
+++ b/packages/grafana-prometheus/src/language_provider.mock.ts
@@ -10,6 +10,7 @@ export class EmptyLanguageProviderMock {
   getLabelKeys = jest.fn().mockReturnValue([]);
   getLabelValues = jest.fn().mockReturnValue([]);
   getSeries = jest.fn().mockReturnValue({ __name__: [] });
+  getSeriesValues = jest.fn().mockReturnValue([]);
   fetchSeries = jest.fn().mockReturnValue([]);
   fetchSeriesLabels = jest.fn().mockReturnValue([]);
   fetchSeriesLabelsMatch = jest.fn().mockReturnValue([]);

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.test.tsx
@@ -33,6 +33,7 @@ const createMockDatasource = () => {
       fetchSeriesValuesWithMatch: jest.fn().mockResolvedValue(['value1', 'value2']),
       getLabelValues: jest.fn().mockResolvedValue(['value1', 'value2']),
       getSeries: jest.fn().mockResolvedValue({ __name__: ['metric1', 'metric2'] }),
+      getSeriesValues: jest.fn().mockResolvedValue(['metric1', 'metric2']),
       loadMetricsMetadata: jest.fn().mockResolvedValue({}),
       metricsMetadata: { metric1: { type: 'counter', help: 'help text' } },
     },

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -244,7 +244,7 @@ async function getMetrics(
   let metrics: string[];
   if (query.labels.length > 0) {
     const expr = promQueryModeller.renderLabels(query.labels);
-    metrics = (await datasource.languageProvider.getSeries(timeRange, expr, true))['__name__'] ?? [];
+    metrics = (await datasource.languageProvider.getSeriesValues(timeRange, '__name__', expr)) ?? [];
   } else {
     metrics = (await datasource.languageProvider.getLabelValues(timeRange, '__name__')) ?? [];
   }

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.test.tsx
@@ -99,10 +99,10 @@ describe('PromQueryBuilder', () => {
     });
     await openMetricSelect(container);
     await waitFor(() =>
-      expect(languageProvider.getSeries).toHaveBeenCalledWith(
+      expect(languageProvider.getSeriesValues).toHaveBeenCalledWith(
         expect.anything(),
-        '{label_name="label_value"}',
-        expect.anything()
+        expect.anything(),
+        '{label_name="label_value"}'
       )
     );
   });


### PR DESCRIPTION
When we have labels selected and want to refresh the list of metrics that match this grafana would use an expensive /api/v1/series call instead of /api/v1/label/__name__/values with matchers, even if the datasource is configured to be ble to use matchers in label values calls.

This PR makes the builder use the function that respects the datasource configurtion instead.
