### PR TITLE
[release-12.0.1] Graphite: Ensure template variables are interpolated correctly

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -446,6 +446,22 @@ describe('graphiteDatasource', () => {
       expect(results[2]).toBe('target=' + encodeURIComponent('asPercent(series1,sumSeries(series1))'));
     });
 
+    it('should replace target placeholder when nesting query references with template variables', () => {
+      ctx.templateSrv.init([{ type: 'query', name: 'metric', current: { value: ['aMetricName'] } }]);
+      const originalTargetMap = {
+        A: '[[metric]]',
+        B: 'sumSeries(#A)',
+        C: 'asPercent(#A,#B)',
+      };
+      const results = ctx.ds.buildGraphiteParams(
+        {
+          targets: [{ target: '[[metric]]' }, { target: 'sumSeries(#A)' }, { target: 'asPercent(#A,#B)' }],
+        },
+        originalTargetMap
+      );
+      expect(results[2]).toBe('target=' + encodeURIComponent('asPercent(aMetricName,sumSeries(aMetricName))'));
+    });
+
     it('should fix wrong minute interval parameters', () => {
       const originalTargetMap = {
         A: "summarize(prod.25m.count, '25m', 'sum')",

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1026,7 +1026,7 @@ export class GraphiteDatasource
       }
 
       targetValue = targets[target.refId];
-      targetValue = targetValue.replace(regex, nestedSeriesRegexReplacer);
+      targetValue = this.templateSrv.replace(targetValue.replace(regex, nestedSeriesRegexReplacer));
       targets[target.refId] = targetValue;
 
       if (!target.hide) {


### PR DESCRIPTION
Backport e60ece33893cccbec2cfbdc41a6e00f0a4b8d084 from #105354

---

Follow on from #104471. This PR ensures that nested queries that contain template variables correctly have those variables interpolated as a part of the final query generation.
