### PR TITLE
[release-11.6.3] Run Init Provisioners at Server Initialization

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,7 +131,7 @@ func (s *Server) Init() error {
 		return err
 	}
 
-	return nil
+	return s.provisioningService.RunInitProvisioners(s.context)
 }
 
 // Run initializes and starts services. This will block until all services have

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -183,21 +183,18 @@ func (ps *ProvisioningServiceImpl) RunInitProvisioners(ctx context.Context) erro
 		return err
 	}
 
-	err = ps.ProvisionAlerting(ctx)
-	if err != nil {
-		ps.log.Error("Failed to provision alerting", "error", err)
-		return err
-	}
-
 	return nil
 }
 
 func (ps *ProvisioningServiceImpl) Run(ctx context.Context) error {
 	var err error
 
-	// run Init Provisioners only once
 	ps.onceInitProvisioners.Do(func() {
-		err = ps.RunInitProvisioners(ctx)
+		// Run Alerting Provisioning only once.
+		// It can't be initialized at RunInitProvisioners because it
+		// depends on the Server to be already running and listening
+		// to /apis endpoints.
+		err = ps.ProvisionAlerting(ctx)
 	})
 
 	if err != nil {


### PR DESCRIPTION
Backport 82bbbf1a985dbb3f5eca828c6c1669b136820790 from #105080

---


**What is this feature?**

This PR moves the calling of `provisioningService.RunInitProvisioners` back to Server initialization*, ensuring the initialization of the necessary Provisioners.

* This was moved in https://github.com/grafana/grafana/pull/99473, 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/8548

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
