### PR TITLE
DashboardScenePage: Reset state manager to default when unmounting.

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
@@ -21,7 +21,11 @@ import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { setupLoadDashboardMockReject, setupLoadDashboardRuntimeErrorMock } from '../utils/test-utils';
 
 import { DashboardScenePage, Props } from './DashboardScenePage';
-import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
+import {
+  DashboardScenePageStateManager,
+  DashboardScenePageStateManagerV2,
+  getDashboardScenePageStateManager,
+} from './DashboardScenePageStateManager';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -80,7 +84,7 @@ function setup({ routeProps }: { routeProps?: Partial<GrafanaRouteComponentProps
     );
   };
 
-  return { rerender, context, props };
+  return { rerender, context, props, unmount: renderResult.unmount };
 }
 
 const simpleDashboard: Dashboard = {
@@ -389,6 +393,22 @@ describe('DashboardScenePage', () => {
 
       expect(await screen.findByTestId('dashboard-page-error')).toBeInTheDocument();
       expect(await screen.findByTestId('dashboard-page-error')).toHaveTextContent('Runtime error');
+    });
+  });
+
+  describe('UnifiedDashboardScenePageStateManager', () => {
+    it('should reset active manager when unmounting', async () => {
+      const manager = getDashboardScenePageStateManager();
+      const { unmount } = setup();
+      manager.setActiveManager('v2');
+
+      await waitForDashboardToRender();
+
+      expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManagerV2);
+
+      unmount();
+
+      expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManager);
     });
   });
 });

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
@@ -399,15 +399,11 @@ describe('DashboardScenePage', () => {
   describe('UnifiedDashboardScenePageStateManager', () => {
     it('should reset active manager when unmounting', async () => {
       const manager = getDashboardScenePageStateManager();
-      const { unmount } = setup();
       manager.setActiveManager('v2');
-
-      await waitForDashboardToRender();
+      const { unmount } = setup();
 
       expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManagerV2);
-
       unmount();
-
       expect(manager['activeManager']).toBeInstanceOf(DashboardScenePageStateManager);
     });
   });

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -50,6 +50,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     return () => {
       preserveDashboardSceneStateInLocalStorage(locationService.getSearch(), uid);
       stateManager.clearState();
+      stateManager.resetActiveManager();
     };
 
     // removing slug and path (which has slug in it) from dependencies to prevent unmount when data links reference

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -878,6 +878,9 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       this.activeManager = this.v2Manager;
     }
   }
+  public resetActiveManager() {
+    this.setActiveManager('v1');
+  }
 }
 
 const managers: {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/105655