### PR TITLE
Alerting docs: document Prometheus YAML import tool update

### DIFF
--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -66,8 +66,6 @@ To convert data source-managed alert rules to Grafana managed alerts:
 
 1. Navigate to the Data source-managed alert rules section and click **Import to Grafana-managed rules**.
 
-   Alternately, you can click **More > Import alert rules** to open the import rules page.
-
 1. Select from the input source whether you want to import rules from and existing Loki or Mimir data source or from a Prometheus YAML file.
 
    If you choose to import a Prometheus data source rule from a YAML file, an, **Upload file** button appears. Click this to upload your YAML file.

--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -23,7 +23,7 @@ refs:
 
 # Import data source-managed alert rules
 
-Grafana provides an internal tool in Alerting which allows you to import Mimir and Loki alert rules as Grafana-managed alert rules. To import Prometheus rules, use the [API](ref:import-ds-rules-api).
+Grafana provides an internal tool in Alerting which allows you to import Mimir, Loki, and Prometheus alert rules as Grafana-managed alert rules. 
 
 ## Before you begin
 
@@ -66,9 +66,13 @@ To convert data source-managed alert rules to Grafana managed alerts:
 
 1. Navigate to the Data source-managed alert rules section and click **Import to Grafana-managed rules**.
 
-   The import alert rules page opens.
+   Alternately, you can click **More > Import alert rules** to open the import rules page. 
 
-1. In the Data source dropdown, select the Loki or Mimir data source of the alert rules.
+1. Select from the input source whether you want to import rules from and existing Loki or Mimir data source or from a Prometheus YAML file. 
+
+   If you choose to import a Prometheus data source rule from a YAML file, an, **Upload file** button appears. Click this to upload your YAML file. 
+
+1. In the Data source dropdown, select the data source of the alert rules.
 
 1. In Additional settings, select a target folder or designate a new folder to import the rules into.
 

--- a/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
+++ b/docs/sources/alerting/alerting-rules/alerting-migration/_index.md
@@ -23,7 +23,7 @@ refs:
 
 # Import data source-managed alert rules
 
-Grafana provides an internal tool in Alerting which allows you to import Mimir, Loki, and Prometheus alert rules as Grafana-managed alert rules. 
+Grafana provides an internal tool in Alerting which allows you to import Mimir, Loki, and Prometheus alert rules as Grafana-managed alert rules.
 
 ## Before you begin
 
@@ -66,11 +66,11 @@ To convert data source-managed alert rules to Grafana managed alerts:
 
 1. Navigate to the Data source-managed alert rules section and click **Import to Grafana-managed rules**.
 
-   Alternately, you can click **More > Import alert rules** to open the import rules page. 
+   Alternately, you can click **More > Import alert rules** to open the import rules page.
 
-1. Select from the input source whether you want to import rules from and existing Loki or Mimir data source or from a Prometheus YAML file. 
+1. Select from the input source whether you want to import rules from and existing Loki or Mimir data source or from a Prometheus YAML file.
 
-   If you choose to import a Prometheus data source rule from a YAML file, an, **Upload file** button appears. Click this to upload your YAML file. 
+   If you choose to import a Prometheus data source rule from a YAML file, an, **Upload file** button appears. Click this to upload your YAML file.
 
 1. In the Data source dropdown, select the data source of the alert rules.
 


### PR DESCRIPTION
documentation for prom YAML import feature.
- took out reference that said users can't import prometheus rules in the tool.
- added the More > Import alert rules UI path to the tool
- added a step for the YAML file upload button.

is related to: https://github.com/grafana/grafana/pull/105807