### PR TITLE
fix(unified-storage): race in resource server watch

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -937,7 +937,10 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		// items.
 		listReq := &resourcepb.ListRequest{
 			Options: req.Options,
-			Limit:   1,
+			// This has right now no effect, as the list request only uses the limit if it lists from history or trash.
+			// It might be worth adding it in a subsequent PR. We only list once during setup of the watch, so it's
+			// fine for now.
+			Limit: 1,
 		}
 
 		rv, err := s.backend.ListIterator(ctx, listReq, func(ListIterator) error { return nil })

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -918,15 +918,45 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	}
 	defer s.broadcaster.Unsubscribe(stream)
 
+	// Determine a safe starting resource-version for the watch.
+	// When the client requests SendInitialEvents we will use the resource-version
+	// of the last object returned from the initial list (handled below).
+	// When the client supplies an explicit `since` we honour that.
+	// In the remaining case (SendInitialEvents == false && since == 0) we need
+	// a high-water-mark representing the current state of storage so that we
+	// donʼt replay events that happened before the watch was established. Using
+	// `mostRecentRV` – which is updated asynchronously by the broadcaster – is
+	// subject to races because the broadcaster may not yet have observed the
+	// latest committed writes. Instead we ask the backend directly for the
+	// current resource-version.
+	var mostRecentRV int64
 	if !req.SendInitialEvents && req.Since == 0 {
-		// This is a temporary hack only relevant for tests to ensure that the first events are sent.
-		// This is required because the SQL backend polls the database every 100ms.
-		// TODO: Implement a getLatestResourceVersion method in the backend.
-		time.Sleep(10 * time.Millisecond)
+		// We only need the current RV. A cheap way to obtain it is to issue a
+		// List with a very small limit and read the listRV returned by the
+		// iterator. The callback is a no-op so we avoid materialising any
+		// items.
+		listReq := &resourcepb.ListRequest{
+			Options: req.Options,
+			Limit:   1,
+		}
+
+		rv, err := s.backend.ListIterator(ctx, listReq, func(ListIterator) error { return nil })
+		if err != nil {
+			// Fallback to the broadcasterʼs view if the backend lookup fails.
+			// This preserves previous behaviour while still eliminating the
+			// common race in the majority of cases.
+			s.log.Warn("watch: failed to fetch current RV from backend, falling back to broadcaster", "err", err)
+			mostRecentRV = s.mostRecentRV.Load()
+		} else {
+			mostRecentRV = rv
+		}
+	} else {
+		// For all other code-paths we either already have an explicit RV or we
+		// will derive it from the initial list below.
+		mostRecentRV = s.mostRecentRV.Load()
 	}
 
-	mostRecentRV := s.mostRecentRV.Load() // get the latest resource version
-	var initialEventsRV int64             // resource version coming from the initial events
+	var initialEventsRV int64 // resource version coming from the initial events
 	if req.SendInitialEvents {
 		// Backfill the stream by adding every existing entities.
 		initialEventsRV, err = s.backend.ListIterator(ctx, &resourcepb.ListRequest{Options: req.Options}, func(iter ListIterator) error {


### PR DESCRIPTION
I examined the flakiness in the `TestEtcdWatchSemantics` suite and identified a race in how the watch start-RV is picked when `SendInitialEvents` is `false` and the caller supplies no explicit `resourceVersion`.

Previously we used `mostRecentRV` (which trails the real storage RV until the broadcaster processes the last write), then slept for 10 ms as a workaround. If the watcher was created in the narrow window before the broadcaster had caught up, events that happened prior to the watch were (incorrectly) replayed, producing the failure [we saw](https://github.com/grafana/grafana-enterprise/actions/runs/15169659151/job/42656319898?pr=8661).

Fix implemented:
- Removed the brittle time.Sleep hack.
- When `SendInitialEvents == false && since == 0` we now ask the backend directly for the current RV via calling once ListIterator.
- Fall back to the broadcaster’s RV only if that backend lookup fails, preserving prior behaviour in unusual error cases.
Updated comments for clarity; added a warning log when we must fall back.

This guarantees we always start the watch at the real storage high-water-mark, eliminating the race that surfaced as unexpected `ADDED` events and order reversals.