### PR TITLE
Alerting: Use default_datasource_uid as the default target for recording rules in UI

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -73,6 +73,8 @@ export interface UnifiedAlertingConfig {
   // will be undefined if implementation is not "multiple"
   alertStateHistoryPrimary?: string;
   recordingRulesEnabled?: boolean;
+  // will be undefined if no default datasource is configured
+  defaultRecordingRulesTargetDatasourceUID?: string;
 }
 
 /** Supported OAuth services

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -159,6 +159,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     alertStateHistoryBackend: undefined,
     alertStateHistoryPrimary: undefined,
     recordingRulesEnabled: false,
+    defaultRecordingRulesTargetDatasourceUID: undefined,
   };
   applicationInsightsConnectionString?: string;
   applicationInsightsEndpointUrl?: string;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -94,10 +94,11 @@ type FrontendSettingsAnalyticsDTO struct {
 }
 
 type FrontendSettingsUnifiedAlertingDTO struct {
-	MinInterval              string `json:"minInterval"`
-	AlertStateHistoryBackend string `json:"alertStateHistoryBackend,omitempty"`
-	AlertStateHistoryPrimary string `json:"alertStateHistoryPrimary,omitempty"`
-	RecordingRulesEnabled    bool   `json:"recordingRulesEnabled"`
+	MinInterval                              string `json:"minInterval"`
+	AlertStateHistoryBackend                 string `json:"alertStateHistoryBackend,omitempty"`
+	AlertStateHistoryPrimary                 string `json:"alertStateHistoryPrimary,omitempty"`
+	RecordingRulesEnabled                    bool   `json:"recordingRulesEnabled"`
+	DefaultRecordingRulesTargetDatasourceUID string `json:"defaultRecordingRulesTargetDatasourceUID,omitempty"`
 }
 
 // Enterprise-only

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -351,6 +351,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 	}
 
 	frontendSettings.UnifiedAlerting.RecordingRulesEnabled = hs.Cfg.UnifiedAlerting.RecordingRules.Enabled
+	frontendSettings.UnifiedAlerting.DefaultRecordingRulesTargetDatasourceUID = hs.Cfg.UnifiedAlerting.RecordingRules.DefaultDatasourceUID
 
 	if hs.Cfg.UnifiedAlerting.Enabled != nil {
 		frontendSettings.UnifiedAlertingEnabled = *hs.Cfg.UnifiedAlerting.Enabled

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
@@ -1,3 +1,6 @@
+import { GrafanaConfig } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
 import { mockAlertQuery, mockDataSource, mockReduceExpression, mockThresholdExpression } from '../mocks';
 import { testWithFeatureToggles } from '../test/test-utils';
 import { RuleFormType } from '../types/rule-form';
@@ -189,5 +192,29 @@ describe('getDefaultManualRouting', () => {
     expect(getDefautManualRouting()).toBe(true);
     localStorage.removeItem(MANUAL_ROUTING_KEY);
     expect(getDefautManualRouting()).toBe(true);
+  });
+});
+
+describe('getDefaultFormValues', () => {
+  // This is for Typescript. GrafanaBootConfig returns narrower types than GrafanaConfig
+  const grafanaConfig: GrafanaConfig = config;
+  const uaConfig = grafanaConfig.unifiedAlerting;
+
+  afterEach(() => {
+    uaConfig.defaultRecordingRulesTargetDatasourceUID = undefined;
+  });
+
+  it('should set targetDatasourceUid from config when defaultRecordingRulesTargetDatasourceUID is provided', () => {
+    const expectedDatasourceUid = 'test-datasource-uid';
+    uaConfig.defaultRecordingRulesTargetDatasourceUID = expectedDatasourceUid;
+
+    const result = getDefaultFormValues();
+
+    expect(result.targetDatasourceUid).toBe(expectedDatasourceUid);
+  });
+
+  it('should set targetDatasourceUid to undefined when defaultRecordingRulesTargetDatasourceUID is not provided', () => {
+    const result = getDefaultFormValues();
+    expect(result.targetDatasourceUid).toBeUndefined();
   });
 });

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.ts
@@ -71,6 +71,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     overrideTimings: false,
     muteTimeIntervals: [],
     editorSettings: getDefaultEditorSettings(),
+    targetDatasourceUid: config.unifiedAlerting?.defaultRecordingRulesTargetDatasourceUID,
 
     // cortex / loki
     namespace: '',

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -297,7 +297,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         folder: { title: namespace, uid: ga.namespace_uid },
         isPaused: ga.is_paused,
         metric: ga.record?.metric,
-        targetDatasourceUid: ga.record?.target_datasource_uid,
+        targetDatasourceUid: ga.record?.target_datasource_uid || defaultFormValues.targetDatasourceUid,
       };
     } else if (rulerRuleType.grafana.rule(rule)) {
       // grafana alerting rule


### PR DESCRIPTION
**What is this feature?**

Pre-populates the "Target data source" selector when creating or copying Grafana recording rules from `recording_rules.default_datasource_uid` if it's present.

**Why do we need this feature?**

Before Grafana 12.1 target datasource for recording rules was configured in the config file. In Grafana 12.1 it is done per-recording rule. For the migration from the old configuration, for example when a user already has recording rules and they don't have a target data source, a configuration options was added:

```ini
[recording_rules]

default_datasource_uid = 123
```

Currently, when creating new Grafana recording rules, users manually select the target Prometheus data source. The same happens when they are changing existing recording rules created before Grafana 12.1, when the rules don't have target data source configured.

With this change the form is pre-populated with the default target data source uid from the config file.

**Who is this feature for?**

Users of Grafana recording rules.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
