### PR TITLE
VQB: Add selected columns to GROUP BY dropdown (#106349)

### DIFF
--- a/packages/grafana-sql/src/components/visual-query-builder/SQLGroupByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SQLGroupByRow.tsx
@@ -2,10 +2,10 @@ import { SelectableValue } from '@grafana/data';
 
 import { QueryWithDefaults } from '../../defaults';
 import { DB, SQLQuery } from '../../types';
+import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
 import { useSqlChange } from '../../utils/useSqlChange';
 
 import { GroupByRow } from './GroupByRow';
-import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
 
 interface SQLGroupByRowProps {
   fields: SelectableValue[];
@@ -16,6 +16,6 @@ interface SQLGroupByRowProps {
 
 export function SQLGroupByRow({ fields, query, onQueryChange, db }: SQLGroupByRowProps) {
   const { onSqlChange } = useSqlChange({ query, onQueryChange, db });
-  let columnsWithIndices: SelectableValue[]=getColumnsWithIndices(query, fields);
+  let columnsWithIndices: SelectableValue[] = getColumnsWithIndices(query, fields);
   return <GroupByRow columns={columnsWithIndices} sql={query.sql!} onSqlChange={onSqlChange} />;
 }

--- a/packages/grafana-sql/src/components/visual-query-builder/SQLGroupByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SQLGroupByRow.tsx
@@ -5,6 +5,7 @@ import { DB, SQLQuery } from '../../types';
 import { useSqlChange } from '../../utils/useSqlChange';
 
 import { GroupByRow } from './GroupByRow';
+import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
 
 interface SQLGroupByRowProps {
   fields: SelectableValue[];
@@ -15,6 +16,6 @@ interface SQLGroupByRowProps {
 
 export function SQLGroupByRow({ fields, query, onQueryChange, db }: SQLGroupByRowProps) {
   const { onSqlChange } = useSqlChange({ query, onQueryChange, db });
-
-  return <GroupByRow columns={fields} sql={query.sql!} onSqlChange={onSqlChange} />;
+  let columnsWithIndices: SelectableValue[]=getColumnsWithIndices(query, fields);
+  return <GroupByRow columns={columnsWithIndices} sql={query.sql!} onSqlChange={onSqlChange} />;
 }

--- a/packages/grafana-sql/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -2,11 +2,10 @@ import { SelectableValue } from '@grafana/data';
 
 import { QueryWithDefaults } from '../../defaults';
 import { DB, SQLQuery } from '../../types';
+import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
 import { useSqlChange } from '../../utils/useSqlChange';
 
 import { OrderByRow } from './OrderByRow';
-
-import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
 
 type SQLOrderByRowProps = {
   fields: SelectableValue[];
@@ -17,6 +16,6 @@ type SQLOrderByRowProps = {
 
 export function SQLOrderByRow({ fields, query, onQueryChange, db }: SQLOrderByRowProps) {
   const { onSqlChange } = useSqlChange({ query, onQueryChange, db });
-  let columnsWithIndices: SelectableValue[]=getColumnsWithIndices(query, fields);
+  let columnsWithIndices: SelectableValue[] = getColumnsWithIndices(query, fields);
   return <OrderByRow sql={query.sql!} onSqlChange={onSqlChange} columns={columnsWithIndices} />;
 }

--- a/packages/grafana-sql/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -6,6 +6,8 @@ import { useSqlChange } from '../../utils/useSqlChange';
 
 import { OrderByRow } from './OrderByRow';
 
+import { getColumnsWithIndices } from '../../utils/getColumnsWithIndices';
+
 type SQLOrderByRowProps = {
   fields: SelectableValue[];
   query: QueryWithDefaults;
@@ -15,26 +17,6 @@ type SQLOrderByRowProps = {
 
 export function SQLOrderByRow({ fields, query, onQueryChange, db }: SQLOrderByRowProps) {
   const { onSqlChange } = useSqlChange({ query, onQueryChange, db });
-  let columnsWithIndices: SelectableValue[] = [];
-
-  if (fields) {
-    const options = query.sql?.columns?.map((c, i) => {
-      const value = c.name ? `${c.name}(${c.parameters?.map((p) => p.name)})` : c.parameters?.map((p) => p.name);
-      return {
-        value,
-        label: `${i + 1} - ${value}`,
-      };
-    });
-    columnsWithIndices = [
-      {
-        value: '',
-        label: 'Selected columns',
-        options,
-        expanded: true,
-      },
-      ...fields,
-    ];
-  }
-
+  let columnsWithIndices: SelectableValue[]=getColumnsWithIndices(query, fields);
   return <OrderByRow sql={query.sql!} onSqlChange={onSqlChange} columns={columnsWithIndices} />;
 }

--- a/packages/grafana-sql/src/utils/getColumnsWithIndices.ts
+++ b/packages/grafana-sql/src/utils/getColumnsWithIndices.ts
@@ -1,0 +1,28 @@
+import { SelectableValue } from '@grafana/data';
+import { SQLQuery } from '../types';
+
+export function getColumnsWithIndices(query: SQLQuery, fields: SelectableValue[]): SelectableValue[] {
+  if (!fields || !query.sql?.columns) {
+    return fields;
+  }
+
+  const options = query.sql.columns.map((c, i) => {
+    const value = c.name
+      ? `${c.name}(${c.parameters?.map((p) => p.name).join(', ')})`
+      : c.parameters?.map((p) => p.name).join(', ');
+    return {
+      value,
+      label: `${i + 1} - ${value}`,
+    };
+  });
+
+  return [
+    {
+      value: '',
+      label: 'Selected columns',
+      options,
+      expanded: true,
+    },
+    ...fields,
+  ];
+}

--- a/packages/grafana-sql/src/utils/getColumnsWithIndices.ts
+++ b/packages/grafana-sql/src/utils/getColumnsWithIndices.ts
@@ -1,4 +1,5 @@
 import { SelectableValue } from '@grafana/data';
+
 import { SQLQuery } from '../types';
 
 export function getColumnsWithIndices(query: SQLQuery, fields: SelectableValue[]): SelectableValue[] {


### PR DESCRIPTION
## What this PR does / why we need it
Fixes an inconsistency in the Visual Query Builder where the GROUP BY dropdown did not show selected columns as options, while the ORDER BY dropdown did. This made it impossible to group by columns that were already selected in the query.

## Changes made
- Extracted the column selection logic from `SQLOrderByRow.tsx` into a reusable utility function `getColumnsWithIndices`
- Applied the same logic to `SQLGroupByRow.tsx` to show selected columns in the GROUP BY dropdown
- Both ORDER BY and GROUP BY dropdowns now consistently display:
  - A "Selected columns" group containing all columns from the SELECT clause with index labels
  - All available table fields
  
## Files changed

- `packages/grafana-sql/src/utils/getColumnsWithIndices.ts` - New utility function extracted from ORDER BY logic
- `packages/grafana-sql/src/components/visual-query-builder/SQLOrderByRow.tsx` - Refactored to use the new utility function
- `packages/grafana-sql/src/components/visual-query-builder/SQLGroupByRow.tsx` - Updated to include selected columns in dropdown

Fixes #106349