### PR TITLE
Alerting: Add custom headers support for recording rules custom datasource writer

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -656,6 +656,7 @@ func createRecordingWriter(featureToggles featuremgmt.FeatureToggles, settings s
 		if featureToggles.IsEnabledGlobally(featuremgmt.FlagGrafanaManagedRecordingRulesDatasources) {
 			cfg := writer.DatasourceWriterConfig{
 				Timeout:              settings.Timeout,
+				CustomHeaders:        settings.CustomHeaders,
 				DefaultDatasourceUID: settings.DefaultDatasourceUID,
 			}
 

--- a/pkg/services/ngalert/writer/testing.go
+++ b/pkg/services/ngalert/writer/testing.go
@@ -20,6 +20,7 @@ type TestRemoteWriteTarget struct {
 	mtx             sync.Mutex
 	RequestsCount   int
 	LastRequestBody string
+	LastHeaders     http.Header
 
 	ExpectedPath string
 }
@@ -30,6 +31,7 @@ func NewTestRemoteWriteTarget(t *testing.T) *TestRemoteWriteTarget {
 	target := &TestRemoteWriteTarget{
 		RequestsCount:   0,
 		LastRequestBody: "",
+		LastHeaders:     http.Header{},
 		ExpectedPath:    RemoteWriteEndpoint,
 	}
 
@@ -41,6 +43,7 @@ func NewTestRemoteWriteTarget(t *testing.T) *TestRemoteWriteTarget {
 		target.mtx.Lock()
 		defer target.mtx.Unlock()
 		target.RequestsCount += 1
+		target.LastHeaders = r.Header.Clone()
 		bd, err := io.ReadAll(r.Body)
 		defer func() {
 			_ = r.Body.Close()
@@ -81,4 +84,5 @@ func (s *TestRemoteWriteTarget) Reset() {
 	defer s.mtx.Unlock()
 	s.RequestsCount = 0
 	s.LastRequestBody = ""
+	s.LastHeaders = http.Header{}
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds support for custom HTTP headers to recording rules data source writer. When a recording rule uses a custom data source (currently behind the `grafanaManagedRecordingRulesDatasources` feature flag, but will be the default in the future), it will now use the `recording_rules.custom_headers` configuration option.

**Why do we need this feature?**

Currently, `DatasourceWriter` does not support custom headers, while `PrometheusWriter` (the writer which is used when `grafanaManagedRecordingRulesDatasources` is false and the `url` in `recording_rules` config section is set) does support them.

**Who is this feature for?**

Users of Grafana recording rules.
