### PR TITLE
Alerting: Add need more info for import ui datasource field

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -22,7 +22,7 @@ const ui = {
     yaml: byRole('radio', { name: /Import rules from a Prometheus YAML file./ }),
   },
   dsImport: {
-    dsPicker: byLabelText('Data source'),
+    dsPicker: byLabelText(/data source/i, { selector: '#datasource-picker' }),
     mimirDsOption: byRole('button', { name: /Mimir Prometheus$/ }),
   },
   yamlImport: {

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
@@ -31,6 +31,7 @@ import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { CreateNewFolder } from '../create-folder/CreateNewFolder';
 import { CloudRulesSourcePicker } from '../rule-editor/CloudRulesSourcePicker';
+import { NeedHelpInfo } from '../rule-editor/NeedHelpInfo';
 
 import { ConfirmConversionModal } from './ConfirmConvertModal';
 import { NamespaceAndGroupFilter } from './NamespaceAndGroupFilter';
@@ -449,7 +450,22 @@ function DataSourceField() {
 
   return (
     <Field
-      label={t('alerting.import-to-gma.datasource.label', 'Data source')}
+      label={
+        <Stack direction="row" gap={1}>
+          <Text variant="bodySmall" color="secondary">
+            {t('alerting.import-to-gma.datasource.label', 'Data source')}
+          </Text>
+          <NeedHelpInfo
+            externalLink={'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/alerting-migration/'}
+            linkText={`Read importing to Grafana alerting`}
+            contentText={t(
+              'alerting.import-to-gma.datasource.help-info.content',
+              'The dropdown only displays Mimir or Loki data sources that have the ruler API available.'
+            )}
+            title={t('alerting.import-to-gma.datasource.help-info.title', 'Data source')}
+          />
+        </Stack>
+      }
       invalid={!!errors.selectedDatasourceName}
       error={errors.selectedDatasourceName?.message}
       htmlFor="datasource-picker"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1518,6 +1518,10 @@
         "title": "Confirm import"
       },
       "datasource": {
+        "help-info": {
+          "content": "The dropdown only displays Mimir or Loki data sources that have the ruler API available.",
+          "title": "Data source"
+        },
         "label": "Data source",
         "required-message": "Please select a data source"
       },


### PR DESCRIPTION
**What is this feature?**

This PR adds the `Need help` to the data sources field in the import to GMA UI

**Why do we need this feature?**

We want to make it clear why some datasources are or are not shown in this dropdown

**Who is this feature for?**

Alerting users
**Special notes for your reviewer:**


https://github.com/user-attachments/assets/404991ec-331d-44d0-8895-03b9c9cd992d



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
