### PR TITLE
Library elements: Enable RBAC by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -261,10 +261,6 @@ export interface FeatureToggles {
   */
   sseGroupByDatasource?: boolean;
   /**
-  * Enables RBAC support for library panels
-  */
-  libraryPanelRBAC?: boolean;
-  /**
   * Enables running Loki queries in parallel
   */
   lokiRunQueriesInParallel?: boolean;

--- a/pkg/services/featuremgmt/toggles-gitlog.csv
+++ b/pkg/services/featuremgmt/toggles-gitlog.csv
@@ -218,7 +218,6 @@ grafanaAPIServerWithExperimentalAPIs,2023-10-06T18:55:22Z,,717a9dd6160e352ff7c18
 panelMonitoring,2023-10-09T05:19:08Z,,ef82767dabea7d19cd8efac0c36ed590d4d767f4,Victor Marin
 navAdminSubsections,2023-10-10T10:50:44Z,2023-11-17T10:04:34Z,f56cc6fdc01dbf2efb802f22650cb2bef0c40179,Ashley Harrison
 recoveryThreshold,2023-10-10T14:51:50Z,,810fbc3327841da6d21f945e75cad9daf040e625,Yuri Tseretyan
-libraryPanelRBAC,2023-10-11T23:30:50Z,,a12cb8cbf3a9b33841b2f2cb1522be11de78c86a,kay delaney
 awsDatasourcesNewFormStyling,2023-10-12T08:59:10Z,2024-07-22T12:48:17Z,2771fb940342aa152377b26b9554eb15082f90ac,Ida Štambuk
 cachingOptimizeSerializationMemoryUsage,2023-10-12T16:56:49Z,,94ce87571ddfcede0fb7a229a65502b385d5bca3,Michael Mandrus
 panelTitleSearchInV1,2023-10-13T12:04:24Z,2025-01-21T09:59:32Z,bf2f2540da7a4e4b8d80e1fa4ae3d05868cf7b69,Arati R

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -55,7 +55,6 @@ dashgpt,GA,@grafana/dashboards-squad,false,false,true
 aiGeneratedDashboardChanges,experimental,@grafana/dashboards-squad,false,false,true
 reportingRetries,preview,@grafana/sharing-squad,false,true,false
 sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,false
-libraryPanelRBAC,experimental,@grafana/dashboards-squad,false,true,false
 lokiRunQueriesInParallel,privatePreview,@grafana/observability-logs,false,false,false
 externalCorePlugins,GA,@grafana/plugins-platform-backend,false,false,false
 externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -231,10 +231,6 @@ const (
 	// Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.
 	FlagSseGroupByDatasource = "sseGroupByDatasource"
 
-	// FlagLibraryPanelRBAC
-	// Enables RBAC support for library panels
-	FlagLibraryPanelRBAC = "libraryPanelRBAC"
-
 	// FlagLokiRunQueriesInParallel
 	// Enables running Loki queries in parallel
 	FlagLokiRunQueriesInParallel = "lokiRunQueriesInParallel"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1846,19 +1846,6 @@
     },
     {
       "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1743693517832",
-        "creationTimestamp": "2023-10-11T23:30:50Z"
-      },
-      "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
         "name": "localeFormatPreference",
         "resourceVersion": "1743693517832",
         "creationTimestamp": "2025-03-31T13:59:07Z"

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -10,7 +10,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/web"
@@ -22,23 +21,13 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 	l.RouteRegister.Group("/api/library-elements", func(entities routing.RouteRegister) {
 		uidScope := ScopeLibraryPanelsProvider.GetResourceScopeUID(ac.Parameter(":uid"))
 
-		if l.features.IsEnabledGlobally(featuremgmt.FlagLibraryPanelRBAC) {
-			entities.Post("/", authorize(ac.EvalPermission(ActionLibraryPanelsCreate)), routing.Wrap(l.createHandler))
-			entities.Delete("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsDelete, uidScope)), routing.Wrap(l.deleteHandler))
-			entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))
-			entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
-			entities.Get("/:uid/connections/", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getConnectionsHandler))
-			entities.Get("/name/:name", routing.Wrap(l.getByNameHandler))
-			entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler))
-		} else {
-			entities.Post("/", routing.Wrap(l.createHandler))
-			entities.Delete("/:uid", routing.Wrap(l.deleteHandler))
-			entities.Get("/", routing.Wrap(l.getAllHandler))
-			entities.Get("/:uid", routing.Wrap(l.getHandler))
-			entities.Get("/:uid/connections/", routing.Wrap(l.getConnectionsHandler))
-			entities.Get("/name/:name", routing.Wrap(l.getByNameHandler))
-			entities.Patch("/:uid", routing.Wrap(l.patchHandler))
-		}
+		entities.Post("/", authorize(ac.EvalPermission(ActionLibraryPanelsCreate)), routing.Wrap(l.createHandler))
+		entities.Delete("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsDelete, uidScope)), routing.Wrap(l.deleteHandler))
+		entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))
+		entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
+		entities.Get("/:uid/connections/", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getConnectionsHandler))
+		entities.Get("/name/:name", routing.Wrap(l.getByNameHandler))
+		entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler))
 	})
 }
 
@@ -151,13 +140,11 @@ func (l *LibraryElementService) getHandler(c *contextmodel.ReqContext) response.
 		return l.toLibraryElementError(err, "Failed to get library element")
 	}
 
-	if l.features.IsEnabled(ctx, featuremgmt.FlagLibraryPanelRBAC) {
-		allowed, err := l.AccessControl.Evaluate(ctx, c.SignedInUser, ac.EvalPermission(ActionLibraryPanelsRead, ScopeLibraryPanelsProvider.GetResourceScopeUID(web.Params(c.Req)[":uid"])))
-		if err != nil {
-			return response.Error(http.StatusInternalServerError, "unable to evaluate library panel permissions", err)
-		} else if !allowed {
-			return response.Error(http.StatusForbidden, "insufficient permissions for getting library panel", err)
-		}
+	allowed, err := l.AccessControl.Evaluate(ctx, c.SignedInUser, ac.EvalPermission(ActionLibraryPanelsRead, ScopeLibraryPanelsProvider.GetResourceScopeUID(web.Params(c.Req)[":uid"])))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "unable to evaluate library panel permissions", err)
+	} else if !allowed {
+		return response.Error(http.StatusForbidden, "insufficient permissions for getting library panel", err)
 	}
 
 	return response.JSON(http.StatusOK, model.LibraryElementResponse{Result: element})
@@ -192,13 +179,11 @@ func (l *LibraryElementService) getAllHandler(c *contextmodel.ReqContext) respon
 		return l.toLibraryElementError(err, "Failed to get library elements")
 	}
 
-	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagLibraryPanelRBAC) {
-		filteredPanels, err := l.filterLibraryPanelsByPermission(c, elementsResult.Elements)
-		if err != nil {
-			return l.toLibraryElementError(err, "Failed to evaluate permissions")
-		}
-		elementsResult.Elements = filteredPanels
+	filteredPanels, err := l.filterLibraryPanelsByPermission(c, elementsResult.Elements)
+	if err != nil {
+		return l.toLibraryElementError(err, "Failed to evaluate permissions")
 	}
+	elementsResult.Elements = filteredPanels
 
 	return response.JSON(http.StatusOK, model.LibraryElementSearchResponse{Result: elementsResult})
 }
@@ -299,16 +284,12 @@ func (l *LibraryElementService) getByNameHandler(c *contextmodel.ReqContext) res
 		return l.toLibraryElementError(err, "Failed to get library element")
 	}
 
-	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagLibraryPanelRBAC) {
-		filteredElements, err := l.filterLibraryPanelsByPermission(c, elements)
-		if err != nil {
-			return l.toLibraryElementError(err, err.Error())
-		}
-
-		return response.JSON(http.StatusOK, model.LibraryElementArrayResponse{Result: filteredElements})
-	} else {
-		return response.JSON(http.StatusOK, model.LibraryElementArrayResponse{Result: elements})
+	filteredElements, err := l.filterLibraryPanelsByPermission(c, elements)
+	if err != nil {
+		return l.toLibraryElementError(err, err.Error())
 	}
+
+	return response.JSON(http.StatusOK, model.LibraryElementArrayResponse{Result: filteredElements})
 }
 
 func (l *LibraryElementService) filterLibraryPanelsByPermission(c *contextmodel.ReqContext, elements []model.LibraryElementDTO) ([]model.LibraryElementDTO, error) {


### PR DESCRIPTION
**What is this feature?**

This PR enables `libraryPanelRBAC` by default, which has been in Grafana since 10.2+.

[see thread](https://raintank-corp.slack.com/archives/C0764C1GSBH/p1749696825184489)