### PR TITLE
datasources: querier: more robust error handling, and report no errors for single-tenant

### DIFF
--- a/pkg/registry/apis/query/client.go
+++ b/pkg/registry/apis/query/client.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"errors"
 
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
@@ -17,5 +16,6 @@ func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, 
 }
 
 func (s *CommonDataSourceClientSupplier) GetInstanceConfigurationSettings(_ context.Context) (clientapi.InstanceConfigurationSettings, error) {
-	return clientapi.InstanceConfigurationSettings{}, errors.New("get instance configuration settings is not implemented")
+	// FIXME: for now it's an empty structure, we'll find a way to fill it correctly.
+	return clientapi.InstanceConfigurationSettings{}, nil
 }

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -186,8 +186,9 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		// Fetch information on the grafana instance (e.g. feature toggles)
 		instanceConfig, err := b.clientSupplier.GetInstanceConfigurationSettings(ctx)
 		if err != nil {
-			b.log.Error("failed to get instance configuration settings", "err", err)
-			responder.Error(err)
+			msg := "failed to get instance configuration settings"
+			b.log.Error(msg, "err", err)
+			responder.Error(errors.New(msg))
 			return
 		}
 

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -187,6 +187,8 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		instanceConfig, err := b.clientSupplier.GetInstanceConfigurationSettings(ctx)
 		if err != nil {
 			b.log.Error("failed to get instance configuration settings", "err", err)
+			responder.Error(err)
+			return
 		}
 
 		// Actually run the query (includes expressions)

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -3,7 +3,6 @@ package query
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -172,5 +171,6 @@ func (m mockClient) CheckHealth(ctx context.Context, req *backend.CheckHealthReq
 }
 
 func (m mockClient) GetInstanceConfigurationSettings(_ context.Context) (clientapi.InstanceConfigurationSettings, error) {
-	return clientapi.InstanceConfigurationSettings{}, errors.New("get instance configuration settings is not implemented")
+	// FIXME: for now it's an empty structure, we'll find a way to fill it correctly.
+	return clientapi.InstanceConfigurationSettings{}, nil
 }

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -171,6 +171,5 @@ func (m mockClient) CheckHealth(ctx context.Context, req *backend.CheckHealthReq
 }
 
 func (m mockClient) GetInstanceConfigurationSettings(_ context.Context) (clientapi.InstanceConfigurationSettings, error) {
-	// FIXME: for now it's an empty structure, we'll find a way to fill it correctly.
 	return clientapi.InstanceConfigurationSettings{}, nil
 }


### PR DESCRIPTION
- we adjust the single-tenant path to not return an error
    - this will be equivalent to what we have now, because now, even though we return an `error` with the empty-object, we do use the empty-object
- we adjust the caller place to be more strict, and report an error when the call fails.