### PR TITLE
docs: remove deprecation notice on Grafonnet

### DIFF
--- a/docs/sources/observability-as-code/get-started.md
+++ b/docs/sources/observability-as-code/get-started.md
@@ -84,5 +84,5 @@ If you're already using established Infrastructure as Code or other configuratio
   - Integrate with GitOps workflows for seamless version control and deployment.
 
 - [Crossplane](https://github.com/grafana/crossplane-provider-grafana) lets you manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
-- [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically. It is currently in the process of being deprecated.
+- [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically.
 - [Grizzly](https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/grizzly/dashboards-folders-datasources/) is a deprecated command-line tool that simplifies managing Grafana resources using Kubernetes-inspired YAML syntax.


### PR DESCRIPTION
Grafonnet is not being deprecated, likely the copy got mixed up with Grizzly being deprecated. This PR removes the offending sentence.
