### PR TITLE
AuthZ-Service: Add traces to cache

### DIFF
--- a/pkg/services/authz/rbac/cache.go
+++ b/pkg/services/authz/rbac/cache.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/grafana/authlib/cache"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 func userIdentifierCacheKey(namespace, userUID string) string {
@@ -50,20 +52,24 @@ type cacheWrap[T any] interface {
 type cacheWrapImpl[T any] struct {
 	cache  cache.Cache
 	logger log.Logger
+	tracer tracing.Tracer
 	ttl    time.Duration
 }
 
 // cacheWrap is a wrapper around the authlib Cache that provides typed Get and Set methods
 // it handles encoding/decoding for a specific type.
-func newCacheWrap[T any](cache cache.Cache, logger log.Logger, ttl time.Duration) cacheWrap[T] {
+func newCacheWrap[T any](cache cache.Cache, logger log.Logger, tracer tracing.Tracer, ttl time.Duration) cacheWrap[T] {
 	if ttl == 0 {
 		logger.Info("cache ttl is 0, using noop cache")
 		return &noopCache[T]{}
 	}
-	return &cacheWrapImpl[T]{cache: cache, logger: logger, ttl: ttl}
+	return &cacheWrapImpl[T]{cache: cache, logger: logger, tracer: tracer, ttl: ttl}
 }
 
 func (c *cacheWrapImpl[T]) Get(ctx context.Context, key string) (T, bool) {
+	ctx, span := c.tracer.Start(ctx, "cacheWrap.Get")
+	defer span.End()
+	span.SetAttributes(attribute.Bool("hit", false))
 	logger := c.logger.FromContext(ctx)
 
 	var value T
@@ -81,10 +87,13 @@ func (c *cacheWrapImpl[T]) Get(ctx context.Context, key string) (T, bool) {
 		return value, false
 	}
 
+	span.SetAttributes(attribute.Bool("hit", true))
 	return value, true
 }
 
 func (c *cacheWrapImpl[T]) Set(ctx context.Context, key string, value T) {
+	ctx, span := c.tracer.Start(ctx, "cacheWrap.Set")
+	defer span.End()
 	logger := c.logger.FromContext(ctx)
 
 	data, err := json.Marshal(value)

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -94,12 +94,12 @@ func NewService(
 		tracer:          tracer,
 		metrics:         newMetrics(reg),
 		mapper:          newMapper(),
-		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, longCacheTTL),
-		permCache:       newCacheWrap[map[string]bool](cache, logger, settings.CacheTTL),
-		permDenialCache: newCacheWrap[bool](cache, logger, settings.CacheTTL),
-		teamCache:       newCacheWrap[[]int64](cache, logger, settings.CacheTTL),
-		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, settings.CacheTTL),
-		folderCache:     newCacheWrap[folderTree](cache, logger, settings.CacheTTL),
+		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
+		permCache:       newCacheWrap[map[string]bool](cache, logger, tracer, settings.CacheTTL),
+		permDenialCache: newCacheWrap[bool](cache, logger, tracer, settings.CacheTTL),
+		teamCache:       newCacheWrap[[]int64](cache, logger, tracer, settings.CacheTTL),
+		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, settings.CacheTTL),
+		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, settings.CacheTTL),
 		sf:              new(singleflight.Group),
 	}
 }

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -1516,17 +1516,18 @@ func setupService() *Service {
 	cache := cache.NewLocalCache(cache.Config{Expiry: 5 * time.Minute, CleanupInterval: 5 * time.Minute})
 	logger := log.New("authz-rbac-service")
 	fStore := &fakeStore{}
+	tracer := tracing.NewNoopTracerService()
 	return &Service{
 		logger:          logger,
 		mapper:          newMapper(),
-		tracer:          tracing.NewNoopTracerService(),
+		tracer:          tracer,
 		metrics:         newMetrics(nil),
-		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, longCacheTTL),
-		permCache:       newCacheWrap[map[string]bool](cache, logger, shortCacheTTL),
-		permDenialCache: newCacheWrap[bool](cache, logger, shortCacheTTL),
-		teamCache:       newCacheWrap[[]int64](cache, logger, shortCacheTTL),
-		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, longCacheTTL),
-		folderCache:     newCacheWrap[folderTree](cache, logger, shortCacheTTL),
+		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
+		permCache:       newCacheWrap[map[string]bool](cache, logger, tracer, shortCacheTTL),
+		permDenialCache: newCacheWrap[bool](cache, logger, tracer, shortCacheTTL),
+		teamCache:       newCacheWrap[[]int64](cache, logger, tracer, shortCacheTTL),
+		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, longCacheTTL),
+		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, shortCacheTTL),
 		settings:        Settings{AnonOrgRole: "Viewer"},
 		store:           fStore,
 		permissionStore: fStore,


### PR DESCRIPTION
This PR adds traces to the cache wrapper so we can see wether the cache was hit or not and how long it took.