### PR TITLE
Internationalisation: Always initialise a default i18n instance

### DIFF
--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -30,17 +30,20 @@ export async function loadPluginResources(id: string, language: string, loaders?
 }
 
 // exported for testing
-export async function initDefaultI18nInstance() {
+export function initDefaultI18nInstance() {
   // If the resources are not an object, we need to initialize the plugin translations
   if (getI18nInstance().options?.resources && typeof getI18nInstance().options.resources === 'object') {
     return;
   }
 
-  await getI18nInstance().use(initReactI18next).init({
+  const initPromise = getI18nInstance().use(initReactI18next).init({
     resources: {},
     returnEmptyString: false,
     lng: DEFAULT_LANGUAGE, // this should be the locale of the phrases in our source JSX
   });
+  tFunc = getI18nInstance().t;
+  transComponent = (props: TransProps) => <I18NextTrans shouldUnescape {...props} />;
+  return initPromise;
 }
 
 // exported for testing
@@ -171,6 +174,7 @@ export function addResourceBundle(language: string, namespace: string, resources
 }
 
 export const t: TFunction = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
+  initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
       console.warn(
@@ -189,10 +193,12 @@ export const t: TFunction = (id: string, defaultMessage: string, values?: Record
 };
 
 export function useTranslate() {
+  initDefaultI18nInstance();
   return { t };
 }
 
 export function Trans(props: TransProps) {
+  initDefaultI18nInstance();
   const Component = transComponent ?? I18NextTrans;
   return <Component shouldUnescape {...props} />;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- always initialise a default i18n instance

**Why do we need this feature?**

- allows for plugins using packages that provide translations to gracefully fall back to english if the plugin hasn't called `initPluginTranslations`

**Who is this feature for?**

- plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/98962

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
