### PR TITLE
Chore: update triage project for Elasticsearch

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -160,7 +160,7 @@
     "name": "datasource/Elasticsearch",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/97"
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {


### PR DESCRIPTION
This updates the label -> project automation to send ElasticSearch issues to the correct project.