### PR TITLE
Crypto: Use crypto/pbkdf2 instead of x

### DIFF
--- a/pkg/services/encryption/encryption.go
+++ b/pkg/services/encryption/encryption.go
@@ -2,9 +2,8 @@ package encryption
 
 import (
 	"context"
+	"crypto/pbkdf2"
 	"crypto/sha256"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -44,5 +43,5 @@ type Provider interface {
 
 // KeyToBytes key length needs to be 32 bytes
 func KeyToBytes(secret, salt string) ([]byte, error) {
-	return pbkdf2.Key([]byte(secret), []byte(salt), 10000, 32, sha256.New), nil
+	return pbkdf2.Key(sha256.New, secret, []byte(salt), 10000, 32)
 }

--- a/pkg/util/encoding.go
+++ b/pkg/util/encoding.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -9,8 +10,6 @@ import (
 	"io"
 	"mime/quotedprintable"
 	"strings"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -51,7 +50,10 @@ func GetRandomString(n int, alphabets ...byte) (string, error) {
 
 // EncodePassword encodes a password using PBKDF2.
 func EncodePassword(password string, salt string) (string, error) {
-	newPasswd := pbkdf2.Key([]byte(password), []byte(salt), 10000, 50, sha256.New)
+	newPasswd, err := pbkdf2.Key(sha256.New, password, []byte(salt), 10000, 50)
+	if err != nil {
+		return "", err
+	}
 	return hex.EncodeToString(newPasswd), nil
 }
 

--- a/pkg/util/encryption.go
+++ b/pkg/util/encryption.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -146,5 +145,5 @@ func Encrypt(payload []byte, secret string) ([]byte, error) {
 
 // Key needs to be 32bytes
 func encryptionKeyToBytes(secret, salt string) ([]byte, error) {
-	return pbkdf2.Key([]byte(secret), []byte(salt), 10000, 32, sha256.New), nil
+	return pbkdf2.Key(sha256.New, secret, []byte(salt), 10000, 32)
 }


### PR DESCRIPTION
The x/crypto/pbkdf2 package does not support the FIPS-140-only mode. We need to use the upstream package whenever possible instead.

This doesn't fix FIPS-140-only mode for Grafana, but it is a small move of the needle towards that.