### PR TITLE
docs(alerting): OpsGenie instructions for other alertmanagers

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-opsgenie.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-opsgenie.md
@@ -41,10 +41,12 @@ To create your Opsgenie integration in Grafana Alerting, complete the following 
 1. Enter a contact point name.
 1. From the **Integration** list, select **Opsgenie**.
 1. In the **API key** field, paste in your API key.
-1. In the **Alert API URL**, enter `https://api.opsgenie.com/v2/alerts`.
+1. Configure the **Alert API URL**.
+   1. For Grafana Alertmanager, enter `https://api.opsgenie.com/v2/alerts`.
+   1. For other Alertmanagers, enter the host for sending Opsgenie API requests, depending on the hosted region. 
 1. Click **Test** to check that your integration works.
 
-   ** For Grafana Alertmanager only.**
+   **For Grafana Alertmanager only.**
 
    A test alert notification is sent to the Alerts page in Opsgenie.
 

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-opsgenie.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-opsgenie.md
@@ -43,7 +43,7 @@ To create your Opsgenie integration in Grafana Alerting, complete the following 
 1. In the **API key** field, paste in your API key.
 1. Configure the **Alert API URL**.
    1. For Grafana Alertmanager, enter `https://api.opsgenie.com/v2/alerts`.
-   1. For other Alertmanagers, enter the host for sending Opsgenie API requests, depending on the hosted region. 
+   1. For other Alertmanagers, enter the host for sending Opsgenie API requests, depending on the hosted region.
 1. Click **Test** to check that your integration works.
 
    **For Grafana Alertmanager only.**


### PR DESCRIPTION
This PR clarifies Grafana Alerting OpsGenie instructions.

> When using the grafana AM, one needs to use the /v2/alerts endpoint (procedure step 6), but when doing self-managed, one does not.
