### PR TITLE
Alerting: Include rules imported in the UI into prometheus_imported_rules metric

### DIFF
--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -88,7 +88,8 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 			}
 		}
 
-		if rule.ImportedFromPrometheus() {
+		_, hasConvertedPrometheusRuleLabel := rule.GetLabels()[models.ConvertedPrometheusRuleLabel]
+		if rule.ImportedFromPrometheus() || hasConvertedPrometheusRuleLabel {
 			orgsRulesPrometheusImported[rule.OrgID]++
 		}
 

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -729,38 +729,45 @@ func TestSchedule_updateRulesMetrics(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		// The metric includes alert rules with either internal ConvertedPrometheusRuleLabel label,
+		// or when AlertRule.ImportedFromPrometheus() returns true.
 		alertRule1 := models.RuleGen.With(
 			models.RuleGen.WithOrgID(firstOrgID),
 			models.RuleGen.WithPrometheusOriginalRuleDefinition("1"),
 		).GenerateRef()
 
-		t.Run("it should show one imported rule in a single org", func(t *testing.T) {
-			sch.updateRulesMetrics([]*models.AlertRule{alertRule1})
+		alertRule2 := models.RuleGen.With(
+			models.RuleGen.WithOrgID(firstOrgID),
+			models.RuleGen.WithLabel(models.ConvertedPrometheusRuleLabel, "true"),
+		).GenerateRef()
+
+		t.Run("it should show two imported rules in a single org", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRule1, alertRule2})
 
 			expectedMetric := fmt.Sprintf(
 				`# HELP grafana_alerting_prometheus_imported_rules The number of rules imported from a Prometheus-compatible source.
 								# TYPE grafana_alerting_prometheus_imported_rules gauge
-								grafana_alerting_prometheus_imported_rules{org="%[1]d"} 1
+								grafana_alerting_prometheus_imported_rules{org="%[1]d"} 2
 				`, alertRule1.OrgID)
 
 			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_prometheus_imported_rules")
 			require.NoError(t, err)
 		})
 
-		alertRule2 := models.RuleGen.With(
+		alertRule3 := models.RuleGen.With(
 			models.RuleGen.WithOrgID(secondOrgID),
 			models.RuleGen.WithPrometheusOriginalRuleDefinition("1"),
 		).GenerateRef()
 
-		t.Run("it should show two imported rules in two orgs", func(t *testing.T) {
-			sch.updateRulesMetrics([]*models.AlertRule{alertRule1, alertRule2})
+		t.Run("it should show three imported rules in two orgs", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRule1, alertRule2, alertRule3})
 
 			expectedMetric := fmt.Sprintf(
 				`# HELP grafana_alerting_prometheus_imported_rules The number of rules imported from a Prometheus-compatible source.
 								# TYPE grafana_alerting_prometheus_imported_rules gauge
-								grafana_alerting_prometheus_imported_rules{org="%[1]d"} 1
+								grafana_alerting_prometheus_imported_rules{org="%[1]d"} 2
 								grafana_alerting_prometheus_imported_rules{org="%[2]d"} 1
-				`, alertRule1.OrgID, alertRule2.OrgID)
+				`, firstOrgID, secondOrgID)
 
 			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_prometheus_imported_rules")
 			require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

This change ensures that all Prometheus-imported rules are counted in the `grafana_alerting_prometheus_imported_rules` metric, regardless of whether they were imported via API or the UI. 

When an alert rule is imported in either UI or API, a special internal [__converted_prometheus_rule__](https://github.com/grafana/grafana/blob/31a9ddc47a00262d9a2370b11d2efe7a34dbf15c/pkg/services/ngalert/models/alert_rule.go#L158) label is added to the rule.

Before this PR the `grafana_alerting_prometheus_imported_rules` metric showed only the number of alert rules that were [imported](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/alerting-migration/) in the API and were marked as "Provisioned" (read-only): `ImportedFromPrometheus() == true`.