### PR TITLE
Dashboard Provisioning: Fix re-provisioning on each run

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -101,7 +101,7 @@ func (fr *FileReader) walkDisk(ctx context.Context) error {
 		return err
 	}
 
-	provisionedDashboardRefs, err := getProvisionedDashboardsByPath(ctx, fr.dashboardProvisioningService, fr.Cfg.Name)
+	provisionedDashboardRefs, err := fr.getProvisionedDashboardsByPath(ctx, fr.dashboardProvisioningService, fr.Cfg.Name)
 	if err != nil {
 		return err
 	}
@@ -326,7 +326,7 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 	return provisioningMetadata, nil
 }
 
-func getProvisionedDashboardsByPath(ctx context.Context, service dashboards.DashboardProvisioningService, name string) (
+func (fr *FileReader) getProvisionedDashboardsByPath(ctx context.Context, service dashboards.DashboardProvisioningService, name string) (
 	map[string]*dashboards.DashboardProvisioning, error) {
 	arr, err := service.GetProvisionedDashboardData(ctx, name)
 	if err != nil {
@@ -335,6 +335,13 @@ func getProvisionedDashboardsByPath(ctx context.Context, service dashboards.Dash
 
 	byPath := map[string]*dashboards.DashboardProvisioning{}
 	for _, pd := range arr {
+		// as a part of the migration of dashboards to unified storage, the dashboard provisiong data will be stored as
+		// an annotation on the dashboard. in modes 0-2, that will only return the relative path. however, we will be comparing
+		// that to the data stored in the dashboard_provisioning table, so we need to change it into the resolved path
+		if !strings.HasPrefix(pd.ExternalID, fr.resolvedPath()) {
+			pd.ExternalID = fr.resolvedPath() + "/" + pd.ExternalID
+		}
+
 		byPath[pd.ExternalID] = pd
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug where we were re-provisioning all provisioned dashboards upon each startup (or whenever the update interval is set to). When we [switched](https://github.com/grafana/grafana/pull/105440) to using the relative path in the dashboard object in the k8s flow, we began to save the relative path to the map of provisioned dashboards. This map was then compared [here](https://github.com/grafana/grafana/blob/a8fd34cec4f9d7097065a62448b76121026471b0/pkg/services/provisioning/dashboards/file_reader.go#L241) to what is stored in the dashboard_provisioning table, which stores the full path. So it would consider it an orphaned dashboard, delete that provisioned dashboard, and recreate.

This especially becomes an issue for dashboards provisioned by titles (and not uid or id), because if multiple replicas run the provisioning at the exact same time, we can have two dashboards with the same title now, so both will succeed and we will end up with duplicates (both in the dashboard & the dashboard_provisioning table). I will follow-up with something to address that, but wanted to at least reduce the frequency of this issue with this fix for now

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/support-escalations/issues/16399