### PR TITLE
Alerting: Fix deadlocks in provenance table

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -353,6 +353,10 @@ export interface FeatureToggles {
   */
   alertmanagerRemoteSecondary?: boolean;
   /**
+  * Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL
+  */
+  alertingProvenanceLockWrites?: boolean;
+  /**
   * Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
   */
   alertmanagerRemotePrimary?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -586,6 +586,14 @@ var (
 			Owner:       grafanaAlertingSquad,
 		},
 		{
+			Name:              "alertingProvenanceLockWrites",
+			Description:       "Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaAlertingSquad,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+		},
+		{
 			Name:        "alertmanagerRemotePrimary",
 			Description: "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -77,6 +77,7 @@ cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-e
 prometheusCodeModeMetricNamesSearch,experimental,@grafana/oss-big-tent,false,false,true
 addFieldFromCalculationStatFunctions,GA,@grafana/dataviz-squad,false,false,true
 alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false
+alertingProvenanceLockWrites,experimental,@grafana/alerting-squad,false,false,false
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 extractFieldsNameDeduplication,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -319,6 +319,10 @@ const (
 	// Enable Grafana to sync configuration and state with a remote Alertmanager.
 	FlagAlertmanagerRemoteSecondary = "alertmanagerRemoteSecondary"
 
+	// FlagAlertingProvenanceLockWrites
+	// Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL
+	FlagAlertingProvenanceLockWrites = "alertingProvenanceLockWrites"
+
 	// FlagAlertmanagerRemotePrimary
 	// Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
 	FlagAlertmanagerRemotePrimary = "alertmanagerRemotePrimary"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -353,6 +353,20 @@
     },
     {
       "metadata": {
+        "name": "alertingProvenanceLockWrites",
+        "resourceVersion": "1753284360846",
+        "creationTimestamp": "2025-07-23T15:26:00Z"
+      },
+      "spec": {
+        "description": "Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingQueryAndExpressionsStepMode",
         "resourceVersion": "1750434297879",
         "creationTimestamp": "2024-09-26T06:33:14Z"

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -71,50 +72,60 @@ func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, org
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.
 
-		// Check if the record exists with FOR UPDATE lock.
-		// If it does, we just update, otherwise we upsert the record.
-		// This is done to avoid deadlocks that can occur in MySQL when multiple transactions try to
-		// insert records (even different) because of the gap and insert intention locks.
-		exists, err := sess.Table(provenanceRecord{}).
-			Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
-			ForUpdate().
-			Exist()
-		if err != nil {
-			return fmt.Errorf("failed to check if provenance record exists: %w", err)
+		if st.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingProvenanceLockWrites) {
+			return st.setProvenanceWithLocking(sess, recordKey, recordType, org, p)
 		}
-
-		if exists {
-			// Update existing record
-			_, err = sess.Table(provenanceRecord{}).
-				Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
-				Update(map[string]interface{}{
-					"provenance": p,
-				})
-			if err != nil {
-				return fmt.Errorf("failed to update provenance status: %w", err)
-			}
-		} else {
-			// Still upsert in case it was created while we were checking
-			upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
-				provenanceRecord{}.TableName(),
-				[]string{"record_key", "record_type", "org_id"},
-				[]string{"record_key", "record_type", "org_id", "provenance"})
-
-			params := []interface{}{
-				recordKey,
-				recordType,
-				org,
-				p,
-			}
-
-			_, err := sess.SQL(upsertSQL, params...).Query()
-			if err != nil {
-				return fmt.Errorf("failed to store provisioning status: %w", err)
-			}
-		}
-
-		return nil
+		return st.setProvenanceUpsert(sess, recordKey, recordType, org, p)
 	})
+}
+
+func (st DBstore) setProvenanceUpsert(sess *db.Session, recordKey, recordType string, org int64, p models.Provenance) error {
+	upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
+		provenanceRecord{}.TableName(),
+		[]string{"record_key", "record_type", "org_id"},
+		[]string{"record_key", "record_type", "org_id", "provenance"})
+
+	params := []interface{}{
+		recordKey,
+		recordType,
+		org,
+		p,
+	}
+
+	_, err := sess.SQL(upsertSQL, params...).Query()
+	if err != nil {
+		return fmt.Errorf("failed to store provisioning status: %w", err)
+	}
+	return nil
+}
+
+func (st DBstore) setProvenanceWithLocking(sess *db.Session, recordKey, recordType string, org int64, p models.Provenance) error {
+	// Check if the record exists with FOR UPDATE lock.
+	// If it does, we just update, otherwise we upsert the record.
+	// This is done to avoid deadlocks that can occur in MySQL when multiple transactions try to
+	// insert records (even different) because of the gap and insert intention locks.
+	exists, err := sess.Table(provenanceRecord{}).
+		Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+		ForUpdate().
+		Exist()
+	if err != nil {
+		return fmt.Errorf("failed to check if provenance record exists: %w", err)
+	}
+
+	if exists {
+		_, err = sess.Table(provenanceRecord{}).
+			Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+			Update(map[string]interface{}{
+				"provenance": p,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to store provisioning status: %w", err)
+		}
+		return nil
+	}
+
+	// Still upsert in case it was created while we were checking
+	return st.setProvenanceUpsert(sess, recordKey, recordType, org, p)
 }
 
 // DeleteProvenance deletes the provenance record from the table

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -70,21 +70,47 @@ func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, org
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.
-		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
-			provenanceRecord{}.TableName(),
-			[]string{"record_key", "record_type", "org_id"},
-			[]string{"record_key", "record_type", "org_id", "provenance"})
 
-		params := []interface{}{
-			recordKey,
-			recordType,
-			org,
-			p,
+		// Check if the record exists with FOR UPDATE lock.
+		// If it does, we just update, otherwise we upsert the record.
+		// This is done to avoid deadlocks that can occur in MySQL when multiple transactions try to
+		// insert records (even different) because of the gap and insert intention locks.
+		exists, err := sess.Table(provenanceRecord{}).
+			Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+			ForUpdate().
+			Exist()
+		if err != nil {
+			return fmt.Errorf("failed to check if provenance record exists: %w", err)
 		}
 
-		_, err := sess.SQL(upsertSQL, params...).Query()
-		if err != nil {
-			return fmt.Errorf("failed to store provisioning status: %w", err)
+		if exists {
+			// Update existing record
+			_, err = sess.Table(provenanceRecord{}).
+				Where("record_key = ? AND record_type = ? AND org_id = ?", recordKey, recordType, org).
+				Update(map[string]interface{}{
+					"provenance": p,
+				})
+			if err != nil {
+				return fmt.Errorf("failed to update provenance status: %w", err)
+			}
+		} else {
+			// Still upsert in case it was created while we were checking
+			upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
+				provenanceRecord{}.TableName(),
+				[]string{"record_key", "record_type", "org_id"},
+				[]string{"record_key", "record_type", "org_id", "provenance"})
+
+			params := []interface{}{
+				recordKey,
+				recordType,
+				org,
+				p,
+			}
+
+			_, err := sess.SQL(upsertSQL, params...).Query()
+			if err != nil {
+				return fmt.Errorf("failed to store provisioning status: %w", err)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
**What is this feature?**

This PR further improves concurrent updates to the provenance table (a follow-up for https://github.com/grafana/grafana/pull/101688). The fix explicitly checks for a provenance record using `SELECT ... FOR UPDATE` for the databases that support it before performing either an update or upsert operation. This preemptive locking reduces the possibility of deadlocks in MySQL.

This works only with the `alertingProvenanceLockWrites` feature flag enabled.

**Why do we need this feature?**

The current implementation (directly performing upserts without prior locking) may still encounter deadlocks because of the gap and insert-intention locks in some configurations, for example, with repeatable-read transaction isolation level in MySQL+InnoDB.

This PR fixes this. I ran some tests multiple times on MySQL and PostgreSQL (both repeatable-read, and read-commited for both databases), and in both cases concurrent updates worked fine:

```
# call concurrent inserts/updates of multiple rule groups with 20 rules each
mimirtool rules sync --rule-dirs test-tmp --concurrency 10
...
Sync Summary: 600 Groups Created, 0 Groups Updated, 0 Groups Deleted

# update the folder: add new namespaces and delete some old namespaces

mimirtool rules sync --rule-dirs test-tmp --concurrency 10
...
Sync Summary: 600 Groups Created, 100 Groups Updated, 400 Groups Deleted
```


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
