### PR TITLE
Revert change of order of checks when setting up resource DB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -225,6 +225,7 @@ require (
 	github.com/grafana/grafana/pkg/semconv v0.0.0-20250422074709-7c8433fbb2c2 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250506052906-7a2fc797fb4a // @grafana/grafana-search-and-storage
 	github.com/grafana/grafana/pkg/storage/unified/resource v0.0.0-20250506052906-7a2fc797fb4a // @grafana/grafana-search-and-storage
+	github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0-20250516070222-10994220504a // @grafana/grafana-search-and-storage
 )
 
 require (
@@ -571,8 +572,6 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-require github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0-20250516070222-10994220504a
 
 // Use fork of crewjam/saml with fixes for some issues until changes get merged into upstream
 replace github.com/crewjam/saml => github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56

--- a/go.mod
+++ b/go.mod
@@ -572,6 +572,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+require github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0-20250516070222-10994220504a
+
 // Use fork of crewjam/saml with fixes for some issues until changes get merged into upstream
 replace github.com/crewjam/saml => github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56
 

--- a/go.sum
+++ b/go.sum
@@ -1633,6 +1633,8 @@ github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250506052906-7a
 github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250506052906-7a2fc797fb4a/go.mod h1:/eXW4g4cROVmDxH0OhCoXmp9n+xULrmnncMUyFHXxP0=
 github.com/grafana/grafana/pkg/storage/unified/resource v0.0.0-20250506052906-7a2fc797fb4a h1:7QIwgb9nZmVPRjSi+UQDhjxrAWmEVExXLh4+TfoN/MU=
 github.com/grafana/grafana/pkg/storage/unified/resource v0.0.0-20250506052906-7a2fc797fb4a/go.mod h1:fs8tmn4kliX1914EZfGOL+A6BUqejjbdL+7Dj9ZmZPA=
+github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0-20250516070222-10994220504a h1:fWG9hWi5V7Lj/x1/SZwbvHOpVpGixUcdV7Prc6wO2uk=
+github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0-20250516070222-10994220504a/go.mod h1:hKusgccNxdAcv1x3cMSM46XYcUeLB7tWjnPP6m9tbG4=
 github.com/grafana/jsonparser v0.0.0-20240425183733-ea80629e1a32 h1:NznuPwItog+rwdVg8hAuGKP29ndRSzJAwhxKldkP8oQ=
 github.com/grafana/jsonparser v0.0.0-20240425183733-ea80629e1a32/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
 github.com/grafana/loki/pkg/push v0.0.0-20231124142027-e52380921608 h1:ZYk42718kSXOiIKdjZKljWLgBpzL5z1yutKABksQCMg=
@@ -3402,6 +3404,7 @@ google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
+google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/services/secrets/migrator/provisioning.go
+++ b/pkg/services/secrets/migrator/provisioning.go
@@ -49,7 +49,8 @@ func (p provisioningSecrets) reEncrypt(
 			Find(&rows)
 	}); err != nil {
 		logger.Warn("Could not find any provisioning secrets to re-encrypt", "error", err, "action", action)
-		return false
+		// resource table may not exists (when not using unified storage and right db), so we don't report error here.
+		return true
 	}
 
 	var failures int

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -104,6 +104,10 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		return p, fmt.Errorf("invalid db type specified: %s", dbType)
 
 	// If we have an empty Resource API db config, try with the core Grafana database config
+	case grafanaDBType != "":
+		p.registerMetrics = true
+		p.engine, err = getEngine(cfg)
+		return p, err
 	case grafanaDB != nil:
 		// try to use the grafana db connection (should only happen in tests)
 		if fallbackGetter.Bool(grafanaDBInstrumentQueriesKey) {
@@ -111,10 +115,6 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		}
 		p.engine = grafanaDB.GetEngine()
 		return p, nil
-	case grafanaDBType != "":
-		p.registerMetrics = true
-		p.engine, err = getEngine(cfg)
-		return p, err
 	default:
 		return p, fmt.Errorf("no database type specified")
 	}


### PR DESCRIPTION
This was introduced in https://github.com/grafana/grafana/pull/105010 to avoid error when provisioning secrets accessed wrong database. Unfortunately this doesn't work in our cloud environment. Given that provisioning secrets is temporary solution waiting for the secret service to get rolled out for real, we will rather silently ignore its errors when it works with wrong database, rather than break our production environment.