### PR TITLE
Actions: Propagate exit code in unit tests

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -74,6 +74,7 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # Set up repository clone
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -86,18 +87,28 @@ jobs:
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
+
+      # Prepare what we need to upload test results
       - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD/\//_}.xml" >> "$GITHUB_ENV"
         env:
           SHARD: ${{ matrix.shard }}
       - run: go install github.com/jstemmer/go-junit-report/v2@85bf4716ac1f025f2925510a9f5e9f5bb347c009
+
+      # Run code
       - name: Generate Go code
         run: make gen-go
       - name: Run unit tests
         env:
           SHARD: ${{ matrix.shard }}
         run: |
+          set -euo pipefail
+
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
+          # This tee requires pipefail to be set, otherwise `go test`'s exit code is thrown away.
+          # That means having no `-o pipefail` => failing tests => exit code 0, which is wrong.
           go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > "$RESULTS_FILE")
+
+      # Upload results to GCS
       - name: Log in to GCS
         if: github.repository == 'grafana/grafana' && (success() || failure())
         uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0


### PR DESCRIPTION
When we run the Grafana Enterprise tests and a unit test fails, `tee` will still return exit code 0. That means the test suite is regarded as successful, despite `go test` returning exit code 1 (or any other non-zero code).

To deal with this, we should be using `set -o pipefail`. It still permits the `tee` to fully complete, but it will return the right-most non-zero exit code (i.e. of `go test`) at the end of executing the pipeline.
