### PR TITLE
ProvisionedDashboard: Fix backend fails to delete dashboard due to missing branch and file

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -45,6 +45,7 @@ type GithubRepository interface {
 	Owner() string
 	Repo() string
 	Client() pgh.Client
+	EnsureBranchExists(ctx context.Context, branchName string) error
 }
 
 func NewGitHub(
@@ -279,7 +280,7 @@ func (r *githubRepository) Create(ctx context.Context, path, ref string, data []
 	}
 	ctx, _ = r.logger(ctx, ref)
 
-	if err := r.ensureBranchExists(ctx, ref); err != nil {
+	if err := r.EnsureBranchExists(ctx, ref); err != nil {
 		return err
 	}
 
@@ -314,7 +315,7 @@ func (r *githubRepository) Update(ctx context.Context, path, ref string, data []
 	}
 	ctx, _ = r.logger(ctx, ref)
 
-	if err := r.ensureBranchExists(ctx, ref); err != nil {
+	if err := r.EnsureBranchExists(ctx, ref); err != nil {
 		return err
 	}
 
@@ -365,7 +366,7 @@ func (r *githubRepository) Delete(ctx context.Context, path, ref, comment string
 	}
 	ctx, _ = r.logger(ctx, ref)
 
-	if err := r.ensureBranchExists(ctx, ref); err != nil {
+	if err := r.EnsureBranchExists(ctx, ref); err != nil {
 		return err
 	}
 
@@ -482,7 +483,7 @@ func isValidGitBranchName(branch string) bool {
 	return true
 }
 
-func (r *githubRepository) ensureBranchExists(ctx context.Context, branchName string) error {
+func (r *githubRepository) EnsureBranchExists(ctx context.Context, branchName string) error {
 	if !isValidGitBranchName(branchName) {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{

--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -81,6 +81,13 @@ func (r *DualReadWriter) Delete(ctx context.Context, opts DualWriteOptions) (*Pa
 		return nil, fmt.Errorf("folder delete not supported")
 	}
 
+	// First ensure the branch exists if we're using a GitHub repository
+	if githubRepo, ok := r.repo.(repository.GithubRepository); ok && opts.Ref != "" {
+		if err := githubRepo.EnsureBranchExists(ctx, opts.Ref); err != nil {
+			return nil, fmt.Errorf("ensure branch exists: %w", err)
+		}
+	}
+
 	file, err := r.repo.Read(ctx, opts.Path, opts.Ref)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %w", err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This blocks: https://github.com/grafana/git-ui-sync-project/issues/277. 
I ran into a problem when deleting a file from a new branch, the operation fails because:
1. The delete flow first tries to read the file
2. The read operation fails because the branch doesn't exist yet
3. And operation ends here leading FE receiving "File not found error"

Solution: Expose `EnsureBranchExists` as a public method in the `GithubRepository` interface and Modify `DualReadWriter.Delete` to check branch existence before file operations. This ensure branch exists before attempting to read the file.

**Before change:**  
https://github.com/user-attachments/assets/0d18d15a-5a6b-4bca-8bb4-ebd2ca8d9439.


**After change:**  

https://github.com/user-attachments/assets/1a1c7a77-978d-45f9-bb2e-208ca80a4ed2.  



**Why do we need this feature?**

To unblock: https://github.com/grafana/git-ui-sync-project/issues/277. 

**Who is this feature for?**

Git Sync UI

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/git-ui-sync-project/issues/279

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
