### PR TITLE
Azure: Fix resource name determination in template variable queries

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
@@ -37,11 +37,11 @@ jest.mock('@grafana/runtime', () => ({
 const getResourceGroups = jest.fn().mockResolvedValue([{ resourceGroupURI: 'rg', resourceGroupName: 'rg', count: 1 }]);
 const getResourceNames = jest.fn().mockResolvedValue([
   {
-    id: 'foobarID',
+    id: '/subscriptions/subID/resourceGroups/resourceGroup/providers/foobarProvider/foobarType/foobar',
     name: 'foobar',
     subscriptionId: 'subID',
     resourceGroup: 'resourceGroup',
-    type: 'foobarType',
+    type: 'foobarProvider/foobarType',
     location: 'london',
   },
 ]);

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -15,6 +15,7 @@ import { AzureMonitorOption, AzureMonitorQuery, AzureQueryType } from '../../typ
 import useLastError from '../../utils/useLastError';
 import ArgQueryEditor from '../ArgQueryEditor';
 import LogsQueryEditor from '../LogsQueryEditor';
+import { parseResourceURI } from '../ResourcePicker/utils';
 
 import GrafanaTemplateVariableFnInput from './GrafanaTemplateVariableFn';
 
@@ -182,7 +183,12 @@ const VariableEditor = (props: Props) => {
   useEffect(() => {
     if (subscription && resourceGroup && namespace) {
       datasource.getResourceNames(subscription, resourceGroup, namespace).then((resources) => {
-        setResources(resources.map((s) => ({ label: s.name, value: s.name })));
+        setResources(
+          resources.map((s) => {
+            const parsedResource = parseResourceURI(s.id);
+            return { label: s.name, value: parsedResource.resourceName };
+          })
+        );
       });
     }
   }, [datasource, subscription, resourceGroup, namespace]);

--- a/public/app/plugins/datasource/azuremonitor/variables.ts
+++ b/public/app/plugins/datasource/azuremonitor/variables.ts
@@ -11,6 +11,7 @@ import {
 import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import UrlBuilder from './azure_monitor/url_builder';
+import { parseResourceURI } from './components/ResourcePicker/utils';
 import VariableEditor from './components/VariableEditor/VariableEditor';
 import DataSource from './datasource';
 import { migrateQuery } from './grafanaTemplateVariableFns';
@@ -29,7 +30,7 @@ export function parseResourceNamesAsTemplateVariable(resources: RawAzureResource
 
     return {
       text: r.name,
-      value: r.name,
+      value: parseResourceURI(r.id).resourceName,
     };
   });
 }


### PR DESCRIPTION
Resource names should be determined from the ID to ensure we correctly determine the resource name. Some resources can be a sub-resource and in these cases the parent resource should be included in the resource name. Examples of this would be SQL server databases which are sub-resources of SQL servers.

Fixes an issue introduced in #101695.  
Fixes #104071.