### PR TITLE
Alerting: Fix contact points tab visibility when user can only create

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -154,6 +154,20 @@ describe('contact points', () => {
 
         expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
       });
+
+      test('defaults to contact points tab if user has only read permission', async () => {
+        grantUserPermissions([AccessControlAction.AlertingReceiversRead]);
+        renderWithProvider(<ContactPointsPageContents />);
+
+        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+      });
+
+      test('defaults to contact points tab if user has only create permission', async () => {
+        grantUserPermissions([AccessControlAction.AlertingReceiversCreate]);
+        renderWithProvider(<ContactPointsPageContents />);
+
+        expect(await screen.findByText(/create contact point/i)).toBeInTheDocument();
+      });
     });
 
     describe('templates tab', () => {

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -196,8 +196,11 @@ const useTabQueryParam = (defaultTab: ActiveTab) => {
 
 export const ContactPointsPageContents = () => {
   const { selectedAlertmanager } = useAlertmanager();
-  const [, showContactPointsTab] = useAlertmanagerAbility(AlertmanagerAction.ViewContactPoint);
+  const [, canViewContactPoints] = useAlertmanagerAbility(AlertmanagerAction.ViewContactPoint);
+  const [, canCreateContactPoints] = useAlertmanagerAbility(AlertmanagerAction.CreateContactPoint);
   const [, showTemplatesTab] = useAlertmanagerAbility(AlertmanagerAction.ViewNotificationTemplate);
+
+  const showContactPointsTab = canViewContactPoints || canCreateContactPoints;
 
   // Depending on permissions, user may not have access to all tabs,
   // but we can default to picking the first one that they definitely _do_ have access to


### PR DESCRIPTION
Contact points tab was not being displayed by default for users with only `alert.notifications.receivers:create` and
not `alert.notifications.receivers:read` when navigating via sidebar.

For example, a user with basic role `None` and `Contact Point Creator` role.

<details><summary>Before</summary>
<p>

![Screenshot from 2025-06-13 12-56-21](https://github.com/user-attachments/assets/b8739b04-3223-4909-af2d-cfeea3f69e0b)


</p>
</details> 

<details><summary>After</summary>
<p>

![Screenshot from 2025-06-13 11-05-04](https://github.com/user-attachments/assets/bd8f52c2-e903-4e7f-904d-04848a591f34)


</p>
</details> 