### PR TITLE
Canvas: Fix desync between scene and InfiniteViewer zoom/position on element addition

### DIFF
--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -65,6 +65,8 @@ export class Scene {
   width = 0;
   height = 0;
   scale = 1;
+  scrollLeft = 0;
+  scrollTop = 0;
   // style doesn't seem to be used anywhere
   // style: CSSProperties = {};
   data?: PanelData;
@@ -181,6 +183,12 @@ export class Scene {
     setTimeout(() => {
       // if (this.div) {
       if (this.viewportDiv && this.viewerDiv) {
+        if (!this.shouldPanZoom) {
+          this.scale = 1;
+          this.scrollLeft = 0;
+          this.scrollTop = 0;
+        }
+
         // If editing is enabled, clear selecto instance
         const destroySelecto = enableEditing;
         initMoveable(destroySelecto, enableEditing, this);
@@ -191,10 +199,6 @@ export class Scene {
         // update initial connections svg size
         this.updateConnectionsSize();
         this.fitContent(this, zoomToContent);
-
-        if (!this.shouldPanZoom) {
-          this.scale = 1;
-        }
       }
     });
     return this.root;

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -411,6 +411,8 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
     displayHorizontalScroll: false,
     displayVerticalScroll: false,
   });
+  scene.infiniteViewer.setZoom(scene.scale);
+  scene.infiniteViewer.scrollTo(scene.scrollLeft, scene.scrollTop);
 
   // Handles context menu activation
   // Uses openContextMenu with coordinates when available (after CanvasContextMenu mounts), but
@@ -485,5 +487,8 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
   scene.infiniteViewer!.on('scroll', () => {
     scene.updateConnectionsSize();
     scene.scale = scene.infiniteViewer!.getZoom();
+
+    scene.scrollLeft = scene.infiniteViewer!.getScrollLeft();
+    scene.scrollTop = scene.infiniteViewer!.getScrollTop();
   });
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Description:
When in pan & zoom mode, adding a new element after zooming in or out causes a desynchronization between the scene scale and the InfiniteViewer scale. This happens because rootLayout.reinitializeMoveable() resets the InfiniteViewer’s position and zoom to their default values.

As a result, the viewer scale and scene scale become misaligned, which affects the positioning of newly created connections.

Proposed Solution
Persist the InfiniteViewer’s top, left, and zoom scale values to maintain synchronization with the scene scale. These values should be reapplied when a new element is added.

Acceptance Criteria
InfiniteViewer position and zoom remain consistent with scene scale after adding a new element.

Connections appear in the correct position after new element addition.
Pan & zoom mode behaves as expected - no regressions in element interaction or connection placement.
Pan & zoom disabling should not break existing elements or connections.

Before:

https://github.com/user-attachments/assets/8105355c-9c22-4547-877c-5140fdba23ba


After:

https://github.com/user-attachments/assets/066adec9-665d-48c9-8796-17e3f9e3c1af



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #106150 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
