### PR TITLE
I18n: Allow pseudo-locale to be enabled in production builds

### DIFF
--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -11,6 +11,14 @@ import { ResourceLoader, Resources, TFunction, TransProps, TransType } from './t
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
 
+const VALID_LANGUAGES = [
+  ...LANGUAGES,
+  {
+    name: 'Pseudo',
+    code: PSEUDO_LOCALE,
+  },
+];
+
 function initTFuncAndTransComponent({ id, ns }: { id?: string; ns?: string[] } = {}) {
   if (id) {
     tFunc = getI18nInstance().getFixedT(null, id);
@@ -101,7 +109,6 @@ async function initTranslations({
   language = DEFAULT_LANGUAGE,
   module,
 }: InitializeI18nOptions): Promise<{ language: string | undefined }> {
-  const validLanguages = [...LANGUAGES.map((language) => language.code), PSEUDO_LOCALE];
   const options: InitOptions = {
     // We don't bundle any translations, we load them async
     partialBundledLanguages: true,
@@ -111,7 +118,7 @@ async function initTranslations({
     returnEmptyString: false,
 
     // Required to ensure that `resolvedLanguage` is set property when an invalid language is passed (such as through 'detect')
-    supportedLngs: validLanguages,
+    supportedLngs: VALID_LANGUAGES.map((lang) => lang.code),
     fallbackLng: DEFAULT_LANGUAGE,
 
     ns,
@@ -126,7 +133,7 @@ async function initTranslations({
     const detection: DetectorOptions = { order: ['navigator'], caches: [] };
     options.detection = detection;
   } else {
-    options.lng = LANGUAGES.find((lang) => lang.code === language)?.code ?? undefined;
+    options.lng = VALID_LANGUAGES.find((lang) => lang.code === language)?.code ?? undefined;
   }
 
   if (module) {
@@ -168,7 +175,7 @@ export function getNamespaces() {
 }
 
 export async function changeLanguage(language?: string) {
-  const validLanguage = LANGUAGES.find((lang) => lang.code === language)?.code ?? DEFAULT_LANGUAGE;
+  const validLanguage = VALID_LANGUAGES.find((lang) => lang.code === language)?.code ?? DEFAULT_LANGUAGE;
   await getI18nInstance().changeLanguage(validLanguage);
 }
 

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -132,7 +132,7 @@ async function initTranslations({
     getI18nInstance().use(initReactI18next); // passes i18n down to react-i18next
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (language === PSEUDO_LOCALE) {
     const { default: Pseudo } = await import('i18next-pseudo');
     getI18nInstance().use(
       new Pseudo({

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -99,6 +99,7 @@ async function initTranslations({
   language = DEFAULT_LANGUAGE,
   module,
 }: InitializeI18nOptions): Promise<{ language: string | undefined }> {
+  const validLanguages = [...LANGUAGES.map((language) => language.code), PSEUDO_LOCALE];
   const options: InitOptions = {
     // We don't bundle any translations, we load them async
     partialBundledLanguages: true,
@@ -108,7 +109,7 @@ async function initTranslations({
     returnEmptyString: false,
 
     // Required to ensure that `resolvedLanguage` is set property when an invalid language is passed (such as through 'detect')
-    supportedLngs: LANGUAGES.map((language) => language.code),
+    supportedLngs: validLanguages,
     fallbackLng: DEFAULT_LANGUAGE,
 
     ns,

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -28,13 +28,15 @@ export async function loadPluginResources(id: string, language: string, loaders?
     return;
   }
 
+  const resolvedLanguage = language === PSEUDO_LOCALE ? DEFAULT_LANGUAGE : language;
+
   return Promise.all(
     loaders.map(async (loader) => {
       try {
-        const resources = await loader(language);
-        addResourceBundle(language, id, resources);
+        const resources = await loader(resolvedLanguage);
+        addResourceBundle(resolvedLanguage, id, resources);
       } catch (error) {
-        console.error(`Error loading resources for plugin ${id} and language: ${language}`, error);
+        console.error(`Error loading resources for plugin ${id} and language: ${resolvedLanguage}`, error);
       }
     })
   );

--- a/packages/grafana-i18n/src/languages.test.ts
+++ b/packages/grafana-i18n/src/languages.test.ts
@@ -20,6 +20,7 @@ const expectedLanguages = [
   { code: 'pl-PL', name: 'Polski' },
   { code: 'sv-SE', name: 'Svenska' },
   { code: 'tr-TR', name: 'Türkçe' },
+  { code: 'pseudo', name: 'Pseudo-locale', hidden: true },
 ];
 
 describe('LANGUAGES', () => {
@@ -27,19 +28,28 @@ describe('LANGUAGES', () => {
     expect(LANGUAGES).toEqual(expectedLanguages);
   });
 
-  it('should include the pseudo-locale in development mode', async () => {
-    process.env.NODE_ENV = 'development';
-    jest.resetModules();
-    const { LANGUAGES: languages } = await import('./languages');
-
-    expect(languages).toEqual([...expectedLanguages, { code: 'pseudo', name: 'Pseudo-locale' }]);
+  it('should match a canonical locale definition', () => {
+    for (const lang of LANGUAGES) {
+      const resolved = Intl.getCanonicalLocales(lang.code);
+      expect(lang.code).toEqual(resolved[0]);
+    }
   });
 
-  it('should not include the pseudo-locale in production mode', async () => {
-    process.env.NODE_ENV = 'production';
-    jest.resetModules();
-    const { LANGUAGES: languages } = await import('./languages');
+  it('should have locale codes including the country code', () => {
+    for (const lang of LANGUAGES) {
+      if (lang.code === 'pseudo') {
+        // special case pseudo because its not a real language
+        continue;
+      }
+      expect(lang.code).toMatch(/^[a-z]{2}-[a-zA-Z]+$/);
+    }
+  });
 
-    expect(languages).toEqual(expectedLanguages);
+  it('should not have duplicate languages codes', () => {
+    for (let i = 0; i < LANGUAGES.length; i++) {
+      const lang = LANGUAGES[i];
+      const index = LANGUAGES.findIndex((v) => v.code === lang.code);
+      expect(index).toBe(i);
+    }
   });
 });

--- a/packages/grafana-i18n/src/languages.test.ts
+++ b/packages/grafana-i18n/src/languages.test.ts
@@ -20,7 +20,6 @@ const expectedLanguages = [
   { code: 'pl-PL', name: 'Polski' },
   { code: 'sv-SE', name: 'Svenska' },
   { code: 'tr-TR', name: 'Türkçe' },
-  { code: 'pseudo', name: 'Pseudo-locale', hidden: true },
 ];
 
 describe('LANGUAGES', () => {

--- a/packages/grafana-i18n/src/languages.ts
+++ b/packages/grafana-i18n/src/languages.ts
@@ -22,8 +22,14 @@ import {
 } from './constants';
 
 interface TranslationDefinition {
+  /** IETF language tag */
   code: string;
+
+  /** The language name in its own language (e.g. "Français" for French) */
   name: string;
+
+  /** Indicates the language should be hidden from the UI, but is still a valid translation */
+  hidden?: boolean;
 }
 
 /**
@@ -49,8 +55,5 @@ export const LANGUAGES: TranslationDefinition[] = [
   { code: POLISH_POLAND, name: 'Polski' },
   { code: SWEDISH_SWEDEN, name: 'Svenska' },
   { code: TURKISH_TURKEY, name: 'Türkçe' },
+  { code: PSEUDO_LOCALE, name: 'Pseudo-locale', hidden: process.env.NODE_ENV !== 'development' },
 ];
-
-if (process.env.NODE_ENV === 'development') {
-  LANGUAGES.push({ code: PSEUDO_LOCALE, name: 'Pseudo-locale' });
-}

--- a/packages/grafana-i18n/src/languages.ts
+++ b/packages/grafana-i18n/src/languages.ts
@@ -18,7 +18,6 @@ import {
   POLISH_POLAND,
   SWEDISH_SWEDEN,
   TURKISH_TURKEY,
-  PSEUDO_LOCALE,
 } from './constants';
 
 interface TranslationDefinition {
@@ -55,5 +54,4 @@ export const LANGUAGES: TranslationDefinition[] = [
   { code: POLISH_POLAND, name: 'Polski' },
   { code: SWEDISH_SWEDEN, name: 'Svenska' },
   { code: TURKISH_TURKEY, name: 'Türkçe' },
-  { code: PSEUDO_LOCALE, name: 'Pseudo-locale', hidden: process.env.NODE_ENV !== 'development' },
 ];

--- a/packages/grafana-i18n/src/languages.ts
+++ b/packages/grafana-i18n/src/languages.ts
@@ -26,9 +26,6 @@ interface TranslationDefinition {
 
   /** The language name in its own language (e.g. "Français" for French) */
   name: string;
-
-  /** Indicates the language should be hidden from the UI, but is still a valid translation */
-  hidden?: boolean;
 }
 
 /**

--- a/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
@@ -161,6 +161,24 @@ describe('SharedPreferences', () => {
     expect(langSelect).toHaveValue('Default');
   });
 
+  it('does not render the pseudo-locale', async () => {
+    const langSelect = await screen.findByRole('combobox', { name: /language/i });
+
+    // Open the combobox and wait for the options to be rendered
+    await userEvent.click(langSelect);
+
+    // TODO: The input value should be cleared when clicked, but for some reason it's not?
+    // checking langSelect.value beforehand indicates that it is cleared, but after using
+    // userEvent.type the default value comes back?
+    await userEvent.type(
+      langSelect,
+      '{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}Pseudo'
+    );
+
+    const option = screen.queryByRole('option', { name: 'Pseudo-locale' });
+    expect(option).not.toBeInTheDocument();
+  });
+
   it('saves the users new preferences', async () => {
     await selectComboboxOptionInTest(await screen.findByRole('combobox', { name: 'Interface theme' }), 'Dark');
     await selectOptionInTest(screen.getByLabelText('Timezone'), 'Australia/Sydney');

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -42,21 +42,22 @@ export type State = UserPreferencesDTO & {
   isSubmitting: boolean;
 };
 function getLanguageOptions(): ComboboxOption[] {
-  const languageOptions = LANGUAGES.map((v) => ({
-    value: v.code,
-    label: v.name,
-  })).sort((a, b) => {
-    if (a.value === PSEUDO_LOCALE) {
-      return 1;
-    }
+  const languageOptions = LANGUAGES.filter((v) => !v.hidden) // filter out pseudo-locale
+    .map((v) => ({
+      value: v.code,
+      label: v.name,
+    }))
+    .sort((a, b) => {
+      if (a.value === PSEUDO_LOCALE) {
+        return 1;
+      }
 
-    if (b.value === PSEUDO_LOCALE) {
-      return -1;
-    }
+      if (b.value === PSEUDO_LOCALE) {
+        return -1;
+      }
 
-    return a.label.localeCompare(b.label);
-  });
-
+      return a.label.localeCompare(b.label);
+    });
   const options = [
     {
       value: '',

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -42,30 +42,26 @@ export type State = UserPreferencesDTO & {
   isSubmitting: boolean;
 };
 function getLanguageOptions(): ComboboxOption[] {
-  let languageOptions = LANGUAGES.filter((v) => !v.hidden) // filter out pseudo-locale
-    .map((v) => ({
-      value: v.code,
-      label: v.name,
-    }))
-    .sort((a, b) => {
-      if (a.value === PSEUDO_LOCALE) {
-        return 1;
-      }
+  const languageOptions = LANGUAGES.map((v) => ({
+    value: v.code,
+    label: v.name,
+  })).sort((a, b) => {
+    if (a.value === PSEUDO_LOCALE) {
+      return 1;
+    }
 
-      if (b.value === PSEUDO_LOCALE) {
-        return -1;
-      }
+    if (b.value === PSEUDO_LOCALE) {
+      return -1;
+    }
 
-      return a.label.localeCompare(b.label);
-    });
+    return a.label.localeCompare(b.label);
+  });
 
   if (process.env.NODE_ENV === 'development') {
-    languageOptions = languageOptions.concat([
-      {
-        value: PSEUDO_LOCALE,
-        label: 'Pseudo-locale',
-      },
-    ]);
+    languageOptions.push({
+      value: PSEUDO_LOCALE,
+      label: 'Pseudo-locale',
+    });
   }
 
   const options = [

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -42,7 +42,7 @@ export type State = UserPreferencesDTO & {
   isSubmitting: boolean;
 };
 function getLanguageOptions(): ComboboxOption[] {
-  const languageOptions = LANGUAGES.filter((v) => !v.hidden) // filter out pseudo-locale
+  let languageOptions = LANGUAGES.filter((v) => !v.hidden) // filter out pseudo-locale
     .map((v) => ({
       value: v.code,
       label: v.name,
@@ -58,6 +58,16 @@ function getLanguageOptions(): ComboboxOption[] {
 
       return a.label.localeCompare(b.label);
     });
+
+  if (process.env.NODE_ENV === 'development') {
+    languageOptions = languageOptions.concat([
+      {
+        value: PSEUDO_LOCALE,
+        label: 'Pseudo-locale',
+      },
+    ]);
+  }
+
   const options = [
     {
       value: '',

--- a/public/app/core/internationalization/constants.test.ts
+++ b/public/app/core/internationalization/constants.test.ts
@@ -1,26 +1,6 @@
-import { uniqBy } from 'lodash';
-
 import { LANGUAGES, VALID_LANGUAGES } from './constants';
 
 describe('internationalization constants', () => {
-  it('should match a canonical locale definition', () => {
-    for (const lang of LANGUAGES) {
-      const resolved = Intl.getCanonicalLocales(lang.code);
-      expect(lang.code).toEqual(resolved[0]);
-    }
-  });
-
-  it('should have locale codes including the country code', () => {
-    for (const lang of LANGUAGES) {
-      expect(lang.code).toMatch(/^[a-z]{2}-[a-zA-Z]+$/);
-    }
-  });
-
-  it('should not have duplicate languages codes', () => {
-    const uniqLocales = uniqBy(LANGUAGES, (v) => v.code);
-    expect(LANGUAGES).toHaveLength(uniqLocales.length);
-  });
-
   it('should have a correct list of valid locale codes', () => {
     expect(VALID_LANGUAGES).toEqual(LANGUAGES.map((v) => v.code));
   });

--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -4,13 +4,9 @@ import { uniq } from 'lodash';
 import { DEFAULT_LANGUAGE, PSEUDO_LOCALE, LANGUAGES as SUPPORTED_LANGUAGES } from '@grafana/i18n';
 
 export type LocaleFileLoader = () => Promise<ResourceKey>;
-export interface LanguageDefinition<Namespace extends string = string> {
-  /** IETF language tag for the language e.g. en-US */
-  code: string;
 
-  /** Language name to show in the UI. Should be formatted local to that language e.g. Français for French */
-  name: string;
-
+type BaseLanguageDefinition = (typeof SUPPORTED_LANGUAGES)[number];
+export interface LanguageDefinition<Namespace extends string = string> extends BaseLanguageDefinition {
   /** Function to load translations */
   loader: Record<Namespace, LocaleFileLoader>;
 }


### PR DESCRIPTION
**What is this feature?**

Allows pseudo-localisation in production builds using `?lang=pseudo` query string parameter.

Previously, this was gated behind a `process.env.NODE_ENV === "development"` which meant it was code-eliminated when we built Grafana.

Now, pseudo-locale is always considered a valid locale, but it is hidden from the Preferences UI in non-dev builds. The `i18next-pseudo` module is still loaded async so it doesn't increase the bundle size for most users who would never use it.

**Why do we need this feature?**

To allow for better i18n QA-ing

**Who is this feature for?**

Developers and translators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/106706