### PR TITLE
Prometheus: Fix visual query builder parsing of binary expressions in function calls

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -427,7 +427,6 @@ function handleBinary(expr: string, node: SyntaxNode, context: InternalContext) 
     }
 
     visQuery.operations.splice(idx, 0, makeBinOp(opDef, expr, right, !!binModifier?.isBool));
-    // visQuery.operations.push(makeBinOp(opDef, expr, right, !!binModifier?.isBool));
   } else if (rightBinary) {
     // Due to the way binary ops are parsed we can get a binary operation on the right that starts with a number which
     // is a factor for a current binary operation. So we have to add it as an operation now.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes visual query builder for Prometheus grammar on page reload/query duplication/changing value in a visual builder block

**Why do we need this feature?**

Some queries generated from visual builder break on page reload, because they are considered ambiguous. Also it breaks on duplication and changing value in visual block. 
Example of such query: 
`count_values("countGroups", count_values by(group) ("countReplicated", Foo{} == 0) == 8)`
It is clearly structured and ordered, but is considered ambiguous.

**Who is this feature for?**

Prometheus users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I added a test and fixed others that were considered ambiguous. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
