### PR TITLE
K8s: Dashboards /apis: Fix library element connections

### DIFF
--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
@@ -65,7 +65,7 @@ func ToUnifiedStorage(c utils.CommandLine, cfg *setting.Cfg, sqlStore db.DB) err
 	migrator := legacy.NewDashboardAccess(
 		legacysql.NewDatabaseProvider(sqlStore),
 		authlib.OrgNamespaceFormatter,
-		nil, provisioning, sort.ProvideService(),
+		nil, provisioning, nil, sort.ProvideService(),
 	)
 
 	if c.Bool("non-interactive") {

--- a/pkg/registry/apis/dashboard/legacy/migrate.go
+++ b/pkg/registry/apis/dashboard/legacy/migrate.go
@@ -15,6 +15,7 @@ import (
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/librarypanels"
 	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -46,9 +47,10 @@ type LegacyMigrator interface {
 func ProvideLegacyMigrator(
 	sql db.DB, // direct access to tables
 	provisioning provisioning.ProvisioningService, // only needed for dashboard settings
+	libraryPanelSvc librarypanels.Service,
 ) LegacyMigrator {
 	dbp := legacysql.NewDatabaseProvider(sql)
-	return NewDashboardAccess(dbp, authlib.OrgNamespaceFormatter, nil, provisioning, sort.ProvideService())
+	return NewDashboardAccess(dbp, authlib.OrgNamespaceFormatter, nil, provisioning, libraryPanelSvc, sort.ProvideService())
 }
 
 type BlobStoreInfo struct {

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/librarypanels"
 	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/search/sort"
@@ -110,6 +111,7 @@ func RegisterAPIService(
 	sorter sort.Service,
 	quotaService quota.Service,
 	folderStore folder.FolderStore,
+	libraryPanelSvc librarypanels.Service,
 	restConfigProvider apiserver.RestConfigProvider,
 	userService user.Service,
 ) *DashboardsAPIBuilder {
@@ -137,7 +139,7 @@ func RegisterAPIService(
 		folderClient:                 folderClient,
 
 		legacy: &DashboardStorage{
-			Access:           legacy.NewDashboardAccess(dbp, namespacer, dashStore, provisioning, sorter),
+			Access:           legacy.NewDashboardAccess(dbp, namespacer, dashStore, provisioning, libraryPanelSvc, sorter),
 			DashboardService: dashboardService,
 		},
 		reg: reg,

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -2400,3 +2400,91 @@ func runDashboardListTest(t *testing.T, ctx TestContext) {
 		}
 	})
 }
+
+// TODO: this only works on mode0-2 right now. In modes 3+, we need to start returning the connections endpoint
+// from retrieving the panel count from search / indexing the dashboard library panels
+func TestDashboardWithLibraryPanel(t *testing.T) {
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
+	for _, dualWriterMode := range dualWriterModes {
+		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
+
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				DisableAnonymous: true,
+				EnableFeatureToggles: []string{
+					"unifiedStorageSearch",
+					"kubernetesClientDashboardsFolders",
+				},
+			})
+			ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
+			adminClient := getResourceClient(t, ctx.Helper, ctx.AdminUser, getDashboardGVR())
+
+			// create the library element first
+			libraryElement := map[string]interface{}{
+				"kind": 1,
+				"name": "Test Library Panel",
+				"model": map[string]interface{}{
+					"type":  "timeseries",
+					"title": "Test Library Panel",
+				},
+			}
+			libraryElementURL := "/api/library-elements"
+			libraryElementData, err := postHelper(t, &ctx, libraryElementURL, libraryElement, ctx.AdminUser)
+			require.NoError(t, err)
+			require.NotNil(t, libraryElementData)
+			data := libraryElementData["result"].(map[string]interface{})
+			uid := data["uid"].(string)
+			require.NotEmpty(t, uid)
+
+			// then reference the library element in the dashboard
+			dashboard := createDashboardObject(t, "Library Panel Test", "", 1)
+			dashboard.Object["spec"].(map[string]interface{})["panels"] = []interface{}{
+				map[string]interface{}{
+					"id":    1,
+					"title": "Library Panel",
+					"type":  "library-panel-ref",
+					"libraryPanel": map[string]interface{}{
+						"uid":  uid,
+						"name": "Test Library Panel",
+					},
+				},
+			}
+
+			createdDash, err := adminClient.Resource.Create(context.Background(), dashboard, v1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, createdDash)
+
+			// should have created a library panel connection
+			connectionsURL := fmt.Sprintf("/api/library-elements/%s/connections", uid)
+			connectionsData, err := getDashboardViaHTTP(t, &ctx, connectionsURL, ctx.AdminUser)
+			require.NoError(t, err)
+			require.NotNil(t, connectionsData)
+			connections := connectionsData["result"].([]interface{})
+			require.Len(t, connections, 1)
+		})
+	}
+}
+
+func postHelper(t *testing.T, ctx *TestContext, path string, body interface{}, user apis.User) (map[string]interface{}, error) {
+	bodyJSON, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	resp := apis.DoRequest(ctx.Helper, apis.RequestParams{
+		User:        user,
+		Method:      http.MethodPost,
+		Path:        path,
+		Body:        bodyJSON,
+		ContentType: "application/json",
+	}, &struct{}{})
+
+	if resp.Response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to post: %s", resp.Response.Status)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(resp.Body, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response JSON: %v", err)
+	}
+
+	return result, nil
+}

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -2407,7 +2407,6 @@ func TestDashboardWithLibraryPanel(t *testing.T) {
 	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
-
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -2401,10 +2401,10 @@ func runDashboardListTest(t *testing.T, ctx TestContext) {
 	})
 }
 
-// TODO: this only works on mode0-2 right now. In modes 3+, we need to start returning the connections endpoint
+// TODO: this only works on mode0-3 right now. In modes 4/5, we need to start returning the connections endpoint
 // from retrieving the panel count from search / indexing the dashboard library panels
 func TestDashboardWithLibraryPanel(t *testing.T) {
-	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug ***in mode 0-3 only*** where we were not adding the dashboard <-> library panel connections when saving a dashboard directly through the new `/apis` endpoint.

This will need to be followed up with a larger change to unblock modes4/5. But for now, adding this to unblock the `kubernetesDashboards` feature flag rollout.

https://github.com/grafana/grafana-app-platform-squad/issues/43