### PR TITLE
[release-11.6.2] Transformations: Include other counts as numbers when assessing field types

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -132,7 +132,7 @@ export enum ReducerID {
 }
 
 export function getFieldTypeForReducer(id: ReducerID, fallback: FieldType): FieldType {
-  return id === ReducerID.count
+  return id === ReducerID.count || id === ReducerID.distinctCount || id === ReducerID.changeCount
     ? FieldType.number
     : id === ReducerID.allIsNull || id === ReducerID.allIsZero
       ? FieldType.boolean


### PR DESCRIPTION
Backport 2bbd5faf6da8dbc33320fd8e375a2f041a8b6a46 from #102109

---

Follow up to https://github.com/grafana/grafana/pull/101753

Distinct counts and change counts should also always be numbers. 

I am going to follow up this ticket with some tests around this.
