### PR TITLE
Chore: Prepare for k8s v0.33.1 upgrade

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apiserver/pkg/util/openapi"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stracing "k8s.io/component-base/tracing"
-	utilversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-openapi/pkg/common"
 
@@ -231,23 +230,7 @@ func SetupConfig(
 	serverConfig.SkipOpenAPIInstallation = false
 	serverConfig.BuildHandlerChainFunc = buildHandlerChainFuncFromBuilders(builders)
 
-	v := utilversion.DefaultKubeEffectiveVersion()
-	patchver := 0 // required for semver
-
-	info := v.BinaryVersion().Info()
-	info.BuildDate = time.Unix(buildTimestamp, 0).UTC().Format(time.RFC3339)
-	info.GitVersion = fmt.Sprintf("%s.%s.%d+grafana-v%s", info.Major, info.Minor, patchver, buildVersion)
-	info.GitCommit = fmt.Sprintf("%s@%s", buildBranch, buildCommit)
-	info.GitTreeState = fmt.Sprintf("grafana v%s", buildVersion)
-
-	info2 := v.EmulationVersion().Info()
-	info2.BuildDate = info.BuildDate
-	info2.GitVersion = fmt.Sprintf("%s.%s.%d+grafana-v%s", info2.Major, info2.Minor, patchver, buildVersion)
-	info2.GitCommit = info.GitCommit
-	info2.GitTreeState = info.GitTreeState
-
-	serverConfig.EffectiveVersion = v
-
+	serverConfig.EffectiveVersion = getEffectiveVersion(buildTimestamp, buildVersion, buildCommit, buildBranch)
 	// set priority for aggregated discovery
 	for i, b := range builders {
 		gvs := GetGroupVersions(b)

--- a/pkg/services/apiserver/builder/version.go
+++ b/pkg/services/apiserver/builder/version.go
@@ -1,0 +1,90 @@
+package builder
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	utilcompatibility "k8s.io/apiserver/pkg/util/compatibility"
+	"k8s.io/component-base/compatibility"
+)
+
+// wrapper that will include grafana version in the /version response
+type grafanaVersion struct {
+	info *apimachineryversion.Info
+	wrap compatibility.EffectiveVersion
+}
+
+func getEffectiveVersion(
+	buildTimestamp int64,
+	buildVersion string,
+	buildCommit string,
+	buildBranch string,
+) compatibility.EffectiveVersion {
+	v := utilcompatibility.DefaultBuildEffectiveVersion()
+	patchver := 0 // required for semver
+
+	info := v.Info()
+	info.BuildDate = time.Unix(buildTimestamp, 0).UTC().Format(time.RFC3339)
+	info.GitVersion = fmt.Sprintf("%s.%s.%d+grafana-v%s", info.Major, info.Minor, patchver, buildVersion)
+	info.GitCommit = fmt.Sprintf("%s@%s", buildBranch, buildCommit)
+	info.GitTreeState = fmt.Sprintf("grafana v%s", buildVersion)
+
+	info2 := v.EmulationVersion().Info()
+	info2.BuildDate = info.BuildDate
+	info2.GitVersion = fmt.Sprintf("%s.%s.%d+grafana-v%s", info2.Major, info2.Minor, patchver, buildVersion)
+	info2.GitCommit = info.GitCommit
+	info2.GitTreeState = info.GitTreeState
+
+	return &grafanaVersion{
+		wrap: v,
+		info: info,
+	}
+}
+
+// Info implements compatibility.EffectiveVersion.
+// This returns the grafana info along with the standard k8s info
+func (g *grafanaVersion) Info() *apimachineryversion.Info {
+	return g.info // otherwise the info gets replaced :(
+}
+
+// AllowedEmulationVersionRange implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) AllowedEmulationVersionRange() string {
+	return g.wrap.AllowedEmulationVersionRange()
+}
+
+// AllowedMinCompatibilityVersionRange implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) AllowedMinCompatibilityVersionRange() string {
+	return g.wrap.AllowedMinCompatibilityVersionRange()
+}
+
+// BinaryVersion implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) BinaryVersion() *version.Version {
+	return g.wrap.BinaryVersion()
+}
+
+// EmulationVersion implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) EmulationVersion() *version.Version {
+	return g.wrap.EmulationVersion()
+}
+
+// EqualTo implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) EqualTo(other compatibility.EffectiveVersion) bool {
+	return g.wrap.EqualTo(other)
+}
+
+// MinCompatibilityVersion implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) MinCompatibilityVersion() *version.Version {
+	return g.wrap.MinCompatibilityVersion()
+}
+
+// String implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) String() string {
+	return g.wrap.String()
+}
+
+// Validate implements compatibility.EffectiveVersion.
+func (g *grafanaVersion) Validate() []error {
+	return g.wrap.Validate()
+}

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -133,7 +133,6 @@ func (c *K8sTestHelper) loadAPIGroups() {
 		rsp := DoRequest(c, RequestParams{
 			User: c.Org1.Viewer,
 			Path: "/apis",
-			// Accept: "application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json",
 		}, &metav1.APIGroupList{})
 
 		if rsp.Response.StatusCode == http.StatusOK {
@@ -707,7 +706,7 @@ func (c *K8sTestHelper) GetGroupVersionInfoJSON(group string) string {
 	disco := c.NewDiscoveryClient()
 	req := disco.RESTClient().Get().
 		Prefix("apis").
-		SetHeader("Accept", "application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json")
+		SetHeader("Accept", "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json")
 
 	result := req.Do(context.Background())
 	require.NoError(c.t, result.Error())
@@ -736,7 +735,7 @@ func (c *K8sTestHelper) GetGroupVersionInfoJSON(group string) string {
 		}
 	}
 
-	require.Fail(c.t, "could not find discovery info for: ", group)
+	require.Failf(c.t, "could not find discovery info for: %s", group)
 	return ""
 }
 


### PR DESCRIPTION
Extracted from https://github.com/grafana/grafana/pull/105307

This applies some of the version compatible code changes required in v33+