### PR TITLE
Tempo: Enable native histograms for Tempo service graph 

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -341,6 +341,9 @@ datasources:
         queries:
           - name: 'Metrics'
             query: 'sum(rate({$$__tags}[5m]))'
+      serviceMap:
+        datasourceUid: 'gdev-prometheus'
+        histogramType: 'both' # 'classic' or 'native' or 'both'
 
   - name: gdev-pyroscope
     type: grafana-pyroscope-datasource

--- a/devenv/docker/blocks/tempo/docker-compose.yaml
+++ b/devenv/docker/blocks/tempo/docker-compose.yaml
@@ -90,6 +90,7 @@
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
+      - --enable-feature=native-histograms
     volumes:
       - ./docker/blocks/tempo/prometheus.yaml:/etc/prometheus.yaml
     links:

--- a/devenv/docker/blocks/tempo/tempo.yaml
+++ b/devenv/docker/blocks/tempo/tempo.yaml
@@ -60,6 +60,7 @@ storage:
 overrides:
   defaults:
     metrics_generator:
+      generate_native_histograms: both # 'classic' or 'native' or 'both'
       processors: [local-blocks, service-graphs, span-metrics]
 
 stream_over_http_enabled: true

--- a/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
@@ -21,6 +21,36 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
     { label: 'Both', value: 'both' },
   ];
 
+  const nativeHistogramDocs = (
+    <>
+      Select which type of histograms are configured in the {metricsGeneratorDocsLink()}. If native histograms are configured, you must also configure native histograms ingestion in {prometheusNativeHistogramsDocsLink()} or {mimirNativeHistogramsDocsLink()}.
+    </>
+  )
+
+  function metricsGeneratorDocsLink() {
+    return (
+      <a style={{ textDecoration: 'underline' }} href="https://grafana.com/docs/tempo/latest/setup-and-configuration/metrics-generator/" target="_blank" rel="noopener noreferrer">
+        Tempo metrics generator
+      </a>
+    )
+  }
+
+  function prometheusNativeHistogramsDocsLink() {
+    return (
+      <a style={{ textDecoration: 'underline' }} href="https://prometheus.io/docs/specs/native_histograms/#native-histograms" target="_blank" rel="noopener noreferrer">
+        Prometheus
+      </a>
+    )
+  }
+
+  function mimirNativeHistogramsDocsLink() {
+    return (
+      <a style={{ textDecoration: 'underline' }} href="https://grafana.com/docs/mimir/latest/configure/configure-native-histograms-ingestion/#configure-native-histograms-globally" target="_blank" rel="noopener noreferrer">
+        Mimir
+      </a>
+    )
+  }
+
   return (
     <div className={styles.container}>
       <InlineFieldRow className={styles.row}>
@@ -60,9 +90,10 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
       </InlineFieldRow>
       <InlineFieldRow className={styles.row}>
         <InlineField
-          tooltip="Select which type of histograms are configured in Tempo and Prometheus"
+          tooltip={nativeHistogramDocs}
           label="Histogram type"
           labelWidth={26}
+          interactive={true}
         >
           <Combobox
             id="histogram-type-select"

--- a/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
@@ -4,7 +4,7 @@ import {
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, InlineField, InlineFieldRow, useStyles2 } from '@grafana/ui';
+import { Button, InlineField, InlineFieldRow, useStyles2, Combobox } from '@grafana/ui';
 
 import { TempoJsonData } from '../types';
 
@@ -14,6 +14,12 @@ interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {}
 
 export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
   const styles = useStyles2(getStyles);
+
+  const histogramOptions = [
+    { label: 'Classic', value: 'classic' },
+    { label: 'Native', value: 'native' },
+    { label: 'Both', value: 'both' },
+  ];
 
   return (
     <div className={styles.container}>
@@ -51,6 +57,26 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
             Clear
           </Button>
         ) : null}
+      </InlineFieldRow>
+      <InlineFieldRow className={styles.row}>
+        <InlineField
+          tooltip="Select which type of histograms are configured in Tempo and Prometheus"
+          label="Histogram type"
+          labelWidth={26}
+        >
+          <Combobox
+            id="histogram-type-select"
+            value={options.jsonData.serviceMap?.histogramType || 'classic'}
+            width={40}
+            options={histogramOptions}
+            onChange={(value) =>
+              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'serviceMap', {
+                ...options.jsonData.serviceMap,
+                histogramType: value.value,
+              })
+            }
+          />
+        </InlineField>
       </InlineFieldRow>
     </div>
   );

--- a/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
@@ -23,32 +23,49 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
 
   const nativeHistogramDocs = (
     <>
-      Select which type of histograms are configured in the {metricsGeneratorDocsLink()}. If native histograms are configured, you must also configure native histograms ingestion in {prometheusNativeHistogramsDocsLink()} or {mimirNativeHistogramsDocsLink()}.
+      Select which type of histograms are configured in the {metricsGeneratorDocsLink()}. If native histograms are
+      configured, you must also configure native histograms ingestion in {prometheusNativeHistogramsDocsLink()} or{' '}
+      {mimirNativeHistogramsDocsLink()}.
     </>
-  )
+  );
 
   function metricsGeneratorDocsLink() {
     return (
-      <a style={{ textDecoration: 'underline' }} href="https://grafana.com/docs/tempo/latest/setup-and-configuration/metrics-generator/" target="_blank" rel="noopener noreferrer">
+      <a
+        style={{ textDecoration: 'underline' }}
+        href="https://grafana.com/docs/tempo/latest/setup-and-configuration/metrics-generator/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Tempo metrics generator
       </a>
-    )
+    );
   }
 
   function prometheusNativeHistogramsDocsLink() {
     return (
-      <a style={{ textDecoration: 'underline' }} href="https://prometheus.io/docs/specs/native_histograms/#native-histograms" target="_blank" rel="noopener noreferrer">
+      <a
+        style={{ textDecoration: 'underline' }}
+        href="https://prometheus.io/docs/specs/native_histograms/#native-histograms"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Prometheus
       </a>
-    )
+    );
   }
 
   function mimirNativeHistogramsDocsLink() {
     return (
-      <a style={{ textDecoration: 'underline' }} href="https://grafana.com/docs/mimir/latest/configure/configure-native-histograms-ingestion/#configure-native-histograms-globally" target="_blank" rel="noopener noreferrer">
+      <a
+        style={{ textDecoration: 'underline' }}
+        href="https://grafana.com/docs/mimir/latest/configure/configure-native-histograms-ingestion/#configure-native-histograms-globally"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Mimir
       </a>
-    )
+    );
   }
 
   return (
@@ -89,12 +106,7 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
         ) : null}
       </InlineFieldRow>
       <InlineFieldRow className={styles.row}>
-        <InlineField
-          tooltip={nativeHistogramDocs}
-          label="Histogram type"
-          labelWidth={26}
-          interactive={true}
-        >
+        <InlineField tooltip={nativeHistogramDocs} label="Histogram type" labelWidth={26} interactive={true}>
           <Combobox
             id="histogram-type-select"
             value={options.jsonData.serviceMap?.histogramType || 'classic'}

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -42,6 +42,8 @@ import {
   makeTempoLink,
   getFieldConfig,
   getEscapedSpanNames,
+  makeHistogramLink,
+  makePromServiceMapRequest,
 } from './datasource';
 import mockJson from './test/mockJsonResponse.json';
 import mockServiceGraph from './test/mockServiceGraph.json';
@@ -812,7 +814,7 @@ describe('Tempo service graph view', () => {
         },
         {
           url: '',
-          title: 'Request histogram',
+          title: 'Request classic histogram',
           internal: {
             query: {
               expr: 'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))',
@@ -909,7 +911,7 @@ describe('Tempo service graph view', () => {
         },
         {
           url: '',
-          title: 'Request histogram',
+          title: 'Request classic histogram',
           internal: {
             query: {
               expr: 'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{client="${__data.fields.sourceName}",client_service_namespace="${__data.fields.sourceNamespace}",server="${__data.fields.targetName}",server_service_namespace="${__data.fields.targetNamespace}"}[$__rate_interval])) by (le, client, server, server_service_namespace, client_service_namespace))',
@@ -1247,6 +1249,85 @@ describe('should provide functionality for ad-hoc filters', () => {
   });
 });
 
+describe('histogram type functionality', () => {
+  it('should create correct histogram links for classic histogram type', () => {
+    const datasourceUid = 'prom';
+    const source = 'client="${__data.fields.source}",';
+    const target = 'server="${__data.fields.target}"';
+    const serverSumBy = 'server';
+
+    const links = makeHistogramLink(datasourceUid, source, target, serverSumBy);
+    expect(links).toHaveLength(1);
+    expect(links[0].title).toBe('Request classic histogram');
+    expect(links[0].internal.query.expr).toBe(
+      'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))'
+    );
+  });
+
+  it('should create correct histogram links for native histogram type', () => {
+    const datasourceUid = 'prom';
+    const source = 'client="${__data.fields.source}",';
+    const target = 'server="${__data.fields.target}"';
+    const serverSumBy = 'server';
+
+    const links = makeHistogramLink(datasourceUid, source, target, serverSumBy, 'native');
+    expect(links).toHaveLength(1);
+    expect(links[0].title).toBe('Request native histogram');
+    expect(links[0].internal.query.expr).toBe(
+      'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))'
+    );
+  });
+
+  it('should create correct histogram links for both histogram types', () => {
+    const datasourceUid = 'prom';
+    const source = 'client="${__data.fields.source}",';
+    const target = 'server="${__data.fields.target}"';
+    const serverSumBy = 'server';
+
+    const links = makeHistogramLink(datasourceUid, source, target, serverSumBy, 'both');
+    expect(links).toHaveLength(2);
+    expect(links[0].title).toBe('Request classic histogram');
+    expect(links[1].title).toBe('Request native histogram');
+    expect(links[0].internal.query.expr).toBe(
+      'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))'
+    );
+    expect(links[1].internal.query.expr).toBe(
+      'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))'
+    );
+  });
+
+  it('should include histogram type in field config', () => {
+    const datasourceUid = 'prom';
+    const tempoDatasourceUid = 'tempo';
+    const targetField = '__data.fields.target';
+    const tempoField = '__data.fields.target';
+    const sourceField = '__data.fields.source';
+
+    const fieldConfig = getFieldConfig(datasourceUid, tempoDatasourceUid, targetField, tempoField, sourceField, undefined, 'native');
+    const histogramLink = fieldConfig.links.find(link => link.title === 'Request native histogram');
+    expect(histogramLink).toBeDefined();
+    expect(histogramLink?.internal?.query).toBeDefined();
+    if (histogramLink?.internal?.query && 'expr' in histogramLink.internal.query) {
+      expect(histogramLink.internal.query.expr).toBe(
+        'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds{client="${__data.fields.source}",server="${__data.fields.target}"}[$__rate_interval])) by (le, client, server))'
+      );
+    }
+  });
+
+  it('should handle histogram type in service map query', () => {
+    const request = makePromServiceMapRequest({
+      targets: [{ serviceMapQuery: '{service="test"}' }],
+      range: getDefaultTimeRange(),
+    } as DataQueryRequest<TempoQuery>, 'native');
+
+    const bucketMetric = request.targets.find((t: PromQuery) => t.expr.includes('_bucket'));
+    expect(bucketMetric).toBeUndefined();
+
+    const nativeMetric = request.targets.find((t: PromQuery) => t.expr.includes('traces_service_graph_request_server_seconds'));
+    expect(nativeMetric).toBeDefined();
+  });
+});
+
 const prometheusMock = (): DataSourceApi => {
   return {
     query: jest.fn(() =>
@@ -1456,7 +1537,7 @@ const serviceGraphLinks = [
   },
   {
     url: '',
-    title: 'Request histogram',
+    title: 'Request classic histogram',
     internal: {
       query: {
         expr: 'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{server="${__data.fields.id}"}[$__rate_interval])) by (le, client, server))',

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -1303,8 +1303,16 @@ describe('histogram type functionality', () => {
     const tempoField = '__data.fields.target';
     const sourceField = '__data.fields.source';
 
-    const fieldConfig = getFieldConfig(datasourceUid, tempoDatasourceUid, targetField, tempoField, sourceField, undefined, 'native');
-    const histogramLink = fieldConfig.links.find(link => link.title === 'Request native histogram');
+    const fieldConfig = getFieldConfig(
+      datasourceUid,
+      tempoDatasourceUid,
+      targetField,
+      tempoField,
+      sourceField,
+      undefined,
+      'native'
+    );
+    const histogramLink = fieldConfig.links.find((link) => link.title === 'Request native histogram');
     expect(histogramLink).toBeDefined();
     expect(histogramLink?.internal?.query).toBeDefined();
     if (histogramLink?.internal?.query && 'expr' in histogramLink.internal.query) {
@@ -1315,15 +1323,20 @@ describe('histogram type functionality', () => {
   });
 
   it('should handle histogram type in service map query', () => {
-    const request = makePromServiceMapRequest({
-      targets: [{ serviceMapQuery: '{service="test"}' }],
-      range: getDefaultTimeRange(),
-    } as DataQueryRequest<TempoQuery>, 'native');
+    const request = makePromServiceMapRequest(
+      {
+        targets: [{ serviceMapQuery: '{service="test"}' }],
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest<TempoQuery>,
+      'native'
+    );
 
     const bucketMetric = request.targets.find((t: PromQuery) => t.expr.includes('_bucket'));
     expect(bucketMetric).toBeUndefined();
 
-    const nativeMetric = request.targets.find((t: PromQuery) => t.expr.includes('traces_service_graph_request_server_seconds'));
+    const nativeMetric = request.targets.find((t: PromQuery) =>
+      t.expr.includes('traces_service_graph_request_server_seconds')
+    );
     expect(nativeMetric).toBeDefined();
   });
 });

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -521,7 +521,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         serviceMapQuery(options, datasourceUid, tempoDsUid, histogramType).pipe(
           concatMap((result) =>
             rateQuery(options, result, datasourceUid).pipe(
-              // this will need the histogram type too
               concatMap((result) => errorAndDurationQuery(options, result, datasourceUid, tempoDsUid, histogramType))
             )
           )

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -515,7 +515,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         hasServiceMapQuery: targets.serviceMap[0].serviceMapQuery ? true : false,
       });
 
-      const {datasourceUid, histogramType} = this.serviceMap;
+      const { datasourceUid, histogramType } = this.serviceMap;
       const tempoDsUid = this.uid;
       subQueries.push(
         serviceMapQuery(options, datasourceUid, tempoDsUid, histogramType).pipe(
@@ -1213,7 +1213,7 @@ export function makeHistogramLink(
   serverSumBy: string,
   histogramType?: string
 ) {
-  const createHistogramLink = (metric: string, title: string) => 
+  const createHistogramLink = (metric: string, title: string) =>
     makePromLink(
       title,
       `histogram_quantile(0.9, sum(rate(${metric}{${source}${target}}[$__rate_interval])) by (le, client, ${serverSumBy}))`,
@@ -1340,11 +1340,14 @@ function makeTempoLinkServiceMap(
   };
 }
 
-export function makePromServiceMapRequest(options: DataQueryRequest<TempoQuery>, histogramType?: string): DataQueryRequest<PromQuery> {
+export function makePromServiceMapRequest(
+  options: DataQueryRequest<TempoQuery>,
+  histogramType?: string
+): DataQueryRequest<PromQuery> {
   return {
     ...options,
     targets: serviceMapMetrics
-      .map<PromQuery[]>((metric) => {        
+      .map<PromQuery[]>((metric) => {
         if (histogramType === 'native' && metric.includes('_bucket')) {
           metric = metric.replace('_bucket', '');
         }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -112,7 +112,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
     datasourceUid?: string;
-    histogramType?: string;
+    histogramType?: 'classic' | 'native' | 'both';
   };
   search?: {
     hide?: boolean;

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1206,7 +1206,7 @@ export function getFieldConfig(
   };
 }
 
-function makeHistogramLink(
+export function makeHistogramLink(
   datasourceUid: string,
   source: string,
   target: string,
@@ -1340,7 +1340,7 @@ function makeTempoLinkServiceMap(
   };
 }
 
-function makePromServiceMapRequest(options: DataQueryRequest<TempoQuery>, histogramType?: string): DataQueryRequest<PromQuery> {
+export function makePromServiceMapRequest(options: DataQueryRequest<TempoQuery>, histogramType?: string): DataQueryRequest<PromQuery> {
   return {
     ...options,
     targets: serviceMapMetrics

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -31,6 +31,10 @@ export const durationMetric = {
   expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{}[$__range])) by (le))',
   params: [],
 };
+export const nativeHistogramDurationMetric = {
+  expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency{}[$__range])) by (le))',
+  params: [],
+};
 export const defaultTableFilter = 'span_kind="SPAN_KIND_SERVER"';
 
 export const serviceMapMetrics = [

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -15,6 +15,7 @@ export const secondsMetric = 'traces_service_graph_request_server_seconds_sum';
 export const totalsMetric = 'traces_service_graph_request_total';
 export const failedMetric = 'traces_service_graph_request_failed_total';
 export const histogramMetric = 'traces_service_graph_request_server_seconds_bucket';
+export const nativeHistogramMetric = 'traces_service_graph_request_server_seconds';
 
 export const rateMetric = {
   expr: 'sum(rate(traces_spanmetrics_calls_total{}[$__range])) by (span_name)',

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -7,6 +7,7 @@ export interface TempoJsonData extends DataSourceJsonData {
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
     datasourceUid?: string;
+    histogramType?: 'classic' | 'native' | 'both';
   };
   search?: {
     hide?: boolean;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/105904

![Screenshot 2025-05-25 at 11 15 44 PM](https://github.com/user-attachments/assets/1ae8f143-e981-42b7-b78e-2b8a25b6bbfc)

![Screenshot 2025-05-25 at 11 27 51 PM](https://github.com/user-attachments/assets/a78a478b-b046-44a2-a6b7-d915221c86ca)

**What is this feature?**

This enables native histograms to be used in the Service Graph (service map) in Tempo which is also used in AppO11y. It also updates the Tempo data source in devenv so that both native histograms and classic are generated by Tempo and ingested by Prometheus.

**Why do we need this feature?**

Native histograms in Prometheus will be GA soon in Grafana. This supports that initiative.

**Who is this feature for?**

This is for users of Tempo and users of AppoO11y that have configured Tempo to generate native histograms.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana/issues/105904

**What was changed to make this happen?**:

1. Tempo config page for Service Map configuration now has a select to opt in to this feature, `classic`, `native`, `both`
2. When both or native is selected, this changes the links to Prometheus histogram queries
![Screenshot 2025-05-25 at 11 11 15 PM](https://github.com/user-attachments/assets/d03df6ff-8706-44d6-a670-57439a680b72)
3. Service Map error and duration queries use native histograms if configured only for `native`. Default is `classic`

**How to Test**:

1. Run gdev-tempo but make sure you delete your docker containers related to Tempo as the Tempo and Prometheus configs have been updated.
2. See that the gdev tempo data source config page shows that 'both' is selected under service map config section.
3. This will create links to both classic and native histograms in the service map Prom links.
4. If you change the option to `native` these two files and rebuild the containers you will see only native histograms used.
  - devenv/datasources.yaml =>  

```
      serviceMap:
        datasourceUid: 'gdev-prometheus'
        histogramType: 'native'
```

  - tempo.yaml =>  `generate_native_histograms: native`

5. This will also use a native histogram for the error and duration query as well as queries generated by the service map metrics.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
