### PR TITLE
CI: Select all packages in sharded tests

### DIFF
--- a/scripts/ci/backend-tests/pkgs-with-tests-named.sh
+++ b/scripts/ci/backend-tests/pkgs-with-tests-named.sh
@@ -44,7 +44,7 @@ done
 shift $((OPTIND - 1))
 
 if [[ ${#dirs[@]} -eq 0 ]]; then
-    dirs+=("./...")
+    readarray -t dirs <<< "$(find . -type f -name 'go.mod' -exec dirname '{}' ';' | awk '{ print $1 "/..."; }')"
 fi
 if [ -z "$beginningWith" ]; then
     for pkg in "${dirs[@]}"; do

--- a/scripts/ci/backend-tests/shard.sh
+++ b/scripts/ci/backend-tests/shard.sh
@@ -100,7 +100,7 @@ if [[ $n -gt $m ]]; then
     exit 1
 fi
 if [[ ${#dirs[@]} -eq 0 ]]; then
-    dirs+=("./...")
+    readarray -t dirs <<< "$(find . -type f -name 'go.mod' -exec dirname '{}' ';' | awk '{ print $1 "/..."; }')"
 fi
 # If dirs is just ("-"), read from stdin instead.
 if [[ ${#dirs[@]} -eq 1 && "${dirs[0]}" == "-" ]]; then


### PR DESCRIPTION
Previously, we did not include all packages, rather only packages managed by the root `go.mod` file. What we want, however, is to have _all_ packages included, including apps, unified storage, etc., all of which use their own submodules.

Example after this change:

```
$ ./scripts/ci/backend-tests/shard.sh -N1/4 | grep advisor
/home/mariell/work/grafana/apps/advisor/pkg/app
/home/mariell/work/grafana/apps/advisor/pkg/app/checks/datasourcecheck
```