### PR TITLE
Azure: Fix legend formatting

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -118,7 +118,9 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 		filterInBody = false
 		if resourceUri != nil {
 			azureURL = fmt.Sprintf("%s/providers/microsoft.insights/metrics", *resourceUri)
-			resourceMap[*resourceUri] = dataquery.AzureMonitorResource{ResourceGroup: resourceGroup, ResourceName: resourceName}
+			// Store the resource URI in the map lowercased to avoid case sensitivity issues
+			uriLower := strings.ToLower(*resourceUri)
+			resourceMap[uriLower] = dataquery.AzureMonitorResource{ResourceGroup: resourceGroup, ResourceName: resourceName}
 		}
 	} else {
 		for _, r := range azJSONModel.Resources {
@@ -135,7 +137,9 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 			}
 
 			if resourceUri != nil {
-				resourceMap[*resourceUri] = r
+				// Store the resource URI in the map lowercased to avoid case sensitivity issues
+				uriLower := strings.ToLower(*resourceUri)
+				resourceMap[uriLower] = r
 			}
 			resourceIDs = append(resourceIDs, fmt.Sprintf("Microsoft.ResourceId eq '%s'", *resourceUri))
 		}
@@ -597,7 +601,7 @@ func getQueryUrl(query *types.AzureMonitorQuery, azurePortalUrl, resourceID, res
 func formatAzureMonitorLegendKey(query *types.AzureMonitorQuery, resourceId string, amr *types.AzureMonitorResponse, labels data.Labels, subscription string) string {
 	alias := query.Alias
 	subscriptionId := query.Subscription
-	resource := query.Resources[resourceId]
+	resource := query.Resources[strings.ToLower(resourceId)]
 	metricName := amr.Value[0].Name.LocalizedValue
 	namespace := amr.Namespace
 	// Could be a collision problem if there were two keys that varied only in case, but I don't think that would happen in azure.

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -301,10 +301,10 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			if tt.azureMonitorVariedProperties["resources"] != nil {
 				resourceSlice := tt.azureMonitorVariedProperties["resources"].([]dataquery.AzureMonitorResource)
 				for _, resource := range resourceSlice {
-					resources[fmt.Sprintf("/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", *resource.ResourceGroup, *resource.ResourceName)] = resource
+					resources[strings.ToLower(fmt.Sprintf("/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", *resource.ResourceGroup, *resource.ResourceName))] = resource
 				}
 			} else {
-				resources["/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana"] = dataquery.AzureMonitorResource{ResourceGroup: strPtr("grafanastaging"), ResourceName: strPtr("grafana")}
+				resources[strings.ToLower("/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana")] = dataquery.AzureMonitorResource{ResourceGroup: strPtr("grafanastaging"), ResourceName: strPtr("grafana")}
 			}
 
 			azureMonitorQuery := &types.AzureMonitorQuery{
@@ -368,7 +368,7 @@ func TestCustomNamespace(t *testing.T) {
 
 func TestAzureMonitorParseResponse(t *testing.T) {
 	resources := map[string]dataquery.AzureMonitorResource{}
-	resources["/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana"] =
+	resources[strings.ToLower("/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana")] =
 		dataquery.AzureMonitorResource{ResourceGroup: strPtr("grafanastaging"), ResourceName: strPtr("grafana")}
 	subscription := "12345678-aaaa-bbbb-cccc-123456789abc"
 
@@ -486,7 +486,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				Params: url.Values{
 					"aggregation": {"Average"},
 				},
-				Resources:    map[string]dataquery.AzureMonitorResource{"/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanatest/providers/Microsoft.Storage/storageAccounts/testblobaccount/blobServices/default/providers/Microsoft.Insights/metrics": {ResourceGroup: strPtr("grafanatest"), ResourceName: strPtr("testblobaccount")}},
+				Resources:    map[string]dataquery.AzureMonitorResource{strings.ToLower("/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanatest/providers/Microsoft.Storage/storageAccounts/testblobaccount/blobServices/default/providers/Microsoft.Insights/metrics"): {ResourceGroup: strPtr("grafanatest"), ResourceName: strPtr("testblobaccount")}},
 				Subscription: subscription,
 			},
 		},


### PR DESCRIPTION
Azure can return resource URIs with inconsistent casing. This can cause legend aliases to fail.

This change ensures the resource URIs are consistently stored in the `query.resources` map with the keys lowercased. The lookup against the map is then also consistently lowercased.

This only applies to metric queries.

Fixes grafana/support-escalations#16517