### PR TITLE
[release-12.0.1] RBAC: Dont additionally cache all users permissions

### DIFF
--- a/pkg/services/accesscontrol/cacheutils.go
+++ b/pkg/services/accesscontrol/cacheutils.go
@@ -30,10 +30,6 @@ func (s *SearchOptions) HashString() (string, error) {
 	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
 }
 
-func GetUserPermissionCacheKey(user identity.Requester) string {
-	return fmt.Sprintf("rbac-permissions-%s", user.GetCacheKey())
-}
-
 func GetSearchPermissionCacheKey(log log.Logger, user identity.Requester, searchOptions SearchOptions) (string, error) {
 	searchHash, err := searchOptions.HashString()
 	if err != nil {

--- a/pkg/services/accesscontrol/cacheutils_test.go
+++ b/pkg/services/accesscontrol/cacheutils_test.go
@@ -6,77 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	claims "github.com/grafana/authlib/types"
-
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
 var testLogger = log.New("test")
-
-func TestPermissionCacheKey(t *testing.T) {
-	testcases := []struct {
-		name         string
-		signedInUser *user.SignedInUser
-		expected     string
-	}{
-		{
-			name: "should return correct key for user",
-			signedInUser: &user.SignedInUser{
-				OrgID:        1,
-				UserID:       1,
-				FallbackType: claims.TypeUser,
-			},
-			expected: "rbac-permissions-1-user-1",
-		},
-		{
-			name: "should return correct key for api key",
-			signedInUser: &user.SignedInUser{
-				OrgID:            1,
-				ApiKeyID:         1,
-				IsServiceAccount: false,
-				FallbackType:     claims.TypeUser,
-			},
-			expected: "rbac-permissions-1-api-key-1",
-		},
-		{
-			name: "should return correct key for service account",
-			signedInUser: &user.SignedInUser{
-				OrgID:            1,
-				UserID:           1,
-				IsServiceAccount: true,
-				FallbackType:     claims.TypeUser,
-			},
-			expected: "rbac-permissions-1-service-account-1",
-		},
-		{
-			name: "should return correct key for matching a service account with userId -1",
-			signedInUser: &user.SignedInUser{
-				OrgID:            1,
-				UserID:           -1,
-				IsServiceAccount: true,
-				FallbackType:     claims.TypeUser, // NOTE, this is still a service account!
-			},
-			expected: "rbac-permissions-1-service-account--1",
-		},
-		{
-			name: "should use org role if no unique id",
-			signedInUser: &user.SignedInUser{
-				OrgID:        1,
-				OrgRole:      org.RoleNone,
-				FallbackType: claims.TypeUser,
-			},
-			expected: "rbac-permissions-1-user-None",
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, GetUserPermissionCacheKey(tc.signedInUser))
-		})
-	}
-}
 
 func TestGetSearchPermissionCacheKey(t *testing.T) {
 	keyInputs := []struct {


### PR DESCRIPTION
Backport cfba630f5cab358cd9ce33ba249ba80d5377647f from #105607

---

**What is this feature?**

Revert additional caching of whole users permissions set introduced in https://github.com/grafana/grafana-enterprise/pull/7121 and https://github.com/grafana/grafana/pull/92673. It seems like it's significantly increases memory consumption and might lead to OOM at some instances without providing notable performance gain.

**Why do we need this feature?**

Some customers report Grafana goes OOM after upgrading from 11.2.x.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Left - before, right - after:

<img width="2199" alt="Screenshot 2025-05-19 at 13 05 54" src="https://github.com/user-attachments/assets/cd2c6117-194f-40b8-8162-09e3f282569c" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
