### PR TITLE
DevEx: Only build backend, increase debounce delay and ignore test files

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,7 @@
 [run]
 init_cmds = [
-  ["make","GO_BUILD_DEV=1", "build-go"],
+  ["make", "update-workspace"],
+  ["make", "GO_BUILD_DEV=1", "build-backend"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]
@@ -14,10 +15,12 @@ watch_dirs = [
   "$WORKDIR/devenv/dev-dashboards",
 ]
 watch_exts = [".go", ".ini", ".toml", ".template.html"]
-ignore_files = [".*_gen.go"]
-build_delay = 1500
+ignore_files = [".*_gen.go", ".*_test.go", "pkg/extensions/ext.go"]
+build_delay = 10000
 cmds = [
-  ["make", "GO_BUILD_DEV=1", "build-go-fast"],
+  ["sleep", "1"],
+  ["make", "gen-go"],
+  ["make", "GO_BUILD_DEV=1", "build-backend"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
Trying to improve a bit the experience when doing `make run`.

Problems:
1) It takes too long to build:
- Removing extra `gen-go` (`update-workspace` already runs it);
- Only build the backend, not all 3 binaries.

2) Build errors when reloading:
- Increase debounce delay to 10s to see if that helps with trigger of reloads for many edits in a short time;
- Also run `sleep 1`+`make gen-go` in incremental builds, so cases of linking/unlinking Enterprise codebase won't break, as well as changes to the wiring in general;

Extra: Ignore test file changes as they won't affect the build and Enterprise ext file that was triggering a double build with Enterprise.