### PR TITLE
ui(alerting): Add `NeedHelp` section for the `Missing series evaluations to resolve` setting

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -373,30 +373,62 @@ export function GrafanaEvaluationBehaviorStep({
                 label={t('alerting.alert.missing-series-resolve', 'Missing series evaluations to resolve')}
                 description={t(
                   'alerting.alert.description-missing-series-evaluations',
-                  'How many consecutive evaluation intervals with no data for a dimension must pass before the alert state is considered stale and automatically resolved. If no value is provided, the value will default to 2.'
+                  'The number of consecutive evaluation intervals a dimension must be missing before the alert instance becomes stale, and is then automatically resolved and evicted. Defaults to 2 if empty.'
                 )}
                 invalid={!!errors.missingSeriesEvalsToResolve?.message}
                 error={errors.missingSeriesEvalsToResolve?.message}
                 className={styles.inlineField}
                 htmlFor="missing-series-resolve"
               >
-                <Input
-                  placeholder={t(
-                    'alerting.grafana-evaluation-behavior-step.missing-series-resolve-placeholder',
-                    'Default: 2'
-                  )}
-                  id="missing-series-resolve"
-                  {...register('missingSeriesEvalsToResolve', {
-                    pattern: {
-                      value: /^\d+$/,
-                      message: t(
-                        'alerting.grafana-evaluation-behavior-step.message.must-be-a-positive-integer',
-                        'Must be a positive integer.'
-                      ),
-                    },
-                  })}
-                  width={21}
-                />
+                <Stack direction="row" gap={0.5} alignItems="center">
+                  <Input
+                    placeholder={t(
+                      'alerting.grafana-evaluation-behavior-step.missing-series-resolve-placeholder',
+                      'Default: 2'
+                    )}
+                    id="missing-series-resolve"
+                    {...register('missingSeriesEvalsToResolve', {
+                      pattern: {
+                        value: /^\d+$/,
+                        message: t(
+                          'alerting.grafana-evaluation-behavior-step.message.must-be-a-positive-integer',
+                          'Must be a positive integer.'
+                        ),
+                      },
+                    })}
+                    width={21}
+                  />
+                  <NeedHelpInfo
+                    contentText={
+                      <>
+                        <p>
+                          {t(
+                            'alerting.alert-missing-evaluations-to-stale.help-info.text1',
+                            'An alert instance is considered stale if the alert rule query returns data, but the specific dimension (or series) for that alert instance is missing for several consecutive evaluation intervals.'
+                          )}
+                        </p>
+                        <p>
+                          {t(
+                            'alerting.alert-missing-evaluations-to-stale.help-info.text2',
+                            'A stale alert instance is resolved and then evicted.'
+                          )}
+                        </p>
+                        {t(
+                          'alerting.alert-missing-evaluations-to-stale.help-info.text3',
+                          'This setting defines how many consecutive evaluation intervals must pass without data before an alert instance is considered stale. Defaults to 2 if empty.'
+                        )}
+                      </>
+                    }
+                    externalLink={
+                      'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/state-alert-instances/'
+                    }
+                    linkText={t(
+                      'alerting.alert-missing-evaluations-to-stale.help-info.link-text',
+                      `Read more about stale alert instances`
+                    )}
+                    title={t('alerting.alert-missing-evaluations-to-stale.help-info.title', 'Stale alert instances')}
+                  />
+                </Stack>
               </Field>
             </>
           )}

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -420,7 +420,7 @@ export function GrafanaEvaluationBehaviorStep({
                       </>
                     }
                     externalLink={
-                      'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/state-alert-instances/'
+                      'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances/'
                     }
                     linkText={t(
                       'alerting.alert-missing-evaluations-to-stale.help-info.link-text',

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx
@@ -166,7 +166,7 @@ export const Details = ({ rule }: DetailsProps) => {
                 value={missingSeriesEvalsToResolve}
                 tooltipValue={t(
                   'alerting.alert.description-missing-series-evaluations',
-                  'How many consecutive evaluation intervals with no data for a dimension must pass before the alert state is considered stale and automatically resolved. If no value is provided, the value will default to 2.'
+                  'The number of consecutive evaluation intervals a dimension must be missing before the alert instance becomes stale, and is then automatically resolved and evicted. Defaults to 2 if empty.'
                 )}
               />
             )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -352,7 +352,7 @@
     "alert": {
       "alert-state": "Alert state",
       "annotations": "Annotations",
-      "description-missing-series-evaluations": "How many consecutive evaluation intervals with no data for a dimension must pass before the alert state is considered stale and automatically resolved. If no value is provided, the value will default to 2.",
+      "description-missing-series-evaluations": "The number of consecutive evaluation intervals a dimension must be missing before the alert instance becomes stale, and is then automatically resolved and evicted. Defaults to 2 if empty.",
       "evaluation": "Evaluation",
       "evaluation-paused": "Alert evaluation currently paused",
       "evaluation-paused-description": "Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.",
@@ -427,6 +427,15 @@
     },
     "alert-instance-state-filter": {
       "state": "State"
+    },
+    "alert-missing-evaluations-to-stale": {
+      "help-info": {
+        "title": "Stale alert instances",
+        "link-text": "Read more about stale alert instances",
+        "text1": "An alert instance is considered stale if the alert rule query returns data, but the specific dimension (or series) for that alert instance is missing for several consecutive evaluation intervals.",
+        "text2": "A stale alert instance is resolved and then evicted.",
+        "text3": "This setting defines how many consecutive evaluation intervals must pass without data before an alert instance is considered stale. Defaults to 2 if empty."
+      }
     },
     "alert-label": {
       "tooltip-remove-label": "Remove label"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -428,15 +428,6 @@
     "alert-instance-state-filter": {
       "state": "State"
     },
-    "alert-missing-evaluations-to-stale": {
-      "help-info": {
-        "title": "Stale alert instances",
-        "link-text": "Read more about stale alert instances",
-        "text1": "An alert instance is considered stale if the alert rule query returns data, but the specific dimension (or series) for that alert instance is missing for several consecutive evaluation intervals.",
-        "text2": "A stale alert instance is resolved and then evicted.",
-        "text3": "This setting defines how many consecutive evaluation intervals must pass without data before an alert instance is considered stale. Defaults to 2 if empty."
-      }
-    },
     "alert-label": {
       "tooltip-remove-label": "Remove label"
     },
@@ -458,6 +449,15 @@
       "export": "Export",
       "silence-notifications": "Silence notifications",
       "with-modifications": "With modifications"
+    },
+    "alert-missing-evaluations-to-stale": {
+      "help-info": {
+        "link-text": "Read more about stale alert instances",
+        "text1": "An alert instance is considered stale if the alert rule query returns data, but the specific dimension (or series) for that alert instance is missing for several consecutive evaluation intervals.",
+        "text2": "A stale alert instance is resolved and then evicted.",
+        "text3": "This setting defines how many consecutive evaluation intervals must pass without data before an alert instance is considered stale. Defaults to 2 if empty.",
+        "title": "Stale alert instances"
+      }
     },
     "alert-recording-rule-form": {
       "evaluation-behaviour": {


### PR DESCRIPTION
The “Missing series evaluations to resolve” setting was introduced in https://github.com/grafana/grafana/pull/102808.

New users are often confused with NoData and stale scenarios.   To address this, we’re improving the documentation with a dedicated page explaining how stale alert instances work:  https://github.com/grafana/grafana/pull/105415

This PR aims to improve a bit the UI for the new setting.
It adds a NeedHelp section that details the behavior of stale alert instances, including a link to the upcoming new docs.


![Screenshot 2025-05-15 at 11 14 22 (1)](https://github.com/user-attachments/assets/8a47b0d5-7657-445b-a8df-4fcc81aeafe5)






TODOs:
- [x] Merge this PR only after https://github.com/grafana/grafana/pull/105415 is published under `/docs/grafana/latest/`.

Next:
- [ ] Trigger automatic Crowdin translations

