### PR TITLE
Transformations: Transpose transformation should use the displayName

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/transpose.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/transpose.test.ts
@@ -103,7 +103,7 @@ describe('Transpose transformer', () => {
         {
           name: 'Field',
           type: FieldType.string,
-          values: ['january', 'february', 'metricName'],
+          values: ['january', 'february', 'type'],
           config: {},
         },
         {

--- a/packages/grafana-data/src/transformations/transformers/transpose.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/transpose.test.ts
@@ -90,18 +90,20 @@ describe('Transpose transformer', () => {
           name: 'metricName',
           type: FieldType.string,
           values: ['metricA', 'metricB', 'metricC', 'metricD', 'metricE'],
+          config: {
+            displayName: 'type',
+          },
         },
       ],
     });
-    // toDataFrame removes state
-    seriesB.fields[3].state = { displayName: 'type' };
+
     await expect(transformDataFrame([cfgB], [seriesB])).toEmitValuesWith((received) => {
       const result = received[0];
       expect(result[0].fields).toEqual([
         {
           name: 'Field',
           type: FieldType.string,
-          values: ['january', 'february', 'type'],
+          values: ['january', 'february', 'metricName'],
           config: {},
         },
         {

--- a/packages/grafana-data/src/transformations/transformers/transpose.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/transpose.test.ts
@@ -86,9 +86,15 @@ describe('Transpose transformer', () => {
         { name: 'env', type: FieldType.string, values: ['dev', 'prod', 'staging', 'release', 'beta'] },
         { name: 'january', type: FieldType.number, values: [11, 12, 13, 14, 15] },
         { name: 'february', type: FieldType.number, values: [6, 7, 8, 9, 10] },
-        { name: 'type', type: FieldType.string, values: ['metricA', 'metricB', 'metricC', 'metricD', 'metricE'] },
+        {
+          name: 'metricName',
+          type: FieldType.string,
+          values: ['metricA', 'metricB', 'metricC', 'metricD', 'metricE'],
+        },
       ],
     });
+    // toDataFrame removes state
+    seriesB.fields[3].state = { displayName: 'type' };
     await expect(transformDataFrame([cfgB], [seriesB])).toEmitValuesWith((received) => {
       const result = received[0];
       expect(result[0].fields).toEqual([

--- a/packages/grafana-data/src/transformations/transformers/transpose.ts
+++ b/packages/grafana-data/src/transformations/transformers/transpose.ts
@@ -38,8 +38,12 @@ function transposeDataFrame(options: TransposeTransformerOptions, data: DataFram
       ? [firstName, ...fieldValuesAsStrings(firstField, firstField.values)]
       : [firstName, ...firstField.values.map((_, i) => restName)];
     const rows = useFirstFieldAsHeaders
-      ? frame.fields.map((field) => field.name).slice(1)
-      : frame.fields.map((field) => field.name);
+      ? frame.fields
+          .map((field) => {
+            return field.state?.displayName ?? field.name;
+          })
+          .slice(1)
+      : frame.fields.map((field) => field.state?.displayName ?? field.name);
     const fieldType = determineFieldType(
       useFirstFieldAsHeaders
         ? frame.fields.map((field) => field.type).slice(1)

--- a/packages/grafana-data/src/transformations/transformers/transpose.ts
+++ b/packages/grafana-data/src/transformations/transformers/transpose.ts
@@ -1,5 +1,6 @@
 import { map } from 'rxjs/operators';
 
+import { cacheFieldDisplayNames } from '../../field/fieldState';
 import { DataFrame, Field, FieldType } from '../../types/dataFrame';
 import { DataTransformerInfo } from '../../types/transformations';
 
@@ -28,6 +29,8 @@ export const transposeTransformer: DataTransformerInfo<TransposeTransformerOptio
 };
 
 function transposeDataFrame(options: TransposeTransformerOptions, data: DataFrame[]): DataFrame[] {
+  cacheFieldDisplayNames(data);
+
   return data.map((frame) => {
     const firstField = frame.fields[0];
     const firstName = !options.firstFieldName ? 'Field' : options.firstFieldName;


### PR DESCRIPTION
**What is this feature?**

If a field was renamed prior to the transpose transformation, the transformation should use that name instead of the original name.

**Which issue(s) does this PR fix?**:

Fixes #[105465](https://github.com/grafana/grafana/issues/105465)
Fixes #[103946](https://github.com/grafana/grafana/issues/103946)

**Special notes for your reviewer:**
Please see dashboard linked in issue for replication

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
