### PR TITLE
api/admin: Skip TestIntegration_AdminApiReencrypt test.

### DIFF
--- a/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestIntegration_AdminApiReencrypt_Enterprise(t *testing.T) {
+	t.Skip("This test is currently broken, investigating...")
+
 	getSecretsFunctions := map[string]func(*testing.T, *server.TestEnv) map[int]secret{}
 	getSecretsFunctions["settings"] = func(t *testing.T, env *server.TestEnv) map[int]secret {
 		return getSettingSecrets(t, env.SQLStore)

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -36,6 +36,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration_AdminApiReencrypt(t *testing.T) {
+	t.Skip("This test is currently broken, investigating...")
+
 	const (
 		dataSourceTable              = "data_source"
 		secretsTable                 = "secrets"


### PR DESCRIPTION
This PR disables `TestIntegration_AdminApiReencrypt` test while we're investigating why it's failing.

Update: fixing failing test requires https://github.com/grafana/grafana-enterprise/pull/8309.