### PR TITLE
[release-10.4.20] Alerting: Provisioning API returns 403 on quota exceeded for rule group PUT

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -499,6 +499,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *contextmodel.ReqContext, a
 	if errors.Is(err, store.ErrOptimisticLock) {
 		return ErrResp(http.StatusConflict, err, "")
 	}
+	if errors.Is(err, alerting_models.ErrQuotaReached) {
+		return ErrResp(http.StatusForbidden, err, "")
+	}
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -400,7 +400,14 @@ func TestProvisioningApi(t *testing.T) {
 			quotas.EXPECT().LimitExceeded()
 			env.quotas = &quotas
 			sut := createProvisioningSrvSutFromEnv(t, &env)
-			group := createTestAlertRuleGroup(1)
+			group := definitions.AlertRuleGroup{
+				Title:    "test rule group",
+				Interval: 60,
+				Rules: []definitions.ProvisionedAlertRule{
+					createTestAlertRule("test-alert-rule", 1),
+				},
+			}
+			group.Rules[0].UID = "" // The rule is only created if UID is empty.
 			rc := createTestRequestCtx()
 
 			response := sut.RoutePutAlertRuleGroup(&rc, group, "folder-uid", group.Title)

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -393,6 +393,20 @@ func TestProvisioningApi(t *testing.T) {
 				require.Contains(t, string(response.Body()), "invalid alert rule")
 			})
 		})
+
+		t.Run("have reached the rule quota, PUT returns 403", func(t *testing.T) {
+			env := createTestEnv(t, testConfig)
+			quotas := provisioning.MockQuotaChecker{}
+			quotas.EXPECT().LimitExceeded()
+			env.quotas = &quotas
+			sut := createProvisioningSrvSutFromEnv(t, &env)
+			group := createTestAlertRuleGroup(1)
+			rc := createTestRequestCtx()
+
+			response := sut.RoutePutAlertRuleGroup(&rc, group, "folder-uid", group.Title)
+
+			require.Equal(t, 403, response.Status())
+		})
 	})
 
 	t.Run("exports", func(t *testing.T) {


### PR DESCRIPTION
Backport 1df888c51778ad3c02497d98d521435d990516ea from #106409

---

`PUT /api/v1/provisioning/folder/:folderUid/rule-groups/:group` currently returns a 500 HTTP error when provisioning more alert rules than the limit allows. It should return a 403, the same way `POST /api/v1/provisioning/alert-rules` returns a 403 in such cases.

---

FTR, I'm able to reproduce the issue locally when calling the API with the following Grafana config:

```ini
[quota]
enabled = true
org_alert_rule = 1
```
