### PR TITLE
fix: etcd watch semantic strict order not expected on sendInitialEvents false

### DIFF
--- a/pkg/apiserver/storage/testing/watcher_tests.go
+++ b/pkg/apiserver/storage/testing/watcher_tests.go
@@ -1468,9 +1468,11 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 			require.NoError(t, err, "failed to create watch: %v")
 			defer w.Stop()
 
-			// make sure we only get initial events
-			testCheckResultsInRandomOrder(t, w, scenario.expectedInitialEventsInRandomOrder(createdPods))
-			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEventsInStrictOrder(createdPods))
+			if scenario.sendInitialEvents == nil || (*scenario.sendInitialEvents && scenario.resourceVersion == "") {
+				testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEventsInStrictOrder(createdPods))
+			} else {
+				testCheckResultsInRandomOrder(t, w, scenario.expectedInitialEventsInRandomOrder(createdPods))
+			}
 			testCheckNoMoreResults(t, w)
 
 			createdPods = []*example.Pod{}


### PR DESCRIPTION
Fixes: https://drone.grafana.net/grafana/grafana/245827/1/8