### PR TITLE
alerting(ui): update the descriptions of the MQTT Message settings

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1406,7 +1406,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					},
 					InputType:    InputTypeText,
 					Placeholder:  "json",
-					Description:  "The format of the message to be sent. If set to 'json', the message will be sent as a JSON object. If set to 'text', the message will be sent as a plain text string. By default json is used.",
+					Description:  "If set to 'json', the notification message is the default JSON payload, and the Message field sets only the message field in the payload. If set to 'text', the Message field defines the entire payload. The default is 'json'.",
 					PropertyName: "messageFormat",
 					Required:     false,
 				},
@@ -1422,6 +1422,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
+					Description:  "In 'json' Message format, sets the message field of the default JSON payload. In 'text' Message format, defines the entire payload.",
 					Placeholder:  alertingTemplates.DefaultMessageEmbed,
 					PropertyName: "message",
 				},

--- a/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
+++ b/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
@@ -2724,7 +2724,7 @@ export const grafanaAlertNotifiers: Record<GrafanaNotifierType, NotifierDTO> = {
         inputType: 'text',
         label: 'Message format',
         description:
-          "The format of the message to be sent. If set to 'json', the message will be sent as a JSON object. If set to 'text', the message will be sent as a plain text string. By default json is used.",
+          "If set to 'json', the notification message is the default JSON payload, and the Message field sets only the message field in the payload. If set to 'text', the Message field defines the entire payload. The default is 'json'.",
         placeholder: 'json',
         propertyName: 'messageFormat',
         selectOptions: [
@@ -2767,7 +2767,8 @@ export const grafanaAlertNotifiers: Record<GrafanaNotifierType, NotifierDTO> = {
         element: 'textarea',
         inputType: '',
         label: 'Message',
-        description: '',
+        description:
+          "In 'json' Message format, sets the message field of the default JSON payload. In 'text' Message format, defines the entire payload.",
         placeholder: '{{ template "default.message" . }}',
         propertyName: 'message',
         selectOptions: null,


### PR DESCRIPTION
This PR updates the descriptions of the MQTT Message and Message format fields for clarity.

Here's a related docs PR: https://github.com/grafana/grafana/pull/106566


![Screenshot 2025-06-12 at 09 43 09](https://github.com/user-attachments/assets/4aaa51a2-16d8-49d6-9a45-8232f75937c6)
