### PR TITLE
[release-11.6.3] Profiles: Stop passing response headers for Grafana-Pyroscope and parca datasources

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -119,7 +119,7 @@ func (d *PyroscopeDatasource) profileTypes(ctx context.Context, req *backend.Cal
 		ctxLogger.Error("Failed to marshal response", "error", err, "function", logEntrypoint())
 		return err
 	}
-	err = sender.Send(&backend.CallResourceResponse{Body: bodyData, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: bodyData, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send response", "error", err, "function", logEntrypoint())
 		return err
@@ -167,7 +167,7 @@ func (d *PyroscopeDatasource) labelNames(ctx context.Context, req *backend.CallR
 		ctxLogger.Error("Failed to marshal response", "error", err, "function", logEntrypoint())
 		return err
 	}
-	err = sender.Send(&backend.CallResourceResponse{Body: jsonResponse, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: jsonResponse, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send response", "error", err, "function", logEntrypoint())
 		return err
@@ -207,7 +207,7 @@ func (d *PyroscopeDatasource) labelValues(ctx context.Context, req *backend.Call
 		return err
 	}
 
-	err = sender.Send(&backend.CallResourceResponse{Body: data, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: data, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send response", "error", err, "function", logEntrypoint())
 		return err

--- a/pkg/tsdb/parca/resources.go
+++ b/pkg/tsdb/parca/resources.go
@@ -65,7 +65,7 @@ func (d *ParcaDatasource) callProfileTypes(ctx context.Context, req *backend.Cal
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
-	err = sender.Send(&backend.CallResourceResponse{Body: data, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: data, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send data to Parca", "error", err, "function", logEntrypoint())
 		span.RecordError(err)
@@ -98,7 +98,7 @@ func (d *ParcaDatasource) callLabelNames(ctx context.Context, req *backend.CallR
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
-	err = sender.Send(&backend.CallResourceResponse{Body: data, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: data, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send data to Parca", "error", err, "function", logEntrypoint())
 		span.RecordError(err)
@@ -142,7 +142,7 @@ func (d *ParcaDatasource) callLabelValues(ctx context.Context, req *backend.Call
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
-	err = sender.Send(&backend.CallResourceResponse{Body: data, Headers: req.Headers, Status: 200})
+	err = sender.Send(&backend.CallResourceResponse{Body: data, Status: 200})
 	if err != nil {
 		ctxLogger.Error("Failed to send data to Parca", "error", err, "function", logEntrypoint())
 		span.RecordError(err)


### PR DESCRIPTION
Backport 8fdf86e56f19c619bbcdc89a6780292a6fae2db0 from #106577

---

Unfortunately the first attempt to ifx the datasources parca and grafana-pyroscope wrongly passing request headers https://github.com/grafana/grafana/pull/106293/ caused bigger issues:

When opening a datasource in Explore we are seeing:

![image](https://github.com/user-attachments/assets/67c58d2f-9c4f-489e-8cdd-5387d91ac5f2)


```
fetch.js:290 
       
           GET https://ops.grafana-ops.net/api/datasources/uid/grafanacloud-profiles/resources/profileTypes?start=1749651900000&end=1749655560000 net::ERR_HTTP2_PROTOCOL_ERROR
```

This is because the actual response headers indicate a wrong content-type and content-length:

```
Accept-Encoding:[gzip]
Content-Encoding:[gzip]
Content-Length:[302]
Content-Type:[application/proto] 
Date:[Wed, 11 Jun 2025 15:48:08 GMT]
Grafana-Trace-Id:[0ee47cd76fe95c48]
Server:[envoy]
X-Envoy-Upstream-Service-Time:[81]]
```

I am proposing to revert the initial commit and just passing an empty header around:

- **Revert "pkgs/tsdb/[grafana-pyroscope-datasource|parca]: Fix use of request headers in responses"**
- **No longer pass the request headers**
