### PR TITLE
Chore: Replace usages of golang.org/x/net/context with stdlib context package

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
+	"context"
 	"sort"
 	"strings"
 
-	"golang.org/x/net/context"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/services/authz/rbac/store/store.go
+++ b/pkg/services/authz/rbac/store/store.go
@@ -1,9 +1,8 @@
 package store
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	claims "github.com/grafana/authlib/types"
 

--- a/pkg/services/ngalert/accesscontrol/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol/accesscontrol.go
@@ -1,7 +1,7 @@
 package accesscontrol
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"

--- a/pkg/services/ngalert/accesscontrol/rules.go
+++ b/pkg/services/ngalert/accesscontrol/rules.go
@@ -1,10 +1,9 @@
 package accesscontrol
 
 import (
+	"context"
 	"fmt"
 	"slices"
-
-	"golang.org/x/net/context"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/expr"

--- a/pkg/storage/legacysql/dualwrite/utils.go
+++ b/pkg/storage/legacysql/dualwrite/utils.go
@@ -1,7 +1,8 @@
 package dualwrite
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"


### PR DESCRIPTION
The package is ancient (predated Go 1.7!!)
> Package context defines the Context type, which carries deadlines, cancellation signals, and other request-scoped values across API boundaries and between processes. As of Go 1.7 this package is available in the standard library under the name [context](https://pkg.go.dev/context), and migrating to it can be done automatically with [go fix](https://go.dev/cmd/go#hdr-Update_packages_to_use_new_APIs).

So I am updating its usage by running `go fix` :) 