### PR TITLE
Folders: Correctly resolve nested folder breadcrumbs

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -386,7 +386,7 @@ func (hs *HTTPServer) GetFolderDescendantCounts(c *contextmodel.ReqContext) resp
 func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folder) (dtos.Folder, error) {
 	ctx := c.Req.Context()
 	toDTO := func(f *folder.Folder, checkCanView bool) (dtos.Folder, error) {
-		canEditEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScope(f.UID))
+		canEditEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		canEdit, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canEditEvaluator)
 		canSave := canEdit
 		canAdminEvaluator := accesscontrol.EvalAll(
@@ -394,7 +394,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 			accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
 		)
 		canAdmin, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canAdminEvaluator)
-		canDeleteEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScope(f.UID))
+		canDeleteEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		canDelete, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canDeleteEvaluator)
 
 		// Finding creator and last updater of the folder
@@ -409,7 +409,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		acMetadata, _ := hs.getFolderACMetadata(c, f)
 
 		if checkCanView {
-			canViewEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScope(f.UID))
+			canViewEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 			canView, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canViewEvaluator)
 			if !canView {
 				return dtos.Folder{

--- a/pkg/registry/apis/folders/sub_access.go
+++ b/pkg/registry/apis/folders/sub_access.go
@@ -68,7 +68,7 @@ func (r *subAccessREST) Connect(ctx context.Context, name string, opts runtime.O
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		access := &folders.FolderAccessInfo{}
-		canEditEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScope(f.UID))
+		canEditEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		access.CanEdit, _ = r.ac.Evaluate(ctx, user, canEditEvaluator)
 		access.CanSave = access.CanEdit
 		canAdminEvaluator := accesscontrol.EvalAll(
@@ -76,7 +76,7 @@ func (r *subAccessREST) Connect(ctx context.Context, name string, opts runtime.O
 			accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
 		)
 		access.CanAdmin, _ = r.ac.Evaluate(ctx, user, canAdminEvaluator)
-		canDeleteEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScope(f.UID))
+		canDeleteEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		access.CanDelete, _ = r.ac.Evaluate(ctx, user, canDeleteEvaluator)
 		responder.Object(http.StatusOK, access)
 	}), nil


### PR DESCRIPTION
**What is this feature?**

Changes in https://github.com/grafana/grafana/pull/104645 introduced a bug where the wrong scope was used for evaluating access to parent folders. This meant that folder breadcrumbs were not displayed correctly. This PR corrects the scope (from using ID based scope to UID based scope for folder access evaluation). 

**Why do we need this feature?**

To correctly display folder breadcrumbs.

**Who is this feature for?**

Nested folder users. 