### PR TITLE
Azure: Fix Application Insights metadata requests

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -40,6 +40,68 @@ func filterTablesWithData(tables []types.MetadataTable) []types.MetadataTable {
 	return filtered
 }
 
+func writeErrorResponse(rw http.ResponseWriter, statusCode int, message string) error {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(statusCode)
+
+	// Set error response to initial error message
+	errorBody := map[string]string{"error": message}
+
+	// Attempt to locate JSON portion in error message
+	re := regexp.MustCompile(`\{.*\}`)
+	jsonPart := re.FindString(message)
+	if jsonPart != "" {
+		var jsonData map[string]interface{}
+		if unmarshalErr := json.Unmarshal([]byte(jsonPart), &jsonData); unmarshalErr != nil {
+			errorBody["error"] = fmt.Sprintf("Invalid JSON format in error message. Raw error: %s", message)
+			backend.Logger.Error("failed to unmarshal JSON error message", "error", unmarshalErr)
+		} else {
+			// Extract relevant fields for a formatted error message
+			errorType, ok := jsonData["error"].(string)
+			if ok {
+				errorDescription, ok := jsonData["error_description"].(string)
+				if !ok {
+					backend.Logger.Error("unable to convert error_description to string", "rawError", jsonData["error_description"])
+					// Attempt to just format the error as a string
+					errorDescription = fmt.Sprintf("%v", jsonData["error_description"])
+				}
+				if errorType == "" {
+					errorType = "UnknownError"
+				}
+
+				errorBody["error"] = fmt.Sprintf("%s: %s", errorType, errorDescription)
+			} else {
+				nestedError, ok := jsonData["error"].(map[string]interface{})
+
+				if !ok {
+					errorBody["error"] = fmt.Sprintf("Invalid JSON format in error message. Raw error: %s", message)
+					backend.Logger.Error("failed to unmarshal JSON error message", "error", unmarshalErr)
+				}
+
+				errorType := nestedError["code"].(string)
+				errorDescription, ok := nestedError["message"].(string)
+				if !ok {
+					backend.Logger.Error("unable to convert error_description to string", "rawError", jsonData["error_description"])
+					// Attempt to just format the error as a string
+					errorDescription = fmt.Sprintf("%v", nestedError["message"])
+				}
+
+				if errorType == "" {
+					errorType = "UnknownError"
+				}
+				errorBody["error"] = fmt.Sprintf("%s: %s", errorType, errorDescription)
+			}
+		}
+	}
+
+	jsonRes, _ := json.Marshal(errorBody)
+	_, err := rw.Write(jsonRes)
+	if err != nil {
+		return fmt.Errorf("unable to write HTTP response: %v", err)
+	}
+	return nil
+}
+
 func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
 	if req.URL.Path == "/usage/basiclogs" {
 		newUrl := &url.URL{
@@ -49,14 +111,21 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 		}
 		return e.GetBasicLogsUsage(req.Context(), newUrl.String(), cli, rw, req.Body)
 	} else if strings.Contains(req.URL.Path, "/metadata") {
+		isAppInsights := strings.Contains(req.URL.Path, "Microsoft.Insights/components")
 		// Add necessary headers
-		req.Header.Set("Prefer", "metadata-format-v4,exclude-resourcetypes,exclude-customfunctions")
+		if isAppInsights {
+			// metadata-format-v4 is not supported for AppInsights resources
+			req.Header.Set("Prefer", "metadata-format-v3,exclude-resourcetypes,exclude-customfunctions")
+		} else {
+			req.Header.Set("Prefer", "metadata-format-v4,exclude-resourcetypes,exclude-customfunctions")
+		}
 		queryParams := req.URL.Query()
 		// Add necessary query params
 		queryParams.Add("select", "categories,solutions,tables,workspaces")
 		req.URL.RawQuery = queryParams.Encode()
 		resp, err := cli.Do(req)
 		if err != nil {
+			writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("failed to fetch metadata: %w", err))
 			return nil, fmt.Errorf("failed to fetch metadata: %w", err)
 		}
 
@@ -69,22 +138,30 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 		encoding := resp.Header.Get("Content-Encoding")
 		body, err := decode(encoding, resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read metadata response: %w", err)
+			writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("failed to read metadata response: %s", err))
 		}
 
 		if resp.StatusCode != http.StatusOK {
+			writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("metadata API error: %s", string(body)))
 			return nil, fmt.Errorf("metadata API error: %s", string(body))
 		}
 
 		var metadata types.AzureLogAnalyticsMetadata
 		err = json.Unmarshal(body, &metadata)
 		if err != nil {
+			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal metadata response: %s", err))
 			return nil, fmt.Errorf("failed to unmarshal metadata response: %w", err)
 		}
-		metadata.Tables = filterTablesWithData(metadata.Tables)
+
+		// AppInsights metadata requests do not return the HasData field
+		// So we return all tables
+		if !isAppInsights {
+			metadata.Tables = filterTablesWithData(metadata.Tables)
+		}
 
 		responseBody, err := json.Marshal(metadata)
 		if err != nil {
+			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("failed to marshal metadata response: %s", err))
 			return nil, fmt.Errorf("failed to marshal metadata response: %w", err)
 		}
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -128,7 +128,6 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 		req.URL.RawQuery = queryParams.Encode()
 		resp, err := cli.Do(req)
 		if err != nil {
-			writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("failed to fetch metadata: %s", err))
 			return nil, writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("failed to fetch metadata: %s", err))
 		}
 


### PR DESCRIPTION
Application Insights schema requests are failing due to the changes made in #99055. The header `Prefer=metadata-format-v4,exclude-resourcetypes,exclude-customfunctions` was added to support retrieving the `hasData` field to identify tables in a workspace with data.

However, Application Insights resources do not support this header, leading to the request failing.

Additionally, the error returned by the API was not correctly parsed, causing misleading alerts to be shown to the user with no actual information in the Grafana logs.

This PR rectifies that by removing the header for metadata requests to Application Insights resources. The `hasData` check is also skipped for Application Insights resources.

Finally, the error parsing logic has been improved to ensure errors are logged and sent to the frontend.