### PR TITLE
Scopes: Add wrapping to selected scopes in command palette

### DIFF
--- a/public/app/features/commandPalette/ScopesRow.tsx
+++ b/public/app/features/commandPalette/ScopesRow.tsx
@@ -26,19 +26,21 @@ export function ScopesRow({ treeScopes, isDirty, apply, toggleNode }: Props) {
         <span className={styles.scopesText}>
           <Trans i18nKey={'command-palette.scopes.selected-scopes-label'}>Scopes: </Trans>
         </span>
-        {treeScopes?.map((scope) => {
-          return (
-            <FilterPill
-              key={scope.scopeName}
-              selected={true}
-              icon={'times'}
-              label={scope.title}
-              onClick={() => {
-                toggleNode(scope);
-              }}
-            />
-          );
-        })}
+        <Stack wrap={'wrap'}>
+          {treeScopes?.map((scope) => {
+            return (
+              <FilterPill
+                key={scope.scopeName}
+                selected={true}
+                icon={'times'}
+                label={scope.title}
+                onClick={() => {
+                  toggleNode(scope);
+                }}
+              />
+            );
+          })}
+        </Stack>
       </Stack>
       {isDirty && (
         <Button


### PR DESCRIPTION
Adds wrapping to selected scopes row so if lots of scopes are selected they don't overflow the container.

Before
<img width="572" alt="Screenshot 2025-05-22 at 14 37 47" src="https://github.com/user-attachments/assets/7c1a4bee-0770-4906-8401-db80b26bd5f0" />

After
<img width="577" alt="Screenshot 2025-05-22 at 14 33 39" src="https://github.com/user-attachments/assets/b4ecf0c6-f99d-4cc7-9664-91ac7ae0d696" />
