### PR TITLE
Alerting: Filter out synthetic datasource-managed rules when importing to GMA

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.test.tsx
@@ -1,5 +1,8 @@
+import { config } from '@grafana/runtime';
 import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
+import { pluginMeta, pluginMetaToPluginConfig } from '../../testSetup/plugins';
+import { SupportedPlugin } from '../../types/pluginBridges';
 import { GRAFANA_ORIGIN_LABEL } from '../../utils/labels';
 
 import { SYNTHETICS_RULE_NAMES, filterRulerRulesConfig } from './ConfirmConvertModal';
@@ -21,7 +24,7 @@ describe('filterRulerRulesConfig', () => {
             alert: 'Alert2',
             expr: 'down == 1',
             labels: {
-              [GRAFANA_ORIGIN_LABEL]: 'true',
+              [GRAFANA_ORIGIN_LABEL]: `plugin/${SupportedPlugin.Slo}`,
             },
           },
         ],
@@ -57,6 +60,7 @@ describe('filterRulerRulesConfig', () => {
   };
 
   it('should filter by namespace', () => {
+    config.apps = { [SupportedPlugin.Slo]: pluginMetaToPluginConfig(pluginMeta[SupportedPlugin.Slo]) };
     const { filteredConfig, someRulesAreSkipped } = filterRulerRulesConfig(mockRulesConfig, 'namespace1');
 
     expect(filteredConfig).toEqual({

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.test.tsx
@@ -2,7 +2,7 @@ import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import { GRAFANA_ORIGIN_LABEL } from '../../utils/labels';
 
-import { filterRulerRulesConfig } from './ConfirmConvertModal';
+import { SYNTHETICS_RULE_NAMES, filterRulerRulesConfig } from './ConfirmConvertModal';
 
 describe('filterRulerRulesConfig', () => {
   const mockRulesConfig: RulerRulesConfigDTO = {
@@ -32,6 +32,13 @@ describe('filterRulerRulesConfig', () => {
           {
             alert: 'Alert3',
             expr: 'error == 1',
+          },
+          {
+            alert: SYNTHETICS_RULE_NAMES[0],
+            expr: 'error == 1',
+            labels: {
+              namespace: 'synthetic_monitoring',
+            },
           },
         ],
       },
@@ -183,5 +190,47 @@ describe('filterRulerRulesConfig', () => {
 
     expect(filteredConfig).toEqual({});
     expect(someRulesAreSkipped).toBe(false);
+  });
+
+  it('should filter out synthetics rules', () => {
+    const { filteredConfig, someRulesAreSkipped } = filterRulerRulesConfig(mockRulesConfig);
+
+    expect(filteredConfig).toEqual({
+      namespace1: [
+        {
+          name: 'group1',
+          rules: [
+            {
+              alert: 'Alert1',
+              expr: 'up == 0',
+              labels: {
+                severity: 'warning',
+              },
+            },
+          ],
+        },
+        {
+          name: 'group2',
+          rules: [
+            {
+              alert: 'Alert3',
+              expr: 'error == 1',
+            },
+          ],
+        },
+      ],
+      namespace2: [
+        {
+          name: 'group3',
+          rules: [
+            {
+              alert: 'Alert4',
+              expr: 'test == 0',
+            },
+          ],
+        },
+      ],
+    });
+    expect(someRulesAreSkipped).toBe(true);
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -8,16 +8,24 @@ import { locationService } from '@grafana/runtime';
 import { Alert, CodeEditor, Collapse, ConfirmModal, Modal, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
-import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
+import { RulerRuleDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import { trackImportToGMAError, trackImportToGMASuccess } from '../../Analytics';
 import { convertToGMAApi } from '../../api/convertToGMAApi';
 import { GRAFANA_ORIGIN_LABEL } from '../../utils/labels';
 import { createListFilterLink } from '../../utils/navigation';
+import { rulerRuleType } from '../../utils/rules';
 
 import { ImportFormValues } from './ImportToGMARules';
 import { useGetRulesThatMightBeOverwritten, useGetRulesToBeImported } from './hooks';
 import { parseYamlFileToRulerRulesConfigDTO } from './yamlToRulerConverter';
+
+export const SYNTHETICS_RULE_NAMES = [
+  'SyntheticMonitoringCheckFailureAtHighSensitivity',
+  'SyntheticMonitoringCheckFailureAtMediumSensitivity',
+  'SyntheticMonitoringCheckFailureAtLowSensitivity',
+  'instance_job_severity:probe_success:mean5m',
+];
 
 type ModalProps = Pick<ComponentProps<typeof ConfirmModal>, 'isOpen' | 'onDismiss'> & {
   isOpen: boolean;
@@ -220,7 +228,9 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
 
 /**
  * Filter the ruler rules config to be imported. It filters the rules by namespace and group name.
- * It also filters out the rules that have the '__grafana_origin' label.
+ * It also filters out the rules that have the '__grafana_origin' label, and rules from synthetics that have the
+ * 'namespace: synthetic_monitoring' label.
+ * Precondition: these rules are cloud rules.
  * @param rulerRulesConfig - The ruler rules config to be imported
  * @param namespace - The namespace to filter the rules by
  * @param groupName - The group name to filter the rules by
@@ -248,8 +258,8 @@ export function filterRulerRulesConfig(
       })
       .map((group) => {
         const filteredRules = group.rules.filter((rule) => {
-          const hasGrafanaOriginLabel = rule.labels?.[GRAFANA_ORIGIN_LABEL];
-          if (hasGrafanaOriginLabel) {
+          const shouldSkip = shouldSkipRule(rule);
+          if (shouldSkip) {
             someRulesAreSkipped = true;
             return false;
           }
@@ -269,6 +279,35 @@ export function filterRulerRulesConfig(
   });
 
   return { filteredConfig, someRulesAreSkipped };
+}
+
+/*
+This function is used to check if the rule should be skipped.
+It checks if the rule has the '__grafana_origin' label, and if the rule is from synthetics.
+If the rule has the '__grafana_origin' label, it is skipped.
+If the rule is from synthetics, it is skipped.
+*/
+function shouldSkipRule(rule: RulerRuleDTO): boolean {
+  // check if the rule has the '__grafana_origin' label
+  const hasGrafanaOriginLabel = rule.labels?.[GRAFANA_ORIGIN_LABEL];
+  if (hasGrafanaOriginLabel) {
+    return true;
+  }
+  // check if the rule is from synthetics
+  const hasSyntheticsLabels = rule.labels?.namespace === 'synthetic_monitoring';
+  if (rulerRuleType.dataSource.rule(rule)) {
+    let hasSyntheticsRuleName = false;
+    if (rulerRuleType.dataSource.alertingRule(rule)) {
+      hasSyntheticsRuleName = SYNTHETICS_RULE_NAMES.some((name) => rule.alert?.includes(name));
+    } else {
+      // recording rule
+      hasSyntheticsRuleName = SYNTHETICS_RULE_NAMES.some((name) => rule.record?.includes(name));
+    }
+    if (hasSyntheticsRuleName && hasSyntheticsLabels) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function RulesPreview({ rules }: { rules: RulerRulesConfigDTO }) {


### PR DESCRIPTION

**What is this feature?**

This PR adds additional filter when importing datasource-managed rules through the UI.
It skips rules from synthetics monitoring see more context [here](https://raintank-corp.slack.com/archives/C075N182HFW/p1749038803494859?thread_ts=1749035526.869169&cid=C075N182HFW) 

**Why do we need this feature?**

Rules managed by plugins should not be imported. Synthetics rules don't use the `__grafana_origin` to indicate that they are managed by a plugin, so we need to filtering out these rules differently.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
