### PR TITLE
Alerting: Support PDC in Grafana-managed recording rules

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -934,7 +934,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool, cfgOverrides ...conf
 		cfg, featureToggles, nil, nil, rr, sqlStore, kvStore, nil, nil, quotatest.New(false, nil),
 		secretsService, nil, alertMetrics, mockFolder, accessControl, dashboardService, nil, bus, fakeAccessControlService,
 		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore,
-		httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
+		httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -45,6 +45,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/services/notifications"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugincontext"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
@@ -78,37 +79,39 @@ func ProvideService(
 	tracer tracing.Tracer,
 	ruleStore *store.DBstore,
 	httpClientProvider httpclient.Provider,
+	pluginContextProvider *plugincontext.Provider,
 	resourcePermissions accesscontrol.ReceiverPermissionsService,
 	userService user.Service,
 ) (*AlertNG, error) {
 	ng := &AlertNG{
-		Cfg:                  cfg,
-		FeatureToggles:       featureToggles,
-		DataSourceCache:      dataSourceCache,
-		DataSourceService:    dataSourceService,
-		RouteRegister:        routeRegister,
-		SQLStore:             sqlStore,
-		KVStore:              kvStore,
-		ExpressionService:    expressionService,
-		DataProxy:            dataProxy,
-		QuotaService:         quotaService,
-		SecretsService:       secretsService,
-		Metrics:              m,
-		Log:                  log.New("ngalert"),
-		NotificationService:  notificationService,
-		folderService:        folderService,
-		accesscontrol:        ac,
-		dashboardService:     dashboardService,
-		renderService:        renderService,
-		bus:                  bus,
-		AccesscontrolService: accesscontrolService,
-		annotationsRepo:      annotationsRepo,
-		pluginsStore:         pluginsStore,
-		tracer:               tracer,
-		store:                ruleStore,
-		httpClientProvider:   httpClientProvider,
-		ResourcePermissions:  resourcePermissions,
-		userService:          userService,
+		Cfg:                   cfg,
+		FeatureToggles:        featureToggles,
+		DataSourceCache:       dataSourceCache,
+		DataSourceService:     dataSourceService,
+		RouteRegister:         routeRegister,
+		SQLStore:              sqlStore,
+		KVStore:               kvStore,
+		ExpressionService:     expressionService,
+		DataProxy:             dataProxy,
+		QuotaService:          quotaService,
+		SecretsService:        secretsService,
+		Metrics:               m,
+		Log:                   log.New("ngalert"),
+		NotificationService:   notificationService,
+		folderService:         folderService,
+		accesscontrol:         ac,
+		dashboardService:      dashboardService,
+		renderService:         renderService,
+		bus:                   bus,
+		AccesscontrolService:  accesscontrolService,
+		annotationsRepo:       annotationsRepo,
+		pluginsStore:          pluginsStore,
+		tracer:                tracer,
+		store:                 ruleStore,
+		httpClientProvider:    httpClientProvider,
+		pluginContextProvider: pluginContextProvider,
+		ResourcePermissions:   resourcePermissions,
+		userService:           userService,
 	}
 
 	if ng.IsDisabled() {
@@ -124,30 +127,31 @@ func ProvideService(
 
 // AlertNG is the service for evaluating the condition of an alert definition.
 type AlertNG struct {
-	Cfg                 *setting.Cfg
-	FeatureToggles      featuremgmt.FeatureToggles
-	DataSourceCache     datasources.CacheService
-	DataSourceService   datasources.DataSourceService
-	RouteRegister       routing.RouteRegister
-	SQLStore            db.DB
-	KVStore             kvstore.KVStore
-	ExpressionService   *expr.Service
-	DataProxy           *datasourceproxy.DataSourceProxyService
-	QuotaService        quota.Service
-	SecretsService      secrets.Service
-	Metrics             *metrics.NGAlert
-	NotificationService notifications.Service
-	Log                 log.Logger
-	renderService       rendering.Service
-	ImageService        image.ImageService
-	RecordingWriter     schedule.RecordingWriter
-	schedule            schedule.ScheduleService
-	stateManager        *state.Manager
-	folderService       folder.Service
-	dashboardService    dashboards.DashboardService
-	Api                 *api.API
-	httpClientProvider  httpclient.Provider
-	InstanceStore       state.InstanceStore
+	Cfg                   *setting.Cfg
+	FeatureToggles        featuremgmt.FeatureToggles
+	DataSourceCache       datasources.CacheService
+	DataSourceService     datasources.DataSourceService
+	RouteRegister         routing.RouteRegister
+	SQLStore              db.DB
+	KVStore               kvstore.KVStore
+	ExpressionService     *expr.Service
+	DataProxy             *datasourceproxy.DataSourceProxyService
+	QuotaService          quota.Service
+	SecretsService        secrets.Service
+	Metrics               *metrics.NGAlert
+	NotificationService   notifications.Service
+	Log                   log.Logger
+	renderService         rendering.Service
+	ImageService          image.ImageService
+	RecordingWriter       schedule.RecordingWriter
+	schedule              schedule.ScheduleService
+	stateManager          *state.Manager
+	folderService         folder.Service
+	dashboardService      dashboards.DashboardService
+	Api                   *api.API
+	httpClientProvider    httpclient.Provider
+	pluginContextProvider *plugincontext.Provider
+	InstanceStore         state.InstanceStore
 	// StartupInstanceReader is used to fetch the state of alerts on startup.
 	StartupInstanceReader state.InstanceReader
 
@@ -317,7 +321,7 @@ func (ng *AlertNG) init() error {
 	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService)
 	conditionValidator := eval.NewConditionValidator(ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore)
 
-	recordingWriter, err := createRecordingWriter(ng.Cfg.UnifiedAlerting.RecordingRules, ng.httpClientProvider, ng.DataSourceService, clk, ng.Metrics.GetRemoteWriterMetrics())
+	recordingWriter, err := createRecordingWriter(ng.Cfg.UnifiedAlerting.RecordingRules, ng.httpClientProvider, ng.DataSourceService, ng.pluginContextProvider, clk, ng.Metrics.GetRemoteWriterMetrics())
 	if err != nil {
 		return fmt.Errorf("failed to initialize recording writer: %w", err)
 	}
@@ -649,7 +653,7 @@ func createRemoteAlertmanager(ctx context.Context, cfg remote.AlertmanagerConfig
 	return remote.NewAlertmanager(ctx, cfg, notifier.NewFileStore(cfg.OrgID, kvstore), decryptFn, autogenFn, m, tracer)
 }
 
-func createRecordingWriter(settings setting.RecordingRuleSettings, httpClientProvider httpclient.Provider, datasourceService datasources.DataSourceService, clock clock.Clock, m *metrics.RemoteWriter) (schedule.RecordingWriter, error) {
+func createRecordingWriter(settings setting.RecordingRuleSettings, httpClientProvider httpclient.Provider, datasourceService datasources.DataSourceService, pluginContextProvider *plugincontext.Provider, clock clock.Clock, m *metrics.RemoteWriter) (schedule.RecordingWriter, error) {
 	logger := log.New("ngalert.writer")
 
 	if settings.Enabled {
@@ -662,7 +666,7 @@ func createRecordingWriter(settings setting.RecordingRuleSettings, httpClientPro
 		logger.Info("Setting up remote write using data sources",
 			"timeout", cfg.Timeout, "default_datasource_uid", cfg.DefaultDatasourceUID)
 
-		return writer.NewDatasourceWriter(cfg, datasourceService, httpClientProvider, clock, logger, m), nil
+		return writer.NewDatasourceWriter(cfg, datasourceService, httpClientProvider, pluginContextProvider, clock, logger, m), nil
 	}
 
 	return writer.NoopWriter{}, nil

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -808,7 +810,8 @@ func setupDatasourceWriter(t *testing.T, target *writer.TestRemoteWriteTarget, r
 		DefaultDatasourceUID: "",
 	}
 
-	return writer.NewDatasourceWriter(cfg, dss, provider, clock.NewMock(),
+	mockPluginConfig := &mockPluginContextProvider{}
+	return writer.NewDatasourceWriter(cfg, dss, provider, mockPluginConfig, clock.NewMock(),
 		log.New("test"), m.GetRemoteWriterMetrics())
 }
 
@@ -816,4 +819,10 @@ type testClientProvider struct{}
 
 func (t testClientProvider) New(options ...httpclient.Options) (*http.Client, error) {
 	return &http.Client{}, nil
+}
+
+type mockPluginContextProvider struct{}
+
+func (m *mockPluginContextProvider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error) {
+	return backend.PluginContext{}, nil
 }

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -91,7 +91,7 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration, opts ...TestEnvOpti
 	ng, err := ngalert.ProvideService(
 		cfg, options.featureToggles, nil, nil, routing.NewRouteRegister(), sqlStore, kvstore.NewFakeKVStore(), nil, nil, quotatest.New(false, nil),
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac,
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(tb, err)
 

--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -11,10 +11,12 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	gocache "github.com/patrickmn/go-cache"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -44,13 +46,18 @@ type DatasourceWriterConfig struct {
 	CustomHeaders map[string]string
 }
 
+type PluginContextProvider interface {
+	GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error)
+}
+
 type DatasourceWriter struct {
-	cfg                DatasourceWriterConfig
-	datasources        datasources.DataSourceService
-	httpClientProvider HttpClientProvider
-	clock              clock.Clock
-	l                  log.Logger
-	metrics            *metrics.RemoteWriter
+	cfg                   DatasourceWriterConfig
+	datasources           datasources.DataSourceService
+	httpClientProvider    HttpClientProvider
+	pluginContextProvider PluginContextProvider
+	clock                 clock.Clock
+	l                     log.Logger
+	metrics               *metrics.RemoteWriter
 
 	writers *gocache.Cache
 }
@@ -59,18 +66,20 @@ func NewDatasourceWriter(
 	cfg DatasourceWriterConfig,
 	datasources datasources.DataSourceService,
 	httpClientProvider HttpClientProvider,
+	pluginContextProvider PluginContextProvider,
 	clock clock.Clock,
 	l log.Logger,
 	metrics *metrics.RemoteWriter,
 ) *DatasourceWriter {
 	return &DatasourceWriter{
-		cfg:                cfg,
-		datasources:        datasources,
-		httpClientProvider: httpClientProvider,
-		clock:              clock,
-		l:                  l,
-		metrics:            metrics,
-		writers:            gocache.New(cacheExpiration, cacheCleanupInterval),
+		cfg:                   cfg,
+		datasources:           datasources,
+		httpClientProvider:    httpClientProvider,
+		pluginContextProvider: pluginContextProvider,
+		clock:                 clock,
+		l:                     l,
+		metrics:               metrics,
+		writers:               gocache.New(cacheExpiration, cacheCleanupInterval),
 	}
 }
 
@@ -167,7 +176,19 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 		return nil, err
 	}
 
-	ho, err := is.HTTPClientOptions(ctx)
+	httpClientCtx := ctx
+	if w.pluginContextProvider != nil {
+		pluginCtx, err := w.pluginContextProvider.GetWithDataSource(ctx, ds.Type, nil, ds)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get plugin context: %w", err)
+		}
+		httpClientCtx = backend.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
+	} else {
+		// This should not happen, but if the plugin context provider is not set, log a warning.
+		w.l.Warn("Plugin context provider is not set for the data source writer, PDC-enabled data sources may not work correctly", "datasource_uid", dsUID, "datasource_type", ds.Type)
+	}
+
+	ho, err := is.HTTPClientOptions(httpClientCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -185,10 +206,11 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 	cfg := PrometheusWriterConfig{
 		URL: u.String(),
 		HTTPOptions: httpclient.Options{
-			Timeouts:  ho.Timeouts,
-			TLS:       ho.TLS,
-			BasicAuth: ho.BasicAuth,
-			Header:    headers,
+			Timeouts:     ho.Timeouts,
+			TLS:          ho.TLS,
+			BasicAuth:    ho.BasicAuth,
+			Header:       headers,
+			ProxyOptions: ho.ProxyOptions,
 		},
 		Timeout: w.cfg.Timeout,
 	}

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -524,7 +524,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	_, err = ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, ngalertfakes.NewFakeKVStore(t), nil, nil, quotaService,
 		secretsService, nil, m, &foldertest.FakeService{}, &acmock.Mock{}, &dashboards.FakeDashboardService{}, nil, b, &acmock.Mock{},
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), usertest.NewUserServiceFake(),
 	)
 	require.NoError(t, err)
 	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), cfg, quotaService, storesrv.ProvideSystemUsersService())


### PR DESCRIPTION
**What is this feature?**

This PR adds support for [Private Data source Connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) (PDC) in Grafana-managed recording rules. Recording rules can now write metrics to data sources that are configured with PDC.

**Why do we need this feature?**

Previously, Grafana-managed recording rules would fail when trying to write to data sources configured with PDC.

**Special notes for your reviewer:**

Normal recording rules still work:
1. [Recording rule](https://ephemeral15111821106677alexan.grafana-dev.net/alerting/grafana/beou52ds5r3lsb/view)
2. [Its metric](https://ephemeral15111821106677alexan.grafana-dev.net/explore?schemaVersion=1&panes=%7B%22yr6%22:%7B%22datasource%22:%22grafanacloud-prom%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22vector_333%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22grafanacloud-prom%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

Recording rule to a PDC data source:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/aee97f36-72c6-4d58-8de0-95650ec169ed" />

Metric: 
<img width="700" alt="image" src="https://github.com/user-attachments/assets/cece8082-b9d1-4e42-8c30-05dbf1a2c633" />



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
