### PR TITLE
Docs: Remove public preview card from cloud migration audit logging section

### DIFF
--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -328,8 +328,6 @@ external group.
 
 #### Cloud migration management
 
-{{< docs/public-preview product="Cloud Migration Assistant" featureFlag="onPremToCloudMigrations" >}}
-
 | Action                           | Distinguishing fields                                       |
 | -------------------------------- | ----------------------------------------------------------- |
 | Connect to a cloud instance      | `{"action": "connect-instance"}`                            |


### PR DESCRIPTION
Because the feature is now GA!