### PR TITLE
Alerting: Fix incorrect "not" wording for active timings

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/ActiveTimingFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/ActiveTimingFields.tsx
@@ -23,7 +23,7 @@ export function ActiveTimingFields({ alertmanager }: BaseAlertmanagerArgs) {
       data-testid="am-active-timing-select"
       description={t(
         'alerting.mute-timing-fields.am-active-timing-select-description-active-timings',
-        'Select a time interval to define when not to send notifications for this alert rule'
+        'Select a time interval to define when to only send notifications for this alert rule'
       )}
       className={styles.muteTimingField}
       invalid={!!errors.contactPoints?.[alertmanager]?.activeTimeIntervals}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1795,7 +1795,7 @@
       "title-delete-mute-timing": "Delete mute timing"
     },
     "mute-timing-fields": {
-      "am-active-timing-select-description-active-timings": "Select a time interval to define when not to send notifications for this alert rule",
+      "am-active-timing-select-description-active-timings": "Select a time interval to define when to only send notifications for this alert rule",
       "am-mute-timing-select-description-mute-timings": "Select a mute timing to define when not to send notifications for this alert rule",
       "am-mute-timing-select-label-mute-timings": "Mute timings"
     },


### PR DESCRIPTION
The help text for active timings on an alert was confusing, indicating that the time range would cause the alert not to notify, when it actually works as the only time the alert would notify.
