### PR TITLE
fix: preinstall sync plugins have priority over preinstall_async plugin

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -145,13 +145,15 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 			delete(preinstallPluginsAsync, disabledPlugin)
 			delete(preinstallPluginsSync, disabledPlugin)
 		}
+		for _, plugin := range preinstallPluginsSync {
+			cfg.PreinstallPluginsSync = append(cfg.PreinstallPluginsSync, plugin)
+			// preinstallSync plugin has priority over preinstallAsync
+			delete(preinstallPluginsAsync, plugin.ID)
+		}
 		for _, plugin := range preinstallPluginsAsync {
 			cfg.PreinstallPluginsAsync = append(cfg.PreinstallPluginsAsync, plugin)
 		}
 
-		for _, plugin := range preinstallPluginsSync {
-			cfg.PreinstallPluginsSync = append(cfg.PreinstallPluginsSync, plugin)
-		}
 		installPluginsInAsync := pluginsSection.Key("preinstall_async").MustBool(true)
 		if !installPluginsInAsync {
 			for key, plugin := range preinstallPluginsAsync {

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -237,6 +237,13 @@ func Test_readPluginSettings(t *testing.T) {
 					return plugins
 				}(),
 			},
+			{
+				name:         "when same plugin is defined in preinstall and preinstall_sync, should be only in preinstallSync",
+				rawInput:     "plugin1",
+				rawInputSync: "plugin1",
+				expected:     defaultPreinstallPluginsList,
+				expectedSync: []InstallPlugin{{ID: "plugin1"}},
+			},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Installing plugin

**Why do we need this feature?**

When same plugin is defined in both `preinstall_async` and `preinstall_sync` it should be only installed through sync list.


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
