### PR TITLE
Canvas: Align connection anchors and element rotation

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -304,59 +304,6 @@ export class ElementState implements LayerElement {
       //   : parseFloat(getComputedStyle(this.div?.parentElement!).borderWidth);
     }
 
-    // For elements with rotation, a delta needs to be applied to account for bounding box rotation
-    // TODO: Fix behavior for top+bottom, left+right, center, and scale constraints
-    let rotationTopOffset = 0;
-    let rotationLeftOffset = 0;
-    if (this.options.placement?.rotation && this.options.placement?.width && this.options.placement?.height) {
-      const rotationDegrees = this.options.placement.rotation;
-      const rotationRadians = (Math.PI / 180) * rotationDegrees;
-      let rotationOffset = rotationRadians;
-
-      switch (true) {
-        case rotationDegrees >= 0 && rotationDegrees < 90:
-          // no-op
-          break;
-        case rotationDegrees >= 90 && rotationDegrees < 180:
-          rotationOffset = Math.PI - rotationRadians;
-          break;
-        case rotationDegrees >= 180 && rotationDegrees < 270:
-          rotationOffset = Math.PI + rotationRadians;
-          break;
-        case rotationDegrees >= 270:
-          rotationOffset = -rotationRadians;
-          break;
-      }
-
-      const calculateDelta = (dimension1: number, dimension2: number) =>
-        (dimension1 / 2) * Math.sin(rotationOffset) + (dimension2 / 2) * (Math.cos(rotationOffset) - 1);
-
-      rotationTopOffset = calculateDelta(this.options.placement.width, this.options.placement.height);
-      rotationLeftOffset = calculateDelta(this.options.placement.height, this.options.placement.width);
-    }
-    console.log({ rotationTopOffset, rotationLeftOffset });
-
-    // const relativeTop =
-    //   elementContainer && parentContainer
-    //     ? Math.round(elementContainer.top - parentContainer.top - parentBorderWidth + rotationTopOffset) /
-    //       transformScale
-    //     : 0;
-    // const relativeBottom =
-    //   elementContainer && parentContainer
-    //     ? Math.round(parentContainer.bottom - parentBorderWidth - elementContainer.bottom + rotationTopOffset) /
-    //       transformScale
-    //     : 0;
-    // const relativeLeft =
-    //   elementContainer && parentContainer
-    //     ? Math.round(elementContainer.left - parentContainer.left - parentBorderWidth + rotationLeftOffset) /
-    //       transformScale
-    //     : 0;
-    // const relativeRight =
-    //   elementContainer && parentContainer
-    //     ? Math.round(parentContainer.right - parentBorderWidth - elementContainer.right + rotationLeftOffset) /
-    //       transformScale
-    //     : 0;
-
     const relativeTop = Math.round(elSize.top);
     const relativeBottom = Math.round(scene.height - elSize.top - elSize.height);
     const relativeLeft = Math.round(elSize.left);

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -136,6 +136,10 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
 
       if (targetedElement) {
         targetedElement.applyRotate(event);
+
+        if (scene.connections.connectionsNeedUpdate(targetedElement) && scene.moveableActionCallback) {
+          scene.moveableActionCallback(true);
+        }
       }
     })
     .on('rotateGroup', (e) => {

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -9,12 +9,12 @@ import { findElementByTarget } from 'app/features/canvas/runtime/sceneElementMan
 
 import { ConnectionState } from '../../types';
 import {
-  calcRotationXY,
   calculateAngle,
   // calculateCoordinates,
   calculateCoordinates2,
   getConnections,
   getElementTransformAndDimensions,
+  getNormalizedRotatedOffset,
   getParentBoundingClientRect,
   isConnectionSource,
   isConnectionTarget,
@@ -249,28 +249,18 @@ export class Connections {
     //
     if (!event.buttons) {
       if (this.connectionSource && this.connectionSource.div && this.connectionSource.div.parentElement) {
-        // Get source element transform and dimensions (including rotation)
-        const sourceRect = getElementTransformAndDimensions(this.connectionSource.div);
-
-        // Get parent rect for coordinate calculations
-        const parentRect = this.scene.viewerDiv?.getBoundingClientRect();
-
-        if (!parentRect) {
-          return;
-        }
-
-        const { x: sourceX, y: sourceY } = calcRotationXY(sourceRect, connectionLineX1, connectionLineY1);
+        const { x: sourceX, y: sourceY } = getNormalizedRotatedOffset(
+          this.connectionSource.div,
+          connectionLineX1,
+          connectionLineY1
+        );
 
         let targetX;
         let targetY;
         let targetName;
 
         if (this.connectionTarget && this.connectionTarget.div) {
-          // Get target element transform and dimensions (including rotation)
-          const targetRect = getElementTransformAndDimensions(this.connectionTarget.div);
-          const { x: targetXRaw, y: targetYRaw } = calcRotationXY(targetRect, x, y);
-          targetX = targetXRaw;
-          targetY = targetYRaw;
+          ({ x: targetX, y: targetY } = getNormalizedRotatedOffset(this.connectionTarget.div, x, y));
           targetName = this.connectionTarget.options.name;
         } else {
           // if there is no target (open connection)

--- a/public/app/plugins/panel/canvas/types.ts
+++ b/public/app/plugins/panel/canvas/types.ts
@@ -56,13 +56,3 @@ export enum StrokeDasharray {
   Dashed = '8 8',
   Dotted = '3',
 }
-
-export interface Rect {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-  x: number;
-  y: number;
-  rotation: number;
-}

--- a/public/app/plugins/panel/canvas/types.ts
+++ b/public/app/plugins/panel/canvas/types.ts
@@ -56,3 +56,13 @@ export enum StrokeDasharray {
   Dashed = '8 8',
   Dotted = '3',
 }
+
+export interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  rotation: number;
+}

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -255,17 +255,17 @@ export const getElementTransformAndDimensions = (element: Element) => {
 export const getNormalizedRotatedOffset = (div: HTMLDivElement, x: number, y: number) => {
   const { left, top, width, height, rotation } = getElementTransformAndDimensions(div);
   // Calculate center of source element
-  const centerY = top + height / 2;
   const centerX = left + width / 2;
+  const centerY = top + height / 2;
 
   // Calculate the offset from the center to the connection start point
   let dx = x - centerX;
   let dy = y - centerY;
 
   // Adjust for rotation
-  const rotationRad = (rotation || 0) * (Math.PI / 180);
-  const cos = Math.cos(-rotationRad);
-  const sin = Math.sin(-rotationRad);
+  const rad = rotation * (Math.PI / 180);
+  const cos = Math.cos(-rad);
+  const sin = Math.sin(-rad);
   // Rotate the delta by the negative of the element's rotation
   const rotatedDx = dx * cos - dy * sin;
   const rotatedDy = dx * sin + dy * cos;
@@ -287,10 +287,12 @@ export const getRotatedConnectionPoint = (div: HTMLDivElement, normalizedX: numb
   const offsetY = -(normalizedY * height) / 2;
 
   // Convert rotation to radians
-  const rad = (rotation * Math.PI) / 180;
+  const rad = rotation * (Math.PI / 180);
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
   // Apply rotation to offset
-  const rotatedOffsetX = offsetX * Math.cos(rad) - offsetY * Math.sin(rad);
-  const rotatedOffsetY = offsetX * Math.sin(rad) + offsetY * Math.cos(rad);
+  const rotatedOffsetX = offsetX * cos - offsetY * sin;
+  const rotatedOffsetY = offsetX * sin + offsetY * cos;
 
   const x = centerX + rotatedOffsetX;
   const y = centerY + rotatedOffsetY;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update improves the positioning of connection anchors in the Canvas panel. Previously, when elements were rotated, their connection anchors did not align correctly, leading to visual and functional inconsistencies. With this change, connection anchors now accurately follow the element’s rotation, ensuring correct placement and improved interaction.

This feature is part of the broader Canvas pan and zoom adjustments.

Before:
<img width="545" alt="Screenshot 2025-05-26 at 12 43 50" src="https://github.com/user-attachments/assets/09ade3a6-8390-452d-a9c4-db8268bc48cc" />

After:
<img width="520" alt="Screenshot 2025-05-26 at 12 44 57" src="https://github.com/user-attachments/assets/dc698c64-c164-4222-8428-3f6bc2c4ecad" />

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #105994 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
