### PR TITLE
FlameGraph: Add support for regex search patterns and multiple search terms

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
@@ -4,9 +4,9 @@ import { useRef, useCallback } from 'react';
 
 import { createDataFrame, createTheme } from '@grafana/data';
 
+import { FlameGraphDataContainer } from './FlameGraph/dataTransform';
 import { data } from './FlameGraph/testData/dataNestedSet';
 import FlameGraphContainer, { labelSearch } from './FlameGraphContainer';
-import { FlameGraphDataContainer } from './FlameGraph/dataTransform';
 import { MIN_WIDTH_TO_SHOW_BOTH_TOPTABLE_AND_FLAMEGRAPH } from './constants';
 
 jest.mock('react-use', () => ({

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
@@ -149,6 +149,12 @@ describe('labelSearch', () => {
       expect(found.size).toBe(107);
     });
 
+    it('falls back to fuzzy with malformed regex', () => {
+      const search = 'deduplicatingSlice[.';
+      let found = labelSearch(search, container);
+      expect(found.size).toBe(1);
+    });
+
     it('no results', () => {
       const search = 'term_not_found';
       let found = labelSearch(search, container);
@@ -198,6 +204,12 @@ describe('labelSearch', () => {
     it('regex not found, fuzzy not found', () => {
       const term = 'not_found_suffix$,not_found_fuzzy';
       let found = labelSearch(term, container);
+      expect(found.size).toBe(0);
+    });
+
+    it('does not match empty terms', () => {
+      const search = ',,,,,';
+      let found = labelSearch(search, container);
       expect(found.size).toBe(0);
     });
   });

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.test.tsx
@@ -99,21 +99,24 @@ describe('FlameGraphContainer', () => {
     render(<FlameGraphContainerWithProps />);
 
     // Checking for presence of this function before filter
-    const matchingText = 'net/http.HandlerFunc.ServeHTTP';
+    const matchingText1 = 'net/http.HandlerFunc.ServeHTTP';
+    const matchingText2 = 'runtime.gcBgMarkWorker';
     const nonMatchingText = 'runtime.systemstack';
 
-    expect(screen.queryAllByText(matchingText).length).toBe(1);
+    expect(screen.queryAllByText(matchingText1).length).toBe(1);
+    expect(screen.queryAllByText(matchingText2).length).toBe(1);
     expect(screen.queryAllByText(nonMatchingText).length).toBe(1);
 
     // Apply the filter
-    const searchInput = await screen.getByPlaceholderText('Search...');
-    await userEvent.type(searchInput, 'Handler serve');
+    const searchInput = screen.getByPlaceholderText('Search...');
+    await userEvent.type(searchInput, 'Handler serve,gcBgMarkWorker');
 
     // We have to wait for filter to take effect
     await waitFor(() => {
       expect(screen.queryAllByText(nonMatchingText).length).toBe(0);
     });
     // Check we didn't lose the one that should match
-    expect(screen.queryAllByText(matchingText).length).toBe(1);
+    expect(screen.queryAllByText(matchingText1).length).toBe(1);
+    expect(screen.queryAllByText(matchingText2).length).toBe(1);
   });
 });

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
@@ -317,29 +317,67 @@ function useColorScheme(dataContainer: FlameGraphDataContainer | undefined) {
 /**
  * Based on the search string it does a fuzzy search over all the unique labels, so we can highlight them later.
  */
-function useLabelSearch(
+export function useLabelSearch(
   search: string | undefined,
   data: FlameGraphDataContainer | undefined
 ): Set<string> | undefined {
   return useMemo(() => {
-    if (search && data) {
-      const terms = search.split(',');
-      const foundLabels = new Set<string>();
+    if (!search || !data) {
+      // In this case undefined means there was no search so no attempt to
+      // highlighting anything should be made.
+      return undefined;
+    }
 
-      for (let term of terms) {
-        let idxs = ufuzzy.filter(data.getUniqueLabels(), term);
-        if (idxs) {
-          for (let idx of idxs) {
-            foundLabels.add(data.getUniqueLabels()[idx]);
-          }
-        }
+    return labelSearch(search, data);
+  }, [search, data]);
+}
+
+export function labelSearch(search: string, data: FlameGraphDataContainer): Set<string> {
+  const foundLabels = new Set<string>();
+  const terms = search.split(',');
+
+  const regexFilter = (labels: string[], pattern: string): boolean => {
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern);
+    } catch (e) {
+      return false;
+    }
+
+    let foundMatch = false;
+    for (let label of labels) {
+      if (!regex.test(label)) {
+        continue;
       }
 
-      return foundLabels;
+      foundLabels.add(label);
+      foundMatch = true;
     }
-    // In this case undefined means there was no search so no attempt to highlighting anything should be made.
-    return undefined;
-  }, [search, data]);
+    return foundMatch;
+  };
+
+  const fuzzyFilter = (labels: string[], term: string): boolean => {
+    let idxs = ufuzzy.filter(labels, term);
+    if (!idxs) {
+      return false;
+    }
+
+    let foundMatch = false;
+    for (let idx of idxs) {
+      foundLabels.add(labels[idx]);
+      foundMatch = true;
+    }
+    return foundMatch;
+  };
+
+  for (let term of terms) {
+    const found = regexFilter(data.getUniqueLabels(), term);
+    if (!found) {
+      fuzzyFilter(data.getUniqueLabels(), term);
+    }
+  }
+
+  return foundLabels;
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
@@ -323,12 +323,15 @@ function useLabelSearch(
 ): Set<string> | undefined {
   return useMemo(() => {
     if (search && data) {
+      const terms = search.split(',');
       const foundLabels = new Set<string>();
-      let idxs = ufuzzy.filter(data.getUniqueLabels(), search);
 
-      if (idxs) {
-        for (let idx of idxs) {
-          foundLabels.add(data.getUniqueLabels()[idx]);
+      for (let term of terms) {
+        let idxs = ufuzzy.filter(data.getUniqueLabels(), term);
+        if (idxs) {
+          for (let idx of idxs) {
+            foundLabels.add(data.getUniqueLabels()[idx]);
+          }
         }
       }
 

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
@@ -371,6 +371,10 @@ export function labelSearch(search: string, data: FlameGraphDataContainer): Set<
   };
 
   for (let term of terms) {
+    if (!term) {
+      continue;
+    }
+
     const found = regexFilter(data.getUniqueLabels(), term);
     if (!found) {
       fuzzyFilter(data.getUniqueLabels(), term);


### PR DESCRIPTION
Related: https://github.com/grafana/profiles-drilldown/issues/528

Fixes: https://github.com/grafana/profiles-drilldown/issues/530

**What is this feature?**

Improves the flame graph search bar to support regex patterns and searching for multiple terms at once. This brings the behavior inline with the "Search services" search bar in the Profiles Drilldown app.

<img width="1698" alt="Screenshot 2025-06-04 at 3 46 42 PM" src="https://github.com/user-attachments/assets/d3424ba7-03b6-4636-b27b-d11808030ac9" />

Terms are separated by commas and are OR'd together. Terms are first attempted to match as a regex, then using the existing fuzzy search. A term that forms an invalid regex will fall back to a fuzzy search.

Here is a demo of this feature. First `scanobject` is searched, then `futex`, finally a term to find all frames that end in a digit.

https://github.com/user-attachments/assets/5897f53f-3cd8-4d50-adb3-cda992fb0687

**Why do we need this feature?**

This aligns the flame graph component with existing behaviors in the Profiles Drilldown app and power users with more control over how they search for content in the flame graph.

**Who is this feature for?**

Pyroscope users.

Please check that:
- [x] It works as expected from a user's perspective.

/cc @simonswine 
