### PR TITLE
Storage: Take `migration_locking` setting into account

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/migrator.go
+++ b/pkg/storage/unified/sql/db/migrations/migrator.go
@@ -17,6 +17,9 @@ func MigrateResourceStore(_ context.Context, engine *xorm.Engine, cfg *setting.C
 
 	initResourceTables(mg)
 
-	// since it's a new feature enable migration locking by default
-	return mg.Start(true, 0)
+	sec := cfg.Raw.Section("database")
+	return mg.Start(
+		sec.Key("migration_locking").MustBool(true),
+		sec.Key("locking_attempt_timeout_sec").MustInt(),
+	)
 }

--- a/pkg/storage/unified/sql/db/migrations/migrator.go
+++ b/pkg/storage/unified/sql/db/migrations/migrator.go
@@ -9,8 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func MigrateResourceStore(_ context.Context, engine *xorm.Engine, cfg *setting.Cfg) error {
-	// TODO: use the context.Context
+func MigrateResourceStore(ctx context.Context, engine *xorm.Engine, cfg *setting.Cfg) error {
 
 	mg := migrator.NewScopedMigrator(engine, cfg, "resource")
 	mg.AddCreateMigration()
@@ -18,7 +17,8 @@ func MigrateResourceStore(_ context.Context, engine *xorm.Engine, cfg *setting.C
 	initResourceTables(mg)
 
 	sec := cfg.Raw.Section("database")
-	return mg.Start(
+	return mg.RunMigrations(
+		ctx,
 		sec.Key("migration_locking").MustBool(true),
 		sec.Key("locking_attempt_timeout_sec").MustInt(),
 	)

--- a/pkg/storage/unified/sql/db/migrations/migrator.go
+++ b/pkg/storage/unified/sql/db/migrations/migrator.go
@@ -10,7 +10,6 @@ import (
 )
 
 func MigrateResourceStore(ctx context.Context, engine *xorm.Engine, cfg *setting.Cfg) error {
-
 	mg := migrator.NewScopedMigrator(engine, cfg, "resource")
 	mg.AddCreateMigration()
 


### PR DESCRIPTION
Fixes #100256 

We no longer ignore `migration_locking` in unified storage, so users running database systems that don't support it can still run Grafana at their own risk, especially when running in HA.

This can be tested by running Grafana against percona. I used the following file to run it in docker compose locally:

```docker
version: '3.8'

services:
  percona:
    image: percona/percona-xtradb-cluster:8.0
    container_name: percona-xtradb
    environment:
      MYSQL_ROOT_PASSWORD: rootpass
      CLUSTER_NAME: pxc-cluster
      XTRABACKUP_PASSWORD: xtrabackuppass
      MYSQL_DATABASE: grafana
      MYSQL_USER: grafana
      MYSQL_PASSWORD: grafana
    ports:
      - "3306:3306"
    volumes:
      - percona_data:/var/lib/mysql
    # Bootstrap the cluster and set pxc_strict_mode to ENFORCING
    command: >
      --wsrep-new-cluster
      --pxc_strict_mode=ENFORCING
      --log-error-verbosity=3
    healthcheck:
      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpass"]
      interval: 5s
      timeout: 5s
      retries: 30

volumes:
  percona_data: 
```

And the following grafana.ini to make it fail
```toml 
[database]
type = mysql
host = 127.0.0.1:3306
name = grafana
user = grafana
password = grafana
```

And the following grafana.ini to fix it
```toml
[database]
type = mysql
host = 127.0.0.1:3306
name = grafana
user = grafana
password = grafana
migration_locking = false
```