### PR TITLE
Alerting: Add provenance to Prometheus API

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -120,7 +120,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkingProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		apiprometheus.NewPrometheusSrv(logger, api.StateManager, api.Scheduler, api.RuleStore, ruleAuthzService),
+		apiprometheus.NewPrometheusSrv(logger, api.StateManager, api.Scheduler, api.RuleStore, ruleAuthzService, api.ProvenanceStore),
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkingRuler(

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -1984,6 +1984,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			require.Equal(t, "webhook-a", rg.Rules[0].NotificationSettings.Receiver)
 		})
 	})
+
+	t.Run("provenance as expected", func(t *testing.T) {
+		// TODO: add test which checks that the basic provenance is empty for rules that are not provisioned
+		// TODO: add test which verifies rule that has provenance record is returned with appropriate provenance
+		// TODO: add test which verifies a mix of rules with and without provenance is returned correctly
+	})
 }
 
 func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, PrometheusSrv) {

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -749,6 +749,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 				fakeSch,
 				ruleStore,
 				&fakeRuleAccessControlService{},
+				fakes.NewFakeProvisioningStore(),
 			)
 
 			response := api.RouteGetRuleStatuses(c)
@@ -811,6 +812,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			newFakeSchedulerReader(t).setupStates(fakeAIM),
 			ruleStore,
 			accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
+			fakes.NewFakeProvisioningStore(),
 		)
 
 		permissions := createPermissionsForRules(slices.Concat(rulesInGroup1, rulesInGroup2, rulesInGroup3), orgID)
@@ -937,6 +939,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			newFakeSchedulerReader(t).setupStates(fakeAIM),
 			ruleStore,
 			accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
+			fakes.NewFakeProvisioningStore(),
 		)
 
 		permissions := createPermissionsForRules(allRules, orgID)
@@ -1081,6 +1084,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 				newFakeSchedulerReader(t).setupStates(fakeAIM),
 				ruleStore,
 				accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
+				fakes.NewFakeProvisioningStore(),
 			)
 
 			c := &contextmodel.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &user.SignedInUser{OrgID: orgID, Permissions: createPermissionsForRules(rules, orgID)}}
@@ -1987,6 +1991,7 @@ func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, Promet
 	fakeAIM := NewFakeAlertInstanceManager(t)
 	fakeSch := newFakeSchedulerReader(t).setupStates(fakeAIM)
 	fakeAuthz := &fakeRuleAccessControlService{}
+	fakeProvisioning := fakes.NewFakeProvisioningStore()
 
 	api := *NewPrometheusSrv(
 		log.NewNopLogger(),
@@ -1994,6 +1999,7 @@ func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, Promet
 		fakeSch,
 		fakeStore,
 		fakeAuthz,
+		fakeProvisioning,
 	)
 
 	return fakeStore, fakeAIM, api

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/util"
@@ -41,21 +42,27 @@ type StatusReader interface {
 	Status(key ngmodels.AlertRuleKey) (ngmodels.RuleStatus, bool)
 }
 
-type PrometheusSrv struct {
-	log     log.Logger
-	manager state.AlertInstanceManager
-	status  StatusReader
-	store   RuleStoreReader
-	authz   RuleGroupAccessControlService
+type ProvenanceStore interface {
+	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
 }
 
-func NewPrometheusSrv(log log.Logger, manager state.AlertInstanceManager, status StatusReader, store RuleStoreReader, authz RuleGroupAccessControlService) *PrometheusSrv {
+type PrometheusSrv struct {
+	log             log.Logger
+	manager         state.AlertInstanceManager
+	status          StatusReader
+	store           RuleStoreReader
+	authz           RuleGroupAccessControlService
+	provenanceStore ProvenanceStore
+}
+
+func NewPrometheusSrv(log log.Logger, manager state.AlertInstanceManager, status StatusReader, store RuleStoreReader, authz RuleGroupAccessControlService, provenanceStore ProvenanceStore) *PrometheusSrv {
 	return &PrometheusSrv{
-		log:     log,
-		manager: manager,
-		status:  status,
-		store:   store,
-		authz:   authz,
+		log,
+		manager,
+		status,
+		store,
+		authz,
+		provenanceStore,
 	}
 }
 
@@ -274,12 +281,20 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 		}
 	}
 
+	provenanceRecords, err := srv.provenanceStore.GetProvenances(c.Req.Context(), c.GetOrgID(), (&ngmodels.AlertRule{}).ResourceType())
+	if err != nil {
+		ruleResponse.Status = "error"
+		ruleResponse.Error = fmt.Sprintf("failed to get provenances visible to the user: %s", err.Error())
+		ruleResponse.ErrorType = apiv1.ErrServer
+		return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
+	}
+
 	ruleResponse = PrepareRuleGroupStatuses(srv.log, srv.store, RuleGroupStatusesOptions{
 		Ctx:               c.Req.Context(),
 		OrgID:             c.OrgID,
 		Query:             c.Req.Form,
 		AllowedNamespaces: allowedNamespaces,
-	}, RuleStatusMutatorGenerator(srv.status), RuleAlertStateMutatorGenerator(srv.manager))
+	}, RuleStatusMutatorGenerator(srv.status), RuleAlertStateMutatorGenerator(srv.manager), provenanceRecords)
 
 	return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 }
@@ -379,7 +394,7 @@ func RuleAlertStateMutatorGenerator(manager state.AlertInstanceManager) RuleAler
 	}
 }
 
-func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts RuleGroupStatusesOptions, ruleStatusMutator RuleStatusMutator, alertStateMutator RuleAlertStateMutator) apimodels.RuleResponse {
+func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts RuleGroupStatusesOptions, ruleStatusMutator RuleStatusMutator, alertStateMutator RuleAlertStateMutator, provenanceRecords map[string]ngmodels.Provenance) apimodels.RuleResponse {
 	ruleResponse := apimodels.RuleResponse{
 		DiscoveryBase: apimodels.DiscoveryBase{
 			Status: "success",
@@ -502,7 +517,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 			break
 		}
 
-		ruleGroup, totals := toRuleGroup(log, rg.GroupKey, rg.Folder, rg.Rules, limitAlertsPerRule, stateFilterSet, matchers, labelOptions, ruleStatusMutator, alertStateMutator)
+		ruleGroup, totals := toRuleGroup(log, rg.GroupKey, rg.Folder, rg.Rules, provenanceRecords, limitAlertsPerRule, stateFilterSet, matchers, labelOptions, ruleStatusMutator, alertStateMutator)
 		ruleGroup.Totals = totals
 		for k, v := range totals {
 			rulesTotals[k] += v
@@ -653,7 +668,7 @@ func matchersMatch(matchers []*labels.Matcher, labels map[string]string) bool {
 	return true
 }
 
-func toRuleGroup(log log.Logger, groupKey ngmodels.AlertRuleGroupKey, folderFullPath string, rules []*ngmodels.AlertRule, limitAlerts int64, stateFilterSet map[eval.State]struct{}, matchers labels.Matchers, labelOptions []ngmodels.LabelOption, ruleStatusMutator RuleStatusMutator, ruleAlertStateMutator RuleAlertStateMutator) (*apimodels.RuleGroup, map[string]int64) {
+func toRuleGroup(log log.Logger, groupKey ngmodels.AlertRuleGroupKey, folderFullPath string, rules []*ngmodels.AlertRule, provenanceRecords map[string]ngmodels.Provenance, limitAlerts int64, stateFilterSet map[eval.State]struct{}, matchers labels.Matchers, labelOptions []ngmodels.LabelOption, ruleStatusMutator RuleStatusMutator, ruleAlertStateMutator RuleAlertStateMutator) (*apimodels.RuleGroup, map[string]int64) {
 	newGroup := &apimodels.RuleGroup{
 		Name: groupKey.RuleGroup,
 		// file is what Prometheus uses for provisioning, we replace it with namespace which is the folder in Grafana.
@@ -665,6 +680,10 @@ func toRuleGroup(log log.Logger, groupKey ngmodels.AlertRuleGroupKey, folderFull
 
 	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
+		provenance := ngmodels.ProvenanceNone
+		if prov, exists := provenanceRecords[rule.ResourceID()]; exists {
+			provenance = prov
+		}
 		alertingRule := apimodels.AlertingRule{
 			State:                 "inactive",
 			Name:                  rule.Title,
@@ -674,12 +693,13 @@ func toRuleGroup(log log.Logger, groupKey ngmodels.AlertRuleGroupKey, folderFull
 			KeepFiringFor:         rule.KeepFiringFor.Seconds(),
 			Annotations:           apimodels.LabelsFromMap(rule.Annotations),
 			Rule: apimodels.Rule{
-				UID:       rule.UID,
-				Name:      rule.Title,
-				FolderUID: rule.NamespaceUID,
-				Labels:    apimodels.LabelsFromMap(rule.GetLabels(labelOptions...)),
-				Type:      rule.Type().String(),
-				IsPaused:  rule.IsPaused,
+				UID:        rule.UID,
+				Name:       rule.Title,
+				FolderUID:  rule.NamespaceUID,
+				Labels:     apimodels.LabelsFromMap(rule.GetLabels(labelOptions...)),
+				Type:       rule.Type().String(),
+				IsPaused:   rule.IsPaused,
+				Provenance: apimodels.Provenance(provenance),
 			},
 		}
 

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/util"
@@ -43,7 +42,7 @@ type StatusReader interface {
 }
 
 type ProvenanceStore interface {
-	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
+	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]ngmodels.Provenance, error)
 }
 
 type PrometheusSrv struct {

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -289,12 +289,19 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 		return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 	}
 
-	ruleResponse = PrepareRuleGroupStatuses(srv.log, srv.store, RuleGroupStatusesOptions{
-		Ctx:               c.Req.Context(),
-		OrgID:             c.OrgID,
-		Query:             c.Req.Form,
-		AllowedNamespaces: allowedNamespaces,
-	}, RuleStatusMutatorGenerator(srv.status), RuleAlertStateMutatorGenerator(srv.manager), provenanceRecords)
+	ruleResponse = PrepareRuleGroupStatuses(
+		srv.log,
+		srv.store,
+		RuleGroupStatusesOptions{
+			Ctx:               c.Req.Context(),
+			OrgID:             c.OrgID,
+			Query:             c.Req.Form,
+			AllowedNamespaces: allowedNamespaces,
+		},
+		RuleStatusMutatorGenerator(srv.status),
+		RuleAlertStateMutatorGenerator(srv.manager),
+		provenanceRecords,
+	)
 
 	return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 }

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -185,6 +185,7 @@ type Rule struct {
 	EvaluationTime       float64                        `json:"evaluationTime"`
 	IsPaused             bool                           `json:"isPaused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notificationSettings,omitempty"`
+	Provenance           Provenance                     `json:"provenance,omitempty"`
 }
 
 // Alert has info for an alert.


### PR DESCRIPTION
This adds provenance to the Prometheus API in grafana to enable compatibility with the new alert list page.
