### PR TITLE
K8s: Only register internal kind once

### DIFF
--- a/pkg/services/apiserver/builder/runner/builder.go
+++ b/pkg/services/apiserver/builder/runner/builder.go
@@ -75,8 +75,12 @@ func (b *appBuilder) InstallSchema(scheme *runtime.Scheme) error {
 				Group:   gv.Group,
 				Version: runtime.APIVersionInternal,
 			}
-			scheme.AddKnownTypeWithName(gvInternal.WithKind(kind.Kind()), kind.ZeroValue())
-			scheme.AddKnownTypeWithName(gvInternal.WithKind(kind.Kind()+"List"), kind.ZeroListValue())
+
+			// only register internal kind once
+			if _, ok := scheme.KnownTypes(gvInternal)[kind.Kind()]; !ok {
+				scheme.AddKnownTypeWithName(gvInternal.WithKind(kind.Kind()), kind.ZeroValue())
+				scheme.AddKnownTypeWithName(gvInternal.WithKind(kind.Kind()+"List"), kind.ZeroListValue())
+			}
 
 			if len(kind.SelectableFields()) == 0 {
 				continue


### PR DESCRIPTION
While working on a workshop for how to define another version of playlists, it began failing here with this error:
```
panic: Double registration of different types for playlist.grafana.app/__internal, Kind=Playlist: old=github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1.Playlist, new=github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v1.Playlist in scheme "pkg/runtime/scheme.go:110"
```

This PR prevents registering the internal version twice for a simple app when they have multiple versions.