### PR TITLE
Dashboards - E2E test - New layout - textbox variable

### DIFF
--- a/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -78,7 +78,7 @@ describe('Dashboard edit - variables', () => {
       type: 'textbox',
       name: 'VariableUnderTest',
       value: 'foo',
-      label: 'VariableUnderTest', // constant doesn't really need a label
+      label: 'VariableUnderTest',
     };
 
     // common steps to add a new variable

--- a/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -91,6 +91,7 @@ describe('Dashboard edit - variables', () => {
     field.should('be.visible');
     field.find('input').should('be.visible').clear().type(variable.value).blur();
 
+    // select the variable in the dashboard and confirm the variable value is set
     e2e.pages.Dashboard.SubMenu.submenuItem().should('be.visible').click();
     e2e.pages.Dashboard.SubMenu.submenuItemLabels(variable.label).should('be.visible').contains(variable.label);
 

--- a/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -92,6 +92,7 @@ describe('Dashboard edit - variables', () => {
     field.find('input').should('be.visible').clear().type(variable.value).blur();
 
     e2e.pages.Dashboard.SubMenu.submenuItem().should('be.visible').click();
+    e2e.pages.Dashboard.SubMenu.submenuItemLabels(variable.label).should('be.visible').contains(variable.label);
 
     // assert the panel is visible and has the correct value
     e2e.components.Panels.Panel.content()

--- a/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -67,4 +67,38 @@ describe('Dashboard edit - variables', () => {
         cy.get('.markdown-html').should('include.text', `VariableUnderTest: ${variable.value}`);
       });
   });
+
+  it('can add a new textbox variable', () => {
+    e2e.pages.Dashboards.visit();
+
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1` });
+    cy.contains(DASHBOARD_NAME).should('be.visible');
+
+    const variable: Variable = {
+      type: 'textbox',
+      name: 'VariableUnderTest',
+      value: 'foo',
+      label: 'VariableUnderTest', // constant doesn't really need a label
+    };
+
+    // common steps to add a new variable
+    flows.newEditPaneVariableClick();
+    flows.newEditPanelCommonVariableInputs(variable);
+
+    // set the textbox variable value
+    const type = 'variable-type Value';
+    const field = e2e.components.PanelEditor.OptionsPane.fieldLabel(type);
+    field.should('be.visible');
+    field.find('input').should('be.visible').clear().type(variable.value).blur();
+
+    e2e.pages.Dashboard.SubMenu.submenuItem().should('be.visible').click();
+
+    // assert the panel is visible and has the correct value
+    e2e.components.Panels.Panel.content()
+      .should('be.visible')
+      .first()
+      .within(() => {
+        cy.get('.markdown-html').should('include.text', `VariableUnderTest: ${variable.value}`);
+      });
+  });
 });


### PR DESCRIPTION
Adds an E2E test case for the edit pane/inline textbox variable editor.
