### PR TITLE
Eslint: Allow 'unset' in no-border-radius-literal lint rule

### DIFF
--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -18,6 +18,8 @@ Check if border-radius theme tokens are used.
 
 To improve the consistency across Grafana we encourage devs to use tokens instead of custom values. In this case, we want the `borderRadius` to use the appropriate token such as `theme.shape.radius.default`, `theme.shape.radius.pill` or `theme.shape.radius.circle`.
 
+Instead of using `0` to remove a previously set border-radius, use `unset`.
+
 ### `no-unreduced-motion`
 
 Avoid direct use of `animation*` or `transition*` properties.

--- a/packages/grafana-eslint-rules/rules/no-border-radius-literal.cjs
+++ b/packages/grafana-eslint-rules/rules/no-border-radius-literal.cjs
@@ -4,6 +4,26 @@ const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/grafana/grafana/blob/main/packages/grafana-eslint-rules/README.md#${name}`
 );
 
+const BORDER_RADIUS_PROPERTIES = [
+  'borderRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+];
+
+function isValidBorderRadiusLiteralValue(node) {
+  if (node.type !== AST_NODE_TYPES.Literal) {
+    return true;
+  }
+
+  if (node.value === 0 || node.value === '0px') {
+    return true;
+  }
+
+  return false;
+}
+
 const borderRadiusRule = createRule({
   create(context) {
     return {
@@ -11,8 +31,8 @@ const borderRadiusRule = createRule({
         if (
           node.type === AST_NODE_TYPES.Property &&
           node.key.type === AST_NODE_TYPES.Identifier &&
-          node.key.name === 'borderRadius' &&
-          node.value.type === AST_NODE_TYPES.Literal
+          BORDER_RADIUS_PROPERTIES.includes(node.key.name) &&
+          !isValidBorderRadiusLiteralValue(node.value)
         ) {
           context.report({
             node,

--- a/packages/grafana-eslint-rules/rules/no-border-radius-literal.cjs
+++ b/packages/grafana-eslint-rules/rules/no-border-radius-literal.cjs
@@ -34,6 +34,9 @@ const borderRadiusRule = createRule({
             context.report({
               node,
               messageId: 'borderRadiusNoZeroValue',
+              fix(fixer) {
+                return fixer.replaceText(node.value, "'unset'");
+              },
             });
           } else {
             // Otherwise, require theme tokens are used
@@ -49,6 +52,7 @@ const borderRadiusRule = createRule({
   name: 'no-border-radius-literal',
   meta: {
     type: 'problem',
+    fixable: 'code',
     docs: {
       description: 'Check if border-radius theme tokens are used',
     },

--- a/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
+++ b/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
@@ -14,8 +14,12 @@ RuleTester.setDefaultConfig({
   },
 });
 
-const expectedError = {
-  messageId: 'borderRadiusId',
+const useTokenError = {
+  messageId: 'borderRadiusUseTokens',
+};
+
+const noZeroValueError = {
+  messageId: 'borderRadiusNoZeroValue',
 };
 
 const ruleTester = new RuleTester();
@@ -44,28 +48,31 @@ ruleTester.run('eslint no-border-radius-literal', noBorderRadiusLiteral, {
       code: `css({ borderBottomRightRadius: theme.shape.radius.pill })`,
     },
 
-    // 0 is allowed for no border radius
+    // allow values to remove border radius
     {
-      code: `css({ borderRadius: 0 })`,
+      code: `css({ borderRadius: 'initial' })`,
+    },
+    {
+      code: `css({ borderRadius: 'unset' })`,
     },
   ],
 
   invalid: [
     {
       code: `css({ borderRadius: '2px' })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ borderRadius: 2 })`, // should error on px shorthand
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ lineHeight: 1 }, { borderRadius: '2px' })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css([{ lineHeight: 1 }, { borderRadius: '2px' }])`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       name: 'nested classes',
@@ -77,23 +84,37 @@ css({
     },
   },
 })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ borderTopLeftRadius: 1 })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ borderTopRightRadius: "2px" })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ borderBottomLeftRadius: 3 })`,
-      errors: [expectedError],
+      errors: [useTokenError],
     },
     {
       code: `css({ borderBottomRightRadius: "4px" })`,
-      errors: [expectedError],
+      errors: [useTokenError],
+    },
+
+    // should use unset or initial to remove border radius
+    {
+      code: `css({ borderRadius: 0 })`,
+      errors: [noZeroValueError],
+    },
+    {
+      code: `css({ borderRadius: '0px' })`,
+      errors: [noZeroValueError],
+    },
+    {
+      code: `css({ borderRadius: "0%" })`,
+      errors: [noZeroValueError],
     },
   ],
 });

--- a/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
+++ b/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
@@ -31,11 +31,32 @@ ruleTester.run('eslint no-border-radius-literal', noBorderRadiusLiteral, {
     {
       code: `css({ borderRadius: theme.shape.radius.pill })`,
     },
+    {
+      code: `css({ borderTopLeftRadius: theme.shape.radius.pill })`,
+    },
+    {
+      code: `css({ borderTopRightRadius: theme.shape.radius.pill })`,
+    },
+    {
+      code: `css({ borderBottomLeftRadius: theme.shape.radius.pill })`,
+    },
+    {
+      code: `css({ borderBottomRightRadius: theme.shape.radius.pill })`,
+    },
+
+    // 0 is allowed for no border radius
+    {
+      code: `css({ borderRadius: 0 })`,
+    },
   ],
 
   invalid: [
     {
       code: `css({ borderRadius: '2px' })`,
+      errors: [expectedError],
+    },
+    {
+      code: `css({ borderRadius: 2 })`, // should error on px shorthand
       errors: [expectedError],
     },
     {
@@ -56,6 +77,22 @@ css({
     },
   },
 })`,
+      errors: [expectedError],
+    },
+    {
+      code: `css({ borderTopLeftRadius: 1 })`,
+      errors: [expectedError],
+    },
+    {
+      code: `css({ borderTopRightRadius: "2px" })`,
+      errors: [expectedError],
+    },
+    {
+      code: `css({ borderBottomLeftRadius: 3 })`,
+      errors: [expectedError],
+    },
+    {
+      code: `css({ borderBottomRightRadius: "4px" })`,
       errors: [expectedError],
     },
   ],

--- a/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
+++ b/packages/grafana-eslint-rules/tests/no-border-radius-literal.test.js
@@ -106,14 +106,17 @@ css({
     // should use unset or initial to remove border radius
     {
       code: `css({ borderRadius: 0 })`,
+      output: `css({ borderRadius: 'unset' })`,
       errors: [noZeroValueError],
     },
     {
       code: `css({ borderRadius: '0px' })`,
+      output: `css({ borderRadius: 'unset' })`,
       errors: [noZeroValueError],
     },
     {
       code: `css({ borderRadius: "0%" })`,
+      output: `css({ borderRadius: 'unset' })`,
       errors: [noZeroValueError],
     },
   ],

--- a/packages/grafana-ui/src/components/Button/ButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Button/ButtonGroup.tsx
@@ -27,14 +27,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
 
     '> .button-group:not(:first-child) > button, > button:not(:first-child)': {
-      borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0,
+      borderTopLeftRadius: 'unset',
+      borderBottomLeftRadius: 'unset',
       borderLeft: `1px solid rgba(255, 255, 255, 0.12)`,
     },
 
     '> .button-group:not(:last-child) > button, > button:not(:last-child)': {
-      borderTopRightRadius: 0,
-      borderBottomRightRadius: 0,
+      borderTopRightRadius: 'unset',
+      borderBottomRightRadius: 'unset',
       borderRight: `1px solid rgba(0, 0, 0, 0.12)`,
     },
   }),

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -168,8 +168,8 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       '&:not(:first-child):last-child': {
         '> input': {
           borderLeft: 'none',
-          borderTopLeftRadius: 0,
-          borderBottomLeftRadius: 0,
+          borderTopLeftRadius: 'unset',
+          borderBottomLeftRadius: 'unset',
         },
       },
 
@@ -177,8 +177,8 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       '&:first-child:not(:last-child)': {
         '> input': {
           borderRight: 'none',
-          borderTopRightRadius: 0,
-          borderBottomRightRadius: 0,
+          borderTopRightRadius: 'unset',
+          borderBottomRightRadius: 'unset',
         },
       },
 
@@ -186,10 +186,10 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       '&:not(:first-child):not(:last-child)': {
         '> input': {
           borderRight: 'none',
-          borderTopRightRadius: 0,
-          borderBottomRightRadius: 0,
-          borderTopLeftRadius: 0,
-          borderBottomLeftRadius: 0,
+          borderTopRightRadius: 'unset',
+          borderBottomRightRadius: 'unset',
+          borderTopLeftRadius: 'unset',
+          borderBottomLeftRadius: 'unset',
         },
       },
 
@@ -238,20 +238,20 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       position: 'relative',
 
       '&:first-child': {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
+        borderTopRightRadius: 'unset',
+        borderBottomRightRadius: 'unset',
         '> :last-child': {
-          borderTopRightRadius: 0,
-          borderBottomRightRadius: 0,
+          borderTopRightRadius: 'unset',
+          borderBottomRightRadius: 'unset',
         },
       },
 
       '&:last-child': {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
+        borderTopLeftRadius: 'unset',
+        borderBottomLeftRadius: 'unset',
         '> :first-child': {
-          borderTopLeftRadius: 0,
-          borderBottomLeftRadius: 0,
+          borderTopLeftRadius: 'unset',
+          borderBottomLeftRadius: 'unset',
         },
       },
       '> *:focus': {
@@ -266,8 +266,8 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
         paddingLeft: theme.spacing(1),
         paddingRight: theme.spacing(0.5),
         borderRight: 'none',
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
+        borderTopRightRadius: 'unset',
+        borderBottomRightRadius: 'unset',
       })
     ),
     suffix: cx(
@@ -277,8 +277,8 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
         paddingLeft: theme.spacing(1),
         paddingRight: theme.spacing(1),
         borderLeft: 'none',
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
+        borderTopLeftRadius: 'unset',
+        borderBottomLeftRadius: 'unset',
         right: 0,
       })
     ),

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -118,8 +118,8 @@ export class RefreshPicker extends PureComponent<Props> {
         {!noIntervalPicker && (
           <ButtonSelect
             className={css({
-              borderTopLeftRadius: 0,
-              borderBottomLeftRadius: 0,
+              borderTopLeftRadius: 'unset',
+              borderBottomLeftRadius: 'unset',
             })}
             value={selectedValue}
             options={options}

--- a/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
+++ b/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { cx } from '@emotion/css';
 import { omit } from 'lodash';
 import { InputHTMLAttributes } from 'react';
 import * as React from 'react';
@@ -26,19 +26,6 @@ export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onRe
   interactive?: boolean;
 }
 
-const getSecretFormFieldStyles = () => {
-  return {
-    noRadiusInput: css({
-      borderBottomRightRadius: '0 !important',
-      borderTopRightRadius: '0 !important',
-    }),
-    noRadiusButton: css({
-      borderBottomLeftRadius: '0 !important',
-      borderTopLeftRadius: '0 !important',
-    }),
-  };
-};
-
 /**
  * Form field that has 2 states configured and not configured. If configured it will not show its contents and adds
  * a reset button that will clear the input and makes it accessible. In non configured state it behaves like normal
@@ -58,7 +45,6 @@ export const SecretFormField = ({
   interactive,
   ...inputProps
 }: Props) => {
-  const styles = getSecretFormFieldStyles();
   return (
     <FormField
       label={label!}
@@ -70,7 +56,7 @@ export const SecretFormField = ({
           <>
             <input
               type="text"
-              className={cx(`gf-form-input width-${inputWidth}`, styles.noRadiusInput)}
+              className={`gf-form-input width-${inputWidth}`}
               disabled={true}
               value="configured"
               {...omit(inputProps, 'value')}

--- a/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
+++ b/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
@@ -1,4 +1,3 @@
-import { cx } from '@emotion/css';
 import { omit } from 'lodash';
 import { InputHTMLAttributes } from 'react';
 import * as React from 'react';

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -6,6 +6,7 @@ package extensions
 import (
 	_ "cloud.google.com/go/kms/apiv1"
 	_ "cloud.google.com/go/kms/apiv1/kmspb"
+	_ "cloud.google.com/go/spanner"
 	_ "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	_ "github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
 	_ "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
@@ -29,13 +30,6 @@ import (
 	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
 	_ "github.com/stretchr/testify/require"
 	_ "golang.org/x/time/rate"
-	_ "k8s.io/api"
-	_ "k8s.io/apimachinery/pkg/util/httpstream/spdy"
-	_ "k8s.io/apimachinery/pkg/util/proxy"
-	_ "k8s.io/kube-aggregator/pkg/apiserver/scheme"
-	_ "k8s.io/kube-aggregator/pkg/generated/openapi"
-	_ "k8s.io/kube-aggregator/pkg/registry/apiservice/rest"
-	_ "sigs.k8s.io/randfill"
 	_ "xorm.io/builder"
 
 	_ "github.com/grafana/authlib/authn"

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -99,8 +99,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     // No border for second element (inputs) as label and input border is shared
     '> :nth-child(2)': css({
-      borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0,
+      borderTopLeftRadius: 'unset',
+      borderBottomLeftRadius: 'unset',
     }),
   }),
   labelWrapper: css({

--- a/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`VariableQueryEditor renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="css-1h17wob-input-suffix"
+              class="css-1ms3s8l-input-suffix"
             >
               <svg
                 aria-hidden="true"


### PR DESCRIPTION
Changes the no-border-radius-literal lint rule to:
 - allow using `unset` or `initial` as a border radius to remove a previously value
 - give a specific error when using 0 values to use `unset` instead
   - this has an auto-fix! 
 - apply the rule to the corner-specific border radius rules