### PR TITLE
Alerting: Hide labels section if we only have private labels

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -24,6 +24,7 @@ import { grantPermissionsHelper } from '../../test/test-utils';
 import { setupDataSources } from '../../testSetup/datasources';
 import { Annotation } from '../../utils/constants';
 import { DataSourceType } from '../../utils/datasource';
+import { GRAFANA_ORIGIN_LABEL } from '../../utils/labels';
 import * as ruleId from '../../utils/rule-id';
 import { stringifyIdentifier } from '../../utils/rule-id';
 
@@ -285,6 +286,19 @@ describe('RuleViewer', () => {
         const versionSummary = screen.getByRole('heading', { level: 4 });
         expect(versionSummary).toHaveTextContent(/Version 5 updated by alerting/i);
         expect(versionSummary).toHaveTextContent(/Version 6 updated by provisioning/i);
+      });
+
+      it('should not show any labels if we only have private labels', async () => {
+        const ruleIdentifier = ruleId.fromCombinedRule('grafana', mockRule);
+        const rule = getGrafanaRule({
+          name: 'Test alert',
+          labels: {
+            [GRAFANA_ORIGIN_LABEL]: 'plugins/synthetic-monitoring-app',
+          },
+        });
+
+        await renderRuleViewer(rule, ruleIdentifier);
+        expect(screen.queryByText('Labels')).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { chain, isEmpty, truncate } from 'lodash';
+import { chain, truncate } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useMeasure } from 'react-use';
 
@@ -40,6 +40,7 @@ import { useReturnTo } from '../../hooks/useReturnTo';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { Annotation } from '../../utils/constants';
 import { ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
+import { labelsSize } from '../../utils/labels';
 import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink } from '../../utils/navigation';
 import {
@@ -188,7 +189,7 @@ const createMetadata = (rule: CombinedRule): PageInfoItem[] => {
 
   const hasDashboardAndPanel = dashboardUID && panelID;
   const hasDashboard = dashboardUID;
-  const hasLabels = !isEmpty(labels);
+  const hasLabels = labelsSize(labels) > 0;
 
   const interval = group.interval;
   const styles = useStyles2(getStyles);


### PR DESCRIPTION
**What is this feature?**

Minor bug fix to hide the labels section if we only have private labels.

**Before**
<img width="409" alt="Screenshot 2025-05-26 at 09 39 54" src="https://github.com/user-attachments/assets/62777831-5587-4940-a4d2-caa6dee64d1c" />
