### PR TITLE
[release-12.0.1] [DOC] Make notes consistent in Git Sync docs

### DIFF
--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -15,7 +15,7 @@ weight: 200
 
 # Set up file provisioning
 
-{{< admonition type="note" >}}
+{{< admonition type="caution" >}}
 Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet.
 
 Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -15,7 +15,7 @@ weight: 100
 
 # Set up Git Sync
 
-{{< admonition type="note" >}}
+{{< admonition type="caution" >}}
 Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet.
 
 Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -15,7 +15,7 @@ weight: 300
 
 # Work with provisioned dashboards
 
-{{< admonition type="note" >}}
+{{< admonition type="caution" >}}
 Git Sync and File path provisioning an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana. These features aren't available publicly in Grafana Cloud yet.
 
 Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -18,6 +18,13 @@ weight: 400
 
 # Manage provisioned repositories with Git Sync
 
+{{< admonition type="caution" >}}
+Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet.
+
+Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+
+{{< /admonition >}}
+
 After you have set up Git Sync, you can synchronize dashboards and changes to existing dashboards to your configured GitHub repository.
 If you push a change in the repository, those changes are mirrored in your Grafana instance.
 


### PR DESCRIPTION
Backport d0d941fe8d8d5ebe20896affba3d39de58f63bdf from #105695

---

Fixes inconsistent admonitions that warn customers that Git Sync is experimental.

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
