### PR TITLE
K8s: Get trash fixes

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -780,7 +780,12 @@ func (b *backend) getHistory(ctx context.Context, req *resourcepb.ListRequest, c
 			listReq.MinRV = latestDeletedRV + 1
 		}
 
-		rows, err := dbutil.QueryRows(ctx, tx, sqlResourceHistoryGet, listReq)
+		var rows db.Rows
+		if listReq.Trash {
+			rows, err = dbutil.QueryRows(ctx, tx, sqlResourceTrash, listReq)
+		} else {
+			rows, err = dbutil.QueryRows(ctx, tx, sqlResourceHistoryGet, listReq)
+		}
 		if rows != nil {
 			defer func() {
 				if err := rows.Close(); err != nil {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -782,6 +782,8 @@ func (b *backend) getHistory(ctx context.Context, req *resourcepb.ListRequest, c
 
 		var rows db.Rows
 		if listReq.Trash {
+			// unlike history, trash will not return an object if an object of the same name is live
+			// (i.e. in the resource table)
 			rows, err = dbutil.QueryRows(ctx, tx, sqlResourceTrash, listReq)
 		} else {
 			rows, err = dbutil.QueryRows(ctx, tx, sqlResourceHistoryGet, listReq)

--- a/pkg/storage/unified/sql/data/resource_history_get.sql
+++ b/pkg/storage/unified/sql/data/resource_history_get.sql
@@ -15,9 +15,6 @@ WHERE 1 = 1
   {{ if .Key.Name }}
   AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
   {{ end }}
-  {{ if .Trash }}
-  AND {{ .Ident "action" }} = 3
-  {{ end }}
   {{ if (gt .StartRV 0) }}
   {{ if .SortAscending }}
   AND {{ .Ident "resource_version" }} > {{ .Arg .StartRV }}

--- a/pkg/storage/unified/sql/data/resource_trash.sql
+++ b/pkg/storage/unified/sql/data/resource_trash.sql
@@ -40,8 +40,15 @@ WHERE 1 = 1
   AND h.{{ .Ident "group" }}     = {{ .Arg .Key.Group }}
   AND h.{{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
   AND h.{{ .Ident "action" }} = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM {{ .Ident "resource" }} r
+    WHERE r.{{ .Ident "namespace" }} = h.{{ .Ident "namespace" }}
+      AND r.{{ .Ident "group" }} = h.{{ .Ident "group" }}
+      AND r.{{ .Ident "resource" }} = h.{{ .Ident "resource" }}
+      AND r.{{ .Ident "name" }} = h.{{ .Ident "name" }}
+  )
 {{ if .SortAscending }}
-ORDER BY resource_version ASC
+ORDER BY h.{{ .Ident "resource_version" }} ASC
 {{ else }}
-ORDER BY resource_version DESC
+ORDER BY h.{{ .Ident "resource_version" }} DESC
 {{ end }}

--- a/pkg/storage/unified/sql/data/resource_trash.sql
+++ b/pkg/storage/unified/sql/data/resource_trash.sql
@@ -1,0 +1,47 @@
+SELECT
+  h.{{ .Ident "guid" }},
+  h.{{ .Ident "resource_version" }},
+  h.{{ .Ident "namespace" }},
+  h.{{ .Ident "group" }},
+  h.{{ .Ident "resource" }},
+  h.{{ .Ident "name" }},
+  h.{{ .Ident "folder" }},
+  h.{{ .Ident "value" }}
+FROM {{ .Ident "resource_history" }} h
+INNER JOIN (
+  SELECT {{ .Ident "name" }}, MAX({{ .Ident "resource_version" }}) as max_rv
+  FROM {{ .Ident "resource_history" }}
+  WHERE 1 = 1
+    AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+    AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+    AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+    {{ if .Key.Name }}
+    AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+    {{ end }}
+    AND {{ .Ident "action" }} = 3
+    {{ if (gt .StartRV 0) }}
+    {{ if .SortAscending }}
+    AND {{ .Ident "resource_version" }} > {{ .Arg .StartRV }}
+    {{ else }}
+    AND {{ .Ident "resource_version" }} < {{ .Arg .StartRV }}
+    {{ end }}
+    {{ end }}
+    {{ if (gt .MinRV 0) }}
+    AND {{ .Ident "resource_version" }} >= {{ .Arg .MinRV }}
+    {{ end }}
+    {{ if (gt .ExactRV 0) }}
+    AND {{ .Ident "resource_version" }} = {{ .Arg .ExactRV }}
+    {{ end }}
+  GROUP BY {{ .Ident "name" }}
+) max_versions ON h.{{ .Ident "name" }} = max_versions.{{ .Ident "name" }} 
+  AND h.{{ .Ident "resource_version" }} = max_versions.max_rv
+WHERE 1 = 1
+  AND h.{{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+  AND h.{{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+  AND h.{{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+  AND h.{{ .Ident "action" }} = 3
+{{ if .SortAscending }}
+ORDER BY resource_version ASC
+{{ else }}
+ORDER BY resource_version DESC
+{{ end }}

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -46,6 +46,7 @@ var (
 	sqlResourceHistoryGet          = mustTemplate("resource_history_get.sql")
 	sqlResourceHistoryDelete       = mustTemplate("resource_history_delete.sql")
 	sqlResourceHistoryPrune        = mustTemplate("resource_history_prune.sql")
+	sqlResourceTrash               = mustTemplate("resource_trash.sql")
 	sqlResourceInsertFromHistory   = mustTemplate("resource_insert_from_history.sql")
 
 	// sqlResourceLabelsInsert = mustTemplate("resource_labels_insert.sql")

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -245,6 +245,9 @@ func TestUnifiedStorageQueries(t *testing.T) {
 						},
 					},
 				},
+			},
+
+			sqlResourceTrash: {
 				{
 					Name: "read trash",
 					Data: &sqlGetHistoryRequest{

--- a/pkg/storage/unified/sql/testdata/mysql--resource_trash-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_trash-read trash second page.sql
@@ -1,0 +1,35 @@
+SELECT
+  h.`guid`,
+  h.`resource_version`,
+  h.`namespace`,
+  h.`group`,
+  h.`resource`,
+  h.`name`,
+  h.`folder`,
+  h.`value`
+FROM `resource_history` h
+INNER JOIN (
+  SELECT `name`, MAX(`resource_version`) as max_rv
+  FROM `resource_history`
+  WHERE 1 = 1
+    AND `namespace` = 'nn'
+    AND `group`     = 'gg'
+    AND `resource`  = 'rr'
+    AND `action` = 3
+    AND `resource_version` < 123456
+  GROUP BY `name`
+) max_versions ON h.`name` = max_versions.`name` 
+  AND h.`resource_version` = max_versions.max_rv
+WHERE 1 = 1
+  AND h.`namespace` = 'nn'
+  AND h.`group`     = 'gg'
+  AND h.`resource`  = 'rr'
+  AND h.`action` = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM `resource` r
+    WHERE r.`namespace` = h.`namespace`
+      AND r.`group` = h.`group`
+      AND r.`resource` = h.`resource`
+      AND r.`name` = h.`name`
+  )
+ORDER BY h.`resource_version` DESC

--- a/pkg/storage/unified/sql/testdata/mysql--resource_trash-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_trash-read trash.sql
@@ -1,0 +1,34 @@
+SELECT
+  h.`guid`,
+  h.`resource_version`,
+  h.`namespace`,
+  h.`group`,
+  h.`resource`,
+  h.`name`,
+  h.`folder`,
+  h.`value`
+FROM `resource_history` h
+INNER JOIN (
+  SELECT `name`, MAX(`resource_version`) as max_rv
+  FROM `resource_history`
+  WHERE 1 = 1
+    AND `namespace` = 'nn'
+    AND `group`     = 'gg'
+    AND `resource`  = 'rr'
+    AND `action` = 3
+  GROUP BY `name`
+) max_versions ON h.`name` = max_versions.`name` 
+  AND h.`resource_version` = max_versions.max_rv
+WHERE 1 = 1
+  AND h.`namespace` = 'nn'
+  AND h.`group`     = 'gg'
+  AND h.`resource`  = 'rr'
+  AND h.`action` = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM `resource` r
+    WHERE r.`namespace` = h.`namespace`
+      AND r.`group` = h.`group`
+      AND r.`resource` = h.`resource`
+      AND r.`name` = h.`name`
+  )
+ORDER BY h.`resource_version` DESC

--- a/pkg/storage/unified/sql/testdata/postgres--resource_trash-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_trash-read trash second page.sql
@@ -1,0 +1,35 @@
+SELECT
+  h."guid",
+  h."resource_version",
+  h."namespace",
+  h."group",
+  h."resource",
+  h."name",
+  h."folder",
+  h."value"
+FROM "resource_history" h
+INNER JOIN (
+  SELECT "name", MAX("resource_version") as max_rv
+  FROM "resource_history"
+  WHERE 1 = 1
+    AND "namespace" = 'nn'
+    AND "group"     = 'gg'
+    AND "resource"  = 'rr'
+    AND "action" = 3
+    AND "resource_version" < 123456
+  GROUP BY "name"
+) max_versions ON h."name" = max_versions."name" 
+  AND h."resource_version" = max_versions.max_rv
+WHERE 1 = 1
+  AND h."namespace" = 'nn'
+  AND h."group"     = 'gg'
+  AND h."resource"  = 'rr'
+  AND h."action" = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM "resource" r
+    WHERE r."namespace" = h."namespace"
+      AND r."group" = h."group"
+      AND r."resource" = h."resource"
+      AND r."name" = h."name"
+  )
+ORDER BY h."resource_version" DESC

--- a/pkg/storage/unified/sql/testdata/postgres--resource_trash-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_trash-read trash.sql
@@ -1,0 +1,34 @@
+SELECT
+  h."guid",
+  h."resource_version",
+  h."namespace",
+  h."group",
+  h."resource",
+  h."name",
+  h."folder",
+  h."value"
+FROM "resource_history" h
+INNER JOIN (
+  SELECT "name", MAX("resource_version") as max_rv
+  FROM "resource_history"
+  WHERE 1 = 1
+    AND "namespace" = 'nn'
+    AND "group"     = 'gg'
+    AND "resource"  = 'rr'
+    AND "action" = 3
+  GROUP BY "name"
+) max_versions ON h."name" = max_versions."name" 
+  AND h."resource_version" = max_versions.max_rv
+WHERE 1 = 1
+  AND h."namespace" = 'nn'
+  AND h."group"     = 'gg'
+  AND h."resource"  = 'rr'
+  AND h."action" = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM "resource" r
+    WHERE r."namespace" = h."namespace"
+      AND r."group" = h."group"
+      AND r."resource" = h."resource"
+      AND r."name" = h."name"
+  )
+ORDER BY h."resource_version" DESC

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_trash-read trash second page.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_trash-read trash second page.sql
@@ -1,0 +1,35 @@
+SELECT
+  h."guid",
+  h."resource_version",
+  h."namespace",
+  h."group",
+  h."resource",
+  h."name",
+  h."folder",
+  h."value"
+FROM "resource_history" h
+INNER JOIN (
+  SELECT "name", MAX("resource_version") as max_rv
+  FROM "resource_history"
+  WHERE 1 = 1
+    AND "namespace" = 'nn'
+    AND "group"     = 'gg'
+    AND "resource"  = 'rr'
+    AND "action" = 3
+    AND "resource_version" < 123456
+  GROUP BY "name"
+) max_versions ON h."name" = max_versions."name" 
+  AND h."resource_version" = max_versions.max_rv
+WHERE 1 = 1
+  AND h."namespace" = 'nn'
+  AND h."group"     = 'gg'
+  AND h."resource"  = 'rr'
+  AND h."action" = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM "resource" r
+    WHERE r."namespace" = h."namespace"
+      AND r."group" = h."group"
+      AND r."resource" = h."resource"
+      AND r."name" = h."name"
+  )
+ORDER BY h."resource_version" DESC

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_trash-read trash.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_trash-read trash.sql
@@ -1,0 +1,34 @@
+SELECT
+  h."guid",
+  h."resource_version",
+  h."namespace",
+  h."group",
+  h."resource",
+  h."name",
+  h."folder",
+  h."value"
+FROM "resource_history" h
+INNER JOIN (
+  SELECT "name", MAX("resource_version") as max_rv
+  FROM "resource_history"
+  WHERE 1 = 1
+    AND "namespace" = 'nn'
+    AND "group"     = 'gg'
+    AND "resource"  = 'rr'
+    AND "action" = 3
+  GROUP BY "name"
+) max_versions ON h."name" = max_versions."name" 
+  AND h."resource_version" = max_versions.max_rv
+WHERE 1 = 1
+  AND h."namespace" = 'nn'
+  AND h."group"     = 'gg'
+  AND h."resource"  = 'rr'
+  AND h."action" = 3
+  AND NOT EXISTS (
+    SELECT 1 FROM "resource" r
+    WHERE r."namespace" = h."namespace"
+      AND r."group" = h."group"
+      AND r."resource" = h."resource"
+      AND r."name" = h."name"
+  )
+ORDER BY h."resource_version" DESC


### PR DESCRIPTION
**What is this feature?**

This PR updates the get trash endpoint:
```
http://localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/org-5/dashboards?labelSelector=grafana.app/get-trash=true
```

To help with implementing dashboard restore in the frontend. The two things it does is:
1. Only returns the latest resource version in the resource_history table. This is to prevent the dashboard from showing up multiple times in the UI if a dashboard has been deleted / restored / deleted again.
2. Only adds an item to the trash list _if_ it does not exist in the resource table. This is so when a dashboard is restored, it won't still show up in the trash endpoint.

**Who is this feature for?**

Frontend and restoring dashboards :) 
