### PR TITLE
CI: Fix calling 'move_packages' in wrong directory

### DIFF
--- a/pkg/build/daggerbuild/scripts/drone_build_main.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_main.sh
@@ -35,4 +35,4 @@ echo "Final list of artifacts:"
 cat assets.txt
 
 # Move the tar.gz packages to their expected locations
-cat assets.txt | IS_MAIN=true go run ./scripts/move_packages.go ./dist/main
+cat assets.txt | IS_MAIN=true go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/main

--- a/pkg/build/daggerbuild/scripts/drone_build_main_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_main_enterprise.sh
@@ -33,4 +33,4 @@ dagger run --silent go run ./pkg/build/cmd \
 cat assets.txt
 
 # Move the tar.gz packages to their expected locations
-cat assets.txt | DESTINATION=gs://grafana-downloads IS_MAIN=true go run ./scripts/move_packages.go ./dist/main
+cat assets.txt | DESTINATION=gs://grafana-downloads IS_MAIN=true go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/main

--- a/pkg/build/daggerbuild/scripts/drone_build_main_pro.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_main_pro.sh
@@ -28,5 +28,5 @@ dagger run --silent go run ./pkg/build/cmd \
 
 echo "Final list of artifacts:"
 # Move the tar.gz packages to their expected locations
-cat assets.txt | grep -v "public" | DESTINATION=gs://grafana-downloads-enterprise2 IS_MAIN=true go run ./scripts/move_packages.go ./dist/main
-cat assets.txt | grep "public" | DESTINATION=gs://grafana-static-assets IS_MAIN=true go run ./scripts/move_packages.go ./dist/cdn
+cat assets.txt | grep -v "public" | DESTINATION=gs://grafana-downloads-enterprise2 IS_MAIN=true go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/main
+cat assets.txt | grep "public" | DESTINATION=gs://grafana-static-assets IS_MAIN=true go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/cdn

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_enterprise.sh
@@ -48,4 +48,4 @@ dagger run --silent go run ./pkg/build/cmd \
   --destination=${local_dst} > assets.txt
 
 # Move the tar.gz packages to their expected locations
-cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease
+cat assets.txt | go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/prerelease

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_grafana.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_grafana.sh
@@ -44,4 +44,4 @@ dagger run --silent go run ./pkg/build/cmd \
   --version=${DRONE_TAG} \
   --destination=${local_dst} > assets.txt
 
-cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease
+cat assets.txt | go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/prerelease

--- a/pkg/build/daggerbuild/scripts/drone_build_tag_pro.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_tag_pro.sh
@@ -38,4 +38,4 @@ dagger run --silent go run ./pkg/build/cmd \
   --destination=${local_dst} > assets.txt
 
 # Move the tar.gz packages to their expected locations
-cat assets.txt | go run ./scripts/move_packages.go ./dist/prerelease
+cat assets.txt | go run ./pkg/build/daggerbuild/scripts/move_packages.go ./dist/prerelease


### PR DESCRIPTION
Unfortunately this doesn't get used in PRs so it wasn't caught. Something to add to the list