### PR TITLE
Preferences: PATCH when just changing theme

### DIFF
--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -46,10 +46,7 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
 
   // Persist new theme
   const service = new PreferencesService('user');
-  const currentPref = await service.load();
-
-  await service.update({
-    ...currentPref,
+  await service.patch({
     theme: themeId,
   });
 }


### PR DESCRIPTION
Updates the `changeTheme` method to instead use the PATCH method to update just the theme. This avoids the need to load the preferences first in order to replace the whole object.

Tested it works when the user doesn't have any existing preferences 👍 (`DELETE FROM preferences;`)