### PR TITLE
Datasources: add description field to data source

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4595,6 +4595,7 @@ exports[`no gf-form usage`] = {
     "public/app/features/datasources/components/BasicSettings.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
+      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
     "public/app/features/datasources/components/ButtonRow.tsx:5381": [

--- a/e2e/various-suite/datasource-description.spec.ts
+++ b/e2e/various-suite/datasource-description.spec.ts
@@ -1,0 +1,229 @@
+import { e2e } from '../utils';
+
+const PROMETHEUS_DATASOURCE_ID = 'Prometheus';
+const TESTDATA_DATASOURCE_ID = 'TestData DB';
+const TEST_DATASOURCE_NAME = 'E2E Test Datasource';
+const TEST_DESCRIPTION = 'This is a test description for e2e testing';
+const UPDATED_DESCRIPTION = 'Updated test description for verification';
+
+describe('Datasource Description Field', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'), true);
+  });
+
+  it('should display description field on Prometheus datasource settings page', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(PROMETHEUS_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Verify description field exists
+    e2e.pages.DataSource.description().should('exist').should('be.visible');
+
+    // Verify it's a textarea field
+    e2e.pages.DataSource.description().should('match', 'textarea');
+
+    // Verify placeholder or label
+    e2e.pages.DataSource.description().should('have.attr', 'placeholder').should('not.be.empty');
+  });
+
+  it('should display description field on TestData datasource settings page', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(TESTDATA_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Verify description field exists
+    e2e.pages.DataSource.description().should('exist').should('be.visible');
+  });
+
+  it('should allow user to add and save a description for a new datasource', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(PROMETHEUS_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Fill in required fields
+    e2e.components.DataSource.Prometheus.configPage.connectionSettings().type('http://prometheus:9090');
+    e2e.pages.DataSource.name().clear().type(TEST_DATASOURCE_NAME);
+
+    // Add description
+    e2e.pages.DataSource.description().clear().type(TEST_DESCRIPTION);
+
+    // Verify description was entered
+    e2e.pages.DataSource.description().should('have.value', TEST_DESCRIPTION);
+
+    // Save datasource
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation
+    e2e.pages.DataSource.alert().should('exist');
+  });
+
+  it('should persist description after saving and editing datasource', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(TESTDATA_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Fill in required fields
+    e2e.pages.DataSource.name().clear().type(`${TEST_DATASOURCE_NAME}_persist`);
+
+    // Add description
+    e2e.pages.DataSource.description().clear().type(TEST_DESCRIPTION);
+
+    // Save datasource
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation
+    e2e.pages.DataSource.alert().should('exist');
+
+    // Refresh the page to verify persistence
+    cy.reload();
+
+    // Verify description persisted
+    e2e.pages.DataSource.description().should('have.value', TEST_DESCRIPTION);
+
+    // Verify name persisted as well (sanity check)
+    e2e.pages.DataSource.name().should('have.value', `${TEST_DATASOURCE_NAME}_persist`);
+  });
+
+  it('should allow user to edit existing description', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(TESTDATA_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Fill in required fields
+    e2e.pages.DataSource.name().clear().type(`${TEST_DATASOURCE_NAME}_edit`);
+
+    // Add initial description
+    e2e.pages.DataSource.description().clear().type(TEST_DESCRIPTION);
+
+    // Save datasource
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation
+    e2e.pages.DataSource.alert().should('exist');
+
+    // Edit description
+    e2e.pages.DataSource.description().clear().type(UPDATED_DESCRIPTION);
+
+    // Verify updated description
+    e2e.pages.DataSource.description().should('have.value', UPDATED_DESCRIPTION);
+
+    // Save again
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation
+    e2e.pages.DataSource.alert().should('exist');
+
+    // Refresh to verify updated description persisted
+    cy.reload();
+    e2e.pages.DataSource.description().should('have.value', UPDATED_DESCRIPTION);
+  });
+
+  it('should allow empty description (optional field)', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(TESTDATA_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Fill in required fields but leave description empty
+    e2e.pages.DataSource.name().clear().type(`${TEST_DATASOURCE_NAME}_empty`);
+
+    // Verify description field is empty
+    e2e.pages.DataSource.description().should('have.value', '');
+
+    // Save datasource without description
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation - should succeed
+    e2e.pages.DataSource.alert().should('exist');
+
+    // Verify name was saved (sanity check)
+    e2e.pages.DataSource.name().should('have.value', `${TEST_DATASOURCE_NAME}_empty`);
+
+    // Verify description remained empty
+    e2e.pages.DataSource.description().should('have.value', '');
+  });
+
+  it('should handle long descriptions gracefully', () => {
+    const longDescription = 'A'.repeat(500); // Very long description
+
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(TESTDATA_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Fill in required fields
+    e2e.pages.DataSource.name().clear().type(`${TEST_DATASOURCE_NAME}_long`);
+
+    // Add long description
+    e2e.pages.DataSource.description().clear().type(longDescription);
+
+    // Verify long description was entered
+    e2e.pages.DataSource.description().should('have.value', longDescription);
+
+    // Save datasource
+    e2e.pages.DataSource.saveAndTest().click();
+
+    // Wait for save confirmation
+    e2e.pages.DataSource.alert().should('exist');
+
+    // Verify long description persisted
+    e2e.pages.DataSource.description().should('have.value', longDescription);
+  });
+
+  it('should display description field in correct location on settings page', () => {
+    // Navigate to add datasource page
+    e2e.pages.AddDataSource.visit();
+    e2e.pages.AddDataSource.dataSourcePluginsV2(PROMETHEUS_DATASOURCE_ID)
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+
+    // Verify description field appears after name field
+    e2e.pages.DataSource.name().should('be.visible');
+    e2e.pages.DataSource.description().should('be.visible');
+
+    // Verify both fields are in the settings section
+    e2e.pages.DataSource.name().should('be.visible');
+    e2e.pages.DataSource.description().should('be.visible');
+
+    // Test tab navigation between name and description
+    e2e.pages.DataSource.name().focus();
+    e2e.pages.DataSource.name().tab();
+    e2e.pages.DataSource.description().should('be.focused');
+  });
+
+  afterEach(() => {
+    // Clean up test datasources by navigating to datasources list and removing any test datasources
+    e2e.pages.DataSources.visit();
+
+    // Try to clean up any datasources that start with our test name
+    cy.get('body').then(($body) => {
+      if ($body.find(`[data-testid*="${TEST_DATASOURCE_NAME}"]`).length > 0) {
+        cy.get(`[data-testid*="${TEST_DATASOURCE_NAME}"]`).each(($el) => {
+          cy.wrap($el).click();
+          e2e.pages.DataSource.delete().click();
+          cy.get('[data-testid="Confirm Modal Danger Button"]').click();
+        });
+      }
+    });
+  });
+});

--- a/e2e/various-suite/datasource-description.spec.ts
+++ b/e2e/various-suite/datasource-description.spec.ts
@@ -207,7 +207,7 @@ describe('Datasource Description Field', () => {
 
     // Test tab navigation between name and description
     e2e.pages.DataSource.name().focus();
-    e2e.pages.DataSource.name().tab();
+    e2e.pages.DataSource.name().type('{tab}');
     e2e.pages.DataSource.description().should('be.focused');
   });
 

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -656,6 +656,7 @@ export interface DataSourceSettings<T extends DataSourceJsonData = DataSourceJso
   uid: string;
   orgId: number;
   name: string;
+  description?: string;
   typeLogoUrl: string;
   type: string;
   typeName: string;
@@ -689,6 +690,7 @@ export interface DataSourceInstanceSettings<T extends DataSourceJsonData = DataS
   uid: string;
   type: string;
   name: string;
+  description?: string;
   apiVersion?: string;
   meta: DataSourcePluginMeta;
   cachingConfig?: PluginQueryCachingConfig;

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -63,7 +63,7 @@ export const versionedPages = {
       [MIN_GRAFANA_VERSION]: 'Data source settings page name input field',
     },
     description: {
-      [MIN_GRAFANA_VERSION]: 'Data source settings page description input field',
+      '12.1.0': 'Data source settings page description input field',
     },
     delete: {
       [MIN_GRAFANA_VERSION]: 'Data source settings page Delete button',

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -62,6 +62,9 @@ export const versionedPages = {
       '10.3.0': 'data-testid Data source settings page name input field',
       [MIN_GRAFANA_VERSION]: 'Data source settings page name input field',
     },
+    description: {
+      [MIN_GRAFANA_VERSION]: 'Data source settings page description input field',
+    },
     delete: {
       [MIN_GRAFANA_VERSION]: 'Data source settings page Delete button',
     },

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -715,6 +715,7 @@ func (hs *HTTPServer) convertModelToDtos(ctx context.Context, ds *datasources.Da
 		UID:              ds.UID,
 		OrgId:            ds.OrgID,
 		Name:             ds.Name,
+		Description:      ds.Description,
 		Url:              ds.URL,
 		Type:             ds.Type,
 		Access:           ds.Access,

--- a/pkg/api/dtos/datasource.go
+++ b/pkg/api/dtos/datasource.go
@@ -13,6 +13,7 @@ type DataSource struct {
 	UID              string                 `json:"uid"`
 	OrgId            int64                  `json:"orgId"`
 	Name             string                 `json:"name"`
+	Description      string                 `json:"description"`
 	Type             string                 `json:"type"`
 	TypeLogoUrl      string                 `json:"typeLogoUrl"`
 	Access           datasources.DsAccess   `json:"access"`
@@ -37,6 +38,7 @@ type DataSourceListItemDTO struct {
 	UID         string               `json:"uid"`
 	OrgId       int64                `json:"orgId"`
 	Name        string               `json:"name"`
+	Description string               `json:"description"`
 	Type        string               `json:"type"`
 	TypeName    string               `json:"typeName"`
 	TypeLogoUrl string               `json:"typeLogoUrl"`

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -47,10 +47,11 @@ type DataSource struct {
 	OrgID   int64 `json:"orgId,omitempty" xorm:"org_id"`
 	Version int   `json:"version,omitempty"`
 
-	Name   string   `json:"name"`
-	Type   string   `json:"type"`
-	Access DsAccess `json:"access"`
-	URL    string   `json:"url" xorm:"url"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Access      DsAccess `json:"access"`
+	URL         string   `json:"url" xorm:"url"`
 	// swagger:ignore
 	Password      string `json:"-"`
 	User          string `json:"user"`
@@ -153,6 +154,7 @@ func (ds DataSource) AllowedCookies() []string {
 // Also acts as api DTO
 type AddDataSourceCommand struct {
 	Name            string            `json:"name"`
+	Description     string            `json:"description"`
 	Type            string            `json:"type" binding:"Required"`
 	Access          DsAccess          `json:"access" binding:"Required"`
 	URL             string            `json:"url"`
@@ -180,6 +182,7 @@ type AddDataSourceCommand struct {
 // Also acts as api DTO
 type UpdateDataSourceCommand struct {
 	Name            string            `json:"name" binding:"Required"`
+	Description     string            `json:"description"`
 	Type            string            `json:"type" binding:"Required"`
 	Access          DsAccess          `json:"access" binding:"Required"`
 	URL             string            `json:"url"`

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -260,6 +260,7 @@ func (ss *SqlStore) AddDataSource(ctx context.Context, cmd *datasources.AddDataS
 		ds = &datasources.DataSource{
 			OrgID:           cmd.OrgID,
 			Name:            cmd.Name,
+			Description:     cmd.Description,
 			Type:            cmd.Type,
 			Access:          cmd.Access,
 			URL:             cmd.URL,
@@ -339,6 +340,7 @@ func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.Updat
 			ID:              cmd.ID,
 			OrgID:           cmd.OrgID,
 			Name:            cmd.Name,
+			Description:     cmd.Description,
 			Type:            cmd.Type,
 			Access:          cmd.Access,
 			URL:             cmd.URL,
@@ -374,6 +376,7 @@ func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.Updat
 		// secure json data to the unified secrets table.
 		sess.MustCols("secure_json_data")
 		sess.MustCols("api_version")
+		sess.MustCols("description")
 
 		var updateSession *xorm.Session
 		if cmd.Version != 0 {

--- a/pkg/services/provisioning/datasources/testdata/with-description/datasource.yaml
+++ b/pkg/services/provisioning/datasources/testdata/with-description/datasource.yaml
@@ -1,0 +1,48 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus-with-description
+    description: "This is a Prometheus datasource with a detailed description for monitoring metrics"
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: false
+    editable: true
+    uid: prometheus_desc_test
+
+  - name: loki-with-empty-description
+    description: ""
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+    uid: loki_empty_desc_test
+
+  - name: testdata-no-description
+    type: grafana-testdata-datasource
+    access: proxy
+    orgId: 1
+    isDefault: false
+    editable: true
+    uid: testdata_no_desc_test
+
+  - name: postgres-long-description
+    description: "This is a very long description that tests how the provisioning system handles lengthy description text. It contains multiple sentences and should demonstrate that the description field can handle substantial amounts of text without issues. This helps ensure that users can provide comprehensive documentation for their datasources through the provisioning configuration files."
+    type: grafana-postgresql-datasource
+    access: proxy
+    orgId: 1
+    url: postgres://localhost:5432/mydb
+    user: postgres
+    database: grafana
+    basicAuth: false
+    isDefault: false
+    editable: true
+    uid: postgres_long_desc_test
+    jsonData:
+      sslmode: disable
+      maxOpenConns: 10
+      maxIdleConns: 2
+      maxIdleConnsAuto: true

--- a/pkg/services/provisioning/datasources/types.go
+++ b/pkg/services/provisioning/datasources/types.go
@@ -34,6 +34,7 @@ type upsertDataSourceFromConfig struct {
 	Version int
 
 	Name            string
+	Description     string
 	Type            string
 	Access          string
 	URL             string
@@ -81,6 +82,7 @@ type upsertDataSourceFromConfigV0 struct {
 	OrgID           int64             `json:"org_id" yaml:"org_id"`
 	Version         int               `json:"version" yaml:"version"`
 	Name            string            `json:"name" yaml:"name"`
+	Description     string            `json:"description" yaml:"description"`
 	Type            string            `json:"type" yaml:"type"`
 	Access          string            `json:"access" yaml:"access"`
 	URL             string            `json:"url" yaml:"url"`
@@ -100,6 +102,7 @@ type upsertDataSourceFromConfigV1 struct {
 	OrgID           values.Int64Value     `json:"orgId" yaml:"orgId"`
 	Version         values.IntValue       `json:"version" yaml:"version"`
 	Name            values.StringValue    `json:"name" yaml:"name"`
+	Description     values.StringValue    `json:"description" yaml:"description"`
 	Type            values.StringValue    `json:"type" yaml:"type"`
 	Access          values.StringValue    `json:"access" yaml:"access"`
 	URL             values.StringValue    `json:"url" yaml:"url"`
@@ -130,6 +133,7 @@ func (cfg *configsV1) mapToDatasourceFromConfig(apiVersion int64) *configs {
 		r.Datasources = append(r.Datasources, &upsertDataSourceFromConfig{
 			OrgID:           ds.OrgID.Value(),
 			Name:            ds.Name.Value(),
+			Description:     ds.Description.Value(),
 			Type:            ds.Type.Value(),
 			Access:          ds.Access.Value(),
 			URL:             ds.URL.Value(),
@@ -172,6 +176,7 @@ func (cfg *configsV0) mapToDatasourceFromConfig(apiVersion int64) *configs {
 		r.Datasources = append(r.Datasources, &upsertDataSourceFromConfig{
 			OrgID:           ds.OrgID,
 			Name:            ds.Name,
+			Description:     ds.Description,
 			Type:            ds.Type,
 			Access:          ds.Access,
 			URL:             ds.URL,
@@ -210,6 +215,7 @@ func createInsertCommand(ds *upsertDataSourceFromConfig) *datasources.AddDataSou
 	cmd := &datasources.AddDataSourceCommand{
 		OrgID:           ds.OrgID,
 		Name:            ds.Name,
+		Description:     ds.Description,
 		Type:            ds.Type,
 		Access:          datasources.DsAccess(ds.Access),
 		URL:             ds.URL,
@@ -253,6 +259,7 @@ func createUpdateCommand(ds *upsertDataSourceFromConfig, id int64) *datasources.
 		UID:                     ds.UID,
 		OrgID:                   ds.OrgID,
 		Name:                    ds.Name,
+		Description:             ds.Description,
 		Type:                    ds.Type,
 		Access:                  datasources.DsAccess(ds.Access),
 		URL:                     ds.URL,

--- a/pkg/services/provisioning/datasources/types_test.go
+++ b/pkg/services/provisioning/datasources/types_test.go
@@ -20,4 +20,125 @@ func TestCreateUpdateCommand(t *testing.T) {
 		cmd := createUpdateCommand(ds, 1)
 		require.Equal(t, 1, cmd.Version)
 	})
+
+	t.Run("includes description in the command", func(t *testing.T) {
+		description := "Test datasource description"
+		ds := &upsertDataSourceFromConfig{
+			OrgID:       1,
+			Name:        "test",
+			Description: description,
+			Type:        "prometheus",
+			Access:      "proxy",
+		}
+		cmd := createUpdateCommand(ds, 1)
+		require.Equal(t, description, cmd.Description)
+		require.Equal(t, "test", cmd.Name)
+	})
+
+	t.Run("handles empty description", func(t *testing.T) {
+		ds := &upsertDataSourceFromConfig{
+			OrgID:       1,
+			Name:        "test",
+			Description: "",
+			Type:        "prometheus",
+			Access:      "proxy",
+		}
+		cmd := createUpdateCommand(ds, 1)
+		require.Equal(t, "", cmd.Description)
+	})
+
+	t.Run("handles missing description field", func(t *testing.T) {
+		ds := &upsertDataSourceFromConfig{
+			OrgID:  1,
+			Name:   "test",
+			Type:   "prometheus",
+			Access: "proxy",
+			// Description intentionally omitted
+		}
+		cmd := createUpdateCommand(ds, 1)
+		require.Equal(t, "", cmd.Description) // Should default to empty string
+	})
+}
+
+func TestCreateInsertCommand(t *testing.T) {
+	t.Run("includes description in the command", func(t *testing.T) {
+		description := "Test datasource description for insert"
+		ds := &upsertDataSourceFromConfig{
+			OrgID:       1,
+			Name:        "test-insert",
+			Description: description,
+			Type:        "prometheus",
+			Access:      "proxy",
+			URL:         "http://localhost:9090",
+		}
+		cmd := createInsertCommand(ds)
+		require.Equal(t, description, cmd.Description)
+		require.Equal(t, "test-insert", cmd.Name)
+		require.Equal(t, "prometheus", cmd.Type)
+	})
+
+	t.Run("handles empty description in insert", func(t *testing.T) {
+		ds := &upsertDataSourceFromConfig{
+			OrgID:       1,
+			Name:        "test-empty",
+			Description: "",
+			Type:        "prometheus",
+			Access:      "proxy",
+		}
+		cmd := createInsertCommand(ds)
+		require.Equal(t, "", cmd.Description)
+	})
+
+	t.Run("generates UID when not provided", func(t *testing.T) {
+		ds := &upsertDataSourceFromConfig{
+			OrgID:       1,
+			Name:        "test-uid-generation",
+			Description: "Test with UID generation",
+			Type:        "prometheus",
+			Access:      "proxy",
+		}
+		cmd := createInsertCommand(ds)
+		require.NotEmpty(t, cmd.UID)
+		require.Equal(t, safeUIDFromName("test-uid-generation"), cmd.UID)
+		require.Equal(t, "Test with UID generation", cmd.Description)
+	})
+}
+
+func TestConfigMapping(t *testing.T) {
+	t.Run("configsV0 maps description correctly", func(t *testing.T) {
+		configV0 := &configsV0{
+			Datasources: []*upsertDataSourceFromConfigV0{
+				{
+					OrgID:       1,
+					Name:        "test-v0",
+					Description: "V0 test description",
+					Type:        "prometheus",
+					Access:      "proxy",
+					URL:         "http://localhost:9090",
+				},
+			},
+		}
+
+		mapped := configV0.mapToDatasourceFromConfig(0)
+		require.Equal(t, 1, len(mapped.Datasources))
+		require.Equal(t, "V0 test description", mapped.Datasources[0].Description)
+		require.Equal(t, "test-v0", mapped.Datasources[0].Name)
+	})
+
+	t.Run("handles empty description in V0", func(t *testing.T) {
+		// Test V0 with empty description
+		configV0 := &configsV0{
+			Datasources: []*upsertDataSourceFromConfigV0{
+				{
+					OrgID:       1,
+					Name:        "test-empty-v0",
+					Description: "",
+					Type:        "prometheus",
+					Access:      "proxy",
+				},
+			},
+		}
+		mappedV0 := configV0.mapToDatasourceFromConfig(0)
+		require.Equal(t, "", mappedV0.Datasources[0].Description)
+	})
 }

--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -146,4 +146,8 @@ func addDataSourceMigration(mg *Migrator) {
 	mg.AddMigration("Update secure_json_data column to MediumText", NewRawSQLMigration("").
 		Mysql("ALTER TABLE data_source MODIFY COLUMN secure_json_data MEDIUMTEXT;"),
 	)
+
+	mg.AddMigration("Add description column", NewAddColumnMigration(tableV2, &Column{
+		Name: "description", Type: DB_Text, Nullable: true,
+	}))
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12137,6 +12137,9 @@
         "database": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "isDefault": {
           "type": "boolean"
         },
@@ -14812,6 +14815,9 @@
         "database": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "id": {
           "type": "integer",
           "format": "int64"
@@ -14878,6 +14884,9 @@
           "type": "boolean"
         },
         "database": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         },
         "id": {
@@ -22111,6 +22120,9 @@
           "type": "string"
         },
         "database": {
+          "type": "string"
+        },
+        "description": {
           "type": "string"
         },
         "isDefault": {

--- a/public/app/features/datasources/components/BasicSettings.test.tsx
+++ b/public/app/features/datasources/components/BasicSettings.test.tsx
@@ -7,9 +7,11 @@ import { BasicSettings, Props } from './BasicSettings';
 const setup = () => {
   const props: Props = {
     dataSourceName: 'Graphite',
+    description: 'Test description',
     isDefault: false,
     onDefaultChange: jest.fn(),
     onNameChange: jest.fn(),
+    onDescriptionChange: jest.fn(),
   };
 
   return render(<BasicSettings {...props} />);
@@ -20,6 +22,7 @@ describe('<BasicSettings>', () => {
     setup();
 
     expect(screen.getByTestId(selectors.pages.DataSource.name)).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.pages.DataSource.description)).toBeInTheDocument();
     expect(screen.getByLabelText(/Default/)).toBeInTheDocument();
   });
 });

--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -4,17 +4,27 @@ import * as React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { useTranslate } from '@grafana/i18n';
-import { InlineField, InlineSwitch, Input, Badge, useStyles2 } from '@grafana/ui';
+import { InlineField, InlineSwitch, Input, TextArea, Badge, useStyles2 } from '@grafana/ui';
 
 export interface Props {
   dataSourceName: string;
+  description?: string;
   isDefault: boolean;
   onNameChange: (name: string) => void;
+  onDescriptionChange: (description: string) => void;
   onDefaultChange: (value: boolean) => void;
   disabled?: boolean;
 }
 
-export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange, disabled }: Props) {
+export function BasicSettings({
+  dataSourceName,
+  description,
+  isDefault,
+  onDefaultChange,
+  onNameChange,
+  onDescriptionChange,
+  disabled,
+}: Props) {
   const { t } = useTranslate();
 
   return (
@@ -63,6 +73,29 @@ export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNa
               onChange={(event: React.FormEvent<HTMLInputElement>) => {
                 onDefaultChange(event.currentTarget.checked);
               }}
+            />
+          </InlineField>
+        </div>
+
+        {/* Description */}
+        <div className="gf-form max-width-30">
+          <InlineField
+            label={t('datasources.basic-settings.label-description', 'Description')}
+            tooltip={t(
+              'datasources.basic-settings.tooltip-description',
+              'Optional description to help identify and organize your data sources.'
+            )}
+            grow
+            disabled={disabled}
+            labelWidth={14}
+          >
+            <TextArea
+              id="basic-settings-description"
+              value={description || ''}
+              placeholder={t('datasources.basic-settings.placeholder-description', 'Description (optional)')}
+              onChange={(event) => onDescriptionChange(event.currentTarget.value)}
+              rows={3}
+              data-testid={selectors.pages.DataSource.description}
             />
           </InlineField>
         </div>

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -37,6 +37,7 @@ const setup = (props?: Partial<ViewProps>) => {
         exploreUrl={'/explore'}
         onDelete={jest.fn()}
         onDefaultChange={jest.fn()}
+        onDescriptionChange={jest.fn()}
         onNameChange={jest.fn()}
         onOptionsChange={jest.fn()}
         onTest={jest.fn()}

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -18,6 +18,7 @@ import { DataSourceSettingsState, useDispatch } from 'app/types';
 import {
   dataSourceLoaded,
   setDataSourceName,
+  setDataSourceDescription,
   setIsDefault,
   useDataSource,
   useDataSourceExploreUrl,
@@ -64,6 +65,7 @@ export function EditDataSource({ uid, pageId }: Props) {
   const onUpdate = useUpdateDatasource();
   const onDefaultChange = (value: boolean) => dispatch(setIsDefault(value));
   const onNameChange = (name: string) => dispatch(setDataSourceName(name));
+  const onDescriptionChange = (description: string) => dispatch(setDataSourceDescription(description));
   const onOptionsChange = (ds: DataSourceSettingsType) => dispatch(dataSourceLoaded(ds));
 
   return (
@@ -77,6 +79,7 @@ export function EditDataSource({ uid, pageId }: Props) {
       onDelete={onDelete}
       onDefaultChange={onDefaultChange}
       onNameChange={onNameChange}
+      onDescriptionChange={onDescriptionChange}
       onOptionsChange={onOptionsChange}
       onTest={onTest}
       onUpdate={onUpdate}
@@ -94,6 +97,7 @@ export type ViewProps = {
   onDelete: () => void;
   onDefaultChange: (isDefault: boolean) => AnyAction;
   onNameChange: (name: string) => AnyAction;
+  onDescriptionChange: (description: string) => AnyAction;
   onOptionsChange: (dataSource: DataSourceSettingsType) => AnyAction;
   onTest: () => void;
   onUpdate: (dataSource: DataSourceSettingsType) => Promise<DataSourceSettingsType>;
@@ -109,6 +113,7 @@ export function EditDataSourceView({
   onDelete,
   onDefaultChange,
   onNameChange,
+  onDescriptionChange,
   onOptionsChange,
   onTest,
   onUpdate,
@@ -175,9 +180,11 @@ export function EditDataSourceView({
 
       <BasicSettings
         dataSourceName={dataSource.name}
+        description={dataSource.description}
         isDefault={dataSource.isDefault}
         onDefaultChange={onDefaultChange}
         onNameChange={onNameChange}
+        onDescriptionChange={onDescriptionChange}
         disabled={readOnly || !hasWriteRights}
       />
 

--- a/public/app/features/datasources/state/reducers.test.ts
+++ b/public/app/features/datasources/state/reducers.test.ts
@@ -19,6 +19,7 @@ import {
   initialDataSourceSettingsState,
   initialState,
   setDataSourceName,
+  setDataSourceDescription,
   setDataSourcesLayoutMode,
   setDataSourcesSearchQuery,
   setDataSourceTypeSearchQuery,
@@ -131,6 +132,15 @@ describe('dataSourcesReducer', () => {
         .givenReducer(dataSourcesReducer, initialState)
         .whenActionIsDispatched(setDataSourceName('some name'))
         .thenStateShouldEqual({ ...initialState, dataSource: { name: 'some name' } } as DataSourcesState);
+    });
+  });
+
+  describe('when setDataSourceDescription is dispatched', () => {
+    it('then state should be correct', () => {
+      reducerTester<DataSourcesState>()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setDataSourceDescription('some description'))
+        .thenStateShouldEqual({ ...initialState, dataSource: { description: 'some description' } } as DataSourcesState);
     });
   });
 

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -36,6 +36,7 @@ export const setDataSourcesSearchQuery = createAction<string>('dataSources/setDa
 export const setDataSourcesLayoutMode = createAction<LayoutMode>('dataSources/setDataSourcesLayoutMode');
 export const setDataSourceTypeSearchQuery = createAction<string>('dataSources/setDataSourceTypeSearchQuery');
 export const setDataSourceName = createAction<string>('dataSources/setDataSourceName');
+export const setDataSourceDescription = createAction<string>('dataSources/setDataSourceDescription');
 export const setIsDefault = createAction<boolean>('dataSources/setIsDefault');
 export const setIsSortAscending = createAction<boolean>('dataSources/setIsSortAscending');
 
@@ -93,6 +94,10 @@ export const dataSourcesReducer = (state: DataSourcesState = initialState, actio
 
   if (setDataSourceName.match(action)) {
     return { ...state, dataSource: { ...state.dataSource, name: action.payload } };
+  }
+
+  if (setDataSourceDescription.match(action)) {
+    return { ...state, dataSource: { ...state.dataSource, description: action.payload } };
   }
 
   if (setIsDefault.match(action)) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5612,7 +5612,10 @@
       "aria-label-datasource-settings-page-basic": "Datasource settings page basic settings",
       "basic-settings-name-placeholder-name": "Name",
       "label-default": "Default",
-      "label-name": "Name"
+      "label-description": "Description",
+      "label-name": "Name",
+      "placeholder-description": "Description (optional)",
+      "tooltip-description": "Optional description to help identify and organize your data sources."
     },
     "build-categories": {
       "categories": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2186,6 +2186,9 @@
           "database": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "isDefault": {
             "type": "boolean"
           },
@@ -4861,6 +4864,9 @@
           "database": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "id": {
             "format": "int64",
             "type": "integer"
@@ -4927,6 +4933,9 @@
             "type": "boolean"
           },
           "database": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           },
           "id": {
@@ -12159,6 +12168,9 @@
             "type": "string"
           },
           "database": {
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           },
           "isDefault": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds an optional `description` field to data source instances. It is nullable for backwards compatibility, and otherwise works with legacy API calls & provisioning.

The description field is shown as a text area in the data source editor screen.

**Why do we need this feature?**

As users add more data sources to Grafana it gets harder and harder to identify them by name alone (a problem amplified by how difficult it is to name things well). It's difficult to know whether you should be using 'Prometheus 1' or 'Prometheus 2', what each of those data sources contains, or who should be contacted in the case of any issues.

Additionally, as we rely more on AI assistants to work with Grafana (e.g. with the Grafana MCP server or Grafana Assistant), we need to provide them more context so they can identify the correct data source to use when solving a problem without having to be told by the user.

**Who is this feature for?**

All users of Grafana, particularly those with many data sources in their instance, or those who have configured AI assistants to work with their Grafana instance.

**Which issue(s) does this PR fix?**:

I thought there was one but now I'm less sure. There is a [Grafana-internal Product DNA doc](https://docs.google.com/document/d/1E3Cnem_-Z_L1FWZo2YyrYFX-cEHISlVfjJzBbYPx_68/edit?tab=t.0), though.

**Special notes for your reviewer:**

Screenshot of edit data source page:

![image](https://github.com/user-attachments/assets/3a739bdc-2635-417d-ae4e-97d3baf7fa11)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
