### PR TITLE
fix(unified-storage): use continue token containing both formats for dualwriter

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -551,6 +551,7 @@ type Cfg struct {
 
 	// Unified Storage
 	UnifiedStorage                             map[string]UnifiedStorageConfig
+	MaxPageSizeBytes                           int
 	IndexPath                                  string
 	IndexWorkers                               int
 	IndexMaxBatchSize                          int

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -51,6 +51,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 
 	// Set indexer config for unified storaae
 	section := cfg.Raw.Section("unified_storage")
+	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
 	cfg.IndexWorkers = section.Key("index_workers").MustInt(10)
 	cfg.IndexMaxBatchSize = section.Key("index_max_batch_size").MustInt(100)

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -76,7 +76,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	)
 
 	// Split a dualwriter continue token (legacy, unified) if we received one.
-	// Otherwise, only populated `legacyToken` with the legacy token seperated
+	// Otherwise, only populated `legacyToken` with the legacy token separated
 	// by `|`.
 	legacyToken, unifiedToken, err := parseContinueTokens(options.Continue)
 	if err != nil {

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -133,7 +133,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 		go func(ctxBg context.Context, cancel context.CancelFunc) {
 			defer cancel()
 			defer close(out)
-			unifiedList, err := d.unified.List(ctxBg, options)
+			unifiedList, err := d.unified.List(ctxBg, unifiedOptions)
 			if err != nil {
 				log.Error("failed background LIST to unified", "err", err)
 				return

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -94,7 +94,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 		}
 		unifiedMeta, err := meta.ListAccessor(unifiedList)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to access legacy List MetaData: %w", err)
 		}
 		unifiedMeta.SetContinue(buildContinueToken("", unifiedMeta.GetContinue()))
 		return unifiedList, nil
@@ -106,7 +106,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	}
 	legacyMeta, err := meta.ListAccessor(legacyList)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to access legacy List MetaData: %w", err)
 	}
 	legacyToken = legacyMeta.GetContinue()
 
@@ -125,8 +125,8 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 			}
 			unifiedMeta, err := meta.ListAccessor(unifiedList)
 			if err != nil {
-				log := logging.FromContext(ctxBg).With("method", "List")
-				log.Error("failed background LIST to unified", "err", err)
+				log.Error("failed background LIST to unified", "err",
+					fmt.Errorf("failed to access unified List MetaData: %w", err))
 			}
 			unifiedToken = unifiedMeta.GetContinue()
 		}(context.WithTimeout(context.WithoutCancel(ctx), backgroundReqTimeout))
@@ -144,7 +144,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	}
 	unifiedMeta, err := meta.ListAccessor(unifiedList)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to access legacy List MetaData: %w", err)
 	}
 	unifiedToken = unifiedMeta.GetContinue()
 	legacyMeta.SetContinue(buildContinueToken(legacyToken, unifiedToken))

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -74,7 +74,6 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	var (
 		legacyOptions  = options.DeepCopy()
 		unifiedOptions = options.DeepCopy()
-		unifiedToken   = ""
 		log            = logging.FromContext(ctx).With("method", "List")
 	)
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -110,6 +110,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	// In some cases, where the stores are not in sync yet, the unified storage continue token might already
 	// be empty, while the legacy one is not, as it has more data. In that case we don't want to issue a new
 	// request with an empty continue token, resulting in getting the first page again.
+	// nolint:staticcheck
 	shouldDoUnifiedRequest := true
 	if options.Continue != "" && unifiedToken == "" {
 		shouldDoUnifiedRequest = false

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -1,0 +1,26 @@
+package dualwrite
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// parseContinueTokens splits a dualwriter continue token (legacy, unified) if we received one.
+// If we received a single token that is not separated by a comma, we return the token as is as legacy
+// token and an empty unified token. This is to ensure smooth transition to the new token format.
+func parseContinueTokens(token string) (string, string, error) {
+	if token == "" {
+		return "", "", nil
+	}
+	decodedToken, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decode dualwriter continue token: %w", err)
+	}
+	decodedTokens := strings.Split(string(decodedToken), ",")
+	if len(decodedTokens) > 1 {
+		return decodedTokens[0], decodedTokens[1], nil
+	}
+	return token, "", nil
+
+}

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -7,8 +7,8 @@ import (
 )
 
 // parseContinueTokens splits a dualwriter continue token (legacy, unified) if we received one.
-// If we received a single token that is not separated by a comma, we return the token as is as legacy
-// token and an empty unified token. This is to ensure smooth transition to the new token format.
+// If we receive a single token not separated by a comma, we return the token as-is as a legacy
+// token and an empty unified token. This is to ensure a smooth transition to the new token format.
 func parseContinueTokens(token string) (string, string, error) {
 	if token == "" {
 		return "", "", nil

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -26,6 +26,9 @@ func parseContinueTokens(token string) (string, string, error) {
 }
 
 func buildContinueToken(legacyToken, unifiedToken string) string {
+	if legacyToken == "" && unifiedToken == "" {
+		return ""
+	}
 	return base64.StdEncoding.EncodeToString([]byte(
 		strings.Join([]string{legacyToken, unifiedToken}, ",")))
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -24,3 +24,8 @@ func parseContinueTokens(token string) (string, string, error) {
 	return token, "", nil
 
 }
+
+func buildContinueToken(legacyToken, unifiedToken string) string {
+	return base64.StdEncoding.EncodeToString([]byte(
+		strings.Join([]string{legacyToken, unifiedToken}, ",")))
+}

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -29,6 +29,7 @@ func buildContinueToken(legacyToken, unifiedToken string) string {
 	if legacyToken == "" && unifiedToken == "" {
 		return ""
 	}
+
 	return base64.StdEncoding.EncodeToString([]byte(
 		strings.Join([]string{legacyToken, unifiedToken}, ",")))
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token.go
@@ -22,14 +22,12 @@ func parseContinueTokens(token string) (string, string, error) {
 		return decodedTokens[0], decodedTokens[1], nil
 	}
 	return token, "", nil
-
 }
 
 func buildContinueToken(legacyToken, unifiedToken string) string {
 	if legacyToken == "" && unifiedToken == "" {
 		return ""
 	}
-
 	return base64.StdEncoding.EncodeToString([]byte(
 		strings.Join([]string{legacyToken, unifiedToken}, ",")))
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseContinueToken(t *testing.T) {
+func TestParseContinueTokens(t *testing.T) {
 	tcs := []struct {
 		name         string
 		token        string
@@ -44,6 +44,37 @@ func TestParseContinueToken(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			legacyToken, unifiedToken, err := parseContinueTokens(tc.token)
+			require.NoError(t, err)
+			require.Equal(t, legacyToken, tc.legacyToken)
+			require.Equal(t, unifiedToken, tc.unifiedToken)
+		})
+	}
+}
+
+func TestBuildContinueToken(t *testing.T) {
+	tcs := []struct {
+		name         string
+		legacyToken  string
+		unifiedToken string
+	}{
+		{
+			name:         "Should handle both tokens",
+			legacyToken:  "abc",
+			unifiedToken: "xyz",
+		},
+		{
+			name:        "Should handle legacy token standalone",
+			legacyToken: "abc",
+		},
+		{
+			name:         "Should handle unified token standalone",
+			unifiedToken: "xyz",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			token := buildContinueToken(tc.legacyToken, tc.unifiedToken)
+			legacyToken, unifiedToken, err := parseContinueTokens(token)
 			require.NoError(t, err)
 			require.Equal(t, legacyToken, tc.legacyToken)
 			require.Equal(t, unifiedToken, tc.unifiedToken)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
@@ -89,3 +89,9 @@ func TestBuildContinueToken(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidToken(t *testing.T) {
+	invalidToken := "325232ff4fF->"
+	_, _, err := parseContinueTokens(invalidToken)
+	require.Error(t, err)
+}

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
@@ -91,6 +91,7 @@ func TestBuildContinueToken(t *testing.T) {
 }
 
 func TestInvalidToken(t *testing.T) {
+	// nolint: gosec
 	invalidToken := "325232ff4fF->"
 	_, _, err := parseContinueTokens(invalidToken)
 	require.Error(t, err)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
@@ -53,9 +53,10 @@ func TestParseContinueTokens(t *testing.T) {
 
 func TestBuildContinueToken(t *testing.T) {
 	tcs := []struct {
-		name         string
-		legacyToken  string
-		unifiedToken string
+		name          string
+		legacyToken   string
+		unifiedToken  string
+		shouldBeEmpty bool
 	}{
 		{
 			name:         "Should handle both tokens",
@@ -70,6 +71,10 @@ func TestBuildContinueToken(t *testing.T) {
 			name:         "Should handle unified token standalone",
 			unifiedToken: "xyz",
 		},
+		{
+			name:          "Should handle both tokens empty",
+			shouldBeEmpty: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +83,9 @@ func TestBuildContinueToken(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, legacyToken, tc.legacyToken)
 			require.Equal(t, unifiedToken, tc.unifiedToken)
+			if tc.shouldBeEmpty {
+				require.Equal(t, "", token)
+			}
 		})
 	}
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_continue_token_test.go
@@ -1,0 +1,52 @@
+package dualwrite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseContinueToken(t *testing.T) {
+	tcs := []struct {
+		name         string
+		token        string
+		legacyToken  string
+		unifiedToken string
+	}{
+		{
+			name:         "Should handle empty token",
+			token:        "",
+			legacyToken:  "",
+			unifiedToken: "",
+		},
+		{
+			name:         "Should handle legacy token",
+			token:        "MXwy",
+			legacyToken:  "MXwy",
+			unifiedToken: "",
+		},
+		{
+			name: "Should handle new token format",
+			// both slots taken 'MXwy,eyJvIjoxLCJ2IjoxNzQ5NTY1NTU4MDc4OTkwLCJzIjpmYWxzZX0='
+			token:        "TVh3eSxleUp2SWpveExDSjJJam94TnpRNU5UWTFOVFU0TURjNE9Ua3dMQ0p6SWpwbVlXeHpaWDA9",
+			legacyToken:  "MXwy",
+			unifiedToken: "eyJvIjoxLCJ2IjoxNzQ5NTY1NTU4MDc4OTkwLCJzIjpmYWxzZX0=",
+		},
+		{
+			name: "Should handle new token with only unified token (mode >= 3)",
+			// first slot empty ',eyJvIjoxLCJ2IjoxNzQ5NTY1NTU4MDc4OTkwLCJzIjpmYWxzZX0='
+			token:        "LGV5SnZJam94TENKMklqb3hOelE1TlRZMU5UVTRNRGM0T1Rrd0xDSnpJanBtWVd4elpYMD0=",
+			legacyToken:  "",
+			unifiedToken: "eyJvIjoxLCJ2IjoxNzQ5NTY1NTU4MDc4OTkwLCJzIjpmYWxzZX0=",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyToken, unifiedToken, err := parseContinueTokens(tc.token)
+			require.NoError(t, err)
+			require.Equal(t, legacyToken, tc.legacyToken)
+			require.Equal(t, unifiedToken, tc.unifiedToken)
+		})
+	}
+}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -198,6 +198,8 @@ type ResourceServerOptions struct {
 	storageMetrics *StorageMetrics
 
 	IndexMetrics *BleveIndexMetrics
+
+	MaxPageSizeBytes int
 }
 
 func NewResourceServer(opts ResourceServerOptions) (ResourceServer, error) {
@@ -220,6 +222,11 @@ func NewResourceServer(opts ResourceServerOptions) (ResourceServer, error) {
 		opts.Now = func() int64 {
 			return time.Now().UnixMilli()
 		}
+	}
+
+	if opts.MaxPageSizeBytes <= 0 {
+		// By default, we use 2MB for the page size.
+		opts.MaxPageSizeBytes = 1024 * 1024 * 2
 	}
 
 	// Initialize the blob storage
@@ -250,19 +257,20 @@ func NewResourceServer(opts ResourceServerOptions) (ResourceServer, error) {
 	// Make this cancelable
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &server{
-		tracer:         opts.Tracer,
-		log:            logger,
-		backend:        opts.Backend,
-		blob:           blobstore,
-		diagnostics:    opts.Diagnostics,
-		access:         opts.AccessClient,
-		writeHooks:     opts.WriteHooks,
-		lifecycle:      opts.Lifecycle,
-		now:            opts.Now,
-		ctx:            ctx,
-		cancel:         cancel,
-		storageMetrics: opts.storageMetrics,
-		indexMetrics:   opts.IndexMetrics,
+		tracer:           opts.Tracer,
+		log:              logger,
+		backend:          opts.Backend,
+		blob:             blobstore,
+		diagnostics:      opts.Diagnostics,
+		access:           opts.AccessClient,
+		writeHooks:       opts.WriteHooks,
+		lifecycle:        opts.Lifecycle,
+		now:              opts.Now,
+		ctx:              ctx,
+		cancel:           cancel,
+		storageMetrics:   opts.storageMetrics,
+		indexMetrics:     opts.IndexMetrics,
+		maxPageSizeBytes: opts.MaxPageSizeBytes,
 	}
 
 	if opts.Search.Resources != nil {
@@ -307,6 +315,8 @@ type server struct {
 	// init checking
 	once    sync.Once
 	initErr error
+
+	maxPageSizeBytes int
 }
 
 // Init implements ResourceServer.
@@ -791,7 +801,7 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	if req.Limit < 1 {
 		req.Limit = 50 // default max 50 items in a page
 	}
-	maxPageBytes := 1024 * 1024 * 2 // 2mb/page
+	maxPageBytes := s.maxPageSizeBytes
 	pageBytes := 0
 	rsp := &resourcepb.ListResponse{}
 

--- a/pkg/storage/unified/sql/list_iterator.go
+++ b/pkg/storage/unified/sql/list_iterator.go
@@ -1,6 +1,8 @@
 package sql
 
 import (
+	"sync"
+
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 )
@@ -26,10 +28,18 @@ type listIter struct {
 	group     string
 	name      string
 	folder    string
+
+	mtx          sync.Mutex
+	iteratorDone bool
 }
 
 // ContinueToken implements resource.ListIterator.
 func (l *listIter) ContinueToken() string {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	if l.iteratorDone {
+		return ""
+	}
 	if l.useCurrentRV {
 		return resource.ContinueToken{ResourceVersion: l.rv, StartOffset: l.offset, SortAscending: l.sortAsc}.String()
 	}
@@ -64,10 +74,13 @@ func (l *listIter) Value() []byte {
 
 // Next implements resource.ListIterator.
 func (l *listIter) Next() bool {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
 	if l.rows.Next() {
 		l.offset++
 		l.err = l.rows.Scan(&l.guid, &l.rv, &l.namespace, &l.group, &l.resource, &l.name, &l.folder, &l.value)
 		return true
 	}
+	l.iteratorDone = true
 	return false
 }

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -43,6 +43,12 @@ func NewResourceServer(db infraDB.DB, cfg *setting.Cfg,
 		opts.Blob.URL = "file:///" + dir
 	}
 
+	// This is mostly for testing, being able to influence when we paginate
+	// based on the page size during tests.
+	unifiedStorageCfg := cfg.SectionWithEnvOverrides("unified_storage")
+	maxPageSizeBytes := unifiedStorageCfg.Key("max_page_size_bytes")
+	opts.MaxPageSizeBytes = maxPageSizeBytes.MustInt(0)
+
 	eDB, err := dbimpl.ProvideResourceDB(db, cfg, tracer)
 	if err != nil {
 		return nil, err

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -574,7 +574,6 @@ func doListFoldersTest(t *testing.T, helper *apis.K8sTestHelper, mode grafanares
 			require.Equal(t, "", continueToken)
 		})
 	}
-
 }
 
 func TestIntegrationFolderCreatePermissions(t *testing.T) {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -492,6 +492,12 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 		}
 	}
+	if opts.MaxPageSizeBytes > 0 {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("max_page_size_bytes", fmt.Sprintf("%d", opts.MaxPageSizeBytes))
+		require.NoError(t, err)
+	}
 	if opts.PermittedProvisioningPaths != "" {
 		_, err = pathsSect.NewKey("permitted_provisioning_paths", opts.PermittedProvisioningPaths)
 		require.NoError(t, err)
@@ -556,6 +562,7 @@ type GrafanaOpts struct {
 	QueryRetries                          int64
 	GrafanaComAPIURL                      string
 	UnifiedStorageConfig                  map[string]setting.UnifiedStorageConfig
+	MaxPageSizeBytes                      int
 	PermittedProvisioningPaths            string
 	GrafanaComSSOAPIToken                 string
 	LicensePath                           string

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -492,10 +492,10 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 		}
 	}
-	if opts.MaxPageSizeBytes > 0 {
+	if opts.UnifiedStorageMaxPageSizeBytes > 0 {
 		section, err := getOrCreateSection("unified_storage")
 		require.NoError(t, err)
-		_, err = section.NewKey("max_page_size_bytes", fmt.Sprintf("%d", opts.MaxPageSizeBytes))
+		_, err = section.NewKey("max_page_size_bytes", fmt.Sprintf("%d", opts.UnifiedStorageMaxPageSizeBytes))
 		require.NoError(t, err)
 	}
 	if opts.PermittedProvisioningPaths != "" {
@@ -562,7 +562,7 @@ type GrafanaOpts struct {
 	QueryRetries                          int64
 	GrafanaComAPIURL                      string
 	UnifiedStorageConfig                  map[string]setting.UnifiedStorageConfig
-	MaxPageSizeBytes                      int
+	UnifiedStorageMaxPageSizeBytes        int
 	PermittedProvisioningPaths            string
 	GrafanaComSSOAPIToken                 string
 	LicensePath                           string


### PR DESCRIPTION
This PR introduces a new continue token for the dual writer. This is needed as we need to be able to list in both formats, our legacy one and the new unified one. Currently we only pass the legacy token, which is unusable for unified storage.

This PR:
- Introduces the new dualwriter continue token that combines both formats
- Add tests around token handling for the dualwriter continue token
- Add integration tests that check that listing with continue tokens works in all modes