### PR TITLE
Chore: Batch update changelog.md in main branch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,6 +22,10 @@ on:
         required: false
         default: false
         type: boolean
+      branch:
+        required: false
+        type: string
+        description: "Use specific branch for changelog"
 
   workflow_dispatch:
     inputs:
@@ -45,6 +49,10 @@ on:
         required: false
         default: false
         type: boolean
+      branch:
+        required: false
+        type: string
+        description: "Use specific branch for changelog"
 
 permissions: {}
 
@@ -98,6 +106,12 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
       - name: "Create branch"
+        if: ${{ inputs.branch != '' }}
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: git checkout -b $BRANCH
+      - name: "Create branch"
+        if: ${{ inputs.branch == '' }}
         run: git checkout -b "changelog/${RUN_ID}/${VERSION}"
       - name: "Generate changelog"
         id: changelog
@@ -145,13 +159,25 @@ jobs:
         if: inputs.dry_run != true
         run: git push
       - name: "Create changelog PR"
-        run: >
-          gh pr create \
-            --dry-run="${DRY_RUN}" \
-            --label "no-backport" \
-            --label "no-changelog" \
-            -B "${TARGET}" \
-            --title "Release: update changelog for ${VERSION}" \
-            --body "Changelog changes for release ${VERSION}"
+        run: |
+          if gh pr view &>/dev/null; then
+            echo "Changelog pr has already been created"
+          else
+            gh pr create \
+              --dry-run="${DRY_RUN}" \
+              --label "no-backport" \
+              --label "no-changelog" \
+              -B "${TARGET}" \
+              --title "Release: update changelog" \
+              --body "Changelog changes for release versions:"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Add release version to PR description"
+        if: inputs.dry_run != true
+        run: |
+          gh pr view --json body --jq .body > pr_body.md
+          echo " -  ${VERSION}" >> pr_body.md
+          gh pr edit --body-file pr_body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -112,10 +112,12 @@ jobs:
             exit 0
           fi
 
-          # Chekout the changelog branch if exists, otherwise create a new one
-          git show-ref --verify --quiet "refs/remotes/origin/$WORK_BRANCH" && \
-            git switch --track "origin/$WORK_BRANCH" || \
+          # Checkout the changelog branch if exists, otherwise create a new one
+          if git show-ref --verify --quiet "refs/remotes/origin/$WORK_BRANCH"; then
+            git switch --track "origin/$WORK_BRANCH"
+          else
             git switch -c "$WORK_BRANCH"
+          fi
         env:
           WORK_BRANCH: ${{ inputs.work_branch }}
       - name: "Generate changelog"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ on:
         required: false
         default: false
         type: boolean
-      branch:
+      work_branch:
         required: false
         type: string
         description: "Use specific branch for changelog"
@@ -49,7 +49,7 @@ on:
         required: false
         default: false
         type: boolean
-      branch:
+      work_branch:
         required: false
         type: string
         description: "Use specific branch for changelog"
@@ -107,17 +107,17 @@ jobs:
           git config --local --add --bool push.autoSetupRemote true
       - name: "Create branch"
         run: |
-          BRANCH=${{ inputs.branch }}
-
-          if [[ $BRANCH == '' ]]; then
+          if [[ "$WORK_BRANCH" == '' ]]; then
             git switch -c "changelog/${RUN_ID}/${VERSION}"
             exit 0
           fi
 
           # Chekout the changelog branch if exists, otherwise create a new one
-          git show-ref --verify --quiet "refs/remotes/origin/$BRANCH" && \
-            git switch --track "origin/$BRANCH" || \
-            git switch -c "$BRANCH"
+          git show-ref --verify --quiet "refs/remotes/origin/$WORK_BRANCH" && \
+            git switch --track "origin/$WORK_BRANCH" || \
+            git switch -c "$WORK_BRANCH"
+        env:
+          WORK_BRANCH: ${{ inputs.work_branch }}
       - name: "Generate changelog"
         id: changelog
         uses: ./.github/actions/changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -170,12 +170,13 @@ jobs:
           if gh pr view &>/dev/null; then
             echo "Changelog pr has already been created"
           else
+
             gh pr create \
               --dry-run="${DRY_RUN}" \
               --label "no-backport" \
               --label "no-changelog" \
               -B "${TARGET}" \
-              --title "Release: update changelog" \
+              --title "Release: update changelog for ${TARGET}" \
               --body "Changelog changes for release versions:"
           fi
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -106,13 +106,18 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
       - name: "Create branch"
-        if: ${{ inputs.branch != '' }}
-        env:
-          BRANCH: ${{ inputs.branch }}
-        run: git checkout -b $BRANCH
-      - name: "Create branch"
-        if: ${{ inputs.branch == '' }}
-        run: git checkout -b "changelog/${RUN_ID}/${VERSION}"
+        run: |
+          BRANCH=${{ inputs.branch }}
+
+          if [[ $BRANCH == '' ]]; then
+            git switch -c "changelog/${RUN_ID}/${VERSION}"
+            exit 0
+          fi
+
+          # Chekout the changelog branch if exists, otherwise create a new one
+          git show-ref --verify --quiet "refs/remotes/origin/$BRANCH" && \
+            git switch --track "origin/$BRANCH" || \
+            git switch -c "$BRANCH"
       - name: "Generate changelog"
         id: changelog
         uses: ./.github/actions/changelog

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -55,11 +55,12 @@ jobs:
           fi
 
           echo "Fetching workflow run creation date..."
-          created_at=$(gh run view "$GITHUB_RUN_ID" --json createdAt -q .createdAt)
+          created_at=$(gh run view "$GITHUB_RUN_ID" --repo "$GH_REPO" --json createdAt -q .createdAt)
           formatted_date=$(date -d "$created_at" +%Y-%m-%d)
           echo "release_date=$formatted_date" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           DATE: ${{ inputs.release_date }}
 
       - id: set_release_date

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,6 +43,10 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
+
+    concurrency:
+      group: grafana-release-pr-update-changelog-main
+      cancel-in-progress: false
     name: Create PR to main to update the changelog
     uses: ./.github/workflows/changelog.yml
     with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -32,29 +32,58 @@ on:
         required: false
         default: false
         type: boolean
+      release_date:
+        required: false
+        type: string
+        description: "Release date in format "YYYY-MM-DD"
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  capture-date:
+    runs-on: ubuntu-latest
+    outputs:
+      release_date: ${{ steps.set_release_date.outputs.release_date }}
+    steps:
+      - name: compute_release_date
+        run: |
+          if [[ $DATE != '' ]' then
+            echo "release_date=$DATE" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "Fetching workflow run creation date..."
+          created_at=$(gh run view "$GITHUB_RUN_ID" --json createdAt -q .createdAt)
+          formatted_date=$(date -d "$created_at" +%Y-%m-%d)
+          echo "release_date=$formatted_date" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE: ${{ inputs.release_date }}
+
+      - id: set_release_date
+        run: echo "release_date=$release_date" >> $GITHUB_OUTPUT
+
   push-changelog-to-main:
+    needs: capture-date
     permissions:
       contents: write
       id-token: write
       pull-requests: write
 
+    name: Create PR to main to update the changelog
+    uses: ./.github/workflows/changelog.yml
     concurrency:
       group: grafana-release-pr-update-changelog-main
       cancel-in-progress: false
-    name: Create PR to main to update the changelog
-    uses: ./.github/workflows/changelog.yml
     with:
       previous_version: ${{inputs.previous_version}}
       version: ${{ inputs.version }}
       latest: ${{ inputs.latest }}
       dry_run: ${{ inputs.dry_run }}
       target: main
+      work_branch: changelog/update-changelog-${{ needs.capture-date.outputs.release_date }}
 
   create-prs:
     permissions:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -50,21 +50,21 @@ jobs:
       - name: compute_release_date
         run: |
           if [ -n "$DATE" ]; then
-            echo "release_date=$DATE" >> $GITHUB_ENV
+            echo "release_date=$DATE" >> "$GITHUB_ENV"
             exit 0
           fi
 
           echo "Fetching workflow run creation date..."
           created_at=$(gh run view "$GITHUB_RUN_ID" --repo "$GH_REPO" --json createdAt -q .createdAt)
           formatted_date=$(date -d "$created_at" +%Y-%m-%d)
-          echo "release_date=$formatted_date" >> $GITHUB_ENV
+          echo "release_date=$formatted_date" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           DATE: ${{ inputs.release_date }}
 
       - id: set_release_date
-        run: echo "release_date=$release_date" >> $GITHUB_OUTPUT
+        run: echo "release_date=$release_date" >> "$GITHUB_OUTPUT"
 
   push-changelog-to-main:
     needs: capture-date

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,7 +35,7 @@ on:
       release_date:
         required: false
         type: string
-        description: "Release date in format "YYYY-MM-DD"
+        description: "Release date in format YYYY-MM-DD"
 
 permissions:
   contents: read
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: compute_release_date
         run: |
-          if [[ $DATE != '' ]' then
+          if [ -n "$DATE" ]; then
             echo "release_date=$DATE" >> $GITHUB_ENV
             exit 0
           fi


### PR DESCRIPTION
# Background
Changes intended to prevent conflicts from multiple Release PRs modifying CHANGELOG.md on the main branch by batching changelog updates.

This is achieved by sequencing Generate Changelog jobs and reusing the same working branch for jobs targeting `main`.


## Generate Release PR

### 1. Release Date not specified (2025-05-27)
https://github.com/grafana/grafana/actions/runs/15275440710/job/42960583968

### 2. Release Data specified (2025-01-01)
https://github.com/grafana/grafana/actions/runs/15275543054/job/42960915412

## Generate Changelog
### 1. Working branch not specified (changelog/15270800476/11.6.5)
#### Job Run 
https://github.com/grafana/grafana/actions/runs/15270800476/job/42946154942

#### PR: 
https://github.com/grafana/grafana/pull/106046


### 2. Working branch specified (grambbledook/test-sequential-cl)
#### First Job Run (v11.5.5)
https://github.com/grafana/grafana/actions/runs/15271027372/job/42946617515
#### Second Job Run (v11.6.5)
https://github.com/grafana/grafana/actions/runs/15270800476/job/42946154942

#### PR:
https://github.com/grafana/grafana/pull/106047