### PR TITLE
TimeRangePicker: Show local browser time info on hover

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -182,20 +182,19 @@ describe('TimePickerTooltip', () => {
     expect(screen.getByText(/2024-01-01 00:00:00/)).toBeInTheDocument();
     expect(screen.getByText('to')).toBeInTheDocument();
     expect(screen.getByText(/2024-01-02 00:00:00/)).toBeInTheDocument();
-    expect(screen.getByTestId('time-picker-tooltip-timezone')).toHaveTextContent('UTC, GMT');
+    expect(screen.getByText('UTC, GMT')).toBeInTheDocument();
   });
 
   it('renders time range without timezone if timezone is not passed in', () => {
     render(<TimePickerTooltip timeRange={timeRange} />);
-
-    expect(screen.queryByTestId('time-picker-tooltip-timezone')).not.toBeInTheDocument();
+    expect(screen.queryByText('United States, EDT')).not.toBeInTheDocument();
   });
 
   it('renders time range with browser timezone', () => {
     render(<TimePickerTooltip timeRange={timeRange} timeZone="browser" />);
 
     expect(screen.getByText('Local browser time')).toBeInTheDocument();
-    expect(screen.getByTestId('time-picker-tooltip-timezone')).toHaveTextContent('United States, EDT'); // this was mocked at the beginning, in beforeAll block
+    expect(screen.getByText('United States, EDT')).toBeInTheDocument(); // this was mocked at the beginning, in beforeAll block
   });
 
   it('renders time range with specific timezone', () => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -5,7 +5,7 @@ import { dateTime, makeTimeRange, TimeRange } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 
 import { TimeRangeProvider } from './TimeRangeContext';
-import { TimeRangePicker } from './TimeRangePicker';
+import { TimePickerTooltip, TimeRangePicker } from './TimeRangePicker';
 
 const selectors = e2eSelectors.components.TimePicker;
 
@@ -150,4 +150,57 @@ it('does not submit wrapping forms', async () => {
   await Promise.all(clicks);
 
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+describe('TimePickerTooltip', () => {
+  beforeAll(() => {
+    const mockIntl = {
+      resolvedOptions: () => ({
+        timeZone: 'America/New_York',
+      }),
+    };
+
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => mockIntl as Intl.DateTimeFormat);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  const timeRange: TimeRange = {
+    from: dateTime('2024-01-01T00:00:00Z'),
+    to: dateTime('2024-01-02T00:00:00Z'),
+    raw: {
+      from: dateTime('2024-01-01T00:00:00Z'),
+      to: dateTime('2024-01-02T00:00:00Z'),
+    },
+  };
+
+  it('renders time range with UTC timezone', () => {
+    render(<TimePickerTooltip timeRange={timeRange} timeZone="utc" />);
+
+    expect(screen.getByText(/2024-01-01 00:00:00/)).toBeInTheDocument();
+    expect(screen.getByText('to')).toBeInTheDocument();
+    expect(screen.getByText(/2024-01-02 00:00:00/)).toBeInTheDocument();
+    expect(screen.getByTestId('time-picker-tooltip-timezone')).toHaveTextContent('UTC, GMT');
+  });
+
+  it('renders time range without timezone if timezone is not passed in', () => {
+    render(<TimePickerTooltip timeRange={timeRange} />);
+
+    expect(screen.queryByTestId('time-picker-tooltip-timezone')).not.toBeInTheDocument();
+  });
+
+  it('renders time range with browser timezone', () => {
+    render(<TimePickerTooltip timeRange={timeRange} timeZone="browser" />);
+
+    expect(screen.getByText('Local browser time')).toBeInTheDocument();
+    expect(screen.getByTestId('time-picker-tooltip-timezone')).toHaveTextContent('United States, EDT'); // this was mocked at the beginning, in beforeAll block
+  });
+
+  it('renders time range with specific timezone', () => {
+    render(<TimePickerTooltip timeRange={timeRange} timeZone="Africa/Accra" />);
+
+    expect(screen.getByText('Ghana, GMT')).toBeInTheDocument();
+  });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -325,7 +325,7 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       whiteSpace: 'nowrap',
-      columnGap: '4px',
+      columnGap: theme.spacing(0.4),
     }),
     utc: css({
       color: theme.v1.palette.orange,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -325,7 +325,7 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       whiteSpace: 'nowrap',
-      columnGap: theme.spacing(0.4),
+      columnGap: theme.spacing(0.5),
     }),
     utc: css({
       color: theme.v1.palette.orange,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -13,6 +13,7 @@ import {
   TimeRange,
   TimeZone,
   dateMath,
+  getTimeZoneInfo,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
@@ -25,6 +26,7 @@ import { ToolbarButton } from '../ToolbarButton';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 import { TimePickerContent } from './TimeRangePicker/TimePickerContent';
+import { TimeZoneDescription } from './TimeZonePicker/TimeZoneDescription';
 import { WeekStart } from './WeekStartPicker';
 import { quickOptions } from './options';
 import { useTimeSync } from './utils/useTimeSync';
@@ -238,16 +240,23 @@ const ZoomOutTooltip = () => (
 
 export const TimePickerTooltip = ({ timeRange, timeZone }: { timeRange: TimeRange; timeZone?: TimeZone }) => {
   const styles = useStyles2(getLabelStyles);
+  const now = Date.now();
+
+  // Get timezone info only if timeZone is provided
+  const timeZoneInfo = timeZone ? getTimeZoneInfo(timeZone, now) : undefined;
 
   return (
     <>
-      {dateTimeFormat(timeRange.from, { timeZone })}
       <div className="text-center">
-        <Trans i18nKey="time-picker.range-picker.to">to</Trans>
+        {dateTimeFormat(timeRange.from, { timeZone })}
+        <div className="text-center">
+          <Trans i18nKey="time-picker.range-picker.to">to</Trans>
+        </div>
+        {dateTimeFormat(timeRange.to, { timeZone })}
       </div>
-      {dateTimeFormat(timeRange.to, { timeZone })}
-      <div className="text-center">
+      <div className={styles.container}>
         <span className={styles.utc}>{timeZoneFormatUserFriendly(timeZone)}</span>
+        <TimeZoneDescription testId="time-picker-tooltip-timezone" info={timeZoneInfo} />
       </div>
     </>
   );
@@ -316,6 +325,7 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       whiteSpace: 'nowrap',
+      columnGap: '4px',
     }),
     utc: css({
       color: theme.v1.palette.orange,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -256,7 +256,7 @@ export const TimePickerTooltip = ({ timeRange, timeZone }: { timeRange: TimeRang
       </div>
       <div className={styles.container}>
         <span className={styles.utc}>{timeZoneFormatUserFriendly(timeZone)}</span>
-        <TimeZoneDescription testId="time-picker-tooltip-timezone" info={timeZoneInfo} />
+        <TimeZoneDescription info={timeZoneInfo} />
       </div>
     </>
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
@@ -17,11 +17,7 @@ export const TimeZoneDescription = ({ info }: Props) => {
     return null;
   }
 
-  return (
-    <div className={styles.description}>
-      {description}
-    </div>
-  );
+  return <div className={styles.description}>{description}</div>;
 };
 
 const useDescription = (info?: TimeZoneInfo): string => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
@@ -18,7 +18,7 @@ export const TimeZoneDescription = ({ info }: Props) => {
   }
 
   return (
-    <div data-testid="time-picker-tooltip-timezone" className={styles.description}>
+    <div className={styles.description}>
       {description}
     </div>
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
@@ -7,10 +7,9 @@ import { useStyles2 } from '../../../themes';
 
 interface Props {
   info?: TimeZoneInfo;
-  testId?: string;
 }
 
-export const TimeZoneDescription = ({ info, testId }: Props) => {
+export const TimeZoneDescription = ({ info }: Props) => {
   const styles = useStyles2(getStyles);
   const description = useDescription(info);
 
@@ -19,7 +18,7 @@ export const TimeZoneDescription = ({ info, testId }: Props) => {
   }
 
   return (
-    <div data-testid={testId} className={styles.description}>
+    <div data-testid="time-picker-tooltip-timezone" className={styles.description}>
       {description}
     </div>
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneDescription.tsx
@@ -7,9 +7,10 @@ import { useStyles2 } from '../../../themes';
 
 interface Props {
   info?: TimeZoneInfo;
+  testId?: string;
 }
 
-export const TimeZoneDescription = ({ info }: Props) => {
+export const TimeZoneDescription = ({ info, testId }: Props) => {
   const styles = useStyles2(getStyles);
   const description = useDescription(info);
 
@@ -17,7 +18,11 @@ export const TimeZoneDescription = ({ info }: Props) => {
     return null;
   }
 
-  return <div className={styles.description}>{description}</div>;
+  return (
+    <div data-testid={testId} className={styles.description}>
+      {description}
+    </div>
+  );
 };
 
 const useDescription = (info?: TimeZoneInfo): string => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In TimeRangePicker, when hovering over the timezone, a tooltip is shown with a description that matches the currently displayed timezone.  

**Before change:**  
<img width="343" alt="image" src="https://github.com/user-attachments/assets/6751f82a-88cf-422b-a953-5f91353f47fd" />. 

**After change:**  
<img width="579" alt="image" src="https://github.com/user-attachments/assets/7901c881-6602-4395-b69a-76b0eba2df34" />
<img width="593" alt="image" src="https://github.com/user-attachments/assets/e2bcc2cd-46c1-4287-840f-e791f26b2d21" />


**Why do we need this feature?**

To improve UX and reduce confusion, especially when the timezone is set to the browser's timezone by helping users quickly confirm if the displayed timezone is what they expect.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:
Fixes #99072 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
