### PR TITLE
Datasources: Add HTTPClientOptions method to DataSourceService

### DIFF
--- a/pkg/services/datasources/datasources.go
+++ b/pkg/services/datasources/datasources.go
@@ -39,6 +39,9 @@ type DataSourceService interface {
 	// GetHTTPTransport gets a datasource specific HTTP transport.
 	GetHTTPTransport(ctx context.Context, ds *DataSource, provider httpclient.Provider, customMiddlewares ...sdkhttpclient.Middleware) (http.RoundTripper, error)
 
+	// HTTPClientOptions returns the HTTP client options for the given datasource.
+	HTTPClientOptions(ctx context.Context, ds *DataSource) (*sdkhttpclient.Options, error)
+
 	// DecryptedValues decrypts the encrypted secureJSONData of the provided datasource and
 	// returns the decrypted values.
 	DecryptedValues(ctx context.Context, ds *DataSource) (map[string]string, error)

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -595,7 +595,7 @@ func (s *Service) GetHTTPTransport(ctx context.Context, ds *datasources.DataSour
 		return t.roundTripper, nil
 	}
 
-	opts, err := s.httpClientOptions(ctx, ds)
+	opts, err := s.HTTPClientOptions(ctx, ds)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (s *Service) DecryptedPassword(ctx context.Context, ds *datasources.DataSou
 	return "", err
 }
 
-func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSource) (*sdkhttpclient.Options, error) {
+func (s *Service) HTTPClientOptions(ctx context.Context, ds *datasources.DataSource) (*sdkhttpclient.Options, error) {
 	tlsOptions, err := s.dsTLSOptions(ctx, ds)
 	if err != nil {
 		return nil, err

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -1220,11 +1220,11 @@ func TestService_GetHttpTransport(t *testing.T) {
 		require.NotNil(t, rt)
 		tr := configuredTransport
 
-		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		opts, err := dsService.HTTPClientOptions(context.Background(), &ds)
 		require.NoError(t, err)
 		require.Equal(t, ds.JsonData.MustMap()["grafanaData"], opts.CustomOptions["grafanaData"])
 
-		// make sure we can still marshal the JsonData after httpClientOptions (avoid cycles)
+		// make sure we can still marshal the JsonData after HTTPClientOptions (avoid cycles)
 		_, err = ds.JsonData.MarshalJSON()
 		require.NoError(t, err)
 
@@ -1468,7 +1468,7 @@ func TestService_getProxySettings(t *testing.T) {
 			Type:  "Graphite",
 		}
 
-		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		opts, err := dsService.HTTPClientOptions(context.Background(), &ds)
 		require.NoError(t, err)
 		require.Nil(t, opts.ProxyOptions)
 	})
@@ -1486,7 +1486,7 @@ func TestService_getProxySettings(t *testing.T) {
 			JsonData: sjson,
 		}
 
-		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		opts, err := dsService.HTTPClientOptions(context.Background(), &ds)
 		require.NoError(t, err)
 		require.True(t, opts.ProxyOptions.Enabled)
 		require.Equal(t, opts.ProxyOptions.Auth.Username, ds.UID)
@@ -1518,7 +1518,7 @@ func TestService_getProxySettings(t *testing.T) {
 		err = secretsStore.Set(context.Background(), ds.OrgID, ds.Name, secretskvs.DataSourceSecretType, string(secureJsonData))
 		require.NoError(t, err)
 
-		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		opts, err := dsService.HTTPClientOptions(context.Background(), &ds)
 		require.NoError(t, err)
 		require.True(t, opts.ProxyOptions.Enabled)
 		require.Equal(t, opts.ProxyOptions.Auth.Username, user)


### PR DESCRIPTION
**What is this feature?**

Makes the existing `httpClientOptions` public: `HTTPClientOptions`. In Alerting we support Grafana-managed recording rules, and to make writing requests to datasources we'd like to reuse this method to get datasource-specific HTTP client options.