### PR TITLE
ServiceAccounts: return 404 when deleting a non‑existent service account

### DIFF
--- a/pkg/services/serviceaccounts/api/api.go
+++ b/pkg/services/serviceaccounts/api/api.go
@@ -223,6 +223,7 @@ func (api *ServiceAccountsAPI) validateRole(r *org.RoleType, orgRole org.RoleTyp
 // 400: badRequestError
 // 401: unauthorisedError
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (api *ServiceAccountsAPI) DeleteServiceAccount(ctx *contextmodel.ReqContext) response.Response {
 	saID, err := strconv.ParseInt(web.Params(ctx.Req)[":serviceAccountId"], 10, 64)
@@ -231,7 +232,7 @@ func (api *ServiceAccountsAPI) DeleteServiceAccount(ctx *contextmodel.ReqContext
 	}
 	err = api.service.DeleteServiceAccount(ctx.Req.Context(), ctx.GetOrgID(), saID)
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Service account deletion error", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "Service account deletion error", err)
 	}
 	return response.Success("Service account deleted")
 }

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -102,6 +102,7 @@ func TestServiceAccountsAPI_DeleteServiceAccount(t *testing.T) {
 		desc         string
 		id           int64
 		permissions  []accesscontrol.Permission
+		expectedErr  error
 		expectedCode int
 	}
 
@@ -118,11 +119,21 @@ func TestServiceAccountsAPI_DeleteServiceAccount(t *testing.T) {
 			permissions:  []accesscontrol.Permission{{Action: serviceaccounts.ActionDelete, Scope: "serviceaccounts:id:1"}},
 			expectedCode: http.StatusForbidden,
 		},
+		{
+			desc:         "should return a 404 error if the service account doesn't exist",
+			id:           1,
+			permissions:  []accesscontrol.Permission{{Action: serviceaccounts.ActionDelete, Scope: "serviceaccounts:id:1"}},
+			expectedErr:  serviceaccounts.ErrServiceAccountNotFound.Errorf("service account with id 1 not found"),
+			expectedCode: http.StatusNotFound,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			server := setupTests(t)
+			server := setupTests(t, func(a *ServiceAccountsAPI) {
+				a.service = &satests.FakeServiceAccountService{ExpectedErr: tt.expectedErr}
+			})
+
 			req := server.NewRequest(http.MethodDelete, fmt.Sprintf("/api/serviceaccounts/%d", tt.id), nil)
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByActionContext(context.Background(), tt.permissions)}})
 			res, err := server.Send(req)

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -8877,6 +8877,9 @@
           "403": {
             "$ref": "#/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalServerError"
           }

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -23226,6 +23226,9 @@
           "403": {
             "$ref": "#/components/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/components/responses/internalServerError"
           }


### PR DESCRIPTION
**What is this feature?**

This change surfaces `ErrServiceAccountNotFound` as `404`, mirroring the behaviour introduced for [#64299](https://github.com/grafana/grafana/pull/64299) and consistent with other delete endpoints such as datasources.

**Why do we need this feature?**

Deleting a non‑existent service account currently returns `500`, which breaks callers that rely on semantic HTTP status codes (for example, the Grafana Operator when [reconciling CR deletes](https://github.com/grafana/grafana-operator/pull/1907)).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
