### PR TITLE
Drilldown: Fix js crash when using http

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -60,7 +60,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
     $('.preloader').remove();
 
     // clear any old icon caches
-    const cacheKeys = await window.caches.keys();
+    const cacheKeys = (await window.caches?.keys()) ?? [];
     for (const key of cacheKeys) {
       if (key.startsWith('grafana-icon-cache') && key !== this.iconCacheID) {
         window.caches.delete(key);


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes #105582 

**Special notes for your reviewer:**

- [window.caches](https://developer.mozilla.org/en-US/docs/Web/API/Window/caches) only available in secure context. Added check to prevent access in the first place.
- After more searches, there's [specific flag for this feature](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#feature_detection) but it is easier to just use the `?` checks. Please inform me if using the proper check is necessary