### PR TITLE
[WIP] Zanzana: Run migrations via openFGA 

### DIFF
--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	dashboardalpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	"github.com/grafana/grafana/pkg/infra/localcache"
@@ -71,10 +70,13 @@ func NewServer(cfg setting.ZanzanaServerSettings, openfga OpenFGAServer, logger 
 }
 
 func (s *Server) IsHealthy(ctx context.Context) (bool, error) {
-	_, err := s.openfga.ListStores(ctx, &openfgav1.ListStoresRequest{
-		PageSize: wrapperspb.Int32(1),
-	})
-	return err == nil, nil
+	// remove: Basically we are checking that we have store?
+	// no not at all. we are just checking that we can list a store without error
+	// _, err := s.openfga.ListStores(ctx, &openfgav1.ListStoresRequest{
+	// 	PageSize: wrapperspb.Int32(1),
+	// })
+	ready, err := s.openfga.IsReady(ctx)
+	return err == nil && ready, nil
 }
 
 func (s *Server) getContextuals(subject string) (*openfgav1.ContextualTupleKeys, error) {


### PR DESCRIPTION
**What is this feature?**
We want to run migrations exactly as openFGA does it, if they change something in their schemas. We would not be able to be synced in versions nor use the `IsReady()` flag from openFGA.

This will eventually add `RunMigration` from openFGA, see [issue](https://github.com/openfga/openfga/issues/2440) on openFGA.

**Why do we need this feature?**
We need to use `IsReady()` on our health endpoints for deployments of openFGA.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/identity-access-team/issues/1392