### PR TITLE
Home: update setup guide link/title to Getting Started Guide

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -671,10 +671,6 @@ export interface FeatureToggles {
   */
   exploreLogsLimitedTimeRange?: boolean;
   /**
-  * Used in Home for users who want to return to the onboarding flow or quickly find popular config pages
-  */
-  homeSetupGuide?: boolean;
-  /**
   * Enables the gRPC client to authenticate with the App Platform by using ID & access tokens
   */
   appPlatformGrpcClientAuth?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1148,13 +1148,6 @@ var (
 			Owner:        grafanaObservabilityLogsSquad,
 		},
 		{
-			Name:         "homeSetupGuide",
-			Description:  "Used in Home for users who want to return to the onboarding flow or quickly find popular config pages",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: true,
-			Owner:        growthAndOnboarding,
-		},
-		{
 			Name:              "appPlatformGrpcClientAuth",
 			Description:       "Enables the gRPC client to authenticate with the App Platform by using ID & access tokens",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -149,7 +149,6 @@ alertingPrometheusRulesPrimary,experimental,@grafana/alerting-squad,false,false,
 exploreLogsShardSplitting,experimental,@grafana/observability-logs,false,false,true
 exploreLogsAggregatedMetrics,experimental,@grafana/observability-logs,false,false,true
 exploreLogsLimitedTimeRange,experimental,@grafana/observability-logs,false,false,true
-homeSetupGuide,experimental,@grafana/growth-and-onboarding,false,false,true
 appPlatformGrpcClientAuth,experimental,@grafana/identity-access-team,false,false,false
 groupAttributeSync,privatePreview,@grafana/identity-access-team,false,false,false
 alertingQueryAndExpressionsStepMode,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -607,10 +607,6 @@ const (
 	// Used in Logs Drilldown to limit the time range
 	FlagExploreLogsLimitedTimeRange = "exploreLogsLimitedTimeRange"
 
-	// FlagHomeSetupGuide
-	// Used in Home for users who want to return to the onboarding flow or quickly find popular config pages
-	FlagHomeSetupGuide = "homeSetupGuide"
-
 	// FlagAppPlatformGrpcClientAuth
 	// Enables the gRPC client to authenticate with the App Platform by using ID &amp; access tokens
 	FlagAppPlatformGrpcClientAuth = "appPlatformGrpcClientAuth"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1503,7 +1503,8 @@
       "metadata": {
         "name": "homeSetupGuide",
         "resourceVersion": "1743693517832",
-        "creationTimestamp": "2024-09-25T17:20:04Z"
+        "creationTimestamp": "2024-09-25T17:20:04Z",
+        "deletionTimestamp": "2025-05-20T16:08:36Z"
       },
       "spec": {
         "description": "Used in Home for users who want to return to the onboarding flow or quickly find popular config pages",

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -231,7 +231,7 @@ func (s *ServiceImpl) getHomeNode(c *contextmodel.ReqContext, prefs *pref.Prefer
 		// setup guide (a submenu item under Home)
 		children = append(children, &navtree.NavLink{
 			Id:         "home-setup-guide",
-			Text:       "Getting Started Guide",
+			Text:       "Getting started guide",
 			Url:        "/a/grafana-setupguide-app/getting-started",
 			SortWeight: navtree.WeightHome,
 		})

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -226,7 +226,7 @@ func (s *ServiceImpl) getHomeNode(c *contextmodel.ReqContext, prefs *pref.Prefer
 		SortWeight: navtree.WeightHome,
 	}
 	ctx := c.Req.Context()
-	if s.features.IsEnabled(ctx, featuremgmt.FlagHomeSetupGuide) {
+	if _, exists := s.pluginStore.Plugin(ctx, "grafana-setupguide-app"); exists {
 		var children []*navtree.NavLink
 		// setup guide (a submenu item under Home)
 		children = append(children, &navtree.NavLink{

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -231,8 +231,8 @@ func (s *ServiceImpl) getHomeNode(c *contextmodel.ReqContext, prefs *pref.Prefer
 		// setup guide (a submenu item under Home)
 		children = append(children, &navtree.NavLink{
 			Id:         "home-setup-guide",
-			Text:       "Setup guide",
-			Url:        homeUrl + "/setup-guide",
+			Text:       "Getting Started Guide",
+			Url:        "/a/grafana-setupguide-app/getting-started",
 			SortWeight: navtree.WeightHome,
 		})
 		homeNode.Children = children

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -12,7 +12,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'home':
       return t('nav.home.title', 'Home');
     case 'home-setup-guide':
-      return t('nav.setup-guide.title', 'Getting Started Guide');
+      return t('nav.setup-guide.title', 'Getting started guide');
     case 'new':
       return t('nav.new.title', 'New');
     case 'create':

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -12,7 +12,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'home':
       return t('nav.home.title', 'Home');
     case 'home-setup-guide':
-      return t('nav.setup-guide.title', 'Setup guide');
+      return t('nav.setup-guide.title', 'Getting Started Guide');
     case 'new':
       return t('nav.new.title', 'New');
     case 'create':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6861,7 +6861,7 @@
       "title": "Service accounts"
     },
     "setup-guide": {
-      "title": "Getting Started Guide"
+      "title": "Getting started guide"
     },
     "shared-dashboard": {
       "subtitle": "Manage your organization's externally shared dashboards",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6861,7 +6861,7 @@
       "title": "Service accounts"
     },
     "setup-guide": {
-      "title": "Setup guide"
+      "title": "Getting Started Guide"
     },
     "shared-dashboard": {
       "subtitle": "Manage your organization's externally shared dashboards",


### PR DESCRIPTION
**What is this feature?**

This updates the nav to have the correct title for the getting started guide, under home, and the correct link (skipping the redirect that the current link has).

It also updates the check for injecting the nav item to be based on the plugin's presence, rather than a feature toggle.

**Why do we need this feature?**

The setup guide that was part of the home app has been redirected to the newer getting started guide under the setup guide app. 

It seemed odd to have this item gated behind a feature toggle rather than checking whether the plugin is installed that it will be linking to.

**Who is this feature for?**

Cloud.

**Which issue(s) does this PR fix?**:

Resolves https://github.com/grafana/grafana-setupguide-app/issues/219 (🔐)

cc https://github.com/grafana/OGPM/issues/155 (🔐)

cc https://github.com/grafana/hg-cloud-home-admin/pull/935 (🔐)

cc https://github.com/grafana/grafana/pull/92947

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
