### PR TITLE
Chore: Update apps codegen to v0.38.2

### DIFF
--- a/apps/alerting/notifications/Makefile
+++ b/apps/alerting/notifications/Makefile
@@ -1,4 +1,4 @@
-APP_SDK_VERSION := v0.35.1
+APP_SDK_VERSION := v0.38.2
 APP_SDK_DIR     := $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     := $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/constants.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/constants.go
@@ -3,16 +3,16 @@ package v0alpha1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "notifications.alerting.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v0alpha1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "notifications.alerting.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0alpha1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_metadata_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_metadata_gen.go
@@ -24,5 +24,8 @@ type ReceiverMetadata struct {
 
 // NewReceiverMetadata creates a new ReceiverMetadata object.
 func NewReceiverMetadata() *ReceiverMetadata {
-	return &ReceiverMetadata{}
+	return &ReceiverMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_spec_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_spec_gen.go
@@ -13,7 +13,9 @@ type ReceiverIntegration struct {
 
 // NewReceiverIntegration creates a new ReceiverIntegration object.
 func NewReceiverIntegration() *ReceiverIntegration {
-	return &ReceiverIntegration{}
+	return &ReceiverIntegration{
+		Settings: map[string]interface{}{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -24,5 +26,7 @@ type ReceiverSpec struct {
 
 // NewReceiverSpec creates a new ReceiverSpec object.
 func NewReceiverSpec() *ReceiverSpec {
-	return &ReceiverSpec{}
+	return &ReceiverSpec{
+		Integrations: []ReceiverIntegration{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/routingtree_metadata_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/routingtree_metadata_gen.go
@@ -24,5 +24,8 @@ type RoutingTreeMetadata struct {
 
 // NewRoutingTreeMetadata creates a new RoutingTreeMetadata object.
 func NewRoutingTreeMetadata() *RoutingTreeMetadata {
-	return &RoutingTreeMetadata{}
+	return &RoutingTreeMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/routingtree_spec_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/routingtree_spec_gen.go
@@ -57,6 +57,7 @@ type RoutingTreeSpec struct {
 func NewRoutingTreeSpec() *RoutingTreeSpec {
 	return &RoutingTreeSpec{
 		Defaults: *NewRoutingTreeRouteDefaults(),
+		Routes:   []RoutingTreeRoute{},
 	}
 }
 

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/templategroup_metadata_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/templategroup_metadata_gen.go
@@ -24,5 +24,8 @@ type TemplateGroupMetadata struct {
 
 // NewTemplateGroupMetadata creates a new TemplateGroupMetadata object.
 func NewTemplateGroupMetadata() *TemplateGroupMetadata {
-	return &TemplateGroupMetadata{}
+	return &TemplateGroupMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/timeinterval_metadata_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/timeinterval_metadata_gen.go
@@ -24,5 +24,8 @@ type TimeIntervalMetadata struct {
 
 // NewTimeIntervalMetadata creates a new TimeIntervalMetadata object.
 func NewTimeIntervalMetadata() *TimeIntervalMetadata {
-	return &TimeIntervalMetadata{}
+	return &TimeIntervalMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/timeinterval_spec_gen.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/timeinterval_spec_gen.go
@@ -36,5 +36,7 @@ type TimeIntervalSpec struct {
 
 // NewTimeIntervalSpec creates a new TimeIntervalSpec object.
 func NewTimeIntervalSpec() *TimeIntervalSpec {
-	return &TimeIntervalSpec{}
+	return &TimeIntervalSpec{
+		TimeIntervals: []TimeIntervalInterval{},
+	}
 }

--- a/apps/alerting/notifications/pkg/apis/alerting_manifest.go
+++ b/apps/alerting/notifications/pkg/apis/alerting_manifest.go
@@ -6,9 +6,12 @@
 package apis
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+
+	v0alpha1 "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alerting/v0alpha1"
 )
 
 var ()
@@ -72,16 +75,24 @@ var appManifestData = app.ManifestData{
 	},
 }
 
-func jsonToMap(j string) map[string]any {
-	m := make(map[string]any)
-	json.Unmarshal([]byte(j), &j)
-	return m
-}
-
 func LocalManifest() app.Manifest {
 	return app.NewEmbeddedManifest(appManifestData)
 }
 
 func RemoteManifest() app.Manifest {
 	return app.NewAPIServerManifest("alerting")
+}
+
+var kindVersionToGoType = map[string]resource.Kind{
+	"Receiver/v0alpha1":      v0alpha1.ReceiverKind(),
+	"RoutingTree/v0alpha1":   v0alpha1.RoutingTreeKind(),
+	"TemplateGroup/v0alpha1": v0alpha1.TemplateGroupKind(),
+	"TimeInterval/v0alpha1":  v0alpha1.TimeIntervalKind(),
+}
+
+// ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.
+// If there is no association for the provided Kind and Version, exists will return false.
+func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exists bool) {
+	goType, exists = kindVersionToGoType[fmt.Sprintf("%s/%s", kind, version)]
+	return goType, exists
 }

--- a/apps/dashboard/Makefile
+++ b/apps/dashboard/Makefile
@@ -1,4 +1,4 @@
-APP_SDK_VERSION := v0.35.1
+APP_SDK_VERSION := v0.38.2
 APP_SDK_DIR     := $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     := $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/constants.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/constants.go
@@ -3,16 +3,16 @@ package v0alpha1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "dashboard.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v0alpha1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "dashboard.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0alpha1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_metadata_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_metadata_gen.go
@@ -24,5 +24,8 @@ type DashboardMetadata struct {
 
 // NewDashboardMetadata creates a new DashboardMetadata object.
 func NewDashboardMetadata() *DashboardMetadata {
-	return &DashboardMetadata{}
+	return &DashboardMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/constants.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/constants.go
@@ -3,16 +3,16 @@ package v1beta1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "dashboard.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v1beta1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "dashboard.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v1beta1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_metadata_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_metadata_gen.go
@@ -24,5 +24,8 @@ type DashboardMetadata struct {
 
 // NewDashboardMetadata creates a new DashboardMetadata object.
 func NewDashboardMetadata() *DashboardMetadata {
-	return &DashboardMetadata{}
+	return &DashboardMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/constants.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/constants.go
@@ -3,16 +3,16 @@ package v2alpha1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "dashboard.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v2alpha1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "dashboard.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v2alpha1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_metadata_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_metadata_gen.go
@@ -24,5 +24,8 @@ type DashboardMetadata struct {
 
 // NewDashboardMetadata creates a new DashboardMetadata object.
 func NewDashboardMetadata() *DashboardMetadata {
-	return &DashboardMetadata{}
+	return &DashboardMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
@@ -5,7 +5,6 @@ package v2alpha1
 import (
 	json "encoding/json"
 	errors "errors"
-	fmt "fmt"
 )
 
 // +k8s:openapi-gen=true
@@ -65,7 +64,9 @@ type DashboardDataQueryKind struct {
 
 // NewDashboardDataQueryKind creates a new DashboardDataQueryKind object.
 func NewDashboardDataQueryKind() *DashboardDataQueryKind {
-	return &DashboardDataQueryKind{}
+	return &DashboardDataQueryKind{
+		Spec: map[string]interface{}{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -80,6 +81,7 @@ type DashboardAnnotationPanelFilter struct {
 func NewDashboardAnnotationPanelFilter() *DashboardAnnotationPanelFilter {
 	return &DashboardAnnotationPanelFilter{
 		Exclude: (func(input bool) *bool { return &input })(false),
+		Ids:     []uint32{},
 	}
 }
 
@@ -133,6 +135,7 @@ type DashboardPanelSpec struct {
 // NewDashboardPanelSpec creates a new DashboardPanelSpec object.
 func NewDashboardPanelSpec() *DashboardPanelSpec {
 	return &DashboardPanelSpec{
+		Links:     []DashboardDataLink{},
 		Data:      *NewDashboardQueryGroupKind(),
 		VizConfig: *NewDashboardVizConfigKind(),
 	}
@@ -174,7 +177,9 @@ type DashboardQueryGroupSpec struct {
 // NewDashboardQueryGroupSpec creates a new DashboardQueryGroupSpec object.
 func NewDashboardQueryGroupSpec() *DashboardQueryGroupSpec {
 	return &DashboardQueryGroupSpec{
-		QueryOptions: *NewDashboardQueryOptionsSpec(),
+		Queries:         []DashboardPanelQueryKind{},
+		Transformations: []DashboardTransformationKind{},
+		QueryOptions:    *NewDashboardQueryOptionsSpec(),
 	}
 }
 
@@ -313,6 +318,7 @@ type DashboardVizConfigSpec struct {
 // NewDashboardVizConfigSpec creates a new DashboardVizConfigSpec object.
 func NewDashboardVizConfigSpec() *DashboardVizConfigSpec {
 	return &DashboardVizConfigSpec{
+		Options:     map[string]interface{}{},
 		FieldConfig: *NewDashboardFieldConfigSource(),
 	}
 }
@@ -331,7 +337,8 @@ type DashboardFieldConfigSource struct {
 // NewDashboardFieldConfigSource creates a new DashboardFieldConfigSource object.
 func NewDashboardFieldConfigSource() *DashboardFieldConfigSource {
 	return &DashboardFieldConfigSource{
-		Defaults: *NewDashboardFieldConfig(),
+		Defaults:  *NewDashboardFieldConfig(),
+		Overrides: []DashboardV2alpha1FieldConfigSourceOverrides{},
 	}
 }
 
@@ -417,7 +424,8 @@ type DashboardValueMap struct {
 // NewDashboardValueMap creates a new DashboardValueMap object.
 func NewDashboardValueMap() *DashboardValueMap {
 	return &DashboardValueMap{
-		Type: DashboardMappingTypeValue,
+		Type:    DashboardMappingTypeValue,
+		Options: map[string]DashboardValueMappingResult{},
 	}
 }
 
@@ -526,7 +534,9 @@ type DashboardThresholdsConfig struct {
 
 // NewDashboardThresholdsConfig creates a new DashboardThresholdsConfig object.
 func NewDashboardThresholdsConfig() *DashboardThresholdsConfig {
-	return &DashboardThresholdsConfig{}
+	return &DashboardThresholdsConfig{
+		Steps: []DashboardThreshold{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -693,7 +703,9 @@ type DashboardGridLayoutSpec struct {
 
 // NewDashboardGridLayoutSpec creates a new DashboardGridLayoutSpec object.
 func NewDashboardGridLayoutSpec() *DashboardGridLayoutSpec {
-	return &DashboardGridLayoutSpec{}
+	return &DashboardGridLayoutSpec{
+		Items: []DashboardGridLayoutItemKind{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -779,7 +791,9 @@ type DashboardRowsLayoutSpec struct {
 
 // NewDashboardRowsLayoutSpec creates a new DashboardRowsLayoutSpec object.
 func NewDashboardRowsLayoutSpec() *DashboardRowsLayoutSpec {
-	return &DashboardRowsLayoutSpec{}
+	return &DashboardRowsLayoutSpec{
+		Rows: []DashboardRowsLayoutRowKind{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -837,7 +851,9 @@ type DashboardConditionalRenderingGroupSpec struct {
 
 // NewDashboardConditionalRenderingGroupSpec creates a new DashboardConditionalRenderingGroupSpec object.
 func NewDashboardConditionalRenderingGroupSpec() *DashboardConditionalRenderingGroupSpec {
-	return &DashboardConditionalRenderingGroupSpec{}
+	return &DashboardConditionalRenderingGroupSpec{
+		Items: []DashboardConditionalRenderingVariableKindOrConditionalRenderingDataKindOrConditionalRenderingTimeRangeSizeKind{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -955,6 +971,7 @@ func NewDashboardAutoGridLayoutSpec() *DashboardAutoGridLayoutSpec {
 	return &DashboardAutoGridLayoutSpec{
 		MaxColumnCount: (func(input float64) *float64 { return &input })(3),
 		FillScreen:     (func(input bool) *bool { return &input })(false),
+		Items:          []DashboardAutoGridLayoutItemKind{},
 	}
 }
 
@@ -1018,7 +1035,9 @@ type DashboardTabsLayoutSpec struct {
 
 // NewDashboardTabsLayoutSpec creates a new DashboardTabsLayoutSpec object.
 func NewDashboardTabsLayoutSpec() *DashboardTabsLayoutSpec {
-	return &DashboardTabsLayoutSpec{}
+	return &DashboardTabsLayoutSpec{
+		Tabs: []DashboardTabsLayoutTabKind{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -1090,6 +1109,7 @@ type DashboardDashboardLink struct {
 // NewDashboardDashboardLink creates a new DashboardDashboardLink object.
 func NewDashboardDashboardLink() *DashboardDashboardLink {
 	return &DashboardDashboardLink{
+		Tags:        []string{},
 		AsDropdown:  false,
 		TargetBlank: false,
 		IncludeVars: false,
@@ -1231,6 +1251,7 @@ func NewDashboardQueryVariableSpec() *DashboardQueryVariableSpec {
 		SkipUrlSync:      false,
 		Query:            *NewDashboardDataQueryKind(),
 		Regex:            "",
+		Options:          []DashboardVariableOption{},
 		Multi:            false,
 		IncludeAll:       false,
 		AllowCustomValue: true,
@@ -1446,6 +1467,7 @@ func NewDashboardDatasourceVariableSpec() *DashboardDatasourceVariableSpec {
 				String: (func(input string) *string { return &input })(""),
 			},
 		},
+		Options:          []DashboardVariableOption{},
 		Multi:            false,
 		IncludeAll:       false,
 		Hide:             DashboardVariableHideDontHide,
@@ -1499,6 +1521,7 @@ func NewDashboardIntervalVariableSpec() *DashboardIntervalVariableSpec {
 				String: (func(input string) *string { return &input })(""),
 			},
 		},
+		Options:     []DashboardVariableOption{},
 		Auto:        false,
 		AutoMin:     "",
 		AutoCount:   0,
@@ -1546,6 +1569,7 @@ func NewDashboardCustomVariableSpec() *DashboardCustomVariableSpec {
 		Name:             "",
 		Query:            "",
 		Current:          *NewDashboardVariableOption(),
+		Options:          []DashboardVariableOption{},
 		Multi:            false,
 		IncludeAll:       false,
 		Hide:             DashboardVariableHideDontHide,
@@ -1596,6 +1620,7 @@ func NewDashboardGroupByVariableSpec() *DashboardGroupByVariableSpec {
 				String: (func(input string) *string { return &input })(""),
 			},
 		},
+		Options:     []DashboardVariableOption{},
 		Multi:       false,
 		Hide:        DashboardVariableHideDontHide,
 		SkipUrlSync: false,
@@ -1636,6 +1661,9 @@ type DashboardAdhocVariableSpec struct {
 func NewDashboardAdhocVariableSpec() *DashboardAdhocVariableSpec {
 	return &DashboardAdhocVariableSpec{
 		Name:             "",
+		BaseFilters:      []DashboardAdHocFilterWithLabels{},
+		Filters:          []DashboardAdHocFilterWithLabels{},
+		DefaultKeys:      []DashboardMetricFindValue{},
 		Hide:             DashboardVariableHideDontHide,
 		SkipUrlSync:      false,
 		AllowCustomValue: true,
@@ -1723,11 +1751,16 @@ type DashboardSpec struct {
 // NewDashboardSpec creates a new DashboardSpec object.
 func NewDashboardSpec() *DashboardSpec {
 	return &DashboardSpec{
+		Annotations:  []DashboardAnnotationQueryKind{},
 		CursorSync:   DashboardDashboardCursorSyncOff,
 		Editable:     (func(input bool) *bool { return &input })(true),
+		Elements:     map[string]DashboardElement{},
 		Layout:       *NewDashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabsLayoutKind(),
+		Links:        []DashboardDashboardLink{},
 		Preload:      false,
+		Tags:         []string{},
 		TimeSettings: *NewDashboardTimeSettingsSpec(),
+		Variables:    []DashboardVariableKind{},
 	}
 }
 
@@ -1740,7 +1773,8 @@ type DashboardV2alpha1FieldConfigSourceOverrides struct {
 // NewDashboardV2alpha1FieldConfigSourceOverrides creates a new DashboardV2alpha1FieldConfigSourceOverrides object.
 func NewDashboardV2alpha1FieldConfigSourceOverrides() *DashboardV2alpha1FieldConfigSourceOverrides {
 	return &DashboardV2alpha1FieldConfigSourceOverrides{
-		Matcher: *NewDashboardMatcherConfig(),
+		Matcher:    *NewDashboardMatcherConfig(),
+		Properties: []DashboardDynamicConfigValue{},
 	}
 }
 
@@ -1871,6 +1905,7 @@ func (resource DashboardPanelKindOrLibraryPanelKind) MarshalJSON() ([]byte, erro
 	if resource.LibraryPanelKind != nil {
 		return json.Marshal(resource.LibraryPanelKind)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -1888,7 +1923,7 @@ func (resource *DashboardPanelKindOrLibraryPanelKind) UnmarshalJSON(raw []byte) 
 
 	discriminator, found := parsedAsMap["kind"]
 	if !found {
-		return errors.New("discriminator field 'kind' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -1910,7 +1945,7 @@ func (resource *DashboardPanelKindOrLibraryPanelKind) UnmarshalJSON(raw []byte) 
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true
@@ -1940,6 +1975,7 @@ func (resource DashboardValueMapOrRangeMapOrRegexMapOrSpecialValueMap) MarshalJS
 	if resource.SpecialValueMap != nil {
 		return json.Marshal(resource.SpecialValueMap)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -1957,7 +1993,7 @@ func (resource *DashboardValueMapOrRangeMapOrRegexMapOrSpecialValueMap) Unmarsha
 
 	discriminator, found := parsedAsMap["type"]
 	if !found {
-		return errors.New("discriminator field 'type' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -1995,7 +2031,7 @@ func (resource *DashboardValueMapOrRangeMapOrRegexMapOrSpecialValueMap) Unmarsha
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `type = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true
@@ -2025,6 +2061,7 @@ func (resource DashboardGridLayoutKindOrAutoGridLayoutKindOrTabsLayoutKindOrRows
 	if resource.RowsLayoutKind != nil {
 		return json.Marshal(resource.RowsLayoutKind)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -2042,7 +2079,7 @@ func (resource *DashboardGridLayoutKindOrAutoGridLayoutKindOrTabsLayoutKindOrRow
 
 	discriminator, found := parsedAsMap["kind"]
 	if !found {
-		return errors.New("discriminator field 'kind' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -2080,7 +2117,7 @@ func (resource *DashboardGridLayoutKindOrAutoGridLayoutKindOrTabsLayoutKindOrRow
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true
@@ -2106,6 +2143,7 @@ func (resource DashboardConditionalRenderingVariableKindOrConditionalRenderingDa
 	if resource.ConditionalRenderingTimeRangeSizeKind != nil {
 		return json.Marshal(resource.ConditionalRenderingTimeRangeSizeKind)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -2123,7 +2161,7 @@ func (resource *DashboardConditionalRenderingVariableKindOrConditionalRenderingD
 
 	discriminator, found := parsedAsMap["kind"]
 	if !found {
-		return errors.New("discriminator field 'kind' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -2153,7 +2191,7 @@ func (resource *DashboardConditionalRenderingVariableKindOrConditionalRenderingD
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true
@@ -2183,6 +2221,7 @@ func (resource DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabs
 	if resource.TabsLayoutKind != nil {
 		return json.Marshal(resource.TabsLayoutKind)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -2200,7 +2239,7 @@ func (resource *DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTab
 
 	discriminator, found := parsedAsMap["kind"]
 	if !found {
-		return errors.New("discriminator field 'kind' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -2238,7 +2277,7 @@ func (resource *DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTab
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true
@@ -2284,6 +2323,7 @@ func (resource DashboardQueryVariableKindOrTextVariableKindOrConstantVariableKin
 	if resource.AdhocVariableKind != nil {
 		return json.Marshal(resource.AdhocVariableKind)
 	}
+
 	return []byte("null"), nil
 }
 
@@ -2301,7 +2341,7 @@ func (resource *DashboardQueryVariableKindOrTextVariableKindOrConstantVariableKi
 
 	discriminator, found := parsedAsMap["kind"]
 	if !found {
-		return errors.New("discriminator field 'kind' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -2371,7 +2411,7 @@ func (resource *DashboardQueryVariableKindOrTextVariableKindOrConstantVariableKi
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+	return nil
 }
 
 // +k8s:openapi-gen=true

--- a/apps/dashboard/pkg/apis/dashboard_manifest.go
+++ b/apps/dashboard/pkg/apis/dashboard_manifest.go
@@ -6,9 +6,12 @@
 package apis
 
 import (
-	"encoding/json"
-
+	"fmt"
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+	v0alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	v1beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
+	v2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 )
 
 var ()
@@ -38,16 +41,23 @@ var appManifestData = app.ManifestData{
 	},
 }
 
-func jsonToMap(j string) map[string]any {
-	m := make(map[string]any)
-	json.Unmarshal([]byte(j), &j)
-	return m
-}
-
 func LocalManifest() app.Manifest {
 	return app.NewEmbeddedManifest(appManifestData)
 }
 
 func RemoteManifest() app.Manifest {
 	return app.NewAPIServerManifest("dashboard")
+}
+
+var kindVersionToGoType = map[string]resource.Kind{
+	"Dashboard/v0alpha1": v0alpha1.DashboardKind(),
+	"Dashboard/v1beta1":  v1beta1.DashboardKind(),
+	"Dashboard/v2alpha1": v2alpha1.DashboardKind(),
+}
+
+// ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.
+// If there is no association for the provided Kind and Version, exists will return false.
+func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exists bool) {
+	goType, exists = kindVersionToGoType[fmt.Sprintf("%s/%s", kind, version)]
+	return goType, exists
 }

--- a/apps/folder/Makefile
+++ b/apps/folder/Makefile
@@ -1,4 +1,4 @@
-APP_SDK_VERSION := v0.35.1
+APP_SDK_VERSION := v0.38.2
 APP_SDK_DIR     := $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     := $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/folder/pkg/apis/folder/v1beta1/constants.go
+++ b/apps/folder/pkg/apis/folder/v1beta1/constants.go
@@ -3,16 +3,16 @@ package v1beta1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "folder.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v1beta1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "folder.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v1beta1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/folder/pkg/apis/folder/v1beta1/folder_metadata_gen.go
+++ b/apps/folder/pkg/apis/folder/v1beta1/folder_metadata_gen.go
@@ -24,5 +24,8 @@ type FolderMetadata struct {
 
 // NewFolderMetadata creates a new FolderMetadata object.
 func NewFolderMetadata() *FolderMetadata {
-	return &FolderMetadata{}
+	return &FolderMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/folder/pkg/apis/folder/v1beta1/register.go
+++ b/apps/folder/pkg/apis/folder/v1beta1/register.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	GROUP         = Group
-	VERSION       = Version
+	GROUP         = APIGroup
+	VERSION       = APIVersion
 	RESOURCE      = "folders"
 	APIVERSION    = GROUP + "/" + VERSION
 	RESOURCEGROUP = RESOURCE + "." + GROUP

--- a/apps/folder/pkg/apis/folder_manifest.go
+++ b/apps/folder/pkg/apis/folder_manifest.go
@@ -6,9 +6,12 @@
 package apis
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+
+	v1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 )
 
 var ()
@@ -30,16 +33,21 @@ var appManifestData = app.ManifestData{
 	},
 }
 
-func jsonToMap(j string) map[string]any {
-	m := make(map[string]any)
-	json.Unmarshal([]byte(j), &j)
-	return m
-}
-
 func LocalManifest() app.Manifest {
 	return app.NewEmbeddedManifest(appManifestData)
 }
 
 func RemoteManifest() app.Manifest {
 	return app.NewAPIServerManifest("folder")
+}
+
+var kindVersionToGoType = map[string]resource.Kind{
+	"Folder/v1beta1": v1beta1.FolderKind(),
+}
+
+// ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.
+// If there is no association for the provided Kind and Version, exists will return false.
+func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exists bool) {
+	goType, exists = kindVersionToGoType[fmt.Sprintf("%s/%s", kind, version)]
+	return goType, exists
 }

--- a/apps/iam/Makefile
+++ b/apps/iam/Makefile
@@ -1,4 +1,4 @@
-APP_SDK_VERSION := v0.35.1
+APP_SDK_VERSION := v0.38.2
 APP_SDK_DIR     := $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     := $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/iam/pkg/apis/iam/v0alpha1/constants.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/constants.go
@@ -3,16 +3,16 @@ package v0alpha1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "iam.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v0alpha1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "iam.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0alpha1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/iam/pkg/apis/iam/v0alpha1/corerole_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/corerole_metadata_gen.go
@@ -24,5 +24,8 @@ type CoreRoleMetadata struct {
 
 // NewCoreRoleMetadata creates a new CoreRoleMetadata object.
 func NewCoreRoleMetadata() *CoreRoleMetadata {
-	return &CoreRoleMetadata{}
+	return &CoreRoleMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/corerole_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/corerole_spec_gen.go
@@ -30,5 +30,7 @@ type CoreRoleSpec struct {
 
 // NewCoreRoleSpec creates a new CoreRoleSpec object.
 func NewCoreRoleSpec() *CoreRoleSpec {
-	return &CoreRoleSpec{}
+	return &CoreRoleSpec{
+		Permissions: []CoreRolespecPermission{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrole_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrole_metadata_gen.go
@@ -24,5 +24,8 @@ type GlobalRoleMetadata struct {
 
 // NewGlobalRoleMetadata creates a new GlobalRoleMetadata object.
 func NewGlobalRoleMetadata() *GlobalRoleMetadata {
-	return &GlobalRoleMetadata{}
+	return &GlobalRoleMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrole_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrole_spec_gen.go
@@ -30,5 +30,7 @@ type GlobalRoleSpec struct {
 
 // NewGlobalRoleSpec creates a new GlobalRoleSpec object.
 func NewGlobalRoleSpec() *GlobalRoleSpec {
-	return &GlobalRoleSpec{}
+	return &GlobalRoleSpec{
+		Permissions: []GlobalRolespecPermission{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_metadata_gen.go
@@ -24,5 +24,8 @@ type GlobalRoleBindingMetadata struct {
 
 // NewGlobalRoleBindingMetadata creates a new GlobalRoleBindingMetadata object.
 func NewGlobalRoleBindingMetadata() *GlobalRoleBindingMetadata {
-	return &GlobalRoleBindingMetadata{}
+	return &GlobalRoleBindingMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/globalrolebinding_spec_gen.go
@@ -37,7 +37,8 @@ type GlobalRoleBindingSpec struct {
 // NewGlobalRoleBindingSpec creates a new GlobalRoleBindingSpec object.
 func NewGlobalRoleBindingSpec() *GlobalRoleBindingSpec {
 	return &GlobalRoleBindingSpec{
-		RoleRef: *NewGlobalRoleBindingspecRoleRef(),
+		Subjects: []GlobalRoleBindingspecSubject{},
+		RoleRef:  *NewGlobalRoleBindingspecRoleRef(),
 	}
 }
 

--- a/apps/iam/pkg/apis/iam/v0alpha1/resourcepermission_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/resourcepermission_metadata_gen.go
@@ -24,5 +24,8 @@ type ResourcePermissionMetadata struct {
 
 // NewResourcePermissionMetadata creates a new ResourcePermissionMetadata object.
 func NewResourcePermissionMetadata() *ResourcePermissionMetadata {
-	return &ResourcePermissionMetadata{}
+	return &ResourcePermissionMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/resourcepermission_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/resourcepermission_spec_gen.go
@@ -29,7 +29,9 @@ type ResourcePermissionspecPermission struct {
 
 // NewResourcePermissionspecPermission creates a new ResourcePermissionspecPermission object.
 func NewResourcePermissionspecPermission() *ResourcePermissionspecPermission {
-	return &ResourcePermissionspecPermission{}
+	return &ResourcePermissionspecPermission{
+		Verbs: []string{},
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -41,7 +43,8 @@ type ResourcePermissionSpec struct {
 // NewResourcePermissionSpec creates a new ResourcePermissionSpec object.
 func NewResourcePermissionSpec() *ResourcePermissionSpec {
 	return &ResourcePermissionSpec{
-		Resource: *NewResourcePermissionspecResource(),
+		Resource:    *NewResourcePermissionspecResource(),
+		Permissions: []ResourcePermissionspecPermission{},
 	}
 }
 

--- a/apps/iam/pkg/apis/iam/v0alpha1/role_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/role_metadata_gen.go
@@ -24,5 +24,8 @@ type RoleMetadata struct {
 
 // NewRoleMetadata creates a new RoleMetadata object.
 func NewRoleMetadata() *RoleMetadata {
-	return &RoleMetadata{}
+	return &RoleMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/role_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/role_spec_gen.go
@@ -30,5 +30,7 @@ type RoleSpec struct {
 
 // NewRoleSpec creates a new RoleSpec object.
 func NewRoleSpec() *RoleSpec {
-	return &RoleSpec{}
+	return &RoleSpec{
+		Permissions: []RolespecPermission{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_metadata_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_metadata_gen.go
@@ -24,5 +24,8 @@ type RoleBindingMetadata struct {
 
 // NewRoleBindingMetadata creates a new RoleBindingMetadata object.
 func NewRoleBindingMetadata() *RoleBindingMetadata {
-	return &RoleBindingMetadata{}
+	return &RoleBindingMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_spec_gen.go
+++ b/apps/iam/pkg/apis/iam/v0alpha1/rolebinding_spec_gen.go
@@ -37,7 +37,8 @@ type RoleBindingSpec struct {
 // NewRoleBindingSpec creates a new RoleBindingSpec object.
 func NewRoleBindingSpec() *RoleBindingSpec {
 	return &RoleBindingSpec{
-		RoleRef: *NewRoleBindingspecRoleRef(),
+		Subjects: []RoleBindingspecSubject{},
+		RoleRef:  *NewRoleBindingspecRoleRef(),
 	}
 }
 

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -6,9 +6,12 @@
 package apis
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+
+	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
 var ()
@@ -85,16 +88,26 @@ var appManifestData = app.ManifestData{
 	},
 }
 
-func jsonToMap(j string) map[string]any {
-	m := make(map[string]any)
-	json.Unmarshal([]byte(j), &j)
-	return m
-}
-
 func LocalManifest() app.Manifest {
 	return app.NewEmbeddedManifest(appManifestData)
 }
 
 func RemoteManifest() app.Manifest {
 	return app.NewAPIServerManifest("iam")
+}
+
+var kindVersionToGoType = map[string]resource.Kind{
+	"GlobalRole/v0alpha1":         v0alpha1.GlobalRoleKind(),
+	"GlobalRoleBinding/v0alpha1":  v0alpha1.GlobalRoleBindingKind(),
+	"CoreRole/v0alpha1":           v0alpha1.CoreRoleKind(),
+	"Role/v0alpha1":               v0alpha1.RoleKind(),
+	"RoleBinding/v0alpha1":        v0alpha1.RoleBindingKind(),
+	"ResourcePermission/v0alpha1": v0alpha1.ResourcePermissionKind(),
+}
+
+// ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.
+// If there is no association for the provided Kind and Version, exists will return false.
+func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exists bool) {
+	goType, exists = kindVersionToGoType[fmt.Sprintf("%s/%s", kind, version)]
+	return goType, exists
 }

--- a/apps/playlist/Makefile
+++ b/apps/playlist/Makefile
@@ -1,3 +1,29 @@
+APP_SDK_VERSION := v0.38.2
+APP_SDK_DIR     := $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
+APP_SDK_BIN     := $(APP_SDK_DIR)/grafana-app-sdk
+
+.PHONY: install-app-sdk
+install-app-sdk: $(APP_SDK_BIN) ## Install the Grafana App SDK
+
+$(APP_SDK_BIN):
+	@echo "Installing Grafana App SDK version $(APP_SDK_VERSION)"
+	@mkdir -p $(APP_SDK_DIR)
+	# The only way to install specific versions of binaries using `go install`
+	# is by setting GOBIN to the directory you want to install the binary to.
+	GOBIN=$(APP_SDK_DIR) go install github.com/grafana/grafana-app-sdk/cmd/grafana-app-sdk@$(APP_SDK_VERSION)
+	@touch $@
+
+.PHONY: update-app-sdk
+update-app-sdk: ## Update the Grafana App SDK dependency in go.mod
+	go get github.com/grafana/grafana-app-sdk@$(APP_SDK_VERSION)
+	go mod tidy
+
 .PHONY: generate
-generate:
-	@grafana-app-sdk generate -g ./pkg/apis --grouping=group --postprocess --defencoding=none
+generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
+	@$(APP_SDK_BIN) generate \
+		--source=./kinds/ \
+		--gogenpath=./pkg/apis \
+		--grouping=group \
+		--defencoding=none \
+		--noschemasinmanifest \
+		--postprocess

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/constants.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/constants.go
@@ -3,16 +3,16 @@ package v0alpha1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "playlist.grafana.app"
-	// Version is the API version used by all kinds in this package
-	Version = "v0alpha1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "playlist.grafana.app"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0alpha1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_metadata_gen.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_metadata_gen.go
@@ -24,5 +24,8 @@ type PlaylistMetadata struct {
 
 // NewPlaylistMetadata creates a new PlaylistMetadata object.
 func NewPlaylistMetadata() *PlaylistMetadata {
-	return &PlaylistMetadata{}
+	return &PlaylistMetadata{
+		Finalizers: []string{},
+		Labels:     map[string]string{},
+	}
 }

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_object_gen.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_object_gen.go
@@ -18,8 +18,11 @@ import (
 type Playlist struct {
 	metav1.TypeMeta   `json:",inline" yaml:",inline"`
 	metav1.ObjectMeta `json:"metadata" yaml:"metadata"`
-	Spec              PlaylistSpec   `json:"spec" yaml:"spec"`
-	PlaylistStatus    PlaylistStatus `json:"status" yaml:"status"`
+
+	// Spec is the spec of the Playlist
+	Spec PlaylistSpec `json:"spec" yaml:"spec"`
+
+	Status PlaylistStatus `json:"status" yaml:"status"`
 }
 
 func (o *Playlist) GetSpec() any {
@@ -37,14 +40,14 @@ func (o *Playlist) SetSpec(spec any) error {
 
 func (o *Playlist) GetSubresources() map[string]any {
 	return map[string]any{
-		"status": o.PlaylistStatus,
+		"status": o.Status,
 	}
 }
 
 func (o *Playlist) GetSubresource(name string) (any, bool) {
 	switch name {
 	case "status":
-		return o.PlaylistStatus, true
+		return o.Status, true
 	default:
 		return nil, false
 	}
@@ -57,7 +60,7 @@ func (o *Playlist) SetSubresource(name string, value any) error {
 		if !ok {
 			return fmt.Errorf("cannot set status type %#v, not of type PlaylistStatus", value)
 		}
-		o.PlaylistStatus = cast
+		o.Status = cast
 		return nil
 	default:
 		return fmt.Errorf("subresource '%s' does not exist", name)
@@ -219,6 +222,20 @@ func (o *Playlist) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *Playlist) DeepCopy() *Playlist {
+	cpy := &Playlist{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *Playlist) DeepCopyInto(dst *Playlist) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &Playlist{}
 
@@ -262,5 +279,41 @@ func (o *PlaylistList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *PlaylistList) DeepCopy() *PlaylistList {
+	cpy := &PlaylistList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *PlaylistList) DeepCopyInto(dst *PlaylistList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &PlaylistList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *PlaylistSpec) DeepCopy() *PlaylistSpec {
+	cpy := &PlaylistSpec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *PlaylistSpec) DeepCopyInto(dst *PlaylistSpec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of PlaylistStatus
+func (s *PlaylistStatus) DeepCopy() *PlaylistStatus {
+	cpy := &PlaylistStatus{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies PlaylistStatus into another PlaylistStatus object
+func (s *PlaylistStatus) DeepCopyInto(dst *PlaylistStatus) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_spec_gen.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_spec_gen.go
@@ -30,7 +30,9 @@ type PlaylistSpec struct {
 
 // NewPlaylistSpec creates a new PlaylistSpec object.
 func NewPlaylistSpec() *PlaylistSpec {
-	return &PlaylistSpec{}
+	return &PlaylistSpec{
+		Items: []PlaylistItem{},
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/zz_openapi_gen.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/zz_openapi_gen.go
@@ -49,8 +49,9 @@ func schema_pkg_apis_playlist_v0alpha1_Playlist(ref common.ReferenceCallback) co
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1.PlaylistSpec"),
+							Description: "Spec is the spec of the Playlist",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1.PlaylistSpec"),
 						},
 					},
 					"status": {

--- a/apps/playlist/pkg/apis/playlist_manifest.go
+++ b/apps/playlist/pkg/apis/playlist_manifest.go
@@ -6,16 +6,15 @@
 package apis
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+
+	v0alpha1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
 )
 
-var (
-	rawSchemaPlaylistv0alpha1     = []byte(`{"spec":{"properties":{"interval":{"type":"string"},"items":{"items":{"properties":{"type":{"description":"type of the item.","enum":["dashboard_by_tag","dashboard_by_uid","dashboard_by_id"],"type":"string"},"value":{"description":"Value depends on type and describes the playlist item.\n - dashboard_by_id: The value is an internal numerical identifier set by Grafana. This\n is not portable as the numerical identifier is non-deterministic between different instances.\n Will be replaced by dashboard_by_uid in the future. (deprecated)\n - dashboard_by_tag: The value is a tag which is set on any number of dashboards. All\n dashboards behind the tag will be added to the playlist.\n - dashboard_by_uid: The value is the dashboard UID","type":"string"}},"required":["type","value"],"type":"object"},"type":"array"},"title":{"type":"string"}},"required":["title","interval","items"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object","x-kubernetes-preserve-unknown-fields":true}}`)
-	versionSchemaPlaylistv0alpha1 app.VersionSchema
-	_                             = json.Unmarshal(rawSchemaPlaylistv0alpha1, &versionSchemaPlaylistv0alpha1)
-)
+var ()
 
 var appManifestData = app.ManifestData{
 	AppName: "playlist",
@@ -42,17 +41,10 @@ var appManifestData = app.ManifestData{
 							},
 						},
 					},
-					Schema: &versionSchemaPlaylistv0alpha1,
 				},
 			},
 		},
 	},
-}
-
-func jsonToMap(j string) map[string]any {
-	m := make(map[string]any)
-	json.Unmarshal([]byte(j), &j)
-	return m
 }
 
 func LocalManifest() app.Manifest {
@@ -61,4 +53,15 @@ func LocalManifest() app.Manifest {
 
 func RemoteManifest() app.Manifest {
 	return app.NewAPIServerManifest("playlist")
+}
+
+var kindVersionToGoType = map[string]resource.Kind{
+	"Playlist/v0alpha1": v0alpha1.PlaylistKind(),
+}
+
+// ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.
+// If there is no association for the provided Kind and Version, exists will return false.
+func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exists bool) {
+	goType, exists = kindVersionToGoType[fmt.Sprintf("%s/%s", kind, version)]
+	return goType, exists
 }

--- a/pkg/tests/apis/openapi_snapshots/playlist.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/playlist.grafana.app-v0alpha1.json
@@ -893,6 +893,7 @@
             ]
           },
           "spec": {
+            "description": "Spec is the spec of the Playlist",
             "default": {},
             "allOf": [
               {


### PR DESCRIPTION
**What is this feature?**

Now that we have the [latest SDK ](https://github.com/grafana/grafana/pull/105307) installed... we should use it :)

This updates the codegen based on what would be created today.

**Why do we need this feature?**

always moving forward
