### PR TITLE
Alerting: Fix history tab visibility condition

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -22,8 +22,8 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import InfoPausedRule from 'app/features/alerting/unified/components/InfoPausedRule';
 import { RuleActionsButtons } from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import {
-  AlertInstanceTotals,
   AlertInstanceTotalState,
+  AlertInstanceTotals,
   CombinedRule,
   RuleGroupIdentifierV2,
   RuleHealth,

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -22,6 +22,7 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import InfoPausedRule from 'app/features/alerting/unified/components/InfoPausedRule';
 import { RuleActionsButtons } from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import {
+  AlertInstanceTotals,
   AlertInstanceTotalState,
   CombinedRule,
   RuleGroupIdentifierV2,
@@ -95,7 +96,6 @@ const RuleViewer = () => {
   const { annotations, promRule, rulerRule } = rule;
 
   const hasError = isErrorHealth(promRule?.health);
-  const isAlertType = prometheusRuleType.alertingRule(promRule);
 
   const isFederatedRule = isFederatedRuleGroup(rule.group);
   const isProvisioned = rulerRuleType.grafana.rule(rulerRule) && Boolean(rulerRule.grafana_alert.provenance);
@@ -115,7 +115,7 @@ const RuleViewer = () => {
         <Title
           name={title}
           paused={isPaused}
-          state={isAlertType ? promRule.state : undefined}
+          state={prometheusRuleType.alertingRule(promRule) ? promRule.state : undefined}
           health={promRule?.health}
           ruleType={promRule?.type}
           ruleOrigin={ruleOrigin}
@@ -406,8 +406,8 @@ function usePageNav(rule: CombinedRule) {
   const namespaceName = decodeGrafanaNamespace(rule.namespace).name;
   const groupName = rule.group.name;
 
-  const isGrafanaAlertRule = rulerRuleType.grafana.rule(rulerRule) && isAlertType;
-  const grafanaRecordingRule = rulerRuleType.grafana.recordingRule(rulerRule);
+  const isGrafanaAlertRule = rulerRuleType.grafana.alertingRule(rulerRule);
+  const isGrafanaRecordingRule = rulerRuleType.grafana.recordingRule(rulerRule);
   const isRecordingRuleType = prometheusRuleType.recordingRule(promRule);
 
   const pageNav: NavModelItem = {
@@ -453,7 +453,7 @@ function usePageNav(rule: CombinedRule) {
         onClick: () => {
           setActiveTab(ActiveTab.VersionHistory);
         },
-        hideFromTabs: !isGrafanaAlertRule && !grafanaRecordingRule,
+        hideFromTabs: !isGrafanaAlertRule && !isGrafanaRecordingRule,
       },
     ],
     parentItem: {
@@ -476,7 +476,7 @@ function usePageNav(rule: CombinedRule) {
   };
 }
 
-export const calculateTotalInstances = (stats: CombinedRule['instanceTotals']) => {
+export const calculateTotalInstances = (stats: AlertInstanceTotals) => {
   return chain(stats)
     .pick([
       AlertInstanceTotalState.Alerting,


### PR DESCRIPTION
This PR improves the visibility condition of the History tab - It relies on Ruler definition instead of Prometheus to figure out if the tab should be displayed or not

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
