### PR TITLE
Dashboards: Fix FindDashboards when kubernetesClientDashboardsFolders is disabled

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -304,9 +304,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 		return nil, err
 	}
 
-	hits := formatQueryResult(res)
-
-	for _, dashboard := range hits {
+	for _, dashboard := range res {
 		tags, err := json.Marshal(dashboard.Tags)
 		if err != nil {
 			return nil, err
@@ -324,7 +322,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 		}
 
 		list.Results.Rows = append(list.Results.Rows, &resourcepb.ResourceTableRow{
-			Key:   getResourceKey(dashboard, req.Options.Key.Namespace),
+			Key:   getResourceKey(&dashboard, req.Options.Key.Namespace),
 			Cells: cells,
 		})
 	}
@@ -350,35 +348,6 @@ func getResourceKey(item *dashboards.DashboardSearchProjection, namespace string
 		Resource:  dashboard.DASHBOARD_RESOURCE,
 		Name:      item.UID,
 	}
-}
-
-func formatQueryResult(res []dashboards.DashboardSearchProjection) []*dashboards.DashboardSearchProjection {
-	hitList := make([]*dashboards.DashboardSearchProjection, 0)
-	hits := make(map[string]*dashboards.DashboardSearchProjection)
-
-	for _, item := range res {
-		key := fmt.Sprintf("%s-%d", item.UID, item.OrgID)
-		hit, exists := hits[key]
-		if !exists {
-			hit = &dashboards.DashboardSearchProjection{
-				ID:        item.ID,
-				UID:       item.UID,
-				Title:     item.Title,
-				FolderUID: item.FolderUID,
-				Tags:      []string{},
-				IsFolder:  item.IsFolder,
-				SortMeta:  item.SortMeta,
-			}
-			hitList = append(hitList, hit)
-			hits[key] = hit
-		}
-
-		if len(item.Term) > 0 {
-			hit.Tags = append(hit.Tags, item.Term)
-		}
-	}
-
-	return hitList
 }
 
 func (c *DashboardSearchClient) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest, _ ...grpc.CallOption) (*resourcepb.ResourceStatsResponse, error) {

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -44,8 +44,8 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db", // should set type based off of key
 			Sort:         sorter,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder1", Term: "term"},
-			{ID: 2, UID: "uid2", Title: "Test Dashboard2", FolderUID: "folder2"},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder1", Tags: []string{"term"}},
+			{ID: 2, UID: "uid2", Title: "Test Dashboard2", FolderUID: "folder2", Tags: []string{}},
 		}, nil).Once()
 
 		req := &resourcepb.ResourceSearchRequest{
@@ -121,7 +121,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db",
 			Sort:         sortOptionAsc,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(50)},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(50), Tags: []string{}},
 		}, nil).Once()
 
 		req := &resourcepb.ResourceSearchRequest{
@@ -186,7 +186,7 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 			Type:         "dash-db",
 			Sort:         sortOptionAsc,
 		}).Return([]dashboards.DashboardSearchProjection{
-			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(2)},
+			{ID: 1, UID: "uid", Title: "Test Dashboard", FolderUID: "folder", SortMeta: int64(2), Tags: []string{}},
 		}, nil).Once()
 
 		req := &resourcepb.ResourceSearchRequest{

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -841,7 +841,7 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 	require.NoError(t, err)
 
 	orgID := int64(1)
-	insertTestDashboard(t, dashboardStore, "dashboard under general", orgID, 0, "", false)
+	insertTestDashboard(t, dashboardStore, "dashboard under general", orgID, 0, "", false, []string{"tag1", "tag2"})
 
 	ac := acimpl.ProvideAccessControl(features)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
@@ -869,7 +869,7 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	insertTestDashboard(t, dashboardStore, "dashboard under f0", orgID, 0, f0.UID, false)
+	insertTestDashboard(t, dashboardStore, "dashboard under f0", orgID, 0, f0.UID, false, []string{"tag3"})
 
 	subfolder, err := folderServiceWithFlagOn.Create(context.Background(), &folder.CreateFolderCommand{
 		OrgID:        orgID,
@@ -1244,43 +1244,35 @@ func testSearchDashboards(d dashboards.Store, query *dashboards.FindPersistedDas
 
 func makeQueryResult(query *dashboards.FindPersistedDashboardsQuery, res []dashboards.DashboardSearchProjection) model.HitList {
 	hitList := make([]*model.Hit, 0)
-	hits := make(map[int64]*model.Hit)
 
 	for _, item := range res {
-		hit, exists := hits[item.ID]
-		if !exists {
-			hitType := model.DashHitDB
-			if item.IsFolder {
-				hitType = model.DashHitFolder
-			}
-
-			hit = &model.Hit{
-				ID:          item.ID,
-				UID:         item.UID,
-				Title:       item.Title,
-				URI:         "db/" + item.Slug,
-				URL:         dashboards.GetDashboardFolderURL(item.IsFolder, item.UID, item.Slug),
-				Type:        hitType,
-				FolderUID:   item.FolderUID,
-				FolderTitle: item.FolderTitle,
-				Tags:        []string{},
-			}
-
-			if item.FolderUID != "" {
-				hit.FolderURL = dashboards.GetFolderURL(item.FolderUID, item.FolderSlug)
-			}
-
-			if query.Sort.MetaName != "" {
-				hit.SortMeta = item.SortMeta
-				hit.SortMetaName = query.Sort.MetaName
-			}
-
-			hitList = append(hitList, hit)
-			hits[item.ID] = hit
+		hitType := model.DashHitDB
+		if item.IsFolder {
+			hitType = model.DashHitFolder
 		}
-		if len(item.Term) > 0 {
-			hit.Tags = append(hit.Tags, item.Term)
+
+		hit := &model.Hit{
+			ID:          item.ID,
+			UID:         item.UID,
+			Title:       item.Title,
+			URI:         "db/" + item.Slug,
+			URL:         dashboards.GetDashboardFolderURL(item.IsFolder, item.UID, item.Slug),
+			Type:        hitType,
+			FolderUID:   item.FolderUID,
+			FolderTitle: item.FolderTitle,
+			Tags:        item.Tags,
 		}
+
+		if item.FolderUID != "" {
+			hit.FolderURL = dashboards.GetFolderURL(item.FolderUID, item.FolderSlug)
+		}
+
+		if query.Sort.MetaName != "" {
+			hit.SortMeta = item.SortMeta
+			hit.SortMetaName = query.Sort.MetaName
+		}
+
+		hitList = append(hitList, hit)
 	}
 	return hitList
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug in FindDashboards, specifically when kubernetesClientDashboardsFolders is **disabled**. With the feature flag enabled, we already de-duplicate the results in `formatQueryResult`, but in the old flow, we do not. This PR de-duplicates the results in the database service layer, so it is de-duplicated in both flows.

I also updated the `makeQueryResult` that is used by SearchDashboards, as we no longer need to de-dup on that layer.

**Why do we need this feature?**

In G12, we migrated away from using GetDashboards (which is more costly in the k8s flow as it returns the full body) to FindDashboards (which returns a subset of data & relies on search).

For the most use cases of this, having additional rows does not impact things. But for some use cases (like reporting), it checks that we are returning the expected number of dashboards, which we are no longer doing. This breaks specifically the "test send email" flow.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/support-escalations/issues/16274
