### PR TITLE
Plugins: Support suffix in `grafanaDependency`

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -172,7 +172,7 @@
         "grafanaDependency": {
           "type": "string",
           "description": "Required Grafana version for this plugin. Validated using https://github.com/npm/node-semver.",
-          "pattern": "^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?)?$"
+          "pattern": "^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?(-[0-9A-Za-z-.]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x\\*]+)?(\\.[0-9x\\*]+)?(-[0-9A-Za-z-.]+)?)?$"
         },
         "plugins": {
           "type": "array",


### PR DESCRIPTION

**What is this feature?**

We have a few plugins that need to declare the `grafanaDependency` to include an suffix such as `12.0.0-0`. However, this is not valid to the plugin.json schema. This PR adds support for pre version/suffix.

See an example of a failed build due to this: https://github.com/grafana/investigations-app/actions/runs/15203321656/job/42761237170#step:5:268

Example of the regex: https://regex101.com/r/srDORz/1
