### PR TITLE
Chore: Reuse `getCellLinks` in Table Panel

### DIFF
--- a/packages/grafana-ui/src/components/Table/Cells/DataLinksCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/DataLinksCell.tsx
@@ -1,10 +1,10 @@
-import { getCellLinks } from '../../../utils';
+import { getCellLinks } from '../TableNG/utils';
 import { TableCellProps } from '../types';
 
 export const DataLinksCell = (props: TableCellProps) => {
   const { field, row, cellProps, tableStyles } = props;
 
-  const links = getCellLinks(field, row);
+  const links = getCellLinks(field, row.index);
 
   return (
     <div {...cellProps} className={tableStyles.cellContainerText}>

--- a/packages/grafana-ui/src/components/Table/Cells/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/DefaultCell.tsx
@@ -6,11 +6,11 @@ import { DisplayValue, formattedValueToString } from '@grafana/data';
 import { TableCellDisplayMode } from '@grafana/schema';
 
 import { useStyles2 } from '../../../themes';
-import { getCellLinks } from '../../../utils';
 import { clearLinkButtonStyles } from '../../Button';
 import { DataLinksContextMenu } from '../../DataLinks/DataLinksContextMenu';
 import { CellActions } from '../CellActions';
 import { TableCellInspectorMode } from '../TableCellInspector';
+import { getCellLinks } from '../TableNG/utils';
 import { TableStyles } from '../TableRT/styles';
 import { TableCellProps, CustomCellRendererProps, TableCellOptions } from '../types';
 import { getCellColors, getCellOptions } from '../utils';
@@ -23,7 +23,7 @@ export const DefaultCell = (props: TableCellProps) => {
   const showFilters = props.onCellFilterAdded && field.config.filterable;
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellOptions = getCellOptions(field);
-  const cellLinks = getCellLinks(field, row);
+  const cellLinks = getCellLinks(field, row.index);
   const hasLinks = cellLinks?.some((link) => link.href || link.onClick != null);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
   let value: string | ReactElement;
@@ -81,7 +81,7 @@ export const DefaultCell = (props: TableCellProps) => {
     <div key={key} {...rest} className={cellStyle}>
       {hasLinks ? (
         <DataLinksContextMenu
-          links={() => getCellLinks(field, row)?.filter((link) => link.href || link.onClick != null) || []}
+          links={() => getCellLinks(field, row.index)?.filter((link) => link.href || link.onClick != null) || []}
         >
           {(api) => {
             if (api.openMenu) {

--- a/packages/grafana-ui/src/components/Table/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/ImageCell.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { getCellLinks } from '../../../utils';
 import { DataLinksContextMenu } from '../../DataLinks/DataLinksContextMenu';
+import { getCellLinks } from '../TableNG/utils';
 import { TableCellDisplayMode, TableCellProps } from '../types';
 import { getCellOptions } from '../utils';
 
@@ -13,7 +13,7 @@ export const ImageCell = (props: TableCellProps) => {
   const { title, alt } =
     cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { title: undefined, alt: undefined };
   const displayValue = field.display!(cell.value);
-  const hasLinks = Boolean(getCellLinks(field, row)?.length);
+  const hasLinks = Boolean(getCellLinks(field, row.index)?.length);
 
   // The image element
   const img = (
@@ -33,7 +33,7 @@ export const ImageCell = (props: TableCellProps) => {
       {hasLinks ? (
         <DataLinksContextMenu
           style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
-          links={() => getCellLinks(field, row) || []}
+          links={() => getCellLinks(field, row.index) || []}
         >
           {(api) => {
             if (api.openMenu) {

--- a/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
@@ -2,11 +2,11 @@ import { css, cx } from '@emotion/css';
 import { isString } from 'lodash';
 
 import { useStyles2 } from '../../../themes';
-import { getCellLinks } from '../../../utils';
 import { Button, clearLinkButtonStyles } from '../../Button';
 import { DataLinksContextMenu } from '../../DataLinks/DataLinksContextMenu';
 import { CellActions } from '../CellActions';
 import { TableCellInspectorMode } from '../TableCellInspector';
+import { getCellLinks } from '../TableNG/utils';
 import { TableCellProps } from '../types';
 
 export function JSONViewCell(props: TableCellProps): JSX.Element {
@@ -28,14 +28,14 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
     displayValue = JSON.stringify(value, null, ' ');
   }
 
-  const hasLinks = Boolean(getCellLinks(field, row)?.length);
+  const hasLinks = Boolean(getCellLinks(field, row.index)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
   return (
     <div {...cellProps} className={inspectEnabled ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer}>
       <div className={cx(tableStyles.cellText, txt)}>
         {hasLinks ? (
-          <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
+          <DataLinksContextMenu links={() => getCellLinks(field, row.index) || []}>
             {(api) => {
               if (api.openMenu) {
                 return (


### PR DESCRIPTION
`getCellLinks` was similar in old table vs tableNG utils. This PR reuses the tableNg function. We'll keep the old table function in place, as it's exposed in `grafana-ui`.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
