### PR TITLE
Extensions: Add direct dependencies used by Enterprise build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -193,7 +193,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1 // @grafana/grafana-backend-group
 	gopkg.in/yaml.v2 v2.4.0 // @grafana/alerting-backend
 	gopkg.in/yaml.v3 v3.0.1 // @grafana/alerting-backend
-	k8s.io/api v0.32.3 // indirect; @grafana/grafana-app-platform-squad
+	k8s.io/api v0.32.3 // @grafana/grafana-app-platform-squad
 	k8s.io/apimachinery v0.32.3 // @grafana/grafana-app-platform-squad
 	k8s.io/apiserver v0.32.3 // @grafana/grafana-app-platform-squad
 	k8s.io/client-go v0.32.3 // @grafana/grafana-app-platform-squad
@@ -202,6 +202,7 @@ require (
 	k8s.io/kube-aggregator v0.32.0 // @grafana/grafana-app-platform-squad
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // @grafana/grafana-app-platform-squad
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // @grafana/partner-datasources
+	sigs.k8s.io/randfill v1.0.0 // @grafana/grafana-app-platform-squad
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // @grafana-app-platform-squad
 	xorm.io/builder v0.3.6 // @grafana/grafana-backend-group
 )
@@ -569,7 +570,6 @@ require (
 	modernc.org/sqlite v1.37.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -30,6 +30,11 @@ import (
 	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
 	_ "github.com/stretchr/testify/require"
 	_ "golang.org/x/time/rate"
+	_ "k8s.io/api"
+	_ "k8s.io/kube-aggregator/pkg/apiserver/scheme"
+	_ "k8s.io/kube-aggregator/pkg/generated/openapi"
+	_ "k8s.io/kube-aggregator/pkg/registry/apiservice/rest"
+	_ "sigs.k8s.io/randfill"
 	_ "xorm.io/builder"
 
 	_ "github.com/grafana/authlib/authn"
@@ -42,8 +47,4 @@ import (
 	_ "github.com/grafana/e2e"
 	_ "github.com/grafana/gofpdf"
 	_ "github.com/grafana/gomemcache/memcache"
-
-	_ "k8s.io/kube-aggregator/pkg/apiserver/scheme"
-	_ "k8s.io/kube-aggregator/pkg/generated/openapi"
-	_ "k8s.io/kube-aggregator/pkg/registry/apiservice/rest"
 )


### PR DESCRIPTION
`k8s.io/api` and `sigs.k8s.io/randfill` are both being used directly by Enterprise now that the kube aggregator was moved there.