### PR TITLE
ds-querier: handle execute errors better

### DIFF
--- a/pkg/apis/query/v0alpha1/query.go
+++ b/pkg/apis/query/v0alpha1/query.go
@@ -30,11 +30,11 @@ type QueryDataResponse struct {
 // GetResponseCode return the right status code for the response by checking the responses.
 func GetResponseCode(rsp *backend.QueryDataResponse) int {
 	if rsp == nil {
-		return http.StatusBadRequest
+		return http.StatusTeapot // rsp is nil, so we return a teapot
 	}
 	for _, res := range rsp.Responses {
 		if res.Error != nil {
-			return http.StatusBadRequest
+			return int(res.Status)
 		}
 	}
 	return http.StatusOK

--- a/pkg/apis/query/v0alpha1/query.go
+++ b/pkg/apis/query/v0alpha1/query.go
@@ -33,8 +33,12 @@ func GetResponseCode(rsp *backend.QueryDataResponse) int {
 		return http.StatusTeapot // rsp is nil, so we return a teapot
 	}
 	for _, res := range rsp.Responses {
-		if res.Error != nil {
+		if res.Error != nil && res.Status != 0 {
 			return int(res.Status)
+		}
+
+		if res.Error != nil {
+			return http.StatusTeapot // Status is nil but we have an error, so we return a teapot
 		}
 	}
 	return http.StatusOK

--- a/pkg/apis/query/v0alpha1/query_test.go
+++ b/pkg/apis/query/v0alpha1/query_test.go
@@ -93,8 +93,8 @@ func TestGetResponseCode(t *testing.T) {
 			},
 		}))
 	})
-	t.Run("return 400 if there is an error in the responses", func(t *testing.T) {
-		assert.Equal(t, 400, query.GetResponseCode(&backend.QueryDataResponse{
+	t.Run("return 418 if there is an error in the responses but no status code", func(t *testing.T) {
+		assert.Equal(t, 418, query.GetResponseCode(&backend.QueryDataResponse{
 			Responses: map[string]backend.DataResponse{
 				"A": {
 					Error: fmt.Errorf("some wild error"),
@@ -102,8 +102,8 @@ func TestGetResponseCode(t *testing.T) {
 			},
 		}))
 	})
-	t.Run("return 400 if there is a partial error", func(t *testing.T) {
-		assert.Equal(t, 400, query.GetResponseCode(&backend.QueryDataResponse{
+	t.Run("return 418 if there is a partial error but no status code", func(t *testing.T) {
+		assert.Equal(t, 418, query.GetResponseCode(&backend.QueryDataResponse{
 			Responses: map[string]backend.DataResponse{
 				"A": {
 					Error: nil,

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -168,7 +168,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 				return
 			} else {
 				// return the error to the client, will send all non k8s errors as a k8 unexpected error
-				b.log.Error("execute respond with error, no rsp", "err", err)
+				b.log.Error("hit unexpected error while executing query, this will show as an unhandled k8s status error", "err", err)
 				responder.Error(err)
 				return
 			}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -160,21 +160,17 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		// Actually run the query
 		rsp, err := b.execute(ctx, req)
 		if err != nil {
-			// log unexpected errors
-			var k8sErr *errorsK8s.StatusError
-			if errors.As(err, &k8sErr) {
-				// we do not need to log 4xx errors as they are expected
-				if k8sErr.ErrStatus.Code >= 500 {
-					b.log.Error("hit unexpected k8s error while executing query", "err", err, "status", k8sErr.Status())
-				}
-				b.log.Debug("sending a known k8s error to the client", "err", err, "status", k8sErr.Status())
+			b.log.Error("execute error", "http code", query.GetResponseCode(rsp), "err", err)
+			if rsp != nil { // if we have a response, we assume the err is set in the response
+				responder.Object(query.GetResponseCode(rsp), &query.QueryDataResponse{
+					QueryDataResponse: *rsp,
+				})
+				return
 			} else {
-				b.log.Error("hit unexpected error while executing query, this will show as an unhandled k8s status error", "err", err)
+				// return the error to the client, will send all non k8s errors as a k8 unexpected error
+				responder.Error(err)
+				return
 			}
-
-			// return the error to the client, will send all non k8s errors as a k8 unexpected error
-			responder.Error(err)
-			return
 		}
 
 		responder.Object(query.GetResponseCode(rsp), &query.QueryDataResponse{
@@ -270,6 +266,10 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 				}
 			}
 		}
+	}
+
+	if err != nil {
+		rsp = buildErrorResponse(err, req)
 	}
 
 	return rsp, err

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -168,6 +168,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 				return
 			} else {
 				// return the error to the client, will send all non k8s errors as a k8 unexpected error
+				b.log.Error("execute respond with error, no rsp", "err", err)
 				responder.Error(err)
 				return
 			}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -269,6 +269,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 	}
 
 	if err != nil {
+		b.log.Debug("error in single datasource query", "error", err)
 		rsp = buildErrorResponse(err, req)
 	}
 


### PR DESCRIPTION
This addresses two problems:

1. We had lots of "false positive" errors because we'd return `responder.Error` with the error message instead of `responder.Object` with the `qdr` which contains the error message. https://github.com/grafana/grafana/blob/48c5b55cdb50780dc53ec6b9adf14e65e9275442/pkg/registry/apis/query/query.go#L177-L180
2. In a case where we get an error after querying we weren't returning an error qdr, just the err, which resulted in broken parsing of the err. https://github.com/grafana/grafana/blob/48c5b55cdb50780dc53ec6b9adf14e65e9275442/pkg/registry/apis/query/query.go#L215-L218