### PR TITLE
Zanzana: Fix reconciling role with empty UID

### DIFF
--- a/pkg/services/accesscontrol/dualwrite/collectors.go
+++ b/pkg/services/accesscontrol/dualwrite/collectors.go
@@ -154,8 +154,11 @@ func managedPermissionsCollector(store db.DB, kind string) legacyTupleCollector 
 				subject = zanzana.NewTupleEntry(zanzana.TypeUser, p.UserUID, "")
 			} else if len(p.TeamUID) > 0 {
 				subject = zanzana.NewTupleEntry(zanzana.TypeTeam, p.TeamUID, zanzana.RelationTeamMember)
-			} else {
+			} else if len(p.BasicRoleName) > 0 {
 				subject = zanzana.NewTupleEntry(zanzana.TypeRole, zanzana.TranslateBasicRole(p.BasicRoleName), zanzana.RelationAssignee)
+			} else {
+				reconcilerLogger.Debug("unrecognized permission", "permission", p)
+				continue
 			}
 
 			tuple, ok := zanzana.TranslateToResourceTuple(subject, p.Action, p.Kind, p.Identifier)

--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -21,6 +21,7 @@ import (
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/accesscontrol/migrator")
+var reconcilerLogger = log.New("zanzana.reconciler")
 
 // ZanzanaReconciler is a component to reconcile RBAC permissions to zanzana.
 // We should rewrite the migration after we have "migrated" all possible actions
@@ -40,7 +41,7 @@ type ZanzanaReconciler struct {
 func ProvideZanzanaReconciler(cfg *setting.Cfg, features featuremgmt.FeatureToggles, client zanzana.Client, store db.DB, lock *serverlock.ServerLockService, folderService folder.Service) *ZanzanaReconciler {
 	zanzanaReconciler := &ZanzanaReconciler{
 		cfg:      cfg,
-		log:      log.New("zanzana.reconciler"),
+		log:      reconcilerLogger,
 		features: features,
 		client:   client,
 		lock:     lock,


### PR DESCRIPTION
**What is this feature?**

Fix some reconciliation cases where role UID is empty.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/1448

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
