### PR TITLE
SecureValues: Update decrypter format to get rid of actor_ prefix

### DIFF
--- a/public/app/features/secrets-management/constants.ts
+++ b/public/app/features/secrets-management/constants.ts
@@ -1,12 +1,12 @@
 import { Entries } from './types';
 
 // @see https://github.com/grafana/grafana-enterprise/blob/secret-service/feature-branch/src/pkg/extensions/secret/decrypt/allow_list.go
-export const DECRYPT_ALLOW_LIST = ['actor_k6', 'actor_synthetic-monitoring'] as const;
+export const DECRYPT_ALLOW_LIST = ['k6', 'synthetic-monitoring'] as const;
 export type AllowedDecrypter = (typeof DECRYPT_ALLOW_LIST)[number];
 
 export const DECRYPT_ALLOW_LIST_LABEL_MAP: Record<AllowedDecrypter, string> = {
-  actor_k6: 'k6',
-  'actor_synthetic-monitoring': 'Synthetic Monitoring',
+  k6: 'k6',
+  'synthetic-monitoring': 'Synthetic Monitoring',
 };
 
 export const DECRYPT_ALLOW_LIST_OPTIONS = (


### PR DESCRIPTION
We've updated the list to support without `actor_` prefix :)