### PR TITLE
Build: Download arm-linux-musleabihf-cross over https

### DIFF
--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -98,7 +98,7 @@ func GolangContainer(
 		WithExec([]string{"mv", "/zig", "/bin/zig"}).
 		// Install the toolchain specifically for armv7 until we figure out why it's crashing w/ zig container = container.
 		WithExec([]string{"mkdir", "/toolchain"}).
-		WithExec([]string{"wget", "http://musl.cc/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
+		WithExec([]string{"wget", "https://musl.cc/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
 		WithExec([]string{"tar", "-xvf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
 		WithExec([]string{"wget", "https://musl.cc/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
 		WithExec([]string{"tar", "-xvf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"})


### PR DESCRIPTION
Ephemeral Instance builds are failing https://github.com/grafana/grafana/actions/runs/15297433432/job/43029783211

```
179 : [12.5s] | Resolving musl.cc (musl.cc)... 216.82.192.11, 2602:fcdb:0:2::1:11
time=2025-05-28T10:19:23.691Z level=DEBUG msg="error exporting artifact" service=ArtifactStore artifact=deb:pro:linux/amd64/dynamic path=grafana-pro_12.1.0_12345_linux_amd64-dynamic.deb destination=dist checksum=false error="input: container.from.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withMountedCache.withEnvVariable.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withFile.withWorkdir.withFile.withEnvVariable.withMountedCache.withExec.withFile.withFile.withFile.withExec.withExec.withExec.withExec.directory process \"wget http://musl.cc/arm-linux-musleabihf-cross.tgz -P /toolchain\" did not complete successfully: exit code: 4\n"
error exporting artifact 'grafana-pro_12.1.0_12345_linux_amd64-dynamic.deb': input: container.from.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withExec.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withEnvVariable.withMountedCache.withEnvVariable.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withDirectory.withDirectory.withDirectory.withDirectory.withFile.withFile.withWorkdir.withFile.withEnvVariable.withMountedCache.withExec.withFile.withFile.withFile.withExec.withExec.withExec.withExec.directory process "wget http://musl.cc/arm-linux-musleabihf-cross.tgz -P /toolchain" did not complete successfully: exit code: 4
exit status 1
```

If the exit code `4` is from `wget`, it means: `4       Network failure`

Trying to download over HTTPS.