### PR TITLE
Drone: Dagger needs to use go run

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4342,7 +4342,7 @@ steps:
     | tar zx -C /bin
   - apk add docker
   - export GITHUB_TOKEN=$(cat /github-app/token)
-  - dagger run --silent ./pkg/build/cmd artifacts -a $${ARTIFACTS} --grafana-ref=$${GRAFANA_REF}
+  - dagger run --silent go run ./pkg/build/cmd artifacts -a $${ARTIFACTS} --grafana-ref=$${GRAFANA_REF}
     --enterprise-ref=$${ENTERPRISE_REF} --grafana-repo=$${GRAFANA_REPO} --version=$${VERSION}
   depends_on:
   - github-app-generate-token
@@ -5205,6 +5205,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 16b16fc72db02c6f5bd322703f1d7f13c2d1ac38f6efb324590ba14512aadce3
+hmac: 1da5c9da34dc5dbffef8bef4ef84282997cb2363f929fdf4b897d2ee87a33703
 
 ...

--- a/scripts/drone/rgm.star
+++ b/scripts/drone/rgm.star
@@ -346,7 +346,7 @@ def rgm_promotion_pipeline():
         "pull": "always",
         "commands": with_dagger_install([
             "export GITHUB_TOKEN=$(cat /github-app/token)",
-            "dagger run --silent ./pkg/build/cmd artifacts " +
+            "dagger run --silent go run ./pkg/build/cmd artifacts " +
             "-a $${ARTIFACTS} " +
             "--grafana-ref=$${GRAFANA_REF} " +
             "--enterprise-ref=$${ENTERPRISE_REF} " +


### PR DESCRIPTION
This is currently failing:

```
+ dagger run --silent ./pkg/build/cmd artifacts -a ${ARTIFACTS} --grafana-ref=${GRAFANA_REF} --enterprise-ref=${ENTERPRISE_REF} --grafana-repo=${GRAFANA_REPO} --version=${VERSION}
Error: fork/exec ./pkg/build/cmd: permission denied
```

The problem is that the path is a directory to Go source code. We should run it via `go run`.