### PR TITLE
Tempo: Map error message about the time range limit to more human-readable format

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -61,7 +61,7 @@ import {
 } from './resultTransformer';
 import { doTempoMetricsStreaming, doTempoSearchStreaming } from './streaming';
 import { TempoJsonData, TempoQuery } from './types';
-import { getErrorMessage, migrateFromSearchToTraceQLSearch } from './utils';
+import { getErrorMessage, mapErrorMessage, migrateFromSearchToTraceQLSearch } from './utils';
 import { TempoVariableSupport } from './variables';
 
 export const DEFAULT_LIMIT = 20;
@@ -525,7 +525,14 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       );
     }
 
-    return merge(...subQueries);
+    return merge(...subQueries).pipe(
+      map((response) => {
+        if (response.errors?.[0]?.message) {
+          response.errors[0].message = mapErrorMessage(response.errors?.[0]?.message);
+        }
+        return response;
+      })
+    );
   }
 
   applyTemplateVariables(query: TempoQuery, scopedVars: ScopedVars) {

--- a/public/app/plugins/datasource/tempo/utils.ts
+++ b/public/app/plugins/datasource/tempo/utils.ts
@@ -5,10 +5,22 @@ import { generateId } from './SearchTraceQLEditor/TagsInput';
 import { TraceqlFilter, TraceqlSearchScope } from './dataquery.gen';
 import { TempoQuery } from './types';
 
+const LIMIT_MESSAGE = /.*range specified by start and end.*exceeds.*/;
+const LIMIT_MESSAGE_METRICS = /.*metrics query time range exceeds the maximum allowed duration of.*/;
+
+export function mapErrorMessage(errorMessage: string) {
+  if (errorMessage && (LIMIT_MESSAGE.test(errorMessage) || LIMIT_MESSAGE_METRICS.test(errorMessage))) {
+    return 'The selected time range exceeds the maximum allowed duration. Please select a shorter time range.';
+  } else {
+    return errorMessage;
+  }
+}
+
 export const getErrorMessage = (message: string | undefined, prefix?: string) => {
   const err = message ? ` (${message})` : '';
   let errPrefix = prefix ? prefix : 'Error';
-  return `${errPrefix}${err}. Please check the server logs for more details.`;
+  const msg = `${errPrefix}${err}. Please check the server logs for more details.`;
+  return mapErrorMessage(msg);
 };
 
 export async function getDS(uid?: string): Promise<DataSourceApi | undefined> {


### PR DESCRIPTION
Makes the limit error message more human readable:

<img width="1317" alt="Screenshot 2025-06-12 at 14 50 42" src="https://github.com/user-attachments/assets/2c1e1dac-4d9a-4d33-9836-0d0613c443b8" />
<img width="1706" alt="Screenshot 2025-06-12 at 14 50 57" src="https://github.com/user-attachments/assets/1a41a086-ff08-4e4f-92b3-0443e7c522a9" />
