### PR TITLE
Fix Prometheus Metric Registration Panic for plugins_datasource_response_size

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -28,7 +28,8 @@ var (
 			Name:      "datasource_request_duration_seconds",
 			Help:      "histogram of durations of outgoing data source requests sent from Grafana",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
-		}, []string{"datasource", "datasource_type", "code", "method", "secure_socks_ds_proxy_enabled"},
+		},
+		[]string{"datasource", "datasource_type", "code", "method", "secure_socks_ds_proxy_enabled"},
 	)
 
 	datasourceResponseHistogram = promauto.NewHistogramVec(
@@ -40,15 +41,17 @@ var (
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
+		},
+		[]string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
 	)
 
 	datasourceResponseGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "plugins",
-			Name:      "datasource_response_size",
+			Name:      "datasource_response_size_bytes_gauge", // Renamed to avoid conflict
 			Help:      "gauge of external data source response sizes returned to Grafana in bytes",
-		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
+		},
+		[]string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
 	)
 
 	datasourceRequestsInFlight = promauto.NewGaugeVec(
@@ -77,8 +80,6 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 		}
 
 		datasourceLabelName, err := metricutil.SanitizeLabelName(datasourceName)
-		// if the datasource named cannot be turned into a prometheus
-		// label we will skip instrumenting these metrics.
 		if err != nil {
 			return next
 		}
@@ -88,8 +89,6 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 			return next
 		}
 		datasourceLabelType, err := metricutil.SanitizeLabelName(datasourceType)
-		// if the datasource type cannot be turned into a prometheus
-		// label we will skip instrumenting these metrics.
 		if err != nil {
 			return next
 		}


### PR DESCRIPTION
This PR resolves a panic on Grafana startup caused by a duplicate Prometheus metric registration for `plugins_datasource_response_siz`e in `pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go.` The conflict arises between datasourceResponseHistogram (namespace: grafana, name: datasource_response_size_bytes) and datasourceResponseGauge (namespace: plugins, name: datasource_response_size) due to differing metadata.

- Renamed datasourceResponseGauge metric from datasource_response_size to datasource_response_size_bytes_gauge in `pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go` to avoid the conflict.
- Updated executeMiddleware to use the renamed gauge.
- No changes to other metrics or logic.

**Impact:**
- Resolves panic permanently while preserving both histogram and gauge metrics.

**Related Issues:**
- Fixes panic observed during development of CloudWatch plugin fix (grafana/grafana grafana/grafana#104062), although this PR is independent.

**Additional Notes:**
- This panic issue was observed while addressing a CloudWatch plugin issue (#104062) but the fix is submitted separately to keep concerns isolated.

Fixes grafana/grafana-prometheus-datasource#129

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
