### PR TITLE
Stats: Fix grafana_stat_totals_folder

### DIFF
--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -462,11 +462,12 @@ func addToStats(base stats.UserStats, role org.RoleType, count int64) stats.User
 
 func getStatsRequester(orgId int64) *identity.StaticRequester {
 	return &identity.StaticRequester{
-		Type:   claims.TypeServiceAccount,
-		UserID: 1,
-		OrgID:  orgId,
-		Name:   "stats-requester",
-		Login:  "stats-requester",
+		Type:           claims.TypeServiceAccount,
+		UserID:         1,
+		OrgID:          orgId,
+		Name:           "stats-requester",
+		Login:          "stats-requester",
+		IsGrafanaAdmin: true,
 		Permissions: map[int64]map[string][]string{
 			orgId: {
 				"*": {"*"},


### PR DESCRIPTION
## What is this feature?

This PR fixes the folder stats in 11.5.x. The background user needs to be an admin user in the [GetFoldersLegacy](https://github.com/grafana/grafana/blob/v11.5.x/pkg/services/folder/folderimpl/folder.go#L160) function.

## Which issue(s) does this PR fix?:

Fixes #https://github.com/grafana/support-escalations/issues/15860