### PR TITLE
Prometheus: Migrate remaining selectors to data-testid

### DIFF
--- a/e2e/old-arch/various-suite/prometheus-annotations.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-annotations.spec.ts
@@ -56,7 +56,7 @@ describe('Prometheus annotations', () => {
 
     // check for other parts of the annotations
     // min step
-    cy.get(`#${selectors.components.DataSource.Prometheus.annotations.minStep}`);
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.annotations.minStep}"]`);
 
     // title
     e2e.components.DataSource.Prometheus.annotations.title().scrollIntoView().should('exist');

--- a/e2e/old-arch/various-suite/prometheus-annotations.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-annotations.spec.ts
@@ -1,5 +1,3 @@
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 import { addDashboard } from '../utils/flows';
 
@@ -56,7 +54,7 @@ describe('Prometheus annotations', () => {
 
     // check for other parts of the annotations
     // min step
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.annotations.minStep}"]`);
+    e2e.components.DataSource.Prometheus.annotations.minStep().should('exist');
 
     // title
     e2e.components.DataSource.Prometheus.annotations.title().scrollIntoView().should('exist');

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -1,3 +1,5 @@
+import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';
@@ -65,9 +67,9 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="data-testid prometheus-step"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid=${selectors.components.DataSource.Prometheus.queryEditor.step}]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="data-testid prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid=${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -67,11 +67,15 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
+      .scrollIntoView()
+      .should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`)
+      .scrollIntoView()
+      .should('exist');
   });
- 
+
   describe('Code editor', () => {
     it('navigates to the code editor with editor type as code', () => {
       navigateToEditor('Code', 'prometheusCode');

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -1,5 +1,3 @@
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';
@@ -67,13 +65,9 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
-      .scrollIntoView()
-      .should('exist');
+    e2e.components.DataSource.Prometheus.queryEditor.step().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`)
-      .scrollIntoView()
-      .should('exist');
+    e2e.components.DataSource.Prometheus.queryEditor.exemplars().scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -65,9 +65,9 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-test-id="prometheus-step"]`).scrollIntoView().should('exist');
+    cy.get(`[data-test-id="data-testid prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="data-testid prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -65,7 +65,7 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-test-id="data-testid prometheus-step"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="data-testid prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
     cy.get(`[data-testid="data-testid prometheus-exemplars"]`).scrollIntoView().should('exist');
   });

--- a/e2e/old-arch/various-suite/prometheus-editor.spec.ts
+++ b/e2e/old-arch/various-suite/prometheus-editor.spec.ts
@@ -67,11 +67,11 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid=${selectors.components.DataSource.Prometheus.queryEditor.step}]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid=${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.exemplars}"]`).scrollIntoView().should('exist');
   });
-
+ 
   describe('Code editor', () => {
     it('navigates to the code editor with editor type as code', () => {
       navigateToEditor('Code', 'prometheusCode');

--- a/e2e/various-suite/prometheus-annotations.spec.ts
+++ b/e2e/various-suite/prometheus-annotations.spec.ts
@@ -56,7 +56,6 @@ describe('Prometheus annotations', () => {
     // check for other parts of the annotations
     // min step
     e2e.components.DataSource.Prometheus.annotations.minStep().should('exist');
-    
 
     // title
     e2e.components.DataSource.Prometheus.annotations.title().scrollIntoView().should('exist');

--- a/e2e/various-suite/prometheus-annotations.spec.ts
+++ b/e2e/various-suite/prometheus-annotations.spec.ts
@@ -57,7 +57,7 @@ describe('Prometheus annotations', () => {
 
     // check for other parts of the annotations
     // min step
-    cy.get(`#${selectors.components.DataSource.Prometheus.annotations.minStep}`);
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.annotations.minStep}"]`);
 
     // title
     e2e.components.DataSource.Prometheus.annotations.title().scrollIntoView().should('exist');

--- a/e2e/various-suite/prometheus-annotations.spec.ts
+++ b/e2e/various-suite/prometheus-annotations.spec.ts
@@ -1,5 +1,3 @@
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 import { addDashboard } from '../utils/flows';
 
@@ -57,7 +55,8 @@ describe('Prometheus annotations', () => {
 
     // check for other parts of the annotations
     // min step
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.annotations.minStep}"]`);
+    e2e.components.DataSource.Prometheus.annotations.minStep().should('exist');
+    
 
     // title
     e2e.components.DataSource.Prometheus.annotations.title().scrollIntoView().should('exist');

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -65,9 +65,9 @@ describe.skip('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-test-id="prometheus-step"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="data-testid-prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="data-testid-prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -68,7 +68,6 @@ describe.skip('Prometheus query editor', () => {
     e2e.components.DataSource.Prometheus.queryEditor.step().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.exemplars().scrollIntoView().should('exist');
-
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -1,5 +1,3 @@
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';
@@ -67,13 +65,10 @@ describe.skip('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
-      .scrollIntoView()
-      .should('exist');
+    e2e.components.DataSource.Prometheus.queryEditor.step().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
-      .scrollIntoView()
-      .should('exist');
+    e2e.components.DataSource.Prometheus.queryEditor.exemplars().scrollIntoView().should('exist');
+
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -1,3 +1,4 @@
+import { selectors } from '@grafana/e2e-selectors';
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';
@@ -65,9 +66,9 @@ describe.skip('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="data-testid-prometheus-step"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="data-testid-prometheus-exemplars"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -66,9 +66,13 @@ describe.skip('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
+      .scrollIntoView()
+      .should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`).scrollIntoView().should('exist');
+    cy.get(`[data-testid="${selectors.components.DataSource.Prometheus.queryEditor.step}"]`)
+      .scrollIntoView()
+      .should('exist');
   });
 
   describe('Code editor', () => {

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -1,4 +1,5 @@
 import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -250,13 +250,13 @@ export const versionedComponents = {
           '10.4.0': 'data-testid prometheus format',
         },
         step: {
-          '10.4.0': 'prometheus-step', // id for autosize component
+          '10.4.0': 'data-testid prometheus-step', // id for autosize component
         },
         type: {
           '10.4.0': 'data-testid prometheus type', //wrapper for radio button group
         },
         exemplars: {
-          '10.4.0': 'prometheus-exemplars', // id for editor switch component
+          '10.4.0': 'data-testid prometheus-exemplars', // id for editor switch component
         },
         builder: {
           // see QueryBuilder below for commented selectors
@@ -349,7 +349,7 @@ export const versionedComponents = {
       },
       annotations: {
         minStep: {
-          '10.4.0': 'prometheus-annotation-min-step', // id for autosize input
+          '10.4.0': 'data-testid prometheus-annotation-min-step', // id for autosize input
         },
         title: {
           '10.4.0': 'data-testid prometheus annotation title',

--- a/packages/grafana-prometheus/src/components/AnnotationQueryEditor.tsx
+++ b/packages/grafana-prometheus/src/components/AnnotationQueryEditor.tsx
@@ -100,6 +100,7 @@ export const AnnotationQueryEditor = memo(function AnnotationQueryEditor(props: 
               value={query.interval ?? ''}
               onChange={(e) => handleMinStepChange(e.currentTarget.value)}
               id={selectors.components.DataSource.Prometheus.annotations.minStep}
+              data-testid={selectors.components.DataSource.Prometheus.annotations.minStep}
             />
           </EditorField>
         </EditorRow>

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -115,7 +115,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
                 minWidth={10}
                 onCommitChange={onChangeStep}
                 defaultValue={query.interval}
-                data-test-id="prometheus-step"
+                data-testid={selectors.components.DataSource.Prometheus.queryEditor.step}
               />
             </EditorField>
             <EditorField label={t('grafana-prometheus.querybuilder.prom-query-builder-options.label-format', 'Format')}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I want to be able to use getByGrafanaSelector from plugin-e2e package in Amazon Prometheus. This migrates the selectors and tests for the util to be able to recognize the selectors.

