### PR TITLE
Alerting: Provisioning API returns 403 on quota exceeded for rule group PUT

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -499,6 +499,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *contextmodel.ReqContext, a
 	if errors.Is(err, store.ErrOptimisticLock) {
 		return ErrResp(http.StatusConflict, err, "")
 	}
+	if errors.Is(err, alerting_models.ErrQuotaReached) {
+		return ErrResp(http.StatusForbidden, err, "")
+	}
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -645,6 +645,20 @@ func TestProvisioningApi(t *testing.T) {
 			})
 		})
 
+		t.Run("have reached the rule quota, PUT returns 403", func(t *testing.T) {
+			env := createTestEnv(t, testConfig)
+			quotas := provisioning.MockQuotaChecker{}
+			quotas.EXPECT().LimitExceeded()
+			env.quotas = &quotas
+			sut := createProvisioningSrvSutFromEnv(t, &env)
+			group := createTestAlertRuleGroup(1)
+			rc := createTestRequestCtx()
+
+			response := sut.RoutePutAlertRuleGroup(&rc, group, "folder-uid", group.Title)
+
+			require.Equal(t, 403, response.Status())
+		})
+
 		t.Run("are valid", func(t *testing.T) {
 			t.Run("PUT returns 200", func(t *testing.T) {
 				sut := createProvisioningSrvSut(t)


### PR DESCRIPTION
`PUT /api/v1/provisioning/folder/:folderUid/rule-groups/:group` currently returns a 500 HTTP error when provisioning more alert rules than the limit allows. It should return a 403, the same way `POST /api/v1/provisioning/alert-rules` returns a 403 in such cases.

---

FTR, I'm able to reproduce the issue locally when calling the API with the following Grafana config:

```ini
[quota]
enabled = true
org_alert_rule = 1
```