### PR TITLE
[release-11.6.2] ConvertFieldType: Update "join with" to work on array of strings

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -359,7 +359,7 @@ describe('field convert types transformer', () => {
     ]);
   });
 
-  it('will support custom join separators', () => {
+  it('will support custom join separators for field type other', () => {
     const options = {
       conversions: [{ targetField: 'vals', destinationType: FieldType.string, joinWith: '|' }],
     };
@@ -387,6 +387,38 @@ describe('field convert types transformer', () => {
       {
         type: FieldType.string,
         values: ['a|b|2', '3|x|y'],
+      },
+    ]);
+  });
+
+  it('will support custom join separators for field type string', () => {
+    const options = {
+      conversions: [{ targetField: 'string_arrays', destinationType: FieldType.string, joinWith: '&' }],
+    };
+
+    const stringArrayValues = toDataFrame({
+      fields: [
+        {
+          name: 'string_arrays',
+          type: FieldType.string,
+          values: [
+            ['a', 'b', 'c'],
+            ['d', 'e', 'f'],
+          ],
+        },
+      ],
+    });
+
+    const stringified = convertFieldTypes(options, [stringArrayValues]);
+    expect(
+      stringified[0].fields.map(({ type, values }) => ({
+        type,
+        values,
+      }))
+    ).toEqual([
+      {
+        type: FieldType.string,
+        values: ['a&b&c', 'd&e&f'],
       },
     ]);
   });

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -210,12 +210,15 @@ export function fieldToStringField(
       values = values.map((v) => dateTimeParse(v, parseOptions).format(dateFormat));
       break;
 
+    // Handle both "string" and "other" types to ensure compatibility across Grafana versions (10 & 11)
+    // In some cases fields are classified as 'other' in Grafana 10 but as 'string' in Grafana 11
+    case FieldType.string:
     case FieldType.other:
       values = values.map((v) => {
         if (joinWith?.length && Array.isArray(v)) {
           return v.join(joinWith);
         }
-        return JSON.stringify(v); // will quote strings and avoid "object"
+        return field.type === FieldType.other ? JSON.stringify(v) : `${v}`;
       });
       break;
 

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -177,7 +177,7 @@ export const ConvertFieldTypeTransformerEditor = ({
                 <>
                   {shouldRenderJoinWith && (
                     <InlineField label="Join with" tooltip="Use an explicit separator when joining array values">
-                      <Input value={c.joinWith} placeholder={'JSON'} onChange={onJoinWithChange(idx)} width={9} />
+                      <Input value={c.joinWith} placeholder={'JSON'} onChange={onJoinWithChange(idx)} width={16} />
                     </InlineField>
                   )}
                   {targetField?.type === FieldType.time && (

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -132,6 +132,14 @@ export const ConvertFieldTypeTransformerEditor = ({
     <>
       {options.conversions.map((c: ConvertFieldTypeOptions, idx: number) => {
         const targetField = findField(input?.[0], c.targetField);
+
+        // Show "Join with" input when:
+        // - A join value exists (maintains backward compatibility)
+        // - Target field type is 'other' (Grafana 10) or 'string' (Grafana 11)
+        // This ensures consistent UI across versions where arrays may be classified differently.
+        const shouldRenderJoinWith =
+          c.joinWith?.length || (targetField?.type && [FieldType.other, FieldType.string].includes(targetField.type));
+
         return (
           <div key={`${c.targetField}-${idx}`}>
             <InlineFieldRow>
@@ -167,7 +175,7 @@ export const ConvertFieldTypeTransformerEditor = ({
               )}
               {c.destinationType === FieldType.string && (
                 <>
-                  {(c.joinWith?.length || targetField?.type === FieldType.other) && (
+                  {shouldRenderJoinWith && (
                     <InlineField label="Join with" tooltip="Use an explicit separator when joining array values">
                       <Input value={c.joinWith} placeholder={'JSON'} onChange={onJoinWithChange(idx)} width={9} />
                     </InlineField>


### PR DESCRIPTION
Backport b77bf9889045976fc54be64b356e4b58005e1cfc from #105074

---

### What does this PR do? 📓 

Somewhere between Grafana `10.4.18` and `11.6.1`, as noted by a specific Grafana customer, the “Convert field type” transformation and it’s “joinWith” option seemingly busted. 

Can test with this: [Debug_ Escalation re_ groupBy-1746720920909.json](https://github.com/user-attachments/files/20106191/Debug_.Escalation.re_.groupBy-1746720920909.json)

What we can see: 
- Prior to `11.6.1`, their original field type changed from “other” to “string” (see screenshots below).
- The “Convert field type” transform does not correctly handle the “join with” option unless the origin type is of type “other”. 
- Therefore, the “join with” transformation option is busted when the origin field is of type "string".

#### Grafana `10.4.18`

<img width="831" alt="Screenshot 2025-05-07 at 11 36 33 AM" src="https://github.com/user-attachments/assets/3e1898a3-2600-4590-83fa-796883f31eaf" />

#### Grafana `11.6.1`

<img width="828" alt="Screenshot 2025-05-07 at 11 34 57 AM" src="https://github.com/user-attachments/assets/56a304b4-7ef9-4401-a2fa-81378977e340" />

### How does this PR fix this?

I’m honestly not sure where this types issue comes from and when it was introduced. The "Host (allValues)" field going from type “other” to type “string" is totally unknown to me. If anybody has ideas, I’d LOVE to know 😄 

The solution, however, is to allow the “join with” option to render for either origin type “other” or “string”, and then **IF** the fields are joinable (i.e., they’re an array of simple types), we join them.

This should be 1) backwards compatible, no issues, and 2) support this customer and I assume other customer’s use cases.
