### PR TITLE
WIP: SQL Expressions: Add tabular conversion to dataframe

### DIFF
--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -154,8 +154,17 @@ func handleSqlInput(dataFrames data.Frames, isEditMode bool) (mathexp.Results, e
 		if err != nil {
 			return result, fmt.Errorf("failed to convert data frames to long format for sql: %w", err)
 		}
-		result.Values = mathexp.Values{
-			mathexp.TableData{Frame: convertedFrames[0]},
+		if isEditMode {
+			convertedFrames[0].Name = dataFrames[0].RefID + " : Converted to tabular format for SQL Expression"
+			dataFrames[0].Name =  dataFrames[0].RefID + " : Original format"
+			result.Values = mathexp.Values{
+				mathexp.TableData{Frame: convertedFrames[0]},
+				mathexp.TableData{Frame: dataFrames[0]},
+			}
+		} else {
+			result.Values = mathexp.Values{
+				mathexp.TableData{Frame: convertedFrames[0]},
+			}
 		}
 		return result, nil
 	}

--- a/pkg/expr/converter_test.go
+++ b/pkg/expr/converter_test.go
@@ -41,7 +41,7 @@ func TestConvertDataFramesToResults(t *testing.T) {
 
 				for _, dtype := range supported {
 					t.Run(dtype, func(t *testing.T) {
-						resultType, res, err := converter.Convert(context.Background(), dtype, frames, false)
+						resultType, res, err := converter.Convert(context.Background(), dtype, frames, ParseSQLExprInputType("false"))
 						require.NoError(t, err)
 						assert.Equal(t, "single frame series", resultType)
 						require.Len(t, res.Values, 2)
@@ -69,7 +69,7 @@ func TestConvertDataFramesToResults(t *testing.T) {
 
 				for _, dtype := range supported {
 					t.Run(dtype, func(t *testing.T) {
-						resultType, res, err := converter.Convert(context.Background(), dtype, frames, false)
+						resultType, res, err := converter.Convert(context.Background(), dtype, frames, ParseSQLExprInputType("false"))
 						require.NoError(t, err)
 						assert.Equal(t, "multi frame series", resultType)
 						require.Len(t, res.Values, 2)
@@ -102,7 +102,7 @@ func TestConvertDataFramesToResults(t *testing.T) {
 
 			for _, dtype := range supported {
 				t.Run(dtype, func(t *testing.T) {
-					resultType, res, err := converter.Convert(context.Background(), dtype, frames, false)
+					resultType, res, err := converter.Convert(context.Background(), dtype, frames, ParseSQLExprInputType("false"))
 					require.NoError(t, err)
 					assert.Equal(t, "multi frame series", resultType)
 					require.Len(t, res.Values, 2)

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -340,9 +340,13 @@ func buildGraphEdges(dp *simple.DirectedGraph, registry map[string]Node) error {
 			}
 
 			// If the input is SQL, conversion is handled differently
-			if _, ok := cmdNode.Command.(*SQLCommand); ok {
+			if command, ok := cmdNode.Command.(*SQLCommand); ok {
 				if dsNode, ok := neededNode.(*DSNode); ok {
-					dsNode.isInputToSQLExpr = true
+					if command.editMode {
+						dsNode.isInputToSQLExpr = ParseSQLExprInputType("sqlInputEditMode")
+					} else {
+						dsNode.isInputToSQLExpr = ParseSQLExprInputType("sqlInput")
+					}
 				} else {
 					// Only allow data source nodes as SQL expression inputs for now
 					return fmt.Errorf("only data source queries may be inputs to a sql expression, %v is the input for %v", neededVar, cmdNode.RefID())

--- a/pkg/expr/ml.go
+++ b/pkg/expr/ml.go
@@ -130,7 +130,7 @@ func (m *MLNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s *
 	}
 
 	// process the response the same way DSNode does. Use plugin ID as data source type. Semantically, they are the same.
-	responseType, result, err = s.converter.Convert(ctx, mlPluginID, dataFrames, false)
+	responseType, result, err = s.converter.Convert(ctx, mlPluginID, dataFrames, SQLExprInputType(0))
 	return result, err
 }
 

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -48,6 +48,32 @@ type rawNode struct {
 	idx int64
 }
 
+
+// SQLExprInputType indicates if the query is needed for a SQL expression
+type SQLExprInputType int
+
+const (
+	// Not needed for a SQL expression
+	NotSQLInput SQLExprInputType = iota
+	// Needed for a SQL expression, should return intermediate formatting steps
+	SQLInputEditMode
+	// Needed for a SQL expression, return final step only
+	SQLInput
+)
+
+// ParseSQLExprInputType returns a SQLExprInputType from its string representation.
+func ParseSQLExprInputType(s string) (SQLExprInputType) {
+	switch s {
+	case "sqlInputEditMode":
+		return SQLInputEditMode
+	case "sqlInput":
+		return SQLInput
+	default:
+		return NotSQLInput
+	}
+}
+
+
 func getExpressionCommandTypeString(rawQuery map[string]any) (string, error) {
 	rawType, ok := rawQuery["type"]
 	if !ok {
@@ -193,7 +219,7 @@ type DSNode struct {
 	maxDP      int64
 	request    Request
 
-	isInputToSQLExpr bool
+	isInputToSQLExpr SQLExprInputType
 }
 
 func (dn *DSNode) String() string {

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -135,7 +135,7 @@ func (h *ExpressionQueryReader) ReadQuery(
 			eq.Properties = q
 			// TODO: Cascade limit from Grafana config in this (new Expression Parser) branch of the code
 			cellLimit := 0 // zero means no limit
-			eq.Command, err = NewSQLCommand(common.RefID, q.Format, q.Expression, int64(cellLimit), 0, 0)
+			eq.Command, err = NewSQLCommand(common.RefID, q.Format, q.Expression, int64(cellLimit), 0, 0, false)
 		}
 
 	case QueryTypeThreshold:

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNewCommand(t *testing.T) {
-	cmd, err := NewSQLCommand("a", "", "select a from foo, bar", 0, 0, 0)
+	cmd, err := NewSQLCommand("a", "", "select a from foo, bar", 0, 0, 0, false)
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
 	}
@@ -125,7 +125,7 @@ func TestSQLCommandCellLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewSQLCommand("a", "", "select a from foo, bar", tt.limit, 0, 0)
+			cmd, err := NewSQLCommand("a", "", "select a from foo, bar", tt.limit, 0, 0, false)
 			require.NoError(t, err, "Failed to create SQL command")
 
 			vars := mathexp.Vars{}
@@ -153,7 +153,7 @@ func TestSQLCommandMetrics(t *testing.T) {
 	m := metrics.NewTestMetrics()
 
 	// Create a command
-	cmd, err := NewSQLCommand("A", "someformat", "select * from foo", 0, 0, 0)
+	cmd, err := NewSQLCommand("A", "someformat", "select * from foo", 0, 0, 0, false)
 	require.NoError(t, err)
 
 	// Execute successful command

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"go.opentelemetry.io/otel/attribute"
@@ -400,9 +401,9 @@ func (b *QueryAPIBuilder) handleExpressions(ctx context.Context, req parsedReque
 			if !ok {
 				dr, ok := qdr.Responses[refId]
 				if ok {
-					_, isSqlInput := req.SqlInputs[refId]
+					//_, isSqlInput := req.SqlInputs[refId] TODO, fix this
 
-					_, res, err := b.converter.Convert(ctx, req.RefIDTypes[refId], dr.Frames, isSqlInput)
+					_, res, err := b.converter.Convert(ctx, req.RefIDTypes[refId], dr.Frames, expr.ParseSQLExprInputType("sqlInput"))
 					if err != nil {
 						expressionsLogger.Error("error converting frames for expressions", "error", err)
 						res.Error = err
@@ -449,7 +450,7 @@ func (b *QueryAPIBuilder) convertQueryFromAlerting(ctx context.Context, req data
 		return nil, fmt.Errorf("refID '%s' does not exist", refID)
 	}
 	frames := qdr.Responses[refID].Frames
-	_, results, err := b.converter.Convert(ctx, req.PluginId, frames, false)
+	_, results, err := b.converter.Convert(ctx, req.PluginId, frames, expr.ParseSQLExprInputType("notSQLExpr"))
 	if err != nil {
 		b.log.Error("issue converting query from alerting", "err", err)
 		results.Error = err

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -37,8 +37,14 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
   }
 
   query(request: DataQueryRequest<ExpressionQuery>): Observable<DataQueryResponse> {
+    const isEdit = new URLSearchParams(window.location.href).get('editPanel') === '1';
+
     let targets = request.targets.map(async (query: ExpressionQuery): Promise<ExpressionQuery> => {
       const ds = await getDataSourceSrv().get(query.datasource);
+
+      if (isEdit) {
+        query.settings = { ...query.settings, editMode: true };
+      }
 
       if (!ds.interpolateVariablesInQueries) {
         return query;

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -162,6 +162,7 @@ export interface ThresholdExpressionQuery extends ExpressionQuery {
 export interface ExpressionQuerySettings {
   mode?: ReducerMode;
   replaceWithValue?: number;
+  editMode?: boolean;
 }
 
 export interface ClassicCondition {


### PR DESCRIPTION
WIP to discuss options..

**What is this feature?**

We are looking into how to provide more visibility to the sql expression development experience. One aspect of this is an implicit conversion of the dataframe to a "wide" format. Someone attempting to debug their sql expression may be confused why their selection does not match up with the original query. 

For this POC, we pass back an edit mode param from the frontend. If this is passed, the data frame with the SQL expression is not passed back alone. It passes back the converted dataframe and the result from the sql expression. The frame is named something descriptive.

<img width="1180" alt="Screenshot 2025-05-28 at 8 09 30 PM" src="https://github.com/user-attachments/assets/3bfc7419-10be-4bd0-a594-8b9afb552303" />
<img width="1180" alt="Screenshot 2025-05-28 at 8 09 36 PM" src="https://github.com/user-attachments/assets/eeb29b26-b73f-44fe-99f6-be1b67ad7310" />
<img width="1173" alt="Screenshot 2025-05-28 at 8 09 45 PM" src="https://github.com/user-attachments/assets/4162969a-262f-4a15-8d3b-a5c26cf9208a" />

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
