### PR TITLE
[release-12.0.1] Update grafanactl installation instructions

### DIFF
--- a/docs/sources/observability-as-code/grafana-cli/install-grafana-cli.md
+++ b/docs/sources/observability-as-code/grafana-cli/install-grafana-cli.md
@@ -42,5 +42,5 @@ To build `grafanactl` from source you must:
 - Have `go` v1.24 (or greater) installed
 
 ```bash
-go install github.com/grafana/grafanactl/cmd@latest
+go install github.com/grafana/grafanactl/cmd/grafanactl@latest
 ```


### PR DESCRIPTION
Backport d75a930548c795bf8bc15217a480665257acaa5d from #104616

---

**What is this feature?**

This commit updates the docs section for `grafanactl` with correct installation instructions for `go install`.

**Why do we need this feature?**

The package was updated in https://github.com/grafana/grafanactl/pull/81.

**Who is this feature for?**

`grafanactl` users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.**
