### PR TITLE
DashboardLayoutOrchestrator: Refine drag drop logic

### DIFF
--- a/e2e/dashboard-new-layouts/dashboards-move-panel.spec.ts
+++ b/e2e/dashboard-new-layouts/dashboards-move-panel.spec.ts
@@ -8,7 +8,6 @@ describe('Dashboard', () => {
   });
 
   it('can drag and drop panels', () => {
-    e2e.pages.Dashboards.visit();
     e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1` });
 
     e2e.flows.scenes.toggleEditMode();
@@ -30,5 +29,31 @@ describe('Dashboard', () => {
           .contains(/^Panel two$/)
           .should('be.higherThan', panel3);
       });
+  });
+
+  // Note, moving a panel from a nested row to a parent row currently just deletes the panel
+  // This test will need to be updated once the correct behavior is implemented.
+  it('can move panel from nested row to parent row', () => {
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1` });
+
+    e2e.flows.scenes.toggleEditMode();
+
+    e2e.flows.scenes.groupIntoRow();
+    e2e.flows.scenes.groupIntoRow();
+
+    cy.get('[data-testid="data-testid dashboard-row-title-New row"]')
+      .first()
+      .then((el) => {
+        const rect = el.offset();
+        e2e.components.Panels.Panel.headerContainer()
+          .contains(/^Panel one$/)
+          .trigger('pointerdown', { which: 1 })
+          .trigger('pointermove', { clientX: rect.left, clientY: rect.top })
+          .trigger('pointerup');
+      });
+
+    e2e.components.Panels.Panel.headerContainer()
+      .contains(/^Panel one$/)
+      .should('not.exist');
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -102,7 +102,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
 
   private _getDropTargetUnderMouse(evt: MouseEvent): DashboardDropTarget | null {
     const elementsUnderPoint = document.elementsFromPoint(evt.clientX, evt.clientY);
-    let cursorIsInSourceTarget = elementsUnderPoint.some(
+    const cursorIsInSourceTarget = elementsUnderPoint.some(
       (el) => el.getAttribute('data-dashboard-drop-target-key') === this._sourceDropTarget?.state.key
     );
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -101,13 +101,17 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
   }
 
   private _getDropTargetUnderMouse(evt: MouseEvent): DashboardDropTarget | null {
-    const key = document
-      .elementsFromPoint(evt.clientX, evt.clientY)
-      ?.find((element) => {
-        const key = element.getAttribute('data-dashboard-drop-target-key');
+    const elementsUnderPoint = document.elementsFromPoint(evt.clientX, evt.clientY);
+    let cursorIsInSourceTarget = elementsUnderPoint.some(
+      (el) => el.getAttribute('data-dashboard-drop-target-key') === this._sourceDropTarget?.state.key
+    );
 
-        return !!key && key !== this._sourceDropTarget?.state.key;
-      })
+    if (cursorIsInSourceTarget) {
+      return null;
+    }
+
+    const key = elementsUnderPoint
+      ?.find((element) => element.getAttribute('data-dashboard-drop-target-key'))
       ?.getAttribute('data-dashboard-drop-target-key');
 
     if (!key) {


### PR DESCRIPTION
Previously, if any non-source drop target was under the cursor when ending a drag/drop action, that drop target would be selected. However, in cases where drop targets are nested (as with rows, potentially), the top-level row would always be selected as the drop target, even though the cursor was still within the bounds of its more immediate parent, leading to some unintuitive behavior. This PR changes the behavior of `_getDropTargetUnderMouse` so if the source drop target is one of the elements currently under the cursor, we won't consider the drop target as having changed from the source.