### PR TITLE
TimePickerWithHistory: Improve type handling when reading history from localStorage

### DIFF
--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { getDefaultTimeRange, systemDateFormats } from '@grafana/data';
 
-import { TimePickerWithHistory, isValidTimePickerHistoryValue, deserializeHistory } from './TimePickerWithHistory';
+import { TimePickerWithHistory } from './TimePickerWithHistory';
 
 describe('TimePickerWithHistory', () => {
   // In some of the tests we close and re-open the picker. When we do that we must re-find these inputs
@@ -189,66 +189,6 @@ describe('TimePickerWithHistory', () => {
     await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     expect(screen.getByText(/03-12-2022 00:00:00 to 03-12-2022 23:59:59/i)).toBeInTheDocument();
-  });
-});
-
-describe('isValidTimePickerHistoryValue', () => {
-  it('Should return true for TimePickerHistoryItem if format match exactly', () => {
-    const validValue = {
-      from: '2022-12-03T00:00:00.000Z',
-      to: '2022-12-03T23:59:59.000Z',
-    };
-    expect(isValidTimePickerHistoryValue(validValue)).toBe(true);
-  });
-
-  it('Should return false for TimePickerHistoryItem if format did not match exactly', () => {
-    const validValue = {
-      from: '2022-12-03T00:00:00.000Z',
-      to: '2022-12-03T23:59:59.000Z',
-      raw: { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
-    };
-    expect(isValidTimePickerHistoryValue(validValue)).toBe(false);
-  });
-
-  it('Should return false for invalid TimePickerHistoryItem', () => {
-    const invalidValue = { from: null, to: null };
-    expect(isValidTimePickerHistoryValue(invalidValue)).toBe(false);
-  });
-});
-
-describe('deserializeHistory', () => {
-  it('Should return empty array for empty input', () => {
-    expect(deserializeHistory([])).toEqual([]);
-  });
-
-  it('Should return empty array for invalid input', () => {
-    const invalidInputs = [
-      null,
-      undefined,
-      {},
-      { from: null, to: null },
-      { from: undefined, to: undefined },
-      { from: '2022-12-03T00:00:00.000Z' }, // missing 'to'
-      { to: '2022-12-03T23:59:59.000Z' }, // missing 'from'
-      { from: 123, to: '2022-12-03T23:59:59.000Z' }, // non-string 'from'
-      { from: '2022-12-03T00:00:00.000Z', to: 123 }, // non-string 'to'
-      { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z', extra: 'property' }, // extra property
-    ];
-
-    invalidInputs.forEach((input) => {
-      expect(deserializeHistory([input])).toEqual([]);
-    });
-  });
-
-  it('Should return only valid history items', () => {
-    const input = [
-      { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
-      { from: null, to: null }, // invalid item
-      { extra: 'property' }, // invalid item
-    ];
-
-    const result = deserializeHistory(input);
-    expect(result).toHaveLength(1); // Only one valid item
   });
 });
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -13,18 +13,6 @@ describe('TimePickerWithHistory', () => {
   const getApplyButton = () => screen.getByRole('button', { name: 'Apply time range' });
 
   const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
-  const OLD_LOCAL_STORAGE = [
-    {
-      from: '2022-12-03T00:00:00.000Z',
-      to: '2022-12-03T23:59:59.000Z',
-      raw: { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
-    },
-    {
-      from: '2022-12-02T00:00:00.000Z',
-      to: '2022-12-02T23:59:59.000Z',
-      raw: { from: '2022-12-02T00:00:00.000Z', to: '2022-12-02T23:59:59.000Z' },
-    },
-  ];
 
   const NEW_LOCAL_STORAGE = [
     { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -67,6 +67,11 @@ describe('TimePickerWithHistory', () => {
   it('Should load with valid time picker history only', async () => {
     const BAD_LOCAL_STORAGE = [
       { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
+      {
+        from: '2022-12-01T00:00:00.000Z',
+        to: '2022-12-01T23:59:59.000Z',
+        raw: { from: '2022-12-03T00:00:00.000Z', to: '022-12-03T23:59:59.000Z' },
+      },
       {},
       { from: null, to: null },
     ];
@@ -77,6 +82,7 @@ describe('TimePickerWithHistory', () => {
     await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     expect(screen.getByText(/2022-12-03 00:00:00 to 2022-12-03 23:59:59/i)).toBeInTheDocument();
+    expect(screen.queryByText(/2022-12-01 00:00:00 to 2022-12-01 23:59:59/i)).not.toBeInTheDocument(); // Invalid, because of raw
   });
 
   it('Should load with new TimePickerHistoryItem history', async () => {

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -52,28 +52,18 @@ describe('TimePickerWithHistory', () => {
     expect(screen.getByText(/It looks like you haven't used this time picker before/i)).toBeInTheDocument();
   });
 
-  it('Should not load with old TimeRange history', async () => {
-    // TimePickerWithHistory only accepts TimePickerHistoryItem objects
-    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(OLD_LOCAL_STORAGE));
-
-    const timeRange = getDefaultTimeRange();
-    render(<TimePickerWithHistory value={timeRange} {...props} />);
-    await userEvent.click(screen.getByLabelText(/Time range selected/));
-
-    expect(screen.queryByText(/2022-12-03 00:00:00 to 2022-12-03 23:59:59/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/2022-12-02 00:00:00 to 2022-12-02 23:59:59/i)).not.toBeInTheDocument();
-  });
-
   it('Should load with valid time picker history only', async () => {
+    // TimePickerWithHistory only accepts TimePickerHistoryItem objects, invalid history items should be ignored
     const BAD_LOCAL_STORAGE = [
-      { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
+      { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' }, // valid
       {
         from: '2022-12-01T00:00:00.000Z',
         to: '2022-12-01T23:59:59.000Z',
-        raw: { from: '2022-12-03T00:00:00.000Z', to: '022-12-03T23:59:59.000Z' },
+        raw: { from: '2022-12-01T00:00:00.000Z', to: '022-12-01T23:59:59.000Z' }, // Invalid, because it has raw property which doesn't match TimePickerHistoryItem
       },
-      {},
-      { from: null, to: null },
+      {}, // Invalid, because empty
+      { from: null, to: null }, // Invalid, because both value are null
+      { from: '2022-12-04T00:00:00.000Z', to: null }, // Invalid because one value is null
     ];
     window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(BAD_LOCAL_STORAGE));
 
@@ -82,7 +72,8 @@ describe('TimePickerWithHistory', () => {
     await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     expect(screen.getByText(/2022-12-03 00:00:00 to 2022-12-03 23:59:59/i)).toBeInTheDocument();
-    expect(screen.queryByText(/2022-12-01 00:00:00 to 2022-12-01 23:59:59/i)).not.toBeInTheDocument(); // Invalid, because of raw
+    expect(screen.queryByText(/2022-12-01 00:00:00 to 2022-12-01 23:59:59/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/2022-12-04 00:00:00 to 2022-12-04 23:59:59/i)).not.toBeInTheDocument();
   });
 
   it('Should load with new TimePickerHistoryItem history', async () => {

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -82,8 +82,8 @@ function onAppendToHistory(
 
   // Convert DateTime objects to strings
   const toAppend = {
-    from: typeof newTimeRange.raw.from === 'string' ? newTimeRange.raw.from : convertToISOString(newTimeRange.raw.from),
-    to: typeof newTimeRange.raw.to === 'string' ? newTimeRange.raw.to : convertToISOString(newTimeRange.raw.to),
+    from: convertToISOString(newTimeRange.raw.from),
+    to: convertToISOString(newTimeRange.raw.to),
   };
 
   const toStore = limit([toAppend, ...values]);

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,6 +1,6 @@
 import { uniqBy } from 'lodash';
 
-import { AppEvents, TimeRange, isDateTime, rangeUtil } from '@grafana/data';
+import { AppEvents, DateTime, TimeRange, isDateTime, rangeUtil } from '@grafana/data';
 import { useTranslate } from '@grafana/i18n';
 import { TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
@@ -8,6 +8,7 @@ import appEvents from 'app/core/app_events';
 import { LocalStorageValueProvider } from '../LocalStorageValueProvider';
 
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
+const MAX_HISTORY_ITEMS = 4;
 
 interface Props extends Omit<TimeRangePickerProps, 'history' | 'theme'> {}
 
@@ -17,16 +18,12 @@ interface TimePickerHistoryItem {
   to: string;
 }
 
-// We should only be storing TimePickerHistoryItem, but in the past we also stored TimeRange
-export type LSTimePickerHistoryItem = TimePickerHistoryItem | TimeRange;
-
 export const TimePickerWithHistory = (props: Props) => {
   const { t } = useTranslate();
 
   return (
-    <LocalStorageValueProvider<LSTimePickerHistoryItem[]> storageKey={LOCAL_STORAGE_KEY} defaultValue={[]}>
-      {(rawValues, onSaveToStore) => {
-        const values = migrateHistory(rawValues);
+    <LocalStorageValueProvider<TimePickerHistoryItem[]> storageKey={LOCAL_STORAGE_KEY} defaultValue={[]}>
+      {(values, onSaveToStore) => {
         const history = deserializeHistory(values);
 
         return (
@@ -50,28 +47,10 @@ export const TimePickerWithHistory = (props: Props) => {
   );
 };
 
-function deserializeHistory(values: TimePickerHistoryItem[]): TimeRange[] {
-  // The history is saved in UTC and with the default date format, so we need to pass those values to the convertRawToRange
-  return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
-}
-
-/**
- * Migrates/reformat history items to the current format
- * @param values - Array of history items to clean up
- * @returns Array of formatted history items
- */
-export function migrateHistory(values: LSTimePickerHistoryItem[]): TimePickerHistoryItem[] {
+export function deserializeHistory(values: unknown[]): TimeRange[] {
   return values
-    .filter(isValidTimePickerValue) // Filter out invalid values
-    .map((item) => {
-      const fromValue = typeof item.from === 'string' ? item.from : item.from.toISOString();
-      const toValue = typeof item.to === 'string' ? item.to : item.to.toISOString();
-
-      return {
-        from: fromValue,
-        to: toValue,
-      };
-    });
+    .filter(isValidTimePickerHistoryValue) // Filter out invalid values
+    .map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
 }
 
 function onAppendToHistory(
@@ -79,41 +58,61 @@ function onAppendToHistory(
   values: TimePickerHistoryItem[],
   onSaveToStore: (values: TimePickerHistoryItem[]) => void
 ) {
-  if (!isAbsolute(newTimeRange)) {
+  if (!isAbsoluteTimeRange(newTimeRange)) {
+    // If the time range is not absolute, do not append it to history, ex: last 5 minutes
     return;
   }
 
   // Convert DateTime objects to strings
   const toAppend = {
-    from: typeof newTimeRange.raw.from === 'string' ? newTimeRange.raw.from : newTimeRange.raw.from.toISOString(),
-    to: typeof newTimeRange.raw.to === 'string' ? newTimeRange.raw.to : newTimeRange.raw.to.toISOString(),
+    from: typeof newTimeRange.raw.from === 'string' ? newTimeRange.raw.from : convertToISOString(newTimeRange.raw.from),
+    to: typeof newTimeRange.raw.to === 'string' ? newTimeRange.raw.to : convertToISOString(newTimeRange.raw.to),
   };
 
   const toStore = limit([toAppend, ...values]);
   onSaveToStore(toStore);
 }
 
-function isAbsolute(value: TimeRange): boolean {
+function isAbsoluteTimeRange(value: TimeRange): boolean {
   return isDateTime(value.raw.from) || isDateTime(value.raw.to);
 }
 
 function limit(value: TimePickerHistoryItem[]): TimePickerHistoryItem[] {
-  return uniqBy(value, (v) => v.from + v.to).slice(0, 4);
+  return uniqBy(value, (v) => v.from + v.to).slice(0, MAX_HISTORY_ITEMS);
 }
 
 /**
- * Type guard to check if a value is a valid time picker history item
- * @returns True if the value is a valid time picker history item
+ * Check if the value is a valid TimePickerHistoryItem. If it doesn't match the format exactly, it will return false.
+ * @returns true if the value match exactly to TimePickerHistoryItem, false otherwise
  */
-export function isValidTimePickerValue(value: unknown): value is LSTimePickerHistoryItem {
-  if (!value || typeof value !== 'object') {
+export function isValidTimePickerHistoryValue(value: unknown): value is TimePickerHistoryItem {
+  // First check if it's a valid object
+  if (typeof value !== 'object' || value === null) {
     return false;
   }
 
-  if ('from' in value && 'to' in value) {
-    // Check if value object has both from and to properties
-    return !!value.from && !!value.to; // Check if both from and to are not null or undefined
+  // Check if it has exactly two properties
+  if (Object.keys(value).length !== 2) {
+    return false;
   }
 
-  return false;
+  // Check if it has the required properties
+  if (!('from' in value) || !('to' in value)) {
+    return false;
+  }
+
+  // Check if both properties are strings
+  return typeof value.from === 'string' && typeof value.to === 'string';
+}
+
+function convertToISOString(value: DateTime | string): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (!value?.toISOString) {
+    throw console.error('Invalid DateTime object passed to convertToISOString');
+  }
+
+  return value.toISOString();
 }

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -57,10 +57,9 @@ function getValidHistory(values: unknown): TimePickerHistoryItem[] {
   // Check if the values are already in the correct format
 
   for (let item of values) {
-    const isValid = getValidHistoryItem(item);
-    if (isValid) {
-      // If the item is already in the correct format, add it to the result
-      result.push(item);
+    const parsed = getValidHistoryItem(item);
+    if (parsed) {
+      result.push(parsed);
     }
   }
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -60,7 +60,7 @@ function getValidHistory(values: unknown): TimePickerHistoryItem[] {
     const isValid = getValidHistoryItem(item);
     if (isValid) {
       // If the item is already in the correct format, add it to the result
-      result.push(item as TimePickerHistoryItem);
+      result.push(item);
     }
   }
 
@@ -119,12 +119,10 @@ export function getValidHistoryItem(value: unknown): TimePickerHistoryItem | nul
     return null;
   }
 
-  // Safe type assertion after checking properties exist
-  const item = value as { from: unknown; to: unknown };
-
+  const { from, to } = value;
   // Check if both properties are strings
-  if (typeof item.from === 'string' && typeof item.to === 'string') {
-    return { from: item.from, to: item.to };
+  if (typeof from === 'string' && typeof to === 'string') {
+    return { from, to };
   }
 
   return null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

TimePickerWithHistory: Improve type handling when reading history from localStorage, from now on we only support `TimePickerHistoryItem` type range history for display. 
- Remove `migrateHistory` function 
- Remove `LSTimePickerHistoryItem `, only support `TimePickerHistoryItem` and anything doesn't match it will be remove from range history display
- Add MAX_HISTORY_ITEMS constant for better maintainability


**Before:**  invalid time range history will cause page broken and refresh can't fix the issue. 

https://github.com/user-attachments/assets/8941d72c-5127-479a-8588-e419aff2c38e

**After:** invalid time range history will be filter out from display. 

https://github.com/user-attachments/assets/a00dccee-6814-417d-b31e-371605fd8654





**Why do we need this feature?**

This change ensures that invalid time picker history items are properly filtered out before processing, preventing potential runtime errors and improving type safety throughout the component.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #103775 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
