### PR TITLE
issue case sensititvity search fixed

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -83,6 +83,35 @@ describe('optionsPickerReducer', () => {
         });
     };
 
+    describe('Variable search with special characters', () => {
+      it('should match variable options case-insensitively for ä, ö, å', () => {
+        const options = ['ä', 'Ä', 'ö', 'Ö', 'å', 'Å'].map((v) => ({
+          selected: false,
+          text: v,
+          value: v,
+        }));
+
+        let state = {
+          ...optionsPickerInitialState,
+          queryValue: 'ä',
+          options,
+        };
+
+        let newState = optionsPickerReducer(state, updateOptionsAndFilter(options));
+        expect(newState.options.map(o => o.text)).toContain('ä');
+        expect(newState.options.map(o => o.text)).toContain('Ä');
+
+        state = {
+          ...optionsPickerInitialState,
+          queryValue: 'Ä',
+          options,
+        };
+        newState = optionsPickerReducer(state, updateOptionsAndFilter(options));
+        expect(newState.options.map(o => o.text)).toContain('ä');
+        expect(newState.options.map(o => o.text)).toContain('Ä');
+      });
+    });
+
     describe('When toggleOption with undefined option is dispatched', () => {
       it('should update selected values', () => {
         const { initialState } = getVariableTestContext({

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -255,7 +255,9 @@ const optionsPickerSlice = createSlice({
       if (needle === '') {
         opts = action.payload;
       } else if (REGEXP_NON_ASCII.test(needle)) {
-        opts = action.payload.filter((o) => o.text.includes(needle));
+        opts = action.payload.filter((o) =>
+          String(o.text).toLocaleLowerCase().includes(needle.toLocaleLowerCase())
+        );
       } else {
         // with current API, not seeing a way to cache this on state using action.payload's uniqueness
         // since it's recreated and includes selected state on each item :(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes a bug in variable search dropdowns where searches are case-sensitive for special characters like `ä`, `ö`, `å`. It ensures that search input is matched in a case-insensitive manner.

**Why do we need this feature?**

Currently, users must match the exact case of special characters to find matching variable options. This is unintuitive and breaks expected UX behavior for international users. For example, typing "å" doesn't match "Ångström".

**Who is this feature for?**

This feature benefits all Grafana users who use international character sets in their dashboard variables — especially users from regions using accented characters (e.g., German, Swedish, Finnish, etc.).

**Which issue(s) does this PR fix?**

Fixes #105308

**Special notes for your reviewer:**

Please check that:
- [x] The new filtering logic is case-insensitive.
- [x] Search works as expected with variable values like `Äpple`, `Örn`, and `Ångström` using lowercase input.
- [x] There are no regressions in regular ASCII filtering behavior.

The change uses `.toLocaleLowerCase()` to ensure proper case-insensitive matching across different locales.
