### PR TITLE
Secrets: handle secure value update when the secret value is not being updated

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -202,11 +202,6 @@ func (s *SecureValueRest) Update(
 	// TODO: do we need to do this here again? Probably not, but double-check!
 	newSecureValue.Annotations = xkube.CleanAnnotations(newSecureValue.Annotations)
 
-	newSecureValue.Status = secretv0alpha1.SecureValueStatus{
-		Message: "Updating secure value",
-		Phase:   secretv0alpha1.SecureValuePhasePending,
-	}
-
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return nil, false, fmt.Errorf("missing auth info in context")


### PR DESCRIPTION
### Problem

- Client sends an update request without including a new spec.value
- `SecretService.Update` calls `outboxStore.Append` to add a new message to the outbox queue
- `outboxStore.Append` tries to consume secure value and panics because the value is empty 

### Solution

Do not call `outboxStore.Append` if spec.value is not being updated, just update the other secure value fields and succeed immediately