### PR TITLE
Dashboard: Use metadata.generation for dash version in v1

### DIFF
--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -198,7 +198,7 @@ describe('v1 dashboard API', () => {
         });
 
         expect(result.uid).toBe('adh59cn');
-        expect(result.version).toBe(0);
+        expect(result.version).toBe(1);
         expect(result.url).toBe('/d/adh59cn/new-dashboard-saved');
       });
       it('should provide dashboard URL with app sub url configured', async () => {
@@ -224,7 +224,7 @@ describe('v1 dashboard API', () => {
         });
 
         expect(result.uid).toBe('adh59cn');
-        expect(result.version).toBe(0);
+        expect(result.version).toBe(1);
         expect(result.url).toBe('/grafana/d/adh59cn/new-dashboard-saved');
       });
     });
@@ -242,7 +242,7 @@ describe('v1 dashboard API', () => {
         });
 
         expect(result.uid).toBe('adh59cn');
-        expect(result.version).toBe(0);
+        expect(result.version).toBe(1);
         expect(result.url).toBe('/d/adh59cn/new-dashboard-saved');
       });
 
@@ -268,7 +268,7 @@ describe('v1 dashboard API', () => {
         });
 
         expect(result.uid).toBe('adh59cn');
-        expect(result.version).toBe(0);
+        expect(result.version).toBe(1);
         expect(result.url).toBe('/grafana/d/adh59cn/new-dashboard-saved');
       });
     });

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -89,7 +89,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
 
     return {
       uid: v.metadata.name,
-      version: v.spec.version ?? 0,
+      version: v.metadata.generation ?? 0,
       id: v.spec.id ?? 0,
       status: 'success',
       url,


### PR DESCRIPTION
Fixes a bug in v1 k8s dashboards where, after editing and saving a dashboard, it wasn't possible to update the dashboard anymore, but create new dashboard.

This is because in `asSaveDashboardResponseDTO` for v1, we weren't passing `metadata.generation` to `version`. 

To test, you can use this ephemeral instance [dashboard](https://ephemeral15111821105499harisr.grafana-dev.net/d/hanpgqz/new-dashboard?orgId=1&from=now-6h&to=now&timezone=browser&editPanel=1)  which has `kubernetesDashboards` enabled by default, so no need to mess with local storage :) 
 
Please check that:
- [ ] It works as expected from a user's perspective.

