### PR TITLE
Alerting: Correctly persist FiredAt in SyncRuleStatePersister

### DIFF
--- a/pkg/services/ngalert/state/persister_sync_rule.go
+++ b/pkg/services/ngalert/state/persister_sync_rule.go
@@ -53,6 +53,7 @@ func (a *SyncRuleStatePersister) Sync(ctx context.Context, span trace.Span, rule
 			LastEvalTime:      s.LastEvaluationTime,
 			CurrentStateSince: s.StartsAt,
 			CurrentStateEnd:   s.EndsAt,
+			FiredAt:           s.FiredAt,
 			ResolvedAt:        s.ResolvedAt,
 			LastSentAt:        s.LastSentAt,
 			ResultFingerprint: s.ResultFingerprint.String(),

--- a/pkg/services/ngalert/state/persister_sync_rule_test.go
+++ b/pkg/services/ngalert/state/persister_sync_rule_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestSyncRuleStatePersister_Sync(t *testing.T) {
@@ -33,6 +34,7 @@ func TestSyncRuleStatePersister_Sync(t *testing.T) {
 						Labels: data.Labels{
 							"label-1": "value-1",
 						},
+						FiredAt:            util.Pointer(time.Now()),
 						LastEvaluationTime: time.Now(),
 						StartsAt:           time.Now(),
 						EndsAt:             time.Now(),
@@ -72,6 +74,7 @@ func TestSyncRuleStatePersister_Sync(t *testing.T) {
 					LastEvalTime:      s.LastEvaluationTime,
 					CurrentStateSince: s.StartsAt,
 					CurrentStateEnd:   s.EndsAt,
+					FiredAt:           s.FiredAt,
 					ResolvedAt:        s.ResolvedAt,
 					LastSentAt:        s.LastSentAt,
 					ResultFingerprint: s.ResultFingerprint.String(),


### PR DESCRIPTION
**What is this feature?**
With the introduction of `FiredAt`, the flag was persisted via the `SyncStatePersister` but not the `SyncRuleStatePersister` - this PR ensures the `FiredAt` field is also saved with the latter.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
