### PR TITLE
Alerting: Enable pause and unpause bulk actions in the alert list view

### DIFF
--- a/public/app/features/alerting/unified/components/folder-bulk-actions/FolderBulkActionsButton.tsx
+++ b/public/app/features/alerting/unified/components/folder-bulk-actions/FolderBulkActionsButton.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export const FolderBulkActionsButton = ({ folderUID }: Props) => {
   const [pauseSupported, pauseAllowed] = useFolderBulkActionAbility(FolderBulkAction.Pause);
-  const canPause = pauseSupported && pauseAllowed && false; // lets disable pause for now
+  const canPause = pauseSupported && pauseAllowed;
   const [deleteSupported, deleteAllowed] = useFolderBulkActionAbility(FolderBulkAction.Delete);
   const canDelete = deleteSupported && deleteAllowed;
   const [pauseFolder, updateState] = alertingFolderActionsApi.endpoints.pauseFolder.useMutation();


### PR DESCRIPTION
**What is this feature?**

After merging https://github.com/grafana/grafana/pull/104674, 
this PR enables the `pause/unpause` bulk actions in the alert list view.
These bulk actions are in the `folder` level and are `only available for admin` users.
As the rest of folder bulk actions in this list view, are behind the feature toggle `alertingBulkActionsInUI` **enabled by default**.

**Why do we need this feature?**

**Who is this feature for?**
Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1105

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
