### PR TITLE
Secrets: Always clear the status.externalId when receiving requests

### DIFF
--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -691,6 +691,7 @@ func (b *SecretAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, o
 		if ok && sv != nil {
 			sv.Status.Phase = secretv0alpha1.SecureValuePhasePending
 			sv.Status.Message = ""
+			sv.Status.ExternalID = ""
 		}
 	}
 

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -314,13 +314,15 @@ func TestSecureValueRestCreate(t *testing.T) {
 				Description: "desc1",
 			},
 			Status: secretv0alpha1.SecureValueStatus{
-				Phase: secretv0alpha1.SecureValuePhasePending,
+				Phase:      secretv0alpha1.SecureValuePhasePending,
+				ExternalID: "test-external-id",
 			},
 		}
 
 		sv.Spec.Value = secretv0alpha1.NewExposedSecureValue("v1")
-		_, err := sut.CreateSv(testutils.CreateSvWithSv(sv))
+		createdSv, err := sut.CreateSv(testutils.CreateSvWithSv(sv))
 		require.NoError(t, err)
+		require.Empty(t, createdSv.Status.ExternalID)
 
 		sv.Spec.Value = secretv0alpha1.NewExposedSecureValue("v2")
 		_, err = sut.CreateSv(testutils.CreateSvWithSv(sv))


### PR DESCRIPTION
Extra check to make sure we aren't consuming `status` input from the request ever.