### PR TITLE
Advisor: Fix retry behavior for missing item

### DIFF
--- a/apps/advisor/pkg/app/checks/authchecks/check.go
+++ b/apps/advisor/pkg/app/checks/authchecks/check.go
@@ -2,6 +2,7 @@ package authchecks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
@@ -53,6 +54,9 @@ func (c *check) Items(ctx context.Context) ([]any, error) {
 func (c *check) Item(ctx context.Context, id string) (any, error) {
 	ssoSetting, err := c.ssoSettingsService.GetForProviderWithRedactedSecrets(ctx, id)
 	if err != nil {
+		if errors.Is(err, ssosettings.ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return ssoSetting, nil

--- a/apps/advisor/pkg/app/checks/authchecks/check_test.go
+++ b/apps/advisor/pkg/app/checks/authchecks/check_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests" // Correct import path for the mock
 	"github.com/stretchr/testify/require"
@@ -90,5 +91,15 @@ func TestCheck_Item(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, item)
 		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("should return nil when sso settings are not found", func(t *testing.T) {
+		mockService := ssosettingstests.NewMockService(t)
+		mockService.On("GetForProviderWithRedactedSecrets", ctx, providerID).Return(nil, ssosettings.ErrNotFound)
+
+		c := New(mockService)
+		item, err := c.Item(ctx, providerID)
+		require.NoError(t, err)
+		require.Nil(t, item)
 	})
 }

--- a/apps/advisor/pkg/app/checks/datasourcecheck/check.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check.go
@@ -69,10 +69,18 @@ func (c *check) Item(ctx context.Context, id string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.DatasourceSvc.GetDataSource(ctx, &datasources.GetDataSourceQuery{
+	ds, err := c.DatasourceSvc.GetDataSource(ctx, &datasources.GetDataSourceQuery{
 		UID:   id,
 		OrgID: requester.GetOrgID(),
 	})
+	if err != nil {
+		if errors.Is(err, datasources.ErrDataSourceNotFound) {
+			// The data source does not exist, skip the check
+			return nil, nil
+		}
+		return nil, err
+	}
+	return ds, nil
 }
 
 func (c *check) ID() string {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
@@ -231,6 +231,19 @@ func TestCheck_Run(t *testing.T) {
 	})
 }
 
+func TestCheck_Item(t *testing.T) {
+	t.Run("should return nil when datasource is not found", func(t *testing.T) {
+		mockDatasourceSvc := &MockDatasourceSvc{dss: []*datasources.DataSource{}}
+		check := &check{
+			DatasourceSvc: mockDatasourceSvc,
+		}
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+		item, err := check.Item(ctx, "invalid-uid")
+		assert.NoError(t, err)
+		assert.Nil(t, item)
+	})
+}
+
 type MockDatasourceSvc struct {
 	datasources.DataSourceService
 
@@ -239,6 +252,13 @@ type MockDatasourceSvc struct {
 
 func (m *MockDatasourceSvc) GetAllDataSources(context.Context, *datasources.GetAllDataSourcesQuery) ([]*datasources.DataSource, error) {
 	return m.dss, nil
+}
+
+func (m *MockDatasourceSvc) GetDataSource(context.Context, *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
+	if len(m.dss) == 0 {
+		return nil, datasources.ErrDataSourceNotFound
+	}
+	return m.dss[0], nil
 }
 
 type MockPluginContextProvider struct {

--- a/apps/advisor/pkg/app/checks/plugincheck/check.go
+++ b/apps/advisor/pkg/app/checks/plugincheck/check.go
@@ -57,7 +57,7 @@ func (c *check) Items(ctx context.Context) ([]any, error) {
 func (c *check) Item(ctx context.Context, id string) (any, error) {
 	p, exists := c.PluginStore.Plugin(ctx, id)
 	if !exists {
-		return nil, fmt.Errorf("plugin %s not found", id)
+		return nil, nil
 	}
 	return p, nil
 }

--- a/apps/advisor/pkg/app/checks/plugincheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/plugincheck/check_test.go
@@ -154,6 +154,18 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestCheck_Item(t *testing.T) {
+	t.Run("should return nil when plugin is not found", func(t *testing.T) {
+		pluginStore := &mockPluginStore{plugins: []pluginstore.Plugin{}}
+		check := &check{
+			PluginStore: pluginStore,
+		}
+		item, err := check.Item(context.Background(), "invalid-uid")
+		assert.NoError(t, err)
+		assert.Nil(t, item)
+	})
+}
+
 type mockPluginStore struct {
 	pluginstore.Store
 	plugins []pluginstore.Plugin
@@ -161,6 +173,13 @@ type mockPluginStore struct {
 
 func (m *mockPluginStore) Plugins(ctx context.Context, t ...plugins.Type) []pluginstore.Plugin {
 	return m.plugins
+}
+
+func (m *mockPluginStore) Plugin(ctx context.Context, id string) (pluginstore.Plugin, bool) {
+	if len(m.plugins) == 0 {
+		return pluginstore.Plugin{}, false
+	}
+	return m.plugins[0], true
 }
 
 type mockPluginRepo struct {

--- a/apps/advisor/pkg/app/utils_test.go
+++ b/apps/advisor/pkg/app/utils_test.go
@@ -226,6 +226,38 @@ func TestProcessCheckRetry_RetryError(t *testing.T) {
 	assert.Equal(t, checks.StatusAnnotationError, obj.GetAnnotations()[checks.StatusAnnotation])
 }
 
+func TestProcessCheckRetry_SkipMissingItem(t *testing.T) {
+	obj := &advisorv0alpha1.Check{}
+	obj.SetAnnotations(map[string]string{
+		checks.RetryAnnotation:  "item",
+		checks.StatusAnnotation: checks.StatusAnnotationProcessed,
+	})
+	obj.CheckStatus.Report.Failures = []advisorv0alpha1.CheckReportFailure{
+		{
+			ItemID: "item",
+			StepID: "step",
+		},
+	}
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.SetCreatedBy("user:1")
+	client := &mockClient{}
+	typesClient := &mockTypesClient{}
+	ctx := context.TODO()
+
+	check := &mockCheck{
+		items: []any{nil},
+	}
+
+	err = processCheckRetry(ctx, logging.DefaultLogger, client, typesClient, obj, check)
+	assert.NoError(t, err)
+	assert.Equal(t, checks.StatusAnnotationProcessed, obj.GetAnnotations()[checks.StatusAnnotation])
+	assert.Empty(t, obj.GetAnnotations()[checks.RetryAnnotation])
+	assert.Empty(t, obj.CheckStatus.Report.Failures)
+}
+
 func TestProcessCheckRetry_Success(t *testing.T) {
 	obj := &advisorv0alpha1.Check{}
 	obj.SetAnnotations(map[string]string{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Found a bug with the new functionality that retries a single check. When the item is deleted, and only that element is retried, the backend will still try to obtain the item (datasource, plugin, etc.) but fails because it's no longer available. In that case, we need to just remove the failure from the list.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Found it as part of https://github.com/grafana/grafana-community-team/issues/420

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
