### PR TITLE
Remove Python CodeQL check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         # Override automatic language detection by changing the below list
         # Supported options are listed here
         # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
-        language: ['actions', 'javascript', 'go', 'python']
+        language: ['actions', 'javascript', 'go']
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 


### PR DESCRIPTION
We don't have any Python files in the repo anymore since https://github.com/grafana/grafana/commit/c25b0f053c42e1eca53ce59f093cbf47501177ef, which is making PR checks fail because CodeQL throws an error if it does not find files for that language.

Alternatively, if we think we will bring back Python files in the future, we could copy the logic in the linked commit and add a step that checks if there are Python files and skips the CodeQL analysis if not.