### PR TITLE
Geomap: Update CARTO attribution

### DIFF
--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -47,7 +47,7 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
       }
       return new TileLayer({
         source: new XYZ({
-          attributions: `<a href="https://carto.com/attribution/">© CARTO</a>`,
+          attributions: `<a href="https://carto.com/attribution/">©CARTO</a> <a href="https://www.openstreetmap.org/copyright">©OpenStreetMap</a> contributors`,
           url: `https://{1-4}.basemaps.cartocdn.com/${style}/{z}/{x}/{y}.png`,
         }),
       });


### PR DESCRIPTION
Update CARTO attribution to be compliant with section 13 of [the CARTO Basemaps Terms & Conditions](https://drive.google.com/file/d/15W7lHI9LcRKsUCuWgOCWkVwB54HHV5kb/view), as well as [OpenStreetMap's copyright directives](https://www.openstreetmap.org/copyright).

After:
![image](https://github.com/user-attachments/assets/93759712-5a65-40d5-834a-a89f21bf32de)

Fixes #103883