### PR TITLE
Chore: Fix lefthook not running

### DIFF
--- a/lefthook.rc
+++ b/lefthook.rc
@@ -2,5 +2,5 @@
 # the name `lefthook`, as expected by the lefthook pre-commit scripts
 
 lefthook () {
-  GOWORK=off go tool -n -modfile=.citools/src/lefthook/go.mod github.com/evilmartians/lefthook
+  GOWORK=off go tool -modfile=.citools/src/lefthook/go.mod github.com/evilmartians/lefthook "$@"
 }


### PR DESCRIPTION
Fixes the issue introduced in https://github.com/grafana/grafana/pull/104861 where lefthook wouldn't actually run on precommit - it just logged the path to the binary.