### PR TITLE
Chore: Remove `id-token: write` from workflow level

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,7 +39,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   capture-date:


### PR DESCRIPTION
**What is this feature?**

Makes zizmor happy and prevents the following:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/7eb7a9cb-a1c4-42ea-8340-7a22de343ec7" />
