### PR TITLE
e2e - debug / slomo fix

### DIFF
--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -10,7 +10,7 @@ const COMMAND_DELAY = 1000;
 function delay(ms) {
   let now = Date.now();
   const end = now + ms;
-  
+
   do {
     now = Date.now();
   } while (now < end);

--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -13,13 +13,11 @@ function delay(ms) {
 }
 
 if (Cypress.env('SLOWMO')) {
-  Cypress.Commands.overwriteQuery("contains",
-    function (contains, filter, text, userOptions = {}) {
-      delay(COMMAND_DELAY);
-      const call = contains.bind(this);
-      return call(filter, text, userOptions);
-    }
-  );
+  Cypress.Commands.overwriteQuery('contains', function (contains, filter, text, userOptions = {}) {
+    delay(COMMAND_DELAY);
+    const call = contains.bind(this);
+    return call(filter, text, userOptions);
+  });
 
   const commandsToModify = ['clear', 'click', 'reload', 'then', 'trigger', 'type', 'visit'];
   commandsToModify.forEach((command) => {

--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -8,8 +8,12 @@ Cypress.Screenshot.defaults({
 const COMMAND_DELAY = 1000;
 
 function delay(ms) {
-  const end = Date.now() + ms;
-  while (Date.now() < end) {}
+  let now = Date.now();
+  const end = now + ms;
+  
+  do {
+    now = Date.now();
+  } while (now < end);
 }
 
 if (Cypress.env('SLOWMO')) {

--- a/e2e/run-suite
+++ b/e2e/run-suite
@@ -164,6 +164,8 @@ case "$1" in
                 ;;
             "dev")
                 echo "Dev mode"
+                # remove comment to run in slomo ( demo mode )
+                # env[SLOWMO]=1
                 CMD="cypress open"
                 enterpriseSuite=$(basename "${args[2]}")
                 ;;


### PR DESCRIPTION
When running e2e in debug mode the SLOMO feature ( delay the test steps ) is broken due to a change in Cypress newer versions.

This fixes the issue, also adds the same delay at the end of each test, so we can record each test and see the end result. 
This allows using the recordings for demos.