### PR TITLE
Alerting: Add export folder action to the new list view

### DIFF
--- a/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
@@ -75,9 +75,13 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
       return null;
     }
 
+    if (!canPause && !canDelete) {
+      return null;
+    }
+
     return (
       <>
-        {(canPause || canDelete) && <Menu.Divider />}
+        <Menu.Divider />
         {canPause && (
           <>
             <PauseUnpauseActionMenuItem

--- a/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
@@ -77,12 +77,6 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
           <ExportFolderButton onClickExport={() => setIsExporting(true)} />
         </>
       )}
-      <DeleteModal
-        isOpen={isDeleteModalOpen}
-        onConfirm={onConfirmDelete}
-        onDismiss={() => setIsDeleteModalOpen(false)}
-        folderName={folderName}
-      />
     </>
   );
 

--- a/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
@@ -61,10 +61,6 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
   // URLs
   const redirectToListView = useRedirectToListView(viewComponent);
 
-  if (!canPause && !canDelete) {
-    return null;
-  }
-
   if (!folder) {
     return null;
   }
@@ -140,7 +136,7 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
         <MoreButton
           fill="text"
           size="sm"
-          aria-label={t('alerting.list-view.folder-actions.button.title', 'Folder actions')}
+          aria-label={t('alerting.list-view.folder-actions.button.aria-label', 'Folder actions')}
           title={t('alerting.list-view.folder-actions.button.title', 'Actions')}
         />
       </Dropdown>

--- a/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx
@@ -6,7 +6,7 @@ import { Dropdown, Menu } from '@grafana/ui';
 import { useDispatch } from 'app/types';
 
 import { alertingFolderActionsApi } from '../../api/alertingFolderActionsApi';
-import { shouldUsePrometheusRulesPrimary } from '../../featureToggles';
+import { shouldUseAlertingListViewV2, shouldUsePrometheusRulesPrimary } from '../../featureToggles';
 import {
   AlertingAction,
   FolderBulkAction,
@@ -36,7 +36,7 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
 
   // feature toggles
   const bulkActionsEnabled = config.featureToggles.alertingBulkActionsInUI;
-  const listView2Enabled = config.featureToggles.alertingListViewV2 ?? false;
+  const listView2Enabled = shouldUseAlertingListViewV2();
 
   // abilities
   const [pauseSupported, pauseAllowed] = useFolderBulkActionAbility(FolderBulkAction.Pause);
@@ -53,9 +53,9 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
   const [deleteGrafanaRulesFromFolder, deleteState] =
     alertingFolderActionsApi.endpoints.deleteGrafanaRulesFromFolder.useMutation();
 
-  const folderName = useFolder(folderUID).folder?.title || 'unknown folder';
-  const folderUrl = makeFolderLink(folderUID);
   const { folder } = useFolder(folderUID);
+  const folderName = folder?.title || 'unknown folder';
+  const folderUrl = makeFolderLink(folderUID);
   const viewComponent = listView2Enabled ? 'list' : 'grouped';
 
   // URLs
@@ -128,7 +128,7 @@ export const FolderActionsButton = ({ folderUID }: Props) => {
       {canExportRules && (
         <>
           {bulkActionsEnabled && <Menu.Divider />}
-          <ExportFolderButton folderUid={folderUID} onClickExport={() => setIsExporting(true)} />
+          <ExportFolderButton onClickExport={() => setIsExporting(true)} />
         </>
       )}
     </>
@@ -171,12 +171,8 @@ function useRedirectToListView(view: string) {
   return redirectToListView;
 }
 
-function ExportFolderButton({ folderUid, onClickExport }: { folderUid: string; onClickExport: () => void }) {
+function ExportFolderButton({ onClickExport }: { onClickExport: () => void }) {
   const { t } = useTranslate();
-  const { folder } = useFolder(folderUid);
-  if (!folder) {
-    return null;
-  }
   return (
     <Menu.Item
       aria-label={t('alerting.list-view.folder-actions.export.aria-label', 'Export rules folder')}

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -4,13 +4,13 @@ import React, { useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, useTranslate } from '@grafana/i18n';
-import { Badge, Icon, Spinner, Stack, useStyles2 } from '@grafana/ui';
-import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
+import { Badge, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { CombinedRuleGroup, CombinedRuleNamespace, RulesSource } from 'app/types/unified-alerting';
 
 import { useFolder } from '../../hooks/useFolder';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { useRulesAccess } from '../../utils/accessControlHooks';
-import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName, isCloudRulesSource } from '../../utils/datasource';
 import { makeFolderLink } from '../../utils/misc';
 import { groups } from '../../utils/navigation';
 import { isFederatedRuleGroup, isPluginProvidedRule, rulerRuleType } from '../../utils/rules';
@@ -227,6 +227,23 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
 });
 
 RulesGroup.displayName = 'RulesGroup';
+
+// It's a simple component but we render 80 of them on the list page it needs to be fast
+// The Tooltip component is expensive to render and the rulesSource doesn't change often
+// so memoization seems to bring a lot of benefit here
+const CloudSourceLogo = React.memo(({ rulesSource }: { rulesSource: RulesSource | string }) => {
+  const styles = useStyles2(getStyles);
+
+  if (isCloudRulesSource(rulesSource)) {
+    return (
+      <Tooltip content={rulesSource.name} placement="top">
+        <img alt={rulesSource.meta.name} className={styles.dataSourceIcon} src={rulesSource.meta.info.logos.small} />
+      </Tooltip>
+    );
+  }
+
+  return null;
+});
 
 CloudSourceLogo.displayName = 'CloudSourceLogo';
 

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, useTranslate } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Badge, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { CombinedRuleGroup, CombinedRuleNamespace, RulesSource } from 'app/types/unified-alerting';
 
@@ -19,7 +18,7 @@ import { CollapseToggle } from '../CollapseToggle';
 import { RuleLocation } from '../RuleLocation';
 import { GrafanaRuleFolderExporter } from '../export/GrafanaRuleFolderExporter';
 import { decodeGrafanaNamespace } from '../expressions/util';
-import { FolderBulkActionsButton } from '../folder-actions/FolderActionsButton';
+import { FolderActionsButton } from '../folder-actions/FolderActionsButton';
 
 import { ActionIcon } from './ActionIcon';
 import { RuleGroupStats } from './RuleStats';
@@ -68,8 +67,6 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
   const isPluginProvided = group.rules.some((rule) => isPluginProvidedRule(rule.rulerRule ?? rule.promRule));
 
   const canEditGroup = hasRuler && !isProvisioned && !isFederated && !isPluginProvided && canEditRules(rulesSourceName);
-
-  const isFolderBulkActionsEnabled = config.featureToggles.alertingBulkActionsInUI;
 
   // check what view mode we are in
   const isListView = viewMode === 'list';
@@ -139,18 +136,18 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
       }
       if (folder) {
         if (isListView) {
-          actionIcons.push(
-            <ActionIcon
-              aria-label={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
-              data-testid="export-folder"
-              key="export-folder"
-              icon="download-alt"
-              tooltip={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
-              onClick={() => setIsExporting('folder')}
-            />
-          );
-          if (isFolderBulkActionsEnabled && folderUID && isListView) {
-            actionIcons.push(<FolderBulkActionsButton folderUID={folderUID} key="folder-bulk-actions" />);
+          // actionIcons.push(
+          //   <ActionIcon
+          //     aria-label={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
+          //     data-testid="export-folder"
+          //     key="export-folder"
+          //     icon="download-alt"
+          //     tooltip={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
+          //     onClick={() => setIsExporting('folder')}
+          //   />
+          // );
+          if (folderUID && isListView) {
+            actionIcons.push(<FolderActionsButton folderUID={folderUID} key="folder-bulk-actions" />);
           }
         }
       }

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -136,16 +136,6 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
       }
       if (folder) {
         if (isListView) {
-          // actionIcons.push(
-          //   <ActionIcon
-          //     aria-label={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
-          //     data-testid="export-folder"
-          //     key="export-folder"
-          //     icon="download-alt"
-          //     tooltip={t('alerting.rule-group-action.export-rules-folder', 'Export rules folder')}
-          //     onClick={() => setIsExporting('folder')}
-          //   />
-          // );
           if (folderUID && isListView) {
             actionIcons.push(<FolderActionsButton folderUID={folderUID} key="folder-bulk-actions" />);
           }

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -4,13 +4,13 @@ import React, { useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, useTranslate } from '@grafana/i18n';
-import { Badge, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
-import { CombinedRuleGroup, CombinedRuleNamespace, RulesSource } from 'app/types/unified-alerting';
+import { Badge, Icon, Spinner, Stack, useStyles2 } from '@grafana/ui';
+import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { useFolder } from '../../hooks/useFolder';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { useRulesAccess } from '../../utils/accessControlHooks';
-import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName, isCloudRulesSource } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName } from '../../utils/datasource';
 import { makeFolderLink } from '../../utils/misc';
 import { groups } from '../../utils/navigation';
 import { isFederatedRuleGroup, isPluginProvidedRule, rulerRuleType } from '../../utils/rules';
@@ -136,9 +136,7 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
       }
       if (folder) {
         if (isListView) {
-          if (folderUID && isListView) {
-            actionIcons.push(<FolderActionsButton folderUID={folderUID} key="folder-bulk-actions" />);
-          }
+          actionIcons.push(<FolderActionsButton folderUID={folderUID} key="folder-bulk-actions" />);
         }
       }
     }
@@ -229,23 +227,6 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
 });
 
 RulesGroup.displayName = 'RulesGroup';
-
-// It's a simple component but we render 80 of them on the list page it needs to be fast
-// The Tooltip component is expensive to render and the rulesSource doesn't change often
-// so memoization seems to bring a lot of benefit here
-const CloudSourceLogo = React.memo(({ rulesSource }: { rulesSource: RulesSource | string }) => {
-  const styles = useStyles2(getStyles);
-
-  if (isCloudRulesSource(rulesSource)) {
-    return (
-      <Tooltip content={rulesSource.name} placement="top">
-        <img alt={rulesSource.meta.name} className={styles.dataSourceIcon} src={rulesSource.meta.info.logos.small} />
-      </Tooltip>
-    );
-  }
-
-  return null;
-});
 
 CloudSourceLogo.displayName = 'CloudSourceLogo';
 

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -320,7 +320,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       margin: `0 ${theme.spacing(2)}`,
     }),
     actionIcons: css({
-      width: '80px',
+      width: '120px',
       alignItems: 'center',
 
       flexShrink: 0,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1197,10 +1197,6 @@
       "delete-modal-text": "This action will delete all alert rules in the <1>{{folderName}}</1> folder. Nested folders will not be affected.",
       "delete-modal-title": "Delete",
       "error": "Failed to execute action for folder: {{error}}",
-      "more-button": {
-        "title": "Folder actions",
-        "tooltip": "Folder actions"
-      },
       "pause": {
         "button": {
           "label": "Pause all rules"
@@ -1662,13 +1658,17 @@
         "provisioning": "You can also define rules through file provisioning or Terraform"
       },
       "folder-actions": {
+        "button": {
+          "aria-label": "Folder actions",
+          "title": "Actions"
+        },
         "export": {
           "aria-label": "Export rules folder",
-          "tooltip": "Export rules folder"
+          "label": "Export rules folder"
         },
         "view": {
           "aria-label": "View folder",
-          "tooltip": "View folder"
+          "label": "View folder"
         }
       },
       "no-prom-or-loki-rules": "There are no Prometheus or Loki data sources configured",
@@ -2336,7 +2336,6 @@
     "rule-group-action": {
       "details": "rule group details",
       "edit": "edit rule group",
-      "export-rules-folder": "Export rules folder",
       "go-to-folder": "go to folder",
       "manage-permissions": "manage permissions"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1210,9 +1210,6 @@
         "button": {
           "label": "Resume all rules"
         }
-      },
-      "view": {
-        "folder": "View folder"
       }
     },
     "folder-selector": {
@@ -1663,6 +1660,16 @@
         "new-recording-rule": "New recording rule",
         "no-rules-created": "You haven't created any rules yet",
         "provisioning": "You can also define rules through file provisioning or Terraform"
+      },
+      "folder-actions": {
+        "export": {
+          "aria-label": "Export rules folder",
+          "tooltip": "Export rules folder"
+        },
+        "view": {
+          "aria-label": "View folder",
+          "tooltip": "View folder"
+        }
       },
       "no-prom-or-loki-rules": "There are no Prometheus or Loki data sources configured",
       "no-rules": "No rules found.",


### PR DESCRIPTION
**What is this feature?**

This PR adds the export folder button in the new list page.
It also merge all folder actions in a single Actions more button.

**Why do we need this feature?**

This feature was already present in the old list view.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1144

**Special notes for your reviewer:**

**Exporting in the new list page:**

https://github.com/user-attachments/assets/2f1df06d-467d-4cb5-8edc-8c687a3e851f


**In the old list view :**

<img width="1503" alt="Screenshot 2025-06-03 at 09 04 39" src="https://github.com/user-attachments/assets/20f20aae-be2e-484e-acc6-182021855615" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
