### PR TITLE
InfluxDB: Add tracking events to v1 config page

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -118,7 +118,9 @@ export class ConfigEditor extends PureComponent<Props, State> {
               options={versions}
               defaultValue={versionMap[InfluxVersion.InfluxQL]}
               onChange={this.onVersionChanged}
-              onBlur={() => trackInfluxDBConfigV1QueryLanguageSelection({ version: this.props.options.jsonData.version || "" })}
+              onBlur={() =>
+                trackInfluxDBConfigV1QueryLanguageSelection({ version: this.props.options.jsonData.version || '' })
+              }
             />
           </Field>
         </FieldSet>

--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -7,7 +7,7 @@ import {
   SelectableValue,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Alert, DataSourceHttpSettings, InlineField, Select, Field, Input, FieldSet } from '@grafana/ui';
 
 import { BROWSER_MODE_DISABLED_MESSAGE } from '../../../constants';
@@ -117,6 +117,11 @@ export class ConfigEditor extends PureComponent<Props, State> {
               options={versions}
               defaultValue={versionMap[InfluxVersion.InfluxQL]}
               onChange={this.onVersionChanged}
+              onBlur={() => {
+                reportInteraction('influxdb-configv1-query-language-dropdown', {
+                  version: this.props.options.jsonData.version,
+                });
+              }}
             />
           </Field>
         </FieldSet>

--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -7,7 +7,7 @@ import {
   SelectableValue,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { Alert, DataSourceHttpSettings, InlineField, Select, Field, Input, FieldSet } from '@grafana/ui';
 
 import { BROWSER_MODE_DISABLED_MESSAGE } from '../../../constants';
@@ -16,6 +16,7 @@ import { InfluxOptions, InfluxOptionsV1, InfluxVersion } from '../../../types';
 import { InfluxFluxConfig } from './InfluxFluxConfig';
 import { InfluxInfluxQLConfig } from './InfluxInfluxQLConfig';
 import { InfluxSqlConfig } from './InfluxSQLConfig';
+import { trackInfluxDBConfigV1QueryLanguageSelection } from './trackingv1';
 
 const versionMap: Record<InfluxVersion, SelectableValue<InfluxVersion>> = {
   [InfluxVersion.InfluxQL]: {
@@ -117,11 +118,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               options={versions}
               defaultValue={versionMap[InfluxVersion.InfluxQL]}
               onChange={this.onVersionChanged}
-              onBlur={() => {
-                reportInteraction('influxdb-configv1-query-language-dropdown', {
-                  version: this.props.options.jsonData.version,
-                });
-              }}
+              onBlur={() => trackInfluxDBConfigV1QueryLanguageSelection({ version: this.props.options.jsonData.version || "" })}
             />
           </Field>
         </FieldSet>

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
@@ -12,7 +12,11 @@ import { InlineField, InlineFieldRow, Input, SecretInput } from '@grafana/ui';
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
 
 import { WIDTH_SHORT } from './constants';
-import { trackInfluxDBConfigV1FluxDefaultBucketInputField, trackInfluxDBConfigV1FluxOrgInputField, trackInfluxDBConfigV1FluxTokenInputField } from './trackingv1';
+import {
+  trackInfluxDBConfigV1FluxDefaultBucketInputField,
+  trackInfluxDBConfigV1FluxOrgInputField,
+  trackInfluxDBConfigV1FluxTokenInputField,
+} from './trackingv1';
 
 export type Props = DataSourcePluginOptionsEditorProps<InfluxOptions, InfluxSecureJsonData>;
 

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
@@ -6,7 +6,6 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Input, SecretInput } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
@@ -6,6 +6,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Input, SecretInput } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
@@ -29,6 +30,7 @@ export const InfluxFluxConfig = (props: Props) => {
             className="width-20"
             value={jsonData.organization || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'organization')}
+            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-organization-input-field')}
           />
         </InlineField>
       </InlineFieldRow>
@@ -42,6 +44,7 @@ export const InfluxFluxConfig = (props: Props) => {
             className="width-20"
             onReset={() => updateDatasourcePluginResetOption(props, 'token')}
             onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
+            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-token-input-field')}
           />
         </InlineField>
       </InlineFieldRow>
@@ -52,6 +55,7 @@ export const InfluxFluxConfig = (props: Props) => {
             placeholder="default bucket"
             value={jsonData.defaultBucket || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'defaultBucket')}
+            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-default-bucket-input-field')}
           />
         </InlineField>
       </InlineFieldRow>

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxFluxConfig.tsx
@@ -12,6 +12,7 @@ import { InlineField, InlineFieldRow, Input, SecretInput } from '@grafana/ui';
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
 
 import { WIDTH_SHORT } from './constants';
+import { trackInfluxDBConfigV1FluxDefaultBucketInputField, trackInfluxDBConfigV1FluxOrgInputField, trackInfluxDBConfigV1FluxTokenInputField } from './trackingv1';
 
 export type Props = DataSourcePluginOptionsEditorProps<InfluxOptions, InfluxSecureJsonData>;
 
@@ -30,7 +31,7 @@ export const InfluxFluxConfig = (props: Props) => {
             className="width-20"
             value={jsonData.organization || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'organization')}
-            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-organization-input-field')}
+            onBlur={trackInfluxDBConfigV1FluxOrgInputField}
           />
         </InlineField>
       </InlineFieldRow>
@@ -44,7 +45,7 @@ export const InfluxFluxConfig = (props: Props) => {
             className="width-20"
             onReset={() => updateDatasourcePluginResetOption(props, 'token')}
             onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
-            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-token-input-field')}
+            onBlur={trackInfluxDBConfigV1FluxTokenInputField}
           />
         </InlineField>
       </InlineFieldRow>
@@ -55,7 +56,7 @@ export const InfluxFluxConfig = (props: Props) => {
             placeholder="default bucket"
             value={jsonData.defaultBucket || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'defaultBucket')}
-            onBlur={() => reportInteraction('influxdb-configv1-flux-dbdetails-default-bucket-input-field')}
+            onBlur={trackInfluxDBConfigV1FluxDefaultBucketInputField}
           />
         </InlineField>
       </InlineFieldRow>

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
@@ -16,7 +16,11 @@ import { Alert, Field, InlineLabel, Input, SecretInput, Select, useStyles2 } fro
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
 
 import { WIDTH_SHORT } from './constants';
-import { trackInfluxDBConfigV1InfluxQLDatabaseInputField, trackInfluxDBConfigV1InfluxQLPasswordInputField, trackInfluxDBConfigV1InfluxQLUserInputField } from './trackingv1';
+import {
+  trackInfluxDBConfigV1InfluxQLDatabaseInputField,
+  trackInfluxDBConfigV1InfluxQLPasswordInputField,
+  trackInfluxDBConfigV1InfluxQLUserInputField,
+} from './trackingv1';
 
 const httpModes: SelectableValue[] = [
   { label: 'GET', value: 'GET' },

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
@@ -11,12 +11,12 @@ import {
   SelectableValue,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
 import { Alert, Field, InlineLabel, Input, SecretInput, Select, useStyles2 } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
 
 import { WIDTH_SHORT } from './constants';
+import { trackInfluxDBConfigV1InfluxQLDatabaseInputField, trackInfluxDBConfigV1InfluxQLPasswordInputField, trackInfluxDBConfigV1InfluxQLUserInputField } from './trackingv1';
 
 const httpModes: SelectableValue[] = [
   { label: 'GET', value: 'GET' },
@@ -67,7 +67,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
               },
             });
           }}
-          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-database-input-field')}
+          onBlur={trackInfluxDBConfigV1InfluxQLDatabaseInputField}
         />
       </Field>
       <Field
@@ -82,7 +82,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
           className="width-20"
           value={options.user || ''}
           onChange={onUpdateDatasourceOption(props, 'user')}
-          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-user-input-field')}
+          onBlur={trackInfluxDBConfigV1InfluxQLUserInputField}
         />
       </Field>
       <Field
@@ -99,7 +99,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
           className="width-20"
           onReset={() => updateDatasourcePluginResetOption(props, 'password')}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'password')}
-          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-password-input-field')}
+          onBlur={trackInfluxDBConfigV1InfluxQLPasswordInputField}
         />
       </Field>
       <Field

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxInfluxQLConfig.tsx
@@ -11,6 +11,7 @@ import {
   SelectableValue,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Alert, Field, InlineLabel, Input, SecretInput, Select, useStyles2 } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
@@ -66,6 +67,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
               },
             });
           }}
+          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-database-input-field')}
         />
       </Field>
       <Field
@@ -80,6 +82,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
           className="width-20"
           value={options.user || ''}
           onChange={onUpdateDatasourceOption(props, 'user')}
+          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-user-input-field')}
         />
       </Field>
       <Field
@@ -96,6 +99,7 @@ export const InfluxInfluxQLConfig = (props: Props) => {
           className="width-20"
           onReset={() => updateDatasourcePluginResetOption(props, 'password')}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'password')}
+          onBlur={() => reportInteraction('influxdb-configv1-influxql-dbdetails-password-input-field')}
         />
       </Field>
       <Field

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx
@@ -7,6 +7,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Field, InlineLabel, InlineSwitch, Input, SecretInput, useStyles2 } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
@@ -43,6 +44,7 @@ export const InfluxSqlConfig = (props: Props) => {
               },
             });
           }}
+          onBlur={() => reportInteraction('influxdb-configv1-sql-dbdetails-database-input-field')}
         />
       </Field>
       <Field horizontal label={<InlineLabel width={WIDTH_SHORT}>Token</InlineLabel>} className={styles.horizontalField}>
@@ -54,6 +56,7 @@ export const InfluxSqlConfig = (props: Props) => {
           onReset={() => updateDatasourcePluginResetOption(props, 'token')}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
           isConfigured={Boolean(secureJsonFields && secureJsonFields.token)}
+          onBlur={() => reportInteraction('influxdb-configv1-sql-dbdetails-token-input-field')}
         />
       </Field>
       <Field

--- a/public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx
@@ -7,12 +7,12 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
 import { Field, InlineLabel, InlineSwitch, Input, SecretInput, useStyles2 } from '@grafana/ui';
 
 import { InfluxOptions, InfluxSecureJsonData } from '../../../types';
 
 import { WIDTH_SHORT } from './constants';
+import { trackInfluxDBConfigV1SQLDatabaseInputField, trackInfluxDBConfigV1SQLTokenInputField } from './trackingv1';
 
 export type Props = DataSourcePluginOptionsEditorProps<InfluxOptions, InfluxSecureJsonData>;
 
@@ -44,7 +44,7 @@ export const InfluxSqlConfig = (props: Props) => {
               },
             });
           }}
-          onBlur={() => reportInteraction('influxdb-configv1-sql-dbdetails-database-input-field')}
+          onBlur={trackInfluxDBConfigV1SQLDatabaseInputField}
         />
       </Field>
       <Field horizontal label={<InlineLabel width={WIDTH_SHORT}>Token</InlineLabel>} className={styles.horizontalField}>
@@ -56,7 +56,7 @@ export const InfluxSqlConfig = (props: Props) => {
           onReset={() => updateDatasourcePluginResetOption(props, 'token')}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
           isConfigured={Boolean(secureJsonFields && secureJsonFields.token)}
-          onBlur={() => reportInteraction('influxdb-configv1-sql-dbdetails-token-input-field')}
+          onBlur={trackInfluxDBConfigV1SQLTokenInputField}
         />
       </Field>
       <Field

--- a/public/app/plugins/datasource/influxdb/components/editor/config/trackingv1.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/trackingv1.ts
@@ -1,40 +1,40 @@
-import { reportInteraction } from "@grafana/runtime";
+import { reportInteraction } from '@grafana/runtime';
 
-export const trackInfluxDBConfigV1QueryLanguageSelection = (props: { version: string}) => {
-   reportInteraction('influxdb-configv1-query-language-dropdown', props)
+export const trackInfluxDBConfigV1QueryLanguageSelection = (props: { version: string }) => {
+  reportInteraction('influxdb-configv1-query-language-dropdown', props);
 };
 
 // Flux Database Fields
 export const trackInfluxDBConfigV1FluxOrgInputField = () => {
-    reportInteraction('influxdb-configv1-flux-dbdetails-organization-input-field');
+  reportInteraction('influxdb-configv1-flux-dbdetails-organization-input-field');
 };
 
 export const trackInfluxDBConfigV1FluxTokenInputField = () => {
-    reportInteraction('influxdb-configv1-flux-dbdetails-token-input-field')
+  reportInteraction('influxdb-configv1-flux-dbdetails-token-input-field');
 };
 
 export const trackInfluxDBConfigV1FluxDefaultBucketInputField = () => {
-    reportInteraction('influxdb-configv1-flux-dbdetails-default-bucket-input-field')
+  reportInteraction('influxdb-configv1-flux-dbdetails-default-bucket-input-field');
 };
 
 // InfluxQL Database Fields
 export const trackInfluxDBConfigV1InfluxQLDatabaseInputField = () => {
-    reportInteraction('influxdb-configv1-influxql-dbdetails-database-input-field');
+  reportInteraction('influxdb-configv1-influxql-dbdetails-database-input-field');
 };
 
 export const trackInfluxDBConfigV1InfluxQLUserInputField = () => {
-     reportInteraction('influxdb-configv1-influxql-dbdetails-user-input-field');
+  reportInteraction('influxdb-configv1-influxql-dbdetails-user-input-field');
 };
 
 export const trackInfluxDBConfigV1InfluxQLPasswordInputField = () => {
-     reportInteraction('influxdb-configv1-influxql-dbdetails-password-input-field');
+  reportInteraction('influxdb-configv1-influxql-dbdetails-password-input-field');
 };
 
 // SQL Database Fields
 export const trackInfluxDBConfigV1SQLDatabaseInputField = () => {
-    reportInteraction('influxdb-configv1-sql-dbdetails-database-input-field')
-}
+  reportInteraction('influxdb-configv1-sql-dbdetails-database-input-field');
+};
 
 export const trackInfluxDBConfigV1SQLTokenInputField = () => {
-    reportInteraction('influxdb-configv1-sql-dbdetails-token-input-field')
-}
+  reportInteraction('influxdb-configv1-sql-dbdetails-token-input-field');
+};

--- a/public/app/plugins/datasource/influxdb/components/editor/config/trackingv1.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/trackingv1.ts
@@ -1,0 +1,40 @@
+import { reportInteraction } from "@grafana/runtime";
+
+export const trackInfluxDBConfigV1QueryLanguageSelection = (props: { version: string}) => {
+   reportInteraction('influxdb-configv1-query-language-dropdown', props)
+};
+
+// Flux Database Fields
+export const trackInfluxDBConfigV1FluxOrgInputField = () => {
+    reportInteraction('influxdb-configv1-flux-dbdetails-organization-input-field');
+};
+
+export const trackInfluxDBConfigV1FluxTokenInputField = () => {
+    reportInteraction('influxdb-configv1-flux-dbdetails-token-input-field')
+};
+
+export const trackInfluxDBConfigV1FluxDefaultBucketInputField = () => {
+    reportInteraction('influxdb-configv1-flux-dbdetails-default-bucket-input-field')
+};
+
+// InfluxQL Database Fields
+export const trackInfluxDBConfigV1InfluxQLDatabaseInputField = () => {
+    reportInteraction('influxdb-configv1-influxql-dbdetails-database-input-field');
+};
+
+export const trackInfluxDBConfigV1InfluxQLUserInputField = () => {
+     reportInteraction('influxdb-configv1-influxql-dbdetails-user-input-field');
+};
+
+export const trackInfluxDBConfigV1InfluxQLPasswordInputField = () => {
+     reportInteraction('influxdb-configv1-influxql-dbdetails-password-input-field');
+};
+
+// SQL Database Fields
+export const trackInfluxDBConfigV1SQLDatabaseInputField = () => {
+    reportInteraction('influxdb-configv1-sql-dbdetails-database-input-field')
+}
+
+export const trackInfluxDBConfigV1SQLTokenInputField = () => {
+    reportInteraction('influxdb-configv1-sql-dbdetails-token-input-field')
+}


### PR DESCRIPTION
This PR adds `reportInteraction` events to the original InfluxDB configuration page so trends can be tracked in Rudderstack and FullStory. 

Closes https://github.com/grafana/data-sources/issues/586.