### PR TITLE
Azure: Improved identification of Application Insights resouces

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -114,7 +114,7 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 		}
 		return e.GetBasicLogsUsage(req.Context(), newUrl.String(), cli, rw, req.Body)
 	} else if strings.Contains(req.URL.Path, "/metadata") {
-		isAppInsights := strings.Contains(req.URL.Path, "Microsoft.Insights/components")
+		isAppInsights := strings.Contains(strings.ToLower(req.URL.Path), "microsoft.insights/components")
 		// Add necessary headers
 		if isAppInsights {
 			// metadata-format-v4 is not supported for AppInsights resources


### PR DESCRIPTION
Follow on from #105614 - I forgot to convert the URL to lowercase to catch resource namespaces that may have unusual casing.

This fixes that by converting the URL to lowercase and searching for `microsoft.insights/components`.