### PR TITLE
Loki: Fix unescape request path building for Loki API

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -248,7 +248,7 @@ func makeRawRequest(ctx context.Context, lokiDsUrl string, resourcePath string) 
 
 	// we take the path and the query-string only
 	lokiUrl.RawQuery = resourceUrl.RawQuery
-	lokiUrl.Path = path.Join(lokiUrl.Path, resourceUrl.Path)
+	lokiUrl.Path = path.Join(lokiUrl.Path, resourceUrl.EscapedPath())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", lokiUrl.String(), nil)
 

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -280,3 +280,169 @@ func TestApiReturnValues(t *testing.T) {
 		require.ErrorContains(t, err, "foo")
 	})
 }
+
+func TestMakeRawRequest(t *testing.T) {
+	ctx := context.Background()
+	lokiDsUrl := "http://localhost:3100"
+
+	tests := []struct {
+		name          string
+		resourcePath  string
+		expectedPath  string
+		expectedQuery string
+		description   string
+	}{
+		{
+			name:          "basic path without encoding",
+			resourcePath:  "/loki/api/v1/labels",
+			expectedPath:  "/loki/api/v1/labels",
+			expectedQuery: "",
+			description:   "Should handle basic path without any encoding",
+		},
+		{
+			name:          "path with encoded spaces",
+			resourcePath:  "/loki/api/v1/label/my%20label/values",
+			expectedPath:  "/loki/api/v1/label/my%20label/values",
+			expectedQuery: "",
+			description:   "Should preserve %20 encoding for spaces in path segments",
+		},
+		{
+			name:          "path with encoded special characters",
+			resourcePath:  "/loki/api/v1/label/label%40with%23special%24chars/values",
+			expectedPath:  "/loki/api/v1/label/label%40with%23special%24chars/values",
+			expectedQuery: "",
+			description:   "Should preserve encoding for special characters (@#$)",
+		},
+		{
+			name:          "path with encoded slashes",
+			resourcePath:  "/loki/api/v1/label/path%2Fwith%2Fslashes/values",
+			expectedPath:  "/loki/api/v1/label/path%2Fwith%2Fslashes/values",
+			expectedQuery: "",
+			description:   "Should preserve %2F encoding for slashes in path segments",
+		},
+		{
+			name:          "path with query parameters",
+			resourcePath:  "/loki/api/v1/labels?start=2023-01-01T00:00:00Z&end=2023-01-01T01:00:00Z",
+			expectedPath:  "/loki/api/v1/labels",
+			expectedQuery: "start=2023-01-01T00:00:00Z&end=2023-01-01T01:00:00Z",
+			description:   "Should separate path and query parameters correctly",
+		},
+		{
+			name:          "encoded path with query parameters",
+			resourcePath:  "/loki/api/v1/label/my%20label/values?query=%7Bservice%3D%22auth%22%7D",
+			expectedPath:  "/loki/api/v1/label/my%20label/values",
+			expectedQuery: "query=%7Bservice%3D%22auth%22%7D",
+			description:   "Should preserve encoding in both path and query parameters",
+		},
+		{
+			name:          "multiple encoded segments",
+			resourcePath:  "/loki/api/v1/label/env%3Aproduction%2Fservice%40auth/values",
+			expectedPath:  "/loki/api/v1/label/env%3Aproduction%2Fservice%40auth/values",
+			expectedQuery: "",
+			description:   "Should preserve encoding across multiple path segments",
+		},
+		{
+			name:          "path with plus encoding",
+			resourcePath:  "/loki/api/v1/label/label+with+plus/values",
+			expectedPath:  "/loki/api/v1/label/label+with+plus/values",
+			expectedQuery: "",
+			description:   "Should preserve + characters in path segments",
+		},
+		{
+			name:          "path with mixed encoding",
+			resourcePath:  "/loki/api/v1/label/mixed%20encoding+and%2Fspecial%40chars/values?filter=value%2Bwith%2Bplus",
+			expectedPath:  "/loki/api/v1/label/mixed%20encoding+and%2Fspecial%40chars/values",
+			expectedQuery: "filter=value%2Bwith%2Bplus",
+			description:   "Should handle mixed encoding types correctly",
+		},
+		{
+			name:          "path with unicode encoding",
+			resourcePath:  "/loki/api/v1/label/unicode%E2%9C%93check/values",
+			expectedPath:  "/loki/api/v1/label/unicode%E2%9C%93check/values",
+			expectedQuery: "",
+			description:   "Should preserve Unicode character encoding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := makeRawRequest(ctx, lokiDsUrl, tt.resourcePath)
+			require.NoError(t, err, "makeRawRequest should not return an error")
+			require.NotNil(t, req, "Request should not be nil")
+
+			// Test the path
+			require.Equal(t, tt.expectedPath, req.URL.Path, tt.description+" - path mismatch")
+
+			// Test the query
+			require.Equal(t, tt.expectedQuery, req.URL.RawQuery, tt.description+" - query mismatch")
+
+			// Test the base URL is preserved
+			require.Equal(t, "localhost:3100", req.URL.Host, "Host should be preserved")
+			require.Equal(t, "http", req.URL.Scheme, "Scheme should be preserved")
+
+			// Test the method
+			require.Equal(t, "GET", req.Method, "Method should be GET")
+
+			// Test context
+			require.Equal(t, ctx, req.Context(), "Context should be preserved")
+		})
+	}
+}
+
+func TestMakeRawRequest_Errors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid loki URL", func(t *testing.T) {
+		invalidUrl := "://invalid-url"
+		resourcePath := "/loki/api/v1/labels"
+
+		req, err := makeRawRequest(ctx, invalidUrl, resourcePath)
+		require.Error(t, err, "Should return error for invalid loki URL")
+		require.Nil(t, req, "Request should be nil on error")
+	})
+
+	t.Run("invalid resource path", func(t *testing.T) {
+		lokiDsUrl := "http://localhost:3100"
+		invalidResourcePath := "://invalid-resource-path"
+
+		req, err := makeRawRequest(ctx, lokiDsUrl, invalidResourcePath)
+		require.Error(t, err, "Should return error for invalid resource path")
+		require.Nil(t, req, "Request should be nil on error")
+	})
+}
+
+func TestMakeRawRequest_ComplexScenarios(t *testing.T) {
+	ctx := context.Background()
+	lokiDsUrl := "https://loki.example.com:9090/custom/path"
+
+	t.Run("complex base URL with encoded resource path", func(t *testing.T) {
+		resourcePath := "/loki/api/v1/label/complex%2Flabel%40name/values?start=2023-01-01&query=%7Bapp%3D%22test%22%7D"
+
+		req, err := makeRawRequest(ctx, lokiDsUrl, resourcePath)
+		require.NoError(t, err)
+		require.NotNil(t, req)
+
+		// The path should join the base URL path with the resource path
+		expectedPath := "/custom/path/loki/api/v1/label/complex%2Flabel%40name/values"
+		require.Equal(t, expectedPath, req.URL.Path)
+
+		expectedQuery := "start=2023-01-01&query=%7Bapp%3D%22test%22%7D"
+		require.Equal(t, expectedQuery, req.URL.RawQuery)
+
+		require.Equal(t, "loki.example.com:9090", req.URL.Host)
+		require.Equal(t, "https", req.URL.Scheme)
+	})
+
+	t.Run("resource path with fragment", func(t *testing.T) {
+		// Note: fragments are typically not used in server requests and are not sent to servers
+		resourcePath := "/loki/api/v1/labels#fragment"
+
+		req, err := makeRawRequest(ctx, lokiDsUrl, resourcePath)
+		require.NoError(t, err)
+		require.NotNil(t, req)
+
+		// Fragment should be empty in server requests (standard HTTP behavior)
+		require.Equal(t, "", req.URL.Fragment)
+		require.Equal(t, "/custom/path/loki/api/v1/labels", req.URL.Path)
+	})
+}


### PR DESCRIPTION
**What is this feature?**  
This PR fixes the handling of raw, encoded paths in the Loki API integration. Specifically, it ensures that encoded path segments (such as %20 for spaces, %2F for slashes, and other special characters) are preserved and correctly passed through when constructing requests to the Loki backend. This prevents double-unescaping or incorrect path resolution, which could lead to failed or misrouted API calls.

**Why do we need this feature?**  
Previously, the code did not properly preserve encoded path segments when joining paths, which could result in incorrect API requests—especially when paths contained encoded characters. This fix ensures that all encoded characters in the resource path are respected, improving compatibility with Loki endpoints that rely on precise path encoding.

**Who is this feature for?**  
This fix is for users and developers who interact with the Loki API through Grafana, particularly those whose queries or integrations require encoded path segments (e.g., labels or values containing spaces, slashes, or special characters).

**Which issue(s) does this PR fix?**:  

-

**Special notes for your reviewer:**  
Please check that:
- [ ] The fix works as expected from a user's perspective, especially for paths with encoded characters.
- [ ] All relevant test cases are covered, including edge cases for path and query encoding.
- [ ] Documentation is updated if necessary.
- [ ] If this is a notable improvement, consider adding it to the [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

### Summary of changes

- Updated pkg/tsdb/loki/api.go to use resourceUrl.EscapedPath() when joining paths, preserving encoded segments.
- Added comprehensive tests in pkg/tsdb/loki/api_test.go to cover various scenarios involving encoded paths, queries, and error handling.

