### PR TITLE
Dashboards: Add undo/redo actions for changing dashboard title

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
@@ -99,7 +99,11 @@ export function DashboardTitleInput({ dashboard, id }: { dashboard: DashboardSce
       onBlur={(e) => {
         // If the title input is currently focused and we click undo/redo
         // we don't want to mess with the stack
-        if (e.relatedTarget && (e.relatedTarget.id === undoButtonID || e.relatedTarget.id === redoButtonId)) {
+        const clickedUndoRedo =
+          e.relatedTarget && (e.relatedTarget.id === undoButtonID || e.relatedTarget.id === redoButtonId);
+        const titleUnchanged = valueBeforeEdit.current === e.currentTarget.value;
+        const shouldSkip = titleUnchanged || clickedUndoRedo;
+        if (shouldSkip) {
           return;
         }
 

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -98,17 +98,23 @@ export interface RemoveElementActionHelperProps {
   undo: () => void;
 }
 
+export interface ChangeTitleActionHelperProps {
+  oldTitle: string;
+  newTitle: string;
+  source: DashboardScene;
+}
+
 export const dashboardEditActions = {
   /**
    * Registers and peforms an edit action
    */
-  edit: function (props: DashboardEditActionEventPayload) {
+  edit(props: DashboardEditActionEventPayload) {
     props.source.publishEvent(new DashboardEditActionEvent(props), true);
   },
   /**
    * Helper for makeEdit that adds elements
    */
-  addElement: function (props: AddElementActionHelperProps) {
+  addElement(props: AddElementActionHelperProps) {
     const { addedObject, source, perform, undo } = props;
 
     const element = getEditableElementFor(addedObject);
@@ -143,6 +149,19 @@ export const dashboardEditActions = {
       source,
       perform,
       undo,
+    });
+  },
+
+  changeTitle({ source, oldTitle, newTitle }: ChangeTitleActionHelperProps) {
+    dashboardEditActions.edit({
+      description: t('dashboard.title.action', 'Change dashboard title'),
+      source: source,
+      perform: () => {
+        source.setState({ title: newTitle });
+      },
+      undo: () => {
+        source.setState({ title: oldTitle });
+      },
     });
   },
 };

--- a/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/RightActions.tsx
@@ -165,14 +165,16 @@ export const RightActions = ({ dashboard }: { dashboard: DashboardScene }) => {
   );
 };
 
+export const undoButtonID = 'undo-button';
 function UndoButton({ dashboard }: ToolbarActionProps) {
   const editPane = dashboard.state.editPane;
   const { undoStack } = editPane.useState();
   const undoAction = undoStack[undoStack.length - 1];
-  const tooltip = undoAction ? `Undo '${undoAction.description}'` : 'Undo';
+  const tooltip = `Undo${undoAction?.description ? ` '${undoAction.description}'` : ''}`;
 
   return (
     <ToolbarButton
+      id={undoButtonID}
       icon="corner-up-left"
       disabled={undoStack.length === 0}
       onClick={() => editPane.undoAction()}
@@ -181,14 +183,16 @@ function UndoButton({ dashboard }: ToolbarActionProps) {
   );
 }
 
+export const redoButtonId = 'redo-button';
 function RedoButton({ dashboard }: ToolbarActionProps) {
   const editPane = dashboard.state.editPane;
   const { redoStack } = editPane.useState();
   const redoAction = redoStack[redoStack.length - 1];
-  const tooltip = redoAction ? `Redo '${redoAction?.description}'` : 'Redo';
+  const tooltip = `Redo${redoAction?.description ? ` '${redoAction.description}'` : ''}`;
 
   return (
     <ToolbarButton
+      id={redoButtonId}
       icon="corner-up-right"
       disabled={redoStack.length === 0}
       tooltip={tooltip}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4588,6 +4588,9 @@
         "title-not-unique": "This title is not unique"
       }
     },
+    "title": {
+      "action": "Change dashboard title"
+    },
     "toolbar": {
       "add": "Add",
       "alert-rules": "Alert rules",


### PR DESCRIPTION
Adds undo/redo support to modifying the dashboard title.
Will follow up with a similar PR for dashboard descriptions.

See https://github.com/grafana/grafana-org/issues/544