### PR TITLE
EchoSrv: Use inline Rudderstack types

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
     "react-select-event": "5.5.1",
     "redux-mock-store": "1.5.5",
     "rimraf": "6.0.1",
-    "rudder-sdk-js": "2.48.44",
     "sass": "1.83.4",
     "sass-loader": "16.0.4",
     "smtp-tester": "^2.1.0",

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -1,5 +1,3 @@
-import type { apiOptions, identify, load, page, track } from 'rudder-sdk-js'; // SDK is loaded dynamically from config, so we only import types from the SDK package
-
 import { BuildInfo, CurrentUserDTO } from '@grafana/data';
 import {
   EchoBackend,
@@ -12,11 +10,19 @@ import {
 
 import { loadScript } from '../../utils';
 
+type Properties = Record<string, string | boolean | number>;
+
+interface RudderstackAPIOptions {
+  Intercom?: {
+    user_hash: string;
+  };
+}
+
 interface Rudderstack {
-  identify: typeof identify;
-  load: typeof load;
-  page: typeof page;
-  track: typeof track;
+  identify: (identifier: string, traits: Properties, options?: RudderstackAPIOptions) => void;
+  load: (writeKey: string, dataPlaneURL: string, options: { configUrl?: string; destSDKBaseURL?: string }) => void;
+  page: () => void;
+  track: (eventName: string, properties?: Properties) => void;
 }
 
 declare global {
@@ -76,7 +82,7 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
 
     if (options.user) {
       const { identifier, intercomIdentifier } = options.user.analytics;
-      const apiOptions: apiOptions = {};
+      const apiOptions: RudderstackAPIOptions = {};
 
       if (intercomIdentifier) {
         apiOptions.Intercom = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18292,7 +18292,6 @@ __metadata:
     regenerator-runtime: "npm:0.14.1"
     reselect: "npm:5.1.1"
     rimraf: "npm:6.0.1"
-    rudder-sdk-js: "npm:2.48.44"
     rxjs: "npm:7.8.2"
     sass: "npm:1.83.4"
     sass-loader: "npm:16.0.4"
@@ -27968,13 +27967,6 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.1.2"
   checksum: 10/fa6a3e1f73e65bf5763b8a051942477a0852ee072d29ebad0999f02556a73715e72374d9a31ddec3fe023b09702b56f8be3a5a0404816e795ab86ea879183e02
-  languageName: node
-  linkType: hard
-
-"rudder-sdk-js@npm:2.48.44":
-  version: 2.48.44
-  resolution: "rudder-sdk-js@npm:2.48.44"
-  checksum: 10/538bc405c0cb7faf33b910a39d51bd6df53fbdb176d4e83c33821e7a454178b65ced216ad0f055b6dffd201ccc45cead814138e20683e15424a02fb54b894e15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Uses inline types for the window.rudderstack SDK, rather than bringing in the extra package just for it.

Related to https://github.com/grafana/grafana/issues/106426, but updating the SDK version has been paused for now due to implementation questions. 