### PR TITLE
Chore: Fix feature flags template for docs gen

### DIFF
--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -393,6 +393,7 @@ func generateDocsMD() string {
 	buf := `---
 aliases:
   - /docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/
+  - ../../administration/feature-toggles/ # /docs/grafana/latest/administration/feature-toggles/
 description: Learn about feature toggles, which you can enable or disable.
 title: Configure feature toggles
 weight: 150


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/106455 : this makes the template used in `TestFeatureToggleFiles` to align with that change.
