### PR TITLE
ds-querier: small renames

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -254,7 +254,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 		return &backend.QueryDataResponse{}, nil
 	}
 
-	client, err := b.client.GetDataSourceClient(
+	client, err := b.clientSupplier.GetDataSourceClient(
 		ctx,
 		v0alpha1.DataSourceRef{
 			Type: req.PluginId,

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestQueryRestConnectHandler(t *testing.T) {
 	b := &QueryAPIBuilder{
-		client: mockClient{
+		clientSupplier: mockClient{
 			lastCalledWithHeaders: &map[string]string{},
 		},
 		tracer: tracing.InitializeTracerForTest(),
@@ -80,7 +80,7 @@ func TestQueryRestConnectHandler(t *testing.T) {
 		"X-Rule-Type":              "type-1",
 		"X-Rule-Version":           "version-1",
 		"X-Grafana-Org-Id":         "1",
-	}, *b.client.(mockClient).lastCalledWithHeaders)
+	}, *b.clientSupplier.(mockClient).lastCalledWithHeaders)
 }
 
 func TestInstantQueryFromAlerting(t *testing.T) {

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -43,17 +43,17 @@ type QueryAPIBuilder struct {
 
 	authorizer authorizer.Authorizer
 
-	tracer     tracing.Tracer
-	metrics    *metrics.ExprMetrics
-	parser     *queryParser
-	client     clientapi.DataSourceClientSupplier
-	registry   query.DataSourceApiServerRegistry
-	converter  *expr.ResultConverter
-	queryTypes *query.QueryTypeDefinitionList
+	tracer         tracing.Tracer
+	metrics        *metrics.ExprMetrics
+	parser         *queryParser
+	clientSupplier clientapi.DataSourceClientSupplier
+	registry       query.DataSourceApiServerRegistry
+	converter      *expr.ResultConverter
+	queryTypes     *query.QueryTypeDefinitionList
 }
 
 func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
-	client clientapi.DataSourceClientSupplier,
+	clientSupplier clientapi.DataSourceClientSupplier,
 	ar authorizer.Authorizer,
 	registry query.DataSourceApiServerRegistry,
 	legacy service.LegacyDataSourceLookup,
@@ -80,7 +80,7 @@ func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
 	return &QueryAPIBuilder{
 		concurrentQueryLimit: 4,
 		log:                  log.New("query_apiserver"),
-		client:               client,
+		clientSupplier:       clientSupplier,
 		authorizer:           ar,
 		registry:             registry,
 		parser:               newQueryParser(reader, legacy, tracer, log.New("query_parser")),


### PR DESCRIPTION
Just trying to change some names around to make it easier to follow/differentiate when we're using a client vs when we're using a supplier for a client. Noticed while working on some other things