### PR TITLE
feat(unified-storage): round robin queue and scheduler package

### DIFF
--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -35,3 +35,30 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 		}),
 	}
 }
+
+type QOSMetrics struct {
+	QueueLength       *prometheus.GaugeVec   // per slug
+	DiscardedRequests *prometheus.CounterVec // per slug
+	EnqueueDuration   prometheus.Histogram
+}
+
+func ProvideQOSMetrics(reg prometheus.Registerer) *QOSMetrics {
+	return &QOSMetrics{
+		QueueLength: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "storage_server",
+			Name:      "qos_queue_length",
+			Help:      "Number of items in the queue",
+		}, []string{"slug"}),
+		DiscardedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "storage_server",
+			Name:      "qos_discarded_requests_total",
+			Help:      "Total number of discarded requests",
+		}, []string{"slug", "reason"}),
+		EnqueueDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: "storage_server",
+			Name:      "qos_enqueue_duration_seconds",
+			Help:      "Duration of enqueue operation in seconds",
+			Buckets:   prometheus.DefBuckets,
+		}),
+	}
+}

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -37,8 +37,8 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 }
 
 type QOSMetrics struct {
-	QueueLength       *prometheus.GaugeVec   // per slug
-	DiscardedRequests *prometheus.CounterVec // per slug
+	QueueLength       *prometheus.GaugeVec
+	DiscardedRequests *prometheus.CounterVec
 	EnqueueDuration   prometheus.Histogram
 }
 
@@ -48,12 +48,12 @@ func ProvideQOSMetrics(reg prometheus.Registerer) *QOSMetrics {
 			Namespace: "storage_server",
 			Name:      "qos_queue_length",
 			Help:      "Number of items in the queue",
-		}, []string{"slug"}),
+		}, []string{"namespace"}),
 		DiscardedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "storage_server",
 			Name:      "qos_discarded_requests_total",
 			Help:      "Total number of discarded requests",
-		}, []string{"slug", "reason"}),
+		}, []string{"namespace", "reason"}),
 		EnqueueDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "storage_server",
 			Name:      "qos_enqueue_duration_seconds",

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -35,30 +35,3 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 		}),
 	}
 }
-
-type QOSMetrics struct {
-	QueueLength       *prometheus.GaugeVec
-	DiscardedRequests *prometheus.CounterVec
-	EnqueueDuration   prometheus.Histogram
-}
-
-func ProvideQOSMetrics(reg prometheus.Registerer) *QOSMetrics {
-	return &QOSMetrics{
-		QueueLength: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "storage_server",
-			Name:      "qos_queue_length",
-			Help:      "Number of items in the queue",
-		}, []string{"namespace"}),
-		DiscardedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "storage_server",
-			Name:      "qos_discarded_requests_total",
-			Help:      "Total number of discarded requests",
-		}, []string{"namespace", "reason"}),
-		EnqueueDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Namespace: "storage_server",
-			Name:      "qos_enqueue_duration_seconds",
-			Help:      "Duration of enqueue operation in seconds",
-			Buckets:   prometheus.DefBuckets,
-		}),
-	}
-}

--- a/pkg/util/scheduler/queue.go
+++ b/pkg/util/scheduler/queue.go
@@ -181,16 +181,13 @@ func (q *Queue) scheduleRoundRobin() {
 		// Update bookkeeping
 		q.pendingDequeueRequests.Remove(reqElem)
 		tq.items = tq.items[1:]
-		if tq.isEmpty() {
-			tq.clear()
-			q.activeTenants.Remove(tenantElem)
-		}
 
 		// Update metrics
-		q.queueLength.WithLabelValues(tq.id).Set(float64(len(tq.items)))
+		q.queueLength.WithLabelValues(tq.id).Set(float64(tq.len()))
 
 		// Round-robin: move to back if tenant still has items, otherwise remove
 		if tq.isEmpty() {
+			tq.clear()
 			q.activeTenants.Remove(tenantElem)
 		} else {
 			q.activeTenants.MoveToBack(tenantElem)

--- a/pkg/util/scheduler/queue.go
+++ b/pkg/util/scheduler/queue.go
@@ -108,11 +108,7 @@ type Queue struct {
 
 type QueueOptions struct {
 	MaxSizePerTenant int
-
-	// Metrics options
 	Registerer       prometheus.Registerer
-	MetricsNamespace string
-	MetricsSubsystem string
 }
 
 // NewQueue creates a new Queue and starts its dispatcher goroutine.
@@ -135,23 +131,17 @@ func NewQueue(opts *QueueOptions) *Queue {
 	}
 
 	q.queueLength = promauto.With(opts.Registerer).NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: opts.MetricsNamespace,
-		Subsystem: opts.MetricsSubsystem,
-		Name:      "queue_length",
-		Help:      "Number of items in the queue",
+		Name: "queue_length",
+		Help: "Number of items in the queue",
 	}, []string{"namespace"})
 	q.discardedRequests = promauto.With(opts.Registerer).NewCounterVec(prometheus.CounterOpts{
-		Namespace: opts.MetricsNamespace,
-		Subsystem: opts.MetricsSubsystem,
-		Name:      "discarded_requests_total",
-		Help:      "Total number of discarded requests",
+		Name: "discarded_requests_total",
+		Help: "Total number of discarded requests",
 	}, []string{"namespace", "reason"})
 	q.enqueueDuration = promauto.With(opts.Registerer).NewHistogram(prometheus.HistogramOpts{
-		Namespace: opts.MetricsNamespace,
-		Subsystem: opts.MetricsSubsystem,
-		Name:      "enqueue_duration_seconds",
-		Help:      "Duration of enqueue operation in seconds",
-		Buckets:   prometheus.DefBuckets,
+		Name:    "enqueue_duration_seconds",
+		Help:    "Duration of enqueue operation in seconds",
+		Buckets: prometheus.DefBuckets,
 	})
 
 	q.Service = services.NewBasicService(nil, q.dispatcherLoop, q.stopping)

--- a/pkg/util/scheduler/queue.go
+++ b/pkg/util/scheduler/queue.go
@@ -1,0 +1,507 @@
+package scheduler
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var ErrQueueClosed = errors.New("queue closed")
+var ErrTenantQueueFull = errors.New("tenant queue full")
+
+type tenantQueue struct {
+	id    string
+	items []func()
+
+	activeElement *list.Element
+}
+
+type enqueueRequest struct {
+	tenantID string
+	runnable func()
+	respChan chan error
+}
+
+type dequeueRequest struct {
+	ctx      context.Context
+	respChan chan dequeueResponse
+}
+
+type dequeueResponse struct {
+	runnable func()
+	ok       bool
+	err      error
+}
+
+type closeRequest struct {
+	respChan chan struct{}
+}
+
+type lenRequest struct {
+	respChan chan int
+}
+
+type activeTenantsLenRequest struct {
+	respChan chan int
+}
+
+// Queue implements a multi-tenant qos with round-robin fairness using a dispatcher goroutine.
+type Queue struct {
+	enqueueChan           chan enqueueRequest
+	dequeueChan           chan dequeueRequest
+	closeChan             chan closeRequest
+	lenChan               chan lenRequest
+	activeTenantsLenChan  chan activeTenantsLenRequest
+	dispatcherStoppedChan chan struct{}
+
+	maxSizePerTenant int
+
+	// Metrics
+	queueLength       *prometheus.GaugeVec
+	discardedRequests *prometheus.CounterVec
+	enqueueDuration   prometheus.Histogram
+}
+
+type QueueOptions struct {
+	MaxSizePerTenant  int
+	QueueLength       *prometheus.GaugeVec   // per tenant
+	DiscardedRequests *prometheus.CounterVec // per tenant
+	EnqueueDuration   prometheus.Histogram
+}
+
+// NewQueue creates a new Queue and starts its dispatcher goroutine.
+func NewQueue(opts *QueueOptions) *Queue {
+	if opts.MaxSizePerTenant <= 0 {
+		opts.MaxSizePerTenant = 100
+	}
+
+	q := &Queue{
+		enqueueChan:           make(chan enqueueRequest),
+		dequeueChan:           make(chan dequeueRequest),
+		closeChan:             make(chan closeRequest),
+		lenChan:               make(chan lenRequest),
+		activeTenantsLenChan:  make(chan activeTenantsLenRequest),
+		dispatcherStoppedChan: make(chan struct{}),
+		maxSizePerTenant:      opts.MaxSizePerTenant,
+
+		// Metrics
+		queueLength:       opts.QueueLength,
+		discardedRequests: opts.DiscardedRequests,
+		enqueueDuration:   opts.EnqueueDuration,
+	}
+
+	go q.dispatcherLoop()
+
+	return q
+}
+
+type dispatcherState struct {
+	tenantQueues     map[string]*tenantQueue
+	activeTenants    *list.List
+	waitingDequeuers *list.List
+	closed           bool
+	maxSizePerTenant int
+
+	// Metrics
+	queueLength       *prometheus.GaugeVec
+	discardedRequests *prometheus.CounterVec
+}
+
+type firstDequeueItem struct {
+	dequeueReqChan   chan dequeueResponse
+	runnable         func()
+	elementToDequeue *list.Element
+}
+
+func (s *dispatcherState) shouldExit() bool {
+	return s.closed && s.activeTenants.Len() == 0 && s.waitingDequeuers.Len() == 0
+}
+
+func (s *dispatcherState) prepareFirstDequeue() firstDequeueItem {
+	result := firstDequeueItem{}
+
+	elementToDequeue := s.activeTenants.Front()
+	if !s.closed && elementToDequeue != nil && s.waitingDequeuers.Len() > 0 {
+		selectedTenantQ := elementToDequeue.Value.(*tenantQueue)
+		if len(selectedTenantQ.items) > 0 {
+			result.runnable = selectedTenantQ.items[0]
+			result.dequeueReqChan = s.waitingDequeuers.Front().Value.(*dequeueRequest).respChan
+			result.elementToDequeue = elementToDequeue
+		} else {
+			s.activeTenants.Remove(elementToDequeue)
+			selectedTenantQ.activeElement = nil
+		}
+	}
+
+	return result
+}
+
+func (s *dispatcherState) handleEnqueueRequest(req enqueueRequest) {
+	if s.closed {
+		s.discardedRequests.WithLabelValues(req.tenantID, "queue_closed").Inc()
+		req.respChan <- ErrQueueClosed
+		return
+	}
+
+	s.processEnqueue(req)
+}
+
+func (s *dispatcherState) processEnqueue(req enqueueRequest) {
+	tq, exists := s.tenantQueues[req.tenantID]
+	if !exists {
+		tq = &tenantQueue{
+			id:    req.tenantID,
+			items: make([]func(), 0, 8),
+		}
+		s.tenantQueues[req.tenantID] = tq
+	}
+
+	if s.maxSizePerTenant > 0 && len(tq.items) >= s.maxSizePerTenant {
+		s.discardedRequests.WithLabelValues(req.tenantID, "queue_full").Inc()
+		req.respChan <- ErrTenantQueueFull
+		return
+	}
+
+	tq.items = append(tq.items, req.runnable)
+	s.queueLength.WithLabelValues(req.tenantID).Set(float64(len(tq.items)))
+
+	if tq.activeElement == nil {
+		tq.activeElement = s.activeTenants.PushBack(tq)
+	}
+
+	req.respChan <- nil
+}
+
+func (s *dispatcherState) handleDequeueRequest(req dequeueRequest) {
+	if s.closed {
+		s.sendDequeueResponse(req, dequeueResponse{ok: false, err: ErrQueueClosed})
+		return
+	}
+
+	if req.ctx.Err() != nil {
+		s.sendDequeueResponse(req, dequeueResponse{ok: false, err: req.ctx.Err()})
+		return
+	}
+
+	s.waitingDequeuers.PushBack(&req)
+}
+
+func (s *dispatcherState) sendDequeueResponse(req dequeueRequest, resp dequeueResponse) {
+	select {
+	case req.respChan <- resp:
+	default:
+	}
+}
+
+func (s *dispatcherState) completeDequeue(elementToDequeue *list.Element) {
+	dequeuerElement := s.waitingDequeuers.Front()
+	s.waitingDequeuers.Remove(dequeuerElement)
+
+	selectedTenantQ := elementToDequeue.Value.(*tenantQueue)
+	selectedTenantQ.items = selectedTenantQ.items[1:]
+
+	s.queueLength.WithLabelValues(selectedTenantQ.id).Set(float64(len(selectedTenantQ.items)))
+
+	if len(selectedTenantQ.items) == 0 {
+		s.activeTenants.Remove(elementToDequeue)
+		selectedTenantQ.activeElement = nil
+	} else {
+		s.activeTenants.MoveToBack(elementToDequeue)
+	}
+}
+
+func (s *dispatcherState) handleCloseRequest(req closeRequest) {
+	if !s.closed {
+		s.closed = true
+		s.notifyWaitingDequeuers()
+		s.clearQueues()
+	}
+
+	select {
+	case req.respChan <- struct{}{}:
+	default:
+	}
+}
+
+func (s *dispatcherState) notifyWaitingDequeuers() {
+	for e := s.waitingDequeuers.Front(); e != nil; e = e.Next() {
+		waiterReq := e.Value.(*dequeueRequest)
+		s.sendDequeueResponse(*waiterReq, dequeueResponse{ok: false, err: ErrQueueClosed})
+	}
+	s.waitingDequeuers.Init()
+}
+
+func (s *dispatcherState) clearQueues() {
+	// Reset queue length metrics for all tenants before clearing
+	if s.queueLength != nil {
+		for tenantID := range s.tenantQueues {
+			s.queueLength.WithLabelValues(tenantID).Set(0)
+		}
+	}
+
+	s.tenantQueues = make(map[string]*tenantQueue)
+	s.activeTenants.Init()
+}
+
+func (s *dispatcherState) handleLenRequest(req lenRequest) {
+	total := 0
+	for _, tq := range s.tenantQueues {
+		total += len(tq.items)
+	}
+	req.respChan <- total
+}
+
+func (s *dispatcherState) processWaitingDequeuers() {
+	currentWorkerElem := s.waitingDequeuers.Front()
+	for currentWorkerElem != nil && s.activeTenants.Len() > 0 {
+		nextWorkerElem := currentWorkerElem.Next()
+
+		if s.processDequeuer(currentWorkerElem) {
+			break
+		}
+
+		currentWorkerElem = nextWorkerElem
+	}
+}
+
+func (s *dispatcherState) processDequeuer(workerElem *list.Element) bool {
+	workerReq := workerElem.Value.(*dequeueRequest)
+
+	if workerReq.ctx.Err() != nil {
+		s.sendDequeueResponse(*workerReq, dequeueResponse{ok: false, err: workerReq.ctx.Err()})
+		s.waitingDequeuers.Remove(workerElem)
+		return false
+	}
+
+	currentTenantElem := s.activeTenants.Front()
+	if currentTenantElem == nil {
+		return true
+	}
+
+	selectedTenantQ := currentTenantElem.Value.(*tenantQueue)
+	if len(selectedTenantQ.items) == 0 {
+		s.activeTenants.Remove(currentTenantElem)
+		selectedTenantQ.activeElement = nil
+		return true
+	}
+
+	s.sendItemToDequeuer(workerReq, workerElem, currentTenantElem, selectedTenantQ)
+	return false
+}
+
+func (s *dispatcherState) sendItemToDequeuer(
+	workerReq *dequeueRequest,
+	workerElem *list.Element,
+	tenantElem *list.Element,
+	tenantQ *tenantQueue,
+) {
+	itemToSend := tenantQ.items[0]
+	workerReq.respChan <- dequeueResponse{runnable: itemToSend, ok: true, err: nil}
+
+	s.waitingDequeuers.Remove(workerElem)
+	tenantQ.items = tenantQ.items[1:]
+
+	if len(tenantQ.items) == 0 {
+		s.activeTenants.Remove(tenantElem)
+		tenantQ.activeElement = nil
+	} else {
+		s.activeTenants.MoveToBack(tenantElem)
+	}
+}
+
+func (q *Queue) dispatcherLoop() {
+	state := &dispatcherState{
+		tenantQueues:     make(map[string]*tenantQueue),
+		activeTenants:    list.New(),
+		waitingDequeuers: list.New(),
+		closed:           false,
+		maxSizePerTenant: q.maxSizePerTenant,
+
+		// Metrics
+		queueLength:       q.queueLength,
+		discardedRequests: q.discardedRequests,
+	}
+
+	defer close(q.dispatcherStoppedChan)
+
+	for {
+		if state.shouldExit() {
+			return
+		}
+
+		first := state.prepareFirstDequeue()
+
+		select {
+		case req := <-q.enqueueChan:
+			state.handleEnqueueRequest(req)
+
+		case req := <-q.dequeueChan:
+			state.handleDequeueRequest(req)
+
+		case first.dequeueReqChan <- dequeueResponse{runnable: first.runnable, ok: true, err: nil}:
+			state.completeDequeue(first.elementToDequeue)
+
+		case req := <-q.closeChan:
+			state.handleCloseRequest(req)
+
+		case req := <-q.lenChan:
+			state.handleLenRequest(req)
+
+		case req := <-q.activeTenantsLenChan:
+			req.respChan <- state.activeTenants.Len()
+		}
+
+		if !state.closed {
+			state.processWaitingDequeuers()
+		}
+	}
+}
+
+// Enqueue adds a work item to the appropriate tenant's qos.
+// It blocks only if the dispatcher is busy or the tenant queue is full.
+func (q *Queue) Enqueue(ctx context.Context, tenantID string, runnable func()) error {
+	if runnable == nil {
+		return errors.New("cannot enqueue nil runnable")
+	}
+	if tenantID == "" {
+		return errors.New("item requires TenantID")
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	start := time.Now()
+
+	respChan := make(chan error, 1)
+	req := enqueueRequest{
+		tenantID: tenantID,
+		runnable: runnable,
+		respChan: respChan,
+	}
+
+	var err error
+	select {
+	case q.enqueueChan <- req:
+		err = <-respChan
+	case <-q.dispatcherStoppedChan:
+		q.discardedRequests.WithLabelValues(tenantID, "dispatcher_stopped").Inc()
+		err = ErrQueueClosed
+	case <-ctx.Done():
+		q.discardedRequests.WithLabelValues(tenantID, "context_cancelled").Inc()
+		err = ctx.Err()
+	}
+
+	q.enqueueDuration.Observe(time.Since(start).Seconds())
+
+	return err
+}
+
+// Dequeue removes and returns a work item from the qos using linked-list round-robin.
+// It blocks until an item is available for any tenant, the queue is closed,
+// or the context is cancelled.
+func (q *Queue) Dequeue(ctx context.Context) (func(), bool, error) {
+	if ctx.Err() != nil {
+		return nil, false, ctx.Err()
+	}
+
+	respChan := make(chan dequeueResponse, 1)
+	req := dequeueRequest{
+		ctx:      ctx,
+		respChan: respChan,
+	}
+
+	select {
+	case q.dequeueChan <- req:
+		select {
+		case resp := <-respChan:
+			return resp.runnable, resp.ok, resp.err
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-q.dispatcherStoppedChan:
+			select {
+			case resp := <-respChan:
+				return resp.runnable, resp.ok, resp.err
+			default:
+				return nil, false, ErrQueueClosed
+			}
+		}
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case <-q.dispatcherStoppedChan:
+		return nil, false, ErrQueueClosed
+	}
+}
+
+// Close marks the queue as closed and signals the dispatcher.
+// It blocks until the dispatcher acknowledges the close.
+func (q *Queue) Close() {
+	respChan := make(chan struct{})
+	req := closeRequest{respChan: respChan}
+
+	select {
+	case q.closeChan <- req:
+		select {
+		case <-respChan:
+		case <-q.dispatcherStoppedChan:
+		case <-time.After(500 * time.Millisecond):
+		}
+	case <-q.dispatcherStoppedChan:
+	case <-time.After(500 * time.Millisecond):
+		select {
+		case <-q.dispatcherStoppedChan:
+		default:
+			close(q.dispatcherStoppedChan)
+		}
+	}
+}
+
+// StopWait blocks until the dispatcher goroutine has fully stopped.
+// Call Close() first to initiate shutdown.
+func (q *Queue) StopWait() {
+	select {
+	case <-q.dispatcherStoppedChan:
+		return
+	case <-time.After(2 * time.Second):
+		return
+	}
+}
+
+// Len returns the total number of items across all tenants in the qos.
+func (q *Queue) Len() int {
+	respChan := make(chan int, 1)
+	req := lenRequest{respChan: respChan}
+
+	select {
+	case q.lenChan <- req:
+		select {
+		case count := <-respChan:
+			return count
+		case <-q.dispatcherStoppedChan:
+			return 0
+		}
+	case <-q.dispatcherStoppedChan:
+		return 0
+	}
+}
+
+// ActiveTenantsLen returns the number of tenants with items currently in the qos.
+func (q *Queue) ActiveTenantsLen() int {
+	respChan := make(chan int, 1)
+	req := activeTenantsLenRequest{respChan: respChan}
+
+	select {
+	case q.activeTenantsLenChan <- req:
+		select {
+		case count := <-respChan:
+			return count
+		case <-q.dispatcherStoppedChan:
+			return 0
+		}
+	case <-q.dispatcherStoppedChan:
+		return 0
+	}
+}

--- a/pkg/util/scheduler/queue.go
+++ b/pkg/util/scheduler/queue.go
@@ -10,14 +10,61 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	// DefaultMaxSizePerTenant is the default maximum number of items per tenant in the queue.
+	DefaultMaxSizePerTenant = 100
+)
+
 var ErrQueueClosed = errors.New("queue closed")
 var ErrTenantQueueFull = errors.New("tenant queue full")
 
 type tenantQueue struct {
-	id    string
-	items []func()
+	id       string
+	items    []func()
+	isActive bool
+}
 
-	isStoredInActiveTenants *list.Element
+func (tq *tenantQueue) Len() int {
+	return len(tq.items)
+}
+func (tq *tenantQueue) ID() string {
+	return tq.id
+}
+func (tq *tenantQueue) Items() []func() {
+	return tq.items
+}
+func (tq *tenantQueue) SetItems(items []func()) {
+	tq.items = items
+}
+func (tq *tenantQueue) Clear() {
+	tq.items = nil
+	tq.isActive = false
+}
+func (tq *tenantQueue) IsEmpty() bool {
+	return len(tq.items) == 0
+}
+func (tq *tenantQueue) IsFull(maxSize int) bool {
+	return maxSize > 0 && len(tq.items) >= maxSize
+}
+func (tq *tenantQueue) AddRunnable(runnable func()) {
+	tq.items = append(tq.items, runnable)
+}
+func (tq *tenantQueue) RemoveRunnable() {
+	if len(tq.items) > 0 {
+		tq.items = tq.items[1:]
+	}
+	if len(tq.items) == 0 {
+		tq.isActive = false
+	}
+}
+func (tq *tenantQueue) GetRunnable() func() {
+	if len(tq.items) > 0 {
+		return tq.items[0]
+	}
+	return nil
+}
+func (tq *tenantQueue) SetActive() {
+	tq.isActive = true
 }
 
 type enqueueRequest struct {
@@ -37,10 +84,6 @@ type dequeueResponse struct {
 	err      error
 }
 
-type closeRequest struct {
-	respChan chan struct{}
-}
-
 type lenRequest struct {
 	respChan chan int
 }
@@ -55,7 +98,6 @@ type Queue struct {
 
 	enqueueChan           chan enqueueRequest
 	dequeueChan           chan dequeueRequest
-	closeChan             chan closeRequest
 	lenChan               chan lenRequest
 	activeTenantsLenChan  chan activeTenantsLenRequest
 	dispatcherStoppedChan chan struct{}
@@ -68,8 +110,6 @@ type Queue struct {
 	// pendingDequeueRequests is a list of dequeue requests waiting for items
 	// used for notifying when items are available
 	pendingDequeueRequests *list.List
-	// closed indicates if the queue is closed
-	closed bool
 	// maxSizePerTenant is the maximum number of items per tenant
 	maxSizePerTenant int
 
@@ -89,13 +129,12 @@ type QueueOptions struct {
 // NewQueue creates a new Queue and starts its dispatcher goroutine.
 func NewQueue(opts *QueueOptions) *Queue {
 	if opts.MaxSizePerTenant <= 0 {
-		opts.MaxSizePerTenant = 100
+		opts.MaxSizePerTenant = DefaultMaxSizePerTenant
 	}
 
 	q := &Queue{
 		enqueueChan:           make(chan enqueueRequest),
 		dequeueChan:           make(chan dequeueRequest),
-		closeChan:             make(chan closeRequest),
 		lenChan:               make(chan lenRequest),
 		activeTenantsLenChan:  make(chan activeTenantsLenRequest),
 		dispatcherStoppedChan: make(chan struct{}),
@@ -103,7 +142,6 @@ func NewQueue(opts *QueueOptions) *Queue {
 		tenantQueues:           make(map[string]*tenantQueue),
 		activeTenants:          list.New(),
 		pendingDequeueRequests: list.New(),
-		closed:                 false,
 		maxSizePerTenant:       opts.MaxSizePerTenant,
 
 		// Metrics
@@ -112,94 +150,61 @@ func NewQueue(opts *QueueOptions) *Queue {
 		enqueueDuration:   opts.EnqueueDuration,
 	}
 
-	q.Service = services.NewBasicService(nil, q.dispatcherLoop, nil)
+	q.Service = services.NewBasicService(nil, q.dispatcherLoop, q.stopping)
 
 	return q
 }
 
-type firstDequeueItem struct {
-	dequeueRespChan chan dequeueResponse
-	runnable        func()
-	tenantElem      *list.Element
-}
-
 func (q *Queue) shouldExit() bool {
-	return q.closed && q.activeTenants.Len() == 0 && q.pendingDequeueRequests.Len() == 0
-}
-
-func (q *Queue) prepareDequeue() firstDequeueItem {
-	item := firstDequeueItem{}
-
-	pendingTenant := q.activeTenants.Front()
-	if pendingTenant != nil && q.pendingDequeueRequests.Len() > 0 {
-		tq := pendingTenant.Value.(*tenantQueue)
-		if len(tq.items) > 0 {
-			pendingReq := q.pendingDequeueRequests.Front()
-			if pendingReq == nil {
-				return item
-			}
-
-			item.runnable = tq.items[0]
-			item.dequeueRespChan = pendingReq.Value.(*dequeueRequest).respChan
-			item.tenantElem = pendingTenant
-		} else {
-			q.activeTenants.Remove(pendingTenant)
-			tq.isStoredInActiveTenants = nil
-		}
+	select {
+	case <-q.dispatcherStoppedChan:
+		return true
+	default:
+		return false
 	}
-
-	return item
 }
 
-func (q *Queue) handlePendingRequests() {
-	for reqElem := q.pendingDequeueRequests.Front(); reqElem != nil && q.activeTenants.Len() > 0; {
-		req := reqElem.Value.(*dequeueRequest)
-
-		// If the request context is done, respond and remove it.
-		if req.ctx.Err() != nil {
-			req.respChan <- dequeueResponse{ok: false, err: req.ctx.Err()}
-			next := reqElem.Next()
-			q.pendingDequeueRequests.Remove(reqElem)
-			reqElem = next
-			continue
-		}
-
+func (q *Queue) scheduleRoundRobin() {
+	// Process as long as we have both pending requests and active tenants
+	for {
+		// Get the front elements of both lists
+		reqElem := q.pendingDequeueRequests.Front()
 		tenantElem := q.activeTenants.Front()
-		if tenantElem == nil {
+
+		// Exit when either list is empty
+		if reqElem == nil || tenantElem == nil {
 			break
 		}
 
+		req := reqElem.Value.(*dequeueRequest)
 		tq := tenantElem.Value.(*tenantQueue)
-		if len(tq.items) == 0 {
+
+		// Skip empty tenant queues by removing them and continuing
+		if tq.IsEmpty() {
+			tq.Clear()
 			q.activeTenants.Remove(tenantElem)
-			tq.isStoredInActiveTenants = nil
 			continue
 		}
 
-		// Respond to the request with the next runnable.
-		item := tq.items[0]
+		// Get and deliver the runnable item
+		item := tq.GetRunnable()
 		req.respChan <- dequeueResponse{runnable: item, ok: true, err: nil}
-		q.pendingDequeueRequests.Remove(reqElem)
-		tq.items = tq.items[1:]
 
-		if len(tq.items) == 0 {
+		// Update bookkeeping
+		q.pendingDequeueRequests.Remove(reqElem)
+		tq.RemoveRunnable()
+		q.queueLength.WithLabelValues(tq.id).Set(float64(len(tq.items)))
+
+		// Round-robin: move to back if tenant still has items, otherwise remove
+		if tq.IsEmpty() {
 			q.activeTenants.Remove(tenantElem)
-			tq.isStoredInActiveTenants = nil
 		} else {
 			q.activeTenants.MoveToBack(tenantElem)
 		}
-
-		reqElem = q.pendingDequeueRequests.Front()
 	}
 }
 
 func (q *Queue) handleEnqueueRequest(req enqueueRequest) {
-	if q.closed {
-		q.discardedRequests.WithLabelValues(req.tenantID, "queue_closed").Inc()
-		req.respChan <- ErrQueueClosed
-		return
-	}
-
 	tq, exists := q.tenantQueues[req.tenantID]
 	if !exists {
 		tq = &tenantQueue{
@@ -209,79 +214,31 @@ func (q *Queue) handleEnqueueRequest(req enqueueRequest) {
 		q.tenantQueues[req.tenantID] = tq
 	}
 
-	if q.maxSizePerTenant > 0 && len(tq.items) >= q.maxSizePerTenant {
+	if tq.IsFull(q.maxSizePerTenant) {
 		q.discardedRequests.WithLabelValues(req.tenantID, "queue_full").Inc()
 		req.respChan <- ErrTenantQueueFull
 		return
 	}
 
-	tq.items = append(tq.items, req.runnable)
+	tq.AddRunnable(req.runnable)
 	q.queueLength.WithLabelValues(req.tenantID).Set(float64(len(tq.items)))
 
-	if tq.isStoredInActiveTenants == nil {
-		tq.isStoredInActiveTenants = q.activeTenants.PushBack(tq)
+	if !tq.isActive {
+		q.activeTenants.PushBack(tq)
+		tq.SetActive()
 	}
 
 	req.respChan <- nil
 }
 
 func (q *Queue) handleDequeueRequest(req dequeueRequest) {
-	if req.ctx.Err() != nil {
-		req.respChan <- dequeueResponse{ok: false, err: req.ctx.Err()}
-		return
-	}
-
 	q.pendingDequeueRequests.PushBack(&req)
-}
-
-func (q *Queue) completeDequeue(tenantElem *list.Element) {
-	reqElem := q.pendingDequeueRequests.Front()
-	q.pendingDequeueRequests.Remove(reqElem)
-
-	tq := tenantElem.Value.(*tenantQueue)
-	tq.items = tq.items[1:]
-
-	q.queueLength.WithLabelValues(tq.id).Set(float64(len(tq.items)))
-
-	if len(tq.items) == 0 {
-		q.activeTenants.Remove(tenantElem)
-		tq.isStoredInActiveTenants = nil
-		tq.items = nil
-		delete(q.tenantQueues, tq.id)
-	} else {
-		q.activeTenants.MoveToBack(tenantElem)
-	}
-}
-
-func (q *Queue) handleCloseRequest(req closeRequest) {
-	if !q.closed {
-		q.closed = true
-
-		// Notify all pending requests that the queue is closed
-		for e := q.pendingDequeueRequests.Front(); e != nil; e = e.Next() {
-			dequeueReq := e.Value.(*dequeueRequest)
-			dequeueReq.respChan <- dequeueResponse{ok: false, err: ErrQueueClosed}
-		}
-		q.pendingDequeueRequests.Init()
-
-		// Reset queue length metrics for all tenants before clearing
-		if q.queueLength != nil {
-			for tenantID := range q.tenantQueues {
-				q.queueLength.WithLabelValues(tenantID).Set(0)
-			}
-		}
-
-		q.tenantQueues = make(map[string]*tenantQueue)
-		q.activeTenants.Init()
-	}
-
-	req.respChan <- struct{}{}
 }
 
 func (q *Queue) handleLenRequest(req lenRequest) {
 	total := 0
 	for _, tq := range q.tenantQueues {
-		total += len(tq.items)
+		total += tq.Len()
 	}
 	req.respChan <- total
 }
@@ -294,7 +251,7 @@ func (q *Queue) dispatcherLoop(ctx context.Context) error {
 			return nil
 		}
 
-		first := q.prepareDequeue()
+		q.scheduleRoundRobin()
 
 		select {
 		case <-ctx.Done():
@@ -306,21 +263,11 @@ func (q *Queue) dispatcherLoop(ctx context.Context) error {
 		case req := <-q.dequeueChan:
 			q.handleDequeueRequest(req)
 
-		case req := <-q.closeChan:
-			q.handleCloseRequest(req)
-
 		case req := <-q.lenChan:
 			q.handleLenRequest(req)
 
 		case req := <-q.activeTenantsLenChan:
 			req.respChan <- q.activeTenants.Len()
-
-		case first.dequeueRespChan <- dequeueResponse{runnable: first.runnable, ok: true, err: nil}:
-			q.completeDequeue(first.tenantElem)
-		}
-
-		if !q.closed {
-			q.handlePendingRequests()
 		}
 	}
 }
@@ -333,10 +280,6 @@ func (q *Queue) Enqueue(ctx context.Context, tenantID string, runnable func()) e
 	}
 	if tenantID == "" {
 		return errors.New("item requires TenantID")
-	}
-
-	if ctx.Err() != nil {
-		return ctx.Err()
 	}
 
 	start := time.Now()
@@ -352,6 +295,7 @@ func (q *Queue) Enqueue(ctx context.Context, tenantID string, runnable func()) e
 	select {
 	case q.enqueueChan <- req:
 		err = <-respChan
+		q.enqueueDuration.Observe(time.Since(start).Seconds())
 	case <-q.dispatcherStoppedChan:
 		q.discardedRequests.WithLabelValues(tenantID, "dispatcher_stopped").Inc()
 		err = ErrQueueClosed
@@ -360,8 +304,6 @@ func (q *Queue) Enqueue(ctx context.Context, tenantID string, runnable func()) e
 		err = ctx.Err()
 	}
 
-	q.enqueueDuration.Observe(time.Since(start).Seconds())
-
 	return err
 }
 
@@ -369,10 +311,6 @@ func (q *Queue) Enqueue(ctx context.Context, tenantID string, runnable func()) e
 // It blocks until an item is available for any tenant, the queue is closed,
 // or the context is cancelled.
 func (q *Queue) Dequeue(ctx context.Context) (func(), bool, error) {
-	if ctx.Err() != nil {
-		return nil, false, ctx.Err()
-	}
-
 	respChan := make(chan dequeueResponse, 1)
 	req := dequeueRequest{
 		ctx:      ctx,
@@ -401,7 +339,7 @@ func (q *Queue) Dequeue(ctx context.Context) (func(), bool, error) {
 	}
 }
 
-// Len returns the total number of items across all tenants in the qos.
+// Len returns the total number of items across all tenants in the queue.
 func (q *Queue) Len() int {
 	respChan := make(chan int, 1)
 	req := lenRequest{respChan: respChan}
@@ -419,7 +357,7 @@ func (q *Queue) Len() int {
 	}
 }
 
-// ActiveTenantsLen returns the number of tenants with items currently in the qos.
+// ActiveTenantsLen returns the number of tenants with items currently in the queue.
 func (q *Queue) ActiveTenantsLen() int {
 	respChan := make(chan int, 1)
 	req := activeTenantsLenRequest{respChan: respChan}
@@ -435,4 +373,15 @@ func (q *Queue) ActiveTenantsLen() int {
 	case <-q.dispatcherStoppedChan:
 		return 0
 	}
+}
+
+func (q *Queue) stopping(_ error) error {
+	q.queueLength.Reset()
+	q.discardedRequests.Reset()
+	for _, tq := range q.tenantQueues {
+		tq.Clear()
+	}
+	q.activeTenants.Init()
+	q.pendingDequeueRequests.Init()
+	return nil
 }

--- a/pkg/util/scheduler/queue_test.go
+++ b/pkg/util/scheduler/queue_test.go
@@ -1,0 +1,357 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stretchr/testify/require"
+)
+
+func QueueOptionsWithDefaults(opts *QueueOptions) *QueueOptions {
+	if opts == nil {
+		opts = &QueueOptions{}
+	}
+	if opts.MaxSizePerTenant <= 0 {
+		opts.MaxSizePerTenant = 10
+	}
+	if opts.QueueLength == nil {
+		opts.QueueLength = promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"slug"})
+	}
+	if opts.DiscardedRequests == nil {
+		opts.DiscardedRequests = promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"slug", "reason"})
+	}
+	if opts.EnqueueDuration == nil {
+		opts.EnqueueDuration = promauto.With(nil).NewHistogram(prometheus.HistogramOpts{})
+	}
+	return opts
+}
+
+func TestQueue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts *QueueOptions
+		test func(t *testing.T, q *Queue)
+	}{
+		{
+			name: "Simple Enqueue and Dequeue",
+			opts: QueueOptionsWithDefaults(nil),
+			test: func(t *testing.T, q *Queue) {
+				ctx := context.Background()
+				var wg sync.WaitGroup
+				const numItems = 5
+				const tenantID = "tenant-a"
+
+				// Enqueue items
+				for i := 0; i < numItems; i++ {
+					val := i // Capture loop variable
+					err := q.Enqueue(ctx, tenantID, func() {
+						// Simple work item
+						_ = val
+					})
+					require.NoError(t, err, "Enqueue should succeed")
+				}
+				require.Equal(t, numItems, q.Len(), "Queue length after enqueue")
+				require.Equal(t, 1, q.ActiveTenantsLen(), "Active tenants after enqueue")
+
+				// Dequeue items
+				for i := 0; i < numItems; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+						defer cancel()
+						runnable, ok, err := q.Dequeue(dequeueCtx)
+						require.NoError(t, err, "Dequeue should succeed")
+						require.True(t, ok, "Dequeue should return ok=true")
+						require.NotNil(t, runnable, "Dequeued runnable should not be nil")
+					}()
+				}
+
+				wg.Wait()
+
+				// Let's simplify the dequeue check: Dequeue sequentially after enqueueing.
+				qSimple := NewQueue(QueueOptionsWithDefaults(nil))
+				defer qSimple.Close()
+				defer qSimple.StopWait()
+
+				for i := 0; i < numItems; i++ {
+					err := qSimple.Enqueue(ctx, tenantID, func() {})
+					require.NoError(t, err)
+				}
+				require.Equal(t, numItems, qSimple.Len(), "Queue length after enqueue (simple)")
+				require.Equal(t, 1, qSimple.ActiveTenantsLen(), "Active tenants after enqueue (simple)")
+
+				for i := 0; i < numItems; i++ {
+					dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+					runnable, ok, err := qSimple.Dequeue(dequeueCtx)
+					cancel() // Cancel context after use
+					require.NoError(t, err, "Dequeue %d should succeed (simple)", i)
+					require.True(t, ok, "Dequeue %d should return ok=true (simple)", i)
+					require.NotNil(t, runnable, "Dequeued runnable %d should not be nil (simple)", i)
+				}
+
+				require.Equal(t, 0, qSimple.Len(), "Queue length after dequeue (simple)")
+				require.Equal(t, 0, qSimple.ActiveTenantsLen(), "Active tenants after dequeue (simple)")
+
+				// Check dequeue on empty queue times out
+				dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+				_, ok, err := qSimple.Dequeue(dequeueCtx)
+				cancel()
+				require.ErrorIs(t, err, context.DeadlineExceeded, "Dequeue on empty queue should time out")
+				require.False(t, ok, "Dequeue on empty queue should return ok=false")
+			},
+		},
+		{
+			name: "Round Robin Between Tenants",
+			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
+			test: func(t *testing.T, q *Queue) {
+				ctx := context.Background()
+				tenantA := "tenant-a"
+				tenantB := "tenant-b"
+
+				// We'll use a very small test with just 2 items per tenant
+				// to reduce the chance of timeouts or other issues
+
+				// Enqueue items in tenant order: A, B, A, B
+				// Each item will record its tenant ID when executed
+				var results []string
+				var resultsMu sync.Mutex
+
+				makeRunnable := func(id string) func() {
+					return func() {
+						resultsMu.Lock()
+						results = append(results, id)
+						resultsMu.Unlock()
+					}
+				}
+
+				// First tenant A, then B, then A, then B
+				err := q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
+				require.NoError(t, err)
+				err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
+				require.NoError(t, err)
+				err = q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
+				require.NoError(t, err)
+				err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
+				require.NoError(t, err)
+
+				// Verify queue state
+				require.Equal(t, 4, q.Len(), "Queue should have 4 items")
+				require.Equal(t, 2, q.ActiveTenantsLen(), "Should have 2 active tenants")
+
+				// Use a longer timeout to handle CI environment variability
+				dequeueTimeout := 3 * time.Second
+
+				// Dequeue and execute the four items
+				for i := 0; i < 4; i++ {
+					// Use a more reliable context with longer timeout for CI environments
+					dequeueCtx, cancel := context.WithTimeout(ctx, dequeueTimeout)
+					runnable, ok, err := q.Dequeue(dequeueCtx)
+					if !ok || err != nil {
+						// If there's an error, let's check if queue state is still consistent
+						t.Logf("Dequeue %d failed: ok=%v, err=%v", i, ok, err)
+						t.Logf("Queue state: Len=%d, ActiveTenantsLen=%d", q.Len(), q.ActiveTenantsLen())
+					}
+
+					cancel()
+					require.NoError(t, err, "Dequeue %d should succeed", i)
+					require.True(t, ok, "Dequeue %d should return ok=true", i)
+					require.NotNil(t, runnable, "Dequeued runnable %d should not be nil", i)
+					runnable() // Execute to record the tenant ID
+				}
+
+				// Check execution order - should alternate between tenants
+				resultsMu.Lock()
+				expectedOrder := []string{tenantA, tenantB, tenantA, tenantB}
+				equal := len(results) == len(expectedOrder)
+				if equal {
+					for i, v := range expectedOrder {
+						if i >= len(results) || results[i] != v {
+							equal = false
+							break
+						}
+					}
+				}
+
+				if !equal {
+					t.Errorf("Execution order mismatch: expected %v, got %v", expectedOrder, results)
+				}
+				resultsMu.Unlock()
+
+				// Verify queue is now empty
+				require.Equal(t, 0, q.Len())
+				require.Equal(t, 0, q.ActiveTenantsLen())
+			},
+		},
+		{
+			name: "Tenant Queue Full Error",
+			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 2}),
+			test: func(t *testing.T, q *Queue) {
+				ctx := context.Background()
+				tenantID := "tenant-limited"
+
+				// Enqueue up to the limit
+				err := q.Enqueue(ctx, tenantID, func() {})
+				require.NoError(t, err)
+				err = q.Enqueue(ctx, tenantID, func() {})
+				require.NoError(t, err)
+
+				require.Equal(t, 2, q.Len())
+				require.Equal(t, 1, q.ActiveTenantsLen())
+
+				// Enqueue one more, expect error
+				err = q.Enqueue(ctx, tenantID, func() {})
+				require.ErrorIs(t, err, ErrTenantQueueFull, "Expected ErrTenantQueueFull")
+
+				// Len should still be 2
+				require.Equal(t, 2, q.Len())
+
+				// Dequeue one item
+				dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+				_, ok, err := q.Dequeue(dequeueCtx)
+				cancel()
+				require.NoError(t, err)
+				require.True(t, ok)
+				require.Equal(t, 1, q.Len())
+
+				// Now enqueue should succeed again
+				err = q.Enqueue(ctx, tenantID, func() {})
+				require.NoError(t, err, "Enqueue should succeed after dequeueing one item")
+				require.Equal(t, 2, q.Len(), "Length should be back to 2")
+			},
+		},
+		{
+			name: "Close Queue",
+			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
+			test: func(t *testing.T, q *Queue) {
+				ctx := context.Background()
+				tenantID := "tenant-a"
+
+				// Create a channel to signal when the dequeue goroutine has started
+				dequeueStarted := make(chan struct{})
+				dequeueErrChan := make(chan error, 1)
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					// Signal that we're about to start dequeuing
+					close(dequeueStarted)
+
+					// This will block until queue is closed or something is enqueued
+					_, _, err := q.Dequeue(context.Background())
+					dequeueErrChan <- err // Send the error result
+				}()
+
+				// Wait until the dequeue operation has started
+				<-dequeueStarted
+
+				// Close the queue - this should unblock the dequeue with ErrQueueClosed
+				q.Close()
+
+				// Verify the error is ErrQueueClosed
+				select {
+				case err := <-dequeueErrChan:
+					require.ErrorIs(t, err, ErrQueueClosed, "Dequeue should return ErrQueueClosed when queue is closed")
+				case <-time.After(3 * time.Second): // Longer timeout for CI environments
+					t.Fatal("Timed out waiting for blocked Dequeue to return ErrQueueClosed")
+				}
+
+				// Wait for the dequeue goroutine to finish
+				wg.Wait()
+
+				// Further operations should error appropriately
+				_, ok, err := q.Dequeue(ctx)
+				require.ErrorIs(t, err, ErrQueueClosed, "Dequeue after Close should return ErrQueueClosed")
+				require.False(t, ok, "Dequeue after Close should return ok=false")
+
+				err = q.Enqueue(ctx, tenantID, func() {})
+				require.ErrorIs(t, err, ErrQueueClosed, "Enqueue after Close should return ErrQueueClosed")
+
+				// Stop the queue to clean up completely
+				q.StopWait()
+			},
+		},
+		{
+			name: "Enqueue Context Cancellation",
+			opts: QueueOptionsWithDefaults(nil), // Use a higher limit to avoid queue full errors
+			test: func(t *testing.T, q *Queue) {
+				// Create an already canceled context instead of sleeping
+				cancelCtx, cancel := context.WithCancel(context.Background())
+				cancel() // Cancel immediately
+
+				// This should fail with context canceled because the context is already canceled
+				err := q.Enqueue(cancelCtx, "tenant-id", func() {})
+				require.ErrorIs(t, err, context.Canceled, "Expected context canceled error")
+
+				// Now verify the queue is still usable with a valid context
+				err = q.Enqueue(context.Background(), "tenant-id", func() {})
+				require.NoError(t, err, "Should be able to enqueue with valid context")
+
+				// And we can dequeue
+				dequeueCtx, dequeueCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				runnable, ok, err := q.Dequeue(dequeueCtx)
+				dequeueCancel()
+				require.NoError(t, err)
+				require.True(t, ok)
+				require.NotNil(t, runnable)
+			},
+		},
+		{
+			name: "Dequeue Context Cancellation",
+			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
+			test: func(t *testing.T, q *Queue) {
+				// Create an already canceled context instead of using timeout
+				cancelCtx, cancel := context.WithCancel(context.Background())
+				cancel() // Cancel immediately
+
+				// This should return with context.Canceled error immediately
+				runnable, ok, err := q.Dequeue(cancelCtx)
+
+				// Verify the result - should be context.Canceled, not DeadlineExceeded
+				require.Nil(t, runnable, "Runnable should be nil on context cancellation")
+				require.False(t, ok, "ok should be false on context cancellation")
+				require.ErrorIs(t, err, context.Canceled, "Expected context canceled error")
+			},
+		},
+		// Add more test cases here
+	}
+
+	for _, tc := range tests {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run table entries in parallel
+
+			q := NewQueue(tc.opts)
+			// Defer close and stopwait to ensure cleanup even if test fails
+			// Order matters: Close needs to be called before StopWait
+			defer func() {
+				q.Close()
+				q.StopWait()
+			}()
+
+			tc.test(t, q)
+		})
+	}
+}
+
+// TestQueueCleanup tests that the queue can be properly closed and stopped.
+// This is a basic sanity check to ensure our cleanup logic functions correctly.
+func TestQueueCleanup(t *testing.T) {
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+
+	// Explicitly close and wait for dispatcher to stop
+	q.Close()
+	q.StopWait()
+
+	// Queue should now be in a clean, shutdown state
+	_, ok, err := q.Dequeue(context.Background())
+	require.False(t, ok)
+	require.ErrorIs(t, err, ErrQueueClosed)
+}

--- a/pkg/util/scheduler/queue_test.go
+++ b/pkg/util/scheduler/queue_test.go
@@ -33,7 +33,7 @@ func QueueOptionsWithDefaults(opts *QueueOptions) *QueueOptions {
 	return opts
 }
 
-func TestQueue(t *testing.T) {
+func TestQueue(t *testing.T) { //nolint:gocyclo
 	t.Parallel()
 
 	t.Run("SimpleEnqueueAndDequeue", func(t *testing.T) {

--- a/pkg/util/scheduler/queue_test.go
+++ b/pkg/util/scheduler/queue_test.go
@@ -36,691 +36,600 @@ func QueueOptionsWithDefaults(opts *QueueOptions) *QueueOptions {
 func TestQueue(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		opts *QueueOptions
-		test func(t *testing.T, q *Queue)
-	}{
-		{
-			name: "Simple Enqueue and Dequeue",
-			opts: QueueOptionsWithDefaults(nil),
-			test: func(t *testing.T, q *Queue) {
-				ctx := context.Background()
-				var wg sync.WaitGroup
-				const numItems = 5
-				const tenantID = "tenant-a"
-
-				// Enqueue items
-				for i := 0; i < numItems; i++ {
-					val := i // Capture loop variable
-					err := q.Enqueue(ctx, tenantID, func() {
-						// Simple work item
-						_ = val
-					})
-					require.NoError(t, err, "Enqueue should succeed")
-				}
-				require.Equal(t, numItems, q.Len(), "Queue length after enqueue")
-				require.Equal(t, 1, q.ActiveTenantsLen(), "Active tenants after enqueue")
-
-				// Dequeue items
-				for i := 0; i < numItems; i++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-						defer cancel()
-						runnable, ok, err := q.Dequeue(dequeueCtx)
-						require.NoError(t, err, "Dequeue should succeed")
-						require.True(t, ok, "Dequeue should return ok=true")
-						require.NotNil(t, runnable, "Dequeued runnable should not be nil")
-					}()
-				}
-
-				wg.Wait()
-
-				// Let's simplify the dequeue check: Dequeue sequentially after enqueueing.
-				qSimple := NewQueue(QueueOptionsWithDefaults(nil))
-				require.NoError(t, qSimple.StartAsync(context.Background()), "Queue should start")
-				require.NoError(t, qSimple.AwaitRunning(context.Background()), "Queue should be running")
-
-				for i := 0; i < numItems; i++ {
-					err := qSimple.Enqueue(ctx, tenantID, func() {})
-					require.NoError(t, err)
-				}
-				require.Equal(t, numItems, qSimple.Len(), "Queue length after enqueue (simple)")
-				require.Equal(t, 1, qSimple.ActiveTenantsLen(), "Active tenants after enqueue (simple)")
-
-				for i := 0; i < numItems; i++ {
-					dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-					runnable, ok, err := qSimple.Dequeue(dequeueCtx)
-					cancel() // Cancel context after use
-					require.NoError(t, err, "Dequeue %d should succeed (simple)", i)
-					require.True(t, ok, "Dequeue %d should return ok=true (simple)", i)
-					require.NotNil(t, runnable, "Dequeued runnable %d should not be nil (simple)", i)
-				}
-
-				require.Equal(t, 0, qSimple.Len(), "Queue length after dequeue (simple)")
-				require.Equal(t, 0, qSimple.ActiveTenantsLen(), "Active tenants after dequeue (simple)")
-
-				// Check dequeue on empty queue times out
-				dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
-				_, ok, err := qSimple.Dequeue(dequeueCtx)
-				cancel()
-				require.ErrorIs(t, err, context.DeadlineExceeded, "Dequeue on empty queue should time out")
-				require.False(t, ok, "Dequeue on empty queue should return ok=false")
-
-				// Stop the queue
-				qSimple.StopAsync()
-				require.NoError(t, qSimple.AwaitTerminated(context.Background()), "Queue should stop")
-			},
-		},
-		{
-			name: "Round Robin Between Tenants",
-			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
-			test: func(t *testing.T, q *Queue) {
-				ctx := context.Background()
-				tenantA := "tenant-a"
-				tenantB := "tenant-b"
-
-				// We'll use a very small test with just 2 items per tenant
-				// to reduce the chance of timeouts or other issues
-
-				// Enqueue items in tenant order: A, B, A, B
-				// Each item will record its tenant ID when executed
-				var results []string
-				var resultsMu sync.Mutex
-
-				makeRunnable := func(id string) func() {
-					return func() {
-						resultsMu.Lock()
-						results = append(results, id)
-						resultsMu.Unlock()
-					}
-				}
-
-				// First tenant A, then B, then A, then B
-				err := q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
-				require.NoError(t, err)
-				err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
-				require.NoError(t, err)
-				err = q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
-				require.NoError(t, err)
-				err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
-				require.NoError(t, err)
-
-				// Verify queue state
-				require.Equal(t, 4, q.Len(), "Queue should have 4 items")
-				require.Equal(t, 2, q.ActiveTenantsLen(), "Should have 2 active tenants")
-
-				// Use a longer timeout to handle CI environment variability
-				dequeueTimeout := 3 * time.Second
-
-				// Dequeue and execute the four items
-				for i := 0; i < 4; i++ {
-					// Use a more reliable context with longer timeout for CI environments
-					dequeueCtx, cancel := context.WithTimeout(ctx, dequeueTimeout)
-					runnable, ok, err := q.Dequeue(dequeueCtx)
-					if !ok || err != nil {
-						// If there's an error, let's check if queue state is still consistent
-						t.Logf("Dequeue %d failed: ok=%v, err=%v", i, ok, err)
-						t.Logf("Queue state: Len=%d, ActiveTenantsLen=%d", q.Len(), q.ActiveTenantsLen())
-					}
-
-					cancel()
-					require.NoError(t, err, "Dequeue %d should succeed", i)
-					require.True(t, ok, "Dequeue %d should return ok=true", i)
-					require.NotNil(t, runnable, "Dequeued runnable %d should not be nil", i)
-					runnable() // Execute to record the tenant ID
-				}
-
-				// Check execution order - should alternate between tenants
-				resultsMu.Lock()
-				expectedOrder := []string{tenantA, tenantB, tenantA, tenantB}
-				equal := len(results) == len(expectedOrder)
-				if equal {
-					for i, v := range expectedOrder {
-						if i >= len(results) || results[i] != v {
-							equal = false
-							break
-						}
-					}
-				}
-
-				if !equal {
-					t.Errorf("Execution order mismatch: expected %v, got %v", expectedOrder, results)
-				}
-				resultsMu.Unlock()
-
-				// Verify queue is now empty
-				require.Equal(t, 0, q.Len())
-				require.Equal(t, 0, q.ActiveTenantsLen())
-			},
-		},
-		{
-			name: "Tenant Queue Full Error",
-			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 2}),
-			test: func(t *testing.T, q *Queue) {
-				ctx := context.Background()
-				tenantID := "tenant-limited"
-
-				// Enqueue up to the limit
-				err := q.Enqueue(ctx, tenantID, func() {})
-				require.NoError(t, err)
-				err = q.Enqueue(ctx, tenantID, func() {})
-				require.NoError(t, err)
-
-				require.Equal(t, 2, q.Len())
-				require.Equal(t, 1, q.ActiveTenantsLen())
-
-				// Enqueue one more, expect error
-				err = q.Enqueue(ctx, tenantID, func() {})
-				require.ErrorIs(t, err, ErrTenantQueueFull, "Expected ErrTenantQueueFull")
-
-				// Len should still be 2
-				require.Equal(t, 2, q.Len())
-
-				// Dequeue one item
-				dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
-				_, ok, err := q.Dequeue(dequeueCtx)
-				cancel()
-				require.NoError(t, err)
-				require.True(t, ok)
-				require.Equal(t, 1, q.Len())
-
-				// Now enqueue should succeed again
-				err = q.Enqueue(ctx, tenantID, func() {})
-				require.NoError(t, err, "Enqueue should succeed after dequeueing one item")
-				require.Equal(t, 2, q.Len(), "Length should be back to 2")
-			},
-		},
-		{
-			name: "Close Queue",
-			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
-			test: func(t *testing.T, q *Queue) {
-				ctx := context.Background()
-				tenantID := "tenant-a"
-
-				// Create a channel to signal when the dequeue goroutine has started
-				dequeueStarted := make(chan struct{})
-				dequeueErrChan := make(chan error, 1)
-				var wg sync.WaitGroup
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
-					// Signal that we're about to start dequeuing
-					close(dequeueStarted)
-
-					// This will block until queue is closed or something is enqueued
-					_, _, err := q.Dequeue(context.Background())
-					dequeueErrChan <- err // Send the error result
-				}()
-
-				// Wait until the dequeue operation has started
-				<-dequeueStarted
-
-				// Close the queue - this should unblock the dequeue with ErrQueueClosed
-				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-				defer cancel()
-				q.StopAsync()
-
-				// Verify the error is ErrQueueClosed
-				select {
-				case err := <-dequeueErrChan:
-					require.ErrorIs(t, err, ErrQueueClosed, "Dequeue should return ErrQueueClosed when queue is closed")
-				case <-time.After(3 * time.Second): // Longer timeout for CI environments
-					t.Fatal("Timed out waiting for blocked Dequeue to return ErrQueueClosed")
-				}
-
-				// Wait for the dequeue goroutine to finish
-				wg.Wait()
-
-				// Further operations should error appropriately
-				_, ok, err := q.Dequeue(ctx)
-				require.ErrorIs(t, err, ErrQueueClosed, "Dequeue after Close should return ErrQueueClosed")
-				require.False(t, ok, "Dequeue after Close should return ok=false")
-
-				err = q.Enqueue(ctx, tenantID, func() {})
-				require.ErrorIs(t, err, ErrQueueClosed, "Enqueue after Close should return ErrQueueClosed")
-
-				// Stop the queue to clean up completely
-				require.NoError(t, q.AwaitTerminated(ctx), "Queue should stop after close")
-			},
-		},
-		{
-			name: "Enqueue Context Cancellation",
-			opts: QueueOptionsWithDefaults(nil), // Use a higher limit to avoid queue full errors
-			test: func(t *testing.T, q *Queue) {
-				// Create an already canceled context instead of sleeping
-				cancelCtx, cancel := context.WithCancel(context.Background())
-				cancel() // Cancel immediately
-
-				// This should fail with context canceled because the context is already canceled
-				err := q.Enqueue(cancelCtx, "tenant-id", func() {})
-				require.ErrorIs(t, err, context.Canceled, "Expected context canceled error")
-
-				// Now verify the queue is still usable with a valid context
-				err = q.Enqueue(context.Background(), "tenant-id", func() {})
-				require.NoError(t, err, "Should be able to enqueue with valid context")
-
-				// And we can dequeue
-				dequeueCtx, dequeueCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-				runnable, ok, err := q.Dequeue(dequeueCtx)
-				dequeueCancel()
-				require.NoError(t, err)
-				require.True(t, ok)
-				require.NotNil(t, runnable)
-			},
-		},
-		{
-			name: "Dequeue Context Cancellation",
-			opts: QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}),
-			test: func(t *testing.T, q *Queue) {
-				// Create an already canceled context instead of using timeout
-				cancelCtx, cancel := context.WithCancel(context.Background())
-				cancel() // Cancel immediately
-
-				// This should return with context.Canceled error immediately
-				runnable, ok, err := q.Dequeue(cancelCtx)
-
-				// Verify the result - should be context.Canceled, not DeadlineExceeded
-				require.Nil(t, runnable, "Runnable should be nil on context cancellation")
-				require.False(t, ok, "ok should be false on context cancellation")
-				require.ErrorIs(t, err, context.Canceled, "Expected context canceled error")
-			},
-		},
-		{
-			name: "Enqueue after Close",
-			opts: QueueOptionsWithDefaults(nil),
-			test: func(t *testing.T, q *Queue) {
-				// Close the queue first
-				q.StopAsync()
-				require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-
-				// Now try to enqueue - should return ErrQueueClosed
-				err := q.Enqueue(context.Background(), "tenant-id", func() {})
-				require.ErrorIs(t, err, ErrQueueClosed, "Enqueue after Close should return ErrQueueClosed")
-			},
-		},
-		{
-			name: "Dequeue with Timeout",
-			opts: QueueOptionsWithDefaults(nil),
-			test: func(t *testing.T, q *Queue) {
-				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-				defer cancel()
-
-				// This should timeout since nothing is in the queue
-				runnable, ok, err := q.Dequeue(ctx)
-				require.Nil(t, runnable, "Runnable should be nil on timeout")
-				require.False(t, ok, "ok should be false on timeout")
-				require.ErrorIs(t, err, context.DeadlineExceeded, "Expected context deadline exceeded error")
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc // Capture range variable
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel() // Run table entries in parallel
-
-			q := NewQueue(tc.opts)
-			require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-			require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-			// Defer close and stopwait to ensure cleanup even if test fails
-			// Order matters: Close needs to be called before StopWait
-			defer func() {
-				q.StopAsync()
-				require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-			}()
-
-			tc.test(t, q)
-		})
-	}
-}
-
-// TestQueueCleanup tests that the queue can be properly closed and stopped.
-// This is a basic sanity check to ensure our cleanup logic functions correctly.
-func TestQueueCleanup(t *testing.T) {
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	// Explicitly close and wait for dispatcher to stop
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-
-	// Queue should now be in a clean, shutdown state
-	_, ok, err := q.Dequeue(context.Background())
-	require.False(t, ok)
-	require.ErrorIs(t, err, ErrQueueClosed)
-}
-
-// TestConcurrentEnqueuersAndDequeuers tests the queue's ability to handle
-// concurrent enqueuing and dequeuing operations. It ensures that all items
-// are processed correctly and that the queue maintains its integrity under
-// concurrent access.
-func TestConcurrentEnqueuersAndDequeuers(t *testing.T) {
-	t.Parallel()
-
-	q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 100}))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	const numProducers = 5
-	const numConsumers = 3
-	const itemsPerProducer = 20
-	const totalItems = numProducers * itemsPerProducer
-
-	// Track items to verify all are processed
-	processedItems := make(map[string]int)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	// Start consumers first (they'll block until items are available)
-	for i := 0; i < numConsumers; i++ {
-		wg.Add(1)
-		go func(consumerID int) {
-			defer wg.Done()
-			consumerCount := 0
-
-			for {
-				runnable, ok, err := q.Dequeue(ctx)
-				if err != nil {
-					if errors.Is(err, context.DeadlineExceeded) {
-						return
-					}
-					require.NoError(t, err)
-					return
-				}
-
-				if !ok {
-					return
-				}
-
-				// Execute the runnable which will update our tracking
-				runnable()
-				consumerCount++
-
-				// Check if we've processed all expected items
-				mu.Lock()
-				totalProcessed := 0
-				for _, count := range processedItems {
-					totalProcessed += count
-				}
-				done := totalProcessed >= totalItems
-				mu.Unlock()
-
-				if done {
-					return
-				}
-			}
-		}(i)
-	}
-
-	// Start producers
-	for i := 0; i < numProducers; i++ {
-		wg.Add(1)
-		go func(producerID int) {
-			defer wg.Done()
-			tenantID := fmt.Sprintf("tenant-%d", producerID%3) // Use 3 different tenants
-
-			for j := 0; j < itemsPerProducer; j++ {
-				itemID := fmt.Sprintf("p%d-item%d", producerID, j)
-
-				err := q.Enqueue(ctx, tenantID, func() {
-					mu.Lock()
-					processedItems[itemID] = 1
-					mu.Unlock()
-				})
-
-				if err != nil {
-					// Context might have been canceled if test is slow
-					if errors.Is(err, context.DeadlineExceeded) ||
-						errors.Is(err, ErrQueueClosed) {
-						return
-					}
-					require.NoError(t, err)
-				}
-
-				// Small sleep to reduce contention
-				time.Sleep(time.Millisecond)
-			}
-		}(i)
-	}
-
-	// Wait for all goroutines to finish
-	wg.Wait()
-
-	// Check that all items were processed
-	mu.Lock()
-	require.Equal(t, totalItems, len(processedItems),
-		"All enqueued items should have been processed")
-	mu.Unlock()
-
-	// Verify queue is now empty
-	require.Equal(t, 0, q.Len(), "Queue should be empty after processing all items")
-	require.Equal(t, 0, q.ActiveTenantsLen(), "No active tenants should remain after processing")
-	// Stop the queue
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-}
-
-// TestSlowDequeuerHandling tests the queue's behavior when a slow dequeuer
-// is present. It ensures that other tenants' items are still processed
-// in a round-robin fashion, even if one tenant has a slow runnable.
-// This simulates a scenario where one tenant's processing is delayed
-// but the queue should still maintain fairness.
-func TestSlowDequeuerHandling(t *testing.T) {
-	t.Parallel()
-
-	q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	ctx := context.Background()
-	tenantA := "tenant-a"
-	tenantB := "tenant-b"
-	tenantC := "tenant-c"
-
-	// Create channels to track execution order
-	completionOrder := make(chan string, 10)
-	var wg sync.WaitGroup
-
-	// Enqueue a slow item for tenant A
-	wg.Add(1)
-	err := q.Enqueue(ctx, tenantA, func() {
-		defer wg.Done()
-		time.Sleep(300 * time.Millisecond) // Simulate slow processing
-		completionOrder <- "A-slow"
-	})
-	require.NoError(t, err)
-
-	// Enqueue regular items for other tenants
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		err := q.Enqueue(ctx, tenantB, func() {
-			defer wg.Done()
-			completionOrder <- fmt.Sprintf("B-%d", i)
-		})
-		require.NoError(t, err)
-
-		wg.Add(1)
-		err = q.Enqueue(ctx, tenantC, func() {
-			defer wg.Done()
-			completionOrder <- fmt.Sprintf("C-%d", i)
-		})
-		require.NoError(t, err)
-	}
-
-	// Enqueue another item for tenant A
-	wg.Add(1)
-	err = q.Enqueue(ctx, tenantA, func() {
-		defer wg.Done()
-		completionOrder <- "A-fast"
-	})
-	require.NoError(t, err)
-
-	// Start multiple dequeuer goroutines
-	for i := 0; i < 3; i++ {
-		go func() {
-			for j := 0; j < 2; j++ { // Each will dequeue 2 items
-				dequeueCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-				runnable, ok, err := q.Dequeue(dequeueCtx)
-				cancel()
-				if err != nil || !ok {
-					return
-				}
-				runnable()
-			}
+	t.Run("SimpleEnqueueAndDequeue", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		// Defer close and stopwait to ensure cleanup even if test fails
+		// Order matters: Close needs to be called before StopWait
+		defer func() {
+			q.StopAsync()
+			require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
 		}()
-	}
 
-	// Wait for all processing to complete
-	wg.Wait()
-	close(completionOrder)
+		var wg sync.WaitGroup
+		const numItems = 5
+		const tenantID = "tenant-a"
 
-	// Collect completion order
-	execOrder := make([]string, 0, len(completionOrder))
-	for item := range completionOrder {
-		execOrder = append(execOrder, item)
-	}
-
-	// Verify that despite A-slow being dequeued first, other tenants' work completed while it was running
-	slowAPos := -1
-	fastAPos := -1
-	for i, item := range execOrder {
-		if item == "A-slow" {
-			slowAPos = i
+		// Enqueue items
+		for i := 0; i < numItems; i++ {
+			val := i // Capture loop variable
+			err := q.Enqueue(ctx, tenantID, func() {
+				// Simple work item
+				_ = val
+			})
+			require.NoError(t, err, "Enqueue should succeed")
 		}
-		if item == "A-fast" {
-			fastAPos = i
+		require.Equal(t, numItems, q.Len(), "Queue length after enqueue")
+		require.Equal(t, 1, q.ActiveTenantsLen(), "Active tenants after enqueue")
+
+		// Dequeue items
+		for i := 0; i < numItems; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+				runnable, ok, err := q.Dequeue(dequeueCtx)
+				require.NoError(t, err, "Dequeue should succeed")
+				require.True(t, ok, "Dequeue should return ok=true")
+				require.NotNil(t, runnable, "Dequeued runnable should not be nil")
+			}()
 		}
-	}
 
-	// The slow A task was started first but should finish later
-	require.True(t, slowAPos > 0, "A-slow should be in the execution order")
-	require.True(t, fastAPos > 0, "A-fast should be in the execution order")
+		wg.Wait()
 
-	// Verify some items from other tenants completed between the two A items
-	// This confirms round-robin fairness even with slow consumers
-	firstTenantBFoundPos := -1
-	for i, item := range execOrder {
-		if strings.HasPrefix(item, "B-") || strings.HasPrefix(item, "C-") {
-			firstTenantBFoundPos = i
-			break
+		// Let's simplify the dequeue check: Dequeue sequentially after enqueueing.
+		qSimple := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, qSimple.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, qSimple.AwaitRunning(context.Background()), "Queue should be running")
+
+		for i := 0; i < numItems; i++ {
+			err := qSimple.Enqueue(ctx, tenantID, func() {})
+			require.NoError(t, err)
 		}
-	}
+		require.Equal(t, numItems, qSimple.Len(), "Queue length after enqueue (simple)")
+		require.Equal(t, 1, qSimple.ActiveTenantsLen(), "Active tenants after enqueue (simple)")
 
-	// Make sure at least one other tenant item completed
-	require.True(t, firstTenantBFoundPos >= 0,
-		"At least one B or C item should be in execution order")
+		for i := 0; i < numItems; i++ {
+			dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			runnable, ok, err := qSimple.Dequeue(dequeueCtx)
+			cancel() // Cancel context after use
+			require.NoError(t, err, "Dequeue %d should succeed (simple)", i)
+			require.True(t, ok, "Dequeue %d should return ok=true (simple)", i)
+			require.NotNil(t, runnable, "Dequeued runnable %d should not be nil (simple)", i)
+		}
 
-	// Verify length is now 0
-	require.Equal(t, 0, q.Len())
-	require.Equal(t, 0, q.ActiveTenantsLen())
+		require.Equal(t, 0, qSimple.Len(), "Queue length after dequeue (simple)")
+		require.Equal(t, 0, qSimple.ActiveTenantsLen(), "Active tenants after dequeue (simple)")
 
-	// Stop the queue
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-}
+		// Check dequeue on empty queue times out
+		dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		_, ok, err := qSimple.Dequeue(dequeueCtx)
+		cancel()
+		require.ErrorIs(t, err, context.DeadlineExceeded, "Dequeue on empty queue should time out")
+		require.False(t, ok, "Dequeue on empty queue should return ok=false")
 
-// TestQueueActiveTenantsLen tests the ActiveTenantsLen method of the queue.
-// It ensures that the method returns the correct number of active tenants
-// after enqueuing items for different tenants.
-func TestQueueActiveTenantsLen(t *testing.T) {
-	t.Parallel()
-
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	// Enqueue items for different tenants
-	err := q.Enqueue(context.Background(), "tenant1", func() {})
-	require.NoError(t, err)
-	err = q.Enqueue(context.Background(), "tenant2", func() {})
-	require.NoError(t, err)
-
-	// Check active tenants
-	activeTenants := q.ActiveTenantsLen()
-	require.Equal(t, activeTenants, 2)
-
-	// Stop the queue
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-}
-
-// TestQueueLen tests the Len method of the queue. It ensures that the
-// method returns the correct number of items in the queue after enqueuing
-// items for different tenants.
-func TestQueueLen(t *testing.T) {
-	t.Parallel()
-
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	// Enqueue items
-	err := q.Enqueue(context.Background(), "tenant1", func() {})
-	require.NoError(t, err)
-	err = q.Enqueue(context.Background(), "tenant1", func() {})
-	require.NoError(t, err)
-
-	// Check queue length
-	queueLen := q.Len()
-	require.Equal(t, queueLen, 2)
-
-	// Stop the queue
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
-}
-
-func TestQueueGracefulShutdown(t *testing.T) {
-	t.Parallel()
-
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-	require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
-	require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
-
-	processed := make(chan struct{})
-
-	// Enqueue an item that signals when processed
-	err := q.Enqueue(context.Background(), "tenant1", func() {
-		close(processed)
+		// Stop the queue
+		qSimple.StopAsync()
+		require.NoError(t, qSimple.AwaitTerminated(context.Background()), "Queue should stop")
 	})
-	require.NoError(t, err)
 
-	// Start a goroutine to dequeue and run the item
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		runnable, ok, err := q.Dequeue(ctx)
+	t.Run("RoundRobinBetweenTenants", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		tenantA := "tenant-a"
+		tenantB := "tenant-b"
+
+		// We'll use a very small test with just 2 items per tenant
+		// to reduce the chance of timeouts or other issues
+
+		// Enqueue items in tenant order: A, B, A, B
+		// Each item will record its tenant ID when executed
+		var results []string
+		var resultsMu sync.Mutex
+
+		makeRunnable := func(id string) func() {
+			return func() {
+				resultsMu.Lock()
+				results = append(results, id)
+				resultsMu.Unlock()
+			}
+		}
+
+		// First tenant A, then B, then A, then B
+		err := q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
+		require.NoError(t, err)
+		err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
+		require.NoError(t, err)
+		err = q.Enqueue(ctx, tenantA, makeRunnable(tenantA))
+		require.NoError(t, err)
+		err = q.Enqueue(ctx, tenantB, makeRunnable(tenantB))
+		require.NoError(t, err)
+
+		// Verify queue state
+		require.Equal(t, 4, q.Len(), "Queue should have 4 items")
+		require.Equal(t, 2, q.ActiveTenantsLen(), "Should have 2 active tenants")
+
+		// Use a longer timeout to handle CI environment variability
+		dequeueTimeout := 3 * time.Second
+
+		// Dequeue and execute the four items
+		for i := 0; i < 4; i++ {
+			// Use a more reliable context with longer timeout for CI environments
+			dequeueCtx, cancel := context.WithTimeout(ctx, dequeueTimeout)
+			runnable, ok, err := q.Dequeue(dequeueCtx)
+			if !ok || err != nil {
+				// If there's an error, let's check if queue state is still consistent
+				t.Logf("Dequeue %d failed: ok=%v, err=%v", i, ok, err)
+				t.Logf("Queue state: Len=%d, ActiveTenantsLen=%d", q.Len(), q.ActiveTenantsLen())
+			}
+
+			cancel()
+			require.NoError(t, err, "Dequeue %d should succeed", i)
+			require.True(t, ok, "Dequeue %d should return ok=true", i)
+			require.NotNil(t, runnable, "Dequeued runnable %d should not be nil", i)
+			runnable() // Execute to record the tenant ID
+		}
+
+		// Check execution order - should alternate between tenants
+		resultsMu.Lock()
+		expectedOrder := []string{tenantA, tenantB, tenantA, tenantB}
+		equal := len(results) == len(expectedOrder)
+		if equal {
+			for i, v := range expectedOrder {
+				if i >= len(results) || results[i] != v {
+					equal = false
+					break
+				}
+			}
+		}
+
+		if !equal {
+			t.Errorf("Execution order mismatch: expected %v, got %v", expectedOrder, results)
+		}
+		resultsMu.Unlock()
+
+		// Verify queue is now empty
+		require.Equal(t, 0, q.Len())
+		require.Equal(t, 0, q.ActiveTenantsLen())
+	})
+
+	t.Run("TenantQueueFullError", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 2}))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		tenantID := "tenant-limited"
+
+		// Enqueue up to the limit
+		err := q.Enqueue(ctx, tenantID, func() {})
+		require.NoError(t, err)
+		err = q.Enqueue(ctx, tenantID, func() {})
+		require.NoError(t, err)
+
+		require.Equal(t, 2, q.Len())
+		require.Equal(t, 1, q.ActiveTenantsLen())
+
+		// Enqueue one more, expect error
+		err = q.Enqueue(ctx, tenantID, func() {})
+		require.ErrorIs(t, err, ErrTenantQueueFull, "Expected ErrTenantQueueFull")
+
+		// Len should still be 2
+		require.Equal(t, 2, q.Len())
+
+		// Dequeue one item
+		dequeueCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		_, ok, err := q.Dequeue(dequeueCtx)
+		cancel()
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.NotNil(t, runnable)
-		runnable()
-	}()
+		require.Equal(t, 1, q.Len())
 
-	// Wait for the item to be processed
-	select {
-	case <-processed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for item to be processed before shutdown")
-	}
+		// Now enqueue should succeed again
+		err = q.Enqueue(ctx, tenantID, func() {})
+		require.NoError(t, err, "Enqueue should succeed after dequeueing one item")
+		require.Equal(t, 2, q.Len(), "Length should be back to 2")
+	})
 
-	// Now gracefully stop the queue
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(ctx), "Queue should stop")
-	wg.Wait()
+	t.Run("DequeueContextCancellation", func(t *testing.T) {
+		t.Parallel()
 
-	// Check that the queue is closed
-	err = q.Enqueue(context.Background(), "tenant1", func() {})
-	require.ErrorIs(t, err, ErrQueueClosed)
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		// Create an already canceled context instead of using timeout
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		// This should return with context.Canceled error immediately
+		runnable, ok, err := q.Dequeue(cancelCtx)
+
+		// Verify the result - should be context.Canceled, not DeadlineExceeded
+		require.Nil(t, runnable, "Runnable should be nil on context cancellation")
+		require.False(t, ok, "ok should be false on context cancellation")
+		require.ErrorIs(t, err, context.Canceled, "Expected context canceled error")
+	})
+
+	t.Run("DequeueWithTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		// This should timeout since nothing is in the queue
+		runnable, ok, err := q.Dequeue(ctx)
+		require.Nil(t, runnable, "Runnable should be nil on timeout")
+		require.False(t, ok, "ok should be false on timeout")
+		require.ErrorIs(t, err, context.DeadlineExceeded, "Expected context deadline exceeded error")
+	})
+
+	t.Run("EnqueueAfterStopped", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		// Stop the queue first
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+
+		// Now try to enqueue - should return ErrQueueClosed
+		err := q.Enqueue(context.Background(), "tenant-id", func() {})
+		require.ErrorIs(t, err, ErrQueueClosed, "Enqueue after Stop should return ErrQueueClosed")
+	})
+
+	t.Run("DequeueAfterStopped", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(ctx), "Queue should start")
+		require.NoError(t, q.AwaitRunning(ctx), "Queue should be running")
+
+		// Stop the queue first
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+
+		// Now try to dequeue - should return ErrQueueClosed
+		runnable, ok, err := q.Dequeue(context.Background())
+		require.Nil(t, runnable, "Runnable should be nil after Stop")
+		require.False(t, ok, "ok should be false after Stop")
+		require.ErrorIs(t, err, ErrQueueClosed, "Dequeue after Stop should return ErrQueueClosed")
+	})
+
+	t.Run("ConcurrentEnqueuersAndDequeuers", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 100}))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		const numProducers = 5
+		const numConsumers = 3
+		const itemsPerProducer = 20
+		const totalItems = numProducers * itemsPerProducer
+
+		// Track items to verify all are processed
+		processedItems := make(map[string]int)
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		// Start consumers first (they'll block until items are available)
+		for i := 0; i < numConsumers; i++ {
+			wg.Add(1)
+			go func(consumerID int) {
+				defer wg.Done()
+				consumerCount := 0
+
+				for {
+					runnable, ok, err := q.Dequeue(ctx)
+					if err != nil {
+						if errors.Is(err, context.DeadlineExceeded) {
+							return
+						}
+						require.NoError(t, err)
+						return
+					}
+
+					if !ok {
+						return
+					}
+
+					// Execute the runnable which will update our tracking
+					runnable()
+					consumerCount++
+
+					// Check if we've processed all expected items
+					mu.Lock()
+					totalProcessed := 0
+					for _, count := range processedItems {
+						totalProcessed += count
+					}
+					done := totalProcessed >= totalItems
+					mu.Unlock()
+
+					if done {
+						return
+					}
+				}
+			}(i)
+		}
+
+		// Start producers
+		for i := 0; i < numProducers; i++ {
+			wg.Add(1)
+			go func(producerID int) {
+				defer wg.Done()
+				tenantID := fmt.Sprintf("tenant-%d", producerID%3) // Use 3 different tenants
+
+				for j := 0; j < itemsPerProducer; j++ {
+					itemID := fmt.Sprintf("p%d-item%d", producerID, j)
+
+					err := q.Enqueue(ctx, tenantID, func() {
+						mu.Lock()
+						processedItems[itemID] = 1
+						mu.Unlock()
+					})
+
+					if err != nil {
+						// Context might have been canceled if test is slow
+						if errors.Is(err, context.DeadlineExceeded) ||
+							errors.Is(err, ErrQueueClosed) {
+							return
+						}
+						require.NoError(t, err)
+					}
+
+					// Small sleep to reduce contention
+					time.Sleep(time.Millisecond)
+				}
+			}(i)
+		}
+
+		// Wait for all goroutines to finish
+		wg.Wait()
+
+		// Check that all items were processed
+		mu.Lock()
+		require.Equal(t, totalItems, len(processedItems),
+			"All enqueued items should have been processed")
+		mu.Unlock()
+
+		// Verify queue is now empty
+		require.Equal(t, 0, q.Len(), "Queue should be empty after processing all items")
+		require.Equal(t, 0, q.ActiveTenantsLen(), "No active tenants should remain after processing")
+		// Stop the queue
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+	})
+
+	t.Run("SlowDequeuerHandling", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 5}))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		ctx := context.Background()
+		tenantA := "tenant-a"
+		tenantB := "tenant-b"
+		tenantC := "tenant-c"
+
+		// Create channels to track execution order
+		completionOrder := make(chan string, 10)
+		var wg sync.WaitGroup
+
+		// Enqueue a slow item for tenant A
+		wg.Add(1)
+		err := q.Enqueue(ctx, tenantA, func() {
+			defer wg.Done()
+			time.Sleep(300 * time.Millisecond) // Simulate slow processing
+			completionOrder <- "A-slow"
+		})
+		require.NoError(t, err)
+
+		// Enqueue regular items for other tenants
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			err := q.Enqueue(ctx, tenantB, func() {
+				defer wg.Done()
+				completionOrder <- fmt.Sprintf("B-%d", i)
+			})
+			require.NoError(t, err)
+
+			wg.Add(1)
+			err = q.Enqueue(ctx, tenantC, func() {
+				defer wg.Done()
+				completionOrder <- fmt.Sprintf("C-%d", i)
+			})
+			require.NoError(t, err)
+		}
+
+		// Enqueue another item for tenant A
+		wg.Add(1)
+		err = q.Enqueue(ctx, tenantA, func() {
+			defer wg.Done()
+			completionOrder <- "A-fast"
+		})
+		require.NoError(t, err)
+
+		// Start multiple dequeuer goroutines
+		for i := 0; i < 3; i++ {
+			go func() {
+				for j := 0; j < 2; j++ { // Each will dequeue 2 items
+					dequeueCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+					runnable, ok, err := q.Dequeue(dequeueCtx)
+					cancel()
+					if err != nil || !ok {
+						return
+					}
+					runnable()
+				}
+			}()
+		}
+
+		// Wait for all processing to complete
+		wg.Wait()
+		close(completionOrder)
+
+		// Collect completion order
+		execOrder := make([]string, 0, len(completionOrder))
+		for item := range completionOrder {
+			execOrder = append(execOrder, item)
+		}
+
+		// Verify that despite A-slow being dequeued first, other tenants' work completed while it was running
+		slowAPos := -1
+		fastAPos := -1
+		for i, item := range execOrder {
+			if item == "A-slow" {
+				slowAPos = i
+			}
+			if item == "A-fast" {
+				fastAPos = i
+			}
+		}
+
+		// The slow A task was started first but should finish later
+		require.True(t, slowAPos > 0, "A-slow should be in the execution order")
+		require.True(t, fastAPos > 0, "A-fast should be in the execution order")
+
+		// Verify some items from other tenants completed between the two A items
+		// This confirms round-robin fairness even with slow consumers
+		firstTenantBFoundPos := -1
+		for i, item := range execOrder {
+			if strings.HasPrefix(item, "B-") || strings.HasPrefix(item, "C-") {
+				firstTenantBFoundPos = i
+				break
+			}
+		}
+
+		// Make sure at least one other tenant item completed
+		require.True(t, firstTenantBFoundPos >= 0,
+			"At least one B or C item should be in execution order")
+
+		// Verify length is now 0
+		require.Equal(t, 0, q.Len())
+		require.Equal(t, 0, q.ActiveTenantsLen())
+
+		// Stop the queue
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+	})
+
+	t.Run("ActiveTenantsLength", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		// Enqueue items for different tenants
+		err := q.Enqueue(context.Background(), "tenant1", func() {})
+		require.NoError(t, err)
+		err = q.Enqueue(context.Background(), "tenant2", func() {})
+		require.NoError(t, err)
+
+		// Check active tenants
+		activeTenants := q.ActiveTenantsLen()
+		require.Equal(t, activeTenants, 2)
+
+		// Stop the queue
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+	})
+
+	t.Run("QueueLength", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		// Enqueue items
+		err := q.Enqueue(context.Background(), "tenant1", func() {})
+		require.NoError(t, err)
+		err = q.Enqueue(context.Background(), "tenant1", func() {})
+		require.NoError(t, err)
+
+		// Check queue length
+		queueLen := q.Len()
+		require.Equal(t, queueLen, 2)
+
+		// Stop the queue
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(context.Background()), "Queue should stop")
+	})
+
+	t.Run("GracefulShutdown", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		require.NoError(t, q.StartAsync(context.Background()), "Queue should start")
+		require.NoError(t, q.AwaitRunning(context.Background()), "Queue should be running")
+
+		processed := make(chan struct{})
+
+		// Enqueue an item that signals when processed
+		err := q.Enqueue(context.Background(), "tenant1", func() {
+			close(processed)
+		})
+		require.NoError(t, err)
+
+		// Start a goroutine to dequeue and run the item
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			runnable, ok, err := q.Dequeue(ctx)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.NotNil(t, runnable)
+			runnable()
+		}()
+
+		// Wait for the item to be processed
+		select {
+		case <-processed:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for item to be processed before shutdown")
+		}
+
+		// Now gracefully stop the queue
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(ctx), "Queue should stop")
+		wg.Wait()
+
+		// Check that the queue is closed
+		err = q.Enqueue(context.Background(), "tenant1", func() {})
+		require.ErrorIs(t, err, ErrQueueClosed)
+	})
 }

--- a/pkg/util/scheduler/scheduler.go
+++ b/pkg/util/scheduler/scheduler.go
@@ -1,0 +1,193 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// Worker processes items from the qos.
+type Worker struct {
+	id             int
+	queue          *Queue
+	wg             *sync.WaitGroup
+	stopCh         <-chan struct{}
+	dequeueTimeout time.Duration
+	logger         log.Logger
+}
+
+func (w *Worker) run() {
+	defer w.wg.Done()
+	w.logger.Debug("Worker started", "id", w.id)
+
+	for {
+		select {
+		case <-w.stopCh:
+			w.logger.Debug("Worker received stop signal", "id", w.id)
+			return
+		default:
+		}
+
+		dequeueCtx, cancelDequeue := context.WithTimeout(context.Background(), w.dequeueTimeout)
+
+		runnable, ok, err := w.queue.Dequeue(dequeueCtx)
+		cancelDequeue()
+
+		if err != nil {
+			if errors.Is(err, ErrQueueClosed) {
+				w.logger.Debug("Worker exiting due to queue closed", "id", w.id)
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			if errors.Is(err, context.Canceled) {
+				w.logger.Debug("Worker exiting due to context canceled", "id", w.id)
+				return
+			}
+			w.logger.Error("Error dequeuing item", "id", w.id, "error", err)
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-w.stopCh:
+				w.logger.Debug("Worker received stop signal while in backoff", "id", w.id)
+				return
+			}
+			continue
+		}
+
+		if !ok {
+			continue
+		}
+
+		runnable()
+	}
+}
+
+// Scheduler manages a pool of Workers consuming from a FairQueue.
+type Scheduler struct {
+	queue *Queue
+
+	numWorkers int
+	workers    []*Worker
+
+	wg          sync.WaitGroup
+	stopCh      chan struct{}
+	startStopMu sync.Mutex
+
+	dequeueTimeout time.Duration
+
+	running bool
+	logger  log.Logger
+}
+
+// Config holds configuration for the Scheduler.
+type Config struct {
+	NumWorkers     int
+	DequeueTimeout time.Duration
+	Logger         log.Logger
+}
+
+func (c *Config) validate() error {
+	if c.NumWorkers <= 0 {
+		return fmt.Errorf("NumWorkers must be positive, got %d", c.NumWorkers)
+	}
+	if c.DequeueTimeout <= 0 {
+		c.DequeueTimeout = 5 * time.Second
+	}
+	if c.Logger == nil {
+		c.Logger = log.New("qos.scheduler")
+	}
+	return nil
+}
+
+// NewScheduler creates a new scheduler instance.
+func NewScheduler(queue *Queue, config *Config) (*Scheduler, error) {
+	if queue == nil {
+		return nil, errors.New("scheduler: queue cannot be nil")
+	}
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("scheduler: invalid config: %w", err)
+	}
+
+	s := &Scheduler{
+		queue:          queue,
+		numWorkers:     config.NumWorkers,
+		dequeueTimeout: config.DequeueTimeout,
+		workers:        make([]*Worker, 0, config.NumWorkers),
+		logger:         config.Logger,
+	}
+	return s, nil
+}
+
+// Start initializes and starts the worker goroutines.
+func (s *Scheduler) Start() error {
+	s.startStopMu.Lock()
+	defer s.startStopMu.Unlock()
+
+	if s.running {
+		return errors.New("scheduler: already started")
+	}
+
+	s.stopCh = make(chan struct{})
+	s.running = true
+	s.workers = make([]*Worker, 0, s.numWorkers)
+
+	s.logger.Info("Scheduler starting", "numWorkers", s.numWorkers)
+	s.wg.Add(s.numWorkers)
+
+	for i := 0; i < s.numWorkers; i++ {
+		worker := &Worker{
+			id:             i,
+			queue:          s.queue,
+			wg:             &s.wg,
+			stopCh:         s.stopCh,
+			dequeueTimeout: s.dequeueTimeout,
+			logger:         s.logger,
+		}
+		s.workers = append(s.workers, worker)
+		go worker.run()
+	}
+
+	s.logger.Info("Scheduler started")
+	return nil
+}
+
+// Stop signals all workers to stop, closes the qos, and waits for them to finish.
+func (s *Scheduler) Stop() {
+	s.startStopMu.Lock()
+	if !s.running {
+		s.startStopMu.Unlock()
+		s.logger.Info("Scheduler not running, nothing to stop")
+		return
+	}
+
+	s.logger.Info("Scheduler stopping")
+
+	close(s.stopCh)
+	s.running = false
+
+	s.startStopMu.Unlock()
+
+	// Close the queue after signaling workers to allow them to finish current work
+	// while unblocking those waiting in Dequeue.
+	s.queue.Close()
+
+	s.wg.Wait()
+
+	s.startStopMu.Lock()
+	s.workers = nil
+	s.startStopMu.Unlock()
+
+	s.logger.Info("Scheduler stopped")
+}
+
+// IsRunning returns true if the scheduler is currently running.
+func (s *Scheduler) IsRunning() bool {
+	s.startStopMu.Lock()
+	defer s.startStopMu.Unlock()
+	return s.running
+}

--- a/pkg/util/scheduler/scheduler_bench_test.go
+++ b/pkg/util/scheduler/scheduler_bench_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const defaultMaxSizePerTenant = 10000
+const defaultMaxBackoff = 1 * time.Second
+
 func benchScheduler(b *testing.B, numWorkers, numTenants, itemsPerTenant int) {
 	tenantIDs := make([]string, numTenants)
 	for i := range tenantIDs {
@@ -24,11 +27,11 @@ func benchScheduler(b *testing.B, numWorkers, numTenants, itemsPerTenant int) {
 
 	for n := 0; n < b.N; n++ {
 		q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{
-			MaxSizePerTenant: 10000,
+			MaxSizePerTenant: defaultMaxSizePerTenant,
 		}))
 		scheduler, err := NewScheduler(q, &Config{
 			NumWorkers: numWorkers,
-			MaxBackoff: 100 * time.Millisecond,
+			MaxBackoff: defaultMaxBackoff,
 		})
 		require.NoError(b, err)
 

--- a/pkg/util/scheduler/scheduler_bench_test.go
+++ b/pkg/util/scheduler/scheduler_bench_test.go
@@ -1,0 +1,400 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// benchScheduler runs a benchmark with the specified number of workers and tenants
+func benchScheduler(b *testing.B, numWorkers, numTenants, itemsPerTenant int) {
+	// Create a queue with reasonable settings for benchmark
+	q := NewQueue(&QueueOptions{
+		MaxSizePerTenant: 10000, // Increased from 100 to avoid bottlenecks
+	})
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	// Create a scheduler with the requested number of workers
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     numWorkers,
+		DequeueTimeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		b.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	// Start the scheduler
+	if err := scheduler.Start(); err != nil {
+		b.Fatalf("Failed to start scheduler: %v", err)
+	}
+	defer scheduler.Stop()
+
+	// Generate tenant IDs
+	tenantIDs := make([]string, numTenants)
+	for i := 0; i < numTenants; i++ {
+		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
+	}
+
+	// Reset the timer to exclude setup time
+	b.ResetTimer()
+
+	// Track the total number of items processed
+	var processed atomic.Int64
+
+	// Run the benchmark b.N times
+	for n := 0; n < b.N; n++ {
+		// Create a WaitGroup to wait for all items to be processed
+		var wg sync.WaitGroup
+		totalItems := numTenants * itemsPerTenant
+		wg.Add(totalItems)
+
+		// Channel to track when all items have been processed
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		// Track how many items were enqueued
+		var enqueued atomic.Int64
+
+		// Enqueue items for all tenants
+		for i := 0; i < numTenants; i++ {
+			tenantID := tenantIDs[i]
+
+			// Each tenant gets itemsPerTenant items
+			for j := 0; j < itemsPerTenant; j++ {
+				err := q.Enqueue(context.Background(), tenantID, func() {
+					processed.Add(1)
+					wg.Done()
+				})
+				if err != nil {
+					b.Fatalf("Failed to enqueue item: %v", err)
+				}
+				enqueued.Add(1)
+			}
+		}
+
+		// Wait for all items to be processed or timeout
+		select {
+		case <-done:
+			// All items processed
+		case <-time.After(30 * time.Second):
+			b.Fatalf("Timed out waiting for items to be processed. Enqueued: %d, Processed: %d",
+				enqueued.Load(), processed.Load())
+		}
+	}
+
+	// Report custom metrics
+	b.ReportMetric(float64(processed.Load())/b.Elapsed().Seconds(), "items/sec")
+}
+
+// Benchmark with varying numbers of workers (1, 2, 4, 8, 16)
+// Each benchmark uses 10 tenants with 1000 items per tenant
+
+func BenchmarkScheduler_1Worker_10Tenants(b *testing.B) {
+	benchScheduler(b, 1, 10, 1000)
+}
+
+func BenchmarkScheduler_2Workers_10Tenants(b *testing.B) {
+	benchScheduler(b, 2, 10, 1000)
+}
+
+func BenchmarkScheduler_4Workers_10Tenants(b *testing.B) {
+	benchScheduler(b, 4, 10, 1000)
+}
+
+func BenchmarkScheduler_8Workers_10Tenants(b *testing.B) {
+	benchScheduler(b, 8, 10, 1000)
+}
+
+func BenchmarkScheduler_16Workers_10Tenants(b *testing.B) {
+	benchScheduler(b, 16, 10, 1000)
+}
+
+// Benchmark with varying numbers of tenants (1, 10, 100)
+// Each benchmark uses 4 workers with 1000 items per tenant
+
+func BenchmarkScheduler_4Workers_1Tenant(b *testing.B) {
+	benchScheduler(b, 4, 1, 1000)
+}
+
+func BenchmarkScheduler_4Workers_10Tenants_1000Items(b *testing.B) {
+	benchScheduler(b, 4, 10, 1000)
+}
+
+func BenchmarkScheduler_4Workers_100Tenants(b *testing.B) {
+	benchScheduler(b, 4, 100, 1000)
+}
+
+// Benchmark with different ratios of items to workers
+// Each benchmark uses 4 workers with 10 tenants but varies items per tenant
+
+func BenchmarkScheduler_4Workers_10Tenants_100ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 10, 100)
+}
+
+// This is a duplicate of BenchmarkScheduler_4Workers_10Tenants_1000Items
+// Replaced with a more descriptive name
+func BenchmarkScheduler_4Workers_10Tenants_ManyItems(b *testing.B) {
+	benchScheduler(b, 4, 10, 1000)
+}
+
+func BenchmarkScheduler_4Workers_10Tenants_10000ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 10, 10000)
+}
+
+// Benchmark comparing round-robin fairness among tenants
+func BenchmarkSchedulerFairness(b *testing.B) {
+	// Create a queue with much larger capacity to avoid queue full issues
+	q := NewQueue(&QueueOptions{
+		MaxSizePerTenant: 10000, // Increased from 100 to avoid queue full errors
+	})
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	// Create a scheduler with 4 workers
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     4,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.NewNopLogger(),
+	})
+	if err != nil {
+		b.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	// Start the scheduler
+	if err := scheduler.Start(); err != nil {
+		b.Fatalf("Failed to start scheduler: %v", err)
+	}
+	defer scheduler.Stop()
+
+	// Number of tenants and items
+	const numTenants = 10
+	const itemsPerTenant = 1000
+
+	// Generate tenant IDs
+	tenantIDs := make([]string, numTenants)
+	for i := 0; i < numTenants; i++ {
+		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
+	}
+
+	// Track items processed per tenant - make available for detailed debugging
+	processedPerTenant := make([]atomic.Int64, numTenants)
+
+	// Reset the timer to exclude setup time
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		// Reset tenant counters for each benchmark iteration
+		for i := 0; i < numTenants; i++ {
+			processedPerTenant[i].Store(0)
+		}
+
+		// Create a WaitGroup to wait for all items to be processed
+		var wg sync.WaitGroup
+		totalItems := numTenants * itemsPerTenant
+		wg.Add(totalItems)
+
+		// Channel to track when all items have been processed
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		// Enqueue all items for one tenant before moving to the next tenant
+		// This tests that the scheduler maintains fairness even with uneven enqueue patterns
+		for i := 0; i < numTenants; i++ {
+			tenantID := tenantIDs[i]
+			tenantIdx := i // Capture for closure
+
+			// Debug progress of enqueuing
+			b.Logf("Starting to enqueue %d items for tenant %s", itemsPerTenant, tenantID)
+
+			// Count of enqueues per tenant for debugging
+			enqueued := 0
+
+			for j := 0; j < itemsPerTenant; j++ {
+				ctx := context.Background() // Use a background context that won't time out
+
+				err := q.Enqueue(ctx, tenantID, func() {
+					processedPerTenant[tenantIdx].Add(1)
+					wg.Done()
+				})
+
+				if err != nil {
+					b.Fatalf("Failed to enqueue item for tenant %s: %v (enqueued %d items)",
+						tenantID, err, enqueued)
+				}
+				enqueued++
+			}
+
+			b.Logf("Successfully enqueued %d items for tenant %s", enqueued, tenantID)
+		}
+
+		// Wait for all items to be processed or timeout
+		select {
+		case <-done:
+			// All items processed
+			b.Log("All items processed successfully")
+		case <-time.After(30 * time.Second):
+			// Debug unprocessed items per tenant
+			for i := 0; i < numTenants; i++ {
+				b.Logf("Tenant %s: processed %d/%d items",
+					tenantIDs[i], processedPerTenant[i].Load(), itemsPerTenant)
+			}
+			b.Fatalf("Timed out waiting for items to be processed")
+		}
+
+		// Calculate fairness metrics and print detailed results
+		min := int64(itemsPerTenant + 1) // Initialize higher than possible value
+		max := int64(0)
+		var total int64
+
+		for i := 0; i < numTenants; i++ {
+			count := processedPerTenant[i].Load()
+			total += count
+			if count < min {
+				min = count
+			}
+			if count > max {
+				max = count
+			}
+			b.Logf("Tenant %s: processed %d items", tenantIDs[i], count)
+		}
+
+		// Calculate fairness ratio (closer to 1.0 is more fair)
+		fairnessRatio := float64(min) / float64(max)
+		b.Logf("Fairness metrics - Min: %d, Max: %d, Ratio: %.4f", min, max, fairnessRatio)
+		b.ReportMetric(fairnessRatio, "fairness")
+		b.ReportMetric(float64(total)/b.Elapsed().Seconds(), "items/sec")
+	}
+}
+
+// Add a new benchmark with alternating tenant enqueuing pattern
+func BenchmarkSchedulerFairnessAlternating(b *testing.B) {
+	// Create a queue with much larger capacity
+	q := NewQueue(&QueueOptions{
+		MaxSizePerTenant: 10,
+	})
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	// Create a scheduler with 4 workers
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     4,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.NewNopLogger(),
+	})
+	if err != nil {
+		b.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	// Start the scheduler
+	if err := scheduler.Start(); err != nil {
+		b.Fatalf("Failed to start scheduler: %v", err)
+	}
+	defer scheduler.Stop()
+
+	// Number of tenants and items
+	const numTenants = 1000
+	const itemsPerTenant = 1000
+
+	// Generate tenant IDs
+	tenantIDs := make([]string, numTenants)
+	for i := 0; i < numTenants; i++ {
+		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
+	}
+
+	// Track items processed per tenant
+	processedPerTenant := make([]atomic.Int64, numTenants)
+
+	// Reset the timer to exclude setup time
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		// Reset tenant counters for each benchmark iteration
+		for i := 0; i < numTenants; i++ {
+			processedPerTenant[i].Store(0)
+		}
+
+		// Create a WaitGroup to wait for all items to be processed
+		var wg sync.WaitGroup
+		totalItems := numTenants * itemsPerTenant
+		wg.Add(totalItems)
+
+		// Channel to track when all items have been processed
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		// Enqueue in a round-robin pattern (1 item for each tenant, then repeat)
+		// This should provide a more balanced starting state
+		for j := 0; j < itemsPerTenant; j++ {
+			for i := 0; i < numTenants; i++ {
+				tenantID := tenantIDs[i]
+				tenantIdx := i // Capture for closure
+
+				err := q.Enqueue(context.Background(), tenantID, func() {
+					processedPerTenant[tenantIdx].Add(1)
+					wg.Done()
+				})
+
+				if err != nil {
+					b.Fatalf("Failed to enqueue item for tenant %s: %v", tenantID, err)
+				}
+			}
+		}
+
+		// Wait for all items to be processed or timeout
+		select {
+		case <-done:
+			// All items processed
+		case <-time.After(30 * time.Second):
+			// Debug unprocessed items per tenant
+			for i := 0; i < numTenants; i++ {
+				b.Logf("Tenant %s: processed %d/%d items",
+					tenantIDs[i], processedPerTenant[i].Load(), itemsPerTenant)
+			}
+			b.Fatalf("Timed out waiting for items to be processed")
+		}
+
+		// Calculate fairness metrics
+		min := int64(itemsPerTenant + 1)
+		max := int64(0)
+		var total int64
+
+		for i := 0; i < numTenants; i++ {
+			count := processedPerTenant[i].Load()
+			total += count
+			if count < min {
+				min = count
+			}
+			if count > max {
+				max = count
+			}
+			b.Logf("Tenant %s: processed %d items", tenantIDs[i], count)
+		}
+
+		// Calculate fairness ratio (closer to 1.0 is more fair)
+		fairnessRatio := float64(min) / float64(max)
+		b.Logf("Fairness metrics - Min: %d, Max: %d, Ratio: %.4f", min, max, fairnessRatio)
+		b.ReportMetric(fairnessRatio, "fairness")
+		b.ReportMetric(float64(total)/b.Elapsed().Seconds(), "items/sec")
+	}
+}

--- a/pkg/util/scheduler/scheduler_bench_test.go
+++ b/pkg/util/scheduler/scheduler_bench_test.go
@@ -8,97 +8,66 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/require"
 )
 
-// benchScheduler runs a benchmark with the specified number of workers and tenants
 func benchScheduler(b *testing.B, numWorkers, numTenants, itemsPerTenant int) {
-	// Create a queue with reasonable settings for benchmark
-	q := NewQueue(&QueueOptions{
-		MaxSizePerTenant: 10000, // Increased from 100 to avoid bottlenecks
-	})
-	defer func() {
-		q.Close()
-		q.StopWait()
-	}()
-
-	// Create a scheduler with the requested number of workers
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     numWorkers,
-		DequeueTimeout: 100 * time.Millisecond,
-	})
-	if err != nil {
-		b.Fatalf("Failed to create scheduler: %v", err)
-	}
-
-	// Start the scheduler
-	if err := scheduler.Start(); err != nil {
-		b.Fatalf("Failed to start scheduler: %v", err)
-	}
-	defer scheduler.Stop()
-
-	// Generate tenant IDs
 	tenantIDs := make([]string, numTenants)
-	for i := 0; i < numTenants; i++ {
+	for i := range tenantIDs {
 		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
 	}
 
-	// Reset the timer to exclude setup time
 	b.ResetTimer()
-
-	// Track the total number of items processed
 	var processed atomic.Int64
 
-	// Run the benchmark b.N times
 	for n := 0; n < b.N; n++ {
-		// Create a WaitGroup to wait for all items to be processed
+		q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{
+			MaxSizePerTenant: 10000,
+		}))
+		scheduler, err := NewScheduler(q, &Config{
+			NumWorkers: numWorkers,
+			MaxBackoff: 100 * time.Millisecond,
+		})
+		require.NoError(b, err)
+
+		require.NoError(b, scheduler.StartAsync(context.Background()))
+		require.NoError(b, scheduler.AwaitRunning(context.Background()))
+
 		var wg sync.WaitGroup
 		totalItems := numTenants * itemsPerTenant
 		wg.Add(totalItems)
 
-		// Channel to track when all items have been processed
+		for i := 0; i < numTenants; i++ {
+			tenantID := tenantIDs[i]
+			for j := 0; j < itemsPerTenant; j++ {
+				require.NoError(b, q.Enqueue(context.Background(), tenantID, func() {
+					processed.Add(1)
+					wg.Done()
+				}))
+			}
+		}
+
 		done := make(chan struct{})
 		go func() {
 			wg.Wait()
 			close(done)
 		}()
 
-		// Track how many items were enqueued
-		var enqueued atomic.Int64
-
-		// Enqueue items for all tenants
-		for i := 0; i < numTenants; i++ {
-			tenantID := tenantIDs[i]
-
-			// Each tenant gets itemsPerTenant items
-			for j := 0; j < itemsPerTenant; j++ {
-				err := q.Enqueue(context.Background(), tenantID, func() {
-					processed.Add(1)
-					wg.Done()
-				})
-				if err != nil {
-					b.Fatalf("Failed to enqueue item: %v", err)
-				}
-				enqueued.Add(1)
-			}
-		}
-
-		// Wait for all items to be processed or timeout
 		select {
 		case <-done:
-			// All items processed
 		case <-time.After(30 * time.Second):
-			b.Fatalf("Timed out waiting for items to be processed. Enqueued: %d, Processed: %d",
-				enqueued.Load(), processed.Load())
+			b.Fatalf("Timed out: Enqueued=%d, Processed=%d", totalItems, processed.Load())
 		}
+
+		scheduler.StopAsync()
+		require.NoError(b, scheduler.AwaitTerminated(context.Background()))
+		require.Equal(b, services.Terminated, scheduler.State())
 	}
 
-	// Report custom metrics
 	b.ReportMetric(float64(processed.Load())/b.Elapsed().Seconds(), "items/sec")
 }
-
-// Benchmark with varying numbers of workers (1, 2, 4, 8, 16)
-// Each benchmark uses 10 tenants with 1000 items per tenant
 
 func BenchmarkScheduler_1Worker_10Tenants(b *testing.B) {
 	benchScheduler(b, 1, 10, 1000)
@@ -120,148 +89,99 @@ func BenchmarkScheduler_16Workers_10Tenants(b *testing.B) {
 	benchScheduler(b, 16, 10, 1000)
 }
 
-// Benchmark with varying numbers of tenants (1, 10, 100)
-// Each benchmark uses 4 workers with 1000 items per tenant
-
-func BenchmarkScheduler_4Workers_1Tenant(b *testing.B) {
-	benchScheduler(b, 4, 1, 1000)
-}
-
-func BenchmarkScheduler_4Workers_10Tenants_1000Items(b *testing.B) {
-	benchScheduler(b, 4, 10, 1000)
-}
-
-func BenchmarkScheduler_4Workers_100Tenants(b *testing.B) {
-	benchScheduler(b, 4, 100, 1000)
-}
-
-// Benchmark with different ratios of items to workers
-// Each benchmark uses 4 workers with 10 tenants but varies items per tenant
-
 func BenchmarkScheduler_4Workers_10Tenants_100ItemsPerTenant(b *testing.B) {
 	benchScheduler(b, 4, 10, 100)
 }
 
-// This is a duplicate of BenchmarkScheduler_4Workers_10Tenants_1000Items
-// Replaced with a more descriptive name
-func BenchmarkScheduler_4Workers_10Tenants_ManyItems(b *testing.B) {
+func BenchmarkScheduler_4Workers_10Tenants_1000ItemsPerTenant(b *testing.B) {
 	benchScheduler(b, 4, 10, 1000)
 }
 
-func BenchmarkScheduler_4Workers_10Tenants_10000ItemsPerTenant(b *testing.B) {
-	benchScheduler(b, 4, 10, 10000)
+func BenchmarkScheduler_4Workers_100Tenant_100ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 100, 100)
+}
+
+func BenchmarkScheduler_4Workers_100Tenant_1000ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 100, 1000)
+}
+
+func BenchmarkScheduler_4Workers_1000Tenant_100ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 1000, 100)
+}
+
+func BenchmarkScheduler_4Workers_1000Tenant_1000ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 1000, 1000)
+}
+
+func BenchmarkScheduler_4Workers_10000Tenant_10ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 10000, 10)
+}
+
+func BenchmarkScheduler_4Workers_10000Tenant_100ItemsPerTenant(b *testing.B) {
+	benchScheduler(b, 4, 10000, 100)
 }
 
 // Benchmark comparing round-robin fairness among tenants
 func BenchmarkSchedulerFairness(b *testing.B) {
-	// Create a queue with much larger capacity to avoid queue full issues
-	q := NewQueue(&QueueOptions{
-		MaxSizePerTenant: 10000, // Increased from 100 to avoid queue full errors
+	q := NewQueue(QueueOptionsWithDefaults(&QueueOptions{MaxSizePerTenant: 10000}))
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers: 4,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.NewNopLogger(),
 	})
+	require.NoError(b, err)
+
+	require.NoError(b, scheduler.StartAsync(context.Background()))
+	require.NoError(b, scheduler.AwaitRunning(context.Background()))
 	defer func() {
-		q.Close()
-		q.StopWait()
+		scheduler.StopAsync()
+		require.NoError(b, scheduler.AwaitTerminated(context.Background()))
 	}()
 
-	// Create a scheduler with 4 workers
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     4,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.NewNopLogger(),
-	})
-	if err != nil {
-		b.Fatalf("Failed to create scheduler: %v", err)
-	}
-
-	// Start the scheduler
-	if err := scheduler.Start(); err != nil {
-		b.Fatalf("Failed to start scheduler: %v", err)
-	}
-	defer scheduler.Stop()
-
-	// Number of tenants and items
 	const numTenants = 10
 	const itemsPerTenant = 1000
 
-	// Generate tenant IDs
 	tenantIDs := make([]string, numTenants)
-	for i := 0; i < numTenants; i++ {
+	for i := range tenantIDs {
 		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
 	}
-
-	// Track items processed per tenant - make available for detailed debugging
 	processedPerTenant := make([]atomic.Int64, numTenants)
 
-	// Reset the timer to exclude setup time
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		// Reset tenant counters for each benchmark iteration
-		for i := 0; i < numTenants; i++ {
+		for i := range processedPerTenant {
 			processedPerTenant[i].Store(0)
 		}
-
-		// Create a WaitGroup to wait for all items to be processed
 		var wg sync.WaitGroup
 		totalItems := numTenants * itemsPerTenant
 		wg.Add(totalItems)
 
-		// Channel to track when all items have been processed
+		for i := 0; i < numTenants; i++ {
+			tenantID := tenantIDs[i]
+			tenantIdx := i
+			for j := 0; j < itemsPerTenant; j++ {
+				require.NoError(b, q.Enqueue(context.Background(), tenantID, func() {
+					processedPerTenant[tenantIdx].Add(1)
+					wg.Done()
+				}))
+			}
+		}
+
 		done := make(chan struct{})
 		go func() {
 			wg.Wait()
 			close(done)
 		}()
 
-		// Enqueue all items for one tenant before moving to the next tenant
-		// This tests that the scheduler maintains fairness even with uneven enqueue patterns
-		for i := 0; i < numTenants; i++ {
-			tenantID := tenantIDs[i]
-			tenantIdx := i // Capture for closure
-
-			// Debug progress of enqueuing
-			b.Logf("Starting to enqueue %d items for tenant %s", itemsPerTenant, tenantID)
-
-			// Count of enqueues per tenant for debugging
-			enqueued := 0
-
-			for j := 0; j < itemsPerTenant; j++ {
-				ctx := context.Background() // Use a background context that won't time out
-
-				err := q.Enqueue(ctx, tenantID, func() {
-					processedPerTenant[tenantIdx].Add(1)
-					wg.Done()
-				})
-
-				if err != nil {
-					b.Fatalf("Failed to enqueue item for tenant %s: %v (enqueued %d items)",
-						tenantID, err, enqueued)
-				}
-				enqueued++
-			}
-
-			b.Logf("Successfully enqueued %d items for tenant %s", enqueued, tenantID)
-		}
-
-		// Wait for all items to be processed or timeout
 		select {
 		case <-done:
-			// All items processed
-			b.Log("All items processed successfully")
 		case <-time.After(30 * time.Second):
-			// Debug unprocessed items per tenant
-			for i := 0; i < numTenants; i++ {
-				b.Logf("Tenant %s: processed %d/%d items",
-					tenantIDs[i], processedPerTenant[i].Load(), itemsPerTenant)
-			}
 			b.Fatalf("Timed out waiting for items to be processed")
 		}
 
-		// Calculate fairness metrics and print detailed results
-		min := int64(itemsPerTenant + 1) // Initialize higher than possible value
-		max := int64(0)
-		var total int64
-
+		min, max, total := int64(itemsPerTenant+1), int64(0), int64(0)
 		for i := 0; i < numTenants; i++ {
 			count := processedPerTenant[i].Load()
 			total += count
@@ -271,114 +191,79 @@ func BenchmarkSchedulerFairness(b *testing.B) {
 			if count > max {
 				max = count
 			}
-			b.Logf("Tenant %s: processed %d items", tenantIDs[i], count)
 		}
-
-		// Calculate fairness ratio (closer to 1.0 is more fair)
 		fairnessRatio := float64(min) / float64(max)
-		b.Logf("Fairness metrics - Min: %d, Max: %d, Ratio: %.4f", min, max, fairnessRatio)
 		b.ReportMetric(fairnessRatio, "fairness")
 		b.ReportMetric(float64(total)/b.Elapsed().Seconds(), "items/sec")
 	}
+
+	// Stop the scheduler and verify it's terminated
+	scheduler.StopAsync()
+	require.NoError(b, scheduler.AwaitTerminated(context.Background()))
 }
 
 // Add a new benchmark with alternating tenant enqueuing pattern
 func BenchmarkSchedulerFairnessAlternating(b *testing.B) {
-	// Create a queue with much larger capacity
-	q := NewQueue(&QueueOptions{
-		MaxSizePerTenant: 10,
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers: 4,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.NewNopLogger(),
 	})
+	require.NoError(b, err)
+
+	require.NoError(b, scheduler.StartAsync(context.Background()))
+	require.NoError(b, scheduler.AwaitRunning(context.Background()))
 	defer func() {
-		q.Close()
-		q.StopWait()
+		scheduler.StopAsync()
+		require.NoError(b, scheduler.AwaitTerminated(context.Background()))
 	}()
 
-	// Create a scheduler with 4 workers
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     4,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.NewNopLogger(),
-	})
-	if err != nil {
-		b.Fatalf("Failed to create scheduler: %v", err)
-	}
-
-	// Start the scheduler
-	if err := scheduler.Start(); err != nil {
-		b.Fatalf("Failed to start scheduler: %v", err)
-	}
-	defer scheduler.Stop()
-
-	// Number of tenants and items
 	const numTenants = 1000
 	const itemsPerTenant = 1000
 
-	// Generate tenant IDs
 	tenantIDs := make([]string, numTenants)
 	for i := 0; i < numTenants; i++ {
 		tenantIDs[i] = fmt.Sprintf("tenant-%d", i)
 	}
-
-	// Track items processed per tenant
 	processedPerTenant := make([]atomic.Int64, numTenants)
 
-	// Reset the timer to exclude setup time
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		// Reset tenant counters for each benchmark iteration
 		for i := 0; i < numTenants; i++ {
 			processedPerTenant[i].Store(0)
 		}
-
-		// Create a WaitGroup to wait for all items to be processed
 		var wg sync.WaitGroup
 		totalItems := numTenants * itemsPerTenant
 		wg.Add(totalItems)
 
-		// Channel to track when all items have been processed
+		// Enqueue in a round-robin pattern: 1 item per tenant per round
+		for j := 0; j < itemsPerTenant; j++ {
+			for i := 0; i < numTenants; i++ {
+				tenantID := tenantIDs[i]
+				tenantIdx := i
+				require.NoError(b, q.Enqueue(context.Background(), tenantID, func() {
+					processedPerTenant[tenantIdx].Add(1)
+					wg.Done()
+				}))
+			}
+		}
+
 		done := make(chan struct{})
 		go func() {
 			wg.Wait()
 			close(done)
 		}()
 
-		// Enqueue in a round-robin pattern (1 item for each tenant, then repeat)
-		// This should provide a more balanced starting state
-		for j := 0; j < itemsPerTenant; j++ {
-			for i := 0; i < numTenants; i++ {
-				tenantID := tenantIDs[i]
-				tenantIdx := i // Capture for closure
-
-				err := q.Enqueue(context.Background(), tenantID, func() {
-					processedPerTenant[tenantIdx].Add(1)
-					wg.Done()
-				})
-
-				if err != nil {
-					b.Fatalf("Failed to enqueue item for tenant %s: %v", tenantID, err)
-				}
-			}
-		}
-
-		// Wait for all items to be processed or timeout
 		select {
 		case <-done:
-			// All items processed
 		case <-time.After(30 * time.Second):
-			// Debug unprocessed items per tenant
-			for i := 0; i < numTenants; i++ {
-				b.Logf("Tenant %s: processed %d/%d items",
-					tenantIDs[i], processedPerTenant[i].Load(), itemsPerTenant)
-			}
 			b.Fatalf("Timed out waiting for items to be processed")
 		}
 
-		// Calculate fairness metrics
-		min := int64(itemsPerTenant + 1)
-		max := int64(0)
-		var total int64
-
+		min, max, total := int64(itemsPerTenant+1), int64(0), int64(0)
 		for i := 0; i < numTenants; i++ {
 			count := processedPerTenant[i].Load()
 			total += count
@@ -388,13 +273,13 @@ func BenchmarkSchedulerFairnessAlternating(b *testing.B) {
 			if count > max {
 				max = count
 			}
-			b.Logf("Tenant %s: processed %d items", tenantIDs[i], count)
 		}
-
-		// Calculate fairness ratio (closer to 1.0 is more fair)
 		fairnessRatio := float64(min) / float64(max)
-		b.Logf("Fairness metrics - Min: %d, Max: %d, Ratio: %.4f", min, max, fairnessRatio)
 		b.ReportMetric(fairnessRatio, "fairness")
 		b.ReportMetric(float64(total)/b.Elapsed().Seconds(), "items/sec")
 	}
+
+	// Stop the scheduler and verify it's terminated
+	scheduler.StopAsync()
+	require.NoError(b, scheduler.AwaitTerminated(context.Background()))
 }

--- a/pkg/util/scheduler/scheduler_test.go
+++ b/pkg/util/scheduler/scheduler_test.go
@@ -1,0 +1,379 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		expectError   bool
+		expectedError string
+	}{
+		{
+			name: "Valid config",
+			config: Config{
+				NumWorkers:     5,
+				DequeueTimeout: 1 * time.Second,
+				Logger:         log.New("qos.test"),
+			},
+			expectError: false,
+		},
+		{
+			name: "Zero workers",
+			config: Config{
+				NumWorkers:     0,
+				DequeueTimeout: 1 * time.Second,
+			},
+			expectError:   true,
+			expectedError: "NumWorkers must be positive",
+		},
+		{
+			name: "Negative workers",
+			config: Config{
+				NumWorkers:     -1,
+				DequeueTimeout: 1 * time.Second,
+			},
+			expectError:   true,
+			expectedError: "NumWorkers must be positive",
+		},
+		{
+			name: "Nil logger gets default",
+			config: Config{
+				NumWorkers:     1,
+				DequeueTimeout: 1 * time.Second,
+				Logger:         nil,
+			},
+			expectError: false,
+		},
+		{
+			name: "Zero timeout gets default",
+			config: Config{
+				NumWorkers:     1,
+				DequeueTimeout: 0,
+				Logger:         log.New("qos.test"),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.validate()
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				if tc.config.DequeueTimeout == 0 {
+					require.Greater(t, tc.config.DequeueTimeout, time.Duration(0))
+				}
+				require.NotNil(t, tc.config.Logger)
+			}
+		})
+	}
+}
+
+func TestNewScheduler(t *testing.T) {
+	tests := []struct {
+		name        string
+		queue       *Queue
+		config      Config
+		expectError bool
+	}{
+		{
+			name:  "Valid parameters",
+			queue: NewQueue(QueueOptionsWithDefaults(nil)),
+			config: Config{
+				NumWorkers:     2,
+				DequeueTimeout: 1 * time.Second,
+				Logger:         log.New("qos.test"),
+			},
+			expectError: false,
+		},
+		{
+			name:  "Nil queue",
+			queue: nil,
+			config: Config{
+				NumWorkers:     2,
+				DequeueTimeout: 1 * time.Second,
+			},
+			expectError: true,
+		},
+		{
+			name:  "Invalid config",
+			queue: NewQueue(QueueOptionsWithDefaults(nil)),
+			config: Config{
+				NumWorkers:     0, // Invalid
+				DequeueTimeout: 1 * time.Second,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheduler, err := NewScheduler(tc.queue, &tc.config)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Nil(t, scheduler)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, scheduler)
+				require.Equal(t, tc.queue, scheduler.queue)
+				require.Equal(t, tc.config.NumWorkers, scheduler.numWorkers)
+
+				// Ensure the scheduler is properly initialized
+				require.False(t, scheduler.IsRunning())
+				require.Empty(t, scheduler.workers)
+			}
+
+			// Close the queue to prevent leaks
+			if tc.queue != nil {
+				tc.queue.Close()
+				tc.queue.StopWait()
+			}
+		})
+	}
+}
+
+func TestSchedulerStartStop(t *testing.T) {
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     3,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.New("qos.test"),
+	})
+	require.NoError(t, err)
+
+	// Test initial state
+	require.False(t, scheduler.IsRunning())
+
+	// Test Start
+	err = scheduler.Start()
+	require.NoError(t, err)
+	require.True(t, scheduler.IsRunning())
+	require.Len(t, scheduler.workers, 3)
+
+	// Test double start
+	err = scheduler.Start()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already started")
+
+	// Test Stop
+	scheduler.Stop()
+	require.False(t, scheduler.IsRunning())
+	require.Nil(t, scheduler.workers)
+}
+
+func TestSchedulerProcessItems(t *testing.T) {
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	// Use a sync.Map to store results across goroutines safely
+	var processedItems sync.Map
+	var itemCount int32 = 10
+
+	// Create a channel to signal when all items are processed
+	allProcessed := make(chan struct{})
+
+	// Create a WaitGroup to track the completion of all items
+	var wg sync.WaitGroup
+	wg.Add(int(itemCount))
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     2,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.New("qos.test"),
+	})
+	require.NoError(t, err)
+
+	// Start a goroutine to monitor when all items are processed
+	go func() {
+		wg.Wait()
+		close(allProcessed)
+	}()
+
+	// Start the scheduler
+	err = scheduler.Start()
+	require.NoError(t, err)
+
+	// Add items to the queue
+	for i := 0; i < int(itemCount); i++ {
+		itemID := i
+		err := q.Enqueue(context.Background(), "tenant-1", func() {
+			// Mark this item as processed
+			processedItems.Store(itemID, true)
+			wg.Done()
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for all items to be processed with a timeout
+	select {
+	case <-allProcessed:
+		// All items processed successfully
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for all items to be processed")
+	}
+
+	// Verify all items were processed
+	count := 0
+	processedItems.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	require.Equal(t, int(itemCount), count, "Not all items were processed")
+
+	// Stop the scheduler
+	scheduler.Stop()
+}
+
+func TestSchedulerGracefulShutdown(t *testing.T) {
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+	defer func() {
+		q.Close()
+		q.StopWait()
+	}()
+
+	var processed atomic.Int32
+
+	// Create channels to signal task state transitions
+	taskStarted := make(chan struct{})
+	taskFinished := make(chan struct{})
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     1,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.New("qos.test"),
+	})
+	require.NoError(t, err)
+
+	// Start the scheduler
+	err = scheduler.Start()
+	require.NoError(t, err)
+
+	// Add several quick items
+	for i := 0; i < 5; i++ {
+		err := q.Enqueue(context.Background(), "tenant-1", func() {
+			processed.Add(1)
+		})
+		require.NoError(t, err)
+	}
+
+	// Add one long-running item last
+	err = q.Enqueue(context.Background(), "tenant-1", func() {
+		// Signal that the task has started
+		close(taskStarted)
+
+		time.Sleep(100 * time.Millisecond)
+
+		// Signal that the task has finished
+		close(taskFinished)
+	})
+	require.NoError(t, err)
+
+	// Wait for long-running item to start
+	select {
+	case <-taskStarted:
+		// Task started successfully
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for long-running task to start")
+	}
+
+	// Initiate graceful shutdown while long-running task is in progress
+	scheduler.Stop()
+
+	// Verify the long-running task was allowed to complete
+	select {
+	case <-taskFinished:
+		// Task finished successfully
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for long-running task to finish")
+	}
+
+	// Check that all normal items were processed too
+	require.Equal(t, int32(5), processed.Load())
+}
+
+func TestSchedulerWithErrorInQueue(t *testing.T) {
+	q := NewQueue(QueueOptionsWithDefaults(nil))
+
+	// Create a WaitGroup to track completed items
+	var wg sync.WaitGroup
+	var processedCount atomic.Int32
+	const totalItems = 5
+
+	wg.Add(totalItems)
+
+	scheduler, err := NewScheduler(q, &Config{
+		NumWorkers:     2,
+		DequeueTimeout: 100 * time.Millisecond,
+		Logger:         log.New("qos.test"),
+	})
+	require.NoError(t, err)
+
+	// Start the scheduler
+	err = scheduler.Start()
+	require.NoError(t, err)
+
+	// Add a few items
+	for i := 0; i < totalItems; i++ {
+		err := q.Enqueue(context.Background(), "tenant-1", func() {
+			processedCount.Add(1)
+			wg.Done()
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for items to be processed or timeout
+	processingDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(processingDone)
+	}()
+
+	select {
+	case <-processingDone:
+		// Items processed successfully
+	case <-time.After(1 * time.Second):
+		// Continue anyway, some items might not process
+	}
+
+	// Close the queue to simulate an error condition
+	q.Close()
+
+	// When the queue is closed, Dequeue operations should return ErrQueueClosed
+	// Try to add a new item, which should fail
+	err = q.Enqueue(context.Background(), "tenant-1", func() {})
+	require.Error(t, err)
+	require.Equal(t, ErrQueueClosed, err)
+
+	// Explicitly stop the scheduler to ensure it shuts down
+	scheduler.Stop()
+
+	// Verify scheduler has stopped
+	require.False(t, scheduler.IsRunning())
+
+	// Processed count should be at most the total items (some items may not have been processed if queue was closed early)
+	require.LessOrEqual(t, processedCount.Load(), int32(totalItems))
+
+	// Clean up
+	q.StopWait()
+}

--- a/pkg/util/scheduler/scheduler_test.go
+++ b/pkg/util/scheduler/scheduler_test.go
@@ -12,323 +12,266 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSchedulerConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        Config
-		expectError   bool
-		expectedError string
-	}{
-		{
-			name: "Valid config",
-			config: Config{
+func TestScheduler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ConfigValidation", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("ValidConfig", func(t *testing.T) {
+			cfg := Config{
 				NumWorkers: 5,
 				MaxBackoff: 1 * time.Second,
 				Logger:     log.New("qos.test"),
-			},
-			expectError: false,
-		},
-		{
-			name: "Zero workers",
-			config: Config{
+			}
+			err := cfg.validate()
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Logger)
+		})
+
+		t.Run("ZeroWorkersGetDefault", func(t *testing.T) {
+			cfg := Config{
 				NumWorkers: 0,
 				MaxBackoff: 1 * time.Second,
-			},
-			expectError:   true,
-			expectedError: "NumWorkers must be positive",
-		},
-		{
-			name: "Negative workers",
-			config: Config{
-				NumWorkers: -1,
-				MaxBackoff: 1 * time.Second,
-			},
-			expectError:   true,
-			expectedError: "NumWorkers must be positive",
-		},
-		{
-			name: "Nil logger gets default",
-			config: Config{
+			}
+			err := cfg.validate()
+			require.NoError(t, err)
+			require.Equal(t, cfg.NumWorkers, DefaultNumWorkers)
+			require.NotNil(t, cfg.Logger, "Logger should not be nil")
+		})
+
+		t.Run("NilLoggerGetsDefault", func(t *testing.T) {
+			cfg := Config{
 				NumWorkers: 1,
 				MaxBackoff: 1 * time.Second,
 				Logger:     nil,
-			},
-			expectError: false,
-		},
-		{
-			name: "Zero timeout gets default",
-			config: Config{
+			}
+			err := cfg.validate()
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Logger)
+		})
+
+		t.Run("ZeroTimeoutGetsDefault", func(t *testing.T) {
+			cfg := Config{
 				NumWorkers: 1,
 				MaxBackoff: 0,
 				Logger:     log.New("qos.test"),
-			},
-			expectError: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.config.validate()
-			if tc.expectError {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
-			} else {
-				require.NoError(t, err)
-				if tc.config.MaxBackoff == 0 {
-					require.Greater(t, tc.config.MaxBackoff, time.Duration(0))
-				}
-				require.NotNil(t, tc.config.Logger)
 			}
+			err := cfg.validate()
+			require.NoError(t, err)
+			require.Equal(t, cfg.MaxBackoff, DefaultMaxBackoff)
 		})
-	}
-}
 
-func TestNewScheduler(t *testing.T) {
-	tests := []struct {
-		name        string
-		queue       *Queue
-		config      Config
-		expectError bool
-	}{
-		{
-			name:  "Valid parameters",
-			queue: NewQueue(QueueOptionsWithDefaults(nil)),
-			config: Config{
+		t.Run("ZeroRetriesGetsDefault", func(t *testing.T) {
+			cfg := Config{
+				NumWorkers: 1,
+				MaxBackoff: 1 * time.Second,
+				MaxRetries: 0,
+				Logger:     log.New("qos.test"),
+			}
+			err := cfg.validate()
+			require.NoError(t, err)
+			require.Equal(t, cfg.MaxRetries, DefaultMaxRetries)
+		})
+	})
+
+	t.Run("NewScheduler", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("ValidParameters", func(t *testing.T) {
+			q := NewQueue(QueueOptionsWithDefaults(nil))
+			cfg := Config{
 				NumWorkers: 2,
 				MaxBackoff: 1 * time.Second,
 				Logger:     log.New("qos.test"),
-			},
-			expectError: false,
-		},
-		{
-			name:  "Nil queue",
-			queue: nil,
-			config: Config{
-				NumWorkers: 2,
-				MaxBackoff: 1 * time.Second,
-			},
-			expectError: true,
-		},
-		{
-			name:  "Invalid config",
-			queue: NewQueue(QueueOptionsWithDefaults(nil)),
-			config: Config{
-				NumWorkers: 0, // Invalid
-				MaxBackoff: 1 * time.Second,
-			},
-			expectError: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			scheduler, err := NewScheduler(tc.queue, &tc.config)
-			if tc.expectError {
-				require.Error(t, err)
-				require.Nil(t, scheduler)
-				return
 			}
-
-			require.NoError(t, scheduler.StartAsync(context.Background()))
-			require.NoError(t, scheduler.AwaitRunning(context.Background()))
+			scheduler, err := NewScheduler(q, &cfg)
 			require.NoError(t, err)
 			require.NotNil(t, scheduler)
-			require.Equal(t, tc.queue, scheduler.queue)
-			require.Equal(t, tc.config.NumWorkers, scheduler.numWorkers)
+			require.NoError(t, scheduler.StartAsync(context.Background()))
+			require.NoError(t, scheduler.AwaitRunning(context.Background()))
+			require.Equal(t, q, scheduler.queue)
+			require.Equal(t, cfg.NumWorkers, scheduler.numWorkers)
 			require.True(t, scheduler.State() == services.Running)
-
-			if tc.queue != nil {
-				tc.queue.StopAsync()
-				require.NoError(t, tc.queue.AwaitTerminated(context.Background()))
-			}
+			q.StopAsync()
+			require.NoError(t, q.AwaitTerminated(context.Background()))
 		})
-	}
-}
 
-func TestSchedulerLifecycle(t *testing.T) {
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers: 3,
-		MaxBackoff: 100 * time.Millisecond,
-		Logger:     log.New("qos.test"),
+		t.Run("NilQueue", func(t *testing.T) {
+			cfg := Config{
+				NumWorkers: 2,
+				MaxBackoff: 1 * time.Second,
+			}
+			scheduler, err := NewScheduler(nil, &cfg)
+			require.Error(t, err)
+			require.Nil(t, scheduler)
+		})
 	})
-	require.NoError(t, err)
 
-	// Test initial state
-	require.True(t, scheduler.State() == services.New)
+	t.Run("Lifecycle", func(t *testing.T) {
+		t.Parallel()
 
-	// Test starting the scheduler
-	require.NoError(t, scheduler.StartAsync(context.Background()))
-	require.NoError(t, scheduler.AwaitRunning(context.Background()))
-	require.True(t, scheduler.State() == services.Running)
-	// Test stopping the scheduler
-	scheduler.StopAsync()
-	err = scheduler.AwaitTerminated(context.Background())
-	require.NoError(t, err)
-	require.True(t, scheduler.State() == services.Terminated)
-}
-
-func TestSchedulerProcessItems(t *testing.T) {
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-
-	const itemCount = 10
-	var processed sync.Map
-	var wg sync.WaitGroup
-	wg.Add(itemCount)
-
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers: 2,
-		MaxBackoff: 100 * time.Millisecond,
-		Logger:     log.New("qos.test"),
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		scheduler, err := NewScheduler(q, &Config{
+			NumWorkers: 3,
+			MaxBackoff: 100 * time.Millisecond,
+			Logger:     log.New("qos.test"),
+		})
+		require.NoError(t, err)
+		require.True(t, scheduler.State() == services.New)
+		require.NoError(t, scheduler.StartAsync(context.Background()))
+		require.NoError(t, scheduler.AwaitRunning(context.Background()))
+		require.True(t, scheduler.State() == services.Running)
+		scheduler.StopAsync()
+		err = scheduler.AwaitTerminated(context.Background())
+		require.NoError(t, err)
+		require.True(t, scheduler.State() == services.Terminated)
 	})
-	require.NoError(t, err)
 
-	// Start the scheduler and wait until it's running
-	require.NoError(t, scheduler.StartAsync(context.Background()))
-	require.NoError(t, scheduler.AwaitRunning(context.Background()))
+	t.Run("ProcessItems", func(t *testing.T) {
+		t.Parallel()
 
-	// Enqueue items
-	for i := 0; i < itemCount; i++ {
-		itemID := i
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		const itemCount = 10
+		var processed sync.Map
+		var wg sync.WaitGroup
+		wg.Add(itemCount)
+
+		scheduler, err := NewScheduler(q, &Config{
+			NumWorkers: 2,
+			MaxBackoff: 100 * time.Millisecond,
+			Logger:     log.New("qos.test"),
+		})
+		require.NoError(t, err)
+		require.NoError(t, scheduler.StartAsync(context.Background()))
+		require.NoError(t, scheduler.AwaitRunning(context.Background()))
+
+		for i := 0; i < itemCount; i++ {
+			itemID := i
+			require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
+				processed.Store(itemID, true)
+				wg.Done()
+			}))
+		}
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed out waiting for all items to be processed")
+		}
+
+		count := 0
+		processed.Range(func(_, _ any) bool {
+			count++
+			return true
+		})
+		require.Equal(t, itemCount, count, "Not all items were processed")
+
+		scheduler.StopAsync()
+		require.NoError(t, scheduler.AwaitTerminated(context.Background()))
+		require.Equal(t, services.Terminated, scheduler.State())
+	})
+
+	t.Run("GracefulShutdown", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		var processed atomic.Int32
+		taskStarted := make(chan struct{})
+		taskFinished := make(chan struct{})
+
+		scheduler, err := NewScheduler(q, &Config{
+			NumWorkers: 1,
+			MaxBackoff: 100 * time.Millisecond,
+			Logger:     log.New("qos.test"),
+		})
+		require.NoError(t, err)
+		require.NoError(t, scheduler.StartAsync(context.Background()))
+		require.NoError(t, scheduler.AwaitRunning(context.Background()))
+
+		for i := 0; i < 5; i++ {
+			require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
+				processed.Add(1)
+			}))
+		}
+
 		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
-			processed.Store(itemID, true)
-			wg.Done()
-		}))
-	}
-
-	// Wait for all items to be processed or timeout
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timed out waiting for all items to be processed")
-	}
-
-	// Verify all items were processed
-	count := 0
-	processed.Range(func(_, _ any) bool {
-		count++
-		return true
-	})
-	require.Equal(t, itemCount, count, "Not all items were processed")
-
-	// Stop the scheduler and verify it's terminated
-	scheduler.StopAsync()
-	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
-	require.Equal(t, services.Terminated, scheduler.State())
-}
-
-func TestSchedulerGracefulShutdown(t *testing.T) {
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-
-	var processed atomic.Int32
-	taskStarted := make(chan struct{})
-	taskFinished := make(chan struct{})
-
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers: 1,
-		MaxBackoff: 100 * time.Millisecond,
-		Logger:     log.New("qos.test"),
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, scheduler.StartAsync(context.Background()))
-	require.NoError(t, scheduler.AwaitRunning(context.Background()))
-
-	// Enqueue quick items
-	for i := 0; i < 5; i++ {
-		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
+			close(taskStarted)
+			time.Sleep(1 * time.Second)
 			processed.Add(1)
+			close(taskFinished)
 		}))
-	}
 
-	// Enqueue a long-running item
-	require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
-		close(taskStarted)
-		time.Sleep(1 * time.Second) // Simulate long-running task
-		processed.Add(1)
-		close(taskFinished)
-	}))
+		select {
+		case <-taskStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for long-running task to start")
+		}
 
-	// Wait for the long-running item to start
-	select {
-	case <-taskStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for long-running task to start")
-	}
+		scheduler.StopAsync()
 
-	// Initiate graceful shutdown
-	scheduler.StopAsync()
+		select {
+		case <-taskFinished:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for long-running task to finish")
+		}
 
-	// Wait for the long-running item to finish
-	select {
-	case <-taskFinished:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for long-running task to finish")
-	}
-
-	require.Equal(t, int32(6), processed.Load(), "Not all items were processed")
-	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
-}
-
-func TestSchedulerWithErrorInQueue(t *testing.T) {
-	q := NewQueue(QueueOptionsWithDefaults(nil))
-
-	var processedCount atomic.Int32
-	const totalItems = 5
-	var wg sync.WaitGroup
-	wg.Add(totalItems)
-
-	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers: 2,
-		MaxBackoff: 100 * time.Millisecond,
-		Logger:     log.New("qos.test"),
+		require.Equal(t, int32(6), processed.Load(), "Not all items were processed")
+		require.NoError(t, scheduler.AwaitTerminated(context.Background()))
 	})
-	require.NoError(t, err)
 
-	require.NoError(t, scheduler.StartAsync(context.Background()))
-	require.NoError(t, scheduler.AwaitRunning(context.Background()))
+	t.Run("WithErrorInQueue", func(t *testing.T) {
+		t.Parallel()
 
-	// Enqueue items
-	for i := 0; i < totalItems; i++ {
-		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
-			processedCount.Add(1)
-			wg.Done()
-		}))
-	}
+		q := NewQueue(QueueOptionsWithDefaults(nil))
+		var processedCount atomic.Int32
+		const totalItems = 5
+		var wg sync.WaitGroup
+		wg.Add(totalItems)
 
-	// Wait for items to be processed or timeout
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		// Some items may not process if queue is closed early
-	}
+		scheduler, err := NewScheduler(q, &Config{
+			NumWorkers: 2,
+			MaxBackoff: 100 * time.Millisecond,
+			Logger:     log.New("qos.test"),
+		})
+		require.NoError(t, err)
+		require.NoError(t, scheduler.StartAsync(context.Background()))
+		require.NoError(t, scheduler.AwaitRunning(context.Background()))
 
-	// Close the queue to simulate an error condition
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-	q.StopAsync()
-	require.NoError(t, q.AwaitTerminated(ctx))
+		for i := 0; i < totalItems; i++ {
+			require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
+				processedCount.Add(1)
+				wg.Done()
+			}))
+		}
 
-	// Enqueue should fail after queue is closed
-	err = q.Enqueue(context.Background(), "tenant-1", func() {})
-	require.ErrorIs(t, err, ErrQueueClosed)
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			// Some items may not process if queue is closed early
+		}
 
-	// Stop the scheduler and verify it's terminated
-	scheduler.StopAsync()
-	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		q.StopAsync()
+		require.NoError(t, q.AwaitTerminated(ctx))
 
-	// Processed count should be at most totalItems
-	require.LessOrEqual(t, processedCount.Load(), int32(totalItems))
+		err = q.Enqueue(context.Background(), "tenant-1", func() {})
+		require.ErrorIs(t, err, ErrQueueClosed)
+
+		scheduler.StopAsync()
+		require.NoError(t, scheduler.AwaitTerminated(context.Background()))
+		require.LessOrEqual(t, processedCount.Load(), int32(totalItems))
+	})
 }

--- a/pkg/util/scheduler/scheduler_test.go
+++ b/pkg/util/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/stretchr/testify/require"
 )
@@ -21,17 +22,17 @@ func TestSchedulerConfig(t *testing.T) {
 		{
 			name: "Valid config",
 			config: Config{
-				NumWorkers:     5,
-				DequeueTimeout: 1 * time.Second,
-				Logger:         log.New("qos.test"),
+				NumWorkers: 5,
+				MaxBackoff: 1 * time.Second,
+				Logger:     log.New("qos.test"),
 			},
 			expectError: false,
 		},
 		{
 			name: "Zero workers",
 			config: Config{
-				NumWorkers:     0,
-				DequeueTimeout: 1 * time.Second,
+				NumWorkers: 0,
+				MaxBackoff: 1 * time.Second,
 			},
 			expectError:   true,
 			expectedError: "NumWorkers must be positive",
@@ -39,8 +40,8 @@ func TestSchedulerConfig(t *testing.T) {
 		{
 			name: "Negative workers",
 			config: Config{
-				NumWorkers:     -1,
-				DequeueTimeout: 1 * time.Second,
+				NumWorkers: -1,
+				MaxBackoff: 1 * time.Second,
 			},
 			expectError:   true,
 			expectedError: "NumWorkers must be positive",
@@ -48,18 +49,18 @@ func TestSchedulerConfig(t *testing.T) {
 		{
 			name: "Nil logger gets default",
 			config: Config{
-				NumWorkers:     1,
-				DequeueTimeout: 1 * time.Second,
-				Logger:         nil,
+				NumWorkers: 1,
+				MaxBackoff: 1 * time.Second,
+				Logger:     nil,
 			},
 			expectError: false,
 		},
 		{
 			name: "Zero timeout gets default",
 			config: Config{
-				NumWorkers:     1,
-				DequeueTimeout: 0,
-				Logger:         log.New("qos.test"),
+				NumWorkers: 1,
+				MaxBackoff: 0,
+				Logger:     log.New("qos.test"),
 			},
 			expectError: false,
 		},
@@ -73,8 +74,8 @@ func TestSchedulerConfig(t *testing.T) {
 				require.Contains(t, err.Error(), tc.expectedError)
 			} else {
 				require.NoError(t, err)
-				if tc.config.DequeueTimeout == 0 {
-					require.Greater(t, tc.config.DequeueTimeout, time.Duration(0))
+				if tc.config.MaxBackoff == 0 {
+					require.Greater(t, tc.config.MaxBackoff, time.Duration(0))
 				}
 				require.NotNil(t, tc.config.Logger)
 			}
@@ -93,9 +94,9 @@ func TestNewScheduler(t *testing.T) {
 			name:  "Valid parameters",
 			queue: NewQueue(QueueOptionsWithDefaults(nil)),
 			config: Config{
-				NumWorkers:     2,
-				DequeueTimeout: 1 * time.Second,
-				Logger:         log.New("qos.test"),
+				NumWorkers: 2,
+				MaxBackoff: 1 * time.Second,
+				Logger:     log.New("qos.test"),
 			},
 			expectError: false,
 		},
@@ -103,8 +104,8 @@ func TestNewScheduler(t *testing.T) {
 			name:  "Nil queue",
 			queue: nil,
 			config: Config{
-				NumWorkers:     2,
-				DequeueTimeout: 1 * time.Second,
+				NumWorkers: 2,
+				MaxBackoff: 1 * time.Second,
 			},
 			expectError: true,
 		},
@@ -112,8 +113,8 @@ func TestNewScheduler(t *testing.T) {
 			name:  "Invalid config",
 			queue: NewQueue(QueueOptionsWithDefaults(nil)),
 			config: Config{
-				NumWorkers:     0, // Invalid
-				DequeueTimeout: 1 * time.Second,
+				NumWorkers: 0, // Invalid
+				MaxBackoff: 1 * time.Second,
 			},
 			expectError: true,
 		},
@@ -125,255 +126,209 @@ func TestNewScheduler(t *testing.T) {
 			if tc.expectError {
 				require.Error(t, err)
 				require.Nil(t, scheduler)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, scheduler)
-				require.Equal(t, tc.queue, scheduler.queue)
-				require.Equal(t, tc.config.NumWorkers, scheduler.numWorkers)
-
-				// Ensure the scheduler is properly initialized
-				require.False(t, scheduler.IsRunning())
-				require.Empty(t, scheduler.workers)
+				return
 			}
 
-			// Close the queue to prevent leaks
+			require.NoError(t, scheduler.StartAsync(context.Background()))
+			require.NoError(t, scheduler.AwaitRunning(context.Background()))
+			require.NoError(t, err)
+			require.NotNil(t, scheduler)
+			require.Equal(t, tc.queue, scheduler.queue)
+			require.Equal(t, tc.config.NumWorkers, scheduler.numWorkers)
+			require.True(t, scheduler.State() == services.Running)
+
 			if tc.queue != nil {
-				tc.queue.Close()
-				tc.queue.StopWait()
+				tc.queue.StopAsync()
+				require.NoError(t, tc.queue.AwaitTerminated(context.Background()))
 			}
 		})
 	}
 }
 
-func TestSchedulerStartStop(t *testing.T) {
+func TestSchedulerLifecycle(t *testing.T) {
 	q := NewQueue(QueueOptionsWithDefaults(nil))
-	defer func() {
-		q.Close()
-		q.StopWait()
-	}()
 
 	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     3,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.New("qos.test"),
+		NumWorkers: 3,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.New("qos.test"),
 	})
 	require.NoError(t, err)
 
 	// Test initial state
-	require.False(t, scheduler.IsRunning())
+	require.True(t, scheduler.State() == services.New)
 
-	// Test Start
-	err = scheduler.Start()
+	// Test starting the scheduler
+	require.NoError(t, scheduler.StartAsync(context.Background()))
+	require.NoError(t, scheduler.AwaitRunning(context.Background()))
+	require.True(t, scheduler.State() == services.Running)
+	// Test stopping the scheduler
+	scheduler.StopAsync()
+	err = scheduler.AwaitTerminated(context.Background())
 	require.NoError(t, err)
-	require.True(t, scheduler.IsRunning())
-	require.Len(t, scheduler.workers, 3)
-
-	// Test double start
-	err = scheduler.Start()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "already started")
-
-	// Test Stop
-	scheduler.Stop()
-	require.False(t, scheduler.IsRunning())
-	require.Nil(t, scheduler.workers)
+	require.True(t, scheduler.State() == services.Terminated)
 }
 
 func TestSchedulerProcessItems(t *testing.T) {
 	q := NewQueue(QueueOptionsWithDefaults(nil))
-	defer func() {
-		q.Close()
-		q.StopWait()
-	}()
 
-	// Use a sync.Map to store results across goroutines safely
-	var processedItems sync.Map
-	var itemCount int32 = 10
-
-	// Create a channel to signal when all items are processed
-	allProcessed := make(chan struct{})
-
-	// Create a WaitGroup to track the completion of all items
+	const itemCount = 10
+	var processed sync.Map
 	var wg sync.WaitGroup
-	wg.Add(int(itemCount))
+	wg.Add(itemCount)
 
 	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     2,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.New("qos.test"),
+		NumWorkers: 2,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.New("qos.test"),
 	})
 	require.NoError(t, err)
 
-	// Start a goroutine to monitor when all items are processed
-	go func() {
-		wg.Wait()
-		close(allProcessed)
-	}()
+	// Start the scheduler and wait until it's running
+	require.NoError(t, scheduler.StartAsync(context.Background()))
+	require.NoError(t, scheduler.AwaitRunning(context.Background()))
 
-	// Start the scheduler
-	err = scheduler.Start()
-	require.NoError(t, err)
-
-	// Add items to the queue
-	for i := 0; i < int(itemCount); i++ {
+	// Enqueue items
+	for i := 0; i < itemCount; i++ {
 		itemID := i
-		err := q.Enqueue(context.Background(), "tenant-1", func() {
-			// Mark this item as processed
-			processedItems.Store(itemID, true)
+		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
+			processed.Store(itemID, true)
 			wg.Done()
-		})
-		require.NoError(t, err)
+		}))
 	}
 
-	// Wait for all items to be processed with a timeout
+	// Wait for all items to be processed or timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
 	select {
-	case <-allProcessed:
-		// All items processed successfully
+	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for all items to be processed")
 	}
 
 	// Verify all items were processed
 	count := 0
-	processedItems.Range(func(_, _ interface{}) bool {
+	processed.Range(func(_, _ any) bool {
 		count++
 		return true
 	})
-	require.Equal(t, int(itemCount), count, "Not all items were processed")
+	require.Equal(t, itemCount, count, "Not all items were processed")
 
-	// Stop the scheduler
-	scheduler.Stop()
+	// Stop the scheduler and verify it's terminated
+	scheduler.StopAsync()
+	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
+	require.Equal(t, services.Terminated, scheduler.State())
 }
 
 func TestSchedulerGracefulShutdown(t *testing.T) {
 	q := NewQueue(QueueOptionsWithDefaults(nil))
-	defer func() {
-		q.Close()
-		q.StopWait()
-	}()
 
 	var processed atomic.Int32
-
-	// Create channels to signal task state transitions
 	taskStarted := make(chan struct{})
 	taskFinished := make(chan struct{})
 
 	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     1,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.New("qos.test"),
+		NumWorkers: 1,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.New("qos.test"),
 	})
 	require.NoError(t, err)
 
-	// Start the scheduler
-	err = scheduler.Start()
-	require.NoError(t, err)
+	require.NoError(t, scheduler.StartAsync(context.Background()))
+	require.NoError(t, scheduler.AwaitRunning(context.Background()))
 
-	// Add several quick items
+	// Enqueue quick items
 	for i := 0; i < 5; i++ {
-		err := q.Enqueue(context.Background(), "tenant-1", func() {
+		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
 			processed.Add(1)
-		})
-		require.NoError(t, err)
+		}))
 	}
 
-	// Add one long-running item last
-	err = q.Enqueue(context.Background(), "tenant-1", func() {
-		// Signal that the task has started
+	// Enqueue a long-running item
+	require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
 		close(taskStarted)
-
-		time.Sleep(100 * time.Millisecond)
-
-		// Signal that the task has finished
+		time.Sleep(1 * time.Second) // Simulate long-running task
+		processed.Add(1)
 		close(taskFinished)
-	})
-	require.NoError(t, err)
+	}))
 
-	// Wait for long-running item to start
+	// Wait for the long-running item to start
 	select {
 	case <-taskStarted:
-		// Task started successfully
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timed out waiting for long-running task to start")
 	}
 
-	// Initiate graceful shutdown while long-running task is in progress
-	scheduler.Stop()
+	// Initiate graceful shutdown
+	scheduler.StopAsync()
 
-	// Verify the long-running task was allowed to complete
+	// Wait for the long-running item to finish
 	select {
 	case <-taskFinished:
-		// Task finished successfully
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timed out waiting for long-running task to finish")
 	}
 
-	// Check that all normal items were processed too
-	require.Equal(t, int32(5), processed.Load())
+	require.Equal(t, int32(6), processed.Load(), "Not all items were processed")
+	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
 }
 
 func TestSchedulerWithErrorInQueue(t *testing.T) {
 	q := NewQueue(QueueOptionsWithDefaults(nil))
 
-	// Create a WaitGroup to track completed items
-	var wg sync.WaitGroup
 	var processedCount atomic.Int32
 	const totalItems = 5
-
+	var wg sync.WaitGroup
 	wg.Add(totalItems)
 
 	scheduler, err := NewScheduler(q, &Config{
-		NumWorkers:     2,
-		DequeueTimeout: 100 * time.Millisecond,
-		Logger:         log.New("qos.test"),
+		NumWorkers: 2,
+		MaxBackoff: 100 * time.Millisecond,
+		Logger:     log.New("qos.test"),
 	})
 	require.NoError(t, err)
 
-	// Start the scheduler
-	err = scheduler.Start()
-	require.NoError(t, err)
+	require.NoError(t, scheduler.StartAsync(context.Background()))
+	require.NoError(t, scheduler.AwaitRunning(context.Background()))
 
-	// Add a few items
+	// Enqueue items
 	for i := 0; i < totalItems; i++ {
-		err := q.Enqueue(context.Background(), "tenant-1", func() {
+		require.NoError(t, q.Enqueue(context.Background(), "tenant-1", func() {
 			processedCount.Add(1)
 			wg.Done()
-		})
-		require.NoError(t, err)
+		}))
 	}
 
 	// Wait for items to be processed or timeout
-	processingDone := make(chan struct{})
+	done := make(chan struct{})
 	go func() {
 		wg.Wait()
-		close(processingDone)
+		close(done)
 	}()
-
 	select {
-	case <-processingDone:
-		// Items processed successfully
-	case <-time.After(1 * time.Second):
-		// Continue anyway, some items might not process
+	case <-done:
+	case <-time.After(2 * time.Second):
+		// Some items may not process if queue is closed early
 	}
 
 	// Close the queue to simulate an error condition
-	q.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	q.StopAsync()
+	require.NoError(t, q.AwaitTerminated(ctx))
 
-	// When the queue is closed, Dequeue operations should return ErrQueueClosed
-	// Try to add a new item, which should fail
+	// Enqueue should fail after queue is closed
 	err = q.Enqueue(context.Background(), "tenant-1", func() {})
-	require.Error(t, err)
-	require.Equal(t, ErrQueueClosed, err)
+	require.ErrorIs(t, err, ErrQueueClosed)
 
-	// Explicitly stop the scheduler to ensure it shuts down
-	scheduler.Stop()
+	// Stop the scheduler and verify it's terminated
+	scheduler.StopAsync()
+	require.NoError(t, scheduler.AwaitTerminated(context.Background()))
 
-	// Verify scheduler has stopped
-	require.False(t, scheduler.IsRunning())
-
-	// Processed count should be at most the total items (some items may not have been processed if queue was closed early)
+	// Processed count should be at most totalItems
 	require.LessOrEqual(t, processedCount.Load(), int32(totalItems))
-
-	// Clean up
-	q.StopWait()
 }

--- a/pkg/util/scheduler/scheduler_test.go
+++ b/pkg/util/scheduler/scheduler_test.go
@@ -236,6 +236,6 @@ func TestScheduler(t *testing.T) {
 			Logger:     log.New("qos.test"),
 		})
 		require.NoError(t, err)
-		require.ErrorIs(t, services.StartAndAwaitRunning(context.Background(), scheduler), ErrQueueNotRunning)
+		require.ErrorContains(t, services.StartAndAwaitRunning(context.Background(), scheduler), "queue is not running")
 	})
 }


### PR DESCRIPTION
This is part of the QoS effort documented [here](https://docs.google.com/document/d/1tJcFPsxU2oM06YlRVLFJUyaDscxlRP2HVcB8XSh0Dzk/edit?tab=t.0#heading=h.skk2sm1854kd). This PR is particularly focusing on the introduction of a utility package which would handle the core logic around request distribution and ensure quality of service.

**Things to focus in this PR:**

- Queue: Maintains a multi-tenant state of linked lists that manages the distribution of incoming requests.
- Scheduler: A wrapper around the Queue object that enables concurrent handling of requests.
- 3 metrics introduced to track the necessary building blocks of the queue.

**Benchmarks:**
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/util/scheduler
cpu: Apple M4 Pro
BenchmarkScheduler_1Worker_10Tenants-12                                       50          23521228 ns/op            425157 items/sec     7707830 B/op     120117 allocs/op
BenchmarkScheduler_2Workers_10Tenants-12                                      39          28513094 ns/op            350726 items/sec     8073392 B/op     139632 allocs/op
BenchmarkScheduler_4Workers_10Tenants-12                                      42          28159367 ns/op            355130 items/sec     8081821 B/op     140024 allocs/op
BenchmarkScheduler_8Workers_10Tenants-12                                      37          29170310 ns/op            342822 items/sec     8082182 B/op     140027 allocs/op
BenchmarkScheduler_16Workers_10Tenants-12                                     40          29022698 ns/op            344567 items/sec     8082577 B/op     140033 allocs/op
BenchmarkScheduler_4Workers_1Tenant-12                                       412           3242914 ns/op            308372 items/sec      808455 B/op      14005 allocs/op
BenchmarkScheduler_4Workers_10Tenants_1000Items-12                            39          29960671 ns/op            333779 items/sec     8081407 B/op     140018 allocs/op
BenchmarkScheduler_4Workers_100Tenants-12                                      4         293637312 ns/op            340564 items/sec    80821232 B/op    1400196 allocs/op
BenchmarkScheduler_4Workers_10Tenants_100ItemsPerTenant-12                   409           2858352 ns/op            349861 items/sec      808524 B/op      14007 allocs/op
BenchmarkScheduler_4Workers_10Tenants_ManyItems-12                            39          28671477 ns/op            348788 items/sec     8082022 B/op     140026 allocs/op
BenchmarkScheduler_4Workers_10Tenants_10000ItemsPerTenant-12                   4         291686500 ns/op            342842 items/sec    80813402 B/op    1400176 allocs/op
BenchmarkSchedulerFairness-12                                                 42          29463172 ns/op                 1.000 fairness       8081 items/sec     8371614 B/op     140405 allocs/op
--- BENCH: BenchmarkSchedulerFairness-12
    scheduler_bench_test.go:223: Starting to enqueue 1000 items for tenant tenant-0
    scheduler_bench_test.go:243: Successfully enqueued 1000 items for tenant tenant-0
    scheduler_bench_test.go:223: Starting to enqueue 1000 items for tenant tenant-1
    scheduler_bench_test.go:243: Successfully enqueued 1000 items for tenant tenant-1
    scheduler_bench_test.go:223: Starting to enqueue 1000 items for tenant tenant-2
    scheduler_bench_test.go:243: Successfully enqueued 1000 items for tenant tenant-2
    scheduler_bench_test.go:223: Starting to enqueue 1000 items for tenant tenant-3
    scheduler_bench_test.go:243: Successfully enqueued 1000 items for tenant tenant-3
    scheduler_bench_test.go:223: Starting to enqueue 1000 items for tenant tenant-4
    scheduler_bench_test.go:243: Successfully enqueued 1000 items for tenant tenant-4
        ... [output truncated]
BenchmarkSchedulerFairnessAlternating-12                                       1        3118205042 ns/op                 1.000 fairness     320706 items/sec    833917592 B/op  14015674 allocs/op
--- BENCH: BenchmarkSchedulerFairnessAlternating-12
    scheduler_bench_test.go:389: Tenant tenant-0: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-1: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-2: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-3: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-4: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-5: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-6: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-7: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-8: processed 1000 items
    scheduler_bench_test.go:389: Tenant tenant-9: processed 1000 items
        ... [output truncated]
PASS
ok      github.com/grafana/grafana/pkg/util/scheduler   21.461s
```