### PR TITLE
CloudMigrations: Skip default contact point from snapshot

### DIFF
--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -186,6 +186,10 @@ The migration assistant can migrate the majority of Grafana Alerting resources t
 - Notification policy tree
 - Notification templates
 
+{{< admonition type="note">}}
+Unless edited or updated from its defaults, the `grafana-default-email` contact point that is provisioned with every new Grafana instance will not be migrated.
+{{< /admonition >}}
+
 This is sufficient to have your Alerting configuration up and running in Grafana Cloud with minimal effort.
 
 Migration of Silences is not supported by the migration assistant and needs to be configured manually. Alert History is also not available for migration.

--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -187,7 +187,7 @@ The migration assistant can migrate the majority of Grafana Alerting resources t
 - Notification templates
 
 {{< admonition type="note">}}
-Unless edited or updated from its defaults, the `grafana-default-email` contact point that is provisioned with every new Grafana instance will not be migrated.
+The `grafana-default-email` contact point that is provisioned with every new Grafana instance doesn't have a UID by default and won't be migrated unless you edit or update and save it. You do not need to change the contact point for a UID to be generated when saved.
 {{< /admonition >}}
 
 This is sufficient to have your Alerting configuration up and running in Grafana Cloud with minimal effort.

--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -187,7 +187,7 @@ The migration assistant can migrate the majority of Grafana Alerting resources t
 - Notification templates
 
 {{< admonition type="note">}}
-The `grafana-default-email` contact point that is provisioned with every new Grafana instance doesn't have a UID by default and won't be migrated unless you edit or update and save it. You do not need to change the contact point for a UID to be generated when saved.
+The `grafana-default-email` contact point that's provisioned with every new Grafana instance doesn't have a UID by default and won't be migrated unless you edit or update and save it. You do not need to change the contact point for a UID to be generated when saved.
 {{< /admonition >}}
 
 This is sufficient to have your Alerting configuration up and running in Grafana Cloud with minimal effort.

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -92,6 +92,12 @@ func (s *Service) getContactPoints(ctx context.Context, signedInUser *user.Signe
 	contactPoints := make([]contactPoint, 0, len(embeddedContactPoints))
 
 	for _, embeddedContactPoint := range embeddedContactPoints {
+		// This happens in the default contact point, and would otherwise fail to migrate because it has no UID.
+		// If that contact point is edited in any way, an UID is generated.
+		if embeddedContactPoint.UID == "" {
+			continue
+		}
+
 		contactPoints = append(contactPoints, contactPoint{
 			UID:                   embeddedContactPoint.UID,
 			Name:                  embeddedContactPoint.Name,

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -102,14 +102,12 @@ func TestGetContactPoints(t *testing.T) {
 			},
 		}
 
-		defaultEmailContactPointCount := 1
-
 		createdContactPoints := createContactPoints(t, ctx, s, user)
 
 		contactPoints, err := s.getContactPoints(ctx, user)
 		require.NoError(t, err)
 		require.NotNil(t, contactPoints)
-		require.Len(t, contactPoints, len(createdContactPoints)+defaultEmailContactPointCount)
+		require.Len(t, contactPoints, len(createdContactPoints))
 	})
 
 	t.Run("it returns an error when user lacks permission to read contact point secrets", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Filters out the default contact point since it has no UID from the migration snapshot.

In case that contact point is edited in any way, it will generate an UID and thus we can migrate it, because it signals that it no longer has sample default values.

**Why do we need this feature?**

Because it does not have an UID, it fails to migrate always. Moreover, the Cloud instance already has a similar contact point.

**Who is this feature for?**

Cloud Migration users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1418

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
