### PR TITLE
Pagination: Add role="navigation" to improve a11y 

### DIFF
--- a/packages/grafana-ui/src/components/Pagination/Pagination.tsx
+++ b/packages/grafana-ui/src/components/Pagination/Pagination.tsx
@@ -102,7 +102,7 @@ export const Pagination = ({
   const nextPageLabel = t('grafana-ui.pagination.next-page', 'next page');
 
   return (
-    <div className={cx(styles.container, className)}>
+    <div className={cx(styles.container, className)} role="navigation">
       <ol>
         <li className={styles.item}>
           <Button


### PR DESCRIPTION
**What is this feature?**
Improve a11y by properly styling navigation landmarks with the appropriate role attribute.

Applying it to the `<div>` container (which wraps the `<ol>`) is semantically appropriate and passes accessibility best practices.

The `<ol>` is just a list of pagination items — not the region itself.


