### PR TITLE
Alerting: ignore multiple org ids on prom writerf

### DIFF
--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -101,6 +101,9 @@ const (
 
 	// Best effort error messages
 	PrometheusDuplicateTimestampError = "duplicate sample for timestamp"
+
+	// returned in some cases when multiple org IDs are present in the request
+	ErrMimirTooManyOrgIDs = "multiple org IDs present"
 )
 
 var (
@@ -398,8 +401,13 @@ func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 		return nil, false
 	}
 
-	// All 500-range statuses are automatically unexpected and not the fault of the data.
+	// Most 500-range statuses are automatically unexpected and not the fault of the data.
 	if writeErr.StatusCode()/100 == 5 {
+		// mimir does return some errors as 500s that should maybe not be considered as such?
+		// e.g. `multiple org IDs present`. Handle those separately though to make sure they're treated as exceptions
+		if strings.Contains(writeErr.Error(), ErrMimirTooManyOrgIDs) {
+			return errors.Join(ErrRejectedWrite, writeErr), true
+		}
 		return errors.Join(ErrUnexpectedWriteFailure, writeErr), false
 	}
 

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -103,7 +103,7 @@ const (
 	PrometheusDuplicateTimestampError = "duplicate sample for timestamp"
 
 	// returned in some cases when multiple org IDs are present in the request
-	ErrMimirTooManyOrgIDs = "multiple org IDs present"
+	MimirErrTooManyOrgIDs = "multiple org IDs present"
 )
 
 var (
@@ -405,7 +405,7 @@ func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 	if writeErr.StatusCode()/100 == 5 {
 		// mimir does return some errors as 500s that should maybe not be considered as such?
 		// e.g. `multiple org IDs present`. Handle those separately though to make sure they're treated as exceptions
-		if strings.Contains(writeErr.Error(), ErrMimirTooManyOrgIDs) {
+		if strings.Contains(writeErr.Error(), MimirErrTooManyOrgIDs) {
 			return errors.Join(ErrRejectedWrite, writeErr), true
 		}
 		return errors.Join(ErrUnexpectedWriteFailure, writeErr), false


### PR DESCRIPTION
## Context
- Handling this as a user error since it's configuration-related