### PR TITLE
VersionHistoryTable: Fix overflow issue with long notes

### DIFF
--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -22,7 +22,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck, onRestore }
   const { t } = useTranslate();
   return (
     <div className={styles.margin}>
-      <table className="filter-table">
+      <table className={cx('filter-table', styles.table)}>
         <thead>
           <tr>
             <th className="width-4"></th>
@@ -105,6 +105,11 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     margin: css({
       marginBottom: theme.spacing(4),
+    }),
+    table: css({
+      td: {
+        whiteSpace: 'normal !important',
+      },
     }),
   };
 }


### PR DESCRIPTION
Fixes an issue where a saved dashboard with an especially long note would overflow the version history table.

Before:
![Screenshot 2025-06-03 at 13 11 39](https://github.com/user-attachments/assets/b473d28b-3d6b-4022-8057-36df2f4e26f5)

After:
![Screenshot 2025-06-03 at 13 11 00](https://github.com/user-attachments/assets/14d0d38f-da58-4fac-b36e-0d310a131cfa)

Closes #106253