### PR TITLE
Adhoc variable export

### DIFF
--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import { createAdHocVariableAdapter } from 'app/features/variables/adhoc/adapter';
 
 import { LibraryElementKind } from '../../../library-panels/types';
 import { DashboardJson } from '../../../manage-dashboards/types';
@@ -67,6 +68,7 @@ jest.mock('app/features/library-panels/state/api', () => ({
 variableAdapters.register(createQueryVariableAdapter());
 variableAdapters.register(createConstantVariableAdapter());
 variableAdapters.register(createDataSourceVariableAdapter());
+variableAdapters.register(createAdHocVariableAdapter());
 
 describe('dashboard exporter v1', () => {
   it('handles a default datasource in a template variable', async () => {
@@ -272,6 +274,11 @@ describe('dashboard exporter v1', () => {
               current: { value: 'other2', text: 'other2' },
               options: [],
             },
+            {
+              name: 'adhoc',
+              type: 'adhoc',
+              datasource: { uid: 'gfdb', type: 'testdb' },
+            },
           ],
         },
         annotations: {
@@ -418,6 +425,10 @@ describe('dashboard exporter v1', () => {
       expect(exported.templating.list[0].options.length).toBe(0);
       expect(exported.templating.list[0].current.value).toBe(undefined);
       expect(exported.templating.list[0].current.text).toBe(undefined);
+    });
+
+    it('should replace datasource in adhoc query', () => {
+      expect(exported.templating.list[3].datasource.uid).toBe('${DS_GFDB}');
     });
 
     it('should replace datasource in annotation query', () => {

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -237,6 +237,8 @@ export async function makeExportableV1(dashboard: DashboardModel) {
           variable.refresh !== VariableRefresh.never ? variable.refresh : VariableRefresh.onDashboardLoad;
       } else if (variable.type === 'datasource') {
         variable.current = {};
+      } else if (variable.type === 'adhoc') {
+        await templateizeDatasourceUsage(variable);
       }
     }
 


### PR DESCRIPTION
Templatize ad hoc variables when exporting externally.

Fixes https://github.com/grafana/support-escalations/issues/16594

After Export
![image](https://github.com/user-attachments/assets/465ae368-ad01-4ae8-a325-e84826a1f5f1)

After Import of above
![image](https://github.com/user-attachments/assets/ef2eaefd-1786-4b76-97bf-4b4ca3828194)


