### PR TITLE
docs: k8s backend contrib docs minor fixes

### DIFF
--- a/contribute/architecture/k8s-inspired-backend-arch.md
+++ b/contribute/architecture/k8s-inspired-backend-arch.md
@@ -85,7 +85,7 @@ The Apps Approach creates the same Resource API endpoints (`/apis/...`) as the R
 
 ### 2.3 Kubernetes API Compatibility
 
-Grafana's Resource APIs adopt many Kubernetes API conventions but is **not strictly conformant** to the official Kubernetes API specification. We diverge from the Kubernetes architecture and Kubernetes API specification when needed for Grafana's own unique requirements or to avoid operational complexity. Each architectural difference can surface as behavioral or wire-level incompatibility with the vanilla Kubernetes API.
+Grafana's Resource APIs adopts many Kubernetes API conventions but is **not strictly conformant** to the official Kubernetes API specification. We diverge from the Kubernetes architecture and Kubernetes API specification when needed for Grafana's own unique requirements or to avoid operational complexity. Each architectural difference can surface as behavioral or wire-level incompatibility with the vanilla Kubernetes API.
 
 In other words, even when the URLs / resources look Kubernetes-like, some API Server guarantees might not hold. We are adopting Kubernetes API patterns, general structure, and declarative style. A strict, byte-for-byte conformance to the API spec is currently not a goal.
 
@@ -237,13 +237,13 @@ graph TB
 
 Both API styles will coexist for a while. How they interact depends on the specific resource and the stage of migration. The migration generally follows these steps per resource type:
 
-1. **Define schema:** Define the resource using CUE (Apps Approach). Introduce an Alpha version (`v0alpha1`).
+1. **Define schema:** Define the resource using CUE (Apps Approach). Introduce an Alpha version (`v1alpha1`).
 2. **Implement handlers:** Create Resource API handlers (CRUD) interacting with legacy storage. The goal for the initial alpha version is to expose the current functionality of the legacy API through the new Resource API structure, using CUE for schema definition, rather than to undertake a full resource/data model redesign.
 3. **Add feature flag:** Create a flag (e.g., `kubernetesClient<Resource>`), initially off.
 4. **Implement routing/translation:** Modify Legacy API handlers to check the flag and delegate calls to the Resource API or storage layer when active.
-5. **Testing & promotion (Beta):** Enable the flag by default after testing. Promote API to Beta (`v0beta1`). Beta APIs aim for stability but may have breaking changes following a deprecation policy.
+5. **Testing & promotion (Beta):** Enable the flag by default after testing. Promote API to Beta (`v1beta1`). Beta APIs aim for stability but may have breaking changes following a deprecation policy.
 6. **Migrate data to Unified Storage:** Under another feature flag, gradually change the source of truth from legacy to unified storage.
-7. **Stabilization (GA):** Promote to GA (`v0`) when stable. GA APIs provide strong stability guarantees.
+7. **Stabilization (GA):** Promote to GA (`v1`) when stable. GA APIs provide strong stability guarantees.
 8. **Deprecate Legacy API:** Officially deprecate the corresponding Legacy API endpoint after the Resource API reaches GA. Communicate deprecation timelines (e.g., deprecated in X, removed in Y).
 9. **Remove Legacy API:** Remove the Legacy API endpoint after the deprecation period.
 

--- a/contribute/architecture/k8s-inspired-backend-arch.md
+++ b/contribute/architecture/k8s-inspired-backend-arch.md
@@ -43,9 +43,9 @@ The end goal is for the Resource APIs to become the only interface for managing 
 
 - **API implementation approaches:**
   - **Registry Approach (`pkg/registry/apis/...`):** Original method using Go code (`.../register.go` files). While newer resources are primarily defined using CUE in `apps/`, this path is still used for things such as legacy fallbacks for App-defined resources when data for that resource exists outside of unified storage.
-  - **Apps Approach (`apps/...`):** The newer, more modular implementation where APIs are defined using CUE in self-contained modules. Each app defines resources in `kinds/*.cue` files and resources are registered via the App SDK. This is the direction Grafana is moving toward for all resources.
+  - **Apps Approach (`apps/...`):** The newer, more modular implementation where APIs are defined using CUE in self-contained modules. Each app defines resources in `kinds/*.cue` files and resources are registered via the App SDK. This is the direction Grafana is moving towards for all resources.
 - **Unified Storage (`pkg/storage/unified/...`):** Internal abstraction handling resource persistence. It handles the conversion between the Resource API and the underlying storage backend.
-- **`K8sHandler` (`pkg/services/apiserver/client/client.go`):** Internal client facade used by Grafana services. Provides a Kubernetes-like client interface (`Get`, `Create`, etc.) for the Resource API. Acts as an adapter during migration, enabling legacy services to use the Resource API. Does not interact with external systems - it interact only with Grafana's own APIs.
+- **`K8sHandler` (`pkg/services/apiserver/client/client.go`):** Internal client facade used by Grafana services. Provides a Kubernetes-like client interface (`Get`, `Create`, etc.) for the Resource API. Acts as an adapter during migration, enabling legacy services to use the Resource API. Does not interact with external systems - it interacts only with Grafana's own APIs.
 - **Configured SQL database:** Grafana's primary persistence layer (PostgreSQL, MySQL, SQLite). The persistence target for actions initiated within Grafana's UI/Legacy API. It's the default backend for Unified Storage
 - **App SDK (`github.com/grafana/grafana-app-sdk`):** SDK for the Apps Approach. Provides tools for defining resources (CUE) and generating code.
 
@@ -75,21 +75,21 @@ The `apps` directory structure is Grafana's intended future for defining APIs an
 
 **Example: Playlist App (`apps/playlist/`)**
 
-- `kinds/playlist.cue`: CUE schema for the `Playlist` resource kind and its `spec`.
-- `kinds/manifest.cue`: App and resource kind metadata.
-- `pkg/apis/playlist/v0alpha1/`: Generated Go types from the CUE schema.
-- `pkg/app/reconciler_playlist.go`: Reconciler acting on `Playlist` resources.
-- `pkg/registry/apps/playlist/register.go`: Registers the `Playlist` kind and API endpoints using the App SDK.
+- `(plugin)/kinds/playlist.cue`: CUE schema for the `Playlist` resource kind and its `spec`.
+- `(plugin)/kinds/manifest.cue`: App and resource kind metadata.
+- `(plugin)/pkg/apis/playlist/v0alpha1/`: Generated Go types from the CUE schema.
+- `(plugin)/pkg/reconcilers/reconciler_playlist.go`: Reconciler acting on `Playlist` resources.
+- `(root)/pkg/registry/apps/playlist/register.go`: Registers the `Playlist` kind and API endpoints using the App SDK.
 
 The Apps Approach creates the same Resource API endpoints (`/apis/...`) as the Registry Approach, but with a cleaner implementation and improved developer experience. It's the standard pattern for all future Grafana resources.
 
 ### 2.3 Kubernetes API Compatibility
 
-Grafana's Resource APIs adopts many Kubernetes API conventions but is **not strictly conformant** to the official Kubernetes API specification. We diverge from the Kubernetes architecture and Kubernetes API specification when needed for Grafana's own unique requirements or to avoid operational complexity. Each architectural difference can surface as behavioral or wire-level incompatibility with the vanilla Kubernetes API.
+Grafana's Resource APIs adopt many Kubernetes API conventions but is **not strictly conformant** to the official Kubernetes API specification. We diverge from the Kubernetes architecture and Kubernetes API specification when needed for Grafana's own unique requirements or to avoid operational complexity. Each architectural difference can surface as behavioral or wire-level incompatibility with the vanilla Kubernetes API.
 
 In other words, even when the URLs / resources look Kubernetes-like, some API Server guarantees might not hold. We are adopting Kubernetes API patterns, general structure, and declarative style. A strict, byte-for-byte conformance to the API spec is currently not a goal.
 
-The list of major architectural changes include:
+The list of major architectural changes includes:
 
 - **Persistence:** Uses Grafana's configured SQL database (PostgreSQL, MySQL, SQLite) via Unified Storage, not `etcd`.
 - **Auth:** Uses Grafana's standard auth (API keys, sessions, RBAC/Permissions), not Kubernetes ServiceAccounts or RBAC.
@@ -237,13 +237,13 @@ graph TB
 
 Both API styles will coexist for a while. How they interact depends on the specific resource and the stage of migration. The migration generally follows these steps per resource type:
 
-1. **Define schema:** Define the resource using CUE (Apps Approach). Introduce an Alpha version (`v1alpha1`).
+1. **Define schema:** Define the resource using CUE (Apps Approach). Introduce an Alpha version (`v0alpha1`).
 2. **Implement handlers:** Create Resource API handlers (CRUD) interacting with legacy storage. The goal for the initial alpha version is to expose the current functionality of the legacy API through the new Resource API structure, using CUE for schema definition, rather than to undertake a full resource/data model redesign.
 3. **Add feature flag:** Create a flag (e.g., `kubernetesClient<Resource>`), initially off.
 4. **Implement routing/translation:** Modify Legacy API handlers to check the flag and delegate calls to the Resource API or storage layer when active.
-5. **Testing & promotion (Beta):** Enable the flag by default after testing. Promote API to Beta (`v1beta1`). Beta APIs aim for stability but may have breaking changes following a deprecation policy.
+5. **Testing & promotion (Beta):** Enable the flag by default after testing. Promote API to Beta (`v0beta1`). Beta APIs aim for stability but may have breaking changes following a deprecation policy.
 6. **Migrate data to Unified Storage:** Under another feature flag, gradually change the source of truth from legacy to unified storage.
-7. **Stabilization (GA):** Promote to GA (`v1`) when stable. GA APIs provide strong stability guarantees.
+7. **Stabilization (GA):** Promote to GA (`v0`) when stable. GA APIs provide strong stability guarantees.
 8. **Deprecate Legacy API:** Officially deprecate the corresponding Legacy API endpoint after the Resource API reaches GA. Communicate deprecation timelines (e.g., deprecated in X, removed in Y).
 9. **Remove Legacy API:** Remove the Legacy API endpoint after the deprecation period.
 


### PR DESCRIPTION
Minor touches to the K8s inspired document.

~~Also incorporated the [comment from Andres](https://github.com/grafana/grafana/pull/104385#discussion_r2079902019), that states that apps usually start from `v0alpha1`~~