### PR TITLE
New Logs Panel: Add Popover Menu support

### DIFF
--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -74,7 +74,7 @@ export interface Props {
   renderPreview?: boolean;
 }
 
-type PopoverStateType = {
+export type PopoverStateType = {
   selection: string;
   selectedRow: LogRowModel | null;
   popoverMenuCoordinates: { x: number; y: number };

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState, MouseEvent } from 'react';
 import { usePrevious } from 'react-use';
 import { ListChildComponentProps, ListOnItemsRenderedProps } from 'react-window';
 
@@ -26,7 +26,7 @@ interface Props {
   handleOverflow: (index: number, id: string, height?: number) => void;
   loadMore?: (range: AbsoluteTimeRange) => void;
   logs: LogListModel[];
-  onClick: (log: LogListModel) => void;
+  onClick: (e: MouseEvent<HTMLElement>, log: LogListModel) => void;
   scrollElement: HTMLDivElement | null;
   setInitialScrollPosition: () => void;
   showTime: boolean;

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { CSSProperties, memo, useCallback, useEffect, useRef, useState } from 'react';
+import { CSSProperties, memo, useCallback, useEffect, useRef, useState, MouseEvent } from 'react';
 import tinycolor from 'tinycolor2';
 
 import { GrafanaTheme2, LogsDedupStrategy } from '@grafana/data';
@@ -27,7 +27,7 @@ export interface Props {
   showTime: boolean;
   style: CSSProperties;
   styles: LogLineStyles;
-  onClick: (log: LogListModel) => void;
+  onClick: (e: MouseEvent<HTMLElement>, log: LogListModel) => void;
   onOverflow?: (index: number, id: string, height?: number) => void;
   variant?: 'infinite-scroll';
   wrapLogMessage: boolean;
@@ -92,9 +92,12 @@ export const LogLine = ({
   }, [collapsed, index, log, onOverflow]);
 
   const { t } = useTranslate();
-  const handleClick = useCallback(() => {
-    onClick(log);
-  }, [log, onClick]);
+  const handleClick = useCallback(
+    (e: Event) => {
+      onClick(e, log);
+    },
+    [log, onClick]
+  );
 
   const detailsShown = detailsDisplayed(log);
 

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -93,7 +93,7 @@ export const LogLine = ({
 
   const { t } = useTranslate();
   const handleClick = useCallback(
-    (e: Event) => {
+    (e: MouseEvent<HTMLElement>) => {
       onClick(e, log);
     },
     [log, onClick]

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { CoreApp, getDefaultTimeRange, LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 
+import { disablePopoverMenu, enablePopoverMenu, isPopoverMenuDisabled } from '../../utils';
 import { createLogRow } from '../__mocks__/logRow';
 
 import { LogList, Props } from './LogList';
@@ -11,8 +12,22 @@ jest.mock('@grafana/runtime', () => {
   return {
     ...jest.requireActual('@grafana/runtime'),
     usePluginLinks: jest.fn().mockReturnValue({ links: [] }),
+    config: {
+      ...jest.requireActual('@grafana/runtime').config,
+      featureToggles: {
+        ...jest.requireActual('@grafana/runtime').config.featureToggles,
+        logRowsPopoverMenu: true,
+      },
+    },
   };
 });
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  isPopoverMenuDisabled: jest.fn(),
+  disablePopoverMenu: jest.fn(),
+  enablePopoverMenu: jest.fn(),
+}));
 
 describe('LogList', () => {
   let logs: LogRowModel[], defaultProps: Props;
@@ -26,7 +41,7 @@ describe('LogList', () => {
       containerElement: document.createElement('div'),
       dedupStrategy: LogsDedupStrategy.none,
       displayedFields: [],
-      enableLogDetails: false,
+      enableLogDetails: true,
       logs,
       showControls: false,
       showTime: false,
@@ -113,5 +128,108 @@ describe('LogList', () => {
     expect(screen.queryByText('Close log details')).not.toBeInTheDocument();
 
     spy.mockRestore();
+  });
+
+  describe('Popover menu', () => {
+    function setup(overrides: Partial<Props> = {}) {
+      return render(
+        <LogList {...defaultProps} onClickFilterString={jest.fn()} onClickFilterOutString={jest.fn()} {...overrides} />
+      );
+    }
+    let orgGetSelection: () => Selection | null;
+    beforeEach(() => {
+      jest.mocked(isPopoverMenuDisabled).mockReturnValue(false);
+    });
+    beforeAll(() => {
+      orgGetSelection = document.getSelection;
+      jest.spyOn(document, 'getSelection').mockReturnValue({
+        toString: () => 'selected log line',
+        removeAllRanges: () => {},
+        addRange: (range: Range) => {},
+      } as Selection);
+    });
+    afterAll(() => {
+      document.getSelection = orgGetSelection;
+    });
+    it('Does not appear in the document', () => {
+      setup();
+      expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+    });
+    it('Appears after selecting text', async () => {
+      setup();
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.getByText('Copy selection')).toBeInTheDocument();
+      expect(screen.getByText('Add as line contains filter')).toBeInTheDocument();
+      expect(screen.getByText('Add as line does not contain filter')).toBeInTheDocument();
+    });
+    it('Can be disabled', async () => {
+      setup();
+      await userEvent.click(screen.getByText('log message 1'));
+      await userEvent.click(screen.getByText('Disable menu'));
+      await userEvent.click(screen.getByText('Confirm'));
+      expect(disablePopoverMenu).toHaveBeenCalledTimes(1);
+    });
+    it('Does not appear when disabled', async () => {
+      jest.mocked(isPopoverMenuDisabled).mockReturnValue(true);
+      setup();
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+    });
+    it('Can be re-enabled', async () => {
+      jest.mocked(isPopoverMenuDisabled).mockReturnValue(true);
+      const user = userEvent.setup();
+      setup();
+      await user.keyboard('[AltLeft>]'); // Press Alt (without releasing it)
+      await user.click(screen.getByText('log message 1'));
+      expect(enablePopoverMenu).toHaveBeenCalledTimes(1);
+    });
+    it('Does not appear when the props are not defined', async () => {
+      setup({
+        onClickFilterOutString: undefined,
+        onClickFilterString: undefined,
+      });
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+    });
+    it('Appears after selecting text', async () => {
+      const onClickFilterOutString = jest.fn();
+      const onClickFilterString = jest.fn();
+      setup({
+        onClickFilterOutString,
+        onClickFilterString,
+      });
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.getByText('Copy selection')).toBeInTheDocument();
+      await userEvent.click(screen.getByText('Add as line contains filter'));
+
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.getByText('Copy selection')).toBeInTheDocument();
+      await userEvent.click(screen.getByText('Add as line does not contain filter'));
+
+      expect(onClickFilterOutString).toHaveBeenCalledTimes(1);
+      expect(onClickFilterString).toHaveBeenCalledTimes(1);
+    });
+    describe('Interacting with log details', () => {
+      it('Allows text selection even if the popover menu is not available', async () => {
+        setup({
+          onClickFilterOutString: undefined,
+          onClickFilterString: undefined,
+        });
+        await userEvent.click(screen.getByText('log message 1'));
+        expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+        expect(screen.queryByText(/details/)).not.toBeInTheDocument();
+      });
+
+      it('Displays Log Details if there is no text selection', async () => {
+        jest.spyOn(document, 'getSelection').mockReturnValue(null);
+        setup({
+          onClickFilterOutString: undefined,
+          onClickFilterString: undefined,
+        });
+        await userEvent.click(screen.getByText('log message 1'));
+        expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+        expect(screen.getByText(/Fields/)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -350,7 +350,7 @@ const LogListComponent = ({
 
   const handleLogLineClick = useCallback(
     (e: MouseEvent<HTMLElement>, log: LogListModel) => {
-      if (handleTextSelection?.(e, log)) {
+      if (handleTextSelection(e, log)) {
         // Event handled by the parent.
         return;
       }

--- a/public/app/features/logs/components/panel/usePopoverMenu.ts
+++ b/public/app/features/logs/components/panel/usePopoverMenu.ts
@@ -1,0 +1,114 @@
+import { useCallback, useRef, useState, MouseEvent } from 'react';
+
+import { config } from '@grafana/runtime';
+
+import { disablePopoverMenu, enablePopoverMenu, isPopoverMenuDisabled, targetIsElement } from '../../utils';
+import { PopoverStateType } from '../LogRows';
+
+import { useLogListContext } from './LogListContext';
+import { LogListModel } from './processing';
+
+export const usePopoverMenu = (containerElement: HTMLDivElement | null) => {
+  const [popoverState, setPopoverState] = useState<PopoverStateType>({
+    selection: '',
+    selectedRow: null,
+    popoverMenuCoordinates: { x: 0, y: 0 },
+  });
+  const [showDisablePopoverOptions, setShowDisablePopoverOptions] = useState(false);
+  const handleDeselectionRef = useRef<((e: Event) => void) | null>(null);
+  const { onClickFilterOutString, onClickFilterString } = useLogListContext();
+
+  const popoverMenuSupported = useCallback(() => {
+    if (!config.featureToggles.logRowsPopoverMenu || isPopoverMenuDisabled()) {
+      return false;
+    }
+    return Boolean(onClickFilterOutString || onClickFilterString);
+  }, [onClickFilterOutString, onClickFilterString]);
+
+  const closePopoverMenu = useCallback(() => {
+    if (handleDeselectionRef.current) {
+      document.removeEventListener('click', handleDeselectionRef.current);
+      document.removeEventListener('contextmenu', handleDeselectionRef.current);
+      handleDeselectionRef.current = null;
+    }
+    setPopoverState({
+      selection: '',
+      popoverMenuCoordinates: { x: 0, y: 0 },
+      selectedRow: null,
+    });
+  }, []);
+
+  const handleDeselection = useCallback(
+    (e: Event) => {
+      if (targetIsElement(e.target) && !containerElement?.contains(e.target)) {
+        // The mouseup event comes from outside the log rows, close the menu.
+        closePopoverMenu();
+        return;
+      }
+      if (document.getSelection()?.toString()) {
+        return;
+      }
+      closePopoverMenu();
+    },
+    [closePopoverMenu, containerElement]
+  );
+
+  const handleTextSelection = useCallback(
+    (e: MouseEvent<HTMLElement>, row: LogListModel): boolean => {
+      const selection = document.getSelection()?.toString();
+      if (!selection) {
+        return false;
+      }
+      if (e.altKey) {
+        enablePopoverMenu();
+      }
+      if (popoverMenuSupported() === false) {
+        // This signals onRowClick inside LogRow to skip the event because the user is selecting text
+        return selection ? true : false;
+      }
+
+      if (!containerElement) {
+        return false;
+      }
+
+      const MENU_WIDTH = 270;
+      const MENU_HEIGHT = 105;
+      const x = e.clientX + MENU_WIDTH > window.innerWidth ? window.innerWidth - MENU_WIDTH : e.clientX;
+      const y = e.clientY + MENU_HEIGHT > window.innerHeight ? window.innerHeight - MENU_HEIGHT : e.clientY;
+
+      setPopoverState({
+        selection,
+        popoverMenuCoordinates: { x, y },
+        selectedRow: row,
+      });
+      handleDeselectionRef.current = handleDeselection;
+      document.addEventListener('click', handleDeselection);
+      document.addEventListener('contextmenu', handleDeselection);
+      return true;
+    },
+    [containerElement, handleDeselection, popoverMenuSupported]
+  );
+
+  const onDisablePopoverMenu = useCallback(() => {
+    setShowDisablePopoverOptions(true);
+  }, []);
+
+  const onDisableCancel = useCallback(() => {
+    setShowDisablePopoverOptions(false);
+  }, []);
+
+  const onDisableConfirm = useCallback(() => {
+    disablePopoverMenu();
+    setShowDisablePopoverOptions(false);
+  }, []);
+
+  return {
+    closePopoverMenu,
+    handleTextSelection,
+    onDisableCancel,
+    onDisableConfirm,
+    onDisablePopoverMenu,
+    popoverState,
+    showDisablePopoverOptions,
+  };
+};

--- a/public/app/features/logs/components/panel/usePopoverMenu.ts
+++ b/public/app/features/logs/components/panel/usePopoverMenu.ts
@@ -90,8 +90,9 @@ export const usePopoverMenu = (containerElement: HTMLDivElement | null) => {
   );
 
   const onDisablePopoverMenu = useCallback(() => {
+    closePopoverMenu();
     setShowDisablePopoverOptions(true);
-  }, []);
+  }, [closePopoverMenu]);
 
   const onDisableCancel = useCallback(() => {
     setShowDisablePopoverOptions(false);

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -553,6 +553,10 @@ export const LogsPanel = ({
               onClickFilterOutLabel={
                 isOnClickFilterOutLabel(onClickFilterOutLabel) ? onClickFilterOutLabel : defaultOnClickFilterOutLabel
               }
+              onClickFilterString={isOnClickFilterString(onClickFilterString) ? onClickFilterString : undefined}
+              onClickFilterOutString={
+                isOnClickFilterOutString(onClickFilterOutString) ? onClickFilterOutString : undefined
+              }
               onClickShowField={displayedFields !== undefined ? onClickShowField : undefined}
               onClickHideField={displayedFields !== undefined ? onClickHideField : undefined}
               onLogLineHover={onLogRowHover}


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

Adds support for the Popover Menu support.

![2025-06-06 12 07 51](https://github.com/user-attachments/assets/20c6e2d3-2878-4196-a6de-3e9dafac243c)
