### PR TITLE
[release-11.6.2] Table: Fix nested table bug

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -420,9 +420,6 @@ export const RowsList = (props: RowsListProps) => {
     }
   };
 
-  // Key the virtualizer for expanded rows
-  const expandedKey = Object.keys(tableState.expanded).join('|');
-
   // It's a hack for text wrapping.
   // VariableSizeList component didn't know that we manually set row height.
   // So we need to reset the list when the rows high changes.
@@ -435,8 +432,7 @@ export const RowsList = (props: RowsListProps) => {
   return (
     <CustomScrollbar onScroll={handleScroll} hideHorizontalTrack={true} scrollTop={scrollTop}>
       <VariableSizeList
-        // This component needs an unmount/remount when row height, page changes, or expanded rows change
-        key={`${rowHeight}${pageIndex}${expandedKey}`}
+        key={`${rowHeight}${pageIndex}`}
         height={listHeight}
         itemCount={itemCount}
         itemSize={getItemSize}


### PR DESCRIPTION
Backport 0041c7e9b7b7c07829831ab1e38309150af3f37e from #105133

---

### What does this PR do? 📓 

Resolves a custom escalation found here: https://github.com/grafana/support-escalations/issues/16176

Fixes #105048

This is for the old version of table (not TableNG). There's a `key` being added to the `VariableSizeList` that includes an `expandedKey` component that forces a table re-render. I _don't_ think it needs to be there. The key is a combination of page index (for re-rendering the table when the page changes), rowHeight (for re-rendering when cell height changes - e.g., using the panel options), and expandedKey (for re-rendering when expanded rows changes). 

In my testing I found the first two key components to be necessary, but I did not find the `expandedKey` to be necessary. It looks like the table correctly adjusts heights. It also gets rid of the bug mentioned in the customer escalation and issue.

#### Before

https://github.com/user-attachments/assets/a68a2064-52f9-4bb3-b4bd-1c3c2f5eb678

#### After

https://github.com/user-attachments/assets/b04add73-a5ac-475c-bffb-add2e1dbc54a
