### PR TITLE
CI: mirror some CI dependencies

### DIFF
--- a/pkg/build/daggerbuild/backend/build.go
+++ b/pkg/build/daggerbuild/backend/build.go
@@ -33,7 +33,7 @@ func GoLDFlags(flags []LDFlag) string {
 
 // GoBuildCommand returns the arguments for go build to be used in 'WithExec'.
 func GoBuildCommand(output string, ldflags []LDFlag, tags []string, main string) []string {
-	args := []string{"go", "build", "-v", "-x",
+	args := []string{"go", "build",
 		fmt.Sprintf("-ldflags=\"%s\"", GoLDFlags(ldflags)),
 		fmt.Sprintf("-o=%s", output),
 		"-trimpath",

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -93,14 +93,14 @@ func GolangContainer(
 
 	container := golang.Container(d, platform, goVersion).
 		WithExec([]string{"apk", "add", "--update", "wget", "build-base", "alpine-sdk", "musl", "musl-dev", "xz"}).
-		WithExec([]string{"wget", "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz"}).
+		WithExec([]string{"wget", "https://dl.grafana.com/ci/zig-linux-x86_64-0.11.0.tar.xz"}).
 		WithExec([]string{"tar", "--strip-components=1", "-C", "/", "-xf", "zig-linux-x86_64-0.11.0.tar.xz"}).
 		WithExec([]string{"mv", "/zig", "/bin/zig"}).
 		// Install the toolchain specifically for armv7 until we figure out why it's crashing w/ zig container = container.
 		WithExec([]string{"mkdir", "/toolchain"}).
-		WithExec([]string{"wget", "http://musl.cc/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
+		WithExec([]string{"wget", "http://dl.grafana.com/ci/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
 		WithExec([]string{"tar", "-xvf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
-		WithExec([]string{"wget", "https://musl.cc/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
+		WithExec([]string{"wget", "https://dl.grafana.com/ci/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
 		WithExec([]string{"tar", "-xvf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"})
 
 	return WithGoEnv(log, container, distro, opts)

--- a/pkg/build/daggerbuild/msi/builder.go
+++ b/pkg/build/daggerbuild/msi/builder.go
@@ -7,7 +7,7 @@ import (
 
 func Builder(d *dagger.Client) (*dagger.Container, error) {
 	nssm := d.Container().From("busybox").
-		WithExec([]string{"wget", "https://nssm.cc/release/nssm-2.24.zip"}).
+		WithExec([]string{"wget", "https://dl.grafana.com/ci/nssm-2.24.zip"}).
 		WithExec([]string{"unzip", "nssm-2.24.zip"}).
 		Directory("nssm-2.24")
 


### PR DESCRIPTION
And also remove `-v` and `-x` from go build; they're incredibly verbose and are filling up the CI logs completely.