### PR TITLE
fix: keep dual writer mode in sync with kv store

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -155,7 +155,10 @@ func SetDualWritingMode(
 		}
 	case cfg.Mode >= Mode3 && currentMode < Mode3:
 		if cfg.SkipDataSync {
-			return currentMode, nil
+			if err := kvs.Set(ctx, cfg.Kind, fmt.Sprint(cfg.Mode)); err != nil {
+				return Mode0, errDualWriterSetCurrentMode
+			}
+			return cfg.Mode, nil
 		}
 
 		// Transitioning to Mode3 or higher requires data synchronization.

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -20,54 +20,62 @@ func TestSetDualWritingMode(t *testing.T) {
 		kvStore         *fakeNamespacedKV
 		desiredMode     DualWriterMode
 		expectedMode    DualWriterMode
+		expectedKVMode  string
 		skipDataSync    bool
 		serverLockError error
 	}
 	tests :=
 		[]testCase{
 			{
-				name:         "should return a mode 2 dual writer when mode 2 is set as the desired mode",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode2,
-				expectedMode: Mode2,
+				name:           "should return a mode 2 dual writer when mode 2 is set as the desired mode",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode2,
+				expectedMode:   Mode2,
+				expectedKVMode: "2",
 			},
 			{
-				name:         "should return a mode 1 dual writer when mode 1 is set as the desired mode",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode1,
-				expectedMode: Mode1,
+				name:           "should return a mode 1 dual writer when mode 1 is set as the desired mode",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode1,
+				expectedMode:   Mode1,
+				expectedKVMode: "1",
 			},
 			{
-				name:         "should return mode 3 as desired mode when current mode is > 3",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "5"}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode3,
-				expectedMode: Mode3,
+				name:           "should return mode 3 as desired mode when current mode is > 3",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "5"}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode3,
+				expectedMode:   Mode3,
+				expectedKVMode: "3",
 			},
 			{
-				name:         "should return mode 3 as desired mode when current mode is 2",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode3,
-				expectedMode: Mode3,
+				name:           "should return mode 3 as desired mode when current mode is 2",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode3,
+				expectedMode:   Mode3,
+				expectedKVMode: "3",
 			},
 			{
-				name:         "should default to mode 0 if there is no desired mode",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode0,
-				expectedMode: Mode0,
+				name:           "should default to mode 0 if there is no desired mode",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode0,
+				expectedMode:   Mode0,
+				expectedKVMode: "",
 			},
 			{
 				name:            "should keep mode2 when trying to go from mode2 to mode3 and the server lock service returns an error",
 				kvStore:         &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
 				desiredMode:     Mode3,
 				expectedMode:    Mode2,
+				expectedKVMode:  "2",
 				serverLockError: fmt.Errorf("lock already exists"),
 			},
 			{
-				name:         "should keep mode2 when trying to go from mode2 to mode3 and migration is disabled",
-				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
-				desiredMode:  Mode3,
-				expectedMode: Mode3,
-				skipDataSync: true,
+				name:           "should keep mode2 when trying to go from mode2 to mode3 and migration is disabled",
+				kvStore:        &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
+				desiredMode:    Mode3,
+				expectedMode:   Mode3,
+				expectedKVMode: "3",
+				skipDataSync:   true,
 			},
 		}
 
@@ -104,6 +112,10 @@ func TestSetDualWritingMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, tt.expectedMode, dwMode)
+
+		kvMode, _, err := tt.kvStore.Get(context.Background(), "playlist.grafana.app/playlists")
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("%s", tt.expectedKVMode), kvMode, "expected mode for playlist.grafana.app/playlists")
 	}
 }
 
@@ -162,7 +174,7 @@ func (f *fakeNamespacedKV) Get(ctx context.Context, key string) (string, bool, e
 }
 
 func (f *fakeNamespacedKV) Set(ctx context.Context, key, value string) error {
-	f.data[f.namespace+key] = value
+	f.data[key] = value
 	return nil
 }
 

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -115,7 +115,7 @@ func TestSetDualWritingMode(t *testing.T) {
 
 		kvMode, _, err := tt.kvStore.Get(context.Background(), "playlist.grafana.app/playlists")
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%s", tt.expectedKVMode), kvMode, "expected mode for playlist.grafana.app/playlists")
+		require.Equal(t, tt.expectedKVMode, kvMode, "expected mode for playlist.grafana.app/playlists")
 	}
 }
 

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -66,7 +66,7 @@ func TestSetDualWritingMode(t *testing.T) {
 				name:         "should keep mode2 when trying to go from mode2 to mode3 and migration is disabled",
 				kvStore:      &fakeNamespacedKV{data: map[string]string{"playlist.grafana.app/playlists": "2"}, namespace: "storage.dualwriting"},
 				desiredMode:  Mode3,
-				expectedMode: Mode2,
+				expectedMode: Mode3,
 				skipDataSync: true,
 			},
 		}


### PR DESCRIPTION
This PR fully decouples the migration controller logic from dual writer mode setting in grafana. We ensure that we keep the kv store and config ini dual writer modes synced when the **data syncer is disabled**. Before, when moving from mode<3 to mode>=3 we kept the kv store mode in 2, because the migration controller logic was updating it. But now, we want to fully decouple migration logic from modes and thus we do not need that anymore.