### PR TITLE
Geomap: Add HiDPI support to CARTO basemap (#81195)

### DIFF
--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -45,10 +45,11 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
       } else {
         style += '_nolabels';
       }
+      const scale = window.devicePixelRatio > 1 ? '@2x' : '';
       return new TileLayer({
         source: new XYZ({
           attributions: `<a href="https://carto.com/attribution/">©CARTO</a> <a href="https://www.openstreetmap.org/copyright">©OpenStreetMap</a> contributors`,
-          url: `https://{1-4}.basemaps.cartocdn.com/${style}/{z}/{x}/{y}.png`,
+          url: `https://{1-4}.basemaps.cartocdn.com/${style}/{z}/{x}/{y}${scale}.png`,
         }),
       });
     },

--- a/public/app/plugins/panel/geomap/utils/utils.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.ts
@@ -99,7 +99,7 @@ export const getNewOpenLayersMap = (panel: GeomapPanel, options: Options, div: H
   const view = panel.initMapView(options.view);
   return (panel.map = new OpenLayersMap({
     view: view,
-    pixelRatio: 1, // or zoom?
+    pixelRatio: window.devicePixelRatio, // or zoom?
     layers: [], // loaded explicitly below
     controls: [],
     target: div,


### PR DESCRIPTION
This is a cherry pick of a community contribution by @cledwynl: https://github.com/grafana/grafana/pull/99536

**What is this feature?**

This PR adds HiDPI support to Geomap and its CARTO basemap. Other basemaps, OSM and ArcGIS, since they does not serve retina map tiles, will stay blurry as before.

Before:

<img width="722" alt="image" src="https://github.com/user-attachments/assets/39b0896b-d1f5-4438-a71f-2bf2ca6eaa73" />

After:

<img width="721" alt="image" src="https://github.com/user-attachments/assets/70b9c20c-3933-4592-980b-e5acecf151dd" />

Fixes https://github.com/grafana/grafana/issues/81195