### PR TITLE
[release-11.5.6] Alerting: Provisioning API returns 403 on quota exceeded for rule group PUT

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -519,6 +519,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *contextmodel.ReqContext, a
 	if errors.Is(err, store.ErrOptimisticLock) {
 		return ErrResp(http.StatusConflict, err, "")
 	}
+	if errors.Is(err, alerting_models.ErrQuotaReached) {
+		return ErrResp(http.StatusForbidden, err, "")
+	}
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -657,6 +657,26 @@ func TestProvisioningApi(t *testing.T) {
 		})
 	})
 
+	t.Run("have reached the rule quota, PUT returns 403", func(t *testing.T) {
+		env := createTestEnv(t, testConfig)
+		quotas := provisioning.MockQuotaChecker{}
+		quotas.EXPECT().LimitExceeded()
+		env.quotas = &quotas
+		sut := createProvisioningSrvSutFromEnv(t, &env)
+		group := definitions.AlertRuleGroup{
+			Title:    "test rule group",
+			Interval: 60,
+			Rules: []definitions.ProvisionedAlertRule{
+				createTestAlertRule("test-alert-rule", 1),
+			},
+		}
+		rc := createTestRequestCtx()
+
+		response := sut.RoutePutAlertRuleGroup(&rc, group, "folder-uid", group.Title)
+
+		require.Equal(t, 403, response.Status())
+	})
+
 	t.Run("exports", func(t *testing.T) {
 		t.Run("alert rule group", func(t *testing.T) {
 			t.Run("are present, GET returns 200", func(t *testing.T) {


### PR DESCRIPTION
Backport 1df888c51778ad3c02497d98d521435d990516ea from #106409

---

`PUT /api/v1/provisioning/folder/:folderUid/rule-groups/:group` currently returns a 500 HTTP error when provisioning more alert rules than the limit allows. It should return a 403, the same way `POST /api/v1/provisioning/alert-rules` returns a 403 in such cases.

---

FTR, I'm able to reproduce the issue locally when calling the API with the following Grafana config:

```ini
[quota]
enabled = true
org_alert_rule = 1
```
