### PR TITLE
Feature: [[ENTERPRISE]] Panel Exporter (3/3) Adjustable Auth Cookie Domain for Panel Exporter

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -585,6 +585,9 @@ revoke = true
 token_expiration_day_limit =
 
 [auth]
+# Login cookie domain. By default, this is an empty string (same domain as http request). Users can set the cookie domain to 'example.com' which would allow shared login across subdomains, e.g. 'portal.example.com', 'grafana.example.com'
+login_cookie_domain = ""
+
 # Login cookie name
 login_cookie_name = grafana_session
 

--- a/pkg/middleware/cookies/cookies.go
+++ b/pkg/middleware/cookies/cookies.go
@@ -41,7 +41,6 @@ func WriteCookie(w http.ResponseWriter, name string, value string, maxAge int, g
 	}
 
 	options := getCookieOptions()
-
 	cookie := http.Cookie{
 		Name:     name,
 		MaxAge:   maxAge,

--- a/pkg/middleware/cookies/cookies.go
+++ b/pkg/middleware/cookies/cookies.go
@@ -3,7 +3,6 @@ package cookies
 import (
 	"net/http"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -42,9 +41,7 @@ func WriteCookie(w http.ResponseWriter, name string, value string, maxAge int, g
 	}
 
 	options := getCookieOptions()
-	if !featuremgmt.AnyEnabled(&featuremgmt.FeatureManager{}, featuremgmt.FlagPanelExporterCookieDomain) {
-		options.Domain = ""
-	}
+
 	cookie := http.Cookie{
 		Name:     name,
 		MaxAge:   maxAge,

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -31,6 +31,7 @@ const (
 	ClientSAML         = "auth.client.saml"
 	ClientPasswordless = "auth.client.passwordless"
 	ClientLDAP         = "ldap"
+	ClientProvisioning = "auth.client.apiserver.provisioning"
 )
 
 const (

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -31,7 +31,6 @@ const (
 	ClientSAML         = "auth.client.saml"
 	ClientPasswordless = "auth.client.passwordless"
 	ClientLDAP         = "ldap"
-	ClientProvisioning = "auth.client.apiserver.provisioning"
 )
 
 const (
@@ -322,7 +321,10 @@ func WriteSessionCookie(w http.ResponseWriter, cfg *setting.Cfg, token *usertoke
 		maxAge = -1
 	}
 
-	cookies.WriteCookie(w, cfg.LoginCookieName, url.QueryEscape(token.UnhashedToken), maxAge, nil)
+	cookies.WriteCookie(w, cfg.LoginCookieName, url.QueryEscape(token.UnhashedToken), maxAge, func() cookies.CookieOptions {
+		opts := cookieOptions(cfg)()
+		return opts
+	})
 	expiry := token.NextRotation(time.Duration(cfg.TokenRotationIntervalMinutes) * time.Minute)
 	cookies.WriteCookie(w, sessionExpiryCookie, url.QueryEscape(strconv.FormatInt(expiry.Unix(), 10)), maxAge, func() cookies.CookieOptions {
 		opts := cookieOptions(cfg)()
@@ -348,6 +350,7 @@ func cookieOptions(cfg *setting.Cfg) func() cookies.CookieOptions {
 		}
 		return cookies.CookieOptions{
 			Path:             path,
+			Domain:           cfg.LoginCookieDomain,
 			Secure:           cfg.CookieSecure,
 			SameSiteDisabled: cfg.CookieSameSiteDisabled,
 			SameSiteMode:     cfg.CookieSameSiteMode,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -466,6 +466,12 @@ var (
 			FrontendOnly: true,
 		},
 		{
+			Name:         "panelExporterCookieDomain",
+			Description:  "Enables setting the auth cookie domain. Required by Grafana Panel Exporter",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaSharingSquad,
+		},
+		{
 			Name:              "enableNativeHTTPHistogram",
 			Description:       "Enables native HTTP Histograms",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -466,12 +466,6 @@ var (
 			FrontendOnly: true,
 		},
 		{
-			Name:         "panelExporterCookieDomain",
-			Description:  "Enables setting the auth cookie domain. Required by Grafana Panel Exporter",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaSharingSquad,
-		},
-		{
 			Name:              "enableNativeHTTPHistogram",
 			Description:       "Enables native HTTP Histograms",
 			Stage:             FeatureStageExperimental,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -129,13 +129,12 @@ type Cfg struct {
 	Packaging string
 
 	// Paths
-	HomePath                   string
-	ProvisioningPath           string
-	PermittedProvisioningPaths []string
-	DataPath                   string
-	LogsPath                   string
-	PluginsPath                string
-	EnterpriseLicensePath      string
+	HomePath              string
+	ProvisioningPath      string
+	DataPath              string
+	LogsPath              string
+	PluginsPath           string
+	EnterpriseLicensePath string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -144,7 +143,7 @@ type Cfg struct {
 	ImagesDir                      string
 	CSVsDir                        string
 	PDFsDir                        string
-	RendererServerUrl              string
+	RendererUrl                    string
 	RendererCallbackUrl            string
 	RendererAuthToken              string
 	RendererConcurrentRequestLimit int
@@ -176,13 +175,11 @@ type Cfg struct {
 	CSPReportOnlyEnabled bool
 	// CSPReportOnlyTemplate contains the Content Security Policy Report Only template.
 	CSPReportOnlyTemplate           string
+	AngularSupportEnabled           bool
 	EnableFrontendSandboxForPlugins []string
 	DisableGravatar                 bool
 	DataProxyWhiteList              map[string]bool
 	ActionsAllowPostURL             string
-
-	// K8s Dashboard Cleanup
-	K8sDashboardCleanup K8sDashboardCleanupSettings
 
 	TempDataLifetime time.Duration
 
@@ -206,8 +203,6 @@ type Cfg struct {
 	PluginsCDNURLTemplate    string
 	PluginLogBackendRequests bool
 
-	PluginUpdateStrategy string
-
 	// Panels
 	DisableSanitizeHtml bool
 
@@ -228,9 +223,9 @@ type Cfg struct {
 	MinRefreshInterval          string
 	DefaultHomeDashboardPath    string
 	DashboardPerformanceMetrics []string
-	PanelSeriesLimit            int
 
 	// Auth
+	LoginCookieDomain             string
 	LoginCookieName               string
 	LoginMaxInactiveLifetime      time.Duration
 	LoginMaxLifetime              time.Duration
@@ -300,8 +295,8 @@ type Cfg struct {
 	// DistributedCache
 	RemoteCacheOptions *RemoteCacheSettings
 
-	// Deprecated: no longer used
-	ViewersCanEdit bool
+	ViewersCanEdit  bool // Deprecated: no longer used
+	EditorsCanAdmin bool // Deprecated: no longer used
 
 	ApiKeyMaxSecondsToLive int64
 
@@ -425,15 +420,6 @@ type Cfg struct {
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
 
-	// SQLExpressionCellLimit is the maximum number of cells (rows × columns, across all frames) that can be accepted by a SQL expression.
-	SQLExpressionCellLimit int64
-
-	// SQLExpressionOutputCellLimit is the maximum number of cells (rows × columns) that can be outputted by a SQL expression.
-	SQLExpressionOutputCellLimit int64
-
-	// SQLExpressionTimeoutSeconds is the duration a SQL expression will run before timing out
-	SQLExpressionTimeout time.Duration
-
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -549,32 +535,23 @@ type Cfg struct {
 	ShortLinkExpiration int
 
 	// Unified Storage
-	UnifiedStorage                             map[string]UnifiedStorageConfig
-	IndexPath                                  string
-	IndexWorkers                               int
-	IndexMaxBatchSize                          int
-	IndexFileThreshold                         int
-	IndexMinCount                              int
-	EnableSharding                             bool
-	MemberlistBindAddr                         string
-	MemberlistAdvertiseAddr                    string
-	MemberlistJoinMember                       string
-	MemberlistClusterLabel                     string
-	MemberlistClusterLabelVerificationDisabled bool
-	InstanceID                                 string
-	SprinklesApiServer                         string
-	SprinklesApiServerPageLimit                int
-	CACertPath                                 string
-	HttpsSkipVerify                            bool
-
-	// Secrets Management
-	SecretsManagement SecretsManagerSettings
+	UnifiedStorage              map[string]UnifiedStorageConfig
+	IndexPath                   string
+	IndexWorkers                int
+	IndexMaxBatchSize           int
+	IndexFileThreshold          int
+	IndexMinCount               int
+	SprinklesApiServer          string
+	SprinklesApiServerPageLimit int
+	CACertPath                  string
+	HttpsSkipVerify             bool
 }
+
+const UnifiedStorageConfigKeyDashboard = "dashboards.dashboard.grafana.app"
 
 type UnifiedStorageConfig struct {
 	DualWriterMode                       rest.DualWriterMode
 	DualWriterPeriodicDataSyncJobEnabled bool
-	DualWriterMigrationDataSyncDisabled  bool
 	// DataSyncerInterval defines how often the data syncer should run for a resource on the grafana instance.
 	DataSyncerInterval time.Duration
 	// DataSyncerRecordsLimit defines how many records will be processed at max during a sync invocation.
@@ -590,7 +567,7 @@ type InstallPlugin struct {
 // AddChangePasswordLink returns if login form is disabled or not since
 // the same intention can be used to hide both features.
 func (cfg *Cfg) AddChangePasswordLink() bool {
-	return !cfg.DisableLoginForm && !cfg.DisableLogin
+	return !(cfg.DisableLoginForm || cfg.DisableLogin)
 }
 
 type CommandLineArgs struct {
@@ -641,7 +618,6 @@ func RedactedValue(key, value string) string {
 		"CLIENT_SECRET",
 		"ENTERPRISE_LICENSE",
 		"API_DB_PASS",
-		"^TOKEN$",
 		"ID_FORWARDING_TOKEN$",
 		"AUTHENTICATION_TOKEN$",
 		"AUTH_TOKEN$",
@@ -805,9 +781,6 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
-	cfg.SQLExpressionCellLimit = expressions.Key("sql_expression_cell_limit").MustInt64(100000)
-	cfg.SQLExpressionOutputCellLimit = expressions.Key("sql_expression_output_cell_limit").MustInt64(100000)
-	cfg.SQLExpressionTimeout = expressions.Key("sql_expression_timeout").MustDuration(time.Second * 10)
 }
 
 type AnnotationCleanupSettings struct {
@@ -1162,17 +1135,12 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 		return err
 	}
 
-	if err := cfg.readProvisioningSettings(iniFile); err != nil {
-		return err
-	}
-
 	// read dashboard settings
 	dashboards := iniFile.Section("dashboards")
 	cfg.DashboardVersionsToKeep = dashboards.Key("versions_to_keep").MustInt(20)
 	cfg.MinRefreshInterval = valueAsString(dashboards, "min_refresh_interval", "5s")
 	cfg.DefaultHomeDashboardPath = dashboards.Key("default_home_dashboard_path").MustString("")
 	cfg.DashboardPerformanceMetrics = util.SplitString(dashboards.Key("dashboard_performance_metrics").MustString(""))
-	cfg.PanelSeriesLimit = dashboards.Key("panel_series_limit").MustInt(0)
 
 	if err := readUserSettings(iniFile, cfg); err != nil {
 		return err
@@ -1190,7 +1158,9 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.readZanzanaSettings()
 
-	cfg.readRenderingSettings(iniFile)
+	if err := cfg.readRenderingSettings(iniFile); err != nil {
+		return err
+	}
 
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
 	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)
@@ -1275,12 +1245,12 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	panelsSection := iniFile.Section("panels")
 	cfg.DisableSanitizeHtml = panelsSection.Key("disable_sanitize_html").MustBool(false)
 
-	// nolint:staticcheck
-	if err := cfg.readFeatureToggles(iniFile); err != nil {
+	if err := cfg.readPluginSettings(iniFile); err != nil {
 		return err
 	}
 
-	if err := cfg.readPluginSettings(iniFile); err != nil {
+	// nolint:staticcheck
+	if err := cfg.readFeatureToggles(iniFile); err != nil {
 		return err
 	}
 
@@ -1318,7 +1288,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.readDataSourcesSettings()
 	cfg.readDataSourceSecuritySettings()
-	cfg.readK8sDashboardCleanupSettings()
 	cfg.readSqlDataSourceSettings()
 
 	cfg.Storage = readStorageSettings(iniFile)
@@ -1381,7 +1350,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.readFeatureManagementConfig()
 	cfg.readPublicDashboardsSettings()
 	cfg.readCloudMigrationSettings()
-	cfg.readSecretsManagerSettings()
 
 	// read experimental scopes settings.
 	scopesSection := iniFile.Section("scopes")
@@ -1600,6 +1568,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.StrictTransportSecurityMaxAge = security.Key("strict_transport_security_max_age_seconds").MustInt(86400)
 	cfg.StrictTransportSecurityPreload = security.Key("strict_transport_security_preload").MustBool(false)
 	cfg.StrictTransportSecuritySubDomains = security.Key("strict_transport_security_subdomains").MustBool(false)
+	cfg.AngularSupportEnabled = security.Key("angular_support_enabled").MustBool(false)
 	cfg.CSPEnabled = security.Key("content_security_policy").MustBool(false)
 	cfg.CSPTemplate = security.Key("content_security_policy_template").MustString("")
 	cfg.CSPReportOnlyEnabled = security.Key("content_security_policy_report_only").MustBool(false)
@@ -1638,6 +1607,8 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 
 func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	auth := iniFile.Section("auth")
+
+	cfg.LoginCookieDomain = valueAsString(auth, "login_cookie_domain", cfg.Domain)
 
 	cfg.LoginCookieName = valueAsString(auth, "login_cookie_name", "grafana_session")
 	const defaultMaxInactiveLifetime = "7d"
@@ -1761,11 +1732,15 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.ExternalUserMngAnalytics = users.Key("external_manage_analytics").MustBool(false)
 	cfg.ExternalUserMngAnalyticsParams = valueAsString(users, "external_manage_analytics_params", "")
 
-	//nolint:staticcheck
+	// Deprecated
 	cfg.ViewersCanEdit = users.Key("viewers_can_edit").MustBool(false)
-	//nolint:staticcheck
 	if cfg.ViewersCanEdit {
 		cfg.Logger.Warn("[Deprecated] The viewers_can_edit configuration setting is deprecated. Please upgrade viewers to editors.")
+	}
+	// Deprecated
+	cfg.EditorsCanAdmin = users.Key("editors_can_admin").MustBool(false)
+	if cfg.EditorsCanAdmin {
+		cfg.Logger.Warn("[Deprecated] The editors_can_admin configuration setting is deprecated. Please upgrade editors to admin.")
 	}
 
 	userInviteMaxLifetimeVal := valueAsString(users, "user_invite_max_lifetime_duration", "24h")
@@ -1817,11 +1792,25 @@ func readServiceAccountSettings(iniFile *ini.File, cfg *Cfg) error {
 	return nil
 }
 
-func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
+func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) error {
 	renderSec := iniFile.Section("rendering")
-	cfg.RendererServerUrl = valueAsString(renderSec, "server_url", "")
+	cfg.RendererUrl = valueAsString(renderSec, "server_url", "")
 	cfg.RendererCallbackUrl = valueAsString(renderSec, "callback_url", "")
 	cfg.RendererAuthToken = valueAsString(renderSec, "renderer_token", "-")
+
+	if cfg.RendererCallbackUrl == "" {
+		cfg.RendererCallbackUrl = AppUrl
+	} else {
+		if cfg.RendererCallbackUrl[len(cfg.RendererCallbackUrl)-1] != '/' {
+			cfg.RendererCallbackUrl += "/"
+		}
+		_, err := url.Parse(cfg.RendererCallbackUrl)
+		if err != nil {
+			// XXX: Should return an error?
+			cfg.Logger.Error("Invalid callback_url.", "url", cfg.RendererCallbackUrl, "error", err)
+			os.Exit(1)
+		}
+	}
 
 	cfg.RendererConcurrentRequestLimit = renderSec.Key("concurrent_render_request_limit").MustInt(30)
 	cfg.RendererRenderKeyLifeTime = renderSec.Key("render_key_lifetime").MustDuration(5 * time.Minute)
@@ -1831,6 +1820,8 @@ func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
 	cfg.ImagesDir = filepath.Join(cfg.DataPath, "png")
 	cfg.CSVsDir = filepath.Join(cfg.DataPath, "csv")
 	cfg.PDFsDir = filepath.Join(cfg.DataPath, "pdf")
+
+	return nil
 }
 
 func (cfg *Cfg) readAlertingSettings(iniFile *ini.File) error {
@@ -2031,24 +2022,6 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	}
 
 	cfg.LiveAllowedOrigins = originPatterns
-	return nil
-}
-
-func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
-	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
-	cfg.ProvisioningPath = makeAbsolute(provisioning, cfg.HomePath)
-
-	provisioningPaths := strings.TrimSpace(valueAsString(iniFile.Section("paths"), "permitted_provisioning_paths", ""))
-	if provisioningPaths != "|" && provisioningPaths != "" {
-		cfg.PermittedProvisioningPaths = strings.Split(provisioningPaths, "|")
-		for i, s := range cfg.PermittedProvisioningPaths {
-			s = strings.TrimSpace(s)
-			if s == "" {
-				return fmt.Errorf("a provisioning path is empty in '%s' (at index %d)", provisioningPaths, i)
-			}
-			cfg.PermittedProvisioningPaths[i] = makeAbsolute(s, cfg.HomePath)
-		}
-	}
 	return nil
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -129,12 +129,13 @@ type Cfg struct {
 	Packaging string
 
 	// Paths
-	HomePath              string
-	ProvisioningPath      string
-	DataPath              string
-	LogsPath              string
-	PluginsPath           string
-	EnterpriseLicensePath string
+	HomePath                   string
+	ProvisioningPath           string
+	PermittedProvisioningPaths []string
+	DataPath                   string
+	LogsPath                   string
+	PluginsPath                string
+	EnterpriseLicensePath      string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -143,7 +144,7 @@ type Cfg struct {
 	ImagesDir                      string
 	CSVsDir                        string
 	PDFsDir                        string
-	RendererUrl                    string
+	RendererServerUrl              string
 	RendererCallbackUrl            string
 	RendererAuthToken              string
 	RendererConcurrentRequestLimit int
@@ -175,11 +176,13 @@ type Cfg struct {
 	CSPReportOnlyEnabled bool
 	// CSPReportOnlyTemplate contains the Content Security Policy Report Only template.
 	CSPReportOnlyTemplate           string
-	AngularSupportEnabled           bool
 	EnableFrontendSandboxForPlugins []string
 	DisableGravatar                 bool
 	DataProxyWhiteList              map[string]bool
 	ActionsAllowPostURL             string
+
+	// K8s Dashboard Cleanup
+	K8sDashboardCleanup K8sDashboardCleanupSettings
 
 	TempDataLifetime time.Duration
 
@@ -203,6 +206,8 @@ type Cfg struct {
 	PluginsCDNURLTemplate    string
 	PluginLogBackendRequests bool
 
+	PluginUpdateStrategy string
+
 	// Panels
 	DisableSanitizeHtml bool
 
@@ -223,6 +228,7 @@ type Cfg struct {
 	MinRefreshInterval          string
 	DefaultHomeDashboardPath    string
 	DashboardPerformanceMetrics []string
+	PanelSeriesLimit            int
 
 	// Auth
 	LoginCookieDomain             string
@@ -295,8 +301,8 @@ type Cfg struct {
 	// DistributedCache
 	RemoteCacheOptions *RemoteCacheSettings
 
-	ViewersCanEdit  bool // Deprecated: no longer used
-	EditorsCanAdmin bool // Deprecated: no longer used
+	// Deprecated: no longer used
+	ViewersCanEdit bool
 
 	ApiKeyMaxSecondsToLive int64
 
@@ -420,6 +426,15 @@ type Cfg struct {
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
 
+	// SQLExpressionCellLimit is the maximum number of cells (rows × columns, across all frames) that can be accepted by a SQL expression.
+	SQLExpressionCellLimit int64
+
+	// SQLExpressionOutputCellLimit is the maximum number of cells (rows × columns) that can be outputted by a SQL expression.
+	SQLExpressionOutputCellLimit int64
+
+	// SQLExpressionTimeoutSeconds is the duration a SQL expression will run before timing out
+	SQLExpressionTimeout time.Duration
+
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -535,23 +550,32 @@ type Cfg struct {
 	ShortLinkExpiration int
 
 	// Unified Storage
-	UnifiedStorage              map[string]UnifiedStorageConfig
-	IndexPath                   string
-	IndexWorkers                int
-	IndexMaxBatchSize           int
-	IndexFileThreshold          int
-	IndexMinCount               int
-	SprinklesApiServer          string
-	SprinklesApiServerPageLimit int
-	CACertPath                  string
-	HttpsSkipVerify             bool
-}
+	UnifiedStorage                             map[string]UnifiedStorageConfig
+	IndexPath                                  string
+	IndexWorkers                               int
+	IndexMaxBatchSize                          int
+	IndexFileThreshold                         int
+	IndexMinCount                              int
+	EnableSharding                             bool
+	MemberlistBindAddr                         string
+	MemberlistAdvertiseAddr                    string
+	MemberlistJoinMember                       string
+	MemberlistClusterLabel                     string
+	MemberlistClusterLabelVerificationDisabled bool
+	InstanceID                                 string
+	SprinklesApiServer                         string
+	SprinklesApiServerPageLimit                int
+	CACertPath                                 string
+	HttpsSkipVerify                            bool
 
-const UnifiedStorageConfigKeyDashboard = "dashboards.dashboard.grafana.app"
+	// Secrets Management
+	SecretsManagement SecretsManagerSettings
+}
 
 type UnifiedStorageConfig struct {
 	DualWriterMode                       rest.DualWriterMode
 	DualWriterPeriodicDataSyncJobEnabled bool
+	DualWriterMigrationDataSyncDisabled  bool
 	// DataSyncerInterval defines how often the data syncer should run for a resource on the grafana instance.
 	DataSyncerInterval time.Duration
 	// DataSyncerRecordsLimit defines how many records will be processed at max during a sync invocation.
@@ -567,7 +591,7 @@ type InstallPlugin struct {
 // AddChangePasswordLink returns if login form is disabled or not since
 // the same intention can be used to hide both features.
 func (cfg *Cfg) AddChangePasswordLink() bool {
-	return !(cfg.DisableLoginForm || cfg.DisableLogin)
+	return !cfg.DisableLoginForm && !cfg.DisableLogin
 }
 
 type CommandLineArgs struct {
@@ -618,6 +642,7 @@ func RedactedValue(key, value string) string {
 		"CLIENT_SECRET",
 		"ENTERPRISE_LICENSE",
 		"API_DB_PASS",
+		"^TOKEN$",
 		"ID_FORWARDING_TOKEN$",
 		"AUTHENTICATION_TOKEN$",
 		"AUTH_TOKEN$",
@@ -781,6 +806,9 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
+	cfg.SQLExpressionCellLimit = expressions.Key("sql_expression_cell_limit").MustInt64(100000)
+	cfg.SQLExpressionOutputCellLimit = expressions.Key("sql_expression_output_cell_limit").MustInt64(100000)
+	cfg.SQLExpressionTimeout = expressions.Key("sql_expression_timeout").MustDuration(time.Second * 10)
 }
 
 type AnnotationCleanupSettings struct {
@@ -1135,12 +1163,17 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 		return err
 	}
 
+	if err := cfg.readProvisioningSettings(iniFile); err != nil {
+		return err
+	}
+
 	// read dashboard settings
 	dashboards := iniFile.Section("dashboards")
 	cfg.DashboardVersionsToKeep = dashboards.Key("versions_to_keep").MustInt(20)
 	cfg.MinRefreshInterval = valueAsString(dashboards, "min_refresh_interval", "5s")
 	cfg.DefaultHomeDashboardPath = dashboards.Key("default_home_dashboard_path").MustString("")
 	cfg.DashboardPerformanceMetrics = util.SplitString(dashboards.Key("dashboard_performance_metrics").MustString(""))
+	cfg.PanelSeriesLimit = dashboards.Key("panel_series_limit").MustInt(0)
 
 	if err := readUserSettings(iniFile, cfg); err != nil {
 		return err
@@ -1158,9 +1191,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.readZanzanaSettings()
 
-	if err := cfg.readRenderingSettings(iniFile); err != nil {
-		return err
-	}
+	cfg.readRenderingSettings(iniFile)
 
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
 	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)
@@ -1245,12 +1276,12 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	panelsSection := iniFile.Section("panels")
 	cfg.DisableSanitizeHtml = panelsSection.Key("disable_sanitize_html").MustBool(false)
 
-	if err := cfg.readPluginSettings(iniFile); err != nil {
+	// nolint:staticcheck
+	if err := cfg.readFeatureToggles(iniFile); err != nil {
 		return err
 	}
 
-	// nolint:staticcheck
-	if err := cfg.readFeatureToggles(iniFile); err != nil {
+	if err := cfg.readPluginSettings(iniFile); err != nil {
 		return err
 	}
 
@@ -1288,6 +1319,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.readDataSourcesSettings()
 	cfg.readDataSourceSecuritySettings()
+	cfg.readK8sDashboardCleanupSettings()
 	cfg.readSqlDataSourceSettings()
 
 	cfg.Storage = readStorageSettings(iniFile)
@@ -1350,6 +1382,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.readFeatureManagementConfig()
 	cfg.readPublicDashboardsSettings()
 	cfg.readCloudMigrationSettings()
+	cfg.readSecretsManagerSettings()
 
 	// read experimental scopes settings.
 	scopesSection := iniFile.Section("scopes")
@@ -1568,7 +1601,6 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.StrictTransportSecurityMaxAge = security.Key("strict_transport_security_max_age_seconds").MustInt(86400)
 	cfg.StrictTransportSecurityPreload = security.Key("strict_transport_security_preload").MustBool(false)
 	cfg.StrictTransportSecuritySubDomains = security.Key("strict_transport_security_subdomains").MustBool(false)
-	cfg.AngularSupportEnabled = security.Key("angular_support_enabled").MustBool(false)
 	cfg.CSPEnabled = security.Key("content_security_policy").MustBool(false)
 	cfg.CSPTemplate = security.Key("content_security_policy_template").MustString("")
 	cfg.CSPReportOnlyEnabled = security.Key("content_security_policy_report_only").MustBool(false)
@@ -1732,15 +1764,11 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.ExternalUserMngAnalytics = users.Key("external_manage_analytics").MustBool(false)
 	cfg.ExternalUserMngAnalyticsParams = valueAsString(users, "external_manage_analytics_params", "")
 
-	// Deprecated
+	//nolint:staticcheck
 	cfg.ViewersCanEdit = users.Key("viewers_can_edit").MustBool(false)
+	//nolint:staticcheck
 	if cfg.ViewersCanEdit {
 		cfg.Logger.Warn("[Deprecated] The viewers_can_edit configuration setting is deprecated. Please upgrade viewers to editors.")
-	}
-	// Deprecated
-	cfg.EditorsCanAdmin = users.Key("editors_can_admin").MustBool(false)
-	if cfg.EditorsCanAdmin {
-		cfg.Logger.Warn("[Deprecated] The editors_can_admin configuration setting is deprecated. Please upgrade editors to admin.")
 	}
 
 	userInviteMaxLifetimeVal := valueAsString(users, "user_invite_max_lifetime_duration", "24h")
@@ -1792,25 +1820,11 @@ func readServiceAccountSettings(iniFile *ini.File, cfg *Cfg) error {
 	return nil
 }
 
-func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) error {
+func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
 	renderSec := iniFile.Section("rendering")
-	cfg.RendererUrl = valueAsString(renderSec, "server_url", "")
+	cfg.RendererServerUrl = valueAsString(renderSec, "server_url", "")
 	cfg.RendererCallbackUrl = valueAsString(renderSec, "callback_url", "")
 	cfg.RendererAuthToken = valueAsString(renderSec, "renderer_token", "-")
-
-	if cfg.RendererCallbackUrl == "" {
-		cfg.RendererCallbackUrl = AppUrl
-	} else {
-		if cfg.RendererCallbackUrl[len(cfg.RendererCallbackUrl)-1] != '/' {
-			cfg.RendererCallbackUrl += "/"
-		}
-		_, err := url.Parse(cfg.RendererCallbackUrl)
-		if err != nil {
-			// XXX: Should return an error?
-			cfg.Logger.Error("Invalid callback_url.", "url", cfg.RendererCallbackUrl, "error", err)
-			os.Exit(1)
-		}
-	}
 
 	cfg.RendererConcurrentRequestLimit = renderSec.Key("concurrent_render_request_limit").MustInt(30)
 	cfg.RendererRenderKeyLifeTime = renderSec.Key("render_key_lifetime").MustDuration(5 * time.Minute)
@@ -1820,8 +1834,6 @@ func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) error {
 	cfg.ImagesDir = filepath.Join(cfg.DataPath, "png")
 	cfg.CSVsDir = filepath.Join(cfg.DataPath, "csv")
 	cfg.PDFsDir = filepath.Join(cfg.DataPath, "pdf")
-
-	return nil
 }
 
 func (cfg *Cfg) readAlertingSettings(iniFile *ini.File) error {
@@ -2022,6 +2034,24 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	}
 
 	cfg.LiveAllowedOrigins = originPatterns
+	return nil
+}
+
+func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
+	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
+	cfg.ProvisioningPath = makeAbsolute(provisioning, cfg.HomePath)
+
+	provisioningPaths := strings.TrimSpace(valueAsString(iniFile.Section("paths"), "permitted_provisioning_paths", ""))
+	if provisioningPaths != "|" && provisioningPaths != "" {
+		cfg.PermittedProvisioningPaths = strings.Split(provisioningPaths, "|")
+		for i, s := range cfg.PermittedProvisioningPaths {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				return fmt.Errorf("a provisioning path is empty in '%s' (at index %d)", provisioningPaths, i)
+			}
+			cfg.PermittedProvisioningPaths[i] = makeAbsolute(s, cfg.HomePath)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What is this feature?**

Our team at ESnet has been coordinating this feature for a while with the Grafana team. The eventual goal of the feature is to export a running grafana panel into your external application, such as a portal system. Our use case at ESnet is to provide data visualizations alongside user actions in a new version of our https://my.es.net portal.

Because the Panel Exporter system relies on using grafana's built-in auth, and it is likely that users will want both a grafana instance and their portal (which is the case for us), we think that it is important for Enterprise users to be able to set the auth cookie domain. This would allow for a situation where you've set the cookie domain to, for example:

```
example.com
```

The same authentication cookie would then be visible to your portal application at:
```
portal.example.com
```
and the grafana instance at:
```
grafana.example.com
```

Allowing you to sign on to both systems with a minimal code delta and configuration change.

**Why do we need this feature?**

Our team spends a lot of time creating great Grafana visualizations. We have thought through reproducing our grafana panels as free-standing code (and implemented it in many situations) but we have found that we incur about ~50x (5000%) as much development time overhead creating custom visuals and data APIs to back them. This is precisely why we use Grafana: being able to leverage our own work and other's repeatably to create clear, concise visualizations for our network.

**Who is this feature for?**

This feature is likely to be most useful for enterprise users, or users that have already created a rich set of visualizations, but cannot use IFRAMEs in their resulting application. Ours is just such a case. We also would prefer that we can use shared application state (such as shared crosshairs) across embedded panels. This feature enables that functionality as well.

**Which issue(s) does this PR fix?**:

I don't think it fixes any existing issues, but there may be existing feature requests for something like this.

**Special notes for your reviewer:**

This is a relatively major feature for the platform from our perspective. It enables entirely new use cases for the Grafana platform for our organization, and for the US national lab system we support. I'm happy to write out a "notable improvement" for what's new if desired.

There are two accompanying repos for this feature:
React client application: https://github.com/esnet/panel-exporter-demo-react
WebComponent (Vanilla JS) client application: https://github.com/esnet/panel-exporter-demo-wc

Here is a demo video of using a Grafana panel in the react application:
https://www.youtube.com/watch?v=zSX9mBfY1ao


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
