### PR TITLE
TimeRangePicker: Highlight range on hover

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -155,64 +155,54 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
           outline: 0,
         },
 
-      [`${hasActiveSelector}, .react-calendar__tile--active`]: {
-        color: theme.colors.primary.contrastText,
-        fontWeight: theme.typography.fontWeightMedium,
-        background: theme.colors.primary.main,
-        border: '0px',
-      },
+      [`${hasActiveSelector}, .react-calendar__tile--active, .react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart`]:
+        {
+          color: theme.colors.primary.contrastText,
+          fontWeight: theme.typography.fontWeightMedium,
+          background: theme.colors.primary.main,
+          border: '0px',
+        },
 
+      // The --hover modifier is active when the user is selecting a range and hovering over a tile - it shows the pending range.
+      // It is applied to all dates between the clicked date and the hovered date.
+      // The *clicked* date should have primary bg, while *pending* range dates should have hover bg.
       '.react-calendar__tile--hover': {
         backgroundColor: theme.colors.action.hover,
+        borderRadius: 0,
       },
 
-      // '.react-calendar__tile--hoverStart': {
-      //   borderTopRightRadius: '0 !important',
-      //   borderBottomRightRadius: '0 !important',
-      //   borderTopLeftRadius: '20px',
-      //   borderBottomLeftRadius: '20px',
-      // },
+      '.react-calendar__tile--hoverStart': {
+        borderTopLeftRadius: theme.shape.radius.pill,
+        borderBottomLeftRadius: theme.shape.radius.pill,
+      },
 
-      // '.react-calendar__tile--hoverEnd': {
-      //   borderTopLeftRadius: '0 !important',
-      //   borderBottomLeftRadius: '0 !important',
-      //   borderTopRightRadius: '20px',
-      //   borderBottomRightRadius: '20px',
-      // },
+      '.react-calendar__tile--hoverEnd': {
+        borderTopRightRadius: theme.shape.radius.pill,
+        borderBottomRightRadius: theme.shape.radius.pill,
+      },
 
-      // '.react-calendar__tile--hoverBothEnds': {
-      //   borderRadius: '20px',
-      // },
-
-      // '.react-calendar__tile:hover:not(.react-calendar__tile--active):not(.react-calendar__tile--rangeEnd):not(.react-calendar__tile--rangeStart)':
-      //   {
-      //     backgroundColor: theme.colors.action.hover,
-      //   },
+      // Addiitonally, when hovering a date before clicking any, it should show the hover bg.
+      '.react-calendar__tile:hover:not(.react-calendar__tile--hover):not(.react-calendar__tile--active):not(.react-calendar__tile--hasActive)':
+        {
+          backgroundColor: theme.colors.action.hover,
+          borderRadius: theme.shape.radius.pill,
+        },
 
       '.react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart': {
-        padding: 0,
-        border: '0px',
         color: theme.colors.primary.contrastText,
-        fontWeight: theme.typography.fontWeightMedium,
         background: theme.colors.primary.main,
-
-        abbr: {
-          // backgroundColor: theme.colors.primary.main,
-          // borderRadius: theme.shape.radius.pill,
-          display: 'block',
-          paddingTop: '2px',
-          height: '26px',
-        },
       },
 
-      [`${hasActiveSelector}, .react-calendar__tile--rangeStart`]: {
-        borderTopLeftRadius: '20px',
-        borderBottomLeftRadius: '20px',
+      // When the user is selecting a range (they've clicked one date, tiles have --hover), both --rangeStart and --rangeEnd are on the tile.
+      // The --hover classes above  handle the rounding of the tiles so they're contigious with the range
+      [`${hasActiveSelector}, .react-calendar__tile--rangeStart:not(.react-calendar__tile--hover)`]: {
+        borderTopLeftRadius: theme.shape.radius.pill,
+        borderBottomLeftRadius: theme.shape.radius.pill,
       },
 
-      [`${hasActiveSelector}, .react-calendar__tile--rangeEnd`]: {
-        borderTopRightRadius: '20px',
-        borderBottomRightRadius: '20px',
+      [`${hasActiveSelector}, .react-calendar__tile--rangeEnd:not(.react-calendar__tile--hover)`]: {
+        borderTopRightRadius: theme.shape.radius.pill,
+        borderBottomRightRadius: theme.shape.radius.pill,
       },
     }),
   };

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -92,6 +92,7 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
   // If a time range is part of only 1 day but does not encompass the whole day,
   // the class that react-calendar uses is '--hasActive' by itself (without being part of a '--range')
   const hasActiveSelector = `.react-calendar__tile--hasActive:not(.react-calendar__tile--range)`;
+
   return {
     title: css({
       color: theme.colors.text.primary,
@@ -161,10 +162,32 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         border: '0px',
       },
 
-      '.react-calendar__tile:hover:not(.react-calendar__tile--active):not(.react-calendar__tile--rangeEnd):not(.react-calendar__tile--rangeStart)':
-        {
-          backgroundColor: theme.colors.action.hover,
-        },
+      '.react-calendar__tile--hover': {
+        backgroundColor: theme.colors.action.hover,
+      },
+
+      // '.react-calendar__tile--hoverStart': {
+      //   borderTopRightRadius: '0 !important',
+      //   borderBottomRightRadius: '0 !important',
+      //   borderTopLeftRadius: '20px',
+      //   borderBottomLeftRadius: '20px',
+      // },
+
+      // '.react-calendar__tile--hoverEnd': {
+      //   borderTopLeftRadius: '0 !important',
+      //   borderBottomLeftRadius: '0 !important',
+      //   borderTopRightRadius: '20px',
+      //   borderBottomRightRadius: '20px',
+      // },
+
+      // '.react-calendar__tile--hoverBothEnds': {
+      //   borderRadius: '20px',
+      // },
+
+      // '.react-calendar__tile:hover:not(.react-calendar__tile--active):not(.react-calendar__tile--rangeEnd):not(.react-calendar__tile--rangeStart)':
+      //   {
+      //     backgroundColor: theme.colors.action.hover,
+      //   },
 
       '.react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart': {
         padding: 0,
@@ -174,8 +197,8 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         background: theme.colors.primary.main,
 
         abbr: {
-          backgroundColor: theme.colors.primary.main,
-          borderRadius: theme.shape.radius.pill,
+          // backgroundColor: theme.colors.primary.main,
+          // borderRadius: theme.shape.radius.pill,
           display: 'block',
           paddingTop: '2px',
           height: '26px',

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -160,6 +160,7 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
       // The *clicked* date should have primary bg, while *pending* range dates should have hover bg.
       '.react-calendar__tile--hover': {
         backgroundColor: theme.colors.action.hover,
+        // eslint-disable-next-line @grafana/no-border-radius-literal
         borderRadius: 0,
       },
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -155,14 +155,6 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
           outline: 0,
         },
 
-      [`${hasActiveSelector}, .react-calendar__tile--active, .react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart`]:
-        {
-          color: theme.colors.primary.contrastText,
-          fontWeight: theme.typography.fontWeightMedium,
-          background: theme.colors.primary.main,
-          border: '0px',
-        },
-
       // The --hover modifier is active when the user is selecting a range and hovering over a tile - it shows the pending range.
       // It is applied to all dates between the clicked date and the hovered date.
       // The *clicked* date should have primary bg, while *pending* range dates should have hover bg.
@@ -188,11 +180,6 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
           borderRadius: theme.shape.radius.pill,
         },
 
-      '.react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart': {
-        color: theme.colors.primary.contrastText,
-        background: theme.colors.primary.main,
-      },
-
       // When the user is selecting a range (they've clicked one date, tiles have --hover), both --rangeStart and --rangeEnd are on the tile.
       // The --hover classes above  handle the rounding of the tiles so they're contigious with the range
       [`${hasActiveSelector}, .react-calendar__tile--rangeStart:not(.react-calendar__tile--hover)`]: {
@@ -204,6 +191,14 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         borderTopRightRadius: theme.shape.radius.pill,
         borderBottomRightRadius: theme.shape.radius.pill,
       },
+
+      [`${hasActiveSelector}, .react-calendar__tile--active, .react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart`]:
+        {
+          color: theme.colors.primary.contrastText,
+          fontWeight: theme.typography.fontWeightMedium,
+          background: theme.colors.primary.main,
+          border: '0px',
+        },
     }),
   };
 };

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -45,6 +45,7 @@ export class KeybindingSrv {
     // Chromeless pages like login and signup page don't get any global bindings
     if (!route.chromeless) {
       this.bind('?', this.showHelpModal);
+
       this.bind('g h', this.goToHome);
       this.bind('g d', this.goToDashboards);
       this.bind('g e', this.goToExplore);
@@ -52,6 +53,13 @@ export class KeybindingSrv {
       this.bind('g p', this.goToProfile);
       this.bind('esc', this.exit);
       this.bindGlobalEsc();
+
+      if (process.env.NODE_ENV === 'development') {
+        this.bind('`', () => {
+          console.log('Hitting breakpoint - make sure your browser dev tools allows debugger statements');
+          debugger;
+        });
+      }
     }
 
     this.bind('c t', () => toggleTheme(false));

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -53,13 +53,6 @@ export class KeybindingSrv {
       this.bind('g p', this.goToProfile);
       this.bind('esc', this.exit);
       this.bindGlobalEsc();
-
-      if (process.env.NODE_ENV === 'development') {
-        this.bind('`', () => {
-          console.log('Hitting breakpoint - make sure your browser dev tools allows debugger statements');
-          debugger;
-        });
-      }
     }
 
     this.bind('c t', () => toggleTheme(false));


### PR DESCRIPTION
**What is this feature?**


Adds a hover effect to the pending range when selecting a range in the time range picker on Dashboards.

![image](https://github.com/user-attachments/assets/d09cf364-d6ec-4047-85d0-7b0d48f41526)

This is accidentally an iteration on @ywzheng1's PR from yesterday https://github.com/grafana/grafana/pull/106451 - I picked this up myself (after feedback from @jackw), and then saw Yunwen already had something similar!


**Why do we need this feature?**

To give feedback to the user that they're actively selecting a range, and should click to finalise the selection.
