### PR TITLE
Alerting: Add loading spinner for loading groups state

### DIFF
--- a/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Icon, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
 import { DataSourceRuleGroupIdentifier, DataSourceRulesSourceIdentifier, RuleGroup } from 'app/types/unified-alerting';
 
 import { groups } from '../utils/navigation';
@@ -79,6 +79,12 @@ export function PaginatedDataSourceLoader({ rulesSourceIdentifier, application }
           <div>
             <LoadMoreButton onClick={fetchMoreGroups} />
           </div>
+        )}
+        {isLoading && (
+          <Stack direction="row" gap={2} alignItems="baseline" justifyContent="flex-start">
+            <Spinner inline={true} />
+            <Trans i18nKey="alerting.rule-list.loading-more-groups">Loading more groups...</Trans>
+          </Stack>
         )}
         {hasNoRules && (
           <div className={styles.noRules}>

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
@@ -1,7 +1,8 @@
 import { groupBy, isEmpty } from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
 
-import { Icon, Stack, Text } from '@grafana/ui';
+import { Trans } from '@grafana/i18n';
+import { Icon, Spinner, Stack, Text } from '@grafana/ui';
 import { GrafanaRuleGroupIdentifier, GrafanaRulesSourceSymbol } from 'app/types/unified-alerting';
 import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
@@ -77,6 +78,12 @@ export function PaginatedGrafanaLoader() {
           <div>
             <LoadMoreButton onClick={fetchMoreGroups} />
           </div>
+        )}
+        {isLoading && (
+          <Stack direction="row" gap={2} alignItems="center" justifyContent="flex-start">
+            <Spinner inline={true} />
+            <Trans i18nKey="alerting.rule-list.loading-more-groups">Loading more groups...</Trans>
+          </Stack>
         )}
       </Stack>
     </DataSourceSection>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2380,6 +2380,7 @@
         "new-badge": "New!",
         "text": "Import to Grafana-managed rules"
       },
+      "loading-more-groups": "Loading more groups...",
       "more": "More",
       "new-alert-rule": "New alert rule",
       "new-datasource-recording-rule": "New Data source recording rule",


### PR DESCRIPTION
**What is this feature?**

This PR adds a spinner when having loading state after fetching more groups, after clicking `Show more` in the new alert list view.

**Why do we need this feature?**

We need to provide a feedback when the state is loading.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/45a8c84b-c228-4fcf-8330-d443609abc48



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
