### PR TITLE
Dashboards - E2E - remove unnecessary steps

### DIFF
--- a/.github/workflows/e2e-dashboard-new-layouts.yml
+++ b/.github/workflows/e2e-dashboard-new-layouts.yml
@@ -40,23 +40,3 @@ jobs:
           runTests: false
       - name: Run dashboardNewLayouts e2e
         run: yarn e2e:dashboard-new-layouts
-      - name: Post PR comment on fail
-        uses: actions/github-script@v7
-        if: failure()
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const runId = context.runId;
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const runUrl = `${repoUrl}/actions/runs/${runId}`;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `⚠️ E2E workflow for dashboardNewLayouts has failed. [Click here to view the run](${runUrl}).`
-            });
-      - name: Always succeed # This is a workaround to make the job pass even if the previous step fails
-        if: failure()
-        run: exit 0


### PR DESCRIPTION
This workflow is optional.  It won't block PRs.  Adding comments to the PR results in a lot of unnecessary comments/noise in the PR.    

Removing the last 2 steps and just relying on built in GH checks. 
