### PR TITLE
TabsLayoutManagerRendere: Fix custom grid not rendering inside a tab

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -117,7 +117,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     flex: 1,
-    minHeight: 0,
+    // Without this min height, the custom grid (SceneGridLayout) wont render
+    // Should be bigger than paddingTop value
+    // consist of paddingTop + 0.125 = 9px
+    minHeight: theme.spacing(1 + 0.125),
     paddingTop: theme.spacing(1),
   }),
 });


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana/pull/104640

Custom grid did not render in View mode when it was inside a tab in a row ( Row > Tab > Custom Grid)

(e2e for this case is coming in separate PR)

https://github.com/user-attachments/assets/f3a9d209-3c2a-40ec-ad52-8f21e79e03a7

