### PR TITLE
fix(flamegraph): correct diff formatting in flame graph diff tooltip

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.test.tsx
@@ -2,6 +2,7 @@ import { Field, FieldType, createDataFrame } from '@grafana/data';
 
 import { getDiffTooltipData, getTooltipData } from './FlameGraphTooltip';
 import { FlameGraphDataContainer } from './dataTransform';
+import { formatDiff } from './FlameGraphTooltip';
 
 function setupData(unit?: string) {
   const flameGraphData = createDataFrame({
@@ -28,6 +29,23 @@ function setupDiffData() {
   });
   return new FlameGraphDataContainer(flameGraphData, { collapsing: true });
 }
+
+describe('formatDiff', () => {
+  it('must correctly format values ​​less than 1000', () => {
+    expect(formatDiff(8.08)).toBe('8.08%');
+    expect(formatDiff(999.99)).toBe('999.99%');
+  });
+
+  it('must correctly format values ​​equal to or greater than 1000', () => {
+    expect(formatDiff(1000)).toBe('1.00K%');
+    expect(formatDiff(8081.25)).toBe('8.08K%');
+    expect(formatDiff(-2500)).toBe('-2.50K%');
+  });
+
+  it('must handle zero correctly', () => {
+    expect(formatDiff(0)).toBe('0.00%');
+  });
+});''
 
 describe('FlameGraphTooltip', () => {
   it('for bytes', () => {

--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.test.tsx
@@ -2,7 +2,6 @@ import { Field, FieldType, createDataFrame } from '@grafana/data';
 
 import { getDiffTooltipData, getTooltipData } from './FlameGraphTooltip';
 import { FlameGraphDataContainer } from './dataTransform';
-import { formatDiff } from './FlameGraphTooltip';
 
 function setupData(unit?: string) {
   const flameGraphData = createDataFrame({
@@ -29,23 +28,6 @@ function setupDiffData() {
   });
   return new FlameGraphDataContainer(flameGraphData, { collapsing: true });
 }
-
-describe('formatDiff', () => {
-  it('must correctly format values ​​less than 1000', () => {
-    expect(formatDiff(8.08)).toBe('8.08%');
-    expect(formatDiff(999.99)).toBe('999.99%');
-  });
-
-  it('must correctly format values ​​equal to or greater than 1000', () => {
-    expect(formatDiff(1000)).toBe('1.00K%');
-    expect(formatDiff(8081.25)).toBe('8.08K%');
-    expect(formatDiff(-2500)).toBe('-2.50K%');
-  });
-
-  it('must handle zero correctly', () => {
-    expect(formatDiff(0)).toBe('0.00%');
-  });
-});''
 
 describe('FlameGraphTooltip', () => {
   it('for bytes', () => {

--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.tsx
@@ -122,16 +122,6 @@ type DiffTableData = {
   diff: string | number;
 };
 
-export const formatDiff = (value: number): string => {
-  if (Math.abs(value) >= 1000) {
-    return (value / 1000).toFixed(2) + 'K%';
-  }
-  if (value === 0) {
-    return '0.00%';
-  }
-  return value % 1 === 0 ? `${value}%` : value.toFixed(2) + '%';
-};
-
 export const getDiffTooltipData = (
   data: FlameGraphDataContainer,
   item: LevelItem,
@@ -151,6 +141,8 @@ export const getDiffTooltipData = (
   const displayValueRight = getValueWithUnit(data, data.valueDisplayProcessor(item.valueRight!));
 
   const shortValFormat = getValueFormat('short');
+  
+  const formatted = shortValFormat(diff);
 
   return [
     {
@@ -158,7 +150,7 @@ export const getDiffTooltipData = (
       label: '% of total',
       baseline: percentageLeft + '%',
       comparison: percentageRight + '%',
-      diff: formatDiff(diff),
+      diff: formatted.text + '%',
     },
     {
       rowId: '2',

--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraphTooltip.tsx
@@ -110,7 +110,7 @@ export const getTooltipData = (data: FlameGraphDataContainer, item: LevelItem, t
     unitTitle,
     unitValue,
     unitSelf,
-    samples: displayValue.numeric.toLocaleString(),
+    samples: displayValue.numeric.toLocaleString('en-US'),
   };
 };
 
@@ -120,6 +120,16 @@ type DiffTableData = {
   baseline: string | number;
   comparison: string | number;
   diff: string | number;
+};
+
+export const formatDiff = (value: number): string => {
+  if (Math.abs(value) >= 1000) {
+    return (value / 1000).toFixed(2) + 'K%';
+  }
+  if (value === 0) {
+    return '0.00%';
+  }
+  return value % 1 === 0 ? `${value}%` : value.toFixed(2) + '%';
 };
 
 export const getDiffTooltipData = (
@@ -148,7 +158,7 @@ export const getDiffTooltipData = (
       label: '% of total',
       baseline: percentageLeft + '%',
       comparison: percentageRight + '%',
-      diff: shortValFormat(diff).text + '%',
+      diff: formatDiff(diff),
     },
     {
       rowId: '2',


### PR DESCRIPTION
fix: (flamegraph): correct diff formatting in flame graph diff tooltip

Large percentage values in the diff tooltip are now properly formatted with a 'K%' suffix (e.g., 8081.25% becomes 8.08K%).  
Also ensures thousand separators and decimal formatting match test expectations.

Related to #105391.