### PR TITLE
Home: restrict Getting Started Guide link to admins

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -224,17 +224,19 @@ func (s *ServiceImpl) getHomeNode(c *contextmodel.ReqContext, prefs *pref.Prefer
 		Icon:       "home-alt",
 		SortWeight: navtree.WeightHome,
 	}
-	ctx := c.Req.Context()
-	if _, exists := s.pluginStore.Plugin(ctx, "grafana-setupguide-app"); exists {
-		var children []*navtree.NavLink
-		// setup guide (a submenu item under Home)
-		children = append(children, &navtree.NavLink{
-			Id:         "home-setup-guide",
-			Text:       "Getting started guide",
-			Url:        "/a/grafana-setupguide-app/getting-started",
-			SortWeight: navtree.WeightHome,
-		})
-		homeNode.Children = children
+	if c.IsSignedIn && c.HasRole(org.RoleAdmin) {
+		ctx := c.Req.Context()
+		if _, exists := s.pluginStore.Plugin(ctx, "grafana-setupguide-app"); exists {
+			var children []*navtree.NavLink
+			// setup guide (a submenu item under Home)
+			children = append(children, &navtree.NavLink{
+				Id:         "home-setup-guide",
+				Text:       "Getting started guide",
+				Url:        "/a/grafana-setupguide-app/getting-started",
+				SortWeight: navtree.WeightHome,
+			})
+			homeNode.Children = children
+		}
 	}
 	return homeNode
 }


### PR DESCRIPTION
**What is this feature?**

Updates the nav logic to only show the Getting Started Guide link for admins.

**Why do we need this feature?**

With https://github.com/grafana/grafana-setupguide-app/pull/318 (🔐), the Getting Started Guide will only be accessible to admins and will return an error screen for non-admins. We want to reduce the chance of non-admins accessing the guide and seeing this error.

**Who is this feature for?**

Cloud.

**Which issue(s) does this PR fix?**:

Resolves https://github.com/grafana/OGPM/issues/230 (🔐)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
