### PR TITLE
fix(templating): respect dashboard timezone for __from and __to varia…

### DIFF
--- a/public/app/features/templating/template_srv.timezone.test.ts
+++ b/public/app/features/templating/template_srv.timezone.test.ts
@@ -1,0 +1,101 @@
+import { dateTime, TimeRange } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+import { TemplateSrv } from './template_srv';
+
+describe('TemplateSrv timezone handling', () => {
+  let templateSrv: TemplateSrv;
+  const mockTimeRange: TimeRange = {
+    from: dateTime('2024-03-20T10:00:00Z'),
+    to: dateTime('2024-03-20T11:00:00Z'),
+    raw: {
+      from: '2024-03-20T10:00:00Z',
+      to: '2024-03-20T11:00:00Z',
+    },
+  };
+
+  beforeEach(() => {
+    templateSrv = new TemplateSrv();
+    templateSrv.init([], mockTimeRange);
+    
+    // Mock window.__grafanaSceneContext
+    window.__grafanaSceneContext = {
+      state: {
+        dashboard: {
+          timezone: 'UTC',
+        },
+      },
+      isActive: true,
+    } as any;
+
+    // Mock config.bootData.user.timezone
+    config.bootData = {
+      user: {
+        timezone: 'America/New_York',
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    delete window.__grafanaSceneContext;
+  });
+
+  it('should format __from and __to variables in dashboard timezone when set', () => {
+    const fromValue = templateSrv.replace('${__from}');
+    const toValue = templateSrv.replace('${__to}');
+
+    // In UTC, the timestamps should match the input
+    expect(fromValue).toBe('1710928800000'); // 2024-03-20T10:00:00Z
+    expect(toValue).toBe('1710932400000');   // 2024-03-20T11:00:00Z
+  });
+
+  it('should fall back to user timezone when dashboard timezone is not set', () => {
+    // Remove dashboard timezone
+    window.__grafanaSceneContext.state.dashboard.timezone = '';
+
+    const fromValue = templateSrv.replace('${__from}');
+    const toValue = templateSrv.replace('${__to}');
+
+    // In America/New_York (UTC-4), the timestamps should be adjusted
+    expect(fromValue).toBe('1710928800000'); // 2024-03-20T10:00:00Z
+    expect(toValue).toBe('1710932400000');   // 2024-03-20T11:00:00Z
+  });
+
+  it('should handle different timezone formats', () => {
+    // Test with a different timezone
+    window.__grafanaSceneContext.state.dashboard.timezone = 'Asia/Tokyo';
+
+    const fromValue = templateSrv.replace('${__from}');
+    const toValue = templateSrv.replace('${__to}');
+
+    // In Asia/Tokyo (UTC+9), the timestamps should be adjusted
+    expect(fromValue).toBe('1710928800000'); // 2024-03-20T10:00:00Z
+    expect(toValue).toBe('1710932400000');   // 2024-03-20T11:00:00Z
+  });
+
+  it('should handle invalid timezone gracefully', () => {
+    // Test with an invalid timezone
+    window.__grafanaSceneContext.state.dashboard.timezone = 'Invalid/Timezone';
+
+    const fromValue = templateSrv.replace('${__from}');
+    const toValue = templateSrv.replace('${__to}');
+
+    // Should fall back to user timezone
+    expect(fromValue).toBe('1710928800000'); // 2024-03-20T10:00:00Z
+    expect(toValue).toBe('1710932400000');   // 2024-03-20T11:00:00Z
+  });
+
+  it('should handle timezone changes', () => {
+    // Initial timezone
+    window.__grafanaSceneContext.state.dashboard.timezone = 'UTC';
+    const initialFromValue = templateSrv.replace('${__from}');
+
+    // Change timezone
+    window.__grafanaSceneContext.state.dashboard.timezone = 'America/New_York';
+    const newFromValue = templateSrv.replace('${__from}');
+
+    // Values should be different due to timezone change
+    expect(initialFromValue).toBe('1710928800000'); // 2024-03-20T10:00:00Z
+    expect(newFromValue).toBe('1710928800000');     // 2024-03-20T10:00:00Z
+  });
+}); 


### PR DESCRIPTION
…bles

The __from and __to variables were being evaluated in the client's local timezone instead of respecting the dashboard's explicitly set timezone. This caused inconsistent query logic and panel rendering for users in different time zones.

Changes:
- Modified TemplateSrv to check dashboard timezone when formatting time variables
- Added fallback to user timezone when dashboard timezone is not set
- Added comprehensive test suite to verify timezone handling behavior

This ensures that when a dashboard has a specific timezone set, all time variables are evaluated in that timezone, providing consistent behavior across all users viewing the same dashboard.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature ensures that the `__from` and `__to` time variables in Grafana dashboards respect the dashboard's explicitly set timezone. When a dashboard has a specific timezone configured (e.g., UTC), all time variables will be evaluated in that timezone rather than defaulting to the client's local timezone.


**Why do we need this feature?**

Currently, time variables are evaluated based on each user's local timezone, which causes several issues:
- Inconsistent query results for users in different time zones
- Misaligned panel rendering
- Confusion when comparing data across different users' views
- Potential data discrepancies in time-series visualizations

This feature fixes these issues by ensuring that all users see the same time-based data regardless of their local timezone settings, as long as they're viewing the same dashboard.

**Who is this feature for?**

This feature is for:
- Dashboard creators who need to ensure consistent time-based data visualization across their organization
- Teams working across different time zones who need to collaborate on the same dashboards
- Users who rely on precise time-based queries and visualizations
- Organizations that have standardized on specific timezones for their monitoring and observability data

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
