### PR TITLE
Chore: Remove rollup-plugin-dts

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -38,7 +38,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -96,7 +96,6 @@
     "react-dom": "18.3.1",
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "typescript": "5.7.3"

--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { entryPoint, plugins, esmOutput, cjsOutput, tsDeclarationOutput } from '../rollup.config.parts';
+import { entryPoint, plugins, esmOutput, cjsOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -16,18 +16,4 @@ export default [
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-data')],
   },
-  tsDeclarationOutput(pkg),
-  tsDeclarationOutput(pkg, {
-    input: './compiled/unstable.d.ts',
-    output: [
-      {
-        file: './dist/cjs/unstable.d.cts',
-        format: 'cjs',
-      },
-      {
-        file: './dist/esm/unstable.d.mts',
-        format: 'es',
-      },
-    ],
-  }),
 ];

--- a/packages/grafana-data/tsconfig.json
+++ b/packages/grafana-data/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -21,7 +21,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -45,7 +45,6 @@
     "esbuild": "0.25.0",
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0"
   },

--- a/packages/grafana-e2e-selectors/rollup.config.ts
+++ b/packages/grafana-e2e-selectors/rollup.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -11,5 +11,4 @@ export default [
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-e2e-selectors')],
   },
-  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-e2e-selectors/tsconfig.json
+++ b/packages/grafana-e2e-selectors/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -21,7 +21,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -77,7 +77,6 @@
     "jest": "^29.6.4",
     "jest-canvas-mock": "2.5.2",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "ts-jest": "29.2.5",

--- a/packages/grafana-flamegraph/rollup.config.ts
+++ b/packages/grafana-flamegraph/rollup.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -11,5 +11,4 @@ export default [
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-flamegraph')],
   },
-  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-flamegraph/tsconfig.json
+++ b/packages/grafana-flamegraph/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -35,7 +35,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-i18n/rollup.config.ts
+++ b/packages/grafana-i18n/rollup.config.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import copy from 'rollup-plugin-copy';
 
-import { entryPoint, plugins, esmOutput, cjsOutput, tsDeclarationOutput } from '../rollup.config.parts';
+import { entryPoint, plugins, esmOutput, cjsOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -17,5 +17,4 @@ export default [
     ],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-i18n')],
   },
-  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-i18n/tsconfig.json
+++ b/packages/grafana-i18n/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -93,7 +93,6 @@
     "react-dom": "18.3.1",
     "react-select-event": "5.5.1",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "testing-library-selector": "0.3.1",

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -26,7 +26,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "scripts": {

--- a/packages/grafana-prometheus/rollup.config.ts
+++ b/packages/grafana-prometheus/rollup.config.ts
@@ -1,7 +1,7 @@
 import image from '@rollup/plugin-image';
 import { createRequire } from 'node:module';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -12,5 +12,4 @@ export default [
     plugins: [...plugins, image()],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-prometheus')],
   },
-  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-prometheus/tsconfig.json
+++ b/packages/grafana-prometheus/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "alwaysStrict": true,
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "allowJs": true,

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -35,7 +35,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -84,7 +84,6 @@
     "react-dom": "18.3.1",
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "rollup-plugin-sourcemaps": "0.6.3",

--- a/packages/grafana-runtime/rollup.config.ts
+++ b/packages/grafana-runtime/rollup.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -16,18 +16,4 @@ export default [
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-runtime')],
   },
-  tsDeclarationOutput(pkg),
-  tsDeclarationOutput(pkg, {
-    input: './compiled/unstable.d.ts',
-    output: [
-      {
-        file: './dist/cjs/unstable.d.cts',
-        format: 'cjs',
-      },
-      {
-        file: './dist/esm/unstable.d.mts',
-        format: 'es',
-      },
-    ],
-  }),
 ];

--- a/packages/grafana-runtime/tsconfig.json
+++ b/packages/grafana-runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "allowJs": true,

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -18,7 +18,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -42,7 +42,6 @@
     "glob": "^11.0.0",
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "typescript": "5.7.3"

--- a/packages/grafana-schema/rollup.config.ts
+++ b/packages/grafana-schema/rollup.config.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
@@ -16,7 +16,6 @@ export default [
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-schema')],
   },
-  tsDeclarationOutput(pkg, { input: './dist/esm/index.d.ts' }),
   {
     input: Object.fromEntries(
       glob

--- a/packages/grafana-schema/tsconfig.json
+++ b/packages/grafana-schema/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "declarationDir": "./dist/esm",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -193,7 +193,6 @@
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",
     "rollup-plugin-copy": "3.5.0",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "6.2.0",
     "rollup-plugin-node-externals": "^8.0.0",
     "rollup-plugin-svg-import": "3.0.0",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -37,7 +37,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/cjs/index.d.cts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 import copy from 'rollup-plugin-copy';
 import svg from 'rollup-plugin-svg-import';
 
-import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
+import { cjsOutput, entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const icons = rq('../../public/app/core/icons/cached.json');
@@ -38,18 +38,4 @@ export default [
     ],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-ui')],
   },
-  tsDeclarationOutput(pkg),
-  tsDeclarationOutput(pkg, {
-    input: './compiled/unstable.d.ts',
-    output: [
-      {
-        file: './dist/cjs/unstable.d.cts',
-        format: 'cjs',
-      },
-      {
-        file: './dist/esm/unstable.d.mts',
-        format: 'es',
-      },
-    ],
-  }),
 ];

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "declarationDir": "./compiled",
+    "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "allowJs": true,

--- a/packages/rollup.config.parts.ts
+++ b/packages/rollup.config.parts.ts
@@ -44,21 +44,3 @@ export function esmOutput(pkg, pkgName) {
     preserveModulesRoot: resolve(projectCwd, `packages/${pkgName}/src`),
   };
 }
-
-// Copy plugin settings for copying type declarations to both esm and cjs output directories.
-export const copyTypeDeclarationsConfig = {
-  hook: 'writeBundle',
-  targets: [
-    {
-      src: 'compiled/**/*.d.ts',
-      dest: 'dist/esm',
-      rename: (name) => `${name}.mts`,
-    },
-    {
-      src: 'compiled/**/*.d.ts',
-      dest: 'dist/cjs',
-      rename: (name) => `${name}.cts`,
-    },
-  ],
-  flatten: false,
-};

--- a/packages/rollup.config.parts.ts
+++ b/packages/rollup.config.parts.ts
@@ -1,7 +1,6 @@
 // This file contains the common parts of the rollup configuration that are shared across multiple packages.
 import nodeResolve from '@rollup/plugin-node-resolve';
-import { dirname, join, resolve } from 'node:path';
-import dts from 'rollup-plugin-dts';
+import { dirname, resolve } from 'node:path';
 import esbuild from 'rollup-plugin-esbuild';
 import { nodeExternals } from 'rollup-plugin-node-externals';
 
@@ -46,21 +45,20 @@ export function esmOutput(pkg, pkgName) {
   };
 }
 
-// Generate a rollup configuration for rolling up typescript declaration files into a single file.
-export function tsDeclarationOutput(pkg, overrides = {}) {
-  return {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: [
-      {
-        file: pkg.publishConfig.types,
-        format: 'cjs',
-      },
-      {
-        file: join(dirname(pkg.publishConfig.module), 'index.d.mts'),
-        format: 'es',
-      },
-    ],
-    ...overrides,
-  };
-}
+// Copy plugin settings for copying type declarations to both esm and cjs output directories.
+export const copyTypeDeclarationsConfig = {
+  hook: 'writeBundle',
+  targets: [
+    {
+      src: 'compiled/**/*.d.ts',
+      dest: 'dist/esm',
+      rename: (name) => `${name}.mts`,
+    },
+    {
+      src: 'compiled/**/*.d.ts',
+      dest: 'dist/cjs',
+      rename: (name) => `${name}.cts`,
+    },
+  ],
+  flatten: false,
+};

--- a/scripts/prepare-npm-package.js
+++ b/scripts/prepare-npm-package.js
@@ -1,6 +1,5 @@
 import PackageJson from '@npmcli/package-json';
 import { mkdir } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
 
 const cwd = process.cwd();
 
@@ -8,18 +7,17 @@ try {
   const pkgJson = await PackageJson.load(cwd);
   const cjsIndex = pkgJson.content.publishConfig?.main ?? pkgJson.content.main;
   const esmIndex = pkgJson.content.publishConfig?.module ?? pkgJson.content.module;
-  const cjsTypes = pkgJson.content.publishConfig?.types ?? pkgJson.content.types;
-  const esmTypes = `./${join(dirname(esmIndex), 'index.d.mts')}`;
+  const typesIndex = pkgJson.content.publishConfig?.types ?? pkgJson.content.types;
 
   const exports = {
     './package.json': './package.json',
     '.': {
       import: {
-        types: esmTypes,
+        types: typesIndex,
         default: esmIndex,
       },
       require: {
-        types: cjsTypes,
+        types: typesIndex,
         default: cjsIndex,
       },
     },
@@ -43,7 +41,7 @@ try {
 
   pkgJson.update({
     main: cjsIndex,
-    types: cjsTypes,
+    types: typesIndex,
     module: esmIndex,
     exports,
   });
@@ -60,11 +58,11 @@ try {
         ...pkgJson.content.exports,
         [`./${aliasName}`]: {
           import: {
-            types: esmTypes.replace('index', aliasName),
+            types: typesIndex.replace('index', aliasName),
             default: esmIndex.replace('index', aliasName),
           },
           require: {
-            types: cjsTypes.replace('index', aliasName),
+            types: typesIndex.replace('index', aliasName),
             default: cjsIndex.replace('index', aliasName),
           },
         },
@@ -88,7 +86,7 @@ async function createAliasPackageJsonFiles(packageJsonContent, aliasName) {
     const pkgJson = await PackageJson.create(pkgJsonPath, {
       data: {
         name: pkgName,
-        types: `../dist/cjs/${aliasName}.d.cts`,
+        types: `../dist/types/${aliasName}.d.ts`,
         main: `../dist/cjs/${aliasName}.cjs`,
         module: `../dist/esm/${aliasName}.mjs`,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,7 +121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.3, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.24.2, @babel/code-frame@npm:^7.26.2":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.3, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
@@ -3057,7 +3057,6 @@ __metadata:
     react-use: "npm:17.6.0"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     rxjs: "npm:7.8.2"
@@ -3084,7 +3083,6 @@ __metadata:
     esbuild: "npm:0.25.0"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     semver: "npm:^7.7.0"
@@ -3201,7 +3199,6 @@ __metadata:
     react-use: "npm:17.6.0"
     react-virtualized-auto-sizer: "npm:1.0.25"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     tinycolor2: "npm:1.6.0"
@@ -3446,7 +3443,6 @@ __metadata:
     react-use: "npm:17.6.0"
     react-window: "npm:1.8.11"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     rxjs: "npm:7.8.2"
@@ -3490,7 +3486,6 @@ __metadata:
     react-use: "npm:17.6.0"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     rollup-plugin-sourcemaps: "npm:0.6.3"
@@ -3557,7 +3552,6 @@ __metadata:
     glob: "npm:^11.0.0"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     tslib: "npm:2.8.1"
@@ -3751,7 +3745,6 @@ __metadata:
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.22.4"
     rollup-plugin-copy: "npm:3.5.0"
-    rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-esbuild: "npm:6.2.0"
     rollup-plugin-node-externals: "npm:^8.0.0"
     rollup-plugin-svg-import: "npm:3.0.0"
@@ -22074,7 +22067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.10, magic-string@npm:^0.30.5":
+"magic-string@npm:^0.30.5":
   version: 0.30.10
   resolution: "magic-string@npm:0.30.10"
   dependencies:
@@ -27788,22 +27781,6 @@ __metadata:
     globby: "npm:10.0.1"
     is-plain-object: "npm:^3.0.0"
   checksum: 10/706ba6bd2052b95d1037f12963ff4b50749730f18aefad10544f9574aff7c035c88c5dd9ae1f0c0408cf09862e595a0ea4d68e13c2717addaea2bda3ade0d0e0
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-dts@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "rollup-plugin-dts@npm:6.1.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.24.2"
-    magic-string: "npm:^0.30.10"
-  peerDependencies:
-    rollup: ^3.29.4 || ^4
-    typescript: ^4.5 || ^5.0
-  dependenciesMeta:
-    "@babel/code-frame":
-      optional: true
-  checksum: 10/8a66833a5af32f77d9bbc746339097d4af2382e5160f7629d85dcecb4efad12cbfebd37c79147fa688f073c333d71f53135e08a225a3fc3e9a3b3f92c46b2381
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR removes the rollup dts plugin from the npm package build process and updates the publishing scripts that prepare package.json files and validate the packages are as they should be.

**Why do we need this feature?**

This is an interim step to help unblock other teams. [See internal slack thread here](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1748441319990709). For now we'll live with a single types build with the intention to move all the packages tooling from rollup to [rolldown](https://rolldown.rs/) once it comes out of beta.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

If you want to test it locally you can follow these steps:

1. Run `yarn`
2. Run `yarn packages:clean && yarn packages:build`.
4. Run `yarn packages:pack`.
5. Run `cd devenv/local-npm` then `docker compose up` 
6. Run `NPM_TOKEN=NONE ./scripts/publish-npm-packages.sh`.
7. Run `gh repo clone jackw/heywesty-trafficlight-panel` then `git checkout temp/test-no-rollup-dts`
8. Run `npm install`
9. Test out various npm scripts and navigating files via your IDE

I've tested this against my plugin by publishing to the local verdaccio image. 

```
npm run build    

> trafficlight@0.5.2 build
> webpack -c ./.config/webpack/webpack.config.ts --env production

assets by status 340 KiB [compared for emit]
  assets by path img/ 309 KiB 5 assets
  assets by path *.md 6.58 KiB
    asset README.md 4.92 KiB [compared for emit] [from: README.md] [copied]
    asset CHANGELOG.md 1.66 KiB [compared for emit] [from: ../CHANGELOG.md] [copied]
  asset module.js 13.2 KiB [compared for emit] [minimized] (name: module) 1 related asset
  asset LICENSE 11.1 KiB [compared for emit] [from: ../LICENSE] [copied]
assets by status 18.3 KiB [emitted]
  asset 904.js?_cache=fd665123737921057804 5.33 KiB [emitted] [immutable] [minimized] 1 related asset
  asset 611.js?_cache=a999d6fd10345ef74ed0 3.73 KiB [emitted] [immutable] [minimized] 1 related asset
  asset 943.js?_cache=38abcce9f06275167394 3.6 KiB [emitted] [immutable] [minimized] 1 related asset
  asset 390.js?_cache=1df504ff3b9c3d945d57 2.47 KiB [emitted] [immutable] [minimized] 1 related asset
  asset plugin.json 1.84 KiB [emitted] [from: plugin.json] [copied]
  asset 95.js?_cache=e2e573a3bc34f9cfd247 1.33 KiB [emitted] [immutable] [minimized] 1 related asset
cached modules 65.7 KiB (javascript) 6.66 KiB (runtime) [cached] 32 modules
webpack 5.94.0 compiled successfully in 115 ms
```

```
npm run test:ci

> trafficlight@0.5.2 test:ci
> jest --passWithNoTests --maxWorkers 4

(node:74246) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/utils/processTableData.test.ts
(node:74245) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/utils/utils.test.ts
(node:74244) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/utils/processTimeSeriesData.test.ts

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        1.067 s, estimated 2 s
Ran all test suites.
```

```
npm run e2e    

> trafficlight@0.5.2 e2e
> playwright test


Running 7 tests using 6 workers
  7 passed (7.3s)
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
