### PR TITLE
grafana-data: Fix error when field values are null

### DIFF
--- a/packages/grafana-data/src/utils/csv.test.ts
+++ b/packages/grafana-data/src/utils/csv.test.ts
@@ -179,4 +179,23 @@ describe('DataFrame to CSV', () => {
       1589455688623,1234"
     `);
   });
+
+  it('should handle null values', () => {
+    const dataFrame = new MutableDataFrame({
+      fields: [
+        { name: 'Time', values: [1589455688623] },
+        {
+          name: 'Value',
+          type: FieldType.other,
+          values: [null],
+        },
+      ],
+    });
+
+    const csv = toCSV([dataFrame]);
+    expect(csv).toMatchInlineSnapshot(`
+      ""Time","Value"
+      1589455688623,null"
+    `);
+  });
 });

--- a/packages/grafana-data/src/utils/csv.test.ts
+++ b/packages/grafana-data/src/utils/csv.test.ts
@@ -164,11 +164,11 @@ describe('DataFrame to CSV', () => {
   it('should handle field type frame', () => {
     const dataFrame = new MutableDataFrame({
       fields: [
-        { name: 'Time', values: [1589455688623] },
+        { name: 'Time', values: [1589455688623, 1589455692345] },
         {
           name: 'Value',
           type: FieldType.frame,
-          values: [{ value: '1234' }],
+          values: [{ value: '1234' }, { value: '0' }],
         },
       ],
     });
@@ -176,7 +176,8 @@ describe('DataFrame to CSV', () => {
     const csv = toCSV([dataFrame]);
     expect(csv).toMatchInlineSnapshot(`
       ""Time","Value"
-      1589455688623,1234"
+      1589455688623,1234
+      1589455692345,0"
     `);
   });
 
@@ -195,7 +196,7 @@ describe('DataFrame to CSV', () => {
     const csv = toCSV([dataFrame]);
     expect(csv).toMatchInlineSnapshot(`
       ""Time","Value"
-      1589455688623,null"
+      1589455688623,"
     `);
   });
 });

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -310,12 +310,15 @@ export function toCSV(data: DataFrame[], config?: CSVConfig): string {
           }
 
           let v = fields[j].values[i];
-          // For FieldType frame, use value if it exists to prevent exporting [object object]
-          if (fields[j].type === FieldType.frame && v?.value) {
-            v = v.value;
-          }
 
-          csv += v === null ? 'null' : writers[j](v);
+          if (v !== null) {
+            // For FieldType frame, use value if it exists to prevent exporting [object object]
+            if (fields[j].type === FieldType.frame && 'value' in v) {
+              v = v.value;
+            }
+
+            csv += writers[j](v);
+          }
         }
 
         if (i !== length - 1) {

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -306,21 +306,23 @@ export function toCSV(data: DataFrame[], config?: CSVConfig): string {
       for (let i = 0; i < length; i++) {
         for (let j = 0; j < fields.length; j++) {
           if (j > 0) {
-            csv = csv + config.delimiter;
+            csv += config.delimiter;
           }
 
           let v = fields[j].values[i];
           // For FieldType frame, use value if it exists to prevent exporting [object object]
-          if (fields[j].type === FieldType.frame && fields[j].values[i].value) {
-            v = fields[j].values[i].value;
+          if (fields[j].type === FieldType.frame && v?.value) {
+            v = v.value;
           }
-          if (v !== null) {
-            csv = csv + writers[j](v);
+          if (v === null) {
+            csv += 'null';
+          } else {
+            csv += writers[j](v);
           }
         }
 
         if (i !== length - 1) {
-          csv = csv + config.newline;
+          csv += config.newline;
         }
       }
     }

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -314,11 +314,8 @@ export function toCSV(data: DataFrame[], config?: CSVConfig): string {
           if (fields[j].type === FieldType.frame && v?.value) {
             v = v.value;
           }
-          if (v === null) {
-            csv += 'null';
-          } else {
-            csv += writers[j](v);
-          }
+
+          csv += v === null ? 'null' : writers[j](v);
         }
 
         if (i !== length - 1) {


### PR DESCRIPTION
Fixes an issue where CSV download would not work if a field has `null` values.

Note: It's not clear to me who actually owns this code 😅 

See https://github.com/grafana/support-escalations/issues/16644