### PR TITLE
CI: Temporarily disable --verify in nightly release

### DIFF
--- a/pkg/build/daggerbuild/scripts/drone_build_nightly_enterprise.sh
+++ b/pkg/build/daggerbuild/scripts/drone_build_nightly_enterprise.sh
@@ -38,7 +38,7 @@ dagger run --silent go run ./pkg/build/cmd \
   -a docker:enterprise:linux/arm64:ubuntu \
   -a docker:enterprise:linux/arm/v7:ubuntu \
   --checksum \
-  --verify \
+  --verify=false \
   --build-id=${DRONE_BUILD_NUMBER} \
   --grafana-ref=main \
   --enterprise-ref=main \


### PR DESCRIPTION
This disables the e2e smoke tests that run after packages are built. I think a recent change to the e2e suite is causing it to get stuck.