### PR TITLE
ds-querier: return 400 when no code is present

### DIFF
--- a/pkg/apis/query/v0alpha1/query.go
+++ b/pkg/apis/query/v0alpha1/query.go
@@ -31,7 +31,7 @@ type QueryDataResponse struct {
 // GetResponseCode return the right status code for the response by checking the responses.
 func GetResponseCode(rsp *backend.QueryDataResponse) int {
 	if rsp == nil {
-		return http.StatusTeapot // rsp is nil, so we return a teapot
+		return http.StatusBadRequest // rsp is nil, so we return a 400
 	}
 	for _, res := range rsp.Responses {
 		if res.Error != nil && res.Status != 0 {
@@ -39,7 +39,7 @@ func GetResponseCode(rsp *backend.QueryDataResponse) int {
 		}
 
 		if res.Error != nil {
-			return http.StatusTeapot // Status is nil but we have an error, so we return a teapot
+			return http.StatusBadRequest // Status is nil but we have an error, so we return a 400
 		}
 	}
 	return http.StatusOK

--- a/pkg/apis/query/v0alpha1/query_test.go
+++ b/pkg/apis/query/v0alpha1/query_test.go
@@ -93,8 +93,8 @@ func TestGetResponseCode(t *testing.T) {
 			},
 		}))
 	})
-	t.Run("return 418 if there is an error in the responses but no status code", func(t *testing.T) {
-		assert.Equal(t, 418, query.GetResponseCode(&backend.QueryDataResponse{
+	t.Run("return 400 if there is an error in the responses but no status code", func(t *testing.T) {
+		assert.Equal(t, 400, query.GetResponseCode(&backend.QueryDataResponse{
 			Responses: map[string]backend.DataResponse{
 				"A": {
 					Error: fmt.Errorf("some wild error"),
@@ -102,8 +102,8 @@ func TestGetResponseCode(t *testing.T) {
 			},
 		}))
 	})
-	t.Run("return 418 if there is a partial error but no status code", func(t *testing.T) {
-		assert.Equal(t, 418, query.GetResponseCode(&backend.QueryDataResponse{
+	t.Run("return 400 if there is a partial error but no status code", func(t *testing.T) {
+		assert.Equal(t, 400, query.GetResponseCode(&backend.QueryDataResponse{
 			Responses: map[string]backend.DataResponse{
 				"A": {
 					Error: nil,


### PR DESCRIPTION
Other systems currently depend on this being a 400, reverting this until we get around to having a better solution.