### PR TITLE
update TableNG to use the grafana fork of react-data-grid, which supports React 18

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,7 @@ const esModules = [
   'lodash-es',
   'vscode-languageserver-types',
   '@bsull/augurs',
-  "react-data-grid"
+  'react-data-grid',
 ].join('|');
 
 module.exports = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ const esModules = [
   'lodash-es',
   'vscode-languageserver-types',
   '@bsull/augurs',
+  "react-data-grid"
 ].join('|');
 
 module.exports = {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -108,7 +108,7 @@
     "react-calendar": "^5.1.0",
     "react-colorful": "5.6.1",
     "react-custom-scrollbars-2": "4.5.0",
-    "react-data-grid": "7.0.0-beta.46",
+    "react-data-grid": "grafana/react-data-grid#3420f7f2a9e0d707d3313ec5b143a6be53f720b5",
     "react-dropzone": "14.3.8",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,7 +1,7 @@
 import 'react-data-grid/lib/styles.css';
 import { css } from '@emotion/css';
 import { useMemo, useState, useLayoutEffect, useCallback, useRef, useEffect } from 'react';
-import DataGrid, { RenderCellProps, RenderRowProps, Row, SortColumn, DataGridHandle } from 'react-data-grid';
+import { DataGrid, RenderCellProps, RenderRowProps, Row, SortColumn, DataGridHandle } from 'react-data-grid';
 import { useMeasure } from 'react-use';
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,7 +3718,7 @@ __metadata:
     react-calendar: "npm:^5.1.0"
     react-colorful: "npm:5.6.1"
     react-custom-scrollbars-2: "npm:4.5.0"
-    react-data-grid: "npm:7.0.0-beta.46"
+    react-data-grid: "grafana/react-data-grid#3420f7f2a9e0d707d3313ec5b143a6be53f720b5"
     react-dom: "npm:18.3.1"
     react-dropzone: "npm:14.3.8"
     react-highlight-words: "npm:0.21.0"
@@ -25923,15 +25923,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-data-grid@npm:7.0.0-beta.46":
-  version: 7.0.0-beta.46
-  resolution: "react-data-grid@npm:7.0.0-beta.46"
+"react-data-grid@grafana/react-data-grid#3420f7f2a9e0d707d3313ec5b143a6be53f720b5":
+  version: 7.0.0-beta.55
+  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=3420f7f2a9e0d707d3313ec5b143a6be53f720b5"
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ^18.0 || ^19.0
     react-dom: ^18.0 || ^19.0
-  checksum: 10/d8a679b5e22a07293923894591adcac5ad57b8bd28dcc93f7438563384f6acc2287f14394a3ef360bc1dc901defa00b4030aa9af37c70cf53cf121437e0882bc
+  checksum: 10/9fe309924a7b22d0a62f0df69bdc7b9e0df62c5624e96125f2d729500dfe103037cfbe654fa63294d89fc9b5fea618a540160e2e12e7de4c7052049827df3687
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates the path to the installed react-data-grid package to the newly forked https://github.com/grafana/react-data-grid. Specifically, we are publishing builds artifacts to an orphan branch called [react-18-builds](https://github.com/grafana/react-data-grid/tree/react-18-builds).

**Why do we need this feature?**

react-data-grid dropped support for React 18 in February (https://github.com/adazzle/react-data-grid/pull/3503), and we haven't been able to upgrade our version of react-data-grid since. The change needed to continue supporting React 18 is [relatively small](https://github.com/grafana/react-data-grid/commit/9e49997ef0928e568bc2b8b4ee951357f04b3aba) (just reverting back to pre-React-19 usage of existing React features), so this is the simplest path for us to get updates from the project upstream while we wait for a future React 19 upgrade across all of Grafana.

**Who is this feature for?**

Users of Table panel, who will now be able to get important updates to the dependent package.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

- see the `publish.sh` script in the [react-18](https://github.com/grafana/react-data-grid/tree/react-18) branch in our fork. Running that will publish the latest version of the react-18 branch in a new commit, which you can then update in this project.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
