### PR TITLE
K8s: Migrate library elements

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -300,6 +300,10 @@ export interface FeatureToggles {
   */
   kubernetesSnapshots?: boolean;
   /**
+  * Routes library elements requests from /api to the /apis endpoint
+  */
+  kubernetesLibraryPanels?: boolean;
+  /**
   * Use the kubernetes API in the frontend for dashboards
   */
   kubernetesDashboards?: boolean;

--- a/pkg/registry/apis/dashboard/libary_panel.go
+++ b/pkg/registry/apis/dashboard/libary_panel.go
@@ -112,12 +112,6 @@ func (s *LibraryPanelStore) Create(ctx context.Context, obj runtime.Object, crea
 		return nil, apierrors.NewBadRequest("expected LibraryPanel object")
 	}
 
-	if createValidation != nil {
-		if err := createValidation(ctx, obj); err != nil {
-			return nil, err
-		}
-	}
-
 	ns, err := request.NamespaceInfoFrom(ctx, true)
 	if err != nil {
 		return nil, err
@@ -135,7 +129,6 @@ func (s *LibraryPanelStore) Create(ctx context.Context, obj runtime.Object, crea
 
 	dto, err := s.LibraryElementService.CreateElement(ctx, user, *cmd)
 	if err != nil {
-		fmt.Println("CreateElement error", err)
 		if err == model.ErrLibraryElementAlreadyExists {
 			return nil, apierrors.NewAlreadyExists(s.ResourceInfo.GroupResource(), panel.Name)
 		}
@@ -239,6 +232,8 @@ func (s *LibraryPanelStore) Delete(ctx context.Context, name string, deleteValid
 		return nil, false, apierrors.NewUnauthorized("unable to get user from context")
 	}
 
+	// TODO: check if there are any connections to this element, and if so, that those dashboards actually exist
+	// probably should be in the validation hook instead
 	_, err = s.LibraryElementService.DeleteElement(ctx, user, name)
 	if err != nil {
 		if err == model.ErrLibraryElementNotFound {

--- a/pkg/registry/apis/dashboard/libary_panel.go
+++ b/pkg/registry/apis/dashboard/libary_panel.go
@@ -10,9 +10,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
+	"github.com/grafana/grafana/pkg/setting"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -21,12 +26,17 @@ var (
 	_ rest.SingularNameProvider = (*LibraryPanelStore)(nil)
 	_ rest.Getter               = (*LibraryPanelStore)(nil)
 	_ rest.Lister               = (*LibraryPanelStore)(nil)
+	_ rest.Creater              = (*LibraryPanelStore)(nil)
+	_ rest.GracefulDeleter      = (*LibraryPanelStore)(nil)
+	_ rest.Updater              = (*LibraryPanelStore)(nil)
 	_ rest.Storage              = (*LibraryPanelStore)(nil)
 )
 
 type LibraryPanelStore struct {
-	Access       legacy.DashboardAccess
-	ResourceInfo utils.ResourceInfo
+	Access                legacy.DashboardAccess
+	ResourceInfo          utils.ResourceInfo
+	LibraryElementService libraryelements.Service
+	Cfg                   *setting.Cfg
 }
 
 func (s *LibraryPanelStore) New() runtime.Object {
@@ -94,4 +104,155 @@ func (s *LibraryPanelStore) Get(ctx context.Context, name string, options *metav
 		return &found.Items[0], nil
 	}
 	return nil, s.ResourceInfo.NewNotFound(name)
+}
+
+func (s *LibraryPanelStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	panel, ok := obj.(*dashboardV0.LibraryPanel)
+	if !ok {
+		return nil, apierrors.NewBadRequest("expected LibraryPanel object")
+	}
+
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+
+	ns, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, apierrors.NewUnauthorized("unable to get user from context")
+	}
+
+	cmd, err := libraryelements.ConvertToLegacyCreateCommand(panel, ns.OrgID)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("conversion error: %v", err))
+	}
+
+	dto, err := s.LibraryElementService.CreateElement(ctx, user, *cmd)
+	if err != nil {
+		fmt.Println("CreateElement error", err)
+		if err == model.ErrLibraryElementAlreadyExists {
+			return nil, apierrors.NewAlreadyExists(s.ResourceInfo.GroupResource(), panel.Name)
+		}
+		return nil, apierrors.NewInternalError(err)
+	}
+
+	namespacer := request.GetNamespaceMapper(s.Cfg)
+	result, err := libraryelements.ConvertToK8sResource(&dto, namespacer)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("failed to convert result: %w", err))
+	}
+
+	return result, nil
+}
+
+func (s *LibraryPanelStore) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	ns, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, false, err
+	}
+
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, false, apierrors.NewUnauthorized("unable to get user from context")
+	}
+
+	oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) && forceAllowCreate {
+			newObj, err := objInfo.UpdatedObject(ctx, nil)
+			if err != nil {
+				return nil, false, err
+			}
+			created, err := s.Create(ctx, newObj, createValidation, &metav1.CreateOptions{})
+			return created, true, err
+		}
+		return nil, false, err
+	}
+
+	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
+	if err != nil {
+		return nil, false, err
+	}
+
+	panel, ok := newObj.(*dashboardV0.LibraryPanel)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest("expected LibraryPanel object")
+	}
+
+	if updateValidation != nil {
+		if err := updateValidation(ctx, newObj, oldObj); err != nil {
+			return nil, false, err
+		}
+	}
+
+	oldPanel := oldObj.(*dashboardV0.LibraryPanel)
+	version, err := strconv.ParseInt(oldPanel.ResourceVersion, 10, 64)
+	if err != nil {
+		return nil, false, apierrors.NewBadRequest("invalid resource version")
+	}
+
+	cmd, err := libraryelements.ConvertToLegacyPatchCommand(panel, ns.OrgID, version)
+	if err != nil {
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("conversion error: %v", err))
+	}
+
+	dto, err := s.LibraryElementService.PatchElement(ctx, user, *cmd, name)
+	if err != nil {
+		if err == model.ErrLibraryElementNotFound {
+			return nil, false, apierrors.NewNotFound(s.ResourceInfo.GroupResource(), name)
+		}
+		if err == model.ErrLibraryElementVersionMismatch {
+			return nil, false, apierrors.NewConflict(s.ResourceInfo.GroupResource(), name, err)
+		}
+		return nil, false, apierrors.NewInternalError(err)
+	}
+
+	namespacer := request.GetNamespaceMapper(s.Cfg)
+	result, err := libraryelements.ConvertToK8sResource(&dto, namespacer)
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("failed to convert result: %w", err))
+	}
+
+	return result, false, nil
+}
+
+func (s *LibraryPanelStore) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	obj, err := s.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+
+	if deleteValidation != nil {
+		if err := deleteValidation(ctx, obj); err != nil {
+			return nil, false, err
+		}
+	}
+
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, false, apierrors.NewUnauthorized("unable to get user from context")
+	}
+
+	_, err = s.LibraryElementService.DeleteElement(ctx, user, name)
+	if err != nil {
+		if err == model.ErrLibraryElementNotFound {
+			return nil, false, apierrors.NewNotFound(s.ResourceInfo.GroupResource(), name)
+		}
+		if err == model.ErrLibraryElementHasConnections {
+			return nil, false, apierrors.NewBadRequest("library element has connections and cannot be deleted")
+		}
+		return nil, false, apierrors.NewInternalError(err)
+	}
+
+	return obj, true, nil
+}
+
+func (s *LibraryPanelStore) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {
+	return nil, apierrors.NewMethodNotSupported(s.ResourceInfo.GroupResource(), "deletecollection")
 }

--- a/pkg/registry/apis/dashboard/mutate.go
+++ b/pkg/registry/apis/dashboard/mutate.go
@@ -70,6 +70,9 @@ func (b *DashboardsAPIBuilder) Mutate(ctx context.Context, a admission.Attribute
 		resourceInfo = dashboardV2.DashboardResourceInfo
 
 		// Noop for V2
+	case *dashboardV0.LibraryPanel:
+		// Noop for LibraryPanel
+		return nil
 	default:
 		return fmt.Errorf("mutation error: expected to dashboard, got %T", obj)
 	}

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -191,7 +191,7 @@ func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 func (b *DashboardsAPIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
 	op := a.GetOperation()
 
-	if a.GetKind().Kind == "LibraryPanel" {
+	if a.GetResource().Resource == dashv0.LIBRARY_PANEL_RESOURCE {
 		return nil
 	}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -501,6 +501,13 @@ var (
 			RequiresRestart: true, // changes the API routing
 		},
 		{
+			Name:            "kubernetesLibraryPanels",
+			Description:     "Routes library elements requests from /api to the /apis endpoint",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaAppPlatformSquad,
+			RequiresRestart: true, // changes the API routing
+		},
+		{
 			Name:         "kubernetesDashboards",
 			Description:  "Use the kubernetes API in the frontend for dashboards",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -64,6 +64,7 @@ enableNativeHTTPHistogram,experimental,@grafana/grafana-backend-services-squad,f
 disableClassicHTTPHistogram,experimental,@grafana/grafana-backend-services-squad,false,true,false
 formatString,GA,@grafana/dataviz-squad,false,false,true
 kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
+kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
 kubernetesDashboards,experimental,@grafana/grafana-app-platform-squad,false,false,true
 kubernetesClientDashboardsFolders,GA,@grafana/grafana-app-platform-squad,false,false,false
 dashboardDisableSchemaValidationV1,experimental,@grafana/grafana-app-platform-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -267,6 +267,10 @@ const (
 	// Routes snapshot requests from /api to the /apis endpoint
 	FlagKubernetesSnapshots = "kubernetesSnapshots"
 
+	// FlagKubernetesLibraryPanels
+	// Routes library elements requests from /api to the /apis endpoint
+	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
+
 	// FlagKubernetesDashboards
 	// Use the kubernetes API in the frontend for dashboards
 	FlagKubernetesDashboards = "kubernetesDashboards"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1803,6 +1803,19 @@
     },
     {
       "metadata": {
+        "name": "kubernetesLibraryPanels",
+        "resourceVersion": "1749485421142",
+        "creationTimestamp": "2025-06-09T16:10:21Z"
+      },
+      "spec": {
+        "description": "Routes library elements requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesPlaylists",
         "resourceVersion": "1743693517832",
         "creationTimestamp": "2023-10-05T19:00:36Z",

--- a/pkg/services/libraryelements/conversions.go
+++ b/pkg/services/libraryelements/conversions.go
@@ -1,0 +1,364 @@
+package libraryelements
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// LegacyCreateCommandToUnstructured converts a legacy CreateLibraryElementCommand to an unstructured k8s object
+func LegacyCreateCommandToUnstructured(cmd model.CreateLibraryElementCommand) (unstructured.Unstructured, error) {
+	if cmd.Kind != 1 {
+		return unstructured.Unstructured{}, model.ErrLibraryElementUnSupportedElementKind
+	}
+
+	var modelData map[string]interface{}
+	if err := json.Unmarshal(cmd.Model, &modelData); err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to unmarshal model: %w", err)
+	}
+	panelType, _ := modelData["type"].(string)
+	description, _ := modelData["description"].(string)
+	options, _ := modelData["options"].(map[string]interface{})
+	pluginVersion, _ := modelData["pluginVersion"].(string)
+	targets, _ := modelData["targets"].([]interface{})
+	datasource, _ := modelData["datasource"].(map[string]interface{})
+	fieldConfig, _ := modelData["fieldConfig"].(map[string]interface{})
+
+	if options == nil {
+		options = make(map[string]interface{})
+	}
+	if fieldConfig == nil {
+		fieldConfig = make(map[string]interface{})
+	}
+
+	spec := map[string]interface{}{
+		"type":        panelType,
+		"title":       cmd.Name,
+		"description": description,
+		"options":     options,
+		"fieldConfig": fieldConfig,
+	}
+
+	if pluginVersion != "" {
+		spec["pluginVersion"] = pluginVersion
+	}
+	if targets != nil {
+		spec["targets"] = targets
+	}
+	if datasource != nil {
+		spec["datasource"] = datasource
+	}
+
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": spec,
+		},
+	}
+
+	uid := cmd.UID
+	if uid == "" {
+		uid = util.GenerateShortUID()
+	}
+	obj.SetName(uid)
+
+	// TODO
+	//obj.SetFolder(cmd.FolderUID)
+	//obj.SetDeprecatedInternalID()
+
+	return obj, nil
+}
+
+// LegacyPatchCommandToUnstructured converts a legacy PatchLibraryElementCommand to an unstructured k8s object
+func LegacyPatchCommandToUnstructured(cmd model.PatchLibraryElementCommand) (unstructured.Unstructured, error) {
+	var modelData map[string]interface{}
+	if cmd.Model != nil {
+		if err := json.Unmarshal(cmd.Model, &modelData); err != nil {
+			return unstructured.Unstructured{}, fmt.Errorf("failed to unmarshal model: %w", err)
+		}
+	} else {
+		modelData = make(map[string]interface{})
+	}
+
+	spec := make(map[string]interface{})
+
+	spec["title"] = cmd.Name
+	if modelData["type"] != nil {
+		spec["type"] = modelData["type"]
+	}
+	if modelData["description"] != nil {
+		spec["description"] = modelData["description"]
+	}
+	if modelData["options"] != nil {
+		spec["options"] = modelData["options"]
+	} else {
+		spec["options"] = make(map[string]interface{})
+	}
+	if modelData["fieldConfig"] != nil {
+		spec["fieldConfig"] = modelData["fieldConfig"]
+	} else {
+		spec["fieldConfig"] = make(map[string]interface{})
+	}
+	if modelData["pluginVersion"] != nil {
+		spec["pluginVersion"] = modelData["pluginVersion"]
+	}
+	if modelData["targets"] != nil {
+		spec["targets"] = modelData["targets"]
+	}
+	if modelData["datasource"] != nil {
+		spec["datasource"] = modelData["datasource"]
+	}
+
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": spec,
+		},
+	}
+
+	uid := cmd.UID
+	if uid == "" {
+		uid = util.GenerateShortUID()
+	}
+	obj.SetName(uid)
+
+	return obj, nil
+}
+
+// UnstructuredToLegacyLibraryPanelDTO converts an unstructured k8s object to a legacy LibraryElementDTO
+func UnstructuredToLegacyLibraryPanelDTO(item unstructured.Unstructured) (*model.LibraryElementDTO, error) {
+	spec, exists := item.Object["spec"].(map[string]interface{})
+	if !exists {
+		return nil, fmt.Errorf("spec not found in unstructured object")
+	}
+
+	// Reconstruct the model JSON from the spec
+	modelData := make(map[string]interface{})
+
+	if spec["type"] != nil {
+		modelData["type"] = spec["type"]
+	}
+	if spec["title"] != nil {
+		modelData["title"] = spec["title"]
+	}
+	if spec["description"] != nil {
+		modelData["description"] = spec["description"]
+	}
+	if spec["options"] != nil {
+		modelData["options"] = spec["options"]
+	}
+	if spec["fieldConfig"] != nil {
+		modelData["fieldConfig"] = spec["fieldConfig"]
+	}
+	if spec["pluginVersion"] != nil {
+		modelData["pluginVersion"] = spec["pluginVersion"]
+	}
+	if spec["targets"] != nil {
+		modelData["targets"] = spec["targets"]
+	}
+	if spec["datasource"] != nil {
+		modelData["datasource"] = spec["datasource"]
+	}
+
+	modelJSON, err := json.Marshal(modelData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal model: %w", err)
+	}
+
+	title, _ := spec["title"].(string)
+	panelType, _ := spec["type"].(string)
+	description, _ := spec["description"].(string)
+
+	dto := &model.LibraryElementDTO{
+		UID:         item.GetName(),
+		Name:        title,
+		Type:        panelType,
+		Description: description,
+		Model:       modelJSON,
+		Kind:        int64(model.PanelElement),
+		// TODO
+		Version: 1,
+	}
+
+	meta, err := utils.MetaAccessor(&item)
+	if err == nil {
+		dto.ID = meta.GetDeprecatedInternalID() // nolint:staticcheck
+	}
+
+	return dto, nil
+}
+
+// ConvertToK8sResource converts a legacy LibraryElementDTO to a k8s LibraryPanel resource
+func ConvertToK8sResource(dto *model.LibraryElementDTO, namespacer request.NamespaceMapper) (*dashboardV0.LibraryPanel, error) {
+	var modelData map[string]interface{}
+	if err := json.Unmarshal(dto.Model, &modelData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal model: %w", err)
+	}
+
+	spec := dashboardV0.LibraryPanelSpec{
+		Type:        dto.Type,
+		Title:       dto.Name,
+		Description: dto.Description,
+	}
+
+	if options, exists := modelData["options"]; exists {
+		spec.Options = common.Unstructured{Object: options.(map[string]interface{})}
+	} else {
+		spec.Options = common.Unstructured{Object: make(map[string]interface{})}
+	}
+
+	if fieldConfig, exists := modelData["fieldConfig"]; exists {
+		spec.FieldConfig = common.Unstructured{Object: fieldConfig.(map[string]interface{})}
+	} else {
+		spec.FieldConfig = common.Unstructured{Object: make(map[string]interface{})}
+	}
+
+	if pluginVersion, exists := modelData["pluginVersion"].(string); exists {
+		spec.PluginVersion = pluginVersion
+	}
+
+	createdTime := time.Now()
+	if !dto.Meta.Created.IsZero() {
+		createdTime = dto.Meta.Created
+	}
+
+	panel := &dashboardV0.LibraryPanel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              dto.UID,
+			UID:               types.UID(dto.UID),
+			ResourceVersion:   strconv.FormatInt(dto.Version, 10),
+			CreationTimestamp: metav1.NewTime(createdTime),
+			Namespace:         namespacer(dto.OrgID),
+		},
+		Spec: spec,
+	}
+
+	meta, err := utils.MetaAccessor(panel)
+	if err == nil {
+		if !dto.Meta.Updated.IsZero() {
+			meta.SetUpdatedTimestamp(&dto.Meta.Updated)
+		}
+		if dto.ID > 0 {
+			meta.SetDeprecatedInternalID(dto.ID) // nolint:staticcheck
+		}
+		if dto.FolderUID != "" {
+			meta.SetFolder(dto.FolderUID)
+		}
+		meta.SetGeneration(dto.Version)
+	}
+
+	return panel, nil
+}
+
+// ConvertToLegacyCreateCommand converts a k8s LibraryPanel to a legacy CreateLibraryElementCommand
+func ConvertToLegacyCreateCommand(panel *dashboardV0.LibraryPanel, orgID int64) (*model.CreateLibraryElementCommand, error) {
+	spec := panel.Spec
+	modelData := map[string]interface{}{
+		"type":        spec.Type,
+		"title":       spec.Title,
+		"description": spec.Description,
+		"options":     spec.Options.Object,
+		"fieldConfig": spec.FieldConfig.Object,
+	}
+
+	if spec.PluginVersion != "" {
+		modelData["pluginVersion"] = spec.PluginVersion
+	}
+
+	if spec.Targets != nil && len(spec.Targets) > 0 {
+		modelData["targets"] = spec.Targets
+	}
+
+	if spec.Datasource != nil {
+		modelData["datasource"] = spec.Datasource
+	}
+
+	modelJSON, err := json.Marshal(modelData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal model: %w", err)
+	}
+
+	cmd := &model.CreateLibraryElementCommand{
+		UID:   panel.Name,
+		Name:  spec.Title,
+		Model: modelJSON,
+		Kind:  int64(model.PanelElement),
+	}
+
+	meta, err := utils.MetaAccessor(panel)
+	if err == nil {
+		folderUID := meta.GetFolder()
+		if folderUID != "" {
+			cmd.FolderUID = &folderUID
+		}
+	}
+
+	return cmd, nil
+}
+
+// ConvertToLegacyPatchCommand converts a k8s LibraryPanel to a legacy PatchLibraryElementCommand
+func ConvertToLegacyPatchCommand(panel *dashboardV0.LibraryPanel, orgID int64, version int64) (*model.PatchLibraryElementCommand, error) {
+	spec := panel.Spec
+
+	modelData := map[string]interface{}{
+		"type":        spec.Type,
+		"title":       spec.Title,
+		"description": spec.Description,
+		"options":     spec.Options.Object,
+		"fieldConfig": spec.FieldConfig.Object,
+	}
+
+	if spec.PluginVersion != "" {
+		modelData["pluginVersion"] = spec.PluginVersion
+	}
+
+	if spec.Targets != nil && len(spec.Targets) > 0 {
+		modelData["targets"] = spec.Targets
+	}
+
+	if spec.Datasource != nil {
+		modelData["datasource"] = spec.Datasource
+	}
+
+	modelJSON, err := json.Marshal(modelData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal model: %w", err)
+	}
+
+	cmd := &model.PatchLibraryElementCommand{
+		UID:     panel.Name,
+		Name:    spec.Title,
+		Model:   modelJSON,
+		Kind:    int64(model.PanelElement),
+		Version: version,
+	}
+
+	meta, err := utils.MetaAccessor(panel)
+	if err == nil {
+		folderUID := meta.GetFolder()
+		if folderUID != "" {
+			cmd.FolderUID = &folderUID
+		}
+	}
+
+	return cmd, nil
+}
+
+// getLegacyID reads legacy ID from metadata annotations
+func getLegacyLibraryPanelID(item *unstructured.Unstructured) int64 {
+	meta, err := utils.MetaAccessor(item)
+	if err != nil {
+		return 0
+	}
+	return meta.GetDeprecatedInternalID() // nolint:staticcheck
+}

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -54,6 +54,8 @@ func (m *service) ShouldManage(gr schema.GroupResource) bool {
 		return true
 	case "dashboards.dashboard.grafana.app":
 		return true
+	case "librarypanels.dashboard.grafana.app":
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
**What is this feature?**

Reroutes /api to /apis for library elements

Todos:
- [ ] Create
  - [ ] Mode0
  - [ ] Mode5
- [ ] Delete
  - [ ] Mode0
  - [ ] Mode5
- [ ] List
  - [ ] Mode0
  - [ ] Mode5
- [ ] Search
  - [ ] Mode0
  - [ ] Mode5
- [ ] Patch
  - [ ] Mode0
  - [ ] Mode5
- [ ] Get by name
  - [ ] Mode0
  - [ ] Mode5
- [ ] Integration tests

Follow-ups:
- Connections

**Why do we need this feature?**

So we can start to read from unified storage for library elements

