### PR TITLE
i18n: WIP followups

### DIFF
--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
@@ -1093,6 +1093,15 @@ const Foo = () => <div><Trans i18nKey="some-feature.foo.test">test</Trans></div>
         },
       ],
     },
+    {
+      name: 'Auto fixes expressions when configured',
+      code: `const Foo = () => <div>{isAThing || 'test'}</div>`,
+      filename,
+      options: [{ forceFix: ['public/app/features/some-feature'] }],
+      output: `${T_IMPORT}
+const Foo = () => <div>{isAThing || t("some-feature.foo.test", "test")}</div>`,
+      errors: 1,
+    },
 
     {
       name: 'Auto fixes when options are configured - prop',
@@ -1156,6 +1165,26 @@ const Foo = () => {
     label: t("some-feature.foo.label.test", "test"),
   }
 }`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Fixes JSXExpression in attribute if it is simple template literal',
+      code: `
+const Foo = () => <div title={\`foo\`} />`,
+      filename,
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithT',
+              output: `
+${T_IMPORT}
+const Foo = () => <div title={t("some-feature.foo.title-foo", "foo")} />`,
             },
           ],
         },
@@ -1232,13 +1261,6 @@ const Foo = () => {
     },
 
     {
-      name: 'Cannot fix JSXExpression in attribute if it is template literal',
-      code: `const Foo = () => <div title={\`foo\`} />`,
-      filename,
-      errors: [{ messageId: 'noUntranslatedStrings' }],
-    },
-
-    {
       name: 'Cannot fix text outside correct directory location',
       code: `const Foo = () => <div>Untranslated text</div>`,
       filename: 'public/something-else/foo/SomeOtherFile.tsx',
@@ -1256,6 +1278,16 @@ const Foo = () => {
 }`,
       filename,
       errors: [{ messageId: 'noUntranslatedStringsProp' }],
+    },
+
+    {
+      name: 'Cannot fix expression with complicated template literal',
+      code: `
+const Foo = () => {
+  return <div title={foo ? \`Count \$\{someNumber\}\` : \`Another count \$\{someNumber\}\`} />
+}`,
+      filename,
+      errors: [{ messageId: 'noUntranslatedStringsProp' }, { messageId: 'noUntranslatedStringsProp' }],
     },
 
     // TODO: Enable test once all top-level issues have been fixed

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
@@ -196,6 +196,23 @@ ruleTester.run('eslint no-untranslated-strings', noUntranslatedStrings, {
       }`,
       filename,
     },
+
+    {
+      name: 'Template literal with all-non-alphanumeric quasis',
+      code: `const Foo = () => {
+        const someVar = 'foo'
+        return (
+          <div label={\`(\${someVar})\`} />
+          )
+        }`,
+      filename,
+    },
+
+    {
+      name: 'LogicalExpression with template literal with all-non-alphanumeric quasis',
+      code: `<div label={foo ? \`\${someVar} - (\${count\})\` : \`?\`} />`,
+      filename,
+    },
   ],
   invalid: [
     {

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/translation-utils.cjs
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/translation-utils.cjs
@@ -7,6 +7,7 @@
 /** @typedef {import('@typescript-eslint/utils').TSESTree.JSXChild} JSXChild */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.JSXExpressionContainer} JSXExpressionContainer */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.Literal} Literal */
+/** @typedef {import('@typescript-eslint/utils').TSESTree.TemplateLiteral} TemplateLiteral */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.Property} Property */
 /** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleFixer} RuleFixer */
 /** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT',  [{forceFix: string[]}]>} RuleContextWithOptions */
@@ -95,6 +96,17 @@ const stringShouldBeTranslated = (string) => {
     return false;
   }
   return string.trim() && stringIsAlphanumeric(string);
+};
+
+/**
+ * @param {TemplateLiteral} node
+ * @returns {boolean}
+ */
+const templateLiteralShouldBeTranslated = (node) => {
+  const { quasis } = node;
+  return quasis.some((quasi) => {
+    return stringShouldBeTranslated(getNodeValue(quasi));
+  });
 };
 
 /**
@@ -520,6 +532,10 @@ function getNodeValue(node) {
     return String(node.value);
   }
 
+  if (node.type === AST_NODE_TYPES.TemplateElement) {
+    return node.value.raw;
+  }
+
   if (node.type === AST_NODE_TYPES.JSXText) {
     // Return the raw value if we can, so we can work out if there are any HTML entities
     return node.raw;
@@ -553,4 +569,5 @@ module.exports = {
   elementIsTrans,
   stringShouldBeTranslated,
   nodeHasTransAncestor,
+  templateLiteralShouldBeTranslated,
 };

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx
@@ -65,6 +65,7 @@ function PretendTextInput({ onClick }: PretendTextInputProps) {
         </button>
 
         <div className={styles.suffix}>
+          {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
           <Text variant="bodySmall">{`${modKey}+k`}</Text>
         </div>
       </div>

--- a/public/app/features/alerting/unified/AlertGroups.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.tsx
@@ -66,7 +66,7 @@ const AlertGroups = () => {
           title={t('alerting.alert-groups.title-error-loading-notifications', 'Error loading notifications')}
           severity={'error'}
         >
-          {error.message || 'Unknown error'}
+          {error.message || t('alerting.alert-groups.unknown-error', 'Unknown error')}
         </Alert>
       )}
 

--- a/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
@@ -127,7 +127,8 @@ const NotificationPoliciesFilter = ({
             <Trans i18nKey="alerting.common.clear-filters">Clear filters</Trans>
           </Button>
           <Text variant="bodySmall" color="secondary">
-            {matchingCount === 0 && 'No policies matching filters.'}
+            {matchingCount === 0 &&
+              t('alerting.notification-policies-filter.no-policies-matching-filters', 'No policies matching filters.')}
             {matchingCount === 1 && `${matchingCount} policy matches the filters.`}
             {matchingCount > 1 && `${matchingCount} policies match the filters.`}
           </Text>

--- a/public/app/features/alerting/unified/components/notification-policies/NotificationPoliciesList.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/NotificationPoliciesList.tsx
@@ -209,7 +209,8 @@ export const NotificationPoliciesList = () => {
             'Error loading Alertmanager config'
           )}
         >
-          {stringifyErrorLike(fetchPoliciesError) || 'Unknown error.'}
+          {stringifyErrorLike(fetchPoliciesError) ||
+            t('alerting.notification-policies-list.unknown-error', 'Unknown error.')}
         </Alert>
       )}
       {/* show when there is an update error */}

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
@@ -143,7 +143,10 @@ function TemplateSelector({ onSelect, onClose, option, valueInForm }: TemplateSe
         'alerting.template-selector.template-options.label.select-notification-template',
         'Select notification template'
       ),
-      ariaLabel: 'Select notification template',
+      ariaLabel: t(
+        'alerting.template-selector.template-options.ariaLabel.select-notification-template',
+        'Select notification template'
+      ),
       value: 'Existing',
       description: `Select an existing notification template and preview it, or copy it to paste it in the custom tab. ${templateOption === 'Existing' ? 'Clicking Save saves your changes to the selected template.' : ''}`,
     },

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, useTranslate } from '@grafana/i18n';
 import { Icon, Text, useStyles2 } from '@grafana/ui';
 import { DashboardDataDTO } from 'app/types';
 
@@ -24,6 +24,7 @@ const DashboardAnnotationField = ({
   onEditClick: () => void;
   onDeleteClick: () => void;
 }) => {
+  const { t } = useTranslate();
   const styles = useStyles2(getStyles);
 
   const dashboardLink = makeDashboardLink(dashboard?.uid || dashboardUid);
@@ -52,7 +53,8 @@ const DashboardAnnotationField = ({
 
       {panel && (
         <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer" data-testid="panel-annotation">
-          {panel.title || '<No title>'} <Icon name={'external-link-alt'} />
+          {panel.title || t('alerting.dashboard-annotation-field.no-title', '<No title>')}{' '}
+          <Icon name={'external-link-alt'} />
         </a>
       )}
 

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -126,7 +126,8 @@ export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDis
       >
         <div className={cx(styles.dashboardTitle, styles.rowButtonTitle)}>{dashboard.title}</div>
         <div className={styles.dashboardFolder}>
-          <Icon name="folder" /> {dashboard.folderTitle ?? 'Dashboards'}
+          <Icon name="folder" />{' '}
+          {dashboard.folderTitle ?? t('alerting.dashboard-picker.dashboard-row.dashboards', 'Dashboards')}
         </div>
       </button>
     );

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -145,7 +145,9 @@ const RuleViewer = () => {
               topSpacing={2}
             >
               <pre style={{ marginBottom: 0 }}>
-                <code>{rule.promRule?.lastError ?? 'No error message'}</code>
+                <code>
+                  {rule.promRule?.lastError ?? t('alerting.rule-viewer.sub-title-no-error-message', 'No error message')}
+                </code>
               </pre>
             </Alert>
           )}

--- a/public/app/features/alerting/unified/components/rules/RuleHealth.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleHealth.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, useTranslate } from '@grafana/i18n';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { Rule } from 'app/types/unified-alerting';
 
@@ -12,11 +12,17 @@ interface Prom {
 }
 
 export const RuleHealth = ({ rule }: Prom) => {
+  const { t } = useTranslate();
   const style = useStyles2(getStyle);
 
   if (isErrorHealth(rule.health)) {
     return (
-      <Tooltip theme="error" content={rule.lastError || 'No error message provided.'}>
+      <Tooltip
+        theme="error"
+        content={
+          rule.lastError || t('alerting.rule-health.content-no-error-message-provided', 'No error message provided.')
+        }
+      >
         <div className={style.warn}>
           <Icon name="exclamation-triangle" />
           <span>

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useMeasure } from 'react-use';
 
+import { useTranslate } from '@grafana/i18n';
 import { Counter, LoadingBar, Pagination, Stack } from '@grafana/ui';
 import { DEFAULT_PER_PAGE_PAGINATION } from 'app/core/constants';
 import { CombinedRule, CombinedRuleNamespace } from 'app/types/unified-alerting';
@@ -80,6 +81,7 @@ const STATE_TITLES: Record<PromAlertingRuleState, string> = {
 };
 
 const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: CombinedRule[] }) => {
+  const { t } = useTranslate();
   const { page, pageItems, numberOfPages, onPageChange } = usePagination(rules, 1, DEFAULT_PER_PAGE_PAGINATION);
 
   const isFiringState = state !== PromAlertingRuleState.Firing;
@@ -89,7 +91,7 @@ const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: C
     <ListSection
       title={
         <Stack alignItems="center" gap={0}>
-          {STATE_TITLES[state] ?? 'Unknown'}
+          {STATE_TITLES[state] ?? t('alerting.rules-by-state.title-unknown', 'Unknown')}
           <Counter value={rules.length} />
         </Stack>
       }

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
@@ -110,7 +110,8 @@ export default function AlertmanagerConfig({ alertmanagerName, onDismiss, onSave
           'Failed to load Alertmanager configuration'
         )}
       >
-        {loadingError.message ?? 'An unknown error occurred.'}
+        {loadingError.message ??
+          t('alerting.alertmanager-config.an-unknown-error-occurred', 'An unknown error occurred.')}
       </Alert>
     );
   }
@@ -160,7 +161,8 @@ export default function AlertmanagerConfig({ alertmanagerName, onDismiss, onSave
           severity="error"
           title={t('alerting.alertmanager-config.title-oops-something-went-wrong', 'Oops, something went wrong')}
         >
-          {errors.configJSON.message || 'An unknown error occurred.'}
+          {errors.configJSON.message ||
+            t('alerting.alertmanager-config.an-unknown-error-occurred', 'An unknown error occurred.')}
         </Alert>
       )}
 

--- a/public/app/features/alerting/unified/rule-list/StateView.tsx
+++ b/public/app/features/alerting/unified/rule-list/StateView.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { useTranslate } from '@grafana/i18n';
 import { Counter, Pagination, Stack, useStyles2 } from '@grafana/ui';
 import { DEFAULT_PER_PAGE_PAGINATION } from 'app/core/constants';
 import { CombinedRule, CombinedRuleNamespace } from 'app/types/unified-alerting';
@@ -75,6 +76,7 @@ const STATE_TITLES: Record<PromAlertingRuleState, string> = {
 };
 
 const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: CombinedRule[] }) => {
+  const { t } = useTranslate();
   const { page, pageItems, numberOfPages, onPageChange } = usePagination(rules, 1, DEFAULT_PER_PAGE_PAGINATION);
 
   const isFiringState = state !== PromAlertingRuleState.Firing;
@@ -84,7 +86,7 @@ const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: C
     <ListSection
       title={
         <Stack alignItems="center" gap={0}>
-          {STATE_TITLES[state] ?? 'Unknown'}
+          {STATE_TITLES[state] ?? t('alerting.rules-by-state.title-unknown', 'Unknown')}
           <Counter value={rules.length} />
         </Stack>
       }

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -163,7 +163,15 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       );
     }
     if (panelData?.error) {
-      return <p>{panelData.error.message ?? 'There was an error fetching data'}</p>;
+      return (
+        <p>
+          {panelData.error.message ??
+            t(
+              'annotations.standard-annotation-query-editor.there-was-an-error-fetching-data',
+              'There was an error fetching data'
+            )}
+        </p>
+      );
     }
 
     if (!events?.length) {

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
@@ -170,7 +170,7 @@ export function VariableEditorForm({ variable, onTypeChange, onGoBack, onDelete 
                   text={t('dashboard-scene.variable-editor-form.text-running-query', 'Running query...')}
                 />
               ) : (
-                `Run query`
+                t('dashboard-scene.variable-editor-form.run-query', 'Run query')
               )}
             </Button>
           )}

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderTitleItems.tsx
@@ -1,6 +1,7 @@
 import { css, cx } from '@emotion/css';
 
 import { AlertState, DataLink, GrafanaTheme2, LinkModel, PanelData, PanelModel } from '@grafana/data';
+import { useTranslate } from '@grafana/i18n';
 import { Icon, PanelChrome, TimePickerTooltip, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { PanelLinks } from '../PanelLinks';
@@ -22,12 +23,15 @@ export interface Props {
 }
 
 export function PanelHeaderTitleItems(props: Props) {
+  const { t } = useTranslate();
   const { alertState, data, panelId, onShowPanelLinks, panelLinks } = props;
   const styles = useStyles2(getStyles);
 
   // panel health
   const alertStateItem = (
-    <Tooltip content={alertState ?? 'unknown'}>
+    <Tooltip
+      content={alertState ?? t('dashboard.panel-header-title-items.alert-state-item.content-unknown', 'unknown')}
+    >
       <PanelChrome.TitleItem
         className={cx({
           [styles.ok]: alertState === AlertState.OK,

--- a/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
@@ -113,7 +113,10 @@ export const ResourceDimensionEditor = (
           onClear={onClear}
           value={value?.fixed}
           src={srcPath}
-          placeholder={item.settings?.placeholderText ?? 'Select a value'}
+          placeholder={
+            item.settings?.placeholderText ??
+            t('dimensions.resource-dimension-editor.placeholder-select-a-value', 'Select a value')
+          }
           name={niceName(value?.fixed) ?? ''}
           mediaType={mediaType}
           folderName={folderName}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
+import { t } from '@grafana/i18n/internal';
 import { config, reportInteraction } from '@grafana/runtime';
 import { useStyles2, MenuItem, Icon, ContextMenu } from '@grafana/ui';
 
@@ -25,7 +26,7 @@ const renderMenuItems = (
   return links.map((link, i) => (
     <MenuItem
       key={i}
-      label={link.title || 'Link'}
+      label={link.title || t('explore.render-menu-items.label-link', 'Link')}
       onClick={
         link.onClick
           ? (event) => {

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -110,7 +110,12 @@ export function createSpanLinkFactory({
             title: link.title,
             href: link.href,
             onClick: link.onClick,
-            content: <Icon name="link" title={link.title || 'Link'} />,
+            content: (
+              <Icon
+                name="link"
+                title={link.title || t('explore.create-span-link-factory.new-span-links.title-link', 'Link')}
+              />
+            ),
             field: link.origin,
             type: shouldCreatePyroscopeLink ? SpanLinkType.Profiles : SpanLinkType.Unknown,
             target: link.target,

--- a/public/app/features/gops/configuration-tracker/components/Essentials.tsx
+++ b/public/app/features/gops/configuration-tracker/components/Essentials.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, useTranslate } from '@grafana/i18n';
+import { t } from '@grafana/i18n/internal';
 import { Button, Drawer, Dropdown, Icon, LinkButton, Menu, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { RelativeUrl, createRelativeUrl } from 'app/features/alerting/unified/utils/url';
 
@@ -178,7 +179,9 @@ function StepButton({
           </Dropdown>
         );
       } else {
-        return <Text>{stepNotAvailableText ?? 'No options available'} </Text>;
+        return (
+          <Text>{stepNotAvailableText ?? t('gops.step-button.no-options-available', 'No options available')} </Text>
+        );
       }
   }
 }

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -162,7 +162,7 @@ export const LogRowMenuCell = memo(
                 size="md"
                 name="gf-pin"
                 onClick={() => onPinLine && onPinLine(row)}
-                tooltip={pinLineButtonTooltipTitle ?? 'Pin line'}
+                tooltip={pinLineButtonTooltipTitle ?? t('logs.log-row-menu-cell.tooltip-pin-line', 'Pin line')}
                 tooltipPlacement="top"
                 aria-label={t('logs.log-row-menu-cell.aria-label-pin-line', 'Pin line')}
                 tabIndex={0}

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, useTranslate } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { CellProps, Stack, Text, Icon, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/internal';
@@ -118,6 +118,7 @@ function DashboardInfo({ data }: { data: ResourceTableItem }) {
 }
 
 function FolderInfo({ data }: { data: ResourceTableItem }) {
+  const { t } = useTranslate();
   const folderUID = data.refId;
   const skipApiCall = !!data.name && !!data.parentName;
 
@@ -148,7 +149,7 @@ function FolderInfo({ data }: { data: ResourceTableItem }) {
   return (
     <>
       <span>{folderName}</span>
-      <Text color="secondary">{folderParentName ?? 'Dashboards'}</Text>
+      <Text color="secondary">{folderParentName ?? t('migrate-to-cloud.folder-info.dashboards', 'Dashboards')}</Text>
     </>
   );
 }

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 
 import { dateTimeFormatTimeAgo, GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, useTranslate } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 
 import { getLatestCompatibleVersion } from '../helpers';
@@ -18,6 +18,7 @@ interface Props {
 }
 
 export const VersionList = ({ pluginId, versions = [], installedVersion, disableInstallation }: Props) => {
+  const { t } = useTranslate();
   const styles = useStyles2(getStyles);
   const latestCompatibleVersion = getLatestCompatibleVersion(versions);
 
@@ -118,7 +119,9 @@ export const VersionList = ({ pluginId, versions = [], installedVersion, disable
                 {dateTimeFormatTimeAgo(version.updatedAt || version.createdAt)}
               </td>
               {/* Dependency */}
-              <td className={isInstalledVersion ? styles.currentVersion : ''}>{version.grafanaDependency || 'N/A'}</td>
+              <td className={isInstalledVersion ? styles.currentVersion : ''}>
+                {version.grafanaDependency || t('plugins.version-list.na', 'N/A')}
+              </td>
             </tr>
           );
         })}

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -141,7 +141,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                     </Text>
                   </div>
                   <div className={styles.valueColumn}>
-                    <Text variant="body">{status?.sync.state ?? 'N/A'}</Text>
+                    <Text variant="body">{status?.sync.state ?? t('provisioning.repository-overview.na', 'N/A')}</Text>
                   </div>
 
                   <div className={styles.labelColumn}>
@@ -150,7 +150,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                     </Text>
                   </div>
                   <div className={styles.valueColumn}>
-                    <Text variant="body">{status?.sync.job ?? 'N/A'}</Text>
+                    <Text variant="body">{status?.sync.job ?? t('provisioning.repository-overview.na', 'N/A')}</Text>
                   </div>
 
                   <div className={styles.labelColumn}>
@@ -223,7 +223,9 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                       </Text>
                     </div>
                     <div className={styles.valueColumn}>
-                      <Text variant="body">{status?.webhook?.id ?? 'N/A'}</Text>
+                      <Text variant="body">
+                        {status?.webhook?.id ?? t('provisioning.repository-overview.na', 'N/A')}
+                      </Text>
                     </div>
                     <div className={styles.labelColumn}>
                       <Text color="secondary">
@@ -231,7 +233,10 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                       </Text>
                     </div>
                     <div className={styles.valueColumn}>
-                      <Text variant="body">{status?.webhook?.subscribedEvents?.join(', ') ?? 'N/A'}</Text>
+                      <Text variant="body">
+                        {status?.webhook?.subscribedEvents?.join(', ') ??
+                          t('provisioning.repository-overview.na', 'N/A')}
+                      </Text>
                     </div>
                     <div className={styles.labelColumn}>
                       <Text color="secondary">

--- a/public/app/features/serviceaccounts/ServiceAccountTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountTable.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { Trans, useTranslate } from '@grafana/i18n';
+import { t } from '@grafana/i18n/internal';
 import {
   Avatar,
   CellProps,
@@ -143,7 +144,7 @@ const getCellContent = (
         <Stack alignItems="center">
           <Icon name="key-skeleton-alt" />
           <TextLink href={href} aria-label={ariaLabel} color="primary" inline={false}>
-            {value || 'No tokens'}
+            {value || t('serviceaccounts.get-cell-content.no-tokens', 'No tokens')}
           </TextLink>
         </Stack>
       );

--- a/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
@@ -111,7 +111,7 @@ const ServiceAccountListItemComponent = memo(
               <span>
                 <Icon name="key-skeleton-alt"></Icon>
               </span>
-              {serviceAccount.tokens || 'No tokens'}
+              {serviceAccount.tokens || t('serviceaccounts.service-account-list-item.no-tokens', 'No tokens')}
             </div>
           </a>
         </td>

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -2,6 +2,7 @@ import { map } from 'lodash';
 
 import { AzureCredentials } from '@grafana/azure-sdk';
 import { ScopedVars } from '@grafana/data';
+import { t } from '@grafana/i18n/internal';
 import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import ResponseParser from '../azure_monitor/response_parser';
@@ -231,14 +232,20 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
       if (!this.isValidConfigField(this.credentials.tenantId)) {
         return {
           status: 'error',
-          message: 'The Tenant Id field is required.',
+          message: t(
+            'azuremonitor.azure-log-analytics-datasource.message.the-tenant-id-field-is-required',
+            'The Tenant Id field is required.'
+          ),
         };
       }
 
       if (!this.isValidConfigField(this.credentials.clientId)) {
         return {
           status: 'error',
-          message: 'The Client Id field is required.',
+          message: t(
+            'azuremonitor.azure-log-analytics-datasource.message.the-client-id-field-is-required',
+            'The Client Id field is required.'
+          ),
         };
       }
     }

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -2,6 +2,7 @@ import { find } from 'lodash';
 
 import { AzureCredentials } from '@grafana/azure-sdk';
 import { ScopedVars } from '@grafana/data';
+import { t } from '@grafana/i18n/internal';
 import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
@@ -262,14 +263,20 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       if (!this.isValidConfigField(this.credentials.tenantId)) {
         return {
           status: 'error',
-          message: 'The Tenant Id field is required.',
+          message: t(
+            'azuremonitor.azure-monitor-datasource.message.the-tenant-id-field-is-required',
+            'The Tenant Id field is required.'
+          ),
         };
       }
 
       if (!this.isValidConfigField(this.credentials.clientId)) {
         return {
           status: 'error',
-          message: 'The Client Id field is required.',
+          message: t(
+            'azuremonitor.azure-monitor-datasource.message.the-client-id-field-is-required',
+            'The Client Id field is required.'
+          ),
         };
       }
     }

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
@@ -1,5 +1,6 @@
 import { find, get } from 'lodash';
 
+import { t } from '@grafana/i18n/internal';
 import { FetchResponse } from '@grafana/runtime';
 
 import TimeGrainConverter from '../time_grain_converter';
@@ -57,7 +58,7 @@ export default class ResponseParser {
       supportedAggTypes: metricData.supportedAggregationTypes || defaultAggTypes,
 
       supportedTimeGrains: [
-        { label: 'Auto', value: 'auto' },
+        { label: t('azuremonitor.response-parser.label.auto', 'Auto'), value: 'auto' },
         ...ResponseParser.parseTimeGrains(metricData.metricAvailabilities ?? []),
       ],
       dimensions: ResponseParser.parseDimensions(metricData.dimensions ?? []),

--- a/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.tsx
@@ -1,6 +1,7 @@
 import { intersection } from 'lodash';
 import { useState, useMemo } from 'react';
 
+import { useTranslate } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 
 import Datasource from '../../datasource';
@@ -52,13 +53,24 @@ const ArgQueryEditor = ({
   onChange,
   setError,
 }: ArgQueryEditorProps) => {
+  const { t } = useTranslate();
   const [subscriptions, setSubscriptions] = useState<AzureMonitorOption[]>([]);
   useMemo(() => {
     datasource
       .getSubscriptions()
       .then((results) => {
         const selectAllSubscriptionOption = [
-          { label: 'Select all subscriptions', value: 'Select all subscriptions', description: 'Select all' },
+          {
+            label: t(
+              'azuremonitor.arg-query-editor.select-all-subscription-option.label.select-all-subscriptions',
+              'Select all subscriptions'
+            ),
+            value: 'Select all subscriptions',
+            description: t(
+              'azuremonitor.arg-query-editor.select-all-subscription-option.description.select-all',
+              'Select all'
+            ),
+          },
         ];
         const fetchedSubscriptions = results.map((v) => ({ label: v.text, value: v.value, description: v.value }));
         setSubscriptions(selectAllSubscriptionOption.concat(fetchedSubscriptions));

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -46,28 +46,31 @@ export const AzureCredentialsForm = (props: Props) => {
     let opts: Array<SelectableValue<AzureAuthType>> = [
       {
         value: 'clientsecret',
-        label: 'App Registration',
+        label: t(
+          'azuremonitor.azure-credentials-form.auth-type-options.opts.label.app-registration',
+          'App Registration'
+        ),
       },
     ];
 
     if (managedIdentityEnabled) {
       opts.push({
         value: 'msi',
-        label: 'Managed Identity',
+        label: t('azuremonitor.azure-credentials-form.auth-type-options.label.managed-identity', 'Managed Identity'),
       });
     }
 
     if (workloadIdentityEnabled) {
       opts.push({
         value: 'workloadidentity',
-        label: 'Workload Identity',
+        label: t('azuremonitor.azure-credentials-form.auth-type-options.label.workload-identity', 'Workload Identity'),
       });
     }
 
     if (userIdentityEnabled) {
       opts.unshift({
         value: 'currentuser',
-        label: 'Current User',
+        label: t('azuremonitor.azure-credentials-form.auth-type-options.label.current-user', 'Current User'),
       });
     }
 

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
@@ -86,7 +86,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
       if (isFetchError(err)) {
         this.setState({
           error: {
-            title: 'Error requesting subscriptions',
+            title: t(
+              'azuremonitor.config-editor.title.error-requesting-subscriptions',
+              'Error requesting subscriptions'
+            ),
             description: 'Could not request subscriptions from Azure. Check your credentials and try again.',
             details: err?.data?.message,
           },

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
@@ -37,21 +37,30 @@ export const CurrentUserFallbackCredentials = (props: Props) => {
     let opts: Array<SelectableValue<FallbackCredentialAuthTypeOptions>> = [
       {
         value: 'clientsecret',
-        label: 'App Registration',
+        label: t(
+          'azuremonitor.current-user-fallback-credentials.auth-type-options.opts.label.app-registration',
+          'App Registration'
+        ),
       },
     ];
 
     if (managedIdentityEnabled) {
       opts.push({
         value: 'msi',
-        label: 'Managed Identity',
+        label: t(
+          'azuremonitor.current-user-fallback-credentials.auth-type-options.label.managed-identity',
+          'Managed Identity'
+        ),
       });
     }
 
     if (workloadIdentityEnabled) {
       opts.push({
         value: 'workloadidentity',
-        label: 'Workload Identity',
+        label: t(
+          'azuremonitor.current-user-fallback-credentials.auth-type-options.label.workload-identity',
+          'Workload Identity'
+        ),
       });
     }
 
@@ -156,8 +165,14 @@ export const CurrentUserFallbackCredentials = (props: Props) => {
       >
         <RadioButtonGroup
           options={[
-            { label: 'Enabled', value: true },
-            { label: 'Disabled', value: false },
+            {
+              label: t('azuremonitor.current-user-fallback-credentials.label.options-enabled', 'Enabled'),
+              value: true,
+            },
+            {
+              label: t('azuremonitor.current-user-fallback-credentials.label.options-disabled', 'Disabled'),
+              value: false,
+            },
           ]}
           value={credentials.serviceCredentialsEnabled ?? false}
           size={'md'}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FuzzySearch.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/FuzzySearch.tsx
@@ -65,7 +65,10 @@ export const FuzzySearch: React.FC<FuzzySearchProps> = ({
     ? templateVariableOptions
     : [templateVariableOptions];
 
-  const defaultColumn: SelectableValue<string> = { label: 'All Columns *', value: '*' };
+  const defaultColumn: SelectableValue<string> = {
+    label: t('azuremonitor.fuzzy-search.default-column.label.all-columns', 'All Columns *'),
+    value: '*',
+  };
   const selectableOptions = [defaultColumn, ...columnOptions, ...safeTemplateVariables];
 
   const updateFuzzySearch = (column: string, term: string) => {

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/GroupByItem.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/GroupByItem.tsx
@@ -32,7 +32,12 @@ export const GroupByItem: React.FC<GroupByItemProps> = ({
   const columnOptions: Array<SelectableValue<string>> =
     columns.length > 0
       ? columns.map((c) => ({ label: c.label, value: c.value }))
-      : [{ label: 'No columns available', value: '' }];
+      : [
+          {
+            label: t('azuremonitor.group-by-item.column-options.label.no-columns-available', 'No columns available'),
+            value: '',
+          },
+        ];
 
   const selectableOptions: Array<SelectableValue<string>> = [
     ...columnOptions,

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/OrderBySection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/OrderBySection.tsx
@@ -60,8 +60,8 @@ export const OrderBySection: React.FC<OrderBySectionProps> = ({ query, allColumn
   }));
 
   const orderOptions: Array<SelectableValue<string>> = [
-    { label: 'Ascending', value: 'asc' },
-    { label: 'Descending', value: 'desc' },
+    { label: t('azuremonitor.order-by-section.order-options.label.ascending', 'Ascending'), value: 'asc' },
+    { label: t('azuremonitor.order-by-section.order-options.label.descending', 'Descending'), value: 'desc' },
   ];
 
   const handleOrderByChange = (index: number, key: 'column' | 'order', value: string) => {

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/TableSection.tsx
@@ -44,7 +44,7 @@ export const TableSection: React.FC<TableSectionProps> = (props) => {
   }));
 
   const selectAllOption: SelectableValue<string> = {
-    label: 'All Columns',
+    label: t('azuremonitor.table-section.select-all-option.label.all-columns', 'All Columns'),
     value: '__all_columns__',
   };
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsManagement.tsx
@@ -43,8 +43,8 @@ export function LogsManagement({ query, onQueryChange: onChange }: AzureQueryEdi
       >
         <RadioButtonGroup
           options={[
-            { label: 'Analytics', value: false },
-            { label: 'Basic', value: true },
+            { label: t('azuremonitor.logs-management.label.options-analytics', 'Analytics'), value: false },
+            { label: t('azuremonitor.logs-management.label.options-basic', 'Basic'), value: true },
           ]}
           value={query.azureLogAnalytics?.basicLogsQuery ?? false}
           size={'md'}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { PanelData, TimeRange } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, useTranslate } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { config, getTemplateSrv } from '@grafana/runtime';
 import { Alert, LinkButton, Space, Text, TextLink } from '@grafana/ui';
@@ -58,6 +58,7 @@ const LogsQueryEditor = ({
   timeRange,
   data,
 }: LogsQueryEditorProps) => {
+  const { t } = useTranslate();
   const migrationError = useMigrations(datasource, query, onChange);
   const [showBasicLogsToggle, setShowBasicLogsToggle] = useState<boolean>(
     shouldShowBasicLogsToggle(query.azureLogAnalytics?.resources || [], basicLogsEnabled)
@@ -318,9 +319,15 @@ const LogsQueryEditor = ({
                 setError={setError}
                 inputId={'azure-monitor-logs'}
                 options={[
-                  { label: 'Log', value: ResultFormat.Logs },
-                  { label: 'Time series', value: ResultFormat.TimeSeries },
-                  { label: 'Table', value: ResultFormat.Table },
+                  { label: t('azuremonitor.logs-query-editor.label.options-log', 'Log'), value: ResultFormat.Logs },
+                  {
+                    label: t('azuremonitor.logs-query-editor.label.options-time-series', 'Time series'),
+                    value: ResultFormat.TimeSeries,
+                  },
+                  {
+                    label: t('azuremonitor.logs-query-editor.label.options-table', 'Table'),
+                    value: ResultFormat.Table,
+                  },
                 ]}
                 defaultValue={ResultFormat.Logs}
                 setFormatAs={setFormatAs}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
@@ -104,8 +104,12 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
       >
         <RadioButtonGroup
           options={[
-            { label: 'Query', value: 'query', disabled: query.azureLogAnalytics?.mode === 'builder' },
-            { label: 'Dashboard', value: 'dashboard' },
+            {
+              label: t('azuremonitor.time-management.label.options-query', 'Query'),
+              value: 'query',
+              disabled: query.azureLogAnalytics?.mode === 'builder',
+            },
+            { label: t('azuremonitor.time-management.label.options-dashboard', 'Dashboard'), value: 'dashboard' },
           ]}
           value={
             query.azureLogAnalytics?.dashboardTime || query.azureLogAnalytics?.mode === 'builder'
@@ -133,11 +137,16 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
           <Select
             options={[
               {
-                label: 'Default time columns',
-                options: defaultTimeColumns ?? [{ value: 'TimeGenerated', label: 'TimeGenerated' }],
+                label: t('azuremonitor.time-management.label.options-default-time-columns', 'Default time columns'),
+                options: defaultTimeColumns ?? [
+                  {
+                    value: 'TimeGenerated',
+                    label: t('azuremonitor.time-management.label.options-time-generated', 'TimeGenerated'),
+                  },
+                ],
               },
               {
-                label: 'Other time columns',
+                label: t('azuremonitor.time-management.label.options-other-time-columns', 'Other time columns'),
                 options: timeColumns ?? [],
               },
             ]}
@@ -149,7 +158,10 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
                   ? defaultTimeColumns[0]
                   : timeColumns
                     ? timeColumns[0]
-                    : { value: 'TimeGenerated', label: 'TimeGenerated' }
+                    : {
+                        value: 'TimeGenerated',
+                        label: t('azuremonitor.time-management.label.value-time-generated', 'TimeGenerated'),
+                      }
             }
             allowCustomValue
           />

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/useMigrations.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/useMigrations.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { useTranslate } from '@grafana/i18n';
+
 import Datasource from '../../datasource';
 import { AzureMonitorQuery } from '../../types';
 import { isGUIDish } from '../ResourcePicker/utils';
@@ -45,12 +47,16 @@ export default function useMigrations(
   query: AzureMonitorQuery,
   onChange: (newQuery: AzureMonitorQuery) => void
 ) {
+  const { t } = useTranslate();
   const [migrationError, setMigrationError] = useState<ErrorMessage>();
 
   useEffect(() => {
     migrateWorkspaceQueryToResourceQuery(datasource, query, onChange).catch((err) =>
       setMigrationError({
-        title: 'Unable to migrate workspace as a resource',
+        title: t(
+          'azuremonitor.use-migrations.title.unable-migrate-workspace-resource',
+          'Unable to migrate workspace as a resource'
+        ),
         message: err.message,
       })
     );

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
@@ -74,7 +74,7 @@ const DimensionFields = ({ data, query, dimensionOptions, onQueryChange }: Dimen
   const dimensionOperators: Array<SelectableValue<string>> = [
     { label: '==', value: 'eq' },
     { label: '!=', value: 'ne' },
-    { label: 'starts with', value: 'sw' },
+    { label: t('azuremonitor.dimension-fields.dimension-operators.label.starts-with', 'starts with'), value: 'sw' },
   ];
 
   const validDimensionOptions = useMemo(() => {

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
@@ -71,7 +71,7 @@ const QueryEditor = ({
     app !== CoreApp.UnifiedAlerting &&
     app !== CoreApp.CloudAlerting;
   const variableOptionGroup = {
-    label: 'Template Variables',
+    label: t('azuremonitor.query-editor.variable-option-group.label.template-variables', 'Template Variables'),
     options: datasource.getVariables().map((v) => ({ label: v, value: v })),
   };
 

--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx
@@ -41,10 +41,13 @@ export const QueryHeader = ({
   const currentMode = query.azureLogAnalytics?.mode;
 
   const queryTypes: Array<{ value: AzureQueryType; label: string }> = [
-    { value: AzureQueryType.AzureMonitor, label: 'Metrics' },
-    { value: AzureQueryType.LogAnalytics, label: 'Logs' },
-    { value: AzureQueryType.AzureTraces, label: 'Traces' },
-    { value: AzureQueryType.AzureResourceGraph, label: 'Azure Resource Graph' },
+    { value: AzureQueryType.AzureMonitor, label: t('azuremonitor.query-header.query-types.label.metrics', 'Metrics') },
+    { value: AzureQueryType.LogAnalytics, label: t('azuremonitor.query-header.query-types.label.logs', 'Logs') },
+    { value: AzureQueryType.AzureTraces, label: t('azuremonitor.query-header.query-types.label.traces', 'Traces') },
+    {
+      value: AzureQueryType.AzureResourceGraph,
+      label: t('azuremonitor.query-header.query-types.label.azure-resource-graph', 'Azure Resource Graph'),
+    },
   ];
 
   const handleChange = useCallback(

--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TracesQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TracesQueryEditor.tsx
@@ -162,8 +162,14 @@ const TracesQueryEditor = ({
               onQueryChange={onChange}
               inputId="azure-monitor-traces"
               options={[
-                { label: 'Table', value: ResultFormat.Table },
-                { label: 'Trace', value: ResultFormat.Trace },
+                {
+                  label: t('azuremonitor.traces-query-editor.label.options-table', 'Table'),
+                  value: ResultFormat.Table,
+                },
+                {
+                  label: t('azuremonitor.traces-query-editor.label.options-trace', 'Trace'),
+                  value: ResultFormat.Trace,
+                },
               ]}
               defaultValue={ResultFormat.Table}
               setFormatAs={setFormatAs}

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -30,22 +30,64 @@ const VariableEditor = (props: Props) => {
   const { query, onChange, datasource } = props;
   const { t } = useTranslate();
   const AZURE_QUERY_VARIABLE_TYPE_OPTIONS = [
-    { label: 'Subscriptions', value: AzureQueryType.SubscriptionsQuery },
-    { label: 'Resource Groups', value: AzureQueryType.ResourceGroupsQuery },
-    { label: 'Namespaces', value: AzureQueryType.NamespacesQuery },
-    { label: 'Regions', value: AzureQueryType.LocationsQuery },
-    { label: 'Resource Names', value: AzureQueryType.ResourceNamesQuery },
-    { label: 'Metric Names', value: AzureQueryType.MetricNamesQuery },
-    { label: 'Workspaces', value: AzureQueryType.WorkspacesQuery },
-    { label: 'Resource Graph', value: AzureQueryType.AzureResourceGraph },
-    { label: 'Logs', value: AzureQueryType.LogAnalytics },
-    { label: 'Custom Namespaces', value: AzureQueryType.CustomNamespacesQuery },
-    { label: 'Custom Metric Names', value: AzureQueryType.CustomMetricNamesQuery },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.subscriptions', 'Subscriptions'),
+      value: AzureQueryType.SubscriptionsQuery,
+    },
+    {
+      label: t(
+        'azuremonitor.variable-editor.azure_query_variable_type_options.label.resource-groups',
+        'Resource Groups'
+      ),
+      value: AzureQueryType.ResourceGroupsQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.namespaces', 'Namespaces'),
+      value: AzureQueryType.NamespacesQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.regions', 'Regions'),
+      value: AzureQueryType.LocationsQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.resource-names', 'Resource Names'),
+      value: AzureQueryType.ResourceNamesQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.metric-names', 'Metric Names'),
+      value: AzureQueryType.MetricNamesQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.workspaces', 'Workspaces'),
+      value: AzureQueryType.WorkspacesQuery,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.resource-graph', 'Resource Graph'),
+      value: AzureQueryType.AzureResourceGraph,
+    },
+    {
+      label: t('azuremonitor.variable-editor.azure_query_variable_type_options.label.logs', 'Logs'),
+      value: AzureQueryType.LogAnalytics,
+    },
+    {
+      label: t(
+        'azuremonitor.variable-editor.azure_query_variable_type_options.label.custom-namespaces',
+        'Custom Namespaces'
+      ),
+      value: AzureQueryType.CustomNamespacesQuery,
+    },
+    {
+      label: t(
+        'azuremonitor.variable-editor.azure_query_variable_type_options.label.custom-metric-names',
+        'Custom Metric Names'
+      ),
+      value: AzureQueryType.CustomMetricNamesQuery,
+    },
   ];
   if (typeof props.query === 'object' && props.query.queryType === AzureQueryType.GrafanaTemplateVariableFn) {
     // Add the option for the GrafanaTemplateVariableFn only if it's already in use
     AZURE_QUERY_VARIABLE_TYPE_OPTIONS.push({
-      label: 'Grafana Query Function',
+      label: t('azuremonitor.variable-editor.label.grafana-query-function', 'Grafana Query Function'),
       value: AzureQueryType.GrafanaTemplateVariableFn,
     });
   }
@@ -134,7 +176,7 @@ const VariableEditor = (props: Props) => {
       }
     });
     setVariableOptionGroup({
-      label: 'Template Variables',
+      label: t('azuremonitor.variable-editor.label.template-variables', 'Template Variables'),
       options,
     });
   }, [datasource, queryType]);

--- a/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
+++ b/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
@@ -1,4 +1,177 @@
 {
+  "azuremonitor": {
+    "arg-query-editor": {
+      "select-all-subscription-option": {
+        "description": {
+          "select-all": "Select all"
+        },
+        "label": {
+          "select-all-subscriptions": "Select all subscriptions"
+        }
+      }
+    },
+    "azure-credentials-form": {
+      "auth-type-options": {
+        "label": {
+          "current-user": "Current User",
+          "managed-identity": "Managed Identity",
+          "workload-identity": "Workload Identity"
+        },
+        "opts": {
+          "label": {
+            "app-registration": "App Registration"
+          }
+        }
+      }
+    },
+    "azure-log-analytics-datasource": {
+      "message": {
+        "the-client-id-field-is-required": "The Client Id field is required.",
+        "the-tenant-id-field-is-required": "The Tenant Id field is required."
+      }
+    },
+    "azure-monitor-datasource": {
+      "message": {
+        "the-client-id-field-is-required": "The Client Id field is required.",
+        "the-tenant-id-field-is-required": "The Tenant Id field is required."
+      }
+    },
+    "config-editor": {
+      "title": {
+        "error-requesting-subscriptions": "Error requesting subscriptions"
+      }
+    },
+    "current-user-fallback-credentials": {
+      "auth-type-options": {
+        "label": {
+          "managed-identity": "Managed Identity",
+          "workload-identity": "Workload Identity"
+        },
+        "opts": {
+          "label": {
+            "app-registration": "App Registration"
+          }
+        }
+      },
+      "label": {
+        "options-disabled": "Disabled",
+        "options-enabled": "Enabled"
+      }
+    },
+    "dimension-fields": {
+      "dimension-operators": {
+        "label": {
+          "starts-with": "starts with"
+        }
+      }
+    },
+    "fuzzy-search": {
+      "default-column": {
+        "label": {
+          "all-columns": "All Columns *"
+        }
+      }
+    },
+    "group-by-item": {
+      "column-options": {
+        "label": {
+          "no-columns-available": "No columns available"
+        }
+      }
+    },
+    "logs-management": {
+      "label": {
+        "options-analytics": "Analytics",
+        "options-basic": "Basic"
+      }
+    },
+    "logs-query-editor": {
+      "label": {
+        "options-log": "Log",
+        "options-table": "Table",
+        "options-time-series": "Time series"
+      }
+    },
+    "order-by-section": {
+      "order-options": {
+        "label": {
+          "ascending": "Ascending",
+          "descending": "Descending"
+        }
+      }
+    },
+    "query-editor": {
+      "variable-option-group": {
+        "label": {
+          "template-variables": "Template Variables"
+        }
+      }
+    },
+    "query-header": {
+      "query-types": {
+        "label": {
+          "azure-resource-graph": "Azure Resource Graph",
+          "logs": "Logs",
+          "metrics": "Metrics",
+          "traces": "Traces"
+        }
+      }
+    },
+    "response-parser": {
+      "label": {
+        "auto": "Auto"
+      }
+    },
+    "table-section": {
+      "select-all-option": {
+        "label": {
+          "all-columns": "All Columns"
+        }
+      }
+    },
+    "time-management": {
+      "label": {
+        "options-dashboard": "Dashboard",
+        "options-default-time-columns": "Default time columns",
+        "options-other-time-columns": "Other time columns",
+        "options-query": "Query",
+        "options-time-generated": "TimeGenerated",
+        "value-time-generated": "TimeGenerated"
+      }
+    },
+    "traces-query-editor": {
+      "label": {
+        "options-table": "Table",
+        "options-trace": "Trace"
+      }
+    },
+    "use-migrations": {
+      "title": {
+        "unable-migrate-workspace-resource": "Unable to migrate workspace as a resource"
+      }
+    },
+    "variable-editor": {
+      "azure_query_variable_type_options": {
+        "label": {
+          "custom-metric-names": "Custom Metric Names",
+          "custom-namespaces": "Custom Namespaces",
+          "logs": "Logs",
+          "metric-names": "Metric Names",
+          "namespaces": "Namespaces",
+          "regions": "Regions",
+          "resource-graph": "Resource Graph",
+          "resource-groups": "Resource Groups",
+          "resource-names": "Resource Names",
+          "subscriptions": "Subscriptions",
+          "workspaces": "Workspaces"
+        }
+      },
+      "label": {
+        "grafana-query-function": "Grafana Query Function",
+        "template-variables": "Template Variables"
+      }
+    }
+  },
   "components": {
     "advanced-multi": {
       "label-advanced": "Advanced"

--- a/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
@@ -102,12 +102,48 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
 
   const buildAuthenticationOptions = (): Array<SelectableValue<MSSQLAuthenticationType>> => {
     const basicAuthenticationOptions: Array<SelectableValue<MSSQLAuthenticationType>> = [
-      { value: MSSQLAuthenticationType.sqlAuth, label: 'SQL Server Authentication' },
-      { value: MSSQLAuthenticationType.windowsAuth, label: 'Windows Authentication' },
-      { value: MSSQLAuthenticationType.kerberosRaw, label: 'Windows AD: Username + password' },
-      { value: MSSQLAuthenticationType.kerberosKeytab, label: 'Windows AD: Keytab file' },
-      { value: MSSQLAuthenticationType.kerberosCredentialCache, label: 'Windows AD: Credential cache' },
-      { value: MSSQLAuthenticationType.kerberosCredentialCacheLookupFile, label: 'Windows AD: Credential cache file' },
+      {
+        value: MSSQLAuthenticationType.sqlAuth,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.sql-server-authentication',
+          'SQL Server Authentication'
+        ),
+      },
+      {
+        value: MSSQLAuthenticationType.windowsAuth,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.windows-authentication',
+          'Windows Authentication'
+        ),
+      },
+      {
+        value: MSSQLAuthenticationType.kerberosRaw,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.windows-ad-username-password',
+          'Windows AD: Username + password'
+        ),
+      },
+      {
+        value: MSSQLAuthenticationType.kerberosKeytab,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.windows-ad-keytab-file',
+          'Windows AD: Keytab file'
+        ),
+      },
+      {
+        value: MSSQLAuthenticationType.kerberosCredentialCache,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.windows-ad-credential-cache',
+          'Windows AD: Credential cache'
+        ),
+      },
+      {
+        value: MSSQLAuthenticationType.kerberosCredentialCacheLookupFile,
+        label: t(
+          'mssql.configuration-editor.build-authentication-options.basic-authentication-options.label.windows-ad-credential-cache-file',
+          'Windows AD: Credential cache file'
+        ),
+      },
     ];
 
     if (azureAuthIsSupported) {
@@ -121,9 +157,12 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
   };
 
   const encryptOptions: Array<SelectableValue<string>> = [
-    { value: MSSQLEncryptOptions.disable, label: 'disable' },
-    { value: MSSQLEncryptOptions.false, label: 'false' },
-    { value: MSSQLEncryptOptions.true, label: 'true' },
+    {
+      value: MSSQLEncryptOptions.disable,
+      label: t('mssql.configuration-editor.encrypt-options.label.disable', 'disable'),
+    },
+    { value: MSSQLEncryptOptions.false, label: t('mssql.configuration-editor.encrypt-options.label.false', 'false') },
+    { value: MSSQLEncryptOptions.true, label: t('mssql.configuration-editor.encrypt-options.label.true', 'true') },
   ];
 
   return (

--- a/public/app/plugins/datasource/mssql/locales/en-US/mssql.json
+++ b/public/app/plugins/datasource/mssql/locales/en-US/mssql.json
@@ -124,5 +124,28 @@
       "required-credential-cache-path": "Credential cache path is required",
       "required-username": "Username is required"
     }
+  },
+  "mssql": {
+    "configuration-editor": {
+      "build-authentication-options": {
+        "basic-authentication-options": {
+          "label": {
+            "sql-server-authentication": "SQL Server Authentication",
+            "windows-ad-credential-cache": "Windows AD: Credential cache",
+            "windows-ad-credential-cache-file": "Windows AD: Credential cache file",
+            "windows-ad-keytab-file": "Windows AD: Keytab file",
+            "windows-ad-username-password": "Windows AD: Username + password",
+            "windows-authentication": "Windows Authentication"
+          }
+        }
+      },
+      "encrypt-options": {
+        "label": {
+          "disable": "disable",
+          "false": "false",
+          "true": "true"
+        }
+      }
+    }
   }
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -400,7 +400,8 @@
       "no-results": "No results.",
       "text-loading-notifications": "Loading notifications",
       "title-error-loading-notifications": "Error loading notifications",
-      "title-grafana-alerts-delivered-alertmanager": "Grafana alerts are not delivered to Grafana Alertmanager"
+      "title-grafana-alerts-delivered-alertmanager": "Grafana alerts are not delivered to Grafana Alertmanager",
+      "unknown-error": "Unknown error"
     },
     "alert-groups-summary": {
       "text-firing_one": "{{count}} firing",
@@ -523,6 +524,7 @@
       "view-configuration": "View configuration"
     },
     "alertmanager-config": {
+      "an-unknown-error-occurred": "An unknown error occurred.",
       "gma-manual-configuration-description": "The internal Grafana Alertmanager configuration cannot be manually changed. To change this configuration, edit the individual resources through the UI.",
       "gma-manual-configuration-is-not-supported": "Manual configuration changes not supported",
       "message": {
@@ -929,10 +931,16 @@
       "missing-reference": "Expression \"{{source}}\" failed to run because \"{{target}}\" is missing or also failed.",
       "self-reference": "You can't link an expression to itself"
     },
+    "dashboard-annotation-field": {
+      "no-title": "<No title>"
+    },
     "dashboard-picker": {
       "confirm": "Confirm",
       "current-selection-dashboard": "Dashboard: {{dashboardTitle}} ({{ dashboardUid }}) in folder {{ folderTitle }}",
       "current-selection-panel": "Panel: {{ panelTitle }} ({{ panelId }})",
+      "dashboard-row": {
+        "dashboards": "Dashboards"
+      },
       "fallback-dashboards-string": "Dashboards",
       "panel-row": {
         "content-panel-valid-identifier": "This panel does not have a valid identifier.",
@@ -1872,11 +1880,13 @@
     },
     "notification-policies-filter": {
       "label-search-by-contact-point": "Search by contact point",
+      "no-policies-matching-filters": "No policies matching filters.",
       "search-query-input-placeholder-search": "Search"
     },
     "notification-policies-list": {
       "title-error-loading-alertmanager-config": "Error loading Alertmanager config",
-      "title-notification-policies-have-changed": "Notification policies have changed"
+      "title-notification-policies-have-changed": "Notification policies have changed",
+      "unknown-error": "Unknown error."
     },
     "notification-policies-tabs": {
       "label-notification-policies": "Notification Policies",
@@ -2348,6 +2358,7 @@
       }
     },
     "rule-health": {
+      "content-no-error-message-provided": "No error message provided.",
       "error": "error"
     },
     "rule-inspector": {
@@ -2458,6 +2469,7 @@
         "alert-message": "Alert rule has been added or updated. Changes may take up to a minute to appear on the Alert rules list view.",
         "alert-title": "Update in progress"
       },
+      "sub-title-no-error-message": "No error message",
       "title-something-wrong-evaluating-alert": "Something went wrong when evaluating this alert rule"
     },
     "rules": {
@@ -2476,6 +2488,9 @@
       "update-rule": {
         "success": "Rule updated successfully"
       }
+    },
+    "rules-by-state": {
+      "title-unknown": "Unknown"
     },
     "rules-filter": {
       "clear-filters": "Clear filters",
@@ -2700,6 +2715,9 @@
       "existing-templates-selector-placeholder-choose-notification-template": "Choose notification template",
       "loading": "Loading...",
       "template-options": {
+        "ariaLabel": {
+          "select-notification-template": "Select notification template"
+        },
         "label": {
           "select-notification-template": "Select notification template"
         }
@@ -2950,6 +2968,7 @@
       "no-events-found": "No events found",
       "no-query-editor": "Annotations are not supported. This datasource needs to export a QueryEditor",
       "test-annotation-query": "Test annotation query",
+      "there-was-an-error-fetching-data": "There was an error fetching data",
       "title-query-result": "Query result"
     }
   },
@@ -4420,6 +4439,11 @@
       "title-unlink": "Disconnects this panel from the library panel so that you can edit it regularly.",
       "unlink": "Unlink"
     },
+    "panel-header-title-items": {
+      "alert-state-item": {
+        "content-unknown": "unknown"
+      }
+    },
     "panel-links": {
       "aria-label-panel-links": "Panel links"
     },
@@ -5843,7 +5867,8 @@
     "resource-dimension-editor": {
       "label-field": "Field",
       "label-mappings": "Mappings",
-      "label-source": "Source"
+      "label-source": "Source",
+      "placeholder-select-a-value": "Select a value"
     },
     "resource-picker": {
       "render-small-resource-picker": {
@@ -6032,6 +6057,11 @@
       "continue-without-saving": "Continue without saving",
       "save-correlation": "Save correlation",
       "title-unsaved-changes-to-correlation": "Unsaved changes to correlation"
+    },
+    "create-span-link-factory": {
+      "new-span-links": {
+        "title-link": "Link"
+      }
     },
     "draggable-manager-demo": {
       "click-and-drag-gray-divider": "Click and drag the gray divider in the colored area, below.",
@@ -6240,6 +6270,9 @@
     },
     "references": {
       "label-attributes": "attributes"
+    },
+    "render-menu-items": {
+      "label-link": "Link"
     },
     "rich-history": {
       "close-tooltip": "Close query history",
@@ -6789,6 +6822,9 @@
     },
     "progress-status": {
       "your-progress": "Your progress"
+    },
+    "step-button": {
+      "no-options-available": "No options available"
     },
     "use-get-configuration-for-ui": {
       "get-connect-data-source-configuration": {
@@ -7710,6 +7746,7 @@
       "aria-label-unpin-line": "Unpin line",
       "tooltip-copy-shortlink": "Copy shortlink",
       "tooltip-copy-to-clipboard": "Copy to clipboard",
+      "tooltip-pin-line": "Pin line",
       "tooltip-show-context": "Show context",
       "tooltip-unpin-line": "Unpin line"
     },
@@ -7909,6 +7946,7 @@
       "title": "Disconnect from cloud stack"
     },
     "folder-info": {
+      "dashboards": "Dashboards",
       "folder": "Folder {{folderUid}}",
       "unable-to-load-folder": "Unable to load folder"
     },
@@ -9050,6 +9088,7 @@
       "installed-version": "{{versionNumber}} (installed version)",
       "latest-compatible-version": "{{versionNumber}} (latest compatible version)",
       "latest-release-date": "Latest release date",
+      "na": "N/A",
       "no-version-history-was-found": "No version history was found.",
       "version": "Version"
     }
@@ -9372,6 +9411,7 @@
       "job-id": "Job ID:",
       "last-ref": "Last Ref:",
       "messages": "Messages:",
+      "na": "N/A",
       "not-available": "N/A",
       "pull-status": "Pull status",
       "resources": "Resources",
@@ -9995,6 +10035,9 @@
       "enable": "Enable",
       "tooltip-managed-service-account-cannot-modified": "This is a managed service account and cannot be modified"
     },
+    "get-cell-content": {
+      "no-tokens": "No tokens"
+    },
     "get-role-cell": {
       "aria-label-role": "Role"
     },
@@ -10003,6 +10046,7 @@
       "aria-label-role": "Role",
       "disable": "Disable",
       "enable": "Enable",
+      "no-tokens": "No tokens",
       "title-tokens": "Tokens",
       "tooltip-delete-button": "Delete service account {{serviceAccountName}}",
       "tooltip-managed-service-account-cannot-modified": "This is a managed service account and cannot be modified"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5446,6 +5446,7 @@
       "placeholder-descriptive-text": "Descriptive text",
       "placeholder-label-name": "Label name",
       "placeholder-variable-name": "Variable name",
+      "run-query": "Run query",
       "text-running-query": "Running query...",
       "title": {
         "delete-variable": "Delete variable"


### PR DESCRIPTION
WIP

TODO:
- Enable auto fixes for object properties in enterprise
- ~Fix special cases for `null`/`nan` etc - https://github.com/grafana/grafana/pull/105072#discussion_r2100627492~
- ~Fix ternaries/generalise that logic - https://github.com/grafana/grafana/pull/105072#discussion_r2100611823~
- ~Add logic to catch cases such as `foo || 'unknown text'`. This should be easy to do, but there are quite a few cases of it in the code~