### PR TITLE
Dashboards: Pass id prop to Switch component for bool inputs

### DIFF
--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -87,8 +87,7 @@ export const getAllOptionEditors = () => {
     name: 'Boolean',
     description: 'Allows boolean values input',
     editor(props) {
-      const { id, ...rest } = props; // Remove id from properties passed into switch
-      return <Switch {...rest} onChange={(e) => props.onChange(e.currentTarget.checked)} />;
+      return <Switch {...props} onChange={(e) => props.onChange(e.currentTarget.checked)} />;
     },
   };
 

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -122,7 +122,7 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
           });
         }
         builder.addBooleanSwitch({
-          path: 'tooltip',
+          path: 'layer-tooltip',
           name: 'Display tooltip',
           description: 'Show the tooltip for layer',
           defaultValue: true,


### PR DESCRIPTION
Ensures the `id` prop is passed to the `Switch` component for boolean panel option inputs.
Also changes geomap tooltip id to prevent regression (see https://github.com/grafana/grafana/pull/55956)