### PR TITLE
Improve data source config docs for proxy access with basic auth

### DIFF
--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -130,12 +130,12 @@ datasources:
     user:
     # <string> Sets the database name, if necessary.
     database:
-    # <bool> Enables basic authorization (ignored unless
-    # access is direct). If proxied data source requires
-    # basic auth, add a custom HTTP Authorization header
-    # instead (see section below).
+    # <bool> Enables basic auth (only applies when access
+    # is direct). If your proxied data source requires basic
+    # auth, add a custom HTTP Authorization header instead
+    # (see section below).
     basicAuth:
-    # <string> Sets the basic authorization username.
+    # <string> Sets the basic auth username.
     basicAuthUser:
     # <bool> Enables credential headers.
     withCredentials:
@@ -162,7 +162,7 @@ datasources:
       tlsClientKey: '...'
       # <string> Sets the database password, if necessary.
       password:
-      # <string> Sets the basic authorization password.
+      # <string> Sets the basic auth password.
       basicAuthPassword:
     # <int> Sets the version. Used to compare versions when
     # updating. Ignored when creating a new data source.
@@ -255,7 +255,7 @@ All of these settings are optional.
 | `tlsClientCert`     | string | _HTTP\*_, MySQL, PostgreSQL        | TLS Client cert for outgoing requests                    |
 | `tlsClientKey`      | string | _HTTP\*_, MySQL, PostgreSQL        | TLS Client key for outgoing requests                     |
 | `password`          | string | _HTTP\*_, MySQL, PostgreSQL, MSSQL | password                                                 |
-| `basicAuthPassword` | string | _HTTP\*_                           | password for basic authentication                        |
+| `basicAuthPassword` | string | _HTTP\*_                           | password for basic auth                                  |
 | `accessKey`         | string | Amazon CloudWatch                  | Access key for connecting to Amazon CloudWatch           |
 | `secretKey`         | string | Amazon CloudWatch                  | Secret key for connecting to Amazon CloudWatch           |
 | `sigV4AccessKey`    | string | Elasticsearch and Prometheus       | SigV4 access key. Required when using keys auth provider |

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -130,7 +130,10 @@ datasources:
     user:
     # <string> Sets the database name, if necessary.
     database:
-    # <bool> Enables basic authorization.
+    # <bool> Enables basic authorization (ignored unless
+    # access is direct). If proxied data source requires
+    # basic auth, add a custom HTTP Authorization header
+    # instead (see section below).
     basicAuth:
     # <string> Sets the basic authorization username.
     basicAuthUser:


### PR DESCRIPTION
Clarify that basic auth settings only apply to data source in direct access mode.

**What is this feature?**

Improve documentation on configuring a proxied data source that requires basic auth.

**Why do we need this feature?**

Existing documentation describes basic auth settings in data source config YAML, but does not say that they are **ignored unless access is direct**. This caused needless headache in setting up a proxied data source that requires basic auth, causing the browser to pop up repeatedly with basic auth credentials input.

**Who is this feature for?**

Anyone configuring a **proxied** data source that requires **basic auth**.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
