### PR TITLE
Update CODEOWNERS of Loki data source to `@grafana/oss-big-tent`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -191,7 +191,7 @@
 /devenv/docker/blocks/auth/ @grafana/identity-access-team
 
 # Logs code, developers environment
-/devenv/docker/blocks/loki* @grafana/observability-logs
+/devenv/docker/blocks/loki* @grafana/oss-big-tent
 /devenv/docker/blocks/elastic* @grafana/partner-datasources
 /devenv/docker/blocks/self-instrumentation* @grafana/oss-big-tent
 
@@ -333,7 +333,7 @@
 # Observability backend code
 /pkg/tsdb/prometheus/ @grafana/oss-big-tent
 /pkg/tsdb/elasticsearch/ @grafana/partner-datasources
-/pkg/tsdb/loki/ @grafana/observability-logs
+/pkg/tsdb/loki/ @grafana/oss-big-tent
 /pkg/tsdb/tempo/ @grafana/observability-traces-and-profiling
 /pkg/tsdb/grafana-pyroscope-datasource/ @grafana/observability-traces-and-profiling
 /pkg/tsdb/parca/ @grafana/oss-big-tent
@@ -665,7 +665,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/plugins/datasource/graphite/ @grafana/partner-datasources
 /public/app/plugins/datasource/influxdb/ @grafana/partner-datasources
 /public/app/plugins/datasource/jaeger/ @grafana/oss-big-tent
-/public/app/plugins/datasource/loki/ @grafana/observability-logs
+/public/app/plugins/datasource/loki/ @grafana/oss-big-tent
 /public/app/plugins/datasource/mixed/ @grafana/dashboards-squad
 /public/app/plugins/datasource/mssql/ @grafana/partner-datasources
 /public/app/plugins/datasource/mysql/ @grafana/oss-big-tent


### PR DESCRIPTION
This PR updates codeowners of Loki data source to be `@grafana/oss-big-tent`. This is part of Loki data source handover to Big Tent squad. 