### PR TITLE
CI: remove go-version flag

### DIFF
--- a/pkg/build/daggerbuild/scripts/drone_build_main_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_main_enterprise.sh
@@ -25,7 +25,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --grafana-repo="https://github.com/grafana/grafana.git" \
   --enterprise-ref=${DRONE_COMMIT} \
   --github-token=${GITHUB_TOKEN} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base=${UBUNTU_BASE} \
   --alpine-base=${ALPINE_BASE} \
   --patches-repo=${PATCHES_REPO} \

--- a/pkg/build/daggerbuild/scripts/drone_build_main_pro.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_main_pro.sh
@@ -21,7 +21,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --grafana-repo="https://github.com/grafana/grafana.git" \
   --enterprise-ref=${DRONE_COMMIT} \
   --github-token=${GITHUB_TOKEN} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base=${UBUNTU_BASE} \
   --alpine-base=${ALPINE_BASE} \
   --patches-repo=${PATCHES_REPO} \

--- a/pkg/build/daggerbuild/scripts/drone_build_nightly_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_nightly_enterprise.sh
@@ -12,7 +12,7 @@ docker run --privileged --rm tonistiigi/binfmt:qemu-v7.0.0-28 --install all
   # -a deb:enterprise:linux/arm/v7:nightly \
   # -a docker:enterprise:linux/arm/v7 \
   # -a docker:enterprise:linux/arm/v7:ubuntu \
-  
+
 dagger run --silent go run ./pkg/build/cmd \
   artifacts \
   -a targz:enterprise:linux/amd64 \
@@ -46,7 +46,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --github-token=${GITHUB_TOKEN} \
   --destination=${local_dst} \
   --yarn-cache=${YARN_CACHE_FOLDER} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base="${UBUNTU_BASE}" \
   --alpine-base="${ALPINE_BASE}" > assets.txt
 

--- a/pkg/build/daggerbuild/scripts/drone_build_nightly_grafana.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_nightly_grafana.sh
@@ -37,7 +37,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --github-token=${GITHUB_TOKEN} \
   --destination=${local_dst} \
   --yarn-cache=${YARN_CACHE_FOLDER} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base="${UBUNTU_BASE}" \
   --alpine-base="${ALPINE_BASE}" > assets.txt
 

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_enterprise.sh
@@ -42,7 +42,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --grafana-ref=${DRONE_TAG} \
   --grafana-repo=https://github.com/grafana/grafana-security-mirror.git \
   --github-token=${GITHUB_TOKEN} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base="${UBUNTU_BASE}" \
   --alpine-base="${ALPINE_BASE}" \
   --version=${DRONE_TAG} \

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_grafana.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_grafana.sh
@@ -39,7 +39,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-dir=${GRAFANA_DIR} \
   --github-token=${GITHUB_TOKEN} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base="${UBUNTU_BASE}" \
   --alpine-base="${ALPINE_BASE}" \
   --version=${DRONE_TAG} \

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_pro.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_pro.sh
@@ -33,7 +33,6 @@ dagger run --silent go run ./pkg/build/cmd \
   --grafana-repo=https://github.com/grafana/grafana-security-mirror.git \
   --github-token=${GITHUB_TOKEN} \
   --version=${DRONE_TAG} \
-  --go-version=${GO_VERSION} \
   --ubuntu-base="${UBUNTU_BASE}" \
   --alpine-base="${ALPINE_BASE}" \
   --destination=${local_dst} > assets.txt


### PR DESCRIPTION
It's not used anymore, but having a flag in these commands that isn't defined causes it to throw an error.