### PR TITLE
Alerting: Fix debug log line in External Alertmanager sender

### DIFF
--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -185,11 +185,11 @@ func (s *ExternalAlertmanager) SendAlerts(alerts apimodels.PostableAlerts) {
 		s.logger.Debug(
 			"Sending alert",
 			"alert",
-			a,
+			na.String(),
 			"starts_at",
-			a.StartsAt,
+			na.StartsAt,
 			"ends_at",
-			a.EndsAt)
+			na.EndsAt)
 	}
 
 	s.manager.Send(as...)

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -182,7 +182,7 @@ func (s *ExternalAlertmanager) SendAlerts(alerts apimodels.PostableAlerts) {
 		na := s.alertToNotifierAlert(a)
 		as = append(as, na)
 
-		s.logger.Debug("msg",
+		s.logger.Debug(
 			"Sending alert",
 			"alert",
 			a,


### PR DESCRIPTION
Removes the `"msg"` part of the log as this already gets inserted as the first argument by the logger here

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
