### PR TITLE
refactor(unified-storage): set the GUID in the resource server

### DIFF
--- a/pkg/storage/unified/resource/event.go
+++ b/pkg/storage/unified/resource/event.go
@@ -12,6 +12,10 @@ type WriteEvent struct {
 	Key        *resourcepb.ResourceKey    // the request key
 	PreviousRV int64                      // only for Update+Delete
 
+	// GUID is optional and might be used when persisting an event.
+	// It is always set by the resource server.
+	GUID string
+
 	// The json payload (without resourceVersion)
 	Value []byte
 

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	claims "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -393,6 +395,7 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *resour
 		Value:  value,
 		Key:    key,
 		Object: obj,
+		GUID:   uuid.New().String(),
 	}
 
 	if oldValue == nil {
@@ -670,6 +673,7 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*re
 		Key:        req.Key,
 		Type:       resourcepb.WatchEvent_DELETED,
 		PreviousRV: latest.ResourceVersion,
+		GUID:       uuid.New().String(),
 	}
 	requester, ok := claims.AuthInfoFrom(ctx)
 	if !ok {

--- a/pkg/storage/unified/sql/bulk.go
+++ b/pkg/storage/unified/sql/bulk.go
@@ -226,7 +226,7 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 					PreviousRV: -1, // Used for WATCH, but we want to skip watch events
 				},
 				Folder:          req.Folder,
-				GUID:            uuid.NewString(),
+				GUID:            uuid.New().String(),
 				ResourceVersion: rv.next(obj),
 			}); err != nil {
 				return rollbackWithError(fmt.Errorf("insert into resource history: %w", err))

--- a/pkg/storage/unified/testing/search_and_storage.go
+++ b/pkg/storage/unified/testing/search_and_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	claims "github.com/grafana/authlib/types"
@@ -87,6 +88,7 @@ func RunTestSearchAndStorage(t *testing.T, ctx context.Context, backend resource
 				Key:    key,
 				Value:  value,
 				Object: meta,
+				GUID:   uuid.New().String(),
 			})
 			require.NoError(t, err)
 			require.Greater(t, rv, int64(0))

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -1106,6 +1106,7 @@ func writeEvent(ctx context.Context, store resource.StorageBackend, name string,
 	return store.WriteEvent(ctx, resource.WriteEvent{
 		Type:  action,
 		Value: options.Value,
+		GUID:  uuid.New().String(),
 		Key: &resourcepb.ResourceKey{
 			Namespace: options.Namespace,
 			Group:     options.Group,


### PR DESCRIPTION
This PR moves the GUID creation one layer up, directly on the event as an optional attribute. By doing this we can use it in the resource server to do all kind of operations based on the global unique ID of the object. 

This is a prerequisite for the separation of meta storage and raw object storage.