### PR TITLE
Config: Change default value for server.enable_gzip to true

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -69,7 +69,7 @@ router_logging = false
 static_root_path = public
 
 # enable gzip
-enable_gzip = false
+enable_gzip = true
 
 # https certs & key file
 cert_file =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -68,7 +68,7 @@
 ;static_root_path = public
 
 # enable gzip
-;enable_gzip = false
+;enable_gzip = true
 
 # https certs & key file
 ;cert_file =

--- a/docs/sources/developer-resources/api-reference/http-api/admin.md
+++ b/docs/sources/developer-resources/api-reference/http-api/admin.md
@@ -161,7 +161,7 @@ Content-Type: application/json
     "cert_key":"",
     "certs_watch_interval": "0s",
     "domain":"mygraf.com",
-    "enable_gzip":"false",
+    "enable_gzip":"true",
     "enforce_domain":"false",
     "http_addr":"127.0.0.1",
     "http_port":"0000",

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -294,8 +294,7 @@ executed with working directory set to the installation path.
 
 Set this option to `true` to enable HTTP compression, this can improve
 transfer speed and bandwidth utilization. It is recommended that most
-users set it to `true`. By default it is set to `false` for compatibility
-reasons.
+users set it to `true`. Default is `true`.
 
 #### `cert_file`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -294,7 +294,7 @@ executed with working directory set to the installation path.
 
 Set this option to `true` to enable HTTP compression, this can improve
 transfer speed and bandwidth utilization. It is recommended that most
-users set it to `true`. Default is `true`.
+users leave it set at the default of `true`, however compression may increase CPU usage on constrained environments or cause issues with poorly-configured reverse proxies.
 
 #### `cert_file`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -294,7 +294,7 @@ executed with working directory set to the installation path.
 
 Set this option to `true` to enable HTTP compression, this can improve
 transfer speed and bandwidth utilization. It is recommended that most
-users leave it set at the default of `true`, however compression may increase CPU usage on constrained environments or cause issues with poorly-configured reverse proxies.
+users leave it set at the default of `true`, however compression might increase CPU usage on constrained environments or cause issues with poorly-configured reverse proxies.
 
 #### `cert_file`
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2165,7 +2165,7 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	cfg.HTTPPort = valueAsString(server, "http_port", "3000")
 	cfg.RouterLogging = server.Key("router_logging").MustBool(false)
 
-	cfg.EnableGzip = server.Key("enable_gzip").MustBool(false)
+	cfg.EnableGzip = server.Key("enable_gzip").MustBool(true)
 	cfg.EnforceDomain = server.Key("enforce_domain").MustBool(false)
 	staticRoot := valueAsString(server, "static_root_path", "")
 	cfg.StaticRootPath = makeAbsolute(staticRoot, cfg.HomePath)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Change the default value for gzip compression to true (enabled).

**Why do we need this feature?**

Reduces these thing by 2-4x:
- required Bandwith/traffic
- load time

**Who is this feature for?**

Everyone running grafana without a reverse proxy or behind a poorly configured one.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #86860

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

----

# Release notice breaking change

Previously, the `enable_gzip` configuration option in the `[server]` section of the Grafana configuration file, which enables HTTP compression, was disabled by default with the recommendation that most users manually enable it. Starting in Grafana v13.0, this setting is enabled by default.