### PR TITLE
KeybindingSet: fix missing item type

### DIFF
--- a/public/app/core/services/KeybindingSet.test.ts
+++ b/public/app/core/services/KeybindingSet.test.ts
@@ -27,4 +27,18 @@ describe('KeybindingSet', () => {
     expect(mousetrap.unbind).toHaveBeenCalledTimes(1);
     expect(mousetrap.unbind).toHaveBeenCalledWith('a b', 'keydown');
   });
+
+  test('Binds and unbinds keys of a certain type', () => {
+    keyBindingSet.addBinding({
+      key: 'a b',
+      onTrigger: () => {},
+      type: 'keypress',
+    });
+
+    expect(mousetrap.bind).toHaveBeenCalledWith('a b', expect.any(Function), 'keypress');
+
+    keyBindingSet.removeAll();
+
+    expect(mousetrap.unbind).toHaveBeenCalledWith('a b', 'keypress');
+  });
 });

--- a/public/app/core/services/KeybindingSet.test.ts
+++ b/public/app/core/services/KeybindingSet.test.ts
@@ -1,0 +1,30 @@
+import { KeybindingSet } from './KeybindingSet';
+import { mousetrap } from './mousetrap';
+
+jest.mock('./mousetrap');
+
+afterAll(() => {
+  jest.unmock('./mousetrap');
+});
+
+describe('KeybindingSet', () => {
+  let keyBindingSet: KeybindingSet;
+  beforeEach(() => {
+    keyBindingSet = new KeybindingSet();
+  });
+
+  test('Binds and unbinds keys', () => {
+    keyBindingSet.addBinding({
+      key: 'a b',
+      onTrigger: () => {},
+    });
+
+    expect(mousetrap.bind).toHaveBeenCalledTimes(1);
+    expect(mousetrap.bind).toHaveBeenCalledWith('a b', expect.any(Function), 'keydown');
+
+    keyBindingSet.removeAll();
+
+    expect(mousetrap.unbind).toHaveBeenCalledTimes(1);
+    expect(mousetrap.unbind).toHaveBeenCalledWith('a b', 'keydown');
+  });
+});

--- a/public/app/core/services/KeybindingSet.ts
+++ b/public/app/core/services/KeybindingSet.ts
@@ -26,7 +26,10 @@ export class KeybindingSet {
       },
       'keydown'
     );
-    this._binds.push(item);
+    this._binds.push({
+      ...item,
+      type: item.type ?? 'keydown',
+    });
   }
 
   removeAll() {

--- a/public/app/core/services/KeybindingSet.ts
+++ b/public/app/core/services/KeybindingSet.ts
@@ -24,7 +24,7 @@ export class KeybindingSet {
         evt.returnValue = false;
         item.onTrigger();
       },
-      'keydown'
+      item.type ?? 'keydown'
     );
     this._binds.push({
       ...item,


### PR DESCRIPTION
While adding a key binding to the new logs panel, I noticed that the intention was to add a default type (keydown) to the keybindings, which was missing in the clean up part. Additionally, consumers of this util class are not passing a type, as it's not required.

As far as I can tell, it also doesn't have a default within Mousetrap: https://github.com/grafana/grafana/blob/main/public/app/core/services/mousetrap/Mousetrap.ts#L864

Before:

![Test](https://github.com/user-attachments/assets/d5972501-da51-47d1-a09d-787bca2f8950)

After:

![imagen](https://github.com/user-attachments/assets/97d9182f-0bc0-4734-a985-54f25a6c254a)

