### PR TITLE
Actions: Update backport action to commit using grafana-delivery-bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,30 +1,50 @@
 name: Backport PR Creator
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
+  # TODO: This workflow won't work for forks because no secrets are available.
+  # This should, at the least, post the comment with manual backport instructions.
   main:
     if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Clone
-        run: git clone --depth=1 "https://github.com/grafana/grafana.git"
-      - run: cd grafana && git config --local user.name "github-actions[bot]"
-      - run: cd grafana && git config --local user.email "github-actions[bot]@users.noreply.github.com"
-      - run: cd grafana && git config --local --add --bool push.autoSetupRemote true
-      - name: Set remote URL
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cd grafana && git remote set-url origin "https://grafana-delivery-bot:$GIT_TOKEN@github.com/grafana/grafana.git"
+      - name: Get vault secrets
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - name: Checkout Grafana
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 2
+          fetch-tags: false
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true
+
+      - name: Configure git user
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local --add --bool push.autoSetupRemote true
+
       - name: Run backport
         uses: grafana/grafana-github-actions-go/backport@main
         with:
-          path: grafana
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Alternate to https://github.com/grafana/grafana/pull/105724, this PR (hopefully) fixes the backport action by using the grafana-delivery-bot to do the commit to work around Github server-side issues with pushing using the automatic GITHUB_TOKEN secret.

Note that this won't work from community PRs from forks because they don't have access to secrets. If i can confirm that this action works for just internal PRs, I'll work on at least adding the manual backport instructions, and then a longer term solution for community PRs.