### PR TITLE
FE: Specify public_cdn_path in new index.html

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -53,6 +53,10 @@
         window.nonce = '[[.Nonce]]';
       [[end]]
 
+      [[if .Assets.ContentDeliveryURL]]
+        window.public_cdn_path = '[[.Assets.ContentDeliveryURL]]public/build/';
+      [[end]]
+
       window.__grafana_load_failed = function(...args) {
         console.error('Failed to load Grafana', ...args);
       };


### PR DESCRIPTION
This variable needs to be set to tell webpack to load additional assets from the CDN path, instead of from `/public`.

Part of https://github.com/grafana/grafana/issues/104503 