### PR TITLE
TestData: Adds Frame Type to "Predictable" Scenarios to enable SQL expressions

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -974,6 +974,7 @@ func predictablePulse(query backend.DataQuery, model kinds.TestDataQuery) (*data
 	frame := newSeriesForQuery(query, model, 0)
 	frame.Fields = fields
 	frame.Fields[1].Labels = parseLabels(model, 0)
+	setFrameType(frame, data.FrameTypeTimeSeriesMulti, data.FrameTypeVersion{0, 0})
 
 	return frame, nil
 }

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -896,6 +896,7 @@ func predictableCSVWave(query backend.DataQuery, model kinds.TestDataQuery) ([]*
 		if subQ.Name != "" {
 			frame.Name = subQ.Name
 		}
+		setFrameType(frame, data.FrameTypeTimeSeriesMulti, data.FrameTypeVersion{0, 0})
 		frames = append(frames, frame)
 	}
 	return frames, nil

--- a/pkg/tsdb/grafana-testdata-datasource/utils.go
+++ b/pkg/tsdb/grafana-testdata-datasource/utils.go
@@ -46,3 +46,11 @@ func dropValues(frame *data.Frame, percent float64) (*data.Frame, error) {
 
 	return copy, err
 }
+
+func setFrameType(f *data.Frame, t data.FrameType, v data.FrameTypeVersion) {
+	if f.Meta == nil {
+		f.Meta = &data.FrameMeta{}
+	}
+	f.Meta.Type = t
+	f.Meta.TypeVersion = v
+}


### PR DESCRIPTION
**What is this feature?**

Enabled Predictable CSV wave and pulse to work with SQL expressions by adding the frame type. Before it would error as soon as you added multiple series or labels.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
