### PR TITLE
Build: Use absolute paths when passed relatives

### DIFF
--- a/pkg/build/daggerbuild/arguments/grafana.go
+++ b/pkg/build/daggerbuild/arguments/grafana.go
@@ -3,7 +3,6 @@ package arguments
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"path"
 	"path/filepath"
@@ -95,16 +94,30 @@ func GrafanaDirectoryOptsFromFlags(c cliutil.CLIContext) *GrafanaDirectoryOpts {
 }
 
 func cloneOrMount(ctx context.Context, client *dagger.Client, localPath, repo, ref string, ght string) (*dagger.Directory, error) {
-	// If GrafanaDir was provided, then we can just use that one.
-	if path := localPath; path != "" {
-		slog.Info("Using local Grafana found", "path", path)
-		return daggerutil.HostDir(client, path)
+	if localPath != "" {
+		absolute, err := filepath.Abs(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("error getting absolute path for local dir: %w", err)
+		}
+		localPath = absolute
+		slog.Info("Using local directory for repository", "path", localPath, "repo", repo)
+		return daggerutil.HostDir(client, localPath)
+	}
+
+	ght, err := githubToken(ctx, ght)
+	if err != nil {
+		return nil, fmt.Errorf("error acquiring GitHub token: %w", err)
 	}
 
 	return git.CloneWithGitHubToken(client, ght, repo, ref)
 }
 
 func applyPatches(ctx context.Context, client *dagger.Client, src *dagger.Directory, repo, patchesPath, ref, ght string) (*dagger.Directory, error) {
+	ght, err := githubToken(ctx, ght)
+	if err != nil {
+		return nil, fmt.Errorf("error acquiring GitHub token: %w", err)
+	}
+
 	// Clone the patches repository on 'main'
 	dir, err := git.CloneWithGitHubToken(client, ght, repo, ref)
 	if err != nil {
@@ -144,12 +157,7 @@ func applyPatches(ctx context.Context, client *dagger.Client, src *dagger.Direct
 func grafanaDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, error) {
 	o := GrafanaDirectoryOptsFromFlags(opts.CLIContext)
 
-	ght, err := githubToken(ctx, o.GitHubToken)
-	if err != nil {
-		log.Println("No github token found:", err)
-	}
-
-	src, err := cloneOrMount(ctx, opts.Client, o.GrafanaDir, o.GrafanaRepo, o.GrafanaRef, ght)
+	src, err := cloneOrMount(ctx, opts.Client, o.GrafanaDir, o.GrafanaRepo, o.GrafanaRef, o.GitHubToken)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +180,7 @@ func grafanaDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any, er
 		WithFile(".buildinfo.branch", branchFile)
 
 	if o.PatchesRepo != "" {
-		withPatches, err := applyPatches(ctx, opts.Client, src, o.PatchesRepo, o.PatchesPath, o.PatchesRef, ght)
+		withPatches, err := applyPatches(ctx, opts.Client, src, o.PatchesRepo, o.PatchesPath, o.PatchesRef, o.GitHubToken)
 		if err != nil {
 			opts.Log.Debug("patch application skipped", "error", err)
 		} else {
@@ -209,12 +217,7 @@ func enterpriseDirectory(ctx context.Context, opts *pipeline.ArgumentOpts) (any,
 		return nil, fmt.Errorf("error initializing grafana directory: %w", err)
 	}
 
-	ght, err := githubToken(ctx, o.GitHubToken)
-	if err != nil {
-		return nil, nil
-	}
-
-	src, err := cloneOrMount(ctx, opts.Client, o.EnterpriseDir, o.EnterpriseRepo, o.EnterpriseRef, ght)
+	src, err := cloneOrMount(ctx, opts.Client, o.EnterpriseDir, o.EnterpriseRepo, o.EnterpriseRef, o.GitHubToken)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When calling the build packages with e.g. `--enterprise-dir=../`, we'll fail due to Dagger rejecting it as it escapes the workdir. Instead, we should just make them absolute.

At the same time, this fixes a bug where passing an enterprise dir without a github token fails the build.