### PR TITLE
Annotations: Remove prometheus from legacy runner

### DIFF
--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -253,7 +253,6 @@ export function getAnnotationsFromData(
 // polluting public API.
 
 const legacyRunner = [
-  'prometheus',
   'loki',
   'elasticsearch',
   'grafana-opensearch-datasource', // external


### PR DESCRIPTION
Prometheus datasource was recently updated to support new annotations:
https://github.com/grafana/grafana/commit/91561499608fc466a8fae43793cacb8485a156a7

Though it wasn't removed from the legacy runner, causing it to always return empty results.

Fixes: https://github.com/grafana/support-escalations/issues/16491