### PR TITLE
CI: Add placeholder target input to release-pr

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
         description: The version of Grafana that is being released (without the `v` prefix)`
+      target:
+        required: false
+        type: string
+        description: 'Unused: left here for backwards compatibility'
       changelog:
         required: false
         type: boolean


### PR DESCRIPTION
Some old processes are failing because they expect this input to be there.