### PR TITLE
TraceView: Fix infinite loop when calculating span ancestors

### DIFF
--- a/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.test.ts
+++ b/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.test.ts
@@ -54,15 +54,15 @@ describe('spanAncestorIdsSpy', () => {
     references: [
       {
         span: firstParentSpan,
-        referenceType: 'CHILD_OF',
+        refType: 'CHILD_OF',
       },
       {
         span: secondParentSpan,
-        referenceType: 'CHILD_OF'
+        refType: 'CHILD_OF'
       },
     ],
   };
-  
+
   const expectedAncestorIds = [firstParentSpan.spanID, firstParentSecondGrandparentSpan.spanID, rootSpan.spanID];
 
   it('returns an empty array if given falsy span', () => {
@@ -105,15 +105,17 @@ describe('spanAncestorIdsSpy', () => {
                 span: {
                   ...firstParentSecondGrandparentSpan,
                   references: [
-                    ...firstParentSecondGrandparentSpan.references[0],
-                    span: {
-                      ...rootSpan,
-                      references: [
-                        {
-                          span: span,
-                          refType: 'FOLLOWS_FROM',
-                        },
-                      ],
+                    {
+                      ...firstParentSecondGrandparentSpan.references[0],
+                      span: {
+                        ...rootSpan,
+                        references: [
+                          {
+                            span: span, // This isn't a true infinite loop, but it's good enough to validate the test
+                            refType: 'FOLLOWS_FROM',
+                          },
+                        ],
+                      },
                     },
                   ],
                 },

--- a/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
+++ b/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
@@ -34,7 +34,7 @@ export default function spanAncestorIds(span: TraceSpan | TNil): string[] {
   let ref = getFirstAncestor(span);
   while (ref) {
     // Avoid an infinite loop in cases where a span creates a link to its own ancestor
-    if (ancestorIDs.indexOf(ref.spanID) > -1) break;
+    if (ref.spanID == span.spanID) break;
     ancestorIDs.push(ref.spanID);
     ref = getFirstAncestor(ref);
   }

--- a/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
+++ b/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
@@ -34,7 +34,9 @@ export default function spanAncestorIds(span: TraceSpan | TNil): string[] {
   let ref = getFirstAncestor(span);
   while (ref) {
     // Avoid an infinite loop in cases where a span creates a link to its own ancestor
-    if (ref.spanID == span.spanID) break;
+    if (ref.spanID === span.spanID) {
+      break;
+    }
     ancestorIDs.push(ref.spanID);
     ref = getFirstAncestor(ref);
   }

--- a/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
+++ b/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
@@ -33,8 +33,8 @@ export default function spanAncestorIds(span: TraceSpan | TNil): string[] {
   }
   let ref = getFirstAncestor(span);
   while (ref) {
-    // Avoid an infinite loop in cases where a span creates a link to its own ancestor
-    if (ref.spanID === span.spanID) {
+    // Avoid an infinite loop in cases where a span creates a link to its own root ancestor
+    if (ref.spanID === span.spanID || ancestorIDs.indexOf(ref.spanID) > -1) {
       break;
     }
     ancestorIDs.push(ref.spanID);

--- a/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
+++ b/public/app/features/explore/TraceView/components/utils/span-ancestor-ids.tsx
@@ -33,6 +33,8 @@ export default function spanAncestorIds(span: TraceSpan | TNil): string[] {
   }
   let ref = getFirstAncestor(span);
   while (ref) {
+    // Avoid an infinite loop in cases where a span creates a link to its own ancestor
+    if (ancestorIDs.indexOf(ref.spanID) > -1) break;
     ancestorIDs.push(ref.spanID);
     ref = getFirstAncestor(ref);
   }


### PR DESCRIPTION
**What is this feature?**

When querying a Tempo datasource, OpenTelemetry SpanLinks are converted into References with refType FOLLOWS_FROM. However, in some workflows, a child span can potentially create a SpanLink to its own ancestor. This causes an infinite loop when calculating the span ancestor IDs, as the root span loops back to the child span.

**Special notes for your reviewer:**

I haven't been able to get a full dev environment set up to run an actual E2E test in the browser, but I was able to at least run the test I modified and confirm it passed.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
