### PR TITLE
Docs: Improve raw format description and examples

### DIFF
--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -136,23 +136,23 @@ Interpolation result: 'test1.|test2'
 
 ### Raw
 
-Doesn't apply any formatting to the variable.
-Characters that would typically be escaped are left included.
+Doesn't apply any data source-specific formatting to the variable.
 
-Typically, the UID of a data source is converted to the data source name, as shown in the following example:
+For example, in this case, there's a dashboard with a Prometheus data source and a multi-value variable.
+Grafana typically converts the variable values as follows to accommodate Prometheus:
 
 ```bash
-datasourceVariable = 'd7bbe725-9e48-4af8-a0cb-6cb255d873a3'
-String to interpolate: '${datasourceVariable:raw}'
-Interpolation result: 'Prometheus-1'
+servers = ['test1.', 'test2']
+String to interpolate: '${servers}'
+Interpolation result: '(test1 | test2)'
 ```
 
-Using the raw format, a data source variable returns the UID (unique identifier) of the data source instead:
+Using the raw format, the values are returned without that formatting:
 
 ```bash
-datasourceVariable = 'd7bbe725-9e48-4af8-a0cb-6cb255d873a3'
-String to interpolate: '${datasourceVariable:raw}'
-Interpolation result: 'd7bbe725-9e48-4af8-a0cb-6cb255d873a3'
+servers = ['test1.', 'test2']
+String to interpolate: '${servers:raw}'
+Interpolation result: 'test1,test2'
 ```
 
 ### Regex

--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -136,7 +136,18 @@ Interpolation result: 'test1.|test2'
 
 ### Raw
 
-The raw format for a data source variable returns the UID (unique identifier) of the data source, rather than its name.
+Doesn't apply any formatting to the variable.
+Characters that would typically be escaped are left included.
+
+Typically, the UID of a data source is converted to the data source name, as shown in the following example:
+
+```bash
+datasourceVariable = 'd7bbe725-9e48-4af8-a0cb-6cb255d873a3'
+String to interpolate: '${datasourceVariable:raw}'
+Interpolation result: 'Prometheus-1'
+```
+
+Using the raw format, a data source variable returns the UID (unique identifier) of the data source instead:
 
 ```bash
 datasourceVariable = 'd7bbe725-9e48-4af8-a0cb-6cb255d873a3'


### PR DESCRIPTION
Add a clear description of what the raw variable format does.
Add an extra example to show the contrast between what it does and doesn't do.

Preceding conversation:
Small feedback I just received around variable syntax docs. The customer had trouble using modifiers, they wanted to use raw data in their datalinks and they seemed aware of https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/ this doc and they mentioned the raw  modifier description was very confusing and seemed unrelated to their use case. They've used it after I suggested it and it fixed their issue, but they probably wouldn't have thought of using it because of the description.
