### PR TITLE
Remote Alertmanager: Make timeout configurable in alert senders

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -167,7 +167,7 @@ func NewAlertmanager(ctx context.Context, cfg AlertmanagerConfig, store stateSto
 		return nil, err
 	}
 	s.Run()
-	err = s.ApplyConfig(cfg.OrgID, 0, []sender.ExternalAMcfg{{URL: cfg.URL + "/alertmanager"}})
+	err = s.ApplyConfig(cfg.OrgID, 0, []sender.ExternalAMcfg{{URL: cfg.URL + "/alertmanager", Timeout: cfg.Timeout}})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -46,6 +46,7 @@ type ExternalAlertmanager struct {
 type ExternalAMcfg struct {
 	URL     string
 	Headers http.Header
+	Timeout time.Duration
 }
 
 type Option func(*ExternalAlertmanager)
@@ -229,11 +230,16 @@ func buildNotifierConfig(alertmanagers []ExternalAMcfg) (*config.Config, map[str
 			},
 		}
 
+		timeout := am.Timeout
+		if timeout == 0 {
+			timeout = defaultTimeout
+		}
+
 		amConfig := &config.AlertmanagerConfig{
 			APIVersion:              config.AlertmanagerAPIVersionV2,
 			Scheme:                  u.Scheme,
 			PathPrefix:              u.Path,
-			Timeout:                 model.Duration(defaultTimeout),
+			Timeout:                 model.Duration(timeout),
 			ServiceDiscoveryConfigs: sdConfig,
 		}
 


### PR DESCRIPTION
There's a hard-coded timeout of 10s in the alert senders.
This PR allows callers to pass a `Timeout` field to override this default timeout.