### PR TITLE
Fastfrwrd/tableng back to basics

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/HeaderCell.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Property } from 'csstype';
-import React, { useLayoutEffect, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Column, SortDirection } from 'react-data-grid';
 
 import { Field, GrafanaTheme2 } from '@grafana/data';

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/HeaderCell.tsx
@@ -22,7 +22,6 @@ interface HeaderCellProps {
   filter: FilterType;
   setFilter: React.Dispatch<React.SetStateAction<FilterType>>;
   onColumnResize?: TableColumnResizeActionCallback;
-  headerCellRefs: React.MutableRefObject<Record<string, HTMLDivElement>>;
   crossFilterOrder: string[];
   crossFilterRows: { [key: string]: TableRow[] };
   showTypeIcons?: boolean;
@@ -38,7 +37,6 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
   filter,
   setFilter,
   onColumnResize,
-  headerCellRefs,
   crossFilterOrder,
   crossFilterRows,
   showTypeIcons,
@@ -66,13 +64,6 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
     const isMultiSort = event.shiftKey;
     onSort(column.key, direction === 'ASC' ? 'DESC' : 'ASC', isMultiSort);
   };
-
-  // collecting header cell refs to handle manual column resize
-  useLayoutEffect(() => {
-    if (headerRef.current) {
-      headerCellRefs.current[column.key] = headerRef.current;
-    }
-  }, [headerRef, column.key]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // TODO: this is a workaround to handle manual column resize;
   useEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -65,7 +65,7 @@ export function TableCellNG(props: TableCellNGProps) {
     }
     return getCellColors(theme, cellOptions, displayValue);
   }, [theme, cellOptions, displayValue, rowBg, rowIdx]);
-  const styles = useStyles2(getStyles, isRightAligned, colors);
+  const styles = useStyles2(getStyles, height, isRightAligned, colors);
 
   // TODO
   // TableNG provides either an overridden cell width or 'auto' as the cell width value.
@@ -184,11 +184,15 @@ export function TableCellNG(props: TableCellNGProps) {
       ref={divWidthRef}
       className={styles.cell}
       onFocus={hasActions ? () => setIsHovered(true) : undefined}
-      onMouseOver={hasActions ? () => setIsHovered(true) : undefined}
+      onMouseEnter={hasActions ? () => setIsHovered(true) : undefined}
       onBlur={hasActions ? () => setIsHovered(false) : undefined}
       onMouseLeave={hasActions ? () => setIsHovered(false) : undefined}
     >
       {renderedCell}
+      {/* TODO: I really wanted to avoid the `isHovered` state, and just mount all of these
+        icons, unhiding them using CSS, but rendering the IconButton is very expensive and
+        makes the scroll performance terrible. I think it's because of the Tooltip.
+        */}
       {isHovered && hasActions && (
         <div className={cx(styles.cellActions, 'table-cell-actions')}>
           {cellInspect && (
@@ -237,9 +241,12 @@ export function TableCellNG(props: TableCellNGProps) {
   );
 }
 
-const getStyles = (theme: GrafanaTheme2, isRightAligned: boolean, color: CellColors) => ({
+const getStyles = (theme: GrafanaTheme2, defaultRowHeight: number, isRightAligned: boolean, color: CellColors) => ({
   cell: css({
     height: '100%',
+    // this minHeight interacts with the `fit-content` property on
+    // the container for table cell overflow rendering.
+    minHeight: defaultRowHeight - 1,
     alignContent: 'center',
     paddingInline: TABLE.CELL_PADDING,
     // TODO: follow-up on this: change styles on hover on table row level

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -11,6 +11,7 @@ import { t } from '../../../../utils/i18n';
 import { IconButton } from '../../../IconButton/IconButton';
 // import { GeoCell } from '../../Cells/GeoCell';
 import { TableCellInspectorMode } from '../../TableCellInspector';
+import { TABLE } from '../constants';
 import {
   CellColors,
   CustomCellRendererProps,
@@ -28,7 +29,6 @@ import { GeoCell } from './GeoCell';
 import { ImageCell } from './ImageCell';
 import { JSONCell } from './JSONCell';
 import { SparklineCell } from './SparklineCell';
-import { TABLE } from '../constants';
 
 export function TableCellNG(props: TableCellNGProps) {
   const {
@@ -49,6 +49,10 @@ export function TableCellNG(props: TableCellNGProps) {
     replaceVariables,
   } = props;
 
+  // TODO - use `onSelectedCellChange` at the top to maintain the selected state
+  // and show cell actions for accessible cell actions.
+  const isSelected = false;
+
   const cellInspect = field.config?.custom?.inspect ?? false;
   const displayName = getDisplayName(field);
 
@@ -61,12 +65,12 @@ export function TableCellNG(props: TableCellNGProps) {
 
   const isRightAligned = getTextAlign(field) === 'flex-end';
   const displayValue = field.display!(value);
-  let colors: CellColors = { bgColor: '', textColor: '', bgHoverColor: '' };
-  if (rowBg) {
-    colors = rowBg(rowIdx);
-  } else {
-    colors = useMemo(() => getCellColors(theme, cellOptions, displayValue), [theme, cellOptions, displayValue]);
-  }
+  const colors: CellColors = useMemo(() => {
+    if (rowBg) {
+      return rowBg(rowIdx);
+    }
+    return getCellColors(theme, cellOptions, displayValue);
+  }, [theme, cellOptions, displayValue, rowBg, rowIdx]);
   const styles = useStyles2(getStyles, isRightAligned, colors);
 
   // TODO
@@ -212,7 +216,7 @@ export function TableCellNG(props: TableCellNGProps) {
   return (
     <div ref={divWidthRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className={styles.cell}>
       {renderedCell}
-      {isHovered && (cellInspect || showFilters) && (
+      {(isHovered || isSelected) && (cellInspect || showFilters) && (
         <div className={styles.cellActions}>
           {cellInspect && (
             <IconButton
@@ -273,13 +277,13 @@ const getStyles = (theme: GrafanaTheme2, isRightAligned: boolean, color: CellCol
   cellActions: css({
     display: 'flex',
     position: 'absolute',
-    top: '1px',
+    top: 0,
     left: isRightAligned ? 0 : undefined,
     right: isRightAligned ? undefined : 0,
     margin: 'auto',
     height: '100%',
     background: theme.colors.background.secondary,
     color: theme.colors.text.primary,
-    padding: '4px 0px 4px 4px',
+    padding: '4px 0 4px 4px',
   }),
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/TableCellNG.tsx
@@ -3,7 +3,7 @@ import { WKT } from 'ol/format';
 import { Geometry } from 'ol/geom';
 import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { FieldType, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';
+import { FieldType, getDefaultTimeRange, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';
 import { TableAutoCellOptions, TableCellDisplayMode } from '@grafana/schema';
 
 import { useStyles2 } from '../../../../themes/ThemeContext';
@@ -28,6 +28,7 @@ import { GeoCell } from './GeoCell';
 import { ImageCell } from './ImageCell';
 import { JSONCell } from './JSONCell';
 import { SparklineCell } from './SparklineCell';
+import { TABLE } from '../constants';
 
 export function TableCellNG(props: TableCellNGProps) {
   const {
@@ -35,7 +36,7 @@ export function TableCellNG(props: TableCellNGProps) {
     frame,
     value,
     theme,
-    timeRange,
+    timeRange = getDefaultTimeRange(),
     height,
     rowIdx,
     justifyContent,
@@ -263,7 +264,7 @@ const getStyles = (theme: GrafanaTheme2, isRightAligned: boolean, color: CellCol
   cell: css({
     height: '100%',
     alignContent: 'center',
-    paddingInline: '8px',
+    paddingInline: TABLE.CELL_PADDING,
     // TODO: follow-up on this: change styles on hover on table row level
     background: color.bgColor || 'none',
     color: color.textColor,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -582,18 +582,16 @@ function getRowBgFn(field: Field, theme: GrafanaTheme2): ((rowIndex: number) => 
 
 /*
 TODO:
-value formatting
-footer reducers
 column width and min column width via panel config
 hidden
-overlay/expand on hover, active line and cell styling
+overlay/expand on hover
+active line and cell styling
 inspect? actions?
 subtable/ expand
-cell types, backgrounds
 -----
 enable pagination disables footer?
-hover experience is kinda weird
 auto-cell: can we deprecate in favor of newer RDG options?
 -----
 accessible sorting and filtering
+accessible table navigation
 */

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -68,11 +68,9 @@ export function TableNG(props: TableNGProps) {
   } = props;
 
   const theme = useTheme2();
-  const defaultRowHeight = getDefaultRowHeight(theme, cellHeight);
   const styles = useStyles2(getStyles2, {
-    enablePagination: props.enablePagination,
-    noHeader: props.noHeader,
-    defaultRowHeight,
+    enablePagination,
+    noHeader,
   });
   const panelContext = usePanelContext();
 
@@ -133,6 +131,8 @@ export function TableNG(props: TableNGProps) {
   } = useSortedRows(filteredRows, data.fields, {
     initialSortBy,
   });
+
+  const defaultRowHeight = useMemo(() => getDefaultRowHeight(theme, cellHeight), [theme, cellHeight]);
 
   const {
     rows: paginatedRows,
@@ -478,7 +478,7 @@ const getStyles2 = (
     '&:hover': {
       zIndex: theme.zIndex.tooltip,
       whiteSpace: 'pre-line',
-      height: 'fit-content',
+      height: 'min-content',
       minWidth: 'min-content',
     },
   }),
@@ -582,16 +582,15 @@ function getCellClasses(
 
 /*
 TODO:
-column width and min column width via panel config
-buggy hover overflow; smaller text looks bad
 hidden
 overlay/expand on hover
 active line and cell styling
-inspect? actions?
 subtable/ expand
 -----
 enable pagination disables footer?
+pagination + text wrap...
 auto-cell: can we deprecate in favor of newer RDG options?
+overflow hover at the bottom of paginated table
 -----
 accessible sorting and filtering
 accessible table navigation

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -27,10 +27,6 @@ import { TableNGProps, TableRow, TableSummaryRow, TableColumn } from './types';
 import { frameToRecords, getDefaultRowHeight, getFooterStyles, getTextAlign, handleSort } from './utils';
 
 export function TableNG(props: TableNGProps) {
-  const theme = useTheme2();
-  const styles = useStyles2(getStyles2, { enablePagination: props.enablePagination, noHeader: props.noHeader });
-  const panelContext = usePanelContext();
-
   const {
     cellHeight,
     data,
@@ -46,6 +42,15 @@ export function TableNG(props: TableNGProps) {
     width,
   } = props;
 
+  const theme = useTheme2();
+  const defaultRowHeight = getDefaultRowHeight(theme, cellHeight);
+  const styles = useStyles2(getStyles2, {
+    enablePagination: props.enablePagination,
+    noHeader: props.noHeader,
+    defaultRowHeight,
+  });
+  const panelContext = usePanelContext();
+
   const gridHandle = useRef<DataGridHandle>(null);
   const [paginationWrapperRef, { height: paginationHeight }] = useMeasure<HTMLDivElement>();
 
@@ -57,8 +62,6 @@ export function TableNG(props: TableNGProps) {
       footerOptions.reducer.length &&
       footerOptions.reducer[0] === ReducerID.count
   );
-
-  const defaultRowHeight = getDefaultRowHeight(theme, cellHeight);
 
   const rows = useMemo(() => frameToRecords(data), [data]);
   const {
@@ -180,7 +183,7 @@ export function TableNG(props: TableNGProps) {
   const hasSubTable = false;
 
   // todo: don't re-init this on each memoizedData change, only schema/config changes
-  const rowHeight = useRowHeight(columns, data, hasSubTable);
+  const rowHeight = useRowHeight(columns, data, hasSubTable, defaultRowHeight);
 
   // we need to have variables with these exact names for the localization to work properly
   const itemsRangeStart = pageRangeStart;
@@ -304,7 +307,11 @@ export function onRowLeave(panelContext: PanelContext, enableSharedCrosshair: bo
 
 const getStyles2 = (
   theme: GrafanaTheme2,
-  { enablePagination, noHeader }: { enablePagination?: boolean; noHeader?: boolean }
+  {
+    enablePagination,
+    noHeader,
+    defaultRowHeight,
+  }: { enablePagination?: boolean; noHeader?: boolean; defaultRowHeight?: number }
 ) => ({
   grid: css({
     '--rdg-background-color': theme.colors.background.primary,
@@ -352,7 +359,7 @@ const getStyles2 = (
       zIndex: 1,
 
       // this prevents cells with empty content from collapsing to a few px
-      minHeight: 35, // defaultRowHeight
+      minHeight: defaultRowHeight,
     },
   }),
   cellWrapped: css({

--- a/packages/grafana-ui/src/components/Table/TableNG/constants.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/constants.ts
@@ -9,6 +9,7 @@ export const COLUMN = {
 /** Table layout and display constants */
 export const TABLE = {
   CELL_PADDING: 8,
+  HEADER_ROW_HEIGHT: 28,
   MAX_CELL_HEIGHT: 48,
   PAGINATION_LIMIT: 750,
   SCROLL_BAR_WIDTH: 8,

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -127,7 +127,6 @@ describe('TableNG hooks', () => {
         enablePagination: true,
         headerCellHeight: 16,
         paginationHeight: 20,
-        panelPaddingHeight: 16,
         defaultRowHeight: 16,
       });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -294,7 +294,7 @@ export function useScrollbarWidth(ref: RefObject<DataGridHandle>, { height }: Ta
   return scrollbarWidth;
 }
 
-export function useRowHeight(columns: TableColumn[], data: DataFrame, hasSubTable: boolean) {
+export function useRowHeight(columns: TableColumn[], data: DataFrame, hasSubTable: boolean, defaultRowHeight: number) {
   const theme = useTheme2();
 
   const wrappedColIdxs = useMemo(
@@ -331,8 +331,6 @@ export function useRowHeight(columns: TableColumn[], data: DataFrame, hasSubTabl
   }, [theme.typography.fontSize, theme.typography.fontFamily]);
 
   const rowHeight = useMemo(() => {
-    const defaultRowHeight = 35;
-
     if (hasSubTable || wrappedColIdxs.some((v) => v)) {
       const HPADDING = 6;
       const BORDER_RIGHT = 0.666667;
@@ -373,7 +371,7 @@ export function useRowHeight(columns: TableColumn[], data: DataFrame, hasSubTabl
     }
 
     return defaultRowHeight;
-  }, [wrappedColIdxs, hasSubTable, columns, avgCharWidth, ctx]);
+  }, [wrappedColIdxs, hasSubTable, columns, defaultRowHeight, avgCharWidth, ctx]);
 
   return rowHeight;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -43,6 +43,7 @@ interface TableFiltersAndSort {
   // --- rows --- //
   renderedRows: TableRow[];
   numRows: number;
+  columnTypes: Record<string, FieldType>;
   // --- filters --- //
   filter: FilterType;
   setFilter: React.Dispatch<React.SetStateAction<FilterType>>;
@@ -260,6 +261,7 @@ export function useProcessedRows(
 
   return {
     renderedRows: paginatedRows,
+    columnTypes,
     numRows,
     filter,
     setFilter,

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -155,7 +155,6 @@ export interface TableCellNGProps {
   rowIdx: number;
   setContextMenuProps: (props: { value: string; top?: number; left?: number; mode?: TableCellInspectorMode }) => void;
   setIsInspecting: (isInspecting: boolean) => void;
-  shouldTextOverflow: () => boolean;
   theme: GrafanaTheme2;
   timeRange?: TimeRange;
   value: TableCellValue;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -157,7 +157,7 @@ export interface TableCellNGProps {
   setIsInspecting: (isInspecting: boolean) => void;
   shouldTextOverflow: () => boolean;
   theme: GrafanaTheme2;
-  timeRange: TimeRange;
+  timeRange?: TimeRange;
   value: TableCellValue;
   rowBg: Function | undefined;
   onCellFilterAdded?: TableFilterActionCallback;

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -322,6 +322,10 @@ export function getFooterItemNG(rows: TableRow[], field: Field, options: TableFo
 }
 
 export const getFooterStyles = (justifyContent: Property.JustifyContent) => ({
+  footerCellCountRows: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+  }),
   footerCell: css({
     display: 'flex',
     justifyContent: justifyContent || 'space-between',

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -182,12 +182,7 @@ export function isTextCell(key: string, columnTypes: Record<string, string>): bo
 
 export function shouldTextOverflow(
   key: string,
-  row: TableRow,
   columnTypes: ColumnTypes,
-  ctx: CanvasRenderingContext2D,
-  lineHeight: number,
-  defaultRowHeight: number,
-  padding: number,
   textWrap: boolean,
   field: Field,
   cellType: TableCellDisplayMode

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -184,7 +184,6 @@ export function shouldTextOverflow(
   key: string,
   row: TableRow,
   columnTypes: ColumnTypes,
-  headerCellRefs: React.MutableRefObject<Record<string, HTMLDivElement>>,
   ctx: CanvasRenderingContext2D,
   lineHeight: number,
   defaultRowHeight: number,
@@ -506,7 +505,6 @@ export interface MapFrameToGridOptions extends TableNGProps {
   defaultRowHeight: number;
   expandedRows: number[];
   filter: FilterType;
-  headerCellRefs: React.MutableRefObject<Record<string, HTMLDivElement>>;
   isCountRowsSet: boolean;
   ctx: CanvasRenderingContext2D;
   onSortByChange?: (sortBy: TableSortByFieldState[]) => void;

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -27,7 +27,6 @@ import {
 } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../../utils/colors';
-import { TableCellInspectorMode } from '../TableCellInspector';
 
 import { TABLE } from './constants';
 import {
@@ -35,9 +34,7 @@ import {
   TableRow,
   TableFieldOptionsType,
   ColumnTypes,
-  FilterType,
   FrameToRowsConverter,
-  TableNGProps,
   Comparator,
   TableFooterCalc,
 } from './types';
@@ -490,31 +487,6 @@ export const frameToRecords = (frame: DataFrame): TableRow[] => {
   const convert = new Function('frame', fnBody) as unknown as FrameToRowsConverter;
   return convert(frame);
 };
-
-export interface MapFrameToGridOptions extends TableNGProps {
-  columnTypes: ColumnTypes;
-  columnWidth: number | string;
-  crossFilterOrder: string[];
-  crossFilterRows: { [key: string]: TableRow[] };
-  defaultLineHeight: number;
-  defaultRowHeight: number;
-  expandedRows: number[];
-  filter: FilterType;
-  isCountRowsSet: boolean;
-  ctx: CanvasRenderingContext2D;
-  onSortByChange?: (sortBy: TableSortByFieldState[]) => void;
-  rows: TableRow[];
-  renderedRows: TableRow[];
-  setContextMenuProps: (props: { value: string; top?: number; left?: number; mode?: TableCellInspectorMode }) => void;
-  setFilter: React.Dispatch<React.SetStateAction<FilterType>>;
-  setIsInspecting: (isInspecting: boolean) => void;
-  setSortColumns: React.Dispatch<React.SetStateAction<SortColumn[]>>;
-  sortColumns: SortColumn[];
-  styles: { cell: string; cellWrapped: string; dataGrid: string };
-  textWraps: Record<string, boolean>;
-  theme: GrafanaTheme2;
-  showTypeIcons?: boolean;
-}
 
 /* ----------------------------- Data grid comparator ---------------------------- */
 // The numeric: true option is used to sort numbers as strings correctly. It recognizes numeric sequences


### PR DESCRIPTION
- hooked up footer.
- hooked up `defaultRowHeight` (the small/medium/large cell height buttons)
- hooked up TableCellNG
  - made sure actions, text wrap, overflow, inspect, and context menu all work. 
- deleted :fire: the `headerCellRefs` and simplified how header cell height is calculated (it's always 28px for now.)
- cleaned up `shouldTextOverflow`
- replaced some jank in TableCellNG overflow hover handlers with CSS :hover targeting in a parent element
- split up the mega hook into smaller hooks, and updated the tests