### PR TITLE
CommandPalette: Register and display recent actions

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -66,6 +66,10 @@ export class AppChromeService {
     }
   }
 
+  public getCurrentRoutePath() {
+    return this.currentRoute?.path;
+  }
+
   public update(update: Partial<AppChromeState>) {
     const current = this.state.getValue();
     const newState: AppChromeState = {

--- a/public/app/core/services/recentActionsSrv.ts
+++ b/public/app/core/services/recentActionsSrv.ts
@@ -1,0 +1,52 @@
+import { isArray } from 'lodash';
+
+import store from 'app/core/store';
+
+export interface RecentAction {
+  id: string;
+  url: string;
+  title: string;
+  timestamp: number;
+}
+
+const STORAGE_KEY = 'grafana.recentActions';
+const MAX_RECENT_ACTIONS = 5;
+
+export function addRecentAction(action: Omit<RecentAction, 'timestamp'>) {
+  let stored = getRecentActions();
+
+  const newAction = { ...action, timestamp: Date.now() };
+
+  const filtered = [];
+  for (let i = 0; i < stored.length; i++) {
+    if (stored[i].id !== action.id) {
+      filtered.push(stored[i]);
+    }
+  }
+
+  const updated = [newAction, ...filtered];
+
+  for (let i = 0; i < updated.length - 1; i++) {
+    for (let j = i + 1; j < updated.length; j++) {
+      if (updated[i].timestamp < updated[j].timestamp) {
+        const temp = updated[i];
+        updated[i] = updated[j];
+        updated[j] = temp;
+      }
+    }
+  }
+
+  updated.length = Math.min(updated.length, MAX_RECENT_ACTIONS);
+
+  store.set(STORAGE_KEY, JSON.stringify(updated));
+}
+
+export function getRecentActions(): RecentAction[] {
+  try {
+    const raw = store.get(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -20,6 +20,7 @@ import {
   useRegisterRecentScopesActions,
   useRegisterScopesActions,
   useRegisterStaticActions,
+  useRecentGeneralActions,
 } from './actions/useActions';
 import { CommandPaletteAction } from './types';
 import { useMatches } from './useMatches';
@@ -53,6 +54,8 @@ function CommandPaletteContents() {
 
   const queryToggle = useCallback(() => query.toggle(), [query]);
   const { scopesRow } = useRegisterScopesActions(searchQuery, queryToggle, currentRootActionId);
+
+  useRecentGeneralActions(searchQuery);
 
   // Dashboards and folders
   const { searchResults, isFetchingSearchResults } = useSearchResults(searchQuery, showing);

--- a/public/app/features/commandPalette/actions/recentActions.test.ts
+++ b/public/app/features/commandPalette/actions/recentActions.test.ts
@@ -1,0 +1,101 @@
+import { getRecentGeneralActions } from './recentActions';
+
+jest.mock('app/core/services/recentActionsSrv', () => ({
+  getRecentActions: jest.fn(),
+}));
+
+describe('recentActions', () => {
+  let getRecentActionsSpy: jest.SpyInstance;
+
+  const mockRecentItems = [
+    {
+      id: 'dashboard-1',
+      title: 'Viewed Dashboard 1',
+      url: '/d/dashboard-1',
+    },
+    {
+      id: 'explore-1',
+      title: 'Explored Data',
+      url: '/explore',
+    },
+    {
+      id: 'dashboard-2',
+      title: 'Viewed Dashboard 2',
+      url: '/d/dashboard-2',
+    },
+    {
+      id: 'alert-1',
+      title: 'Checked Alert',
+      url: '/alerting/1',
+    },
+    {
+      id: 'settings-1',
+      title: 'Opened Settings',
+      url: '/settings',
+    },
+  ];
+
+  beforeAll(() => {
+    getRecentActionsSpy = jest.spyOn(require('app/core/services/recentActionsSrv'), 'getRecentActions');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getRecentGeneralActions', () => {
+    it('returns an array of CommandPaletteActions based on recent activity', async () => {
+      getRecentActionsSpy.mockReturnValue(mockRecentItems);
+
+      const results = await getRecentGeneralActions();
+
+      expect(getRecentActionsSpy).toHaveBeenCalled();
+      expect(results).toEqual([
+        {
+          id: 'recent-action-dashboard-1',
+          name: 'Viewed Dashboard 1',
+          section: 'Recent actions',
+          url: '/d/dashboard-1',
+          priority: 7,
+        },
+        {
+          id: 'recent-action-explore-1',
+          name: 'Explored Data',
+          section: 'Recent actions',
+          url: '/explore',
+          priority: 7,
+        },
+        {
+          id: 'recent-action-dashboard-2',
+          name: 'Viewed Dashboard 2',
+          section: 'Recent actions',
+          url: '/d/dashboard-2',
+          priority: 7,
+        },
+        {
+          id: 'recent-action-alert-1',
+          name: 'Checked Alert',
+          section: 'Recent actions',
+          url: '/alerting/1',
+          priority: 7,
+        },
+        {
+          id: 'recent-action-settings-1',
+          name: 'Opened Settings',
+          section: 'Recent actions',
+          url: '/settings',
+          priority: 7,
+        },
+      ]);
+    });
+
+    it('returns an empty array if no recent actions are found', async () => {
+      getRecentActionsSpy.mockReturnValue([]);
+
+      const results = await getRecentGeneralActions();
+
+      expect(getRecentActionsSpy).toHaveBeenCalled();
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/public/app/features/commandPalette/actions/recentActions.ts
+++ b/public/app/features/commandPalette/actions/recentActions.ts
@@ -1,0 +1,19 @@
+import { t } from '@grafana/i18n/internal';
+import { getRecentActions } from 'app/core/services/recentActionsSrv';
+
+import { CommandPaletteAction } from '../types';
+import { RECENT_PAGES_PRIORITY } from '../values';
+
+// Retrieves a list of recently performed general actions and maps them into
+// `CommandPaletteAction` objects for display in the command palette.
+export async function getRecentGeneralActions(): Promise<CommandPaletteAction[]> {
+  const recent = getRecentActions();
+
+  return recent.map((item) => ({
+    id: `recent-action-${item.id}`,
+    name: item.title,
+    section: t('command-palette.section.recent-actions', 'Recent actions'),
+    url: item.url,
+    priority: RECENT_PAGES_PRIORITY,
+  }));
+}

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -14,6 +14,7 @@ import { CommandPaletteAction } from '../types';
 import { SCOPES_PRIORITY } from '../values';
 
 import { getRecentDashboardActions } from './dashboardActions';
+import { getRecentGeneralActions } from './recentActions';
 import { getRecentScopesActions } from './recentScopesActions';
 import { useStaticActions } from './staticActions';
 import useExtensionActions from './useExtensionActions';
@@ -50,6 +51,20 @@ export function useRegisterRecentDashboardsActions(searchQuery: string) {
 export function useRegisterRecentScopesActions() {
   const recentScopesActions = getRecentScopesActions();
   useRegisterActions(recentScopesActions, [recentScopesActions]);
+}
+
+export function useRecentGeneralActions(searchQuery: string) {
+  const [recentGeneralActions, setRecentGeneralActions] = useState<CommandPaletteAction[]>([]);
+  useEffect(() => {
+    if (!searchQuery) {
+      getRecentGeneralActions()
+        .then(setRecentGeneralActions)
+        .catch((err) => {
+          console.error('Error loading recent general actions', err);
+        });
+    }
+  }, [searchQuery]);
+  useRegisterActions(recentGeneralActions, [recentGeneralActions]);
 }
 
 /**

--- a/public/app/features/commandPalette/values.ts
+++ b/public/app/features/commandPalette/values.ts
@@ -1,5 +1,6 @@
-export const SCOPES_PRIORITY = 8;
-export const RECENT_SCOPES_PRIORITY = 7;
+export const SCOPES_PRIORITY = 9;
+export const RECENT_SCOPES_PRIORITY = 8;
+export const RECENT_PAGES_PRIORITY = 7;
 export const RECENT_DASHBOARDS_PRIORITY = 6;
 export const ACTIONS_PRIORITY = 5;
 export const DEFAULT_PRIORITY = 4;


### PR DESCRIPTION
Introduces support for registering and displaying recent actions in the command palette. A new service, recentActionsSrv.ts, was implemented to handle the storing and listing of recent actions. The useRecentGeneralActions hook was integrated to expose these actions in the command palette. Additionally, a React effect was added to Page.tsx to call addRecentAction, ensuring that each visited page is tracked and stored in the Grafana store. Tests were also added to cover the new functionality in both Page and recentActions.

Fixes #78227