### PR TITLE
alerting: stop using rule group idx to calculate alert fingerprint

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -318,7 +318,6 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 		writeInt(*rule.PanelID)
 	}
 	writeString(rule.RuleGroup)
-	writeInt(int64(rule.RuleGroupIndex))
 	writeString(string(rule.NoDataState))
 	writeString(string(rule.ExecErrState))
 	if rule.Record != nil {

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -152,13 +152,14 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		f2 := ruleWithFolder{rule: rule, folderTitle: uuid.NewString()}.Fingerprint()
 		require.NotEqual(t, f, f2)
 	})
-	t.Run("Version, Updated, IntervalSeconds, GUID and Annotations should be excluded from fingerprint", func(t *testing.T) {
+	t.Run("Version, Updated, IntervalSeconds, GUID, Annotations and RuleGroupIndex should be excluded from fingerprint", func(t *testing.T) {
 		cp := models.CopyRule(rule)
 		cp.Version++
 		cp.Updated = cp.Updated.Add(1 * time.Second)
 		cp.IntervalSeconds++
 		cp.Annotations = make(map[string]string)
 		cp.Annotations["test"] = "test"
+		cp.RuleGroupIndex++
 		cp.GUID = uuid.NewString()
 
 		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()


### PR DESCRIPTION
## Context
- The group index gets updated when changes have been made to the group, even if it doesn't affect the rule itself
- Since that's used to calculate the rule's fingerprint, which in turn is used on the ruler side to decide whether or not the rule state should be reset, this can lead to weird scenarios (i.e. rule hasn't changed but state gets reset, triggering new notifications)
- E.g. this has been reported when using the grafana-operator: https://github.com/grafana/grafana-operator/issues/1899