### PR TITLE
[release-12.0.1] Add comments explaining what pages the aliases redirect and fix broken aliases

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/_index.md
@@ -1,14 +1,13 @@
 ---
 aliases:
-  - ../../../auth/saml/
-  - ../../../enterprise/configure-saml/
-  - ../../../enterprise/saml/
-  - ../../../enterprise/saml/about-saml/
-  - ../../../enterprise/saml/configure-saml/
-  - ../../../enterprise/saml/enable-saml/
-  - ../../../enterprise/saml/set-up-saml-with-okta/
-  - ../../../enterprise/saml/troubleshoot-saml/
-  - ../../../saml/
+  - ../../../auth/saml/ # /docs/grafana/latest/auth/saml/
+  - ../../../enterprise/configure-saml/ # /docs/grafana/latest/enterprise/configure-saml/
+  - ../../../enterprise/saml/ # /docs/grafana/latest/enterprise/saml/
+  - ../../../enterprise/saml/about-saml/ # /docs/grafana/latest/enterprise/saml/about-saml/
+  - ../../../enterprise/saml/configure-saml/ # /docs/grafana/latest/enterprise/saml/configure-saml/
+  - ../../../enterprise/saml/enable-saml/ # /docs/grafana/latest/enterprise/saml/enable-saml/
+  - ../../../enterprise/saml/set-up-saml-with-okta/ # /docs/grafana/latest/enterprise/saml/set-up-saml-with-okta/
+  - ../../../enterprise/saml/troubleshoot-saml/ # /docs/grafana/latest/enterprise/saml/troubleshoot-saml/
 description: Learn how to configure SAML authentication in Grafana's configuration
   file.
 labels:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-org-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-org-mapping/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-signing-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-signing-encryption/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-single-logout/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-single-logout/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-team-role-mapping/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
@@ -1,7 +1,4 @@
 ---
-aliases:
-  - ./saml/#set-up-saml-with-azure-ad
-  - ../saml/#set-up-saml-with-azure-ad
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/index/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/saml-configuration-options/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/saml-configuration-options/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 labels:
   products:
     - cloud

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/saml-ui/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/saml-ui/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - ../../../../saml/saml-ui/
+  - ../saml-ui/ # /docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml-ui/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/troubleshoot-saml/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/troubleshoot-saml/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - ../../../../saml/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:
   products:


### PR DESCRIPTION
Backport 39e78045577149795774ffced57e526f106b7c88 from #105408

---

New pages don't need redirects and some of these new aliases redirect pages they shouldn't.

https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml-ui/ doesn't get redirected right now in prod but does in the [deploy preview](https://deploy-preview-grafana-105408-zb444pucvq-vp.a.run.app/).


Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

