### PR TITLE
Fix flexbox bug with tooltip when maxWidth is set manually.

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
@@ -56,9 +56,11 @@ export const VizTooltipColorIndicator = ({
 const getStyles = (theme: GrafanaTheme2) => ({
   leading: css({
     marginRight: theme.spacing(0.5),
+    flex: 'none',
   }),
   trailing: css({
     marginLeft: theme.spacing(0.5),
+    flex: 'none',
   }),
   value: css({
     width: '12px',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -129,7 +129,7 @@ export const VizTooltipRow = ({
   return (
     <div className={styles.contentWrapper}>
       {(color || label) && (
-        <div className={styles.valueWrapper}>
+        <div className={styles.labelWrapper}>
           {color && colorPlacement === ColorPlacement.first && (
             <VizTooltipColorIndicator color={color} colorIndicator={colorIndicator} lineStyle={lineStyle} />
           )}
@@ -221,6 +221,12 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
     overflow: 'hidden',
     marginRight: theme.spacing(2),
   }),
+  labelWrapper: css({
+    display: 'flex',
+    alignItems: 'center',
+    flex: '2',
+    minWidth: 0,
+  }),
   value: css({
     fontWeight: 500,
     textOverflow: 'ellipsis',
@@ -229,6 +235,7 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
   valueWrapper: css({
     display: 'flex',
     alignItems: 'center',
+    flex: '1',
   }),
   activeSeries: css({
     fontWeight: theme.typography.fontWeightBold,


### PR DESCRIPTION
fix for #105517

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

User reported an issue when setting the tooltip max width. 

Appears to have been caused by flexbox bugs.

**Why do we need this feature?**

See screenshots in the attached bug

**Who is this feature for?**

Anyone setting tooltip widths

**Which issue(s) does this PR fix?**:

#105517

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
