### PR TITLE
Postgres: Improve invalid port specifier error during health check

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -187,7 +187,7 @@ func (s *Service) generateConnectionString(dsInfo sqleng.DataSourceInfo) (string
 				var err error
 				port, err = strconv.Atoi(sp[1])
 				if err != nil {
-					return "", fmt.Errorf("invalid port in host specifier %q: %w", sp[1], err)
+					return "", fmt.Errorf("%w %q: %w", sqleng.ErrInvalidPortSpecified, sp[1], err)
 				}
 
 				logger.Debug("Generating connection string with network host/port pair", "host", host, "port", port)
@@ -200,7 +200,7 @@ func (s *Service) generateConnectionString(dsInfo sqleng.DataSourceInfo) (string
 				var err error
 				port, err = strconv.Atoi(dsInfo.URL[index+1:])
 				if err != nil {
-					return "", fmt.Errorf("invalid port in host specifier %q: %w", dsInfo.URL[index+1:], err)
+					return "", fmt.Errorf("%w %q: %w", sqleng.ErrInvalidPortSpecified, dsInfo.URL[index+1:], err)
 				}
 
 				logger.Debug("Generating ipv6 connection string with network host/port pair", "host", host, "port", port)
@@ -260,7 +260,7 @@ func (t *postgresQueryResultTransformer) TransformQueryError(_ log.Logger, err e
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	dsHandler, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
-		return &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: err.Error()}, nil
+		return sqleng.ErrToHealthCheckResult(err)
 	}
 	return dsHandler.CheckHealth(ctx, req)
 }

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/errors.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/errors.go
@@ -1,0 +1,7 @@
+package sqleng
+
+import "errors"
+
+var (
+	ErrInvalidPortSpecified error = errors.New("invalid port in host specifier")
+)

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/handler_checkhealth.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/handler_checkhealth.go
@@ -81,6 +81,12 @@ func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
 			details["verboseMessage"] = pqErr.Message
 		}
 	}
+	if errors.Is(err, ErrInvalidPortSpecified) {
+		res.Message = fmt.Sprintf("Connection string error: %s", ErrInvalidPortSpecified.Error())
+		if unwrappedErr := errors.Unwrap(err); unwrappedErr != nil {
+			details["verboseMessage"] = unwrappedErr.Error()
+		}
+	}
 	detailBytes, marshalErr := json.Marshal(details)
 	if marshalErr != nil {
 		return res, nil

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/handler_checkhealth_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/handler_checkhealth_test.go
@@ -2,6 +2,7 @@ package sqleng
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 
@@ -46,6 +47,15 @@ func TestErrToHealthCheckResult(t *testing.T) {
 				Status:      backend.HealthStatusError,
 				Message:     "internal server error",
 				JSONDetails: []byte(`{"errorDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/postgres","verboseMessage":"internal server error"}`),
+			},
+		},
+		{
+			name: "invalid port specifier error",
+			err:  fmt.Errorf("%w %q: %w", ErrInvalidPortSpecified, `"foo.bar.co"`, errors.New(`strconv.Atoi: parsing "foo.bar.co": invalid syntax`)),
+			want: &backend.CheckHealthResult{
+				Status:      backend.HealthStatusError,
+				Message:     "Connection string error: invalid port in host specifier",
+				JSONDetails: []byte(`{"errorDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/postgres","verboseMessage":"invalid port in host specifier \"\\\"foo.bar.co\\\"\": strconv.Atoi: parsing \"foo.bar.co\": invalid syntax"}`),
 			},
 		},
 	}


### PR DESCRIPTION
As part of config success rate improvement, we are normalising the error messages displayed to the user. Error messages were patternised and only shown the high level messsage as error message. Detailed verbose message shown in verbose message section.

## How to test

* Use `postgresql://foo-5432.preview.app.github.dev` as the host URL and see the error message in detail

## Screenshots

### Before

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/d58b3e61-4dc3-4a16-8759-74260981503b" />

### After

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/ddc7cc77-3cec-4134-bfd7-5aebf8672f22" />
