### PR TITLE
SQL Expressions: Always convert on type first

### DIFF
--- a/pkg/expr/convert_to_full_long.go
+++ b/pkg/expr/convert_to_full_long.go
@@ -30,10 +30,6 @@ func ConvertToFullLong(frames data.Frames) (data.Frames, error) {
 		return nil, fmt.Errorf("input frame missing FrameMeta.Type")
 	}
 
-	if !supportedToLongConversion(inputType) {
-		return nil, fmt.Errorf("unsupported input dataframe type %s for full long conversion", inputType)
-	}
-
 	switch inputType {
 	case data.FrameTypeNumericMulti:
 		return convertNumericMultiToFullLong(frames)

--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -129,20 +129,18 @@ func (c *ResultConverter) Convert(ctx context.Context,
 // handleSqlInput normalizes input DataFrames into a single dataframe with no labels for use with SQL expressions.
 //
 // It handles three cases:
-//   1. If the input declares a supported time series or numeric kind in the wide or multi format (via FrameMeta.Type), it converts to a full-long formatted table using ConvertToFullLong.
-//   2. If the input is a single frame (no labels, no declared type), it passes through as-is.
-//   3. If the input has multiple frames or label metadata but lacks a supported type, it returns an error.
+//  1. If the input declares a supported time series or numeric kind in the wide or multi format (via FrameMeta.Type), it converts to a full-long formatted table using ConvertToFullLong.
+//  2. If the input is a single frame (no labels, no declared type), it passes through as-is.
+//  3. If the input has multiple frames or label metadata but lacks a supported type, it returns an error.
 func handleSqlInput(dataFrames data.Frames) mathexp.Results {
 	var result mathexp.Results
 
-	if len(dataFrames) == 0 {
-		result.Error = fmt.Errorf("no frames for SQL conversion")
-		return result
-	}
-
+	// dataframes len > 0 is checked in the caller -- Convert
 	first := dataFrames[0]
 
 	// Single Frame no data case
+	// Note: In the case of a support Frame Type, we may want to return the matching schema
+	// with no rows (e.g. include the `__value__` column). But not sure about this at this time.
 	if len(dataFrames) == 1 && len(first.Fields) == 0 {
 		result.Values = mathexp.Values{
 			mathexp.TableData{Frame: first},

--- a/pkg/expr/converter_test.go
+++ b/pkg/expr/converter_test.go
@@ -129,11 +129,6 @@ func TestHandleSqlInput(t *testing.T) {
 		expectFrame bool
 	}{
 		{
-			name:      "empty input returns error",
-			frames:    data.Frames{},
-			expectErr: "no frames for SQL conversion",
-		},
-		{
 			name:        "single frame with no fields and no type is passed through",
 			frames:      data.Frames{data.NewFrame("")},
 			expectFrame: true,

--- a/pkg/expr/converter_test.go
+++ b/pkg/expr/converter_test.go
@@ -134,9 +134,19 @@ func TestHandleSqlInput(t *testing.T) {
 			expectErr: "no frames for SQL conversion",
 		},
 		{
+			name:        "single frame with no fields and no type is passed through",
+			frames:      data.Frames{data.NewFrame("")},
+			expectFrame: true,
+		},
+		{
+			name:        "single frame with no fields but type timeseries-multi is passed through",
+			frames:      data.Frames{data.NewFrame("").SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti})},
+			expectFrame: true,
+		},
+		{
 			name: "single frame, no labels, no type → passes through",
 			frames: data.Frames{
-				data.NewFrame("test",
+				data.NewFrame("",
 					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
 					data.NewField("value", nil, []*float64{fp(2)}),
 				),
@@ -146,7 +156,7 @@ func TestHandleSqlInput(t *testing.T) {
 		{
 			name: "single frame with labels, but missing FrameMeta.Type → error",
 			frames: data.Frames{
-				data.NewFrame("test",
+				data.NewFrame("",
 					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
 					data.NewField("value", data.Labels{"foo": "bar"}, []*float64{fp(2)}),
 				),
@@ -156,11 +166,11 @@ func TestHandleSqlInput(t *testing.T) {
 		{
 			name: "multiple frames, no type → error",
 			frames: data.Frames{
-				data.NewFrame("frame1",
+				data.NewFrame("",
 					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
 					data.NewField("value", nil, []*float64{fp(2)}),
 				),
-				data.NewFrame("frame2",
+				data.NewFrame("",
 					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
 					data.NewField("value", nil, []*float64{fp(2)}),
 				),

--- a/pkg/expr/converter_test.go
+++ b/pkg/expr/converter_test.go
@@ -148,11 +148,7 @@ func TestHandleSqlInput(t *testing.T) {
 			frames: data.Frames{
 				data.NewFrame("test",
 					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
-					func() *data.Field {
-						f := data.NewField("value", nil, []*float64{fp(2)})
-						f.Labels = data.Labels{"foo": "bar"}
-						return f
-					}(),
+					data.NewField("value", data.Labels{"foo": "bar"}, []*float64{fp(2)}),
 				),
 			},
 			expectErr: "frame has labels but frame type is missing or unsupported",
@@ -174,18 +170,10 @@ func TestHandleSqlInput(t *testing.T) {
 		{
 			name: "supported type (timeseries-multi) triggers ConvertToFullLong",
 			frames: data.Frames{
-				func() *data.Frame {
-					f := data.NewFrame("tsm",
-						data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
-						func() *data.Field {
-							f := data.NewField("value", nil, []*float64{fp(2)})
-							f.Labels = data.Labels{"host": "a"}
-							return f
-						}(),
-					)
-					f.Meta = &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}
-					return f
-				}(),
+				data.NewFrame("",
+					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+					data.NewField("value", data.Labels{"host": "a"}, []*float64{fp(2)}),
+				).SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}),
 			},
 			expectFrame: true,
 		},
@@ -197,7 +185,7 @@ func TestHandleSqlInput(t *testing.T) {
 
 			if tc.expectErr != "" {
 				require.Error(t, res.Error)
-				assert.Contains(t, res.Error.Error(), tc.expectErr)
+				require.ErrorContains(t, res.Error, tc.expectErr)
 			} else {
 				require.NoError(t, res.Error)
 				if tc.expectFrame {


### PR DESCRIPTION
**What is this feature?**

For SQL expressions, we convert labeled metric data into tabular format based on type. Before this PR, we would not do the conversion if something fit into the type, but had no labels and only one frame. This changes behavior to trigger conversion in that case.

**Which issue(s) does this PR fix?**:

Fixes #103124

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
