### PR TITLE
Update backport instructions in contributing docs

### DIFF
--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will be automatically creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
 
 #### Required labels
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -118,9 +118,9 @@ In case the pull request introduces a breaking change you should document this. 
 
 Backporting is the process of copying the pull request into the version branch of one or multiple previous releases.
 
-Backporting is a rare exception, should only be done for _critical bug fixes_, and involves the intervention of a Grafana Labs employee.
+Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If your pull request fixes a critical bug and needs to be backported, add it to the "Critical Bug Release" form so the team can approve the backport and know that a release needs to be made. Specify the correct `backport vx.x` labels for the releases to which the fix needs to be backported. Once approved, the backporting process continues.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will be automatically creataed.
 
 #### Required labels
 


### PR DESCRIPTION
This PR tweaks the backport instructions in the contributing docs to:

 - remove the reference of a 'Critical bug release' form, as this isn't a process we do anymore
 - add additional warning indicating that backporting is not preferred as they go through less manual testing

(@joshhunt is opening this PR from a fork with a member outside of the grafana org to test the backport process)