### PR TITLE
fix(util): flaky debouncer test

### DIFF
--- a/pkg/util/debouncer/debouncer_test.go
+++ b/pkg/util/debouncer/debouncer_test.go
@@ -83,7 +83,8 @@ func TestDebouncer(t *testing.T) {
 			}
 		}
 
-		require.WithinDuration(t, start.Add(time.Millisecond*500), clockMock.Now(), time.Millisecond*100)
+		// Make sure that the execution happened after the maxTimeout of 500ms, but before the next MaxTimeout.
+		require.WithinDuration(t, start.Add(time.Millisecond*500), clockMock.Now(), time.Millisecond*499)
 	})
 
 	t.Run("should handle buffer full", func(t *testing.T) {


### PR DESCRIPTION
The test seems to be too sensitive for the GitHub Actions runner. I now test that the evaluation happens between two timeouts and give it the full range to execute (timeout -1ms). As the timeout is 500ms, instead of expecting it to happen 100ms past the timeout we now give it up to 499ms.