### PR TITLE
Pass builder.APIGroupOptions to legacyStorageGetter

### DIFF
--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/templategroup"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/timeinterval"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder/runner"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert"
@@ -66,7 +67,7 @@ func getAuthorizer(authz accesscontrol.AccessControl) authorizer.Authorizer {
 }
 
 func getLegacyStorage(namespacer request.NamespaceMapper, ng *ngalert.AlertNG) runner.LegacyStorageGetter {
-	return func(gvr schema.GroupVersionResource) grafanarest.Storage {
+	return func(gvr schema.GroupVersionResource, opts builder.APIGroupOptions) grafanarest.Storage {
 		if gvr == receiver.ResourceInfo.GroupVersionResource() {
 			return receiver.NewStorage(ng.Api.ReceiverService, namespacer, ng.Api.ReceiverService)
 		} else if gvr == timeinterval.ResourceInfo.GroupVersionResource() {

--- a/pkg/registry/apps/playlist/register.go
+++ b/pkg/registry/apps/playlist/register.go
@@ -14,6 +14,7 @@ import (
 	playlistapp "github.com/grafana/grafana/apps/playlist/pkg/app"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder/runner"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -48,7 +49,7 @@ func RegisterApp(
 	return provider
 }
 
-func (p *PlaylistAppProvider) legacyStorageGetter(requested schema.GroupVersionResource) grafanarest.Storage {
+func (p *PlaylistAppProvider) legacyStorageGetter(requested schema.GroupVersionResource, opts builder.APIGroupOptions) grafanarest.Storage {
 	gvr := schema.GroupVersionResource{
 		Group:    playlistv0alpha1.PlaylistKind().Group(),
 		Version:  playlistv0alpha1.PlaylistKind().Version(),

--- a/pkg/services/apiserver/builder/runner/builder.go
+++ b/pkg/services/apiserver/builder/runner/builder.go
@@ -21,7 +21,7 @@ import (
 
 var _ AppBuilder = (*appBuilder)(nil)
 
-type LegacyStorageGetter func(schema.GroupVersionResource) grafanarest.Storage
+type LegacyStorageGetter func(schema.GroupVersionResource, builder.APIGroupOptions) grafanarest.Storage
 
 type AppBuilderConfig struct {
 	Authorizer          authorizer.Authorizer
@@ -134,7 +134,7 @@ func (b *appBuilder) getStorage(resourceInfo utils.ResourceInfo, opts builder.AP
 		return nil, err
 	}
 	if b.config.LegacyStorageGetter != nil && opts.DualWriteBuilder != nil {
-		if legacyStorage := b.config.LegacyStorageGetter(resourceInfo.GroupVersionResource()); legacyStorage != nil {
+		if legacyStorage := b.config.LegacyStorageGetter(resourceInfo.GroupVersionResource(), opts); legacyStorage != nil {
 			return opts.DualWriteBuilder(resourceInfo.GroupResource(), legacyStorage, store)
 		}
 	}


### PR DESCRIPTION
Pass builder.APIGroupOptions to legacyStorageGetter.

This is required if we want to allow users to register a legacy store by implementing the resource server StorageBackend interface (same as dashboard). [See here](https://github.com/grafana/grafana/compare/correlation-poc?expand=1#diff-4cb21b19874f544a3322974b4fc2f20761ba67f57c767c605d225e451af0b160R127-R151)