### PR TITLE
Dashboards/E2E: Add test validating transparent bg toggle behavior

### DIFF
--- a/e2e/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
@@ -7,7 +7,7 @@ describe('Dashboard', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
-  it('can edit panel title and description', () => {
+  it('can toggle transparent background switch', () => {
     e2e.pages.Dashboards.visit();
     e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1` });
 

--- a/e2e/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
@@ -1,0 +1,27 @@
+import { e2e } from '../utils';
+
+const PAGE_UNDER_TEST = '5SdHCadmz/panel-tests-graph';
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+  });
+
+  it('can edit panel title and description', () => {
+    e2e.pages.Dashboards.visit();
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1` });
+
+    e2e.flows.scenes.toggleEditMode();
+
+    e2e.flows.scenes.selectPanel(/^No Data Points Warning$/);
+
+    e2e.components.Panels.Panel.title('No Data Points Warning').then((el) => {
+      cy.wrap(el.css('background')).should('not.match', /rgba\(0, 0, 0, 0\)/);
+    });
+
+    cy.get('#transparent-background').click({ force: true });
+    e2e.components.Panels.Panel.title('No Data Points Warning').then((el) => {
+      cy.wrap(el.css('background')).should('match', /rgba\(0, 0, 0, 0\)/);
+    });
+  });
+});


### PR DESCRIPTION
Adds an e2e test validating the behavior of the transparent bg toggle panel option.

Part of the e2e epic: https://github.com/grafana/grafana-org/issues/494