### PR TITLE
Alerting: Fix $value type when single data source is queried

### DIFF
--- a/pkg/services/ngalert/state/template/template.go
+++ b/pkg/services/ngalert/state/template/template.go
@@ -77,18 +77,18 @@ type Data struct {
 	Values map[string]Value
 
 	// Value is the .Value and $value variables in templates.
-	// For single datasource queries, this will be the numeric value of the query.
-	// For multiple datasource queries, this will be the evaluation string.
-	Value string
+	// For single datasource queries, this will be the numeric value of the query (float64).
+	// For multiple datasource queries, this will be the evaluation string (string).
+	Value any
 }
 
 func NewData(labels map[string]string, res eval.Result) Data {
 	values := NewValues(res.Values)
 
 	// By default, use the evaluation string as the Value
-	valueStr := res.EvaluationString
+	var value any = res.EvaluationString
 
-	// If there's exactly one datasource node, use its value instead
+	// If there's exactly one datasource node, use its numeric value instead
 	// This makes the $value variable compatible with Prometheus templating
 	// where $value holds the numeric value of the alert query
 	datasourceNodeCount := 0
@@ -105,13 +105,13 @@ func NewData(labels map[string]string, res eval.Result) Data {
 	}
 
 	if datasourceNodeCount == 1 {
-		valueStr = datasourceNodeValue.String()
+		value = datasourceNodeValue.Value
 	}
 
 	return Data{
 		Labels: labels,
 		Values: values,
-		Value:  valueStr,
+		Value:  value,
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

This changes the type of the `$value` variable in alerting templates. When an alert rule queries a single datasource, it's now a `float64` instead of a `string`. This fixes numeric comparisons in templates like `{{ eq $value 1.0 }}` for single data source queries.

**Why do we need this feature?**

Starting from Grafana 12 `$value` contains the query result when the alert rule queries a single data source. But it was always a string, and while for functions like `humanize` etc. it's not a problem, they work with both strings and numbers, string `$value` caused template expressions like `{{ eq $value 1.0 }}` to fail.

**Who is this feature for?**

Users of Grafana Alerting.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
