### PR TITLE
docs(alerting): document `Keep firing for` in Alert rule evaluation intro

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
@@ -34,10 +34,11 @@ refs:
 
 # Alert rule evaluation
 
-The criteria determining when an alert rule fires are based on two settings:
+The criteria determining when an alert rule fires are based on three settings:
 
 - [Evaluation group](#evaluation-group): how frequently the alert rule is evaluated.
 - [Pending period](#pending-period): how long the condition must be met to start firing.
+- [Keep firing for](#pending-period): how long the alert continues to fire after the condition is no longer met.
 
 {{< figure src="/media/docs/alerting/alert-rule-evaluation-2.png" max-width="750px" alt="Set the evaluation behavior of the alert rule in Grafana." caption="Set alert rule evaluation" >}}
 


### PR DESCRIPTION
This PR mentions  Keep firing for in the Alert rule evaluation intro.

⭐ [Preview](https://deploy-preview-grafana-106139-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/fundamentals/alert-rule-evaluation/)
