### PR TITLE
Logs Panel: interpolate infinite scrolling queries

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -695,7 +695,10 @@ export async function requestMoreLogs(
       dataSource.query({
         ...panelData.request,
         range,
-        targets: targetGroups[uid],
+        targets:
+          'interpolateVariablesInQueries' in dataSource && dataSource.interpolateVariablesInQueries
+            ? dataSource.interpolateVariablesInQueries(targetGroups[uid], panelData.request.scopedVars)
+            : targetGroups[uid],
       })
     );
   }


### PR DESCRIPTION
The infinite scrolling implementation in the Logs visualization uses the request provided to the panel to resolve the datasource instance and manually run a new query with the same expression. Since this is being executed inside the panel, and `datasource.query()` will not apply template variables, we were generating new uninterpolated queries when infinite scrolling was used.