### PR TITLE
ElasticSearch: Fallback parse total hits as int

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -363,7 +363,7 @@ func processHits(dec *json.Decoder, sr *SearchResponse) error {
 					}
 				} else {
 					// Log the error but do not fail the query
-					backend.Logger.Error("failed to decode total hits", "error", err)
+					backend.Logger.Debug("failed to decode total hits", "error", err)
 				}
 			}
 			sr.Hits.Total = total

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -353,14 +353,17 @@ func processHits(dec *json.Decoder, sr *SearchResponse) error {
 			var total *SearchResponseHitsTotal
 			err := dec.Decode(&total)
 			if err != nil {
+				// It's possible that the user is using an older version of Elasticsearch (or one that doesn't return what is expected)
+				// Attempt to parse the total value as an integer in this case
 				totalInt := 0
 				err = dec.Decode(&totalInt)
-				if err != nil {
-					return err
-				}
-
-				total = &SearchResponseHitsTotal{
-					Value: totalInt,
+				if err == nil {
+					total = &SearchResponseHitsTotal{
+						Value: totalInt,
+					}
+				} else {
+					// Log the error but do not fail the query
+					backend.Logger.Error("failed to decode total hits", "error", err)
 				}
 			}
 			sr.Hits.Total = total

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -353,7 +353,15 @@ func processHits(dec *json.Decoder, sr *SearchResponse) error {
 			var total *SearchResponseHitsTotal
 			err := dec.Decode(&total)
 			if err != nil {
-				return err
+				totalInt := 0
+				err = dec.Decode(&totalInt)
+				if err != nil {
+					return err
+				}
+
+				total = &SearchResponseHitsTotal{
+					Value: totalInt,
+				}
 			}
 			sr.Hits.Total = total
 		default:


### PR DESCRIPTION
It's possible that the total hits response may be an `int` rather than the expected object with the properties `value` and `relation`.

In this case, we should attempt to parse the total hits value as an `int`, and if this fails, we should return the error.

If we want to improve this further, we could make this function log the error rather than return it, allowing the logs query to succeed without the required information. I'm open to feedback in the review!

Fixes grafana/data-sources#521.