### PR TITLE
Chore: New backport workflow using workflow_call

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -15,5 +15,4 @@ on:
 jobs:
   trigger:
     if: github.repository == 'grafana/grafana'
-    runs-on: ubuntu-latest
     uses: .github/workflows/backport-workflow.yml

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   trigger:
     if: github.repository == 'grafana/grafana'
-    uses: .github/workflows/backport-workflow.yml
+    uses: ./.github/workflows/backport-workflow.yml

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -1,0 +1,19 @@
+name: Backport PR Creator (trigger)
+
+# This workflow runs on the pull request and then triggers the actual backport
+# workflow using workflow_call. This is necessary because:
+# - Github has issues pushing commits from older branches with the GITHUB_TOKEN (see support ticket #3398520)
+#   so we need to use the grafana-delivery-bot token to push the commits
+# - But secrets are not available in pull_request / pull_request_target, hence the workflow_call
+
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  trigger:
+    if: github.repository == 'grafana/grafana'
+    runs-on: ubuntu-latest
+    uses: .github/workflows/backport-workflow.yml

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -1,0 +1,48 @@
+name: Backport PR Creator (workflow)
+
+# This workflow actually runs the backporter after being triggered by the
+# backport-trigger workflow.
+
+on:
+  workflow_call:
+
+jobs:
+  backport:
+    if: github.repository == 'grafana/grafana'
+    runs-on: ubuntu-latest
+    steps:
+      # Github has timeout issues with pushing up old branches with the automatic GITHUB_TOKEN,
+      # so we need a credential with both commit and workflow permissions to successfully push
+      - name: Get vault secrets
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - name: Checkout Grafana
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 2
+          fetch-tags: false
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true # Explicitly persist credentials to allow git push later on
+
+      - name: Configure git user
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local --add --bool push.autoSetupRemote true
+
+      - name: Run backport
+        uses: grafana/grafana-github-actions-go/backport@main
+        with:
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This PR attempts to fix the backport action by using the grafana-delivery-bot token to do the push. To get access to it, we need to split the workflow into a second triggered via `workflow_call`.