### PR TITLE
New Logs Panel: follow up improvements and fixes

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1179,6 +1179,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                   onPermalinkClick={onPermalinkClick}
                   onPinLine={onPinToContentOutlineClick}
                   onUnpinLine={onPinToContentOutlineClick}
+                  permalinkedRowId={panelState?.logs?.id}
                   pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
                   pinnedLogs={pinnedLogs}
                   showControls

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1179,7 +1179,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                   onPermalinkClick={onPermalinkClick}
                   onPinLine={onPinToContentOutlineClick}
                   onUnpinLine={onPinToContentOutlineClick}
-                  permalinkedRowId={panelState?.logs?.id}
+                  permalinkedLogId={panelState?.logs?.id}
                   pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
                   pinnedLogs={pinnedLogs}
                   showControls

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1063,7 +1063,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                   onOpenContext={onOpenContext}
                   onPermalinkClick={onPermalinkClick}
                   permalinkedRowId={panelState?.logs?.id}
-                  scrollIntoView={scrollIntoView}
                   isFilterLabelActive={props.isFilterLabelActive}
                   onClickFilterString={props.onClickFilterString}
                   onClickFilterOutString={props.onClickFilterOutString}

--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react';
+import { useEffect, useMemo, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
 
 import {
   AbsoluteTimeRange,
@@ -135,6 +135,22 @@ const LogRowsComponent = forwardRef<HTMLDivElement | null, LogRowsComponentProps
       return config.featureToggles.logsInfiniteScrolling ? styles.scrollableLogRows : styles.logRows;
     }, [ref]);
 
+    const scrollIntoView = useCallback(
+      (element: HTMLElement) => {
+        if (rest.scrollIntoView) {
+          rest.scrollIntoView(element);
+          return;
+        }
+        if (scrollElementRef.current) {
+          scrollElementRef.current.scroll({
+            behavior: 'smooth',
+            top: scrollElementRef.current.scrollTop + element.getBoundingClientRect().top - window.innerHeight / 2,
+          });
+        }
+      },
+      [rest]
+    );
+
     return (
       <div className={styles.logRowsContainer}>
         <LogListControls eventBus={eventBus} />
@@ -158,6 +174,7 @@ const LogRowsComponent = forwardRef<HTMLDivElement | null, LogRowsComponentProps
               logsSortOrder={sortOrder}
               scrollElement={scrollElementRef.current}
               prettifyLogMessage={Boolean(prettifyJSON)}
+              scrollIntoView={scrollIntoView}
               showLabels={Boolean(showUniqueLabels)}
               showTime={showTime}
               wrapLogMessage={wrapLogMessage}

--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -96,7 +96,17 @@ export const ControlledLogRows = forwardRef<HTMLDivElement | null, ControlledLog
 ControlledLogRows.displayName = 'ControlledLogRows';
 
 const LogRowsComponent = forwardRef<HTMLDivElement | null, LogRowsComponentProps>(
-  ({ loading, loadMoreLogs, deduplicatedRows = [], range, ...rest }: LogRowsComponentProps, ref) => {
+  (
+    {
+      loading,
+      loadMoreLogs,
+      deduplicatedRows = [],
+      range,
+      scrollIntoView: scrollIntoViewProp,
+      ...rest
+    }: LogRowsComponentProps,
+    ref
+  ) => {
     const {
       app,
       dedupStrategy,
@@ -137,8 +147,8 @@ const LogRowsComponent = forwardRef<HTMLDivElement | null, LogRowsComponentProps
 
     const scrollIntoView = useCallback(
       (element: HTMLElement) => {
-        if (rest.scrollIntoView) {
-          rest.scrollIntoView(element);
+        if (scrollIntoViewProp) {
+          scrollIntoViewProp(element);
           return;
         }
         if (scrollElementRef.current) {
@@ -148,7 +158,7 @@ const LogRowsComponent = forwardRef<HTMLDivElement | null, LogRowsComponentProps
           });
         }
       },
-      [rest]
+      [scrollIntoViewProp]
     );
 
     return (

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -10,7 +10,7 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogMessageAnsi } from '../LogMessageAnsi';
 
 import { LogLineMenu } from './LogLineMenu';
-import { useLogIsPinned, useLogListContext } from './LogListContext';
+import { useLogIsPermalinked, useLogIsPinned, useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 import {
   FIELD_GAP_MULTIPLIER,
@@ -51,6 +51,7 @@ export const LogLine = ({
   );
   const logLineRef = useRef<HTMLDivElement | null>(null);
   const pinned = useLogIsPinned(log);
+  const permalinked = useLogIsPermalinked(log);
 
   useEffect(() => {
     if (!onOverflow || !logLineRef.current) {
@@ -92,7 +93,7 @@ export const LogLine = ({
   return (
     <div style={style}>
       <div
-        className={`${styles.logLine} ${variant ?? ''} ${pinned ? styles.pinnedLogLine : ''} ${detailsShown ? styles.detailsDisplayed : ''}`}
+        className={`${styles.logLine} ${variant ?? ''} ${pinned ? styles.pinnedLogLine : ''} ${permalinked ? styles.permalinkedLogLine : ''} ${detailsShown ? styles.detailsDisplayed : ''}`}
         ref={onOverflow ? logLineRef : undefined}
         onMouseEnter={handleMouseOver}
         onFocus={handleMouseOver}
@@ -314,6 +315,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
       background: `hsla(0, 0%, 0%, 0.2)`,
     }),
     pinnedLogLine: css({
+      backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
+    }),
+    permalinkedLogLine: css({
       backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
     }),
     menuIcon: css({

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -263,7 +263,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.fontSize,
       wordBreak: 'break-all',
       '&:hover': {
-        background: `hsla(0, 0%, 0%, 0.2)`,
+        background: theme.isDark ? `hsla(0, 0%, 0%, 0.3)` : `hsla(0, 0%, 0%, 0.1)`,
       },
       '&.infinite-scroll': {
         '&::before': {
@@ -312,7 +312,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     detailsDisplayed: css({
-      background: `hsla(0, 0%, 0%, 0.2)`,
+      background: theme.isDark ? `hsla(0, 0%, 0%, 0.5)` : `hsla(0, 0%, 0%, 0.1)`,
     }),
     pinnedLogLine: css({
       backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useTranslate } from '@grafana/i18n';
-import { IconButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { getDragStyles, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { LogDetails } from '../LogDetails';
@@ -40,6 +40,7 @@ export const LogLineDetails = ({ containerElement, getFieldLinks, logs, onResize
   const getRows = useCallback(() => logs, [logs]);
   const logRowsStyles = getLogRowStyles(useTheme2());
   const styles = useStyles2(getStyles);
+  const dragStyles = useStyles2(getDragStyles);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslate();
 
@@ -51,7 +52,13 @@ export const LogLineDetails = ({ containerElement, getFieldLinks, logs, onResize
   }, [onResize, setDetailsWidth]);
 
   return (
-    <Resizable onResize={handleResize} defaultSize={{ width: detailsWidth, height: containerElement.clientHeight }}>
+    <Resizable
+      onResize={handleResize}
+      handleClasses={{ left: dragStyles.dragHandleBaseVertical }}
+      defaultSize={{ width: detailsWidth, height: containerElement.clientHeight }}
+      enable={{ left: true }}
+      minWidth={40}
+    >
       <div className={styles.container} ref={containerRef}>
         <IconButton
           name="times"

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -87,4 +87,24 @@ describe('LogList', () => {
     expect(screen.queryByText('Fields')).not.toBeInTheDocument();
     expect(screen.queryByText('Close log details')).not.toBeInTheDocument();
   });
+
+  test('Allows people to select text without opening log details', async () => {
+    const spy = jest.spyOn(document, 'getSelection');
+    spy.mockReturnValue({
+      toString: () => 'selected log line',
+      removeAllRanges: () => {},
+      addRange: (range: Range) => {},
+    } as Selection);
+
+    render(<LogList {...defaultProps} enableLogDetails={true} />);
+
+    await userEvent.click(screen.getByText('log message 1'));
+
+    expect(screen.queryByText('name_of_the_label')).not.toBeInTheDocument();
+    expect(screen.queryByText('value of the label')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fields')).not.toBeInTheDocument();
+    expect(screen.queryByText('Close log details')).not.toBeInTheDocument();
+
+    spy.mockRestore();
+  });
 });

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -7,7 +7,7 @@ import { createLogRow } from '../__mocks__/logRow';
 
 import { LogList, Props } from './LogList';
 
-describe.each([false, true])('LogList with scroll = %s', (noScroll: boolean) => {
+describe('LogList', () => {
   let logs: LogRowModel[], defaultProps: Props;
   beforeEach(() => {
     logs = [
@@ -21,7 +21,6 @@ describe.each([false, true])('LogList with scroll = %s', (noScroll: boolean) => 
       displayedFields: [],
       enableLogDetails: false,
       logs,
-      noScroll,
       showControls: false,
       showTime: false,
       sortOrder: LogsSortOrder.Descending,

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -7,7 +7,7 @@ import { createLogRow } from '../__mocks__/logRow';
 
 import { LogList, Props } from './LogList';
 
-describe('LogList', () => {
+describe.each([false, true])('LogList with scroll = %s', (noScroll: boolean) => {
   let logs: LogRowModel[], defaultProps: Props;
   beforeEach(() => {
     logs = [
@@ -21,6 +21,7 @@ describe('LogList', () => {
       displayedFields: [],
       enableLogDetails: false,
       logs,
+      noScroll,
       showControls: false,
       showTime: false,
       sortOrder: LogsSortOrder.Descending,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -70,6 +70,7 @@ export interface Props {
   onPinLine?: (row: LogRowModel) => void;
   onOpenContext?: (row: LogRowModel, onClose: () => void) => void;
   onUnpinLine?: (row: LogRowModel) => void;
+  permalinkedRowId?: string;
   pinLineButtonTooltipTitle?: PopoverContent;
   pinnedLogs?: string[];
   showControls: boolean;
@@ -89,6 +90,7 @@ type LogListComponentProps = Omit<
   | 'dedupStrategy'
   | 'displayedFields'
   | 'enableLogDetails'
+  | 'permalinkedRowId'
   | 'showTime'
   | 'sortOrder'
   | 'syntaxHighlighting'
@@ -127,6 +129,7 @@ export const LogList = ({
   onPinLine,
   onOpenContext,
   onUnpinLine,
+  permalinkedRowId,
   pinLineButtonTooltipTitle,
   pinnedLogs,
   showControls,
@@ -163,6 +166,7 @@ export const LogList = ({
       onPinLine={onPinLine}
       onOpenContext={onOpenContext}
       onUnpinLine={onUnpinLine}
+      permalinkedRowId={permalinkedRowId}
       pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
       pinnedLogs={pinnedLogs}
       showControls={showControls}
@@ -209,6 +213,7 @@ const LogListComponent = ({
     dedupStrategy,
     filterLevels,
     forceEscape,
+    permalinkedRowId,
     showDetails,
     showTime,
     sortOrder,
@@ -296,8 +301,15 @@ const LogListComponent = ({
   );
 
   const handleScrollPosition = useCallback(() => {
-    listRef.current?.scrollToItem(initialScrollPosition === 'top' ? 0 : logs.length - 1);
-  }, [initialScrollPosition, logs.length]);
+    if (permalinkedRowId) {
+      const index = processedLogs.findIndex((log) => log.uid === permalinkedRowId);
+      if (index >= 0) {
+        listRef.current?.scrollToItem(index, 'start');
+        return;
+      }
+    }
+    listRef.current?.scrollToItem(initialScrollPosition === 'top' ? 0 : processedLogs.length - 1);
+  }, [initialScrollPosition, permalinkedRowId, processedLogs]);
 
   if (!containerElement || listHeight == null) {
     // Wait for container to be rendered

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -18,11 +18,11 @@ import {
   store,
   TimeRange,
 } from '@grafana/data';
-import { PopoverContent, useStyles2, useTheme2 } from '@grafana/ui';
+import { PopoverContent, useTheme2 } from '@grafana/ui';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { InfiniteScroll } from './InfiniteScroll';
-import { getGridTemplateColumns, LogLine, getStyles as getLogLineStyles } from './LogLine';
+import { getGridTemplateColumns } from './LogLine';
 import { LogLineDetails } from './LogLineDetails';
 import { GetRowContextQueryFn } from './LogLineMenu';
 import { LogListContextProvider, LogListState, useLogListContext } from './LogListContext';
@@ -57,7 +57,6 @@ export interface Props {
   logs: LogRowModel[];
   logsMeta?: LogsMetaItem[];
   logSupportsContext?: (row: LogRowModel) => boolean;
-  noScroll?: boolean;
   onClickFilterLabel?: (key: string, value: string, frame?: DataFrame) => void;
   onClickFilterOutLabel?: (key: string, value: string, frame?: DataFrame) => void;
   onClickFilterString?: (value: string, refId?: string) => void;
@@ -116,7 +115,6 @@ export const LogList = ({
   logs,
   logsMeta,
   logSupportsContext,
-  noScroll,
   onClickFilterLabel,
   onClickFilterOutLabel,
   onClickFilterString,
@@ -184,7 +182,6 @@ export const LogList = ({
         loading={loading}
         loadMore={loadMore}
         logs={logs}
-        noScroll={noScroll}
         showControls={showControls}
         timeRange={timeRange}
         timeZone={timeZone}
@@ -202,7 +199,6 @@ const LogListComponent = ({
   loading,
   loadMore,
   logs,
-  noScroll,
   showControls,
   timeRange,
   timeZone,
@@ -346,46 +342,42 @@ const LogListComponent = ({
   return (
     <div className={styles.logListContainer}>
       <div className={styles.logListWrapper} ref={wrapperRef}>
-        {!noScroll ? (
-          <InfiniteScroll
-            displayedFields={displayedFields}
-            handleOverflow={handleOverflow}
-            logs={filteredLogs}
-            loadMore={loadMore}
-            onClick={handleLogLineClick}
-            scrollElement={scrollRef.current}
-            showTime={showTime}
-            sortOrder={sortOrder}
-            timeRange={timeRange}
-            timeZone={timeZone}
-            setInitialScrollPosition={handleScrollPosition}
-            wrapLogMessage={wrapLogMessage}
-          >
-            {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
-              <VariableSizeList
-                className={styles.logList}
-                height={listHeight}
-                itemCount={itemCount}
-                itemSize={getLogLineSize.bind(null, filteredLogs, widthContainer, displayedFields, {
-                  showDuplicates: dedupStrategy !== LogsDedupStrategy.none,
-                  showTime,
-                  wrap: wrapLogMessage,
-                })}
-                itemKey={getItemKey}
-                layout="vertical"
-                onItemsRendered={onItemsRendered}
-                outerRef={scrollRef}
-                ref={listRef}
-                style={{ overflowY: 'scroll' }}
-                width="100%"
-              >
-                {Renderer}
-              </VariableSizeList>
-            )}
-          </InfiniteScroll>
-        ) : (
-          <LogListNoScroll logs={filteredLogs} onClick={handleLogLineClick} />
-        )}
+        <InfiniteScroll
+          displayedFields={displayedFields}
+          handleOverflow={handleOverflow}
+          logs={filteredLogs}
+          loadMore={loadMore}
+          onClick={handleLogLineClick}
+          scrollElement={scrollRef.current}
+          showTime={showTime}
+          sortOrder={sortOrder}
+          timeRange={timeRange}
+          timeZone={timeZone}
+          setInitialScrollPosition={handleScrollPosition}
+          wrapLogMessage={wrapLogMessage}
+        >
+          {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
+            <VariableSizeList
+              className={styles.logList}
+              height={listHeight}
+              itemCount={itemCount}
+              itemSize={getLogLineSize.bind(null, filteredLogs, widthContainer, displayedFields, {
+                showDuplicates: dedupStrategy !== LogsDedupStrategy.none,
+                showTime,
+                wrap: wrapLogMessage,
+              })}
+              itemKey={getItemKey}
+              layout="vertical"
+              onItemsRendered={onItemsRendered}
+              outerRef={scrollRef}
+              ref={listRef}
+              style={{ overflowY: 'scroll' }}
+              width="100%"
+            >
+              {Renderer}
+            </VariableSizeList>
+          )}
+        </InfiniteScroll>
       </div>
       {showDetails.length > 0 && (
         <LogLineDetails
@@ -397,33 +389,6 @@ const LogListComponent = ({
       )}
       {showControls && <LogListControls eventBus={eventBus} />}
     </div>
-  );
-};
-
-interface LogListNoScrollProps {
-  logs: LogListModel[];
-  onClick: (log: LogListModel) => void;
-}
-
-const LogListNoScroll = ({ logs, onClick }: LogListNoScrollProps) => {
-  const { displayedFields, showTime, wrapLogMessage } = useLogListContext();
-  const styles = useStyles2(getLogLineStyles);
-  return (
-    <>
-      {logs.map((log, index) => (
-        <LogLine
-          displayedFields={displayedFields}
-          index={index}
-          key={log.uid}
-          log={log}
-          showTime={showTime}
-          style={{}}
-          styles={styles}
-          onClick={onClick}
-          wrapLogMessage={wrapLogMessage}
-        />
-      ))}
-    </>
   );
 };
 

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -69,7 +69,7 @@ export interface Props {
   onPinLine?: (row: LogRowModel) => void;
   onOpenContext?: (row: LogRowModel, onClose: () => void) => void;
   onUnpinLine?: (row: LogRowModel) => void;
-  permalinkedRowId?: string;
+  permalinkedLogId?: string;
   pinLineButtonTooltipTitle?: PopoverContent;
   pinnedLogs?: string[];
   showControls: boolean;
@@ -89,7 +89,7 @@ type LogListComponentProps = Omit<
   | 'dedupStrategy'
   | 'displayedFields'
   | 'enableLogDetails'
-  | 'permalinkedRowId'
+  | 'permalinkedLogId'
   | 'showTime'
   | 'sortOrder'
   | 'syntaxHighlighting'
@@ -127,7 +127,7 @@ export const LogList = ({
   onPinLine,
   onOpenContext,
   onUnpinLine,
-  permalinkedRowId,
+  permalinkedLogId,
   pinLineButtonTooltipTitle,
   pinnedLogs,
   showControls,
@@ -164,7 +164,7 @@ export const LogList = ({
       onPinLine={onPinLine}
       onOpenContext={onOpenContext}
       onUnpinLine={onUnpinLine}
-      permalinkedRowId={permalinkedRowId}
+      permalinkedLogId={permalinkedLogId}
       pinLineButtonTooltipTitle={pinLineButtonTooltipTitle}
       pinnedLogs={pinnedLogs}
       showControls={showControls}
@@ -209,7 +209,7 @@ const LogListComponent = ({
     dedupStrategy,
     filterLevels,
     forceEscape,
-    permalinkedRowId,
+    permalinkedLogId,
     showDetails,
     showTime,
     sortOrder,
@@ -303,15 +303,15 @@ const LogListComponent = ({
   );
 
   const handleScrollPosition = useCallback(() => {
-    if (permalinkedRowId) {
-      const index = processedLogs.findIndex((log) => log.uid === permalinkedRowId);
+    if (permalinkedLogId) {
+      const index = processedLogs.findIndex((log) => log.uid === permalinkedLogId);
       if (index >= 0) {
         listRef.current?.scrollToItem(index, 'start');
         return;
       }
     }
     listRef.current?.scrollToItem(initialScrollPosition === 'top' ? 0 : processedLogs.length - 1);
-  }, [initialScrollPosition, permalinkedRowId, processedLogs]);
+  }, [initialScrollPosition, permalinkedLogId, processedLogs]);
 
   if (!containerElement || listHeight == null) {
     // Wait for container to be rendered

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -222,7 +222,9 @@ const LogListComponent = ({
   } = useLogListContext();
   const [processedLogs, setProcessedLogs] = useState<LogListModel[]>([]);
   const [listHeight, setListHeight] = useState(
-    app === CoreApp.Explore ? window.innerHeight * 0.75 : containerElement.clientHeight
+    app === CoreApp.Explore
+      ? Math.max(window.innerHeight * 0.8, containerElement.clientHeight)
+      : containerElement.clientHeight
   );
   const theme = useTheme2();
   const listRef = useRef<VariableSizeList | null>(null);
@@ -271,7 +273,11 @@ const LogListComponent = ({
 
   useEffect(() => {
     const handleResize = debounce(() => {
-      setListHeight(app === CoreApp.Explore ? window.innerHeight * 0.75 : containerElement.clientHeight);
+      setListHeight(
+        app === CoreApp.Explore
+          ? Math.max(window.innerHeight * 0.8, containerElement.clientHeight)
+          : containerElement.clientHeight
+      );
     }, 50);
     window.addEventListener('resize', handleResize);
     handleResize();

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -324,6 +324,10 @@ const LogListComponent = ({
 
   const handleLogLineClick = useCallback(
     (log: LogListModel) => {
+      // Let people select text
+      if (document.getSelection()?.toString()) {
+        return;
+      }
       toggleDetails(log);
     },
     [toggleDetails]

--- a/public/app/features/logs/components/panel/LogListContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.test.tsx
@@ -3,13 +3,20 @@ import { ReactNode } from 'react';
 
 import { createLogLine } from '../__mocks__/logRow';
 
-import { useLogListContextData, useLogListContext, useLogIsPinned, LogListContext } from './LogListContext';
+import {
+  useLogListContextData,
+  useLogListContext,
+  useLogIsPinned,
+  LogListContext,
+  useLogIsPermalinked,
+} from './LogListContext';
 import { defaultValue } from './__mocks__/LogListContext';
 
-const log = createLogLine({ rowId: 'yep' });
+const log = createLogLine({ rowId: 'yep', uid: 'uid' });
 const value = {
   ...defaultValue,
   pinnedLogs: ['yep'],
+  permalinkedLogId: log.uid,
 };
 const wrapper = ({ children }: { children: ReactNode }) => (
   <LogListContext.Provider value={value}>{children}</LogListContext.Provider>
@@ -33,9 +40,22 @@ test('Allows to tell if a log is pinned', () => {
   expect(result.current).toBe(true);
 });
 
-test('Allows to tell if a log is pinned', () => {
+test('Allows to tell if a log is not pinned', () => {
   const otherLog = createLogLine({ rowId: 'nope' });
   const { result } = renderHook(() => useLogIsPinned(otherLog), { wrapper });
+
+  expect(result.current).toBe(false);
+});
+
+test('Allows to tell if a log is permalinked', () => {
+  const { result } = renderHook(() => useLogIsPermalinked(log), { wrapper });
+
+  expect(result.current).toBe(true);
+});
+
+test('Allows to tell if a log is not permalinked', () => {
+  const otherLog = createLogLine({ rowId: 'nope' });
+  const { result } = renderHook(() => useLogIsPermalinked(otherLog), { wrapper });
 
   expect(result.current).toBe(false);
 });

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -97,8 +97,8 @@ export const useLogIsPinned = (log: LogListModel) => {
 };
 
 export const useLogIsPermalinked = (log: LogListModel) => {
-  const { permalinkedRowId } = useContext(LogListContext);
-  return permalinkedRowId && permalinkedRowId === log.uid;
+  const { permalinkedLogId } = useContext(LogListContext);
+  return permalinkedLogId && permalinkedLogId === log.uid;
 };
 
 export type LogListState = Pick<
@@ -144,7 +144,7 @@ export interface Props {
   onPinLine?: (row: LogRowModel) => void;
   onOpenContext?: (row: LogRowModel, onClose: () => void) => void;
   onUnpinLine?: (row: LogRowModel) => void;
-  permalinkedRowId?: string;
+  permalinkedLogId?: string;
   pinLineButtonTooltipTitle?: PopoverContent;
   pinnedLogs?: string[];
   prettifyJSON?: boolean;
@@ -184,7 +184,7 @@ export const LogListContextProvider = ({
   onPinLine,
   onOpenContext,
   onUnpinLine,
-  permalinkedRowId,
+  permalinkedLogId,
   pinLineButtonTooltipTitle,
   pinnedLogs,
   prettifyJSON,
@@ -436,7 +436,7 @@ export const LogListContextProvider = ({
         onPinLine,
         onOpenContext,
         onUnpinLine,
-        permalinkedRowId,
+        permalinkedLogId,
         pinLineButtonTooltipTitle,
         pinnedLogs: logListState.pinnedLogs,
         prettifyJSON: logListState.prettifyJSON,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -91,9 +91,14 @@ export const useLogListContext = (): LogListContextData => {
   return useContext(LogListContext);
 };
 
-export const useLogIsPinned = (log: LogRowModel) => {
+export const useLogIsPinned = (log: LogListModel) => {
   const { pinnedLogs } = useContext(LogListContext);
   return pinnedLogs?.some((logId) => logId === log.rowId);
+};
+
+export const useLogIsPermalinked = (log: LogListModel) => {
+  const { permalinkedRowId } = useContext(LogListContext);
+  return permalinkedRowId && permalinkedRowId === log.uid;
 };
 
 export type LogListState = Pick<
@@ -139,6 +144,7 @@ export interface Props {
   onPinLine?: (row: LogRowModel) => void;
   onOpenContext?: (row: LogRowModel, onClose: () => void) => void;
   onUnpinLine?: (row: LogRowModel) => void;
+  permalinkedRowId?: string;
   pinLineButtonTooltipTitle?: PopoverContent;
   pinnedLogs?: string[];
   prettifyJSON?: boolean;
@@ -178,6 +184,7 @@ export const LogListContextProvider = ({
   onPinLine,
   onOpenContext,
   onUnpinLine,
+  permalinkedRowId,
   pinLineButtonTooltipTitle,
   pinnedLogs,
   prettifyJSON,
@@ -217,9 +224,6 @@ export const LogListContextProvider = ({
       syntaxHighlighting,
       wrapLogMessage,
     };
-    if (!shallowCompare(logListState.pinnedLogs ?? [], pinnedLogs ?? [])) {
-      newState.pinnedLogs = pinnedLogs;
-    }
     if (!shallowCompare(logListState, newState)) {
       setLogListState(newState);
     }
@@ -249,6 +253,12 @@ export const LogListContextProvider = ({
       setLogListState({ ...logListState, hasUnescapedContent });
     }
   }, [hasUnescapedContent, logListState]);
+
+  useEffect(() => {
+    if (!shallowCompare(logListState.pinnedLogs ?? [], pinnedLogs ?? [])) {
+      setLogListState({ ...logListState, pinnedLogs });
+    }
+  }, [logListState, pinnedLogs]);
 
   const detailsDisplayed = useCallback(
     (log: LogListModel) => !!showDetails.find((shownLog) => shownLog.uid === log.uid),
@@ -426,6 +436,7 @@ export const LogListContextProvider = ({
         onPinLine,
         onOpenContext,
         onUnpinLine,
+        permalinkedRowId,
         pinLineButtonTooltipTitle,
         pinnedLogs: logListState.pinnedLogs,
         prettifyJSON: logListState.prettifyJSON,

--- a/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext } from 'react';
 
-import { CoreApp, LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { CoreApp, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 
 import { LogListContextData, Props } from '../LogListContext';
+import { LogListModel } from '../processing';
 
 export const LogListContext = createContext<LogListContextData>({
   app: CoreApp.Unknown,
@@ -44,9 +45,14 @@ export const useLogListContext = (): LogListContextData => {
   return useContext(LogListContext);
 };
 
-export const useLogIsPinned = (log: LogRowModel) => {
+export const useLogIsPinned = (log: LogListModel) => {
   const { pinnedLogs } = useContext(LogListContext);
   return pinnedLogs?.some((logId) => logId === log.rowId);
+};
+
+export const useLogIsPermalinked = (log: LogListModel) => {
+  const { permalinkedRowId } = useContext(LogListContext);
+  return permalinkedRowId && permalinkedRowId === log.uid;
 };
 
 export const defaultValue: LogListContextData = {
@@ -114,6 +120,7 @@ export const LogListContextProvider = ({
   onPinLine = jest.fn(),
   onOpenContext = jest.fn(),
   onUnpinLine = jest.fn(),
+  permalinkedRowId,
   pinnedLogs = [],
   showTime = true,
   sortOrder = LogsSortOrder.Descending,
@@ -137,6 +144,7 @@ export const LogListContextProvider = ({
         onPinLine,
         onOpenContext,
         onUnpinLine,
+        permalinkedRowId,
         pinnedLogs,
         setDedupStrategy: jest.fn(),
         setFilterLevels: jest.fn(),

--- a/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
@@ -51,8 +51,8 @@ export const useLogIsPinned = (log: LogListModel) => {
 };
 
 export const useLogIsPermalinked = (log: LogListModel) => {
-  const { permalinkedRowId } = useContext(LogListContext);
-  return permalinkedRowId && permalinkedRowId === log.uid;
+  const { permalinkedLogId } = useContext(LogListContext);
+  return permalinkedLogId && permalinkedLogId === log.uid;
 };
 
 export const defaultValue: LogListContextData = {
@@ -120,7 +120,7 @@ export const LogListContextProvider = ({
   onPinLine = jest.fn(),
   onOpenContext = jest.fn(),
   onUnpinLine = jest.fn(),
-  permalinkedRowId,
+  permalinkedLogId,
   pinnedLogs = [],
   showTime = true,
   sortOrder = LogsSortOrder.Descending,
@@ -144,7 +144,7 @@ export const LogListContextProvider = ({
         onPinLine,
         onOpenContext,
         onUnpinLine,
-        permalinkedRowId,
+        permalinkedLogId,
         pinnedLogs,
         setDedupStrategy: jest.fn(),
         setFilterLevels: jest.fn(),


### PR DESCRIPTION
- Added missing scroll to permalinked log
- Added a resize handle to Log Details
- Fixed: let people select text. If text is selected in the document, Log Details are not toggled.
- Improved height update when resizing the browser with Log Details open

Additional fix: I realized that the "scrollIntoView" in Explore for ControlledLogRows was not working, as ControlledLogRows internally contains the scrollable element, so the callback passed from Explore had no effect. It doesn't affect dashboards or apps.

Part of #99075