### PR TITLE
Chore: Make languageProvider strongly typed

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -245,8 +245,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "19"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "20"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "21"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "23"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "22"]
     ],
     "packages/grafana-data/src/types/explore.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -349,7 +349,7 @@ abstract class DataSourceApi<
   /**
    * Used in explore
    */
-  languageProvider?: any;
+  languageProvider?: LanguageProvider;
 
   getVersion?(optionalOptions?: any): Promise<string>;
 

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
@@ -1,9 +1,10 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
 import { useState } from 'react';
 
-import { DataSourceApi, SelectableValue, TimeRange, toOption } from '@grafana/data';
+import { SelectableValue, TimeRange, toOption } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
+import { PrometheusDatasource } from '../../datasource';
 import { promQueryModeller } from '../PromQueryModeller';
 import { getOperationParamId } from '../operationUtils';
 import { QueryBuilderLabelFilter, QueryBuilderOperationParamEditorProps } from '../shared/types';
@@ -47,7 +48,7 @@ export function LabelParamEditor({
 async function loadGroupByLabels(
   timeRange: TimeRange,
   query: PromVisualQuery,
-  datasource: DataSourceApi
+  datasource: PrometheusDatasource
 ): Promise<SelectableValue[]> {
   let labels: QueryBuilderLabelFilter[] = query.labels;
 

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -1,12 +1,13 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
 import { css, cx } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useEffect, useId, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useId, useState } from 'react';
 
-import { DataSourceApi, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { GrafanaTheme2, TimeRange } from '@grafana/data';
 import { Button, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
+import { PrometheusDatasource } from '../../datasource';
 import { getOperationParamId } from '../operationUtils';
 
 import { OperationHeader } from './OperationHeader';
@@ -23,7 +24,7 @@ export interface Props {
   operation: QueryBuilderOperation;
   index: number;
   query: any;
-  datasource: DataSourceApi;
+  datasource: PrometheusDatasource;
   queryModeller: VisualQueryModeller;
   onChange: (index: number, update: QueryBuilderOperation) => void;
   onRemove: (index: number) => void;

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.tsx
@@ -4,15 +4,17 @@ import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import { useState } from 'react';
 import { useMountedState, usePrevious } from 'react-use';
 
-import { DataSourceApi, GrafanaTheme2, TimeRange } from '@grafana/data';
-import { Button, Cascader, CascaderOption, useStyles2, Stack } from '@grafana/ui';
+import { GrafanaTheme2, TimeRange } from '@grafana/data';
+import { Button, Cascader, CascaderOption, Stack, useStyles2 } from '@grafana/ui';
+
+import { PrometheusDatasource } from '../../datasource';
 
 import { OperationEditor } from './OperationEditor';
 import { QueryBuilderOperation, QueryWithOperations, VisualQueryModeller } from './types';
 
 export interface Props<T extends QueryWithOperations> {
   query: T;
-  datasource: DataSourceApi;
+  datasource: PrometheusDatasource;
   onChange: (query: T) => void;
   onRunQuery: () => void;
   queryModeller: VisualQueryModeller;

--- a/packages/grafana-prometheus/src/querybuilder/shared/types.ts
+++ b/packages/grafana-prometheus/src/querybuilder/shared/types.ts
@@ -4,7 +4,9 @@
  */
 import { ComponentType } from 'react';
 
-import { DataSourceApi, RegistryItem, SelectableValue, TimeRange } from '@grafana/data';
+import { RegistryItem, SelectableValue, TimeRange } from '@grafana/data';
+
+import { PrometheusDatasource } from '../../datasource';
 
 export interface QueryBuilderLabelFilter {
   label: string;
@@ -77,7 +79,7 @@ export interface QueryBuilderOperationEditorProps {
   operation: QueryBuilderOperation;
   index: number;
   query: any;
-  datasource: DataSourceApi;
+  datasource: PrometheusDatasource;
   queryModeller: VisualQueryModeller;
   onChange: (index: number, update: QueryBuilderOperation) => void;
   onRemove: (index: number) => void;
@@ -91,7 +93,7 @@ export interface QueryBuilderOperationParamEditorProps {
   operation: QueryBuilderOperation;
   operationId: string;
   query: any;
-  datasource: DataSourceApi;
+  datasource: PrometheusDatasource;
   timeRange: TimeRange;
   onChange: (index: number, value: QueryBuilderOperationParamValue) => void;
   onRunQuery: () => void;


### PR DESCRIPTION
**What is this feature?**

For spotting type issues earlier and easier, we should type the `languageProvider` strongly. 

