### PR TITLE
SecretsManager: Conditionally lock DB before migrations using config setting

### DIFF
--- a/pkg/registry/apis/secret/contracts/migrator.go
+++ b/pkg/registry/apis/secret/contracts/migrator.go
@@ -1,6 +1,8 @@
 package contracts
 
+import "context"
+
 // SecretDBMigrator is an interface for running database migrations related to secrets management.
 type SecretDBMigrator interface {
-	RunMigrations() error
+	RunMigrations(ctx context.Context, lockDatabase bool) error
 }

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -69,7 +69,10 @@ func RegisterAPIService(
 		return nil, nil
 	}
 
-	if err := secretDBMigrator.RunMigrations(); err != nil {
+	// Some DBs that claim to be MySQL/Postgres-compatible might not support table locking.
+	lockDatabase := cfg.Raw.Section("database").Key("migration_locking").MustBool(true)
+
+	if err := secretDBMigrator.RunMigrations(context.Background(), lockDatabase); err != nil {
 		return nil, fmt.Errorf("running secret database migrations: %w", err)
 	}
 

--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -1,6 +1,7 @@
 package migrator
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -26,12 +27,12 @@ func NewWithEngine(db db.DB) contracts.SecretDBMigrator {
 	return &SecretDB{engine: db.GetEngine()}
 }
 
-func (db *SecretDB) RunMigrations() error {
+func (db *SecretDB) RunMigrations(ctx context.Context, lockDatabase bool) error {
 	mg := migrator.NewScopedMigrator(db.engine, nil, "secret")
 
 	db.AddMigration(mg)
 
-	return mg.Start(true, 0)
+	return mg.RunMigrations(ctx, lockDatabase, 0)
 }
 
 func (*SecretDB) AddMigration(mg *migrator.Migrator) {


### PR DESCRIPTION
Merging the code mostly as-is from the feature branch: `secret-service/feature-branch`.

Chery picked macabu's commit, this adds:
- conditionally lock DB before migrations using config setting

Part of: https://github.com/grafana/grafana-operator-experience-squad/issues/1335