### PR TITLE
DS-querier: define func to fetch instance config settings

### DIFF
--- a/pkg/registry/apis/query/client.go
+++ b/pkg/registry/apis/query/client.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
@@ -11,6 +12,10 @@ type CommonDataSourceClientSupplier struct {
 	Client clientapi.QueryDataClient
 }
 
-func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string) (clientapi.QueryDataClient, error) {
+func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string, _ clientapi.InstanceConfigurationSettings) (clientapi.QueryDataClient, error) {
 	return s.Client, nil
+}
+
+func (s *CommonDataSourceClientSupplier) GetInstanceConfigurationSettings(_ context.Context) (clientapi.InstanceConfigurationSettings, error) {
+	return clientapi.InstanceConfigurationSettings{}, errors.New("get instance configuration settings is not implemented")
 }

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -5,14 +5,23 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 type QueryDataClient interface {
 	QueryData(ctx context.Context, req data.QueryDataRequest) (*backend.QueryDataResponse, error)
 }
 
-// The query runner interface
+type InstanceConfigurationSettings struct {
+	StackID        uint32
+	FeatureToggles featuremgmt.FeatureToggles
+	FullConfig     map[string]map[string]string // configuration file settings
+	Options        map[string]string            // additional settings related to an instance as set by grafana
+}
+
 type DataSourceClientSupplier interface {
 	// Get a client for a given datasource
-	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (QueryDataClient, error)
+	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string, instanceConfig InstanceConfigurationSettings) (QueryDataClient, error)
+	// fetch information on the grafana instance (e.g. feature toggles)
+	GetInstanceConfigurationSettings(ctx context.Context) (InstanceConfigurationSettings, error)
 }

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -152,7 +153,7 @@ type mockClient struct {
 	lastCalledWithHeaders *map[string]string
 }
 
-func (m mockClient) GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (clientapi.QueryDataClient, error) {
+func (m mockClient) GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string, instanceConfig clientapi.InstanceConfigurationSettings) (clientapi.QueryDataClient, error) {
 	*m.lastCalledWithHeaders = headers
 
 	return nil, fmt.Errorf("mock error")
@@ -168,4 +169,8 @@ func (m mockClient) CallResource(ctx context.Context, req *backend.CallResourceR
 
 func (m mockClient) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	return nil, nil
+}
+
+func (m mockClient) GetInstanceConfigurationSettings(_ context.Context) (clientapi.InstanceConfigurationSettings, error) {
+	return clientapi.InstanceConfigurationSettings{}, errors.New("get instance configuration settings is not implemented")
 }


### PR DESCRIPTION
**What is this feature?**

Before executing a query in the ds querier (formerly known as the query service) we will now fetch instance settings such as feature toggles. Previously we did this within the call to get a datasource client, but by doing so we were unable to use enabled feature toggles in query execution without making a secondary call to fetch instance settings. 

**Why do we need this feature?**

So that we can have access to things like feature toggles and other instance settings throughout the query execution process.

**Who is this feature for?**

grafana devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/8637

Relates to: https://github.com/grafana/grafana-enterprise/pull/8666

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
