### PR TITLE
Plugin Configs: Use nodes strip types for processing webpack configs

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3121,9 +3121,6 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/cloud-monitoring/types/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/datasource/cloud-monitoring/webpack.config.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
-    ],
     "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "1"],
@@ -3289,9 +3286,6 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/grafana-testdata-datasource/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
-    "public/app/plugins/datasource/grafana-testdata-datasource/webpack.config.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
     ],
     "public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],
@@ -3644,9 +3638,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "public/app/plugins/datasource/tempo/webpack.config.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
-    ],
     "public/app/plugins/datasource/zipkin/QueryField.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
@@ -3656,9 +3647,6 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/zipkin/utils/transforms.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/plugins/datasource/zipkin/webpack.config.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
     ],
     "public/app/plugins/panel/annolist/AnnoListPanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/e2e/test-plugins/grafana-extensionstest-app/package.json
+++ b/e2e/test-plugins/grafana-extensionstest-app/package.json
@@ -3,8 +3,8 @@
   "version": "12.1.0-pre",
   "private": true,
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "dev": "webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx ."
   },

--- a/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
+++ b/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
@@ -1,7 +1,8 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import grafanaConfig from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
-import { Configuration } from 'webpack';
+import { type Configuration } from 'webpack';
 
 function skipFiles(f: string): boolean {
   if (f.includes('/dist/')) {

--- a/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
+++ b/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
@@ -1,5 +1,4 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-// @ts-ignore - node needs the extension to strip types successfully
 import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
 import { type Configuration } from 'webpack';

--- a/e2e/test-plugins/grafana-test-datasource/package.json
+++ b/e2e/test-plugins/grafana-test-datasource/package.json
@@ -3,8 +3,8 @@
   "version": "12.1.0-pre",
   "private": true,
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "dev": "webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx ."
   },

--- a/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
+++ b/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
@@ -1,7 +1,8 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import grafanaConfig from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
-import { Configuration } from 'webpack';
+import { type Configuration } from 'webpack';
 
 function skipFiles(f: string): boolean {
   if (f.includes('/dist/')) {

--- a/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
+++ b/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
@@ -1,5 +1,4 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-// @ts-ignore - node needs the extension to strip types successfully
 import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
 import { type Configuration } from 'webpack';

--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "tslib": "2.8.1"
   },
+  "type": "module",
   "devDependencies": {
     "@grafana/tsconfig": "^2.0.0",
     "@swc/core": "1.10.12",

--- a/packages/grafana-plugin-configs/tsconfig.json
+++ b/packages/grafana-plugin-configs/tsconfig.json
@@ -6,17 +6,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler"
   },
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs",
-      "target": "es5",
-      "moduleResolution": "Node",
-      "esModuleInterop": true
-    },
-    "transpileOnly": true
-  },
   "extends": "@grafana/tsconfig",
-
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
   "include": ["./types", "."]
 }

--- a/packages/grafana-plugin-configs/tsconfig.json
+++ b/packages/grafana-plugin-configs/tsconfig.json
@@ -4,7 +4,9 @@
     "alwaysStrict": true,
     "declaration": false,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "extends": "@grafana/tsconfig",
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],

--- a/packages/grafana-plugin-configs/types/replace-in-webpack-plugin.d.ts
+++ b/packages/grafana-plugin-configs/types/replace-in-webpack-plugin.d.ts
@@ -1,0 +1,23 @@
+declare module 'replace-in-file-webpack-plugin' {
+  import { Compiler, Plugin } from 'webpack';
+
+  interface ReplaceRule {
+    search: string | RegExp;
+    replace: string | ((match: string) => string);
+  }
+
+  interface ReplaceOption {
+    dir?: string;
+    files?: string[];
+    test?: RegExp | RegExp[];
+    rules: ReplaceRule[];
+  }
+
+  class ReplaceInFilePlugin extends Plugin {
+    constructor(options?: ReplaceOption[]);
+    options: ReplaceOption[];
+    apply(compiler: Compiler): void;
+  }
+
+  export = ReplaceInFilePlugin;
+}

--- a/packages/grafana-plugin-configs/utils.ts
+++ b/packages/grafana-plugin-configs/utils.ts
@@ -3,12 +3,19 @@ import { glob } from 'glob';
 import path from 'path';
 import process from 'process';
 
+// Support for node 22 and 24. Due to the many changes in importing json files
+// across recent node versions we load the json files using fs for simplicity.
+function loadJson(path: string) {
+  const rawJson = fs.readFileSync(path, 'utf8');
+  return JSON.parse(rawJson);
+}
+
 export function getPackageJson() {
-  return require(path.resolve(process.cwd(), 'package.json'));
+  return loadJson(path.resolve(process.cwd(), 'package.json'));
 }
 
 export function getPluginJson() {
-  return require(path.resolve(process.cwd(), 'plugin.json'));
+  return loadJson(path.resolve(process.cwd(), 'plugin.json'));
 }
 
 export async function getEntries(): Promise<Record<string, string>> {

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -2,16 +2,13 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import path from 'path';
-// @ts-expect-error - there are no types for this package
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { type Configuration, BannerPlugin } from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-// @ts-ignore - node needs the extension to strip types successfully
 import { DIST_DIR } from './constants.ts';
-// @ts-ignore - node needs the extension to strip types successfully
 import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils.ts';
 
 function skipFiles(f: string): boolean {

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -4,7 +4,7 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
-import { type Configuration, BannerPlugin } from 'webpack';
+import webpack, { type Configuration } from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
@@ -117,7 +117,7 @@ const config = async (env: Env): Promise<Configuration> => {
           test: /module\.tsx?$/,
           use: [
             {
-              loader: require.resolve('imports-loader'),
+              loader: 'imports-loader',
               options: {
                 imports: `side-effects grafana-public-path`,
               },
@@ -212,7 +212,7 @@ const config = async (env: Env): Promise<Configuration> => {
     plugins: [
       virtualPublicPath,
       // Insert create plugin version information into the bundle so Grafana will load from cdn with script tags.
-      new BannerPlugin({
+      new webpack.BannerPlugin({
         banner: '/* [create-plugin] version: 5.22.0 */',
         raw: true,
         entryOnly: true,

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -9,8 +9,10 @@ import { type Configuration, BannerPlugin } from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-import { DIST_DIR } from './constants';
-import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils';
+// @ts-ignore - node 24 needs the extension to strip types successfully
+import { DIST_DIR } from './constants.ts';
+// @ts-ignore - node 24 needs the extension to strip types successfully
+import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils.ts';
 
 function skipFiles(f: string): boolean {
   if (f.includes('/dist/')) {
@@ -54,9 +56,13 @@ const config = async (env: Env): Promise<Configuration> => {
     cache: {
       type: 'filesystem',
       buildDependencies: {
-        config: [__filename],
+        config: [import.meta.filename],
       },
-      cacheDirectory: path.resolve(__dirname, '../../node_modules/.cache/webpack', path.basename(process.cwd())),
+      cacheDirectory: path.resolve(
+        import.meta.dirname,
+        '../../node_modules/.cache/webpack',
+        path.basename(process.cwd())
+      ),
     },
 
     context: process.cwd(),
@@ -125,10 +131,10 @@ const config = async (env: Env): Promise<Configuration> => {
           exclude: /(node_modules)/,
           test: /\.[tj]sx?$/,
           use: {
-            loader: require.resolve('swc-loader'),
+            loader: 'swc-loader',
             options: {
               jsc: {
-                baseUrl: path.resolve(__dirname),
+                baseUrl: path.resolve(import.meta.dirname),
                 target: 'es2015',
                 loose: false,
                 parser: {
@@ -264,7 +270,7 @@ const config = async (env: Env): Promise<Configuration> => {
               extensions: ['.ts', '.tsx'],
               lintDirtyModulesOnly: true, // don't lint on start, only lint changed files
               cacheLocation: path.resolve(
-                __dirname,
+                import.meta.dirname,
                 '../../node_modules/.cache/eslint-webpack-plugin',
                 path.basename(process.cwd()),
                 '.eslintcache'

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -9,9 +9,9 @@ import { type Configuration, BannerPlugin } from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-// @ts-ignore - node 24 needs the extension to strip types successfully
+// @ts-ignore - node needs the extension to strip types successfully
 import { DIST_DIR } from './constants.ts';
-// @ts-ignore - node 24 needs the extension to strip types successfully
+// @ts-ignore - node needs the extension to strip types successfully
 import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils.ts';
 
 function skipFiles(f: string): boolean {

--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -48,9 +48,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next --config locales/i18next-parser.config.cjs"
   },
   "packageManager": "yarn@4.9.2"

--- a/public/app/plugins/datasource/azuremonitor/webpack.config.ts
+++ b/public/app/plugins/datasource/azuremonitor/webpack.config.ts
@@ -1,7 +1,8 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-import grafanaConfig from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 
 const config = async (env: Record<string, unknown>): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);

--- a/public/app/plugins/datasource/azuremonitor/webpack.config.ts
+++ b/public/app/plugins/datasource/azuremonitor/webpack.config.ts
@@ -1,7 +1,6 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-// @ts-ignore - node needs the extension to strip types successfully
 import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 
 const config = async (env: Record<string, unknown>): Promise<Configuration> => {

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -48,9 +48,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/cloud-monitoring/webpack.config.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/cloud-monitoring/webpack.config.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/webpack.config.ts
@@ -1,3 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
+// eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -33,9 +33,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
@@ -1,4 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
@@ -42,9 +42,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 const configWithFallback = async (env: Record<string, unknown>) => {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
@@ -1,4 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
 const configWithFallback = async (env: Record<string, unknown>) => {
   const response = await config(env);

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -41,9 +41,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/grafana-testdata-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/webpack.config.ts
@@ -1,3 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
+// eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -44,9 +44,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/jaeger/webpack.config.ts
+++ b/public/app/plugins/datasource/jaeger/webpack.config.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 const require = createRequire(import.meta.url);

--- a/public/app/plugins/datasource/jaeger/webpack.config.ts
+++ b/public/app/plugins/datasource/jaeger/webpack.config.ts
@@ -1,7 +1,7 @@
+import { createRequire } from 'node:module';
+
 // @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
-
-import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 

--- a/public/app/plugins/datasource/jaeger/webpack.config.ts
+++ b/public/app/plugins/datasource/jaeger/webpack.config.ts
@@ -1,4 +1,9 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const configWithFallback = async (env: Record<string, unknown>) => {
   const response = await config(env);

--- a/public/app/plugins/datasource/loki/package.json
+++ b/public/app/plugins/datasource/loki/package.json
@@ -44,9 +44,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/loki/webpack.config.ts
+++ b/public/app/plugins/datasource/loki/webpack.config.ts
@@ -1,4 +1,4 @@
-import config from '@grafana/plugin-configs/webpack.config';
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/mssql/package.json
+++ b/public/app/plugins/datasource/mssql/package.json
@@ -35,9 +35,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next --config locales/i18next-parser.config.cjs"
   },
   "packageManager": "yarn@4.9.2"

--- a/public/app/plugins/datasource/mssql/webpack.config.ts
+++ b/public/app/plugins/datasource/mssql/webpack.config.ts
@@ -1,7 +1,8 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-import grafanaConfig from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 
 const config = async (env: Record<string, unknown>): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);

--- a/public/app/plugins/datasource/mssql/webpack.config.ts
+++ b/public/app/plugins/datasource/mssql/webpack.config.ts
@@ -1,7 +1,6 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-// @ts-ignore - node needs the extension to strip types successfully
 import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
 
 const config = async (env: Record<string, unknown>): Promise<Configuration> => {

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -33,9 +33,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/mysql/webpack.config.ts
+++ b/public/app/plugins/datasource/mysql/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/mysql/webpack.config.ts
+++ b/public/app/plugins/datasource/mysql/webpack.config.ts
@@ -1,4 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/parca/package.json
+++ b/public/app/plugins/datasource/parca/package.json
@@ -34,9 +34,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/parca/webpack.config.ts
+++ b/public/app/plugins/datasource/parca/webpack.config.ts
@@ -1,3 +1,4 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node 24 needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
 export default config;

--- a/public/app/plugins/datasource/parca/webpack.config.ts
+++ b/public/app/plugins/datasource/parca/webpack.config.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - node 24 needs the extension to strip types successfully
+// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 export default config;

--- a/public/app/plugins/datasource/parca/webpack.config.ts
+++ b/public/app/plugins/datasource/parca/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 export default config;

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -61,10 +61,10 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
     "build:stats": "yarn build --env stats --profile --json=compilation-stats.json",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/tempo/webpack.config.ts
+++ b/public/app/plugins/datasource/tempo/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/tempo/webpack.config.ts
+++ b/public/app/plugins/datasource/tempo/webpack.config.ts
@@ -1,3 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
+// eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/public/app/plugins/datasource/zipkin/package.json
+++ b/public/app/plugins/datasource/zipkin/package.json
@@ -37,9 +37,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "webpack -w -c ./webpack.config.ts --env development"
+    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/public/app/plugins/datasource/zipkin/webpack.config.ts
+++ b/public/app/plugins/datasource/zipkin/webpack.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - node needs the extension to strip types successfully
 import config from '@grafana/plugin-configs/webpack.config.ts';
 
 // eslint-disable-next-line no-barrel-files/no-barrel-files

--- a/public/app/plugins/datasource/zipkin/webpack.config.ts
+++ b/public/app/plugins/datasource/zipkin/webpack.config.ts
@@ -1,3 +1,5 @@
-import config from '@grafana/plugin-configs/webpack.config';
+// @ts-ignore - node needs the extension to strip types successfully
+import config from '@grafana/plugin-configs/webpack.config.ts';
 
+// eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Part of the effort to get this repo working with latest versions of node. This PR enables experimental type stripping for the webpack configs that are written in typescript and updates the configs to meet nodes type stripping requirements.

**Why do we need this feature?**

So when node 24 is LTS we don't end up scrambling to fix all the ts-node / esm issues that arise throughout the repo.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #105435

**Special notes for your reviewer:**

I've tested these changes locally with nvm and node 23 + 24 and `yarn packages:build` now works without throwing errors.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
