### PR TITLE
Chore: Rename integration tests to follow the common convention

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -418,7 +418,7 @@ func TestHTTPServer_GetDashboardVersions_AccessControl(t *testing.T) {
 	})
 }
 
-func TestDashboardAPIEndpoint(t *testing.T) {
+func TestIntegrationDashboardAPIEndpoint(t *testing.T) {
 	t.Run("Given two dashboards with the same title in different folders", func(t *testing.T) {
 		dashOne := dashboards.NewDashboard("dash")
 		dashOne.ID = 2

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -113,7 +113,7 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg, features featuremgmt.F
 	return m, hs
 }
 
-func TestHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testing.T) {
+func TestIntegrationHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testing.T) {
 	type buildInfo struct {
 		Version string `json:"version"`
 		Commit  string `json:"commit"`
@@ -182,7 +182,7 @@ func TestHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testing.T) {
 	}
 }
 
-func TestHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.T) {
+func TestIntegrationHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.T) {
 	type settings struct {
 		PluginsCDNBaseURL string `json:"pluginsCDNBaseURL"`
 	}
@@ -232,7 +232,7 @@ func TestHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.T) {
 	}
 }
 
-func TestHTTPServer_GetFrontendSettings_apps(t *testing.T) {
+func TestIntegrationHTTPServer_GetFrontendSettings_apps(t *testing.T) {
 	type settings struct {
 		Apps map[string]*plugins.AppDTO `json:"apps"`
 	}
@@ -462,7 +462,7 @@ func newAppSettings(id string, enabled bool) map[string]*pluginsettings.DTO {
 	}
 }
 
-func TestHTTPServer_GetFrontendSettings_translations(t *testing.T) {
+func TestIntegrationHTTPServer_GetFrontendSettings_translations(t *testing.T) {
 	type settings struct {
 		Datasources map[string]plugins.DataSourceDTO `json:"datasources"`
 		Panels      map[string]*plugins.PanelDTO     `json:"panels"`

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -64,7 +64,7 @@ func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 	require.NoError(t, err)
 }
 
-func TestOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
+func TestIntegrationOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 	hs := setupSimpleHTTPServer(featuremgmt.WithFeatures())
 	settings := hs.Cfg
 

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
-func TestCallResource(t *testing.T) {
+func TestIntegrationCallResource(t *testing.T) {
 	staticRootPath, err := filepath.Abs("../../public/")
 	require.NoError(t, err)
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestDataSourceProxy_routeRule(t *testing.T) {
+func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 	cfg := &setting.Cfg{}
 
 	t.Run("Plugin with routes", func(t *testing.T) {

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -57,7 +57,7 @@ import (
 
 const newEmail = "newemail@localhost"
 
-func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
+func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t, sqlstore.InitTestDBOpt{Cfg: settings})
 	hs := &HTTPServer{
@@ -404,7 +404,7 @@ func Test_GetUserByID(t *testing.T) {
 	}
 }
 
-func TestHTTPServer_UpdateUser(t *testing.T) {
+func TestIntegrationHTTPServer_UpdateUser(t *testing.T) {
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
 
@@ -478,7 +478,7 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 	return usr, hs, nsMock
 }
 
-func TestUser_UpdateEmail(t *testing.T) {
+func TestIntegrationUser_UpdateEmail(t *testing.T) {
 	cases := []struct {
 		Name  string
 		Field user.UpdateEmailActionType
@@ -1153,7 +1153,7 @@ func updateUserScenario(t *testing.T, ctx updateUserContext, hs *HTTPServer) {
 	})
 }
 
-func TestHTTPServer_UpdateSignedInUser(t *testing.T) {
+func TestIntegrationHTTPServer_UpdateSignedInUser(t *testing.T) {
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
 

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestPasswordMigrationCommand(t *testing.T) {
+func TestIntegrationPasswordMigrationCommand(t *testing.T) {
 	// setup datasources with password, basic_auth and none
 	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {

--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 )
 
-func TestUnifiedStorageCommand(t *testing.T) {
+func TestIntegrationUnifiedStorageCommand(t *testing.T) {
 	// setup datasources with password, basic_auth and none
 	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -248,7 +248,7 @@ func TestIntegrationKVStore(t *testing.T) {
 	})
 }
 
-func TestGetItems(t *testing.T) {
+func TestIntegrationGetItems(t *testing.T) {
 	kv := createTestableKVStore(t)
 
 	ctx := context.Background()

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
-func TestDatabaseStorageGarbageCollection(t *testing.T) {
+func TestIntegrationDatabaseStorageGarbageCollection(t *testing.T) {
 	sqlstore := db.InitTestDB(t)
 
 	db := &databaseCache{
@@ -58,7 +58,7 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
-func TestSecondSet(t *testing.T) {
+func TestIntegrationSecondSet(t *testing.T) {
 	var err error
 	sqlstore := db.InitTestDB(t)
 

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -33,7 +33,7 @@ func createTestClient(t *testing.T, opts *setting.RemoteCacheSettings, sqlstore 
 	return dc
 }
 
-func TestCachedBasedOnConfig(t *testing.T) {
+func TestIntegrationCachedBasedOnConfig(t *testing.T) {
 	db, cfg := sqlstore.InitTestDB(t)
 	err := cfg.Load(setting.CommandLineArgs{
 		HomePath: "../../../",

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -30,7 +30,7 @@ func createTestableServerLock(t *testing.T) *ServerLockService {
 	}
 }
 
-func TestServerLock(t *testing.T) {
+func TestIntegrationServerLock(t *testing.T) {
 	sl := createTestableServerLock(t)
 	operationUID := "test-operation"
 
@@ -66,7 +66,7 @@ func TestServerLock(t *testing.T) {
 	})
 }
 
-func TestLockAndRelease(t *testing.T) {
+func TestIntegrationLockAndRelease(t *testing.T) {
 	operationUID := "test-operation-release"
 
 	t.Run("create lock and then release it", func(t *testing.T) {

--- a/pkg/infra/usagestats/service/usage_stats_test.go
+++ b/pkg/infra/usagestats/service/usage_stats_test.go
@@ -155,7 +155,7 @@ func TestMetrics(t *testing.T) {
 	})
 }
 
-func TestGetUsageReport_IncludesMetrics(t *testing.T) {
+func TestIntegrationGetUsageReport_IncludesMetrics(t *testing.T) {
 	sqlStore := dbtest.NewFakeDB()
 	uss := createService(t, sqlStore, true)
 	metricName := "stats.test_metric.count"

--- a/pkg/infra/usagestats/statscollector/concurrent_users_test.go
+++ b/pkg/infra/usagestats/statscollector/concurrent_users_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestConcurrentUsersMetrics(t *testing.T) {
+func TestIntegrationConcurrentUsersMetrics(t *testing.T) {
 	sqlStore, cfg := db.InitTestDBWithCfg(t)
 	statsService := statsimpl.ProvideService(&setting.Cfg{}, sqlStore, &dashboards.FakeDashboardService{}, &foldertest.FakeService{}, &orgtest.FakeOrgService{}, featuremgmt.WithFeatures())
 	s := createService(t, cfg, sqlStore, statsService)
@@ -45,7 +45,7 @@ func TestConcurrentUsersMetrics(t *testing.T) {
 	assert.Equal(t, int32(6), stats["stats.auth_token_per_user_le_inf"])
 }
 
-func TestConcurrentUsersStats(t *testing.T) {
+func TestIntegrationConcurrentUsersStats(t *testing.T) {
 	sqlStore, cfg := db.InitTestDBWithCfg(t)
 	statsService := statsimpl.ProvideService(&setting.Cfg{}, sqlStore, &dashboards.FakeDashboardService{}, &foldertest.FakeService{}, &orgtest.FakeOrgService{}, featuremgmt.WithFeatures())
 	s := createService(t, cfg, sqlStore, statsService)

--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestSocialService_ProvideService(t *testing.T) {
+func TestIntegrationSocialService_ProvideService(t *testing.T) {
 	type testEnv struct {
 		features featuremgmt.FeatureToggles
 	}
@@ -138,7 +138,7 @@ func TestSocialService_ProvideService(t *testing.T) {
 	}
 }
 
-func TestSocialService_ProvideService_GrafanaComGrafanaNet(t *testing.T) {
+func TestIntegrationSocialService_ProvideService_GrafanaComGrafanaNet(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		rawIniContent               string

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -156,7 +156,7 @@ func TestCheckHealth(t *testing.T) {
 	})
 }
 
-func TestCallResource(t *testing.T) {
+func TestIntegrationCallResource(t *testing.T) {
 	registry := fakes.NewFakePluginRegistry()
 	p := &plugins.Plugin{
 		JSONData: plugins.JSONData{

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -49,7 +49,7 @@ func setupTestEnv(t testing.TB) *Service {
 	return ac
 }
 
-func TestUsageMetrics(t *testing.T) {
+func TestIntegrationUsageMetrics(t *testing.T) {
 	tests := []struct {
 		name          string
 		expectedValue int
@@ -80,7 +80,7 @@ func TestUsageMetrics(t *testing.T) {
 	}
 }
 
-func TestService_DeclareFixedRoles(t *testing.T) {
+func TestIntegrationService_DeclareFixedRoles(t *testing.T) {
 	tests := []struct {
 		name          string
 		registrations []accesscontrol.RoleRegistration
@@ -165,7 +165,7 @@ func TestService_DeclareFixedRoles(t *testing.T) {
 	}
 }
 
-func TestService_DeclarePluginRoles(t *testing.T) {
+func TestIntegrationService_DeclarePluginRoles(t *testing.T) {
 	tests := []struct {
 		name          string
 		pluginID      string
@@ -278,7 +278,7 @@ func TestService_DeclarePluginRoles(t *testing.T) {
 	}
 }
 
-func TestService_RegisterFixedRoles(t *testing.T) {
+func TestIntegrationService_RegisterFixedRoles(t *testing.T) {
 	tests := []struct {
 		name          string
 		token         licensing.Licensing
@@ -380,7 +380,7 @@ func TestService_RegisterFixedRoles(t *testing.T) {
 	}
 }
 
-func TestService_SearchUsersPermissions(t *testing.T) {
+func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 	searchOption := accesscontrol.SearchOptions{ActionPrefix: "teams"}
 	ctx := context.Background()
 	listAllPerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:*"}}
@@ -601,7 +601,7 @@ func TestService_SearchUsersPermissions(t *testing.T) {
 	}
 }
 
-func TestService_SearchUserPermissions(t *testing.T) {
+func TestIntegrationService_SearchUserPermissions(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name           string
@@ -832,7 +832,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 	}
 }
 
-func TestService_SaveExternalServiceRole(t *testing.T) {
+func TestIntegrationService_SaveExternalServiceRole(t *testing.T) {
 	type run struct {
 		cmd     accesscontrol.SaveExternalServiceRoleCommand
 		wantErr bool
@@ -918,7 +918,7 @@ func TestService_SaveExternalServiceRole(t *testing.T) {
 	}
 }
 
-func TestService_DeleteExternalServiceRole(t *testing.T) {
+func TestIntegrationService_DeleteExternalServiceRole(t *testing.T) {
 	tests := []struct {
 		name              string
 		initCmd           *accesscontrol.SaveExternalServiceRoleCommand
@@ -971,7 +971,7 @@ func TestService_DeleteExternalServiceRole(t *testing.T) {
 	}
 }
 
-func TestService_GetRoleByName(t *testing.T) {
+func TestIntegrationService_GetRoleByName(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -44,7 +44,7 @@ type getUserPermissionsTestCase struct {
 	policyCount        int
 }
 
-func TestAccessControlStore_GetUserPermissions(t *testing.T) {
+func TestIntegrationAccessControlStore_GetUserPermissions(t *testing.T) {
 	tests := []getUserPermissionsTestCase{
 		{
 			desc:               "should successfully get user, team and builtin permissions",
@@ -158,7 +158,7 @@ type getTeamsPermissionsTestCase struct {
 	expected         int
 }
 
-func TestAccessControlStore_GetTeamsPermissions(t *testing.T) {
+func TestIntegrationAccessControlStore_GetTeamsPermissions(t *testing.T) {
 	tests := []getTeamsPermissionsTestCase{
 		{
 			desc:  "should successfully get team permissions",
@@ -230,7 +230,7 @@ func TestAccessControlStore_GetTeamsPermissions(t *testing.T) {
 	}
 }
 
-func TestAccessControlStore_DeleteUserPermissions(t *testing.T) {
+func TestIntegrationAccessControlStore_DeleteUserPermissions(t *testing.T) {
 	t.Run("expect permissions in all orgs to be deleted", func(t *testing.T) {
 		store, permissionsStore, usrSvc, teamSvc, _, sql := setupTestEnv(t)
 		user, _ := createUserAndTeam(t, sql, usrSvc, teamSvc, 1)
@@ -312,7 +312,7 @@ func TestAccessControlStore_DeleteUserPermissions(t *testing.T) {
 	})
 }
 
-func TestAccessControlStore_DeleteTeamPermissions(t *testing.T) {
+func TestIntegrationAccessControlStore_DeleteTeamPermissions(t *testing.T) {
 	t.Run("expect permissions related to team to be deleted", func(t *testing.T) {
 		store, permissionsStore, usrSvc, teamSvc, _, sql := setupTestEnv(t)
 		user, team := createUserAndTeam(t, sql, usrSvc, teamSvc, 1)
@@ -767,7 +767,7 @@ func TestIntegrationAccessControlStore_SearchUsersPermissions(t *testing.T) {
 	}
 }
 
-func TestAccessControlStore_GetUsersBasicRoles(t *testing.T) {
+func TestIntegrationAccessControlStore_GetUsersBasicRoles(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name       string

--- a/pkg/services/accesscontrol/database/externalservices_test.go
+++ b/pkg/services/accesscontrol/database/externalservices_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccessControlStore_SaveExternalServiceRole(t *testing.T) {
+func TestIntegrationAccessControlStore_SaveExternalServiceRole(t *testing.T) {
 	type run struct {
 		cmd     accesscontrol.SaveExternalServiceRoleCommand
 		wantErr bool
@@ -152,7 +152,7 @@ func TestAccessControlStore_SaveExternalServiceRole(t *testing.T) {
 	}
 }
 
-func TestAccessControlStore_DeleteExternalServiceRole(t *testing.T) {
+func TestIntegrationAccessControlStore_DeleteExternalServiceRole(t *testing.T) {
 	extID := "app1"
 	tests := []struct {
 		name    string

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestFilter_Datasources(t *testing.T) {
+func TestIntegrationFilter_Datasources(t *testing.T) {
 	tests := []filterDatasourcesTestCase{
 		{
 			desc:    "expect all data sources to be returned",

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -30,7 +30,7 @@ type getDescriptionTestCase struct {
 	expectedStatus int
 }
 
-func TestApi_getDescription(t *testing.T) {
+func TestIntegrationApi_getDescription(t *testing.T) {
 	tests := []getDescriptionTestCase{
 		{
 			desc: "should return description",
@@ -135,7 +135,7 @@ type getPermissionsTestCase struct {
 	expectedStatus int
 }
 
-func TestApi_getPermissions(t *testing.T) {
+func TestIntegrationApi_getPermissions(t *testing.T) {
 	tests := []getPermissionsTestCase{
 		{
 			desc:       "expect permissions for resource with id 1",
@@ -181,7 +181,7 @@ type setBuiltinPermissionTestCase struct {
 	permissions    []accesscontrol.Permission
 }
 
-func TestApi_setBuiltinRolePermission(t *testing.T) {
+func TestIntegrationApi_setBuiltinRolePermission(t *testing.T) {
 	tests := []setBuiltinPermissionTestCase{
 		{
 			desc:           "should set Edit permission for Viewer",
@@ -260,7 +260,7 @@ type setTeamPermissionTestCase struct {
 	byUID          bool
 }
 
-func TestApi_setTeamPermission(t *testing.T) {
+func TestIntegrationApi_setTeamPermission(t *testing.T) {
 	tests := []setTeamPermissionTestCase{
 		{
 			desc:           "should set Edit permission for team 1",
@@ -367,7 +367,7 @@ type setUserPermissionTestCase struct {
 	permissions    []accesscontrol.Permission
 }
 
-func TestApi_setUserPermission(t *testing.T) {
+func TestIntegrationApi_setUserPermission(t *testing.T) {
 	tests := []setUserPermissionTestCase{
 		{
 			desc:           "should set Edit permission for user 1",
@@ -442,7 +442,7 @@ func TestApi_setUserPermission(t *testing.T) {
 	}
 }
 
-func TestApi_setUserPermissionForTeams(t *testing.T) {
+func TestIntegrationApi_setUserPermissionForTeams(t *testing.T) {
 	type setUserPermissionForTeamsTestCase struct {
 		setUserPermissionTestCase
 		teamCmd *team.CreateTeamCommand

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -31,7 +31,7 @@ type setUserPermissionTest struct {
 	callHook bool
 }
 
-func TestService_SetUserPermission(t *testing.T) {
+func TestIntegrationService_SetUserPermission(t *testing.T) {
 	tests := []setUserPermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -75,7 +75,7 @@ type setTeamPermissionTest struct {
 	callHook bool
 }
 
-func TestService_SetTeamPermission(t *testing.T) {
+func TestIntegrationService_SetTeamPermission(t *testing.T) {
 	tests := []setTeamPermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -124,7 +124,7 @@ type setBuiltInRolePermissionTest struct {
 	callHook bool
 }
 
-func TestService_SetBuiltInRolePermission(t *testing.T) {
+func TestIntegrationService_SetBuiltInRolePermission(t *testing.T) {
 	tests := []setBuiltInRolePermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -166,7 +166,7 @@ type setPermissionsTest struct {
 	expectErr bool
 }
 
-func TestService_SetPermissions(t *testing.T) {
+func TestIntegrationService_SetPermissions(t *testing.T) {
 	tests := []setPermissionsTest{
 		{
 			desc: "should set all permissions",
@@ -235,7 +235,7 @@ func TestService_SetPermissions(t *testing.T) {
 	}
 }
 
-func TestService_RegisterActionSets(t *testing.T) {
+func TestIntegrationService_RegisterActionSets(t *testing.T) {
 	type registerActionSetsTest struct {
 		desc               string
 		options            Options

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -823,7 +823,7 @@ func TestIntegrationTokenCount(t *testing.T) {
 	require.Equal(t, int64(0), count)
 }
 
-func TestRevokeAllUserTokens(t *testing.T) {
+func TestIntegrationRevokeAllUserTokens(t *testing.T) {
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		usr := &user.User{ID: int64(10)}
@@ -856,7 +856,7 @@ func TestRevokeAllUserTokens(t *testing.T) {
 	})
 }
 
-func TestRevokeToken(t *testing.T) {
+func TestIntegrationRevokeToken(t *testing.T) {
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		usr := &user.User{ID: int64(10)}
@@ -887,7 +887,7 @@ func TestRevokeToken(t *testing.T) {
 	})
 }
 
-func TestBatchRevokeAllUserTokens(t *testing.T) {
+func TestIntegrationBatchRevokeAllUserTokens(t *testing.T) {
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		userIds := []int64{1, 2, 3}

--- a/pkg/services/auth/jwt/auth_test.go
+++ b/pkg/services/auth/jwt/auth_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestVerifyUsingPKIXPublicKeyFile(t *testing.T) {
+func TestIntegrationVerifyUsingPKIXPublicKeyFile(t *testing.T) {
 	key := rsaKeys[0]
 	unknownKey := rsaKeys[1]
 
@@ -79,7 +79,7 @@ func TestVerifyUsingPKIXPublicKeyFile(t *testing.T) {
 	})
 }
 
-func TestVerifyUsingJWKSetFile(t *testing.T) {
+func TestIntegrationVerifyUsingJWKSetFile(t *testing.T) {
 	configure := func(t *testing.T, cfg *setting.Cfg) {
 		t.Helper()
 
@@ -118,7 +118,7 @@ func TestVerifyUsingJWKSetFile(t *testing.T) {
 	}, configure)
 }
 
-func TestVerifyUsingJWKSetURL(t *testing.T) {
+func TestIntegrationVerifyUsingJWKSetURL(t *testing.T) {
 	t.Run("should refuse to start with non-https URL", func(t *testing.T) {
 		var err error
 
@@ -160,7 +160,7 @@ func TestVerifyUsingJWKSetURL(t *testing.T) {
 	})
 }
 
-func TestCachingJWKHTTPResponse(t *testing.T) {
+func TestIntegrationCachingJWKHTTPResponse(t *testing.T) {
 	jwkCachingScenario(t, "caches the jwk response", func(t *testing.T, sc cachingScenarioContext) {
 		for i := 0; i < 5; i++ {
 			token := sign(t, &jwKeys[0], jwt.Claims{Subject: subject}, nil)
@@ -200,7 +200,7 @@ func TestCachingJWKHTTPResponse(t *testing.T) {
 	})
 }
 
-func TestSignatureWithNoneAlgorithm(t *testing.T) {
+func TestIntegrationSignatureWithNoneAlgorithm(t *testing.T) {
 	scenario(t, "rejects a token signed with \"none\" algorithm", func(t *testing.T, sc scenarioContext) {
 		token := signNone(t, jwt.Claims{Subject: "foo"})
 		_, err := sc.authJWTSvc.Verify(sc.ctx, token)
@@ -208,7 +208,7 @@ func TestSignatureWithNoneAlgorithm(t *testing.T) {
 	}, configurePKIXPublicKeyFile)
 }
 
-func TestClaimValidation(t *testing.T) {
+func TestIntegrationClaimValidation(t *testing.T) {
 	key := rsaKeys[0]
 
 	scenario(t, "validates iss field for equality", func(t *testing.T, sc scenarioContext) {
@@ -368,7 +368,7 @@ func jwkCachingScenario(t *testing.T, desc string, fn cachingScenarioFunc, cbs .
 	})
 }
 
-func TestBase64Paddings(t *testing.T) {
+func TestIntegrationBase64Paddings(t *testing.T) {
 	key := rsaKeys[0]
 
 	scenario(t, "verifies a token with base64 padding (non compliant rfc7515#section-2 but accepted)", func(t *testing.T, sc scenarioContext) {

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2643,7 +2643,7 @@ func TestCleanUpDashboard(t *testing.T) {
 	}
 }
 
-func TestK8sDashboardCleanupJob(t *testing.T) {
+func TestIntegrationK8sDashboardCleanupJob(t *testing.T) {
 	tests := []struct {
 		name            string
 		featureEnabled  bool

--- a/pkg/services/dashboardsnapshots/service/service_test.go
+++ b/pkg/services/dashboardsnapshots/service/service_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestDashboardSnapshotsService(t *testing.T) {
+func TestIntegrationDashboardSnapshotsService(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	dsStore := dashsnapdb.ProvideStore(sqlStore, cfg)
@@ -97,7 +97,7 @@ func TestDashboardSnapshotsService(t *testing.T) {
 	})
 }
 
-func TestValidateDashboardExists(t *testing.T) {
+func TestIntegrationValidateDashboardExists(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	dsStore := dashsnapdb.ProvideStore(sqlStore, cfg)

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -63,7 +63,7 @@ func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *data
 	return nil, datasources.ErrDataSourceNotFound
 }
 
-func TestService_AddDataSource(t *testing.T) {
+func TestIntegrationService_AddDataSource(t *testing.T) {
 	t.Run("should not fail if the plugin is not installed", func(t *testing.T) {
 		dsService := initDSService(t)
 		dsService.pluginStore = &pluginstore.FakePluginStore{
@@ -354,7 +354,7 @@ func TestService_getAvailableName(t *testing.T) {
 	}
 }
 
-func TestService_UpdateDataSource(t *testing.T) {
+func TestIntegrationService_UpdateDataSource(t *testing.T) {
 	t.Run("should return not found error if datasource not found", func(t *testing.T) {
 		dsService := initDSService(t)
 
@@ -761,7 +761,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 	})
 }
 
-func TestService_DeleteDataSource(t *testing.T) {
+func TestIntegrationService_DeleteDataSource(t *testing.T) {
 	t.Run("should not return an error if data source doesn't exist", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
@@ -1038,7 +1038,7 @@ func TestService_awsServiceNamespace(t *testing.T) {
 }
 
 //nolint:goconst
-func TestService_GetHttpTransport(t *testing.T) {
+func TestIntegrationService_GetHttpTransport(t *testing.T) {
 	cfg := &setting.Cfg{}
 
 	t.Run("Should use cached proxy", func(t *testing.T) {
@@ -1450,7 +1450,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 	})
 }
 
-func TestService_getProxySettings(t *testing.T) {
+func TestIntegrationService_getProxySettings(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))
@@ -1528,7 +1528,7 @@ func TestService_getProxySettings(t *testing.T) {
 	})
 }
 
-func TestService_getTimeout(t *testing.T) {
+func TestIntegrationService_getTimeout(t *testing.T) {
 	cfg := &setting.Cfg{}
 	originalTimeout := sdkhttpclient.DefaultTimeoutOptions.Timeout
 	sdkhttpclient.DefaultTimeoutOptions.Timeout = time.Minute
@@ -1562,7 +1562,7 @@ func TestService_getTimeout(t *testing.T) {
 	}
 }
 
-func TestService_GetDecryptedValues(t *testing.T) {
+func TestIntegrationService_GetDecryptedValues(t *testing.T) {
 	t.Run("should migrate and retrieve values from secure json data", func(t *testing.T) {
 		ds := &datasources.DataSource{
 			ID:   1,
@@ -1621,7 +1621,7 @@ func TestService_GetDecryptedValues(t *testing.T) {
 	})
 }
 
-func TestDataSource_CustomHeaders(t *testing.T) {
+func TestIntegrationDataSource_CustomHeaders(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -358,7 +358,7 @@ func TestIntegrationFolderService(t *testing.T) {
 	})
 }
 
-func TestIntegrationNestedFolderService(t *testing.T) {
+func TestIntegrationNestedFolderServiceBasicOperations(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -726,7 +726,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 	})
 }
 
-func TestNestedFolderServiceFeatureToggle(t *testing.T) {
+func TestIntegrationNestedFolderServiceFeatureToggle(t *testing.T) {
 	nestedFolderStore := folder.NewFakeStore()
 
 	dashStore := dashboards.FakeDashboardStore{}
@@ -757,7 +757,7 @@ func TestNestedFolderServiceFeatureToggle(t *testing.T) {
 	})
 }
 
-func TestFolderServiceDualWrite(t *testing.T) {
+func TestIntegrationFolderServiceDualWrite(t *testing.T) {
 	db, _ := sqlstore.InitTestDB(t)
 	cfg := setting.NewCfg()
 	features := featuremgmt.WithFeatures()
@@ -816,7 +816,7 @@ func TestFolderServiceDualWrite(t *testing.T) {
 	})
 }
 
-func TestNestedFolderService(t *testing.T) {
+func TestIntegrationNestedFolderService(t *testing.T) {
 	t.Run("with feature flag unset", func(t *testing.T) {
 		t.Run("Should create a folder in both dashboard and folders tables", func(t *testing.T) {
 			// dash is needed here because folderSvc.Create expects SaveDashboard to return it
@@ -1690,7 +1690,7 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 	})
 }
 
-func TestFolderServiceGetFolder(t *testing.T) {
+func TestIntegrationFolderServiceGetFolder(t *testing.T) {
 	db, _ := sqlstore.InitTestDB(t)
 
 	signedInAdminUser := user.SignedInUser{UserID: 1, OrgID: orgID, Permissions: map[int64]map[string][]string{
@@ -1801,7 +1801,7 @@ func TestFolderServiceGetFolder(t *testing.T) {
 	}
 }
 
-func TestFolderServiceGetFolders(t *testing.T) {
+func TestIntegrationFolderServiceGetFolders(t *testing.T) {
 	db, cfg := sqlstore.InitTestDB(t)
 	folderStore := ProvideDashboardFolderStore(db)
 
@@ -1872,7 +1872,7 @@ func TestFolderServiceGetFolders(t *testing.T) {
 
 // TODO replace it with an API test under /pkg/tests/api/folders
 // whenever the golang client with get updated to allow filtering child folders by permission
-func TestGetChildrenFilterByPermission(t *testing.T) {
+func TestIntegrationGetChildrenFilterByPermission(t *testing.T) {
 	db, cfg := sqlstore.InitTestDB(t)
 
 	signedInAdminUser := user.SignedInUser{UserID: 1, OrgID: orgID, Permissions: map[int64]map[string][]string{

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -847,7 +847,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 	})
 }
 
-func TestDeleteFoldersFromApiServer(t *testing.T) {
+func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 	fakeK8sClient := new(client.MockK8sHandler)
 	fakeK8sClient.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 	dashboardK8sclient := new(client.MockK8sHandler)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestConnectLibraryPanelsForDashboard(t *testing.T) {
+func TestIntegrationConnectLibraryPanelsForDashboard(t *testing.T) {
 	scenarioWithLibraryPanel(t, "When an admin tries to store a dashboard with a library panel, it should connect the two",
 		func(t *testing.T, sc scenarioContext) {
 			dashJSON := map[string]any{
@@ -348,7 +348,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 		})
 }
 
-func TestImportLibraryPanelsForDashboard(t *testing.T) {
+func TestIntegrationImportLibraryPanelsForDashboard(t *testing.T) {
 	testScenario(t, "When an admin tries to import a dashboard with a library panel that does not exist, it should import the library panel",
 		func(t *testing.T, sc scenarioContext) {
 			var missingUID = "jL6MrxCMz"

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func Test_provideLiveService_RedisUnavailable(t *testing.T) {
+func TestIntegration_provideLiveService_RedisUnavailable(t *testing.T) {
 	cfg := setting.NewCfg()
 
 	cfg.LiveHAEngine = "testredisunavailable"

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -86,7 +86,7 @@ func TestService_Validate(t *testing.T) {
 	}
 }
 
-func TestUserLoginAttempts(t *testing.T) {
+func TestIntegrationUserLoginAttempts(t *testing.T) {
 	ctx := context.Background()
 	cfg := setting.NewCfg()
 	cfg.DisableBruteForceLoginProtection = false
@@ -184,7 +184,7 @@ func TestService_ValidateIPAddress(t *testing.T) {
 	}
 }
 
-func TestIPLoginAttempts(t *testing.T) {
+func TestIntegrationIPLoginAttempts(t *testing.T) {
 	ctx := context.Background()
 	cfg := setting.NewCfg()
 	cfg.DisableIPAddressLoginProtection = false

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestProvisioningApi(t *testing.T) {
+func TestIntegrationProvisioningApi(t *testing.T) {
 	t.Run("policies", func(t *testing.T) {
 		t.Run("successful GET returns 200", func(t *testing.T) {
 			sut := createProvisioningSrvSut(t)
@@ -1619,7 +1619,7 @@ func TestProvisioningApi(t *testing.T) {
 	})
 }
 
-func TestProvisioningApiContactPointExport(t *testing.T) {
+func TestIntegrationProvisioningApiContactPointExport(t *testing.T) {
 	createTestEnv := func(t *testing.T, testConfig string) testEnvironment {
 		env := createTestEnv(t, testConfig)
 		env.ac = &recordingAccessControlFake{

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -63,7 +63,7 @@ func setupAMTest(t *testing.T) *alertmanager {
 	return am
 }
 
-func TestAlertmanager_newAlertmanager(t *testing.T) {
+func TestIntegrationAlertmanager_newAlertmanager(t *testing.T) {
 	am := setupAMTest(t)
 	require.False(t, am.Ready())
 }

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func TestReceiverService_GetReceiver(t *testing.T) {
+func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -61,7 +61,7 @@ func TestReceiverService_GetReceiver(t *testing.T) {
 	})
 }
 
-func TestReceiverService_GetReceivers(t *testing.T) {
+func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -91,7 +91,7 @@ func TestReceiverService_GetReceivers(t *testing.T) {
 	})
 }
 
-func TestReceiverService_DecryptRedact(t *testing.T) {
+func TestIntegrationReceiverService_DecryptRedact(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 

--- a/pkg/services/ngalert/notifier/templates_test.go
+++ b/pkg/services/ngalert/notifier/templates_test.go
@@ -57,7 +57,7 @@ var (
 	}
 )
 
-func TestTemplateDefaultData(t *testing.T) {
+func TestIntegrationTemplateDefaultData(t *testing.T) {
 	am := setupAMTest(t)
 
 	tests := []struct {

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestAlertRuleService(t *testing.T) {
+func TestIntegrationAlertRuleService(t *testing.T) {
 	ruleService := createAlertRuleService(t, nil)
 	var orgID int64 = 1
 	u := &user.SignedInUser{
@@ -754,7 +754,7 @@ func TestAlertRuleService(t *testing.T) {
 	})
 }
 
-func TestCreateAlertRule(t *testing.T) {
+func TestIntegrationCreateAlertRule(t *testing.T) {
 	orgID := rand.Int63()
 	u := &user.SignedInUser{OrgID: orgID, UserUID: util.GenerateShortUID()}
 	groupKey := models.GenerateGroupKey(orgID)
@@ -1983,7 +1983,7 @@ func TestDeleteRuleGroups(t *testing.T) {
 	})
 }
 
-func TestProvisiongWithFullpath(t *testing.T) {
+func TestIntegrationProvisiongWithFullpath(t *testing.T) {
 	tracer := tracing.InitializeTracerForTest()
 	inProcBus := bus.ProvideBus(tracer)
 	sqlStore, cfg := db.InitTestDBWithCfg(t)

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func TestContactPointService(t *testing.T) {
+func TestIntegrationContactPointService(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -360,7 +360,7 @@ func TestContactPointService(t *testing.T) {
 	})
 }
 
-func TestContactPointServiceDecryptRedact(t *testing.T) {
+func TestIntegrationContactPointServiceDecryptRedact(t *testing.T) {
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(db.InitTestDB(t)))
 
 	redactedUser := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -128,7 +128,7 @@ func TestNewAlertmanager(t *testing.T) {
 	}
 }
 
-func TestApplyConfig(t *testing.T) {
+func TestIntegrationApplyConfig(t *testing.T) {
 	const tenantID = "test"
 	// errorHandler returns an error response for the readiness check and state sync.
 	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/services/ngalert/sender/notifier_test.go
+++ b/pkg/services/ngalert/sender/notifier_test.go
@@ -1066,7 +1066,7 @@ func TestStop_DrainingEnabled(t *testing.T) {
 	require.Equal(t, int64(2), alertsReceived.Load())
 }
 
-func TestApplyConfig(t *testing.T) {
+func TestIntegrationApplyConfig(t *testing.T) {
 	targetURL := "alertmanager:9093"
 	targetGroup := &targetgroup.Group{
 		Targets: []model.LabelSet{

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestWarmStateCache(t *testing.T) {
+func TestIntegrationWarmStateCache(t *testing.T) {
 	evaluationTime, err := time.Parse("2006-01-02", "2021-03-25")
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -271,7 +271,7 @@ func TestWarmStateCache(t *testing.T) {
 	})
 }
 
-func TestDashboardAnnotations(t *testing.T) {
+func TestIntegrationDashboardAnnotations(t *testing.T) {
 	evaluationTime, err := time.Parse("2006-01-02", "2022-01-01")
 	require.NoError(t, err)
 
@@ -1450,7 +1450,7 @@ func printAllAnnotations(annos map[int64]annotations.Item) string {
 	return b.String()
 }
 
-func TestStaleResultsHandler(t *testing.T) {
+func TestIntegrationStaleResultsHandler(t *testing.T) {
 	evaluationTime := time.Now().Truncate(time.Second).UTC() // Truncate to the second since we don't store sub-second precision.
 	interval := time.Minute
 
@@ -1737,7 +1737,7 @@ func TestStaleResults(t *testing.T) {
 	})
 }
 
-func TestDeleteStateByRuleUID(t *testing.T) {
+func TestIntegrationDeleteStateByRuleUID(t *testing.T) {
 	interval := time.Minute
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(t, 1)
@@ -1883,7 +1883,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 	}
 }
 
-func TestResetStateByRuleUID(t *testing.T) {
+func TestIntegrationResetStateByRuleUID(t *testing.T) {
 	interval := time.Minute
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(t, 1)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1447,7 +1447,7 @@ func TestIntegrationRuleGroupsCaseSensitive(t *testing.T) {
 	})
 }
 
-func TestIncreaseVersionForAllRulesInNamespaces(t *testing.T) {
+func TestIntegrationIncreaseVersionForAllRulesInNamespaces(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -1496,7 +1496,7 @@ func TestIncreaseVersionForAllRulesInNamespaces(t *testing.T) {
 	})
 }
 
-func TestGetRuleVersions(t *testing.T) {
+func TestIntegrationGetRuleVersions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/services/ngalert/store/org_test.go
+++ b/pkg/services/ngalert/store/org_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestFetchOrgIds(t *testing.T) {
+func TestIntegrationFetchOrgIds(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns empty result when no orgs exist", func(t *testing.T) {

--- a/pkg/services/ngalert/store/range_to_instant_test.go
+++ b/pkg/services/ngalert/store/range_to_instant_test.go
@@ -145,7 +145,7 @@ func TestCanBeInstant(t *testing.T) {
 	}
 }
 
-func TestMigrateLokiQueryToInstant(t *testing.T) {
+func TestIntegrationMigrateLokiQueryToInstant(t *testing.T) {
 	original := createMigrateableLokiRule(t)
 	migrated := createMigrateableLokiRule(t, func(r *models.AlertRule) {
 		r.Data[0] = lokiQuery(t, "A", "instant", "grafanacloud-logs")
@@ -168,7 +168,7 @@ func TestMigrateLokiQueryToInstant(t *testing.T) {
 	require.False(t, canBeOptimized)
 }
 
-func TestMigrateMultiLokiQueryToInstant(t *testing.T) {
+func TestIntegrationMigrateMultiLokiQueryToInstant(t *testing.T) {
 	original := createMultiQueryMigratableLokiRule(t)
 	migrated := createMultiQueryMigratableLokiRule(t, func(r *models.AlertRule) {
 		r.Data[0] = lokiQuery(t, "TotalRequests", "instant", "grafanacloud-logs")
@@ -205,7 +205,7 @@ func TestMigrateMultiLokiQueryToInstant(t *testing.T) {
 	require.False(t, canBeOptimized)
 }
 
-func TestMigratePromQueryToInstant(t *testing.T) {
+func TestIntegrationMigratePromQueryToInstant(t *testing.T) {
 	original := createMigratablePromRule(t)
 	migrated := createMigratablePromRule(t, func(r *models.AlertRule) {
 		r.Data[0] = prometheusQuery(t, "A", promExternalDS, promIsInstant)
@@ -226,7 +226,7 @@ func TestMigratePromQueryToInstant(t *testing.T) {
 	require.False(t, canBeOptimized)
 }
 
-func TestMigrateMultiPromQueryToInstant(t *testing.T) {
+func TestIntegrationMigrateMultiPromQueryToInstant(t *testing.T) {
 	original := createMultiQueryMigratablePromRule(t)
 	migrated := createMultiQueryMigratablePromRule(t, func(r *models.AlertRule) {
 		r.Data[0] = prometheusQuery(t, "TotalRequests", promExternalDS, promIsInstant)

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -108,7 +108,7 @@ func TestCreatingNewDashboardFileReader(t *testing.T) {
 	})
 }
 
-func TestDashboardFileReader(t *testing.T) {
+func TestIntegrationDashboardFileReader(t *testing.T) {
 	logger := log.New("test-logger")
 	cfg := &config{}
 

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -31,7 +31,7 @@ const (
 	twoDashboardsWithUID   = "testdata/test-dashboards/two-dashboards-with-uid"
 )
 
-func TestDuplicatesValidator(t *testing.T) {
+func TestIntegrationDuplicatesValidator(t *testing.T) {
 	fakeService := &dashboards.FakeDashboardProvisioning{}
 	defer fakeService.AssertExpectations(t)
 

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -682,7 +682,7 @@ func TestIntegrationDelete(t *testing.T) {
 	})
 }
 
-func TestDeleteByDashboardUIDs(t *testing.T) {
+func TestIntegrationDeleteByDashboardUIDs(t *testing.T) {
 	var sqlStore db.DB
 	var cfg *setting.Cfg
 	var dashboardStore dashboards.Store
@@ -732,7 +732,7 @@ func TestDeleteByDashboardUIDs(t *testing.T) {
 	})
 }
 
-func TestGetMetrics(t *testing.T) {
+func TestIntegrationGetMetrics(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -307,7 +307,7 @@ const (
 }`
 )
 
-func TestGetQueryDataResponse(t *testing.T) {
+func TestIntegrationGetQueryDataResponse(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, _ := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 	fakeQueryService := &query.FakeQueryService{}
@@ -361,7 +361,7 @@ func TestGetQueryDataResponse(t *testing.T) {
 	})
 }
 
-func TestFindAnnotations(t *testing.T) {
+func TestIntegrationFindAnnotations(t *testing.T) {
 	color := "red"
 	name := "annoName"
 	t.Run("service identity has correct permissions to get annotations dashboards and query datasources", func(t *testing.T) {
@@ -717,7 +717,7 @@ func TestFindAnnotations(t *testing.T) {
 	})
 }
 
-func TestGetMetricRequest(t *testing.T) {
+func TestIntegrationGetMetricRequest(t *testing.T) {
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, nil, nil)
 	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
 	require.NoError(t, err)
@@ -756,7 +756,7 @@ func TestGetMetricRequest(t *testing.T) {
 	})
 }
 
-func TestBuildMetricRequest(t *testing.T) {
+func TestIntegrationBuildMetricRequest(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -60,7 +60,7 @@ func TestLogPrefix(t *testing.T) {
 	assert.Equal(t, LogPrefix, "publicdashboards.service")
 }
 
-func TestGetPublicDashboardForView(t *testing.T) {
+func TestIntegrationGetPublicDashboardForView(t *testing.T) {
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -452,7 +452,7 @@ func TestGetPublicDashboardForView(t *testing.T) {
 	}
 }
 
-func TestGetPublicDashboard(t *testing.T) {
+func TestIntegrationGetPublicDashboard(t *testing.T) {
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -529,7 +529,7 @@ func TestGetPublicDashboard(t *testing.T) {
 	}
 }
 
-func TestGetEnabledPublicDashboard(t *testing.T) {
+func TestIntegrationGetEnabledPublicDashboard(t *testing.T) {
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -594,7 +594,7 @@ func TestGetEnabledPublicDashboard(t *testing.T) {
 
 // We're using sqlite here because testing all of the behaviors with mocks in
 // the correct order is convoluted.
-func TestCreatePublicDashboard(t *testing.T) {
+func TestIntegrationCreatePublicDashboard(t *testing.T) {
 	t.Run("Create public dashboard", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
@@ -975,7 +975,7 @@ func assertFalseIfNull(t *testing.T, expectedValue bool, nullableValue *bool) {
 	}
 }
 
-func TestUpdatePublicDashboard(t *testing.T) {
+func TestIntegrationUpdatePublicDashboard(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 
@@ -1219,7 +1219,7 @@ func assertOldValueIfNull(t *testing.T, expectedValue bool, oldValue bool, nulla
 	}
 }
 
-func TestDeletePublicDashboard(t *testing.T) {
+func TestIntegrationDeletePublicDashboard(t *testing.T) {
 	pubdash := &PublicDashboard{Uid: "2", OrgId: 1, DashboardUid: "uid"}
 
 	type mockFindResponse struct {
@@ -1389,7 +1389,7 @@ func TestDashboardEnabledChanged(t *testing.T) {
 	})
 }
 
-func TestPublicDashboardServiceImpl_ListPublicDashboards(t *testing.T) {
+func TestIntegrationPublicDashboardServiceImpl_ListPublicDashboards(t *testing.T) {
 	features := featuremgmt.WithFeatures()
 	testDB, cfg := db.InitTestDBWithCfg(t)
 	dashStore, err := dashboardsDB.ProvideDashboardStore(testDB, cfg, features, tagimpl.ProvideService(testDB))

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestParseMetricRequest(t *testing.T) {
+func TestIntegrationParseMetricRequest(t *testing.T) {
 	t.Run("Test a simple single datasource query", func(t *testing.T) {
 		tc := setup(t)
 		mr := metricRequestWithQueries(t, `{
@@ -268,7 +268,7 @@ func TestParseMetricRequest(t *testing.T) {
 	})
 }
 
-func TestQueryDataMultipleSources(t *testing.T) {
+func TestIntegrationQueryDataMultipleSources(t *testing.T) {
 	t.Run("can query multiple datasources", func(t *testing.T) {
 		tc := setup(t)
 		query1, err := simplejson.NewJson([]byte(`

--- a/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
@@ -44,7 +44,7 @@ func SetupTestDataSourceSecretMigrationService(t *testing.T, sqlStore db.DB, kvS
 	return migService
 }
 
-func TestMigrate(t *testing.T) {
+func TestIntegrationMigrate(t *testing.T) {
 	t.Run("should migrate from legacy to unified with compatibility", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		kvStore := kvstore.ProvideService(sqlStore)

--- a/pkg/services/secrets/kvstore/sql_test.go
+++ b/pkg/services/secrets/kvstore/sql_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestSecretsKVStoreSQL(t *testing.T) {
+func TestIntegrationSecretsKVStoreSQL(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	kv := NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestSecretsService_EnvelopeEncryption(t *testing.T) {
+func TestIntegrationSecretsService_EnvelopeEncryption(t *testing.T) {
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
 	svc := SetupTestService(t, store)
@@ -90,7 +90,7 @@ func TestSecretsService_EnvelopeEncryption(t *testing.T) {
 	})
 }
 
-func TestSecretsService_DataKeys(t *testing.T) {
+func TestIntegrationSecretsService_DataKeys(t *testing.T) {
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
 	ctx := context.Background()
@@ -168,7 +168,7 @@ func TestSecretsService_DataKeys(t *testing.T) {
 	})
 }
 
-func TestSecretsService_UseCurrentProvider(t *testing.T) {
+func TestIntegrationSecretsService_UseCurrentProvider(t *testing.T) {
 	t.Run("When encryption_provider is not specified explicitly, should use 'secretKey' as a current provider", func(t *testing.T) {
 		testDB := db.InitTestDB(t)
 		svc := SetupTestService(t, database.ProvideSecretsStore(testDB))
@@ -273,7 +273,7 @@ func (f *fakeKMS) Provide() (map[secrets.ProviderID]secrets.Provider, error) {
 	return providers, nil
 }
 
-func TestSecretsService_Run(t *testing.T) {
+func TestIntegrationSecretsService_Run(t *testing.T) {
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
@@ -323,7 +323,7 @@ func TestSecretsService_Run(t *testing.T) {
 	})
 }
 
-func TestSecretsService_ReEncryptDataKeys(t *testing.T) {
+func TestIntegrationSecretsService_ReEncryptDataKeys(t *testing.T) {
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
@@ -370,7 +370,7 @@ func TestSecretsService_ReEncryptDataKeys(t *testing.T) {
 	})
 }
 
-func TestSecretsService_Decrypt(t *testing.T) {
+func TestIntegrationSecretsService_Decrypt(t *testing.T) {
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -117,7 +117,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
+func TestIntegrationProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
 	storeMock := newServiceAccountStoreFake()
 	acSvc := actest.FakeService{}
 	pSvc := &actest.FakePermissionsService{}

--- a/pkg/services/shorturls/shorturlimpl/shorturl_test.go
+++ b/pkg/services/shorturls/shorturlimpl/shorturl_test.go
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestShortURLService(t *testing.T) {
+func TestIntegrationShortURLService(t *testing.T) {
 	user := &user.SignedInUser{UserID: 1}
 	store := db.InitTestDB(t)
 

--- a/pkg/services/sqlstore/migrations/login_attempt_mig.go
+++ b/pkg/services/sqlstore/migrations/login_attempt_mig.go
@@ -44,4 +44,9 @@ func addLoginAttemptMigrations(mg *Migrator) {
 	mg.AddMigration("increase login_attempt.ip_address column length for IPv6 support", NewRawSQLMigration("").
 		Postgres("ALTER TABLE login_attempt ALTER COLUMN ip_address TYPE VARCHAR(50);").
 		Mysql("ALTER TABLE login_attempt MODIFY ip_address VARCHAR(50);"))
+
+	// Use bigint for "created" column to store timestamps (INT is too small)
+	mg.AddMigration("alter table login_attempt alter column created type to bigint", NewRawSQLMigration("").
+		Mysql("ALTER TABLE login_attempt MODIFY created BIGINT;").
+		Postgres("ALTER TABLE login_attempt ALTER COLUMN created TYPE BIGINT;"))
 }

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -371,6 +371,10 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("fix is_paused column for alert_rule_version table", migrator.NewRawSQLMigration("").
 		Postgres(`ALTER TABLE alert_rule_version ALTER COLUMN is_paused SET DEFAULT false;
 UPDATE alert_rule_version SET is_paused = false;`))
+
+	mg.AddMigration("alter table alert_rule_version alter column rule_group_idx type to bigint", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule_version MODIFY rule_group_idx BIGINT;").
+		Postgres("ALTER TABLE alert_rule_version ALTER COLUMN rule_group_idx TYPE BIGINT;"))
 }
 
 func addAlertmanagerConfigMigrations(mg *migrator.Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -300,6 +300,10 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 	mg.AddMigration("fix is_paused column for alert_rule table", migrator.NewRawSQLMigration("").
 		Postgres(`ALTER TABLE alert_rule ALTER COLUMN is_paused SET DEFAULT false;
 UPDATE alert_rule SET is_paused = false;`))
+
+	mg.AddMigration("alter table alert_rule alter column rule_group_idx type to bigint", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule MODIFY rule_group_idx BIGINT;").
+		Postgres("ALTER TABLE alert_rule ALTER COLUMN rule_group_idx TYPE BIGINT;"))
 }
 
 var alertRuleVersionUDX_OrgIdRuleUIDVersion = &migrator.Index{Cols: []string{"rule_org_id", "rule_uid", "version"}, Type: migrator.UniqueIndex}

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFolderUIDFilter(t *testing.T) {
+func TestIntegrationFolderUIDFilter(t *testing.T) {
 	testCases := []struct {
 		description          string
 		uids                 []string

--- a/pkg/services/sqlstore/searchstore/search_test.go
+++ b/pkg/services/sqlstore/searchstore/search_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestBuilder_EqualResults_Basic(t *testing.T) {
+func TestIntegrationBuilder_EqualResults_Basic(t *testing.T) {
 	user := &user.SignedInUser{
 		UserID:  1,
 		OrgID:   1,
@@ -75,7 +75,7 @@ func TestBuilder_EqualResults_Basic(t *testing.T) {
 	}, res)
 }
 
-func TestBuilder_Pagination(t *testing.T) {
+func TestIntegrationBuilder_Pagination(t *testing.T) {
 	user := &user.SignedInUser{
 		UserID:  1,
 		OrgID:   1,
@@ -122,7 +122,7 @@ func TestBuilder_Pagination(t *testing.T) {
 	assert.Equal(t, "P", resPg2[0].Title, "page 2 should start with the 16th dashboard")
 }
 
-func TestBuilder_RBAC(t *testing.T) {
+func TestIntegrationBuilder_RBAC(t *testing.T) {
 	testsCases := []struct {
 		desc            string
 		userPermissions []accesscontrol.Permission

--- a/pkg/services/store/service_test.go
+++ b/pkg/services/store/service_test.go
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestListFiles(t *testing.T) {
+func TestIntegrationListFiles(t *testing.T) {
 	roots := []storageRuntime{publicStaticFilesStorage}
 
 	store := newStandardStorageService(db.InitTestDB(t), roots, func(orgId int64) []storageRuntime {
@@ -94,7 +94,7 @@ func TestListFiles(t *testing.T) {
 	experimental.CheckGoldenJSONFrame(t, "testdata", "public_testdata_js_libraries.golden", testDsFrame, true)
 }
 
-func TestListFilesWithoutPermissions(t *testing.T) {
+func TestIntegrationListFilesWithoutPermissions(t *testing.T) {
 	roots := []storageRuntime{publicStaticFilesStorage}
 
 	store := newStandardStorageService(db.InitTestDB(t), roots, func(orgId int64) []storageRuntime {
@@ -128,7 +128,7 @@ func setupUploadStore(t *testing.T, authService storageAuthService) (StorageServ
 	return store, mockStorage, storageName
 }
 
-func TestShouldUploadWhenNoFileAlreadyExists(t *testing.T) {
+func TestIntegrationShouldUploadWhenNoFileAlreadyExists(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.jpg"
@@ -147,7 +147,7 @@ func TestShouldUploadWhenNoFileAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestShouldFailUploadWithoutAccess(t *testing.T) {
+func TestIntegrationShouldFailUploadWithoutAccess(t *testing.T) {
 	service, _, storageName := setupUploadStore(t, denyAllAuthService)
 
 	err := service.Upload(context.Background(), dummyUser, &UploadRequest{
@@ -158,7 +158,7 @@ func TestShouldFailUploadWithoutAccess(t *testing.T) {
 	require.ErrorIs(t, err, ErrAccessDenied)
 }
 
-func TestShouldFailUploadWhenFileAlreadyExists(t *testing.T) {
+func TestIntegrationShouldFailUploadWhenFileAlreadyExists(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("Get", mock.Anything, "/myFile.jpg", &filestorage.GetFileOptions{WithContents: false}).Return(&filestorage.File{Contents: make([]byte, 0)}, true, nil)
@@ -171,7 +171,7 @@ func TestShouldFailUploadWhenFileAlreadyExists(t *testing.T) {
 	require.ErrorIs(t, err, ErrFileAlreadyExists)
 }
 
-func TestShouldDelegateFileDeletion(t *testing.T) {
+func TestIntegrationShouldDelegateFileDeletion(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("Delete", mock.Anything, "/myFile.jpg").Return(nil)
@@ -180,7 +180,7 @@ func TestShouldDelegateFileDeletion(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestShouldDelegateFolderCreation(t *testing.T) {
+func TestIntegrationShouldDelegateFolderCreation(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("CreateFolder", mock.Anything, "/nestedFolder/mostNestedFolder").Return(nil)
@@ -189,7 +189,7 @@ func TestShouldDelegateFolderCreation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestShouldDelegateFolderDeletion(t *testing.T) {
+func TestIntegrationShouldDelegateFolderDeletion(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 	cmds := []*DeleteFolderCmd{
 		{
@@ -213,7 +213,7 @@ func TestShouldDelegateFolderDeletion(t *testing.T) {
 	}
 }
 
-func TestShouldUploadSvg(t *testing.T) {
+func TestIntegrationShouldUploadSvg(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -232,7 +232,7 @@ func TestShouldUploadSvg(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestShouldNotUploadHtmlDisguisedAsSvg(t *testing.T) {
+func TestIntegrationShouldNotUploadHtmlDisguisedAsSvg(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -246,7 +246,7 @@ func TestShouldNotUploadHtmlDisguisedAsSvg(t *testing.T) {
 	require.ErrorIs(t, err, ErrValidationFailed)
 }
 
-func TestShouldNotUploadJpgDisguisedAsSvg(t *testing.T) {
+func TestIntegrationShouldNotUploadJpgDisguisedAsSvg(t *testing.T) {
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -260,7 +260,7 @@ func TestShouldNotUploadJpgDisguisedAsSvg(t *testing.T) {
 	require.ErrorIs(t, err, ErrValidationFailed)
 }
 
-func TestSetupWithNonUniqueStoragePrefixes(t *testing.T) {
+func TestIntegrationSetupWithNonUniqueStoragePrefixes(t *testing.T) {
 	prefix := "resources"
 	sqlStorage := newSQLStorage(RootStorageMeta{}, prefix, "Testing upload", "dummy descr", &StorageSQLConfig{}, db.InitTestDB(t), 1, false)
 	sqlStorage2 := newSQLStorage(RootStorageMeta{}, prefix, "Testing upload", "dummy descr", &StorageSQLConfig{}, db.InitTestDB(t), 1, false)
@@ -276,7 +276,7 @@ func TestSetupWithNonUniqueStoragePrefixes(t *testing.T) {
 	}, allowAllAuthService, cfg, nil)
 }
 
-func TestContentRootWithNestedStorage(t *testing.T) {
+func TestIntegrationContentRootWithNestedStorage(t *testing.T) {
 	globalOrgID := int64(accesscontrol.GlobalOrgID)
 	testDB := db.InitTestDB(t)
 	orgedUser := &user.SignedInUser{OrgID: 1}
@@ -522,7 +522,7 @@ func TestContentRootWithNestedStorage(t *testing.T) {
 	}
 }
 
-func TestShadowingExistingFolderByNestedContentRoot(t *testing.T) {
+func TestIntegrationShadowingExistingFolderByNestedContentRoot(t *testing.T) {
 	db := db.InitTestDB(t)
 	ctx := context.Background()
 	nestedStorage := newSQLStorage(RootStorageMeta{}, "nested", "Testing upload", "dummy descr", &StorageSQLConfig{}, db, accesscontrol.GlobalOrgID, true)

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1021,7 +1021,7 @@ func createFiveTestUsers(t *testing.T, svc user.Service, fn func(i int) *user.Cr
 	return users
 }
 
-func TestMetricsUsage(t *testing.T) {
+func TestIntegrationMetricsUsage(t *testing.T) {
 	ss, cfg := db.InitTestDBWithCfg(t)
 	userStore := ProvideStore(ss, setting.NewCfg())
 	quotaService := quotaimpl.ProvideService(ss, cfg)

--- a/pkg/storage/unified/federated/federatedtests/stats_test.go
+++ b/pkg/storage/unified/federated/federatedtests/stats_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestDirectSQLStats(t *testing.T) {
+func TestIntegrationDirectSQLStats(t *testing.T) {
 	db, cfg := db.InitTestDBWithCfg(t)
 	ctx := context.Background()
 

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -24,7 +24,7 @@ import (
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
-func TestListIter(t *testing.T) {
+func TestIntegrationListIter(t *testing.T) {
 	ctx := context.Background()
 
 	grafanaDB := db.InitTestDB(t)


### PR DESCRIPTION
Technically, any test that uses real database should be called "TestIntegration..." to cover all the supported databases. Initially we renamed the tests in batches, automatically, but since then things drifted a bit and a few tests are now named as if they are unit tests, so we only run them on SQLite.

This PR changes the names for all the tests that invoke `InitTestDB` but are not `TestIntegration`. We may consider reverting pkg/api test renames because maybe service tests is sufficient.

Now we can see that one test fails for MySQL dialect (which we never tested) - `TestIntegrationMetricsUsage/Get_empty_role_metrics_for_an_org`

A few more failing tests are for PostgreSQL: `TestIntegrationUserLoginAttempts`, `TestIntegrationIPLoginAttempts`, and `TestIntegrationGetRuleVersions`

This adds a migration to ALTER TABLE column to BigInt where timestamps are stored, otherwise PostgreSQL fails to store it as Int:
- https://github.com/grafana/grafana/pull/105987/files#diff-da34c94d481aa57b92b9570bb9997a3ec2d40915ccfccaf56684f3afbeb8d68fR378-R381
- https://github.com/grafana/grafana/pull/105987/files#diff-da34c94d481aa57b92b9570bb9997a3ec2d40915ccfccaf56684f3afbeb8d68fR303-R306
- https://github.com/grafana/grafana/pull/105987/files#diff-f4531bbb02388115e275ccb618a68ab8e4e5a558636d35ab1ede56c4e70fda33R42-R44

Also rewrites a query with a subquery and a JOIN, which was illegal in mysql and thus never worked (and was never tested): https://github.com/grafana/grafana/pull/105987/files#diff-13017324694f53fae56046bf90c5ecd1edce16da7647835df47e5828c7879671R423-R433