### PR TITLE
unistore: split ListIterator and ListHistory in StorageBackend

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -186,11 +186,6 @@ func (r *rowsWrapper) ContinueToken() string {
 	return r.row.token.String()
 }
 
-// ContinueTokenWithCurrentRV implements resource.ListIterator.
-func (r *rowsWrapper) ContinueTokenWithCurrentRV() string {
-	return r.row.token.String()
-}
-
 // Error implements resource.ListIterator.
 func (r *rowsWrapper) Error() error {
 	return r.err

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -229,7 +229,12 @@ func (a *dashboardSqlAccess) ReadResource(ctx context.Context, req *resourcepb.R
 	return rsp
 }
 
-// List implements AppendingStore.
+// ListHistory implements StorageBackend.
+func (a *dashboardSqlAccess) ListHistory(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
+	return a.ListIterator(ctx, req, cb)
+}
+
+// List implements StorageBackend.
 func (a *dashboardSqlAccess) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
 	if req.ResourceVersion != 0 {
 		return 0, apierrors.NewBadRequest("List with explicit resourceVersion is not supported with this storage backend")

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -235,16 +235,16 @@ func isDeletedValue(raw []byte) bool {
 }
 
 func (s *cdkBackend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(ListIterator) error) (int64, error) {
-	if req.Source != resourcepb.ListRequest_STORE {
-		return 0, fmt.Errorf("listing from history not supported in CDK backend")
-	}
-
 	resources, err := buildTree(ctx, s, req.Options.Key)
 	if err != nil {
 		return 0, err
 	}
 	err = cb(resources)
 	return resources.listRV, err
+}
+
+func (s *cdkBackend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, cb func(ListIterator) error) (int64, error) {
+	return 0, fmt.Errorf("listing from history not supported in CDK backend")
 }
 
 func (s *cdkBackend) WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error) {
@@ -333,11 +333,6 @@ func (c *cdkListIterator) Value() []byte {
 
 // ContinueToken implements ListIterator.
 func (c *cdkListIterator) ContinueToken() string {
-	return fmt.Sprintf("index:%d/key:%s", c.index, c.currentKey)
-}
-
-// ContinueTokenWithCurrentRV implements ListIterator.
-func (c *cdkListIterator) ContinueTokenWithCurrentRV() string {
 	return fmt.Sprintf("index:%d/key:%s", c.index, c.currentKey)
 }
 

--- a/pkg/storage/unified/sql/list_iterator.go
+++ b/pkg/storage/unified/sql/list_iterator.go
@@ -8,10 +8,11 @@ import (
 var _ resource.ListIterator = (*listIter)(nil)
 
 type listIter struct {
-	rows    db.Rows
-	offset  int64
-	listRV  int64
-	sortAsc bool
+	rows         db.Rows
+	offset       int64
+	listRV       int64
+	sortAsc      bool
+	useCurrentRV bool
 
 	// any error
 	err error
@@ -29,11 +30,10 @@ type listIter struct {
 
 // ContinueToken implements resource.ListIterator.
 func (l *listIter) ContinueToken() string {
+	if l.useCurrentRV {
+		return resource.ContinueToken{ResourceVersion: l.rv, StartOffset: l.offset, SortAscending: l.sortAsc}.String()
+	}
 	return resource.ContinueToken{ResourceVersion: l.listRV, StartOffset: l.offset, SortAscending: l.sortAsc}.String()
-}
-
-func (l *listIter) ContinueTokenWithCurrentRV() string {
-	return resource.ContinueToken{ResourceVersion: l.rv, StartOffset: l.offset, SortAscending: l.sortAsc}.String()
 }
 
 func (l *listIter) Error() error {

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -219,7 +219,7 @@ func TestListIter(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
-	t.Run("ContinueTokenWithCurrentRV uses current row's RV", func(t *testing.T) {
+	t.Run("ContinueToken uses the current row's RV", func(t *testing.T) {
 		listReq := sqlResourceListRequest{
 			SQLTemplate: sqltemplate.New(dialect),
 			Request:     new(resourcepb.ListRequest),
@@ -229,14 +229,15 @@ func TestListIter(t *testing.T) {
 		require.NoError(t, err)
 
 		iter := &listIter{
-			rows:    rows,
-			listRV:  300,
-			sortAsc: true,
+			rows:         rows,
+			listRV:       300,
+			sortAsc:      true,
+			useCurrentRV: true, // use the current RV for the continue token instead of the listRV
 		}
 
 		require.True(t, iter.Next())
 
-		token := iter.ContinueTokenWithCurrentRV()
+		token := iter.ContinueToken()
 
 		var actual resource.ContinueToken
 		b, err := base64.StdEncoding.DecodeString(token)


### PR DESCRIPTION
Refactor the storage backend to split ListIterator from ListHistory

see https://github.com/grafana/grafana-enterprise/pull/8667
