### PR TITLE
api/admin: Reenable AdminApiReencrypt tests, fix enterprise version of the test.

### DIFF
--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -36,8 +36,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration_AdminApiReencrypt(t *testing.T) {
-	t.Skip("This test is currently broken, investigating...")
-
 	const (
 		dataSourceTable              = "data_source"
 		secretsTable                 = "secrets"


### PR DESCRIPTION
This PR reenabled AdminApiReencrypt integraion tests and fixes `TestIntegration_AdminApiReencrypt_Enterprise` test: 
 access to "key" column needs to use quoting when running on MySQL.

This is required to let https://github.com/grafana/grafana-enterprise/pull/8309 pass its CI checks (using same branch name)