### PR TITLE
CloudMigrations: Omit autoincremented id for alert snapshots

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -135,7 +135,6 @@ type alertRule struct {
 	Title                string                                     `json:"title"`
 	ExecErrState         string                                     `json:"execErrState"`
 	Data                 []definitions.AlertQuery                   `json:"data"`
-	ID                   int64                                      `json:"id"`
 	For                  model.Duration                             `json:"for"`
 	OrgID                int64                                      `json:"orgID"`
 	IsPaused             bool                                       `json:"isPaused"`
@@ -158,7 +157,6 @@ func (s *Service) getAlertRules(ctx context.Context, signedInUser *user.SignedIn
 		}
 
 		provisionedAlertRules = append(provisionedAlertRules, alertRule{
-			ID:                   rule.ID,
 			UID:                  rule.UID,
 			OrgID:                rule.OrgID,
 			FolderUID:            rule.NamespaceUID,
@@ -208,7 +206,6 @@ func (s *Service) getAlertRuleGroups(ctx context.Context, signedInUser *user.Sig
 			}
 
 			provisionedAlertRules = append(provisionedAlertRules, alertRule{
-				ID:                   rule.ID,
 				UID:                  rule.UID,
 				OrgID:                rule.OrgID,
 				FolderUID:            rule.NamespaceUID,


### PR DESCRIPTION
**What is this feature?**

Omit the autoincremented numeric id for alerts in the snapshot and let the API for the cloud instance generate it.

**Why do we need this feature?**

If you tried to migrate alerts from two differente sources/on-prem instances, the autoincremented numeric id would be the same, and since we were creating the resource in cloud with that same id (the API accepts it), it would return an error "conflicting alert rule found" because that id is the primary key on the table.

**Who is this feature for?**

Cloud Migration users

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
