### PR TITLE
Tests: Disable flaky integration tests

### DIFF
--- a/pkg/services/libraryelements/libraryelements_get_all_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_all_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestIntegration_GetAllLibraryElements(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191196704?pr=8583
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206086427?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	testScenario(t, "When an admin tries to get all library panels and none exists, it should return none",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.getAllHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestIntegration_PatchLibraryElement(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191205705?pr=8583
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206095545?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	scenarioWithPanel(t, "When an admin tries to patch a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{Kind: int64(model.PanelElement), Version: 1}

--- a/pkg/services/queryhistory/queryhistory_unstar_test.go
+++ b/pkg/services/queryhistory/queryhistory_unstar_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestIntegrationUnstarQueryInQueryHistory(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191195390?pr=8583
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206085291?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -498,6 +498,10 @@ func TestIntegration_DashboardNestedPermissionFilter(t *testing.T) {
 }
 
 func TestIntegration_DashboardNestedPermissionFilter_WithSelfContainedPermissions(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191196704?pr=8583
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206086427?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	testCases := []struct {
 		desc                    string
 		queryType               string

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -32,6 +32,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationStorageServer(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191194120?pr=8583
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206084276?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	if db.IsTestDBSpanner() {
 		t.Skip("skipping integration test")
 	}
@@ -55,6 +59,9 @@ func TestIntegrationStorageServer(t *testing.T) {
 
 // TestStorageBackend is a test for the StorageBackend interface.
 func TestIntegrationSQLStorageBackend(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15013574205/job/42191194120?pr=8583
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	if db.IsTestDBSpanner() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -506,6 +506,9 @@ spec:
 }
 
 func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T) {
+	// https://github.com/grafana/grafana-enterprise/actions/runs/15019815803/job/42206092834?pr=8603
+	t.Skip("Disabled due to flakiness or timeout with MySQL")
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
Disable integration tests that have flakiness on GHA, mostly with MySQL + Enterprise