### PR TITLE
Canvas: Disable pan when pan+zoom toggle is false

### DIFF
--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -459,6 +459,18 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
     }
   });
 
+  // Prevent wheel scrolling when pan/zoom is disabled
+  scene.viewportDiv!.addEventListener(
+    'wheel',
+    (e) => {
+      if (!scene.shouldPanZoom) {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+      }
+    },
+    { passive: false }
+  );
+
   // Mouse scroll click
   // Only allow panning with middle mouse button (button 1)
   // Left click is reserved for selection/manipulation, right click for context menu


### PR DESCRIPTION
### What does this PR do? 📓 

Handles disabling canvas pan behavior when the pan+zoom is toggled `false`. 

Fixes #106031 