### PR TITLE
ds-querier: handle downstream 500s

### DIFF
--- a/pkg/expr/metrics/metrics.go
+++ b/pkg/expr/metrics/metrics.go
@@ -12,7 +12,6 @@ type ExprMetrics struct {
 	SqlCommandDuration      *prometheus.HistogramVec
 	SqlCommandErrorCount    *prometheus.CounterVec
 	SqlCommandCellCount     *prometheus.HistogramVec
-	QuerierResponseTotal    *prometheus.CounterVec
 }
 
 func newExprMetrics(subsystem string) *ExprMetrics {
@@ -60,12 +59,6 @@ func newExprMetrics(subsystem string) *ExprMetrics {
 			},
 			[]string{"status"},
 		),
-		QuerierResponseTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "grafana",
-			Subsystem: subsystem,
-			Name:      "ds_querier_response_total",
-			Help:      "Number of ds-querier responses",
-		}, []string{"status"}),
 	}
 }
 
@@ -112,8 +105,6 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 		SqlCommandErrorCount: newExprMetrics(metricsSubSystem).SqlCommandErrorCount,
 
 		SqlCommandCellCount: newExprMetrics(metricsSubSystem).SqlCommandCellCount,
-
-		QuerierResponseTotal: newExprMetrics(metricsSubSystem).QuerierResponseTotal,
 	}
 
 	if reg != nil {
@@ -123,7 +114,6 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 			m.SqlCommandDuration,
 			m.SqlCommandErrorCount,
 			m.SqlCommandCellCount,
-			m.QuerierResponseTotal,
 		)
 	}
 

--- a/pkg/expr/metrics/metrics.go
+++ b/pkg/expr/metrics/metrics.go
@@ -12,6 +12,7 @@ type ExprMetrics struct {
 	SqlCommandDuration      *prometheus.HistogramVec
 	SqlCommandErrorCount    *prometheus.CounterVec
 	SqlCommandCellCount     *prometheus.HistogramVec
+	QuerierResponseTotal    *prometheus.CounterVec
 }
 
 func newExprMetrics(subsystem string) *ExprMetrics {
@@ -59,6 +60,12 @@ func newExprMetrics(subsystem string) *ExprMetrics {
 			},
 			[]string{"status"},
 		),
+		QuerierResponseTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Subsystem: subsystem,
+			Name:      "ds_querier_response_total",
+			Help:      "Number of ds-querier responses",
+		}, []string{"status"}),
 	}
 }
 
@@ -105,6 +112,8 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 		SqlCommandErrorCount: newExprMetrics(metricsSubSystem).SqlCommandErrorCount,
 
 		SqlCommandCellCount: newExprMetrics(metricsSubSystem).SqlCommandCellCount,
+
+		QuerierResponseTotal: newExprMetrics(metricsSubSystem).QuerierResponseTotal,
 	}
 
 	if reg != nil {
@@ -114,6 +123,7 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 			m.SqlCommandDuration,
 			m.SqlCommandErrorCount,
 			m.SqlCommandCellCount,
+			m.QuerierResponseTotal,
 		)
 	}
 

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
@@ -95,21 +94,36 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		traceId := span.SpanContext().TraceID()
 		connectLogger := b.log.New("traceId", traceId.String())
 		responder := newResponderWrapper(incomingResponder,
-			func(statusCode int, obj runtime.Object) {
-				if statusCode >= 500 {
-					b.metrics.QuerierResponseTotal.With(prometheus.Labels{"status": "err"}).Inc()
-				} else {
-					b.metrics.QuerierResponseTotal.With(prometheus.Labels{"status": "good"}).Inc()
+			func(statusCode *int, obj runtime.Object) {
+				if *statusCode/100 == 4 {
+					span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
 				}
-				if statusCode >= 400 {
-					connectLogger.Debug("error found in success handler in connect", "statuscode", strconv.Itoa(statusCode))
-					span.SetStatus(codes.Error, fmt.Sprintf("error with HTTP status code %s", strconv.Itoa(statusCode)))
+
+				if *statusCode >= 500 {
+					o, ok := obj.(*query.QueryDataResponse)
+					if ok && o.Responses != nil {
+						for refId, response := range o.Responses {
+							if response.ErrorSource == backend.ErrorSourceDownstream {
+								*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
+								span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+								span.SetAttributes(attribute.String("error.source", "downstream"))
+								break
+							} else if response.Error != nil {
+								connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
+								span.SetStatus(codes.Error, "500 error without downstream error source")
+							} else {
+								span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
+								span.SetAttributes(attribute.String("error.ref_id", refId))
+							}
+						}
+					}
 				}
 			},
+
 			func(err error) {
-				b.metrics.QuerierResponseTotal.With(prometheus.Labels{"status": "err"}).Inc()
-				b.log.Debug("error caught in handler", "err", err)
+				connectLogger.Error("error caught in handler", "err", err)
 				span.SetStatus(codes.Error, "query error")
+
 				if err == nil {
 					return
 				}
@@ -216,7 +230,6 @@ func (b *QueryAPIBuilder) execute(ctx context.Context, req parsedRequestInfo) (q
 			b.log.Debug("error in executeConcurrentQueries", "err", err)
 		}
 	}
-
 	if err != nil {
 		b.log.Debug("error in query phase, skipping expressions", "error", err)
 		return qdr, err //return early here to prevent expressions from being executed if we got an error during the query phase
@@ -475,11 +488,11 @@ func (b *QueryAPIBuilder) convertQueryFromAlerting(ctx context.Context, req data
 
 type responderWrapper struct {
 	wrapped    rest.Responder
-	onObjectFn func(statusCode int, obj runtime.Object)
+	onObjectFn func(statusCode *int, obj runtime.Object)
 	onErrorFn  func(err error)
 }
 
-func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
+func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
 	return &responderWrapper{
 		wrapped:    responder,
 		onObjectFn: onObjectFn,
@@ -489,7 +502,7 @@ func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode in
 
 func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
 	if r.onObjectFn != nil {
-		r.onObjectFn(statusCode, obj)
+		r.onObjectFn(&statusCode, obj)
 	}
 
 	r.wrapped.Object(statusCode, obj)

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -94,7 +94,6 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))
 		traceId := span.SpanContext().TraceID()
 		connectLogger := b.log.New("traceId", traceId.String())
-		b.log = connectLogger
 		responder := newResponderWrapper(incomingResponder,
 			func(statusCode int, obj runtime.Object) {
 				if statusCode >= 500 {
@@ -103,7 +102,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 					b.metrics.QuerierResponseTotal.With(prometheus.Labels{"status": "good"}).Inc()
 				}
 				if statusCode >= 400 {
-					b.log.Debug("error found in success handler in connect", "statuscode", strconv.Itoa(statusCode))
+					connectLogger.Debug("error found in success handler in connect", "statuscode", strconv.Itoa(statusCode))
 					span.SetStatus(codes.Error, fmt.Sprintf("error with HTTP status code %s", strconv.Itoa(statusCode)))
 				}
 			},


### PR DESCRIPTION
We weren't handling `500`s correctly. This change checks if we have a `backend.ErrorSourceDownstream` set for `ErrorSource` and if so rewrite the status code from `500` to `400`. This is done since our SLO tracks `500`s and `downstream` errors should be handled by the plugin/data source instead of the ds-querier.

To enable rewriting the status code I had to tweak the handler function to handle a reference to the status code instead of passing it by value.