### PR TITLE
legacy annotation query - handle undefined scenarios gracefully

### DIFF
--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.test.ts
@@ -48,6 +48,32 @@ describe('LegacyAnnotationQueryRunner', () => {
     });
   });
 
+  describe('when run is called without a valid datasource', () => {
+    it('then it should return empty results when datasource is undefined', async () => {
+      const datasource = undefined;
+      const options = { ...getDefaultOptions(), datasource };
+
+      await expect(runner.run(options)).toEmitValuesWith((received) => {
+        expect(received).toHaveLength(1);
+        const results = received[0];
+        expect(results).toEqual([]);
+      });
+    });
+
+    it('then it should return empty results when annotationQuery is undefined', async () => {
+      const datasource = {
+        annotationQuery: undefined,
+      } as unknown as DataSourceApi;
+      const options = { ...getDefaultOptions(), datasource };
+
+      await expect(runner.run(options)).toEmitValuesWith((received) => {
+        expect(received).toHaveLength(1);
+        const results = received[0];
+        expect(results).toEqual([]);
+      });
+    });
+  });
+
   describe('when canWork is called with incorrect props', () => {
     it('then it should return false', () => {
       const datasource = {

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -25,7 +25,18 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
       return of([]);
     }
 
-    return from(datasource!.annotationQuery!({ range, rangeRaw: range.raw, annotation, dashboard })).pipe(
+    if (datasource?.annotationQuery === undefined) {
+      console.warn('datasource does not have an annotation query');
+      return of([]);
+    }
+
+    const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
+    if (annotationQuery === undefined) {
+      console.warn('datasource does not have an annotation query');
+      return of([]);
+    }
+
+    return from(annotationQuery).pipe(
       catchError(handleAnnotationQueryRunnerError)
     );
   }

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -36,8 +36,6 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
       return of([]);
     }
 
-    return from(annotationQuery).pipe(
-      catchError(handleAnnotationQueryRunnerError)
-    );
+    return from(annotationQuery).pipe(catchError(handleAnnotationQueryRunnerError));
   }
 }


### PR DESCRIPTION
Don't crash if datasource or annotationQuery are undefined.

Fixes https://github.com/grafana/support-escalations/issues/16491
