### PR TITLE
SecretsManager: Update decrypt authorization with service identity

### DIFF
--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -21,7 +21,7 @@ type DecryptStorage interface {
 
 // DecryptAuthorizer is the interface for authorizing decryption requests.
 type DecryptAuthorizer interface {
-	Authorize(ctx context.Context, secureValueDecrypters []string) (identity string, allowed bool)
+	Authorize(ctx context.Context, secureValueName string, secureValueDecrypters []string) (identity string, allowed bool)
 }
 
 // TEMPORARY: Needed to pass it with wire.

--- a/pkg/registry/apis/secret/decrypt/authorizer.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/grafana/authlib/authn"
 	claims "github.com/grafana/authlib/types"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
@@ -22,70 +23,79 @@ func ProvideDecryptAuthorizer(allowList contracts.DecryptAllowList) contracts.De
 }
 
 // authorize checks whether the auth info token has the right permissions to decrypt the secure value.
-func (a *decryptAuthorizer) Authorize(ctx context.Context, secureValueDecrypters []string) (string, bool) {
+func (a *decryptAuthorizer) Authorize(ctx context.Context, secureValueName string, secureValueDecrypters []string) (string, bool) {
 	authInfo, ok := claims.AuthInfoFrom(ctx)
 	if !ok {
 		return "", false
 	}
 
-	tokenPermissions := authInfo.GetTokenPermissions()
-
-	tokenActors := make(map[string]struct{}, 0)
-	for _, permission := range tokenPermissions {
-		// Will look like `secret.grafana.app/securevalues/<actor>:decrypt` for now.
-		gr, verb, found := strings.Cut(permission, ":")
-		if !found {
-			continue
-		}
-
-		// If it isn't decrypt, then we don't care to check.
-		if verb != "decrypt" {
-			continue
-		}
-
-		parts := strings.Split(gr, "/")
-		if len(parts) != 3 {
-			continue
-		}
-
-		group, resource, actor := parts[0], parts[1], parts[2]
-		if group != secretv0alpha1.GROUP || resource != secretv0alpha1.SecureValuesResourceInfo.GetName() || actor == "" {
-			continue
-		}
-
-		// TEMPORARY: while we can't onboard every app into secrets, we can block them from decrypting
-		// securevalues preemptively here before even reaching out to the database.
-		// This check can be removed once we open the gates for any service to use secrets.
-		if _, exists := a.allowList[actor]; !exists {
-			continue
-		}
-
-		tokenActors[actor] = struct{}{}
-	}
-
-	// If we arrived here and the token actors is empty, it means the permissions either have an invalid format,
-	// or it didn't pass the allow list, meaning no allowed decryptor.
-	if len(tokenActors) == 0 {
+	serviceIdentityList, ok := authInfo.GetExtra()[authn.ServiceIdentityKey]
+	if !ok {
 		return "", false
 	}
 
-	// TEMPORARY: while we still need to mix permission and identity, we can use this
-	// to decide whether the SecureValue can be decrypted or not.
-	// Once we have an `actor` field in the JWT claims, we can have a properly formatted permission,
-	// like `secret.grafana.app/securevalues{/<name>}:decrypt` and do regular access control eval,
-	// and for the `decrypters` part here, we can just check it against the `actor` field, which at
-	// that point will have a different format, depending on how the `actor` will be formatted.
-	// Check whether at least one of declared token actors matches the allowed decrypters from the SecureValue.
-	allowed := false
+	// If there's more than one service identity, something is suspicious and we reject it.
+	if len(serviceIdentityList) != 1 {
+		return "", false
+	}
 
-	var identity string
+	serviceIdentity := serviceIdentityList[0]
+
+	// TEMPORARY: while we can't onboard every app into secrets, we can block them from decrypting
+	// securevalues preemptively here before even reaching out to the database.
+	// This check can be removed once we open the gates for any service to use secrets.
+	if _, exists := a.allowList[serviceIdentity]; !exists || serviceIdentity == "" {
+		return serviceIdentity, false
+	}
+
+	// Checks whether the token has the permission to decrypt secure values.
+	if !hasPermissionInToken(authInfo.GetTokenPermissions(), secureValueName) {
+		return serviceIdentity, false
+	}
+
+	// Finally check whether the service identity is allowed to decrypt this secure value.
+	allowed := false
 	for _, decrypter := range secureValueDecrypters {
-		if _, exists := tokenActors[decrypter]; exists {
+		if decrypter == serviceIdentity {
 			allowed = true
-			identity = decrypter
 			break
 		}
 	}
 
-	return identity, allowed
+	return serviceIdentity, allowed
+}
+
+// Adapted from https://github.com/grafana/authlib/blob/1492b99410603ca15730a1805a9220ce48232bc3/authz/client.go#L138
+// Changes: 1) we don't support `*` for verbs; 2) we support specific names in the permission.
+func hasPermissionInToken(tokenPermissions []string, name string) bool {
+	var (
+		group    = secretv0alpha1.GROUP
+		resource = secretv0alpha1.SecureValuesResourceInfo.GetName()
+		verb     = "decrypt"
+	)
+
+	for _, p := range tokenPermissions {
+		tokenGR, tokenVerb, found := strings.Cut(p, ":")
+		if !found || tokenVerb != verb {
+			continue
+		}
+
+		parts := strings.SplitN(tokenGR, "/", 3)
+
+		switch len(parts) {
+		// secret.grafana.app/securevalues:decrypt
+		case 2:
+			if parts[0] == group && parts[1] == resource {
+				return true
+			}
+
+		// secret.grafana.app/securevalues/<name>:decrypt
+		case 3:
+			if parts[0] == group && parts[1] == resource && parts[2] == name && name != "" {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/registry/apis/secret/decrypt/authorizer_test.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer_test.go
@@ -16,127 +16,323 @@ func TestDecryptAuthorizer(t *testing.T) {
 		ctx := context.Background()
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
 		require.Empty(t, identity)
 		require.False(t, allowed)
 	})
 
 	t.Run("when token permissions are empty, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{})
+		ctx := createAuthContext(context.Background(), "identity", []string{})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
+		require.False(t, allowed)
+	})
+
+	t.Run("when service identity is empty, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "", []string{})
+		authorizer := ProvideDecryptAuthorizer(nil)
+
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
 		require.Empty(t, identity)
 		require.False(t, allowed)
 	})
 
 	t.Run("when permission format is malformed (missing verb), it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues/group1"})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		// nameless
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues"})
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
+		require.False(t, allowed)
+
+		// named
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/name"})
+		identity, allowed = authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
 	t.Run("when permission verb is not exactly `decrypt`, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues/group1:something"})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		// nameless
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:*"})
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
+		require.False(t, allowed)
+
+		// named
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/name:something"})
+		identity, allowed = authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
-	t.Run("when permission does not have 3 parts, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues:decrypt"})
+	t.Run("when permission does not have 2 or 3 parts, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app:decrypt"})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
 	t.Run("when permission has group that is not `secret.grafana.app`, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"wrong.group/securevalues/invalid:decrypt"})
+		ctx := createAuthContext(context.Background(), "identity", []string{"wrong.group/securevalues/invalid:decrypt"})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
 	t.Run("when permission has resource that is not `securevalues`, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/invalid-resource/invalid:decrypt"})
 		authorizer := ProvideDecryptAuthorizer(nil)
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		// nameless
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/invalid-resource:decrypt"})
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
+		require.False(t, allowed)
+
+		// named
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/invalid-resource/name:decrypt"})
+		identity, allowed = authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
-	t.Run("when the actor is not in the allow list, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues/allowed2:decrypt"})
+	t.Run("when the identity is not in the allow list, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
 		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"allowed1": {}})
 
-		identity, allowed := authorizer.Authorize(ctx, nil)
-		require.Empty(t, identity)
+		identity, allowed := authorizer.Authorize(ctx, "", nil)
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
-	t.Run("when the actor doesn't match any allowed decrypters, it returns false", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues/group1:decrypt"})
-		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"group1": {}})
+	t.Run("when the identity doesn't match any allowed decrypters, it returns false", func(t *testing.T) {
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
 
-		identity, allowed := authorizer.Authorize(ctx, []string{"group2"})
-		require.Empty(t, identity)
+		// nameless
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"group2"})
+		require.NotEmpty(t, identity)
+		require.False(t, allowed)
+
+		// named
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/name:decrypt"})
+		identity, allowed = authorizer.Authorize(ctx, "", []string{"group2"})
+		require.NotEmpty(t, identity)
 		require.False(t, allowed)
 	})
 
-	t.Run("when the actor matches an allowed decrypter, it returns true", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{"secret.grafana.app/securevalues/group1:decrypt"})
-		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"group1": {}})
+	t.Run("when the identity matches an allowed decrypter, it returns true", func(t *testing.T) {
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
 
-		identity, allowed := authorizer.Authorize(ctx, []string{"group1"})
+		// nameless
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity"})
 		require.True(t, allowed)
-		require.Equal(t, "group1", identity)
+		require.Equal(t, "identity", identity)
+
+		// named
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/name:decrypt"})
+		identity, allowed = authorizer.Authorize(ctx, "name", []string{"identity"})
+		require.True(t, allowed)
+		require.Equal(t, "identity", identity)
 	})
 
 	t.Run("when there are multiple permissions, some invalid, only valid ones are considered", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{
-			"secret.grafana.app/securevalues/group1:decrypt",
+		ctx := createAuthContext(context.Background(), "identity", []string{
+			"secret.grafana.app/securevalues/name1:decrypt",
+			"secret.grafana.app/securevalues/name2:decrypt",
 			"secret.grafana.app/securevalues/invalid:read",
 			"wrong.group/securevalues/group2:decrypt",
-			"secret.grafana.app/securevalues/group2:decrypt",
+			"secret.grafana.app/securevalues/identity:decrypt", // old style of identity+permission
 		})
-		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"group1": {}, "group2": {}})
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
 
-		identity, allowed := authorizer.Authorize(ctx, []string{"group2", "group3"})
+		identity, allowed := authorizer.Authorize(ctx, "name1", []string{"identity"})
 		require.True(t, allowed)
-		require.Equal(t, "group2", identity)
+		require.Equal(t, "identity", identity)
+
+		identity, allowed = authorizer.Authorize(ctx, "name2", []string{"identity"})
+		require.True(t, allowed)
+		require.Equal(t, "identity", identity)
 	})
 
-	t.Run("when multiple valid actors match decrypters, the first match already returns true", func(t *testing.T) {
-		ctx := createAuthContext(context.Background(), []string{
-			"secret.grafana.app/securevalues/group1:decrypt",
-			"secret.grafana.app/securevalues/group2:decrypt",
-		})
-		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"group1": {}, "group2": {}})
+	t.Run("when empty secure value name with specific permission, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/name:decrypt"})
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
 
-		identity, allowed := authorizer.Authorize(ctx, []string{"group2", "group1"})
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity"})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
+	})
+
+	t.Run("when permission has an extra / but no name, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues/:decrypt"})
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
+
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity"})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
+	})
+
+	t.Run("when the decrypters list is empty, meaning nothing can decrypt the secure value, it returns false", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
+
+		identity, allowed := authorizer.Authorize(ctx, "name", []string{})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
+	})
+
+	t.Run("when one of decrypters matches the identity, it returns true", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity1", []string{"secret.grafana.app/securevalues:decrypt"})
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity1": {}, "identity2": {}})
+
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity1", "identity2", "identity3"})
+		require.Equal(t, "identity1", identity)
 		require.True(t, allowed)
-		require.Equal(t, "group2", identity)
+	})
+
+	t.Run("permissions must be case-sensitive and return false", func(t *testing.T) {
+		authorizer := ProvideDecryptAuthorizer(map[string]struct{}{"identity": {}})
+
+		ctx := createAuthContext(context.Background(), "identity", []string{"SECRET.grafana.app/securevalues:decrypt"})
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity"})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
+
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/SECUREVALUES:decrypt"})
+		identity, allowed = authorizer.Authorize(ctx, "", []string{"identity"})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
+
+		ctx = createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:DECRYPT"})
+		identity, allowed = authorizer.Authorize(ctx, "", []string{"identity"})
+		require.Equal(t, "identity", identity)
+		require.False(t, allowed)
 	})
 }
 
-func createAuthContext(ctx context.Context, permissions []string) context.Context {
+func createAuthContext(ctx context.Context, serviceIdentity string, permissions []string) context.Context {
 	requester := &identity.StaticRequester{
 		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
 			Rest: authn.AccessTokenClaims{
-				Permissions: permissions,
+				Permissions:     permissions,
+				ServiceIdentity: serviceIdentity,
 			},
 		},
 	}
 
 	return types.WithAuthInfo(ctx, requester)
+}
+
+// Adapted from https://github.com/grafana/authlib/blob/1492b99410603ca15730a1805a9220ce48232bc3/authz/client_test.go#L18
+func TestHasPermissionInToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		test             string
+		tokenPermissions []string
+		name             string
+		want             bool
+	}{
+		{
+			test:             "Permission matches group/resource",
+			tokenPermissions: []string{"secret.grafana.app/securevalues:decrypt"},
+			want:             true,
+		},
+		{
+			test:             "Permission does not match verb",
+			tokenPermissions: []string{"secret.grafana.app/securevalues:create"},
+			want:             false,
+		},
+		{
+			test:             "Permission does not have support for wildcard verb",
+			tokenPermissions: []string{"secret.grafana.app/securevalues:*"},
+			want:             false,
+		},
+		{
+			test:             "Invalid permission missing verb",
+			tokenPermissions: []string{"secret.grafana.app/securevalues"},
+			want:             false,
+		},
+		{
+			test:             "Permission on the wrong group",
+			tokenPermissions: []string{"other-group.grafana.app/securevalues:decrypt"},
+			want:             false,
+		},
+		{
+			test:             "Permission on the wrong resource",
+			tokenPermissions: []string{"secret.grafana.app/other-resource:decrypt"},
+			want:             false,
+		},
+		{
+			test:             "Permission without group are skipped",
+			tokenPermissions: []string{":decrypt"},
+			want:             false,
+		},
+		{
+			test:             "Group level permission is not supported",
+			tokenPermissions: []string{"secret.grafana.app:decrypt"},
+			want:             false,
+		},
+		{
+			test:             "Permission with name matches group/resource/name",
+			tokenPermissions: []string{"secret.grafana.app/securevalues/name:decrypt"},
+			name:             "name",
+			want:             true,
+		},
+		{
+			test:             "Permission with name2 does not matche group/resource/name1",
+			tokenPermissions: []string{"secret.grafana.app/securevalues/name1:decrypt"},
+			name:             "name2",
+			want:             false,
+		},
+		{
+			test:             "Parts need an exact match",
+			tokenPermissions: []string{"secret.grafana.app/secure:*"},
+			want:             false,
+		},
+		{
+			test:             "Resource specific permission should not allow access to all resources",
+			tokenPermissions: []string{"secret.grafana.app/securevalues/name:decrypt"},
+			name:             "",
+			want:             false,
+		},
+		{
+			test:             "Permission at group/resource should allow access to all resources",
+			tokenPermissions: []string{"secret.grafana.app/securevalues:decrypt"},
+			name:             "name",
+			want:             true,
+		},
+		{
+			test:             "Empty name trying to match everything is not allowed",
+			tokenPermissions: []string{"secret.grafana.app/securevalues/:decrypt"},
+			name:             "",
+			want:             false,
+		},
+		{
+			test:             "Empty name trying to match a specific name is not allowed",
+			tokenPermissions: []string{"secret.grafana.app/securevalues/:decrypt"},
+			name:             "name",
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.test, func(t *testing.T) {
+			t.Parallel()
+
+			got := hasPermissionInToken(tt.tokenPermissions, tt.name)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/registry/apis/secret/decrypt/noop_authorizer.go
+++ b/pkg/registry/apis/secret/decrypt/noop_authorizer.go
@@ -11,6 +11,6 @@ type NoopAlwaysAllowedAuthorizer struct{}
 
 var _ contracts.DecryptAuthorizer = &NoopAlwaysAllowedAuthorizer{}
 
-func (a *NoopAlwaysAllowedAuthorizer) Authorize(ctx context.Context, secureValueDecrypters []string) (identity string, allowed bool) {
+func (a *NoopAlwaysAllowedAuthorizer) Authorize(ctx context.Context, secureValueName string, secureValueDecrypters []string) (identity string, allowed bool) {
 	return "", true
 }

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -425,7 +425,7 @@ spec:
 												"spec": &secretv0alpha1.SecureValueSpec{
 													Description: "A secret in default",
 													Value:       "this is super duper secure",
-													Decrypters:  []string{"actor_k6, actor_synthetic-monitoring"},
+													Decrypters:  []string{"k6, synthetic-monitoring"},
 												},
 											},
 										},
@@ -439,7 +439,7 @@ spec:
 													Description: "A secret in aws",
 													Value:       "this is super duper secure",
 													Keeper:      &exampleKeeperAWS,
-													Decrypters:  []string{"actor_k6, actor_synthetic-monitoring"},
+													Decrypters:  []string{"k6, synthetic-monitoring"},
 												},
 											},
 										},
@@ -453,7 +453,7 @@ spec:
 													Description: "A secret from aws",
 													Ref:         &exampleRef,
 													Keeper:      &exampleKeeperAWS,
-													Decrypters:  []string{"actor_k6"},
+													Decrypters:  []string{"k6"},
 												},
 											},
 										},
@@ -469,7 +469,7 @@ spec:
 												"spec": &secretv0alpha1.SecureValueSpec{
 													Description: "XYZ secret",
 													Value:       "this is super duper secure",
-													Decrypters:  []string{"actor_k6, actor_synthetic-monitoring"},
+													Decrypters:  []string{"k6, synthetic-monitoring"},
 												},
 											},
 										},
@@ -498,8 +498,8 @@ spec:
   description: A secret value
   value: this is super duper secure
   decrypters:
-    - actor_k6 
-    - actor_synthetic-monitoring`,
+    - k6 
+    - synthetic-monitoring`,
 									},
 								},
 								"secret to store in aws keeper": {
@@ -518,8 +518,8 @@ spec:
   keeper: aws-keeper-that-must-already-exist
   value: this is super duper secure
   decrypters:
-    - actor_k6 
-    - actor_synthetic-monitoring`,
+    - k6 
+    - synthetic-monitoring`,
 									},
 								},
 								"secret to reference in aws keeper": {
@@ -538,7 +538,7 @@ spec:
   keeper: aws-keeper-that-must-already-exist
   ref: my-secret-in-aws
   decrypters:
-    - actor_k6`,
+    - k6`,
 									},
 								},
 								"secret with name specified": {
@@ -557,8 +557,8 @@ spec:
   description: XYZ secret
   value: this is super duper secure
   decrypters:
-    - actor_k6 
-    - actor_synthetic-monitoring`,
+    - k6 
+    - synthetic-monitoring`,
 									},
 								},
 							},

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -20,7 +20,7 @@ func TestValidateSecureValue(t *testing.T) {
 				Description: "description",
 				Value:       "value",
 				Keeper:      &keeper,
-				Decrypters:  []string{"actor_app1", "actor_app2"},
+				Decrypters:  []string{"app1", "app2"},
 			},
 		}
 
@@ -175,8 +175,8 @@ func TestValidateSecureValue(t *testing.T) {
 				Description: "description", Ref: &ref,
 
 				Decrypters: []string{
-					"actor_app1",
-					"actor_app1",
+					"app1",
+					"app1",
 				},
 			},
 		}
@@ -186,33 +186,8 @@ func TestValidateSecureValue(t *testing.T) {
 		require.Equal(t, "spec.decrypters.[1]", errs[0].Field)
 	})
 
-	t.Run("`decrypters` must match the expected format", func(t *testing.T) {
-		ref := "ref"
-		sv := &secretv0alpha1.SecureValue{
-			Spec: secretv0alpha1.SecureValueSpec{
-				Description: "description", Ref: &ref,
-
-				Decrypters: []string{
-					"app1",
-					"_app1",
-					"actr_app1",
-					"actor_ ",
-					"actor_",
-				},
-			},
-		}
-
-		errs := ValidateSecureValue(sv, nil, admission.Create, nil)
-		require.Len(t, errs, len(sv.Spec.Decrypters))
-
-		for i, err := range errs {
-			require.Equal(t, fmt.Sprintf("spec.decrypters.[%d]", i), err.Field)
-			require.Contains(t, err.Error(), "a decrypter must have the format `actor_{name}`")
-		}
-	})
-
 	t.Run("when set, the `decrypters` must be one of the allowed in the allow list", func(t *testing.T) {
-		allowList := map[string]struct{}{"actor_app1": {}, "actor_app2": {}}
+		allowList := map[string]struct{}{"app1": {}, "app2": {}}
 		decrypters := slices.Collect(maps.Keys(allowList))
 
 		t.Run("no matches, returns an error", func(t *testing.T) {
@@ -221,7 +196,7 @@ func TestValidateSecureValue(t *testing.T) {
 				Spec: secretv0alpha1.SecureValueSpec{
 					Description: "description", Ref: &ref,
 
-					Decrypters: []string{"actor_app3"},
+					Decrypters: []string{"app3"},
 				},
 			}
 
@@ -275,7 +250,7 @@ func TestValidateSecureValue(t *testing.T) {
 	t.Run("`decrypters` cannot have more than 64 items", func(t *testing.T) {
 		decrypters := make([]string, 0, 64+1)
 		for i := 0; i < 64+1; i++ {
-			decrypters = append(decrypters, fmt.Sprintf("actor_app%d", i))
+			decrypters = append(decrypters, fmt.Sprintf("app%d", i))
 		}
 
 		ref := "ref"

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -247,6 +247,33 @@ func TestValidateSecureValue(t *testing.T) {
 		})
 	})
 
+	t.Run("`decrypters` must be a valid label value", func(t *testing.T) {
+		decrypters := []string{
+			"",              // invalid
+			"is/this/valid", // invalid
+			"is this valid", // invalid
+			"is.this.valid",
+			"is-this-valid",
+			"is_this_valid",
+			"0isthisvalid9",
+			"isthisvalid9",
+			"0isthisvalid",
+			"isthisvalid",
+		}
+
+		ref := "ref"
+		sv := &secretv0alpha1.SecureValue{
+			Spec: secretv0alpha1.SecureValueSpec{
+				Description: "description", Ref: &ref,
+
+				Decrypters: decrypters,
+			},
+		}
+
+		errs := ValidateSecureValue(sv, nil, admission.Create, nil)
+		require.Len(t, errs, 3)
+	})
+
 	t.Run("`decrypters` cannot have more than 64 items", func(t *testing.T) {
 		decrypters := make([]string, 0, 64+1)
 		for i := 0; i < 64+1; i++ {

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -71,7 +71,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		return "", contracts.ErrDecryptNotFound
 	}
 
-	decrypterIdentity, authorized := s.decryptAuthorizer.Authorize(ctx, sv.Decrypters)
+	decrypterIdentity, authorized := s.decryptAuthorizer.Authorize(ctx, name, sv.Decrypters)
 	if !authorized {
 		return "", contracts.ErrDecryptNotAuthorized
 	}

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -679,7 +679,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 			newRaw.SetName(raw.GetName())
 			newRaw.Object["spec"].(map[string]any)["description"] = "New description"
 			newRaw.Object["spec"].(map[string]any)["value"] = "New secure value"
-			newRaw.Object["spec"].(map[string]any)["decrypters"] = []string{"actor_app1", "actor_app2"}
+			newRaw.Object["spec"].(map[string]any)["decrypters"] = []string{"app1", "app2"}
 			newRaw.Object["metadata"].(map[string]any)["annotations"] = map[string]any{"newAnnotation": "newValue"}
 
 			updatedRaw, err := client.Resource.Update(ctx, newRaw, metav1.UpdateOptions{})

--- a/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
@@ -11,5 +11,5 @@ spec:
   description: This is a secret
   value: this is super duper secure
   decrypters:
-    - actor_k6 
-    - actor_synthetic-monitoring
+    - k6
+    - synthetic-monitoring

--- a/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
@@ -12,5 +12,5 @@ spec:
   keeper: my-keeper-1
   value: super duper secure
   decrypters:
-    - actor_k6 
-    - actor_synthetic-monitoring
+    - k6
+    - synthetic-monitoring


### PR DESCRIPTION
> [!IMPORTANT]
> This updates the authorization logic for secret decryption!

## Context
Previously, we were relying on the token `permissions` to identify the service making the decrypt request.

The permission looked like: `secret.grafana.app/securevalues/actor_k6:decrypt`

We'd split the permission string, find the "actor" part, and match it twice:
1) Against the allow list, which is temporary and declared in GE;
2) Against the decrypters, to know if that actor could decrypt the secure value it wanted to.

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1380

## New Behavior!
**Identity**
Recently a `serviceIdentity` field was introduced to the token claims, and can be set when creating a Cloud Access Policy (CAP). So now, we can use the `serviceIdentity` to check:
1) If it matches the allow list, which is still temporary but we need to do it, since we don't want to inadvertently onboard other apps;
2) If it matches at least one decrypter for the secure value.

**Permission**
As for the actual permission check, to answer the question: "does this token have the permission to decrypt securevalues (or a securevalue)?"

The function that checks that is based on the one used by `authlib` for that same purpose, but with some changes tailored for our usage:
- Hardcoded group+resource+verb, since we don't want/need to support anything else;
- No support for `*` on verbs, like `secret.grafana.app/securevalues:*` won't be allowed to decrypt.
- No support for group level permission, like `secret.grafana.app:decrypt`.
- Ability to constrain a securevalue permission by resource name, `secret.grafana.app/securevalues:name` allows the token to ONLY decrypt `name`, and that is if the securevalue itself has allowed the identity to decrypt it to begin with.

**Decrypters**
We can now relax the restriction on decrypters having a specific format `actor_` and update its validation for it to be the same used by the label values, which cannot have characters like `/` or `\`.