### PR TITLE
Docs: Fix missing arm in shrug emoji

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,6 +1,6 @@
 # Kubernetes HACK Alert
 
-This is a hack folder for kubernetes codegen scripts. Oddly, a /hack/ folder seems to be standard kubernetes development practice ¯\_(ツ)\_/¯
+This is a hack folder for kubernetes codegen scripts. Oddly, a /hack/ folder seems to be standard kubernetes development practice ¯\\\_(ツ)_/¯ 
 
 The workflow is a WIP, however we are trying to leverage as many off-the-shelf patterns as possible.
 


### PR DESCRIPTION
**What is this feature?**

The fix is to correct the shrug emoji, which doesn't render correctly in markdown, due to backslash escaping. See: https://www.bryanbraun.com/2020/11/06/using-the-shrug-emoticon-in-markdown/

**Why do we need this feature?**

The right to a right arm is an unalienable right. We can't fix every injustice, but this? THIS? this we CAN fix. 