### PR TITLE
DS-querier: get config settings about sql expressions and use in ds-querier

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -141,10 +141,15 @@ func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles, cfg *setting.
 		if err != nil {
 			return nil, err
 		}
-		q, err := reader.ReadQuery(data.NewDataQuery(map[string]any{
-			"refId": rn.RefID,
-			"type":  rn.QueryType,
-		}), iter)
+		q, err := reader.ReadQuery(
+			data.NewDataQuery(map[string]any{
+				"refId": rn.RefID,
+				"type":  rn.QueryType,
+			}),
+			iter,
+			toggles.IsEnabledGlobally(featuremgmt.FlagSqlExpressions),
+			cfg.SQLExpressionCellLimit,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -135,7 +135,11 @@ func (h *ExpressionQueryReader) ReadQuery(
 		err = iter.ReadVal(q)
 		if err == nil {
 			eq.Properties = q
-			eq.Command, err = NewSQLCommand(common.RefID, q.Format, q.Expression, sqlExpressionCellLimit, 0, 0)
+			// TODO: Cascade limit from Grafana config in this (new Expression Parser) branch of the code
+			cellLimit := 0 // zero means no limit
+			eq.Command, err = NewSQLCommand(common.RefID, q.Format, q.Expression, int64(cellLimit), 0, 0)
+			// should we do this? I'm unclear because I'm trying to match what happens in st and it seems to fire here
+			// eq.Command, err = NewSQLCommand(common.RefID, q.Format, q.Expression, sqlExpressionCellLimit, 0, 0)
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/reader_test.go
+++ b/pkg/expr/reader_test.go
@@ -141,7 +141,7 @@ func TestReaderReduceMode(t *testing.T) {
 
 			reader := NewExpressionQueryReader(featuremgmt.WithFeatures())
 
-			eq, err := reader.ReadQuery(q, iter)
+			eq, err := reader.ReadQuery(q, iter, true, 0)
 
 			if test.expectError {
 				require.Error(t, err)

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -13,10 +13,11 @@ type QueryDataClient interface {
 }
 
 type InstanceConfigurationSettings struct {
-	StackID        uint32
-	FeatureToggles featuremgmt.FeatureToggles
-	FullConfig     map[string]map[string]string // configuration file settings
-	Options        map[string]string            // additional settings related to an instance as set by grafana
+	StackID                uint32
+	SQLExpressionCellLimit int64
+	FeatureToggles         featuremgmt.FeatureToggles
+	FullConfig             map[string]map[string]string // configuration file settings
+	Options                map[string]string            // additional settings related to an instance as set by grafana
 }
 
 type DataSourceClientSupplier interface {

--- a/pkg/registry/apis/query/parser.go
+++ b/pkg/registry/apis/query/parser.go
@@ -65,7 +65,7 @@ func newQueryParser(reader *expr.ExpressionQueryReader, legacy service.LegacyDat
 }
 
 // Split the main query into multiple
-func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRequest) (parsedRequestInfo, error) {
+func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRequest, sqlExpressions bool, sqlExpressionCellLimit int64) (parsedRequestInfo, error) {
 	ctx, span := p.tracer.Start(ctx, "QueryService.parseRequest")
 	defer span.End()
 
@@ -110,7 +110,7 @@ func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRe
 				p.logger.Error("Failed to parse bytes for expression", "error", err)
 				return rsp, err
 			}
-			exp, err := p.reader.ReadQuery(q, iter)
+			exp, err := p.reader.ReadQuery(q, iter, sqlExpressions, sqlExpressionCellLimit)
 			if err != nil {
 				p.logger.Error("Failed to read query for expression", "error", err)
 				return rsp, NewErrorWithRefID(q.RefID, err)

--- a/pkg/registry/apis/query/parser_test.go
+++ b/pkg/registry/apis/query/parser_test.go
@@ -42,7 +42,7 @@ func TestQuerySplitting(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.Error(t, err) // Missing datasource
 		require.Empty(t, split.Requests)
 	})
@@ -61,7 +61,7 @@ func TestQuerySplitting(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.NoError(t, err)
 		require.Len(t, split.Requests, 1)
 		require.Equal(t, "0", split.Requests[0].Request.From)
@@ -170,7 +170,7 @@ func TestQuerySplitting(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.NoError(t, err)
 		require.Len(t, split.Requests, 1)
 		require.Equal(t, "now-1d", split.Requests[0].Request.From)
@@ -198,7 +198,7 @@ func TestQuerySplitting(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.NoError(t, err)
 		require.Len(t, split.Requests, 1)
 		require.Equal(t, "now-1d", split.Requests[0].Request.From)
@@ -223,7 +223,7 @@ func TestQuerySplitting(t *testing.T) {
 				require.NoError(t, err)
 
 				changed := false
-				parsed, err := parser.parseRequest(ctx, &harness.Request)
+				parsed, err := parser.parseRequest(ctx, &harness.Request, true, 0)
 				if err != nil {
 					if !assert.Equal(t, harness.Error, err.Error(), "File %s", file) {
 						changed = true
@@ -281,7 +281,7 @@ func TestSqlInputs(t *testing.T) {
 				}),
 			},
 		},
-	})
+	}, true, 0)
 	require.NoError(t, err)
 	require.Equal(t, parsedRequestInfo.SqlInputs["B"], struct{}{})
 }
@@ -343,7 +343,7 @@ func TestGrafanaDS(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.NoError(t, err)
 		require.Len(t, parsed.Requests, 1)
 		require.Equal(t, "grafana", parsed.Requests[0].PluginId)
@@ -363,7 +363,7 @@ func TestGrafanaDS(t *testing.T) {
 					},
 				}},
 			},
-		})
+		}, true, 0)
 		require.NoError(t, err)
 		require.Len(t, parsed.Requests, 1)
 		require.Equal(t, "grafana", parsed.Requests[0].PluginId)

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -26,6 +26,10 @@ func TestQueryRestConnectHandler(t *testing.T) {
 	b := &QueryAPIBuilder{
 		clientSupplier: mockClient{
 			lastCalledWithHeaders: &map[string]string{},
+			stubbedInstanceConfig: clientapi.InstanceConfigurationSettings{
+				FeatureToggles:         featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
+				SQLExpressionCellLimit: 10,
+			},
 		},
 		tracer: tracing.InitializeTracerForTest(),
 		parser: newQueryParser(expr.NewExpressionQueryReader(featuremgmt.WithFeatures()),
@@ -33,7 +37,9 @@ func TestQueryRestConnectHandler(t *testing.T) {
 		log: log.New("test"),
 	}
 	qr := newQueryREST(b)
+
 	ctx := context.Background()
+
 	mr := mockResponder{}
 
 	handler, err := qr.Connect(ctx, "name", nil, mr)
@@ -150,11 +156,11 @@ func (m mockResponder) Error(err error) {
 
 type mockClient struct {
 	lastCalledWithHeaders *map[string]string
+	stubbedInstanceConfig clientapi.InstanceConfigurationSettings
 }
 
 func (m mockClient) GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string, instanceConfig clientapi.InstanceConfigurationSettings) (clientapi.QueryDataClient, error) {
 	*m.lastCalledWithHeaders = headers
-
 	return nil, fmt.Errorf("mock error")
 }
 

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -52,7 +52,8 @@ type QueryAPIBuilder struct {
 	queryTypes     *query.QueryTypeDefinitionList
 }
 
-func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
+func NewQueryAPIBuilder(
+	features featuremgmt.FeatureToggles,
 	clientSupplier clientapi.DataSourceClientSupplier,
 	ar authorizer.Authorizer,
 	registry query.DataSourceApiServerRegistry,


### PR DESCRIPTION
Depends on https://github.com/grafana/grafana-enterprise/issues/8736

**What is this feature?**

The ds querier needs to grab the feature toggle for sql expressions as well as the cell limit from a instance's configuration settings and pass that in per request. 

**Why do we need this feature?**
The why is described here a bit: https://github.com/grafana/grafana-enterprise/issues/8736

**Who is this feature for?**

grafana devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/8736

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

NOTE: 
- this should be manually tested in the non ds querier pathways to see if I missed anything there. I also noticed we had cell limits for both input and output....I think I might be missing the output cell limit here. 
