### PR TITLE
fix(unified-storage): use batching for index creation

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -25,6 +25,28 @@ import (
 
 const maxBatchSize = 1000
 
+// Pool for BulkIndexItem objects to reduce allocations during bulk indexing.
+// This significantly reduces GC pressure when indexing large datasets (e.g., 100k+ documents).
+var bulkIndexItemPool = &sync.Pool{
+	New: func() interface{} {
+		return &BulkIndexItem{}
+	},
+}
+
+// getBulkIndexItem retrieves a BulkIndexItem from the pool
+func getBulkIndexItem() *BulkIndexItem {
+	return bulkIndexItemPool.Get().(*BulkIndexItem)
+}
+
+// putBulkIndexItem returns a BulkIndexItem to the pool after resetting it
+func putBulkIndexItem(item *BulkIndexItem) {
+	// Reset the item before returning to pool
+	item.Action = 0
+	item.Key = nil
+	item.Doc = nil
+	bulkIndexItemPool.Put(item)
+}
+
 type NamespacedResource struct {
 	Namespace string
 	Group     string
@@ -561,8 +583,11 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 				},
 			},
 		}, func(iter ListIterator) error {
-			// Collect all documents in a single bulk request
-			items := make([]*BulkIndexItem, 0)
+			// Process documents in batches to avoid memory issues
+			// When dealing with large collections (e.g., 100k+ documents),
+			// loading all documents into memory at once can cause OOM errors
+			items := make([]*BulkIndexItem, 0, maxBatchSize)
+			totalIndexed := 0
 
 			for iter.Next() {
 				if err = iter.Error(); err != nil {
@@ -584,21 +609,57 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 					continue
 				}
 
+				// Get a pooled BulkIndexItem and populate it
+				item := getBulkIndexItem()
+				item.Action = ActionIndex
+				item.Doc = doc
+
 				// Add to bulk items
-				items = append(items, &BulkIndexItem{
-					Action: ActionIndex,
-					Doc:    doc,
-				})
+				items = append(items, item)
+
+				// When we reach the batch size, perform bulk index and reset the batch
+				if len(items) >= maxBatchSize {
+					if err = index.BulkIndex(&BulkIndexRequest{
+						Items: items,
+					}); err != nil {
+						// Return items to pool before returning error
+						for _, item := range items {
+							putBulkIndexItem(item)
+						}
+						return err
+					}
+					totalIndexed += len(items)
+
+					// Return all items to the pool
+					for _, item := range items {
+						putBulkIndexItem(item)
+					}
+
+					// Reset the slice for the next batch while preserving capacity
+					items = items[:0]
+				}
 			}
 
-			// Perform single bulk index operation
+			// Index any remaining items in the final batch
 			if len(items) > 0 {
 				if err = index.BulkIndex(&BulkIndexRequest{
 					Items: items,
 				}); err != nil {
+					// Return items to pool before returning error
+					for _, item := range items {
+						putBulkIndexItem(item)
+					}
 					return err
 				}
+				totalIndexed += len(items)
+
+				// Return all remaining items to the pool
+				for _, item := range items {
+					putBulkIndexItem(item)
+				}
 			}
+
+			logger.Debug("Finished indexing documents", "total_indexed", totalIndexed)
 			return iter.Error()
 		})
 		return rv, err

--- a/pkg/storage/unified/resource/search_queue.go
+++ b/pkg/storage/unified/resource/search_queue.go
@@ -109,8 +109,7 @@ func (b *indexQueueProcessor) process(batch []*WrittenEvent) {
 		}
 		resp = append(resp, result)
 
-		// Get a pooled BulkIndexItem
-		item := getBulkIndexItem()
+		item := &BulkIndexItem{}
 		if evt.Type == resourcepb.WatchEvent_DELETED {
 			item.Action = ActionDelete
 			item.Key = evt.Key
@@ -130,13 +129,6 @@ func (b *indexQueueProcessor) process(batch []*WrittenEvent) {
 	}
 
 	err := b.index.BulkIndex(req)
-
-	// Return all items to the pool after processing
-	// This ensures items are returned even if BulkIndex fails
-	for _, item := range req.Items {
-		putBulkIndexItem(item)
-	}
-
 	if err != nil {
 		for _, r := range resp {
 			r.Err = err


### PR DESCRIPTION
**Problem**: The previous index building mechanism involved eagerly loading the entire database response stream into an in-memory array. This approach led to significant memory spikes and OOM errors, particularly during application initialization.

**Solution**: Implemented an optimized index building process that leverages a pre-defined maximum batch size. The system now incrementally reads from the database response stream, populating an array until it reaches the specified batch capacity. Once the batch is full, its contents are written to the index in bulk, and the process continues by reading the next segment of the response stream. This iterative approach significantly reduces peak memory consumption and adheres to established batch size limits.

**Impact**: This enhancement drastically curtails memory footprint during index construction, effectively resolving the OOM errors observed on startup in development environments.


Before:
<img width="1082" alt="Screenshot 2025-05-26 at 23 38 01" src="https://github.com/user-attachments/assets/b5c16948-b40a-454e-8f80-589b8922f2e2" />

After:
<img width="1078" alt="Screenshot 2025-05-26 at 23 37 37" src="https://github.com/user-attachments/assets/0b54a2c1-dd48-43b7-83a0-2c87a32eb2dd" />

Both are the same systems with the exact same data.
