### PR TITLE
SecretsManager: Instrument application and critical flows with tracing

### DIFF
--- a/devenv/docker/blocks/jaegeronly/docker-compose.yaml
+++ b/devenv/docker/blocks/jaegeronly/docker-compose.yaml
@@ -1,0 +1,12 @@
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686" # UI
+      - "14268:14268"
+      - "4317:4317" # OpenTelemetry Protocol (OTLP) over gRPC
+      - "4318:4318" # OpenTelemetry Protocol (OTLP) over HTTP
+    environment:
+      - MEMORY_MAX_TRACES=100000
+      - SPAN_STORAGE_TYPE=badger
+      - COLLECTOR_OTLP_ENABLED=true

--- a/pkg/registry/apis/secret/encryption/cipher/service/service.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
@@ -24,7 +24,7 @@ const (
 // Service must not be used for cipher.
 // Use secrets.Service implementing envelope encryption instead.
 type Service struct {
-	tracer tracing.Tracer
+	tracer trace.Tracer
 	log    log.Logger
 
 	cfg          *setting.Cfg
@@ -35,7 +35,7 @@ type Service struct {
 }
 
 func NewEncryptionService(
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	usageMetrics usagestats.Service,
 	cfg *setting.Cfg,
 ) (*Service, error) {
@@ -101,7 +101,7 @@ func (s *Service) registerUsageMetrics() {
 }
 
 func (s *Service) Decrypt(ctx context.Context, payload []byte, secret string) ([]byte, error) {
-	ctx, span := s.tracer.Start(ctx, "cipher.service.Decrypt")
+	ctx, span := s.tracer.Start(ctx, "CipherService.Decrypt")
 	defer span.End()
 
 	var err error
@@ -163,7 +163,7 @@ func (s *Service) deriveEncryptionAlgorithm(payload []byte) (string, []byte, err
 }
 
 func (s *Service) Encrypt(ctx context.Context, payload []byte, secret string) ([]byte, error) {
-	ctx, span := s.tracer.Start(ctx, "cipher.service.Encrypt")
+	ctx, span := s.tracer.Start(ctx, "CipherService.Encrypt")
 	defer span.End()
 
 	var err error

--- a/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
 	"github.com/grafana/grafana/pkg/setting"
@@ -29,7 +29,7 @@ func newGcmService(t *testing.T) *Service {
 		},
 	}
 
-	svc, err := NewEncryptionService(tracing.InitializeTracerForTest(), usageStats, settings)
+	svc, err := NewEncryptionService(noop.NewTracerProvider().Tracer("test"), usageStats, settings)
 	require.NoError(t, err, "failed to set up encryption service")
 	return svc
 }

--- a/pkg/registry/apis/secret/encryption/manager/manager.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
@@ -164,6 +165,11 @@ func (s *EncryptionManager) Encrypt(ctx context.Context, namespace string, paylo
 			"success":   strconv.FormatBool(err == nil),
 			"operation": OpEncrypt,
 		}).Inc()
+
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+		}
 	}()
 
 	label := encryption.KeyLabel(s.currentProviderID)
@@ -331,6 +337,9 @@ func (s *EncryptionManager) Decrypt(ctx context.Context, namespace string, paylo
 		}).Inc()
 
 		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+
 			s.log.FromContext(ctx).Error("Failed to decrypt secret", "error", err)
 		}
 	}()

--- a/pkg/registry/apis/secret/encryption/manager/manager.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager.go
@@ -12,10 +12,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
@@ -37,7 +38,7 @@ var (
 )
 
 type EncryptionManager struct {
-	tracer     tracing.Tracer
+	tracer     trace.Tracer
 	store      contracts.DataKeyStorage
 	enc        cipher.Cipher
 	cfg        *setting.Cfg
@@ -56,7 +57,7 @@ type EncryptionManager struct {
 
 // ProvideEncryptionManager returns an EncryptionManager that uses the OSS KMS providers, along with any additional third-party (e.g. Enterprise) KMS providers
 func ProvideEncryptionManager(
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	store contracts.DataKeyStorage,
 	cfg *setting.Cfg,
 	usageStats usagestats.Service,
@@ -152,7 +153,9 @@ func (s *EncryptionManager) registerUsageMetrics() {
 var b64 = base64.RawStdEncoding
 
 func (s *EncryptionManager) Encrypt(ctx context.Context, namespace string, payload []byte) ([]byte, error) {
-	ctx, span := s.tracer.Start(ctx, "secretsService.Encrypt")
+	ctx, span := s.tracer.Start(ctx, "EnvelopeEncryptionManager.Encrypt", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+	))
 	defer span.End()
 
 	var err error
@@ -196,6 +199,12 @@ func (s *EncryptionManager) Encrypt(ctx context.Context, namespace string, paylo
 // If there's no current data key in cache nor in database it generates a new random data key,
 // and stores it into both the in-memory cache and database (encrypted by the encryption provider).
 func (s *EncryptionManager) currentDataKey(ctx context.Context, namespace string, label string) (string, []byte, error) {
+	ctx, span := s.tracer.Start(ctx, "EnvelopeEncryptionManager.CurrentDataKey", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("label", label),
+	))
+	defer span.End()
+
 	// We want only one request fetching current data key at time to
 	// avoid the creation of multiple ones in case there's no one existing.
 	s.mtx.Lock()
@@ -255,6 +264,12 @@ func (s *EncryptionManager) dataKeyByLabel(ctx context.Context, namespace, label
 
 // newDataKey creates a new random data key, encrypts it and stores it into the database and cache.
 func (s *EncryptionManager) newDataKey(ctx context.Context, namespace string, label string) (string, []byte, error) {
+	ctx, span := s.tracer.Start(ctx, "EnvelopeEncryptionManager.NewDataKey", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("label", label),
+	))
+	defer span.End()
+
 	// 1. Create new data key.
 	dataKey, err := newRandomDataKey()
 	if err != nil {
@@ -303,7 +318,9 @@ func newRandomDataKey() ([]byte, error) {
 }
 
 func (s *EncryptionManager) Decrypt(ctx context.Context, namespace string, payload []byte) ([]byte, error) {
-	ctx, span := s.tracer.Start(ctx, "secretsService.Decrypt")
+	ctx, span := s.tracer.Start(ctx, "EnvelopeEncryptionManager.Decrypt", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+	))
 	defer span.End()
 
 	var err error
@@ -365,6 +382,12 @@ func (s *EncryptionManager) GetDecryptedValue(ctx context.Context, namespace str
 // dataKeyById looks up for data key in cache.
 // Otherwise, it fetches it from database and returns it decrypted.
 func (s *EncryptionManager) dataKeyById(ctx context.Context, namespace, id string) ([]byte, error) {
+	ctx, span := s.tracer.Start(ctx, "EnvelopeEncryptionManager.GetDataKey", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("id", id),
+	))
+	defer span.End()
+
 	// 0. Get decrypted data key from in-memory cache.
 	if entry, exists := s.dataKeyCache.getById(namespace, id); exists {
 		return entry.dataKey, nil

--- a/pkg/registry/apis/secret/encryption/manager/manager_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager_test.go
@@ -79,7 +79,7 @@ func TestEncryptionService_DataKeys(t *testing.T) {
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	tracer := noop.NewTracerProvider().Tracer("test")
-	store, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), features)
+	store, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), tracer, features)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -188,7 +188,7 @@ func TestEncryptionService_UseCurrentProvider(t *testing.T) {
 		features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 		testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
 		tracer := noop.NewTracerProvider().Tracer("test")
-		encryptionStore, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), features)
+		encryptionStore, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), tracer, features)
 		require.NoError(t, err)
 
 		encMgr, err := ProvideEncryptionManager(
@@ -480,7 +480,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 					},
 				},
 			}
-			store, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), features)
+			store, err := encryptionstorage.ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), tracer, features)
 			require.NoError(t, err)
 
 			usageStats := &usagestats.UsageStatsMock{T: t}

--- a/pkg/registry/apis/secret/encryption/manager/test_helpers.go
+++ b/pkg/registry/apis/secret/encryption/manager/test_helpers.go
@@ -38,7 +38,7 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 			},
 		},
 	}
-	store, err := encryptionstorage.ProvideDataKeyStorage(database, features)
+	store, err := encryptionstorage.ProvideDataKeyStorage(database, tracer, features)
 	require.NoError(tb, err)
 
 	usageStats := &usagestats.UsageStatsMock{T: tb}

--- a/pkg/registry/apis/secret/encryption/manager/test_helpers.go
+++ b/pkg/registry/apis/secret/encryption/manager/test_helpers.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
@@ -22,7 +22,8 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 	tb.Helper()
 
 	testDB := sqlstore.NewTestStore(tb, sqlstore.WithMigrator(migrator.New()))
-	database := database.ProvideDatabase(testDB)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	database := database.ProvideDatabase(testDB, tracer)
 
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	defaultKey := "SdlklWklckeLS"
@@ -43,7 +44,7 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 	usageStats := &usagestats.UsageStatsMock{T: tb}
 
 	encMgr, err := ProvideEncryptionManager(
-		tracing.InitializeTracerForTest(),
+		tracer,
 		store,
 		cfg,
 		usageStats,

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -8,7 +8,6 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -100,6 +99,7 @@ func NewSecretAPIBuilder(
 }
 
 func RegisterAPIService(
+	tracer trace.Tracer,
 	features featuremgmt.FeatureToggles,
 	cfg *setting.Cfg,
 	apiregistration builder.APIRegistrar,
@@ -114,8 +114,6 @@ func RegisterAPIService(
 	secretDBMigrator contracts.SecretDBMigrator,
 	encryptionManager contracts.EncryptionManager,
 ) (*SecretAPIBuilder, error) {
-	tracer := otel.Tracer("github.com/grafana/grafana/pkg/registry/apis/secret")
-
 	ctx, span := tracer.Start(context.Background(), "secret.RegisterAPIService")
 	defer span.End()
 

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -669,7 +669,7 @@ func (b *SecretAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 }
 
 func (b *SecretAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
-	ctx, span := b.tracer.Start(ctx, "SecretAPIBuilder.Mutate")
+	_, span := b.tracer.Start(ctx, "SecretAPIBuilder.Mutate")
 	defer span.End()
 
 	defer func() {

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
@@ -1,8 +1,9 @@
 package secretkeeper
 
 import (
+	"go.opentelemetry.io/otel/trace"
+
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper/sqlkeeper"
 )
@@ -15,7 +16,7 @@ type OSSKeeperService struct {
 var _ contracts.KeeperService = (*OSSKeeperService)(nil)
 
 func ProvideService(
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	store contracts.EncryptedValueStorage,
 	encryptionManager contracts.EncryptionManager,
 ) (*OSSKeeperService, error) {

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager"
@@ -52,7 +52,8 @@ func Test_OSSKeeperService(t *testing.T) {
 func setupTestService(t *testing.T, cfg *setting.Cfg) (*OSSKeeperService, error) {
 	// Initialize data key storage and encrypted value storage with a fake db
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
-	database := database.ProvideDatabase(testDB)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	database := database.ProvideDatabase(testDB, tracer)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, features)
@@ -61,11 +62,11 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*OSSKeeperService, error)
 	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
 	require.NoError(t, err)
 
-	encryptionManager, err := manager.ProvideEncryptionManager(tracing.InitializeTracerForTest(), dataKeyStore, cfg, &usagestats.UsageStatsMock{T: t}, nil)
+	encryptionManager, err := manager.ProvideEncryptionManager(tracer, dataKeyStore, cfg, &usagestats.UsageStatsMock{T: t}, nil)
 	require.NoError(t, err)
 
 	// Initialize the keeper service
-	keeperService, err := ProvideService(tracing.InitializeTracerForTest(), encValueStore, encryptionManager)
+	keeperService, err := ProvideService(tracer, encValueStore, encryptionManager)
 
 	return keeperService, err
 }

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper_test.go
@@ -56,10 +56,10 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*OSSKeeperService, error)
 	database := database.ProvideDatabase(testDB, tracer)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, tracer, features)
 	require.NoError(t, err)
 
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	encryptionManager, err := manager.ProvideEncryptionManager(tracer, dataKeyStore, cfg, &usagestats.UsageStatsMock{T: t}, nil)

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type SQLKeeper struct {
-	tracer            tracing.Tracer
+	tracer            trace.Tracer
 	encryptionManager contracts.EncryptionManager
 	store             contracts.EncryptedValueStorage
 }
@@ -18,7 +19,7 @@ type SQLKeeper struct {
 var _ contracts.Keeper = (*SQLKeeper)(nil)
 
 func NewSQLKeeper(
-	tracer tracing.Tracer,
+	tracer trace.Tracer,
 	encryptionManager contracts.EncryptionManager,
 	store contracts.EncryptedValueStorage,
 ) *SQLKeeper {
@@ -31,7 +32,7 @@ func NewSQLKeeper(
 
 // TODO: parameter cfg is not being used
 func (s *SQLKeeper) Store(ctx context.Context, _ secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {
-	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Store")
+	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Store", trace.WithAttributes(attribute.String("namespace", namespace)))
 	defer span.End()
 
 	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef))
@@ -44,11 +45,18 @@ func (s *SQLKeeper) Store(ctx context.Context, _ secretv0alpha1.KeeperConfig, na
 		return "", fmt.Errorf("unable to store encrypted value: %w", err)
 	}
 
-	return contracts.ExternalID(encryptedVal.UID), nil
+	externalID := contracts.ExternalID(encryptedVal.UID)
+
+	span.SetAttributes(attribute.String("externalID", externalID.String()))
+
+	return externalID, nil
 }
 
 func (s *SQLKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) (secretv0alpha1.ExposedSecureValue, error) {
-	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Expose")
+	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Expose", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("externalID", externalID.String()),
+	))
 	defer span.End()
 
 	encryptedValue, err := s.store.Get(ctx, namespace, externalID.String())
@@ -66,7 +74,10 @@ func (s *SQLKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 }
 
 func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) error {
-	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Delete")
+	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Delete", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("externalID", externalID.String()),
+	))
 	defer span.End()
 
 	err := s.store.Delete(ctx, namespace, externalID.String())
@@ -77,7 +88,10 @@ func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 }
 
 func (s *SQLKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID, exposedValueOrRef string) error {
-	ctx, span := s.tracer.Start(ctx, "sqlKeeper.Update")
+	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Update", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("externalID", externalID.String()),
+	))
 	defer span.End()
 
 	encryptedData, err := s.encryptionManager.Encrypt(ctx, namespace, []byte(exposedValueOrRef))

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
@@ -163,7 +163,7 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*SQLKeeper, error) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	// Initialize the encryption manager
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	usageStats := &usagestats.UsageStatsMock{T: t}
@@ -178,7 +178,7 @@ func setupTestService(t *testing.T, cfg *setting.Cfg) (*SQLKeeper, error) {
 	require.NoError(t, err)
 
 	// Initialize encrypted value storage with a fake db
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	// Initialize the SQLKeeper

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -83,7 +83,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 	keeperMetadataStorage, err := metadata.ProvideKeeperMetadataStorage(database, features)
 	require.NoError(t, err)
 
-	secureValueMetadataStorage, err := metadata.ProvideSecureValueMetadataStorage(database, features)
+	secureValueMetadataStorage, err := metadata.ProvideSecureValueMetadataStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	// Initialize access client + access control

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -80,7 +80,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
-	keeperMetadataStorage, err := metadata.ProvideKeeperMetadataStorage(database, features)
+	keeperMetadataStorage, err := metadata.ProvideKeeperMetadataStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	secureValueMetadataStorage, err := metadata.ProvideSecureValueMetadataStorage(database, tracer, features)

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -102,7 +102,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 			},
 		},
 	}
-	store, err := encryptionstorage.ProvideDataKeyStorage(database, features)
+	store, err := encryptionstorage.ProvideDataKeyStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	usageStats := &usagestats.UsageStatsMock{T: t}
@@ -117,7 +117,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 	require.NoError(t, err)
 
 	// Initialize encrypted value storage with a fake db
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	sqlKeeper := sqlkeeper.NewSQLKeeper(tracer, encryptionManager, encValueStore)

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -76,7 +76,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 
 	database := database.ProvideDatabase(testDB, tracer)
 
-	outboxQueue := metadata.ProvideOutboxQueue(database)
+	outboxQueue := metadata.ProvideOutboxQueue(database, tracer)
 
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -7,13 +7,13 @@ import (
 
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	encryptionstorage "github.com/grafana/grafana/pkg/storage/secret/encryption"
+	"go.opentelemetry.io/otel/trace/noop"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
@@ -71,9 +71,10 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 		opt(&setupCfg)
 	}
 
+	tracer := noop.NewTracerProvider().Tracer("test")
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
 
-	database := database.ProvideDatabase(testDB)
+	database := database.ProvideDatabase(testDB, tracer)
 
 	outboxQueue := metadata.ProvideOutboxQueue(database)
 
@@ -107,7 +108,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 	usageStats := &usagestats.UsageStatsMock{T: t}
 
 	encryptionManager, err := manager.ProvideEncryptionManager(
-		tracing.InitializeTracerForTest(),
+		tracer,
 		store,
 		cfg,
 		usageStats,
@@ -119,7 +120,7 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
 	require.NoError(t, err)
 
-	sqlKeeper := sqlkeeper.NewSQLKeeper(tracing.InitializeTracerForTest(), encryptionManager, encValueStore)
+	sqlKeeper := sqlkeeper.NewSQLKeeper(tracer, encryptionManager, encValueStore)
 
 	var keeperService contracts.KeeperService = newKeeperServiceWrapper(sqlKeeper)
 
@@ -127,11 +128,13 @@ func Setup(t *testing.T, opts ...func(*setupConfig)) Sut {
 		keeperService = setupCfg.keeperService
 	}
 
-	secretService := service.ProvideSecureValueService(accessClient, database, secureValueMetadataStorage, outboxQueue, encryptionManager)
+	secretService := service.ProvideSecureValueService(tracer, accessClient, database, secureValueMetadataStorage, outboxQueue, encryptionManager)
 
-	secureValueRest := reststorage.NewSecureValueRest(secretService, utils.ResourceInfo{})
+	secureValueRest := reststorage.NewSecureValueRest(tracer, secretService, utils.ResourceInfo{})
 
-	worker, err := worker.NewWorker(setupCfg.workerCfg,
+	worker, err := worker.NewWorker(
+		setupCfg.workerCfg,
+		tracer,
 		database,
 		outboxQueue,
 		secureValueMetadataStorage,

--- a/pkg/registry/apis/secret/worker/worker.go
+++ b/pkg/registry/apis/secret/worker/worker.go
@@ -10,11 +10,14 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Consumes and processes messages from the secure value outbox queue
 type Worker struct {
 	config                     Config
+	tracer                     trace.Tracer
 	database                   contracts.Database
 	outboxQueue                contracts.OutboxQueue
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage
@@ -36,6 +39,7 @@ type Config struct {
 
 func NewWorker(
 	config Config,
+	tracer trace.Tracer,
 	database contracts.Database,
 	outboxQueue contracts.OutboxQueue,
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage,
@@ -58,6 +62,7 @@ func NewWorker(
 
 	return &Worker{
 		config:                     config,
+		tracer:                     tracer,
 		database:                   database,
 		outboxQueue:                outboxQueue,
 		secureValueMetadataStorage: secureValueMetadataStorage,
@@ -124,6 +129,16 @@ func (w *Worker) ReceiveAndProcessMessages(ctx context.Context) error {
 }
 
 func (w *Worker) processMessage(ctx context.Context, message contracts.OutboxMessage) error {
+	// Detached and long running process, so we start a new root span every time.
+	ctx, span := w.tracer.Start(ctx, "Worker.ProcessMessage", trace.WithNewRoot(), trace.WithAttributes(
+		attribute.String("message.id", message.MessageID),
+		attribute.String("message.type", string(message.Type)),
+		attribute.String("message.namespace", message.Namespace),
+		attribute.String("message.secureValue.name", message.Name),
+		attribute.Int("message.receive.count", message.ReceiveCount),
+	))
+	defer span.End()
+
 	if message.ReceiveCount >= int(w.config.MaxMessageProcessingAttempts) {
 		if err := w.secureValueMetadataStorage.SetStatus(ctx, xkube.Namespace(message.Namespace), message.Name, secretv0alpha1.SecureValueStatus{Phase: secretv0alpha1.SecureValuePhaseFailed, Message: fmt.Sprintf("Reached max number of attempts to complete operation: %s", message.Type)}); err != nil {
 			return fmt.Errorf("setting secret metadata status to Succeeded: message=%+v", message)

--- a/pkg/storage/secret/database/database.go
+++ b/pkg/storage/secret/database/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
@@ -19,6 +20,7 @@ type contextSessionTxKey struct{}
 type Database struct {
 	dbType string
 	sqlx   *sqlx.DB
+	tracer trace.Tracer
 
 	// Keep the xorm.Engine instance and its references alive until the apiserver is shut down.
 	// This is only needed because the xorm.Engine calls a runtime.SetFinalizer, in a RAII-like pattern to close the DB,
@@ -34,13 +36,14 @@ type Database struct {
 	engine *xorm.Engine
 }
 
-func ProvideDatabase(db db.DB) *Database {
+func ProvideDatabase(db db.DB, tracer trace.Tracer) *Database {
 	engine := db.GetEngine()
 
 	return &Database{
 		dbType: string(db.GetDBType()),
 		sqlx:   sqlx.NewDb(engine.DB().DB, db.GetDialect().DriverName()),
 		engine: engine,
+		tracer: tracer,
 	}
 }
 
@@ -49,24 +52,23 @@ func (db *Database) DriverName() string {
 }
 
 func (db *Database) Transaction(ctx context.Context, callback func(context.Context) error) error {
-	txCtx := ctx
-
 	// If another transaction is already open, we just use that one instead of nesting.
-	sqlxTx, ok := txCtx.Value(contextSessionTxKey{}).(*sqlx.Tx)
+	sqlxTx, ok := ctx.Value(contextSessionTxKey{}).(*sqlx.Tx)
 	if sqlxTx != nil && ok {
 		// We are already in a transaction, so we don't commit or rollback, let the outermost transaction do it.
-		return callback(txCtx)
+		return callback(ctx)
 	}
 
-	tx, err := db.sqlx.Beginx()
+	spanCtx, span := db.tracer.Start(ctx, "database.Transaction")
+	defer span.End()
+
+	sqlxTx, err := db.sqlx.BeginTxx(spanCtx, nil)
 	if err != nil {
 		return err
 	}
 
-	sqlxTx = tx
-
 	// Save it in the context so the transaction can be reused in case it is nested.
-	txCtx = context.WithValue(ctx, contextSessionTxKey{}, sqlxTx)
+	txCtx := context.WithValue(spanCtx, contextSessionTxKey{}, sqlxTx)
 
 	if err := callback(txCtx); err != nil {
 		if rbErr := sqlxTx.Rollback(); rbErr != nil {
@@ -80,19 +82,25 @@ func (db *Database) Transaction(ctx context.Context, callback func(context.Conte
 }
 
 func (db *Database) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	spanCtx, span := db.tracer.Start(ctx, "database.ExecContext")
+	defer span.End()
+
 	// If another transaction is already open, we just use that one instead of nesting.
 	if tx, ok := ctx.Value(contextSessionTxKey{}).(*sqlx.Tx); tx != nil && ok {
-		return tx.ExecContext(ctx, db.sqlx.Rebind(query), args...)
+		return tx.ExecContext(spanCtx, db.sqlx.Rebind(query), args...)
 	}
 
-	return db.sqlx.ExecContext(ctx, db.sqlx.Rebind(query), args...)
+	return db.sqlx.ExecContext(spanCtx, db.sqlx.Rebind(query), args...)
 }
 
 func (db *Database) QueryContext(ctx context.Context, query string, args ...any) (contracts.Rows, error) {
+	spanCtx, span := db.tracer.Start(ctx, "database.QueryContext")
+	defer span.End()
+
 	// If another transaction is already open, we just use that one instead of nesting.
 	if tx, ok := ctx.Value(contextSessionTxKey{}).(*sqlx.Tx); tx != nil && ok {
-		return tx.QueryContext(ctx, db.sqlx.Rebind(query), args...)
+		return tx.QueryContext(spanCtx, db.sqlx.Rebind(query), args...)
 	}
 
-	return db.sqlx.QueryContext(ctx, db.sqlx.Rebind(query), args...)
+	return db.sqlx.QueryContext(spanCtx, db.sqlx.Rebind(query), args...)
 }

--- a/pkg/storage/secret/database/database.go
+++ b/pkg/storage/secret/database/database.go
@@ -60,7 +60,7 @@ func (db *Database) Transaction(ctx context.Context, callback func(context.Conte
 		return callback(ctx)
 	}
 
-	spanCtx, span := db.tracer.Start(ctx, "database.Transaction")
+	spanCtx, span := db.tracer.Start(ctx, "Database.Transaction")
 	defer span.End()
 
 	defer func() {
@@ -90,7 +90,7 @@ func (db *Database) Transaction(ctx context.Context, callback func(context.Conte
 }
 
 func (db *Database) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	spanCtx, span := db.tracer.Start(ctx, "database.ExecContext")
+	spanCtx, span := db.tracer.Start(ctx, "Database.ExecContext")
 	defer span.End()
 
 	// If another transaction is already open, we just use that one instead of nesting.
@@ -102,7 +102,7 @@ func (db *Database) ExecContext(ctx context.Context, query string, args ...any) 
 }
 
 func (db *Database) QueryContext(ctx context.Context, query string, args ...any) (contracts.Rows, error) {
-	spanCtx, span := db.tracer.Start(ctx, "database.QueryContext")
+	spanCtx, span := db.tracer.Start(ctx, "Database.QueryContext")
 	defer span.End()
 
 	// If another transaction is already open, we just use that one instead of nesting.

--- a/pkg/storage/secret/encryption/data_key_store.go
+++ b/pkg/storage/secret/encryption/data_key_store.go
@@ -10,16 +10,19 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // encryptionStoreImpl is the actual implementation of the data key storage.
 type encryptionStoreImpl struct {
 	db      contracts.Database
 	dialect sqltemplate.Dialect
+	tracer  trace.Tracer
 	log     log.Logger
 }
 
-func ProvideDataKeyStorage(db contracts.Database, features featuremgmt.FeatureToggles) (contracts.DataKeyStorage, error) {
+func ProvideDataKeyStorage(db contracts.Database, tracer trace.Tracer, features featuremgmt.FeatureToggles) (contracts.DataKeyStorage, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
 		!features.IsEnabledGlobally(featuremgmt.FlagSecretsManagementAppPlatform) {
 		return &encryptionStoreImpl{}, nil
@@ -28,6 +31,7 @@ func ProvideDataKeyStorage(db contracts.Database, features featuremgmt.FeatureTo
 	store := &encryptionStoreImpl{
 		db:      db,
 		dialect: sqltemplate.DialectForDriver(db.DriverName()),
+		tracer:  tracer,
 		log:     log.New("encryption.store"),
 	}
 
@@ -35,6 +39,12 @@ func ProvideDataKeyStorage(db contracts.Database, features featuremgmt.FeatureTo
 }
 
 func (ss *encryptionStoreImpl) GetDataKey(ctx context.Context, namespace, uid string) (*contracts.SecretDataKey, error) {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.GetDataKey", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("uid", uid),
+	))
+	defer span.End()
+
 	req := readDataKey{
 		SQLTemplate: sqltemplate.New(ss.dialect),
 		Namespace:   namespace,
@@ -87,6 +97,12 @@ func (ss *encryptionStoreImpl) GetDataKey(ctx context.Context, namespace, uid st
 }
 
 func (ss *encryptionStoreImpl) GetCurrentDataKey(ctx context.Context, namespace, label string) (*contracts.SecretDataKey, error) {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.GetCurrentDataKey", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("label", label),
+	))
+	defer span.End()
+
 	req := readCurrentDataKey{
 		SQLTemplate: sqltemplate.New(ss.dialect),
 		Namespace:   namespace,
@@ -139,6 +155,11 @@ func (ss *encryptionStoreImpl) GetCurrentDataKey(ctx context.Context, namespace,
 }
 
 func (ss *encryptionStoreImpl) GetAllDataKeys(ctx context.Context, namespace string) ([]*contracts.SecretDataKey, error) {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.GetAllDataKeys", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+	))
+	defer span.End()
+
 	req := listDataKeys{
 		SQLTemplate: sqltemplate.New(ss.dialect),
 		Namespace:   namespace,
@@ -191,6 +212,13 @@ func (ss *encryptionStoreImpl) GetAllDataKeys(ctx context.Context, namespace str
 }
 
 func (ss *encryptionStoreImpl) CreateDataKey(ctx context.Context, dataKey *contracts.SecretDataKey) error {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.CreateDataKey", trace.WithAttributes(
+		attribute.String("uid", dataKey.UID),
+		attribute.String("namespace", dataKey.Namespace),
+		attribute.Bool("active", dataKey.Active),
+	))
+	defer span.End()
+
 	if !dataKey.Active {
 		return fmt.Errorf("cannot insert deactivated data keys")
 	}
@@ -226,6 +254,11 @@ func (ss *encryptionStoreImpl) CreateDataKey(ctx context.Context, dataKey *contr
 }
 
 func (ss *encryptionStoreImpl) DisableDataKeys(ctx context.Context, namespace string) error {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.DisableDataKeys", trace.WithAttributes(
+		attribute.String("namespace", namespace),
+	))
+	defer span.End()
+
 	req := disableDataKeys{
 		SQLTemplate: sqltemplate.New(ss.dialect),
 		Namespace:   namespace,
@@ -255,6 +288,12 @@ func (ss *encryptionStoreImpl) DisableDataKeys(ctx context.Context, namespace st
 }
 
 func (ss *encryptionStoreImpl) DeleteDataKey(ctx context.Context, namespace, uid string) error {
+	ctx, span := ss.tracer.Start(ctx, "DataKeyStorage.DeleteDataKey", trace.WithAttributes(
+		attribute.String("uid", uid),
+		attribute.String("namespace", namespace),
+	))
+	defer span.End()
+
 	if len(uid) == 0 {
 		return fmt.Errorf("data key id is missing")
 	}

--- a/pkg/storage/secret/encryption/data_key_store_test.go
+++ b/pkg/storage/secret/encryption/data_key_store_test.go
@@ -31,7 +31,7 @@ func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
 	tracer := noop.NewTracerProvider().Tracer("test")
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
-	store, err := ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), features)
+	store, err := ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), tracer, features)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/storage/secret/encryption/data_key_store_test.go
+++ b/pkg/storage/secret/encryption/data_key_store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption"
@@ -28,8 +29,9 @@ const (
 func TestEncryptionStoreImpl_DataKeyLifecycle(t *testing.T) {
 	// Initialize data key storage with a fake db
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
+	tracer := noop.NewTracerProvider().Tracer("test")
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
-	store, err := ProvideDataKeyStorage(database.ProvideDatabase(testDB), features)
+	store, err := ProvideDataKeyStorage(database.ProvideDatabase(testDB, tracer), features)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/storage/secret/encryption/encrypted_value_store_test.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/database"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestEncryptedValueStoreImpl(t *testing.T) {
 	// Initialize data key storage with a fake db
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
-	database := database.ProvideDatabase(testDB)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	database := database.ProvideDatabase(testDB, tracer)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	ctx := context.Background()
 

--- a/pkg/storage/secret/encryption/encrypted_value_store_test.go
+++ b/pkg/storage/secret/encryption/encrypted_value_store_test.go
@@ -20,7 +20,7 @@ func TestEncryptedValueStoreImpl(t *testing.T) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 	ctx := context.Background()
 
-	store, err := ProvideEncryptedValueStorage(database, features)
+	store, err := ProvideEncryptedValueStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	t.Run("creating an encrypted value returns it", func(t *testing.T) {

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -6,6 +6,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -67,7 +68,9 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		if decryptErr == nil {
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_success", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity)
 		} else {
+			span.SetStatus(codes.Error, "Decrypt failed")
 			span.RecordError(decryptErr)
+
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_error", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity, "error", decryptErr)
 		}
 	}()

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	claims "github.com/grafana/authlib/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
@@ -16,6 +18,7 @@ import (
 // TODO: this should be a "decrypt" service rather, so that other services can wire and call it.
 func ProvideDecryptStorage(
 	features featuremgmt.FeatureToggles,
+	tracer trace.Tracer,
 	keeperService contracts.KeeperService,
 	keeperMetadataStorage contracts.KeeperMetadataStorage,
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage,
@@ -31,6 +34,7 @@ func ProvideDecryptStorage(
 	}
 
 	return &decryptStorage{
+		tracer:                     tracer,
 		keeperMetadataStorage:      keeperMetadataStorage,
 		keeperService:              keeperService,
 		secureValueMetadataStorage: secureValueMetadataStorage,
@@ -40,6 +44,7 @@ func ProvideDecryptStorage(
 
 // decryptStorage is the actual implementation of the decrypt storage.
 type decryptStorage struct {
+	tracer                     trace.Tracer
 	keeperMetadataStorage      contracts.KeeperMetadataStorage
 	keeperService              contracts.KeeperService
 	secureValueMetadataStorage contracts.SecureValueMetadataStorage
@@ -48,12 +53,21 @@ type decryptStorage struct {
 
 // Decrypt decrypts a secure value from the keeper.
 func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv0alpha1.ExposedSecureValue, decryptErr error) {
+	ctx, span := s.tracer.Start(ctx, "DecryptStorage.Decrypt", trace.WithAttributes(
+		attribute.String("namespace", namespace.String()),
+		attribute.String("name", name),
+	))
+	defer span.End()
+
 	var decrypterIdentity string
 	// TEMPORARY: While we evaluate all of our auditing needs, provide one for decrypt operations.
 	defer func() {
+		span.SetAttributes(attribute.String("decrypter.identity", decrypterIdentity))
+
 		if decryptErr == nil {
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_success", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity)
 		} else {
+			span.RecordError(decryptErr)
 			logging.FromContext(ctx).Info("Audit log:", "operation", "decrypt_secret_error", "namespace", namespace, "secret_name", name, "decrypter_identity", decrypterIdentity, "error", decryptErr)
 		}
 	}()

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -348,7 +348,7 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	require.NoError(t, err)
 
 	// Initialize the secure value storage
-	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(database, features)
+	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer, allowList)

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -325,10 +325,10 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	database := database.ProvideDatabase(db, tracer)
 
 	// Initialize encryption manager and storage
-	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, features)
+	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, tracer, features)
 	require.NoError(t, err)
 
-	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, features)
+	encValueStore, err := encryptionstorage.ProvideEncryptedValueStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	encryptionManager, err := encryptionmanager.ProvideEncryptionManager(

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/decrypt"
@@ -321,9 +321,8 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	)
 
 	db := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
-	database := database.ProvideDatabase(db)
-
-	tracer := tracing.InitializeTracerForTest()
+	tracer := noop.NewTracerProvider().Tracer("test")
+	database := database.ProvideDatabase(db, tracer)
 
 	// Initialize encryption manager and storage
 	dataKeyStore, err := encryptionstorage.ProvideDataKeyStorage(database, features)
@@ -352,10 +351,10 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	secureValueMetadataStorage, err := ProvideSecureValueMetadataStorage(database, features)
 	require.NoError(t, err)
 
-	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(allowList)
+	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer, allowList)
 
 	// Initialize the decrypt storage
-	decryptSvc, err := ProvideDecryptStorage(features, keeperService, keeperMetadataStorage, secureValueMetadataStorage, decryptAuthorizer)
+	decryptSvc, err := ProvideDecryptStorage(features, tracer, keeperService, keeperMetadataStorage, secureValueMetadataStorage, decryptAuthorizer)
 	require.NoError(t, err)
 
 	return decryptSvc.(*decryptStorage), secureValueMetadataStorage, keeperService, keeperMetadataStorage

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -344,7 +344,7 @@ func setupDecryptTestService(t *testing.T, allowList map[string]struct{}) (*decr
 	keeperService, err := secretkeeper.ProvideService(tracer, encValueStore, encryptionManager)
 	require.NoError(t, err)
 
-	keeperMetadataStorage, err := ProvideKeeperMetadataStorage(database, features)
+	keeperMetadataStorage, err := ProvideKeeperMetadataStorage(database, tracer, features)
 	require.NoError(t, err)
 
 	// Initialize the secure value storage

--- a/pkg/storage/secret/metadata/keeper_store_test.go
+++ b/pkg/storage/secret/metadata/keeper_store_test.go
@@ -340,7 +340,7 @@ func initStorage(t *testing.T) contracts.KeeperMetadataStorage {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	// Initialize the keeper storage
-	keeperMetadataStorage, err := ProvideKeeperMetadataStorage(db, features)
+	keeperMetadataStorage, err := ProvideKeeperMetadataStorage(db, tracer, features)
 	require.NoError(t, err)
 	return keeperMetadataStorage
 }

--- a/pkg/storage/secret/metadata/keeper_store_test.go
+++ b/pkg/storage/secret/metadata/keeper_store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/database"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
@@ -334,7 +335,8 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 
 func initStorage(t *testing.T) contracts.KeeperMetadataStorage {
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
-	db := database.ProvideDatabase(testDB)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	db := database.ProvideDatabase(testDB, tracer)
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	// Initialize the keeper storage

--- a/pkg/storage/secret/metadata/outbox_store.go
+++ b/pkg/storage/secret/metadata/outbox_store.go
@@ -49,7 +49,7 @@ func (s *outboxStore) Append(ctx context.Context, input contracts.AppendOutboxMe
 		attribute.String("name", input.Name),
 		attribute.String("namespace", input.Namespace),
 		attribute.String("type", string(input.Type)),
-		attribute.String("requestId", input.RequestID),
+		attribute.String("requestID", input.RequestID),
 	))
 	defer span.End()
 
@@ -60,7 +60,7 @@ func (s *outboxStore) Append(ctx context.Context, input contracts.AppendOutboxMe
 		}
 
 		if messageID != "" {
-			span.SetAttributes(attribute.String("messageId", messageID))
+			span.SetAttributes(attribute.String("messageID", messageID))
 		}
 	}()
 
@@ -215,7 +215,7 @@ func (s *outboxStore) ReceiveN(ctx context.Context, n uint) ([]contracts.OutboxM
 
 func (s *outboxStore) Delete(ctx context.Context, messageID string) (err error) {
 	ctx, span := s.tracer.Start(ctx, "outboxStore.Append", trace.WithAttributes(
-		attribute.String("messageId", messageID),
+		attribute.String("messageID", messageID),
 	))
 	defer span.End()
 

--- a/pkg/storage/secret/metadata/outbox_store_test.go
+++ b/pkg/storage/secret/metadata/outbox_store_test.go
@@ -115,7 +115,7 @@ func TestOutboxStoreSecureValueOperationInProgress(t *testing.T) {
 
 		ctx := context.Background()
 
-		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
+		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer), tracer)
 
 		_, err := outbox.Append(ctx, contracts.AppendOutboxMessage{
 			RequestID:       "1",
@@ -148,7 +148,7 @@ func TestOutboxStore(t *testing.T) {
 
 	ctx := context.Background()
 
-	outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
+	outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer), tracer)
 
 	m1 := contracts.AppendOutboxMessage{
 		Type:            contracts.CreateSecretOutboxMessage,
@@ -217,7 +217,7 @@ func TestOutboxStoreProperty(t *testing.T) {
 		testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
 		tracer := noop.NewTracerProvider().Tracer("test")
 
-		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
+		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer), tracer)
 
 		model := newOutboxStoreModel()
 

--- a/pkg/storage/secret/metadata/outbox_store_test.go
+++ b/pkg/storage/secret/metadata/outbox_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/database"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 type outboxStoreModel struct {
@@ -110,10 +111,11 @@ func TestOutboxStoreSecureValueOperationInProgress(t *testing.T) {
 		t.Parallel()
 
 		testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
+		tracer := noop.NewTracerProvider().Tracer("test")
 
 		ctx := context.Background()
 
-		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB))
+		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
 
 		_, err := outbox.Append(ctx, contracts.AppendOutboxMessage{
 			RequestID:       "1",
@@ -142,10 +144,11 @@ func TestOutboxStoreSecureValueOperationInProgress(t *testing.T) {
 
 func TestOutboxStore(t *testing.T) {
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
+	tracer := noop.NewTracerProvider().Tracer("test")
 
 	ctx := context.Background()
 
-	outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB))
+	outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
 
 	m1 := contracts.AppendOutboxMessage{
 		Type:            contracts.CreateSecretOutboxMessage,
@@ -212,8 +215,9 @@ func TestOutboxStoreProperty(t *testing.T) {
 	// The number of iterations was decided arbitrarily based on the time the test takes to run
 	for range 10 {
 		testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
+		tracer := noop.NewTracerProvider().Tracer("test")
 
-		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB))
+		outbox := ProvideOutboxQueue(database.ProvideDatabase(testDB, tracer))
 
 		model := newOutboxStoreModel()
 

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -323,7 +323,7 @@ func (s *secureValueMetadataStorage) SetExternalID(ctx context.Context, namespac
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.SetExternalID", trace.WithAttributes(
 		attribute.String("name", name),
 		attribute.String("namespace", namespace.String()),
-		attribute.String("externalId", externalID.String()),
+		attribute.String("externalID", externalID.String()),
 	))
 	defer span.End()
 
@@ -361,7 +361,7 @@ func (s *secureValueMetadataStorage) SetStatus(ctx context.Context, namespace xk
 		attribute.String("namespace", namespace.String()),
 		attribute.String("status.phase", string(status.Phase)),
 		attribute.String("status.message", status.Message),
-		attribute.String("status.externalId", status.ExternalID),
+		attribute.String("status.externalID", status.ExternalID),
 	))
 	defer span.End()
 

--- a/pkg/storage/secret/metadata/secure_value_store_test.go
+++ b/pkg/storage/secret/metadata/secure_value_store_test.go
@@ -43,7 +43,7 @@ func Test_SecureValueMetadataStorage_CreateAndRead(t *testing.T) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 
 	// Initialize the secure value storage
-	secureValueStorage, err := ProvideSecureValueMetadataStorage(db, features)
+	secureValueStorage, err := ProvideSecureValueMetadataStorage(db, tracer, features)
 	require.NoError(t, err)
 
 	// Initialize the keeper storage

--- a/pkg/storage/secret/metadata/secure_value_store_test.go
+++ b/pkg/storage/secret/metadata/secure_value_store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/database"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func createTestKeeper(t *testing.T, ctx context.Context, keeperStorage contracts.KeeperMetadataStorage, name, namespace string) string {
@@ -36,7 +37,8 @@ func createTestKeeper(t *testing.T, ctx context.Context, keeperStorage contracts
 func Test_SecureValueMetadataStorage_CreateAndRead(t *testing.T) {
 	ctx := context.Background()
 	testDB := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator.New()))
-	db := database.ProvideDatabase(testDB)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	db := database.ProvideDatabase(testDB, tracer)
 
 	features := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, featuremgmt.FlagSecretsManagementAppPlatform)
 

--- a/pkg/storage/secret/metadata/secure_value_store_test.go
+++ b/pkg/storage/secret/metadata/secure_value_store_test.go
@@ -47,7 +47,7 @@ func Test_SecureValueMetadataStorage_CreateAndRead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize the keeper storage
-	keeperStorage, err := ProvideKeeperMetadataStorage(db, features)
+	keeperStorage, err := ProvideKeeperMetadataStorage(db, tracer, features)
 	require.NoError(t, err)
 
 	t.Run("create and read a secure value", func(t *testing.T) {


### PR DESCRIPTION
## Changes
Adds support for tracing and instrument following flows with span+attributes:
- SecureValue+Keeper CRUD
- Outbox Queue Worker
- SecureValue Decryption

Removes all imports of `github.com/grafana/grafana/pkg/infra/tracing`, although wiring is still using it in ST (which is fine but easier to replace).

## Examples
![t1](https://github.com/user-attachments/assets/af22c23b-205e-4d14-b63e-19cf409b580a)
![t2](https://github.com/user-attachments/assets/31f724b6-8bfe-4a0d-bbda-d113be2fcd05)
![t3](https://github.com/user-attachments/assets/63757fa7-8621-40d3-bb8f-395d2bfbf749)
