### PR TITLE
Logs: Fixed prettify JSON behavior with unescaped content

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -105,10 +105,7 @@ export const LogRow = ({
   );
   const levelStyles = useMemo(() => getLogLevelStyles(theme, row.logLevel), [row.logLevel, theme]);
   const processedRow = useMemo(
-    () =>
-      row.hasUnescapedContent && forceEscape
-        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
-        : row,
+    () => (row.hasUnescapedContent && forceEscape ? { ...row, entry: escapeUnescapedString(row.entry) } : row),
     [forceEscape, row]
   );
   const errorMessage = checkLogsError(row);
@@ -292,6 +289,7 @@ export const LogRow = ({
             mouseIsOver={mouseIsOver}
             onBlur={onMouseLeave}
             expanded={showDetails}
+            forceEscape={forceEscape}
             logRowMenuIconsBefore={logRowMenuIconsBefore}
             logRowMenuIconsAfter={logRowMenuIconsAfter}
           />

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, getDefaultNormalizer } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 
@@ -232,6 +232,55 @@ line3`;
       expect(screen.getByText(/1 more/)).toBeInTheDocument();
       await userEvent.click(screen.getByText(/1 more/));
       expect(screen.queryByText(/1 more/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Incorrectly escaped content in JSON logs', () => {
+    let entry = '';
+    beforeEach(() => {
+      entry = `{"stacktrace":"stack line 1\\n\\tat stack line 2\\n\\tat stack line 3\\n\\tat stack line 4\\n\\t..."}`;
+    });
+    it('Displays unprettified JSON logs with incorrectly escaped content', async () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000, hasUnescapedContent: true }),
+        prettifyLogMessage: false,
+        forceEscape: false,
+      });
+      expect(screen.getByText(entry)).toBeInTheDocument();
+    });
+
+    it('Displays prettified JSON logs with unescaped content', async () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000, hasUnescapedContent: true }),
+        prettifyLogMessage: true,
+        forceEscape: false,
+      });
+      expect(screen.queryByText(entry)).not.toBeInTheDocument();
+    });
+
+    it('Displays prettified JSON logs with escaped content', async () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000, hasUnescapedContent: true }),
+        prettifyLogMessage: true,
+        forceEscape: true,
+      });
+      expect(screen.queryByText(entry)).not.toBeInTheDocument();
+      expect(screen.getByText(/"stacktrace": "stack line 1/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/\tat stack line 2/, {
+          normalizer: getDefaultNormalizer({ collapseWhitespace: false, trim: true }),
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/\tat stack line 3/, {
+          normalizer: getDefaultNormalizer({ collapseWhitespace: false, trim: true }),
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/\tat stack line 4/, {
+          normalizer: getDefaultNormalizer({ collapseWhitespace: false, trim: true }),
+        })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -7,6 +7,8 @@ import { DataQuery } from '@grafana/schema';
 import { PopoverContent, useTheme2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
+import { escapeUnescapedString } from '../utils';
+
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
@@ -36,6 +38,7 @@ interface Props {
   expanded?: boolean;
   logRowMenuIconsBefore?: ReactNode[];
   logRowMenuIconsAfter?: ReactNode[];
+  forceEscape?: boolean;
 }
 
 interface LogMessageProps {
@@ -115,15 +118,22 @@ const getEllipsisStyles = (theme: GrafanaTheme2) => ({
 });
 
 const restructureLog = (
-  line: string,
+  row: LogRowModel,
   prettifyLogMessage: boolean,
   wrapLogMessage: boolean,
-  expanded: boolean
+  expanded: boolean,
+  forceEscape: boolean
 ): string => {
+  let line = row.raw;
+  console.log(row.raw);
   if (prettifyLogMessage) {
     try {
-      return JSON.stringify(JSON.parse(line), undefined, 2);
+      line = JSON.stringify(JSON.parse(line), undefined, 2);
+      return row.hasUnescapedContent && forceEscape ? escapeUnescapedString(line) : line;
     } catch (error) {}
+  }
+  if (row.hasUnescapedContent && forceEscape) {
+    line = escapeUnescapedString(line);
   }
   // With wrapping disabled, we want to turn it into a single-line log entry unless the line is expanded
   if (!wrapLogMessage && !expanded) {
@@ -151,13 +161,16 @@ export const LogRowMessage = memo((props: Props) => {
     expanded,
     logRowMenuIconsBefore,
     logRowMenuIconsAfter,
+    forceEscape,
   } = props;
-  const { hasAnsi, raw } = row;
+  const { hasAnsi } = row;
   const restructuredEntry = useMemo(
-    () => restructureLog(raw, prettifyLogMessage, wrapLogMessage, Boolean(expanded)),
-    [raw, prettifyLogMessage, wrapLogMessage, expanded]
+    () => restructureLog(row, prettifyLogMessage, wrapLogMessage, Boolean(expanded), Boolean(forceEscape)),
+    [expanded, forceEscape, prettifyLogMessage, row, wrapLogMessage]
   );
   const shouldShowMenu = mouseIsOver || pinned;
+
+  console.log(restructuredEntry, prettifyLogMessage, forceEscape);
 
   return (
     <>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -125,7 +125,6 @@ const restructureLog = (
   forceEscape: boolean
 ): string => {
   let line = row.raw;
-  console.log(row.raw);
   if (prettifyLogMessage) {
     try {
       line = JSON.stringify(JSON.parse(line), undefined, 2);
@@ -169,8 +168,6 @@ export const LogRowMessage = memo((props: Props) => {
     [expanded, forceEscape, prettifyLogMessage, row, wrapLogMessage]
   );
   const shouldShowMenu = mouseIsOver || pinned;
-
-  console.log(restructuredEntry, prettifyLogMessage, forceEscape);
 
   return (
     <>


### PR DESCRIPTION
Before these changes, when JSON logs had escaped new lines and, with prettify JSON enabled, fix escaping was clicked, it broke the pretty print. This was because JSON.parse was silently failing with the added control caracters.

![Error](https://github.com/user-attachments/assets/fa414f31-266d-4df3-9512-4d942382f409)

Now, we're applying the unescaped string replacement after parsing JSON, allowing prettifying of JSON to happen.

![after](https://github.com/user-attachments/assets/67c22d92-ffbd-43e8-aa0f-ce64c9810875)

To reproduce, you can modify https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/loki/data/data.js  to send something like `{"stacktrace":"stack line 1\\n\\tat stack line 2\\n\\tat stack line 3\\n\\tat stack line 4\\n\\t..."}`, containing escaped newlines and tabs. Alternatively, use line_format to generate an equivalent JSON log. With that, you should see the following option, will used to break JSON formatting (when it was enabled):

![imagen](https://github.com/user-attachments/assets/62f22bda-27a0-4671-a29d-7916d9a2724b)

Fixes #104049