### PR TITLE
Dashboard extrension: POC for adding to dashboard from grafana/runtime

### DIFF
--- a/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
+++ b/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
@@ -24,6 +24,7 @@ export function getExploreExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
         icon: 'apps',
         category: 'Dashboards',
         configure: () => {
+          // moving this and the ui to runtime
           const canAddPanelToDashboard =
             contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
             contextSrv.hasPermission(AccessControlAction.DashboardsWrite);


### PR DESCRIPTION


**What is this feature?**

This is. POC to expose "Add to dashboard" so that it can be used in the drilldown apps.

**Why do we need this feature?**

This will improve consumption and adoption

**Who is this feature for?**

This is for users of drilldown apps or other plugins.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/metrics-drilldown/issues/442

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
