### PR TITLE
FieldNameMappingTransformers: Add new transformers: Field Name Mapping

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -201,7 +201,7 @@ Use this transformation to add a new field calculated from two other fields. Eac
   - **All number fields** - Set the left side of a **Binary operation** to apply the calculation to all number fields.
 - **As percentile** - If you select **Row index** mode, then the **As percentile** switch appears. This switch allows you to transform the row index as a percentage of the total number of rows.
 - **Alias** - (Optional) Enter the name of your new field. If you leave this blank, then the field will be named to match the calculation.
-  > **Note:** If a variable will be used in this transformation, the default alias will be interpolated with the value of the variable. Please explicitly define an alias if you would like the alias to not be affected by variable changes.
+  > **Note:** If a variable is used in this transformation, the default alias will be interpolated with the value of the variable. If you want an alias to be unaffected by variable changes, explicitly define the alias.
 - **Replace all fields** - (Optional) Select this option if you want to hide all other fields and display only your calculated field in the visualization.
 
 In the example below, we added two fields together and named them Sum.
@@ -429,6 +429,45 @@ You'll get the following output:
 | Somewhere |     |          |             |           | 5      |
 
 This transformation lets you augment your data by fetching additional information from external sources, providing a more comprehensive dataset for analysis and visualization.
+
+### Rename fields by mapping
+
+Use this transformation to rename fields of all queries by using a mapping from one query.
+
+#### Dataset Example
+
+**Query: Mapping**
+
+| Letter | Name    |
+| ------ | ------- |
+| A      | Alpha   |
+| B      | Beta    |
+| C      | Charlie |
+| D      | Delta   |
+
+**Query: Curves**
+
+| Timestamp           | A   | D   |
+| ------------------- | --- | --- |
+| 1636678740000000000 | 1   | 2   |
+| 1636678680000000000 | 5   | 6   |
+| 1636678620000000000 | 7   | 8   |
+
+With this configuration:
+
+- Series: Mapping
+- Replace: Letter
+- With: Name
+
+You'll get the following output:
+
+#### Transformed Data
+
+| Timestamp           | Alpha | Delta |
+| ------------------- | ----- | ----- |
+| 1636678740000000000 | 1     | 2     |
+| 1636678680000000000 | 5     | 6     |
+| 1636678620000000000 | 7     | 8     |
 
 ### Filter data by query refId
 

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -26,6 +26,10 @@ export {
   type ConvertFieldTypeTransformerOptions,
   convertFieldType,
 } from '../transformations/transformers/convertFieldType';
+export {
+  type FieldNameMappingTransformerOptions,
+  fieldNameMappingTransformer,
+} from '../transformations/transformers/fieldNameMapping';
 export { type FilterFieldsByNameTransformerOptions } from '../transformations/transformers/filterByName';
 export { type FilterFramesByRefIdTransformerOptions } from '../transformations/transformers/filterByRefId';
 export { FormatStringOutput, type FormatStringTransformerOptions } from '../transformations/transformers/formatString';

--- a/packages/grafana-data/src/transformations/transformers.ts
+++ b/packages/grafana-data/src/transformations/transformers.ts
@@ -2,6 +2,7 @@ import { calculateFieldTransformer } from './transformers/calculateField';
 import { concatenateTransformer } from './transformers/concat';
 import { convertFieldTypeTransformer } from './transformers/convertFieldType';
 import { ensureColumnsTransformer } from './transformers/ensureColumns';
+import { fieldNameMappingTransformer } from './transformers/fieldNameMapping';
 import { filterFieldsTransformer, filterFramesTransformer } from './transformers/filter';
 import { filterFieldsByNameTransformer } from './transformers/filterByName';
 import { filterFramesByRefIdTransformer } from './transformers/filterByRefId';
@@ -28,6 +29,7 @@ import { transposeTransformer } from './transformers/transpose';
 
 export const standardTransformers = {
   noopTransformer,
+  fieldNameMappingTransformer,
   filterFieldsTransformer,
   filterFieldsByNameTransformer,
   filterFramesTransformer,

--- a/packages/grafana-data/src/transformations/transformers/fieldNameMapping.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/fieldNameMapping.test.ts
@@ -1,0 +1,118 @@
+import { firstValueFrom } from 'rxjs';
+
+import { toDataFrame } from '../../dataframe/processDataFrame';
+import { getFieldDisplayName } from '../../field/fieldState';
+import { DataFrame, FieldType } from '../../types/dataFrame';
+import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
+import { fieldMatchers } from '../matchers';
+import { FieldMatcherID } from '../matchers/ids';
+import { transformDataFrame } from '../transformDataFrame';
+
+import { fieldNameMappingTransformer, FieldNameMappingTransformerOptions } from './fieldNameMapping';
+import { DataTransformerID } from './ids';
+
+const configRefId = 'config';
+const mappingFrame = toDataFrame({
+  refId: configRefId,
+  fields: [
+    {
+      name: 'letter',
+      config: { displayName: 'letter' },
+      type: FieldType.string,
+      values: ['A', 'B', 'C', 'D'],
+    },
+    {
+      name: 'names',
+      config: { displayName: 'names' },
+      type: FieldType.string,
+      values: ['Alpha', 'Beta', 'Charlie', 'Delta'],
+    },
+    {
+      name: 'ids',
+      config: { displayName: 'ids' },
+      type: FieldType.number,
+      values: [1, 2, 3, 4],
+    },
+  ],
+});
+
+const dataFrame = toDataFrame({
+  fields: [
+    {
+      name: 'A',
+      type: FieldType.string,
+      values: [],
+    },
+    {
+      name: 'C',
+      type: FieldType.string,
+      values: [],
+    },
+    {
+      name: 'E',
+      type: FieldType.string,
+      values: [],
+    },
+  ],
+});
+const data = [mappingFrame, dataFrame];
+
+const baseConfig = {
+  configRefId,
+  from: 'letter',
+  to: 'names',
+};
+
+const baseNames = ['A', 'C', 'E'];
+async function expectMappingNamesToBe(options: FieldNameMappingTransformerOptions, names: string[]) {
+  const conf = { id: DataTransformerID.fieldNameMapping, options };
+  let res = await firstValueFrom(transformDataFrame([conf], data));
+
+  expect(res).toHaveLength(2);
+
+  // Keep non matching fields as is
+  expect(res[0].refId).toBe(configRefId);
+  expect(res[0].fields.map((field) => getFieldDisplayName(field))).toEqual(['letter', 'names', 'ids']);
+
+  expect(res[1].fields.map((field) => getFieldDisplayName(field))).toEqual(names);
+}
+
+describe('Field Name Mapping Transformer', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([fieldNameMappingTransformer]);
+  });
+
+  it('applies the mapping', async () => {
+    expectMappingNamesToBe(baseConfig, ['Alpha', 'Charlie', 'E']);
+  });
+
+  it('convert to string', async () => {
+    expectMappingNamesToBe(
+      {
+        ...baseConfig,
+        to: 'ids',
+      },
+      ['1', '3', 'E']
+    );
+  });
+
+  it('handle non existing target', async () => {
+    expectMappingNamesToBe(
+      {
+        ...baseConfig,
+        to: 'does not exist',
+      },
+      baseNames
+    );
+  });
+
+  it('handle non existing source', async () => {
+    expectMappingNamesToBe(
+      {
+        ...baseConfig,
+        from: 'does not exist',
+      },
+      baseNames
+    );
+  });
+});

--- a/packages/grafana-data/src/transformations/transformers/fieldNameMapping.ts
+++ b/packages/grafana-data/src/transformations/transformers/fieldNameMapping.ts
@@ -1,0 +1,68 @@
+import { map } from 'rxjs/operators';
+
+import { getFieldDisplayName } from '../../field/fieldState';
+import { DataFrame } from '../../types/dataFrame';
+import { DataTransformerInfo } from '../../types/transformations';
+
+import { DataTransformerID } from './ids';
+
+/**
+ * Options for fieldNameMappingTransformer
+ *
+ * @public
+ */
+export interface FieldNameMappingTransformerOptions {
+  configRefId: string;
+  from: string;
+  to: string;
+}
+
+/**
+ * Replaces the displayName of a field by applying a mapping from another query.
+ *
+ * @public
+ */
+export const fieldNameMappingTransformer: DataTransformerInfo<FieldNameMappingTransformerOptions> = {
+  id: DataTransformerID.fieldNameMapping,
+  name: 'Rename fields by mapping',
+  description: 'Rename fields based on a mapping from another query.',
+  defaultOptions: {
+    configRefId: 'Mapping',
+  },
+
+  /**
+   * Return a modified copy of the series. If the transform is not or should not
+   * be applied, just return the input series
+   */
+  operator: (options) => (source) =>
+    source.pipe(
+      map((datasets) => {
+        const mappingDataset = datasets.find((dataset) => dataset.refId === options.configRefId);
+
+        const from = mappingDataset?.fields.find((e) => e.name === options.from)?.values ?? [];
+        const to = mappingDataset?.fields.find((e) => e.name === options.to)?.values ?? [];
+
+        const mapping = new Map();
+        for (let i = 0; i < Math.min(from.length, to.length); ++i) {
+          mapping.set(`${from[i]}`, `${to[i]}`);
+        }
+
+        return datasets.map((dataset) => applyMapping(dataset, mapping));
+      })
+    ),
+};
+
+function applyMapping(dataframe: DataFrame, map: Map<string, string>): DataFrame {
+  return {
+    ...dataframe,
+    fields: dataframe.fields.map((field) => {
+      const name = getFieldDisplayName(field, dataframe);
+      const newName = map.get(name) ?? name;
+      return {
+        ...field,
+        config: { ...field.config, displayName: newName },
+        state: { ...field.state, displayName: newName },
+      };
+    }),
+  };
+}

--- a/packages/grafana-data/src/transformations/transformers/ids.ts
+++ b/packages/grafana-data/src/transformations/transformers/ids.ts
@@ -28,6 +28,7 @@ export enum DataTransformerID {
   prepareTimeSeries = 'prepareTimeSeries',
   convertFieldType = 'convertFieldType',
   fieldLookup = 'fieldLookup',
+  fieldNameMapping = 'fieldNameMapping',
   heatmap = 'heatmap',
   spatial = 'spatial',
   joinByField = 'joinByField',

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -339,6 +339,49 @@ This transformation lets you augment your data by fetching additional informatio
   `;
     },
   },
+  fieldNameMapping: {
+    name: 'Rename fields by mapping',
+    getHelperDocs: function () {
+      return `
+Use this transformation to rename fields of all queries by using a mapping from one query.
+
+#### Dataset Example
+
+**Query: Mapping**
+
+| Letter | Name    |
+|--------|---------|
+| A      | Alpha   |
+| B      | Beta    |
+| C      | Charlie |
+| D      | Delta   |
+
+**Query: Curves**
+
+| Timestamp           | A | D |
+|---------------------|---|---|
+| 1636678740000000000 | 1 | 2 |
+| 1636678680000000000 | 5 | 6 |
+| 1636678620000000000 | 7 | 8 |
+
+With this configuration:
+
+- Series: Mapping
+- Replace: Letter
+- With: Name
+
+You'll get the following output:
+
+#### Transformed Data
+
+| Timestamp           | Alpha | Delta |
+|---------------------|-------|-------|
+| 1636678740000000000 | 1     | 2     |
+| 1636678680000000000 | 5     | 6     |
+| 1636678620000000000 | 7     | 8     |
+  `;
+    },
+  },
   filterByRefId: {
     name: 'Filter data by query refId',
     getHelperDocs: function (imageRenderType: ImageRenderType = ImageRenderType.ShortcodeFigure) {

--- a/public/app/features/transformers/editors/FieldNameMappingEditor.tsx
+++ b/public/app/features/transformers/editors/FieldNameMappingEditor.tsx
@@ -1,0 +1,121 @@
+import {
+  DataTransformerID,
+  standardTransformers,
+  TransformerRegistryItem,
+  TransformerUIProps,
+  TransformerCategory,
+  SelectableValue,
+} from '@grafana/data';
+import { FieldNameMappingTransformerOptions } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
+import { Combobox, InlineField, InlineFieldRow } from '@grafana/ui';
+import { FieldNamePicker } from '@grafana/ui/internal';
+
+import { getTransformationContent } from '../docs/getTransformationContent';
+
+interface Props extends TransformerUIProps<FieldNameMappingTransformerOptions> {}
+
+const fieldNamePickerSettings = {
+  editor: FieldNamePicker,
+  id: '',
+  name: '',
+  settings: { width: 24, isClearable: false },
+};
+
+export function FieldNameMappingTransformerEditor({ input, onChange, options }: Props) {
+  const refIds = input
+    .map((x) => x.refId)
+    .filter((x) => x != null)
+    .map((x) => ({ label: x, value: x }));
+
+  const currentRefId = options.configRefId;
+  const configFrame = input.find((x) => x.refId === currentRefId);
+  const soloConfigFrame = configFrame ? [configFrame] : [];
+
+  const from = configFrame?.fields.find((e) => e.name === options.from)?.values;
+  const to = configFrame?.fields.find((e) => e.name === options.to)?.values;
+
+  const mapping = from && to ? from.map((from, i) => [`${from}`, `${to[i]}`]) : [];
+
+  const onRefIdChange = (value: SelectableValue<string>) => {
+    onChange({
+      ...options,
+      configRefId: value.value ?? options.configRefId,
+    });
+  };
+
+  const onPickFromField = (value?: string) => {
+    onChange({
+      ...options,
+      from: value ?? options.from,
+    });
+  };
+
+  const onPickToField = (value?: string) => {
+    onChange({
+      ...options,
+      to: value ?? options.to,
+    });
+  };
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField
+          label={t('transformers.field-name-mapping-transformer-editor.label-mapping-query', 'Mapping query')}
+          labelWidth={20}
+        >
+          <Combobox onChange={onRefIdChange} options={refIds} value={currentRefId} width={30} />
+        </InlineField>
+      </InlineFieldRow>
+
+      {configFrame && (
+        <>
+          <InlineFieldRow>
+            <InlineField
+              label={t('transformers.field-name-mapping-transformer-editor.label-field-to-replace', 'Field to replace')}
+              labelWidth={20}
+            >
+              <FieldNamePicker
+                context={{ data: soloConfigFrame }}
+                value={options?.from ?? ''}
+                onChange={onPickFromField}
+                item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+
+          <InlineFieldRow>
+            <InlineField
+              label={t('transformers.field-name-mapping-transformer-editor.label-replace-with', 'Replace with')}
+              labelWidth={20}
+            >
+              <FieldNamePicker
+                context={{ data: soloConfigFrame }}
+                value={options?.to ?? ''}
+                onChange={onPickToField}
+                item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+        </>
+      )}
+
+      {mapping.slice(0, 10).map(([from, to]) => (
+        <InlineFieldRow key={from}>
+          {from} - {to}
+        </InlineFieldRow>
+      ))}
+    </>
+  );
+}
+
+export const fieldNameMappingRegistryItem: TransformerRegistryItem<FieldNameMappingTransformerOptions> = {
+  id: DataTransformerID.fieldNameMapping,
+  editor: FieldNameMappingTransformerEditor,
+  transformation: standardTransformers.fieldNameMappingTransformer,
+  name: standardTransformers.fieldNameMappingTransformer.name,
+  description: 'Renames field of query based on the result of another query.',
+  categories: new Set([TransformerCategory.ReorderAndRename]),
+  help: getTransformationContent(DataTransformerID.fieldNameMapping).helperDocs,
+};

--- a/public/app/features/transformers/standardTransformers.ts
+++ b/public/app/features/transformers/standardTransformers.ts
@@ -7,6 +7,7 @@ import { configFromQueryTransformRegistryItem } from './configFromQuery/ConfigFr
 import { calculateFieldTransformRegistryItem } from './editors/CalculateFieldTransformerEditor';
 import { concatenateTransformRegistryItem } from './editors/ConcatenateTransformerEditor';
 import { convertFieldTypeTransformRegistryItem } from './editors/ConvertFieldTypeTransformerEditor';
+import { fieldNameMappingRegistryItem } from './editors/FieldNameMappingEditor';
 import { filterFieldsByNameTransformRegistryItem } from './editors/FilterByNameTransformerEditor';
 import { filterFramesByRefIdTransformRegistryItem } from './editors/FilterByRefIdTransformerEditor';
 import { formatStringTransformerRegistryItem } from './editors/FormatStringTransformerEditor';
@@ -39,6 +40,7 @@ export const getStandardTransformers = (): TransformerRegistryItem[] => {
   return [
     reduceTransformRegistryItem,
     filterFieldsByNameTransformRegistryItem,
+    fieldNameMappingRegistryItem,
     renameByRegexTransformRegistryItem,
     filterFramesByRefIdTransformRegistryItem,
     filterByValueTransformRegistryItem,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10709,6 +10709,11 @@
       "label-field": "Field",
       "label-lookup": "Lookup"
     },
+    "field-name-mapping-transformer-editor": {
+      "label-field-to-replace": "Field to replace",
+      "label-mapping-query": "Mapping query",
+      "label-replace-with": "Replace with"
+    },
     "field-to-config-mapping-editor": {
       "additional-settings": "Additional settings",
       "field": "Field",


### PR DESCRIPTION
**What is this feature?**

This adds a new transformer that allows to rename fields based on the result of another query.

**Why do we need this feature?**

We currently can rename fields by regex or with a static mapping, but for cases where there is a lot of mapping contained in a database, those existing transformations are not enough.

**Who is this feature for?**

This will help users that store temporal data in a TSDB but keep details in a relational database.

> For instance, we only store ID in our Influx database; the nice names are stored in PostgreSQL. With this transformer, we would be able to query the required mapping and display the name directly in Grafana.

**Which issue(s) does this PR fix?**:

This fixes the stale issue #6966 

Fixes #

**Special notes for your reviewer:**

<details><summary>Example debug snapshot dashboard</summary>

```json
{
  "panels": [
    {
      "id": 2,
      "type": "timeseries",
      "title": "Reproduced with embedded data",
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "fieldConfig": {
        "defaults": {
          "custom": {
            "drawStyle": "line",
            "lineInterpolation": "linear",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "lineWidth": 1,
            "fillOpacity": 0,
            "gradientMode": "none",
            "spanNulls": false,
            "insertNulls": false,
            "showPoints": "auto",
            "showValues": false,
            "pointSize": 5,
            "stacking": {
              "mode": "none",
              "group": "A"
            },
            "axisPlacement": "auto",
            "axisLabel": "",
            "axisColorMode": "text",
            "axisBorderShow": false,
            "scaleDistribution": {
              "type": "linear"
            },
            "axisCenteredZero": false,
            "hideFrom": {
              "tooltip": false,
              "viz": false,
              "legend": false
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "color": {
            "mode": "palette-classic"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "transformations": [
        {
          "id": "fieldNameMapping",
          "options": {
            "configRefId": "A",
            "from": "letter",
            "to": "name"
          }
        }
      ],
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "refId": "A",
          "datasource": {
            "type": "grafana",
            "uid": "grafana"
          },
          "queryType": "snapshot",
          "snapshot": [
            {
              "schema": {
                "refId": "A",
                "fields": [
                  {
                    "name": "letter",
                    "type": "string",
                    "typeInfo": {
                      "frame": "string",
                      "nullable": true
                    },
                    "config": {}
                  },
                  {
                    "name": "name",
                    "type": "string",
                    "typeInfo": {
                      "frame": "string",
                      "nullable": true
                    },
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    "a",
                    "b",
                    "c",
                    "d"
                  ],
                  [
                    "alpha",
                    "beta",
                    "charlie",
                    "delta"
                  ]
                ]
              }
            },
            {
              "schema": {
                "refId": "B",
                "meta": {
                  "type": "timeseries-multi",
                  "typeVersion": [
                    0,
                    0
                  ],
                  "custom": {
                    "customStat": 10
                  }
                },
                "fields": [
                  {
                    "name": "time",
                    "type": "time",
                    "typeInfo": {
                      "frame": "time.Time"
                    },
                    "config": {
                      "interval": 300000
                    }
                  },
                  {
                    "name": "a",
                    "type": "number",
                    "typeInfo": {
                      "frame": "float64",
                      "nullable": true
                    },
                    "labels": {},
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    1756210045024,
                    1756210345024,
                    1756210645024,
                    1756210945024,
                    1756211245024,
                    1756211545024,
                    1756211845024,
                    1756212145024,
                    1756212445024,
                    1756212745024,
                    1756213045024,
                    1756213345024,
                    1756213645024,
                    1756213945024,
                    1756214245024,
                    1756214545024,
                    1756214845024,
                    1756215145024,
                    1756215445024,
                    1756215745024,
                    1756216045024,
                    1756216345024,
                    1756216645024,
                    1756216945024,
                    1756217245024,
                    1756217545024,
                    1756217845024,
                    1756218145024,
                    1756218445024,
                    1756218745024,
                    1756219045024,
                    1756219345024,
                    1756219645024,
                    1756219945024,
                    1756220245024,
                    1756220545024,
                    1756220845024,
                    1756221145024,
                    1756221445024,
                    1756221745024,
                    1756222045024,
                    1756222345024,
                    1756222645024,
                    1756222945024,
                    1756223245024,
                    1756223545024,
                    1756223845024,
                    1756224145024,
                    1756224445024,
                    1756224745024,
                    1756225045024,
                    1756225345024,
                    1756225645024,
                    1756225945024,
                    1756226245024,
                    1756226545024,
                    1756226845024,
                    1756227145024,
                    1756227445024,
                    1756227745024,
                    1756228045024,
                    1756228345024,
                    1756228645024,
                    1756228945024,
                    1756229245024,
                    1756229545024,
                    1756229845024,
                    1756230145024,
                    1756230445024,
                    1756230745024,
                    1756231045024,
                    1756231345024
                  ],
                  [
                    48.87916821597058,
                    48.95727798953792,
                    48.88837027672425,
                    49.20592608258294,
                    49.29671019290278,
                    49.79622834776561,
                    49.8369018103848,
                    49.65261359332155,
                    49.52938115397131,
                    49.67555218513717,
                    49.93131645148426,
                    49.49958490561542,
                    49.852954577376124,
                    49.989099240372035,
                    50.34750541126426,
                    50.05402210006257,
                    50.12069303839008,
                    50.57512446400538,
                    50.90078706466935,
                    51.05180215944124,
                    51.12063422609673,
                    51.12363961884963,
                    51.59917426387812,
                    51.106423134226574,
                    51.28651879555677,
                    51.302032880449914,
                    51.376686673715476,
                    51.70841023113546,
                    51.33239272904925,
                    51.069489320201306,
                    50.67403199731736,
                    50.72635079010443,
                    50.7345931229341,
                    51.010300717973315,
                    51.36523753876667,
                    51.55159274768152,
                    51.103044992802516,
                    51.22081598834732,
                    51.21840104912934,
                    51.02875849504194,
                    50.767762761163375,
                    50.649837407403204,
                    50.26267286682655,
                    49.999033223857204,
                    50.00642897853752,
                    49.52257962025496,
                    49.52457482254865,
                    50.01787344095012,
                    49.5219269101314,
                    49.24776922196224,
                    49.32980653479999,
                    49.304581018921375,
                    49.138863380277975,
                    49.24770671271789,
                    49.17936803738252,
                    49.64916164365911,
                    49.413958756851414,
                    49.811814037231514,
                    50.063866045554185,
                    50.01218703640737,
                    50.37449136574854,
                    50.713467748357154,
                    50.42693465761511,
                    50.21660992077692,
                    50.64652503966433,
                    50.89489466808729,
                    50.55769366220394,
                    50.14146517469763,
                    49.91511670356751,
                    49.46899247195219,
                    49.50048307647256,
                    49.62167567118286
                  ]
                ]
              }
            },
            {
              "schema": {
                "refId": "C",
                "meta": {
                  "type": "timeseries-multi",
                  "typeVersion": [
                    0,
                    0
                  ],
                  "custom": {
                    "customStat": 10
                  }
                },
                "fields": [
                  {
                    "name": "time",
                    "type": "time",
                    "typeInfo": {
                      "frame": "time.Time"
                    },
                    "config": {
                      "interval": 300000
                    }
                  },
                  {
                    "name": "b",
                    "type": "number",
                    "typeInfo": {
                      "frame": "float64",
                      "nullable": true
                    },
                    "labels": {},
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    1756210045024,
                    1756210345024,
                    1756210645024,
                    1756210945024,
                    1756211245024,
                    1756211545024,
                    1756211845024,
                    1756212145024,
                    1756212445024,
                    1756212745024,
                    1756213045024,
                    1756213345024,
                    1756213645024,
                    1756213945024,
                    1756214245024,
                    1756214545024,
                    1756214845024,
                    1756215145024,
                    1756215445024,
                    1756215745024,
                    1756216045024,
                    1756216345024,
                    1756216645024,
                    1756216945024,
                    1756217245024,
                    1756217545024,
                    1756217845024,
                    1756218145024,
                    1756218445024,
                    1756218745024,
                    1756219045024,
                    1756219345024,
                    1756219645024,
                    1756219945024,
                    1756220245024,
                    1756220545024,
                    1756220845024,
                    1756221145024,
                    1756221445024,
                    1756221745024,
                    1756222045024,
                    1756222345024,
                    1756222645024,
                    1756222945024,
                    1756223245024,
                    1756223545024,
                    1756223845024,
                    1756224145024,
                    1756224445024,
                    1756224745024,
                    1756225045024,
                    1756225345024,
                    1756225645024,
                    1756225945024,
                    1756226245024,
                    1756226545024,
                    1756226845024,
                    1756227145024,
                    1756227445024,
                    1756227745024,
                    1756228045024,
                    1756228345024,
                    1756228645024,
                    1756228945024,
                    1756229245024,
                    1756229545024,
                    1756229845024,
                    1756230145024,
                    1756230445024,
                    1756230745024,
                    1756231045024,
                    1756231345024
                  ],
                  [
                    36.48254482791848,
                    36.38872017034156,
                    36.01059617374821,
                    36.3007800350125,
                    35.99920617243667,
                    35.74707680577641,
                    36.077251870140756,
                    36.40049171683215,
                    36.65904639394731,
                    37.00371152889968,
                    37.034443335105934,
                    37.3301386701863,
                    37.31784623928508,
                    37.04540796002121,
                    37.087448892966904,
                    37.38420735625477,
                    37.46916977784245,
                    37.9369712740629,
                    38.16336721301677,
                    38.1942658420112,
                    37.86373266471015,
                    37.52770604274358,
                    37.424852819684666,
                    37.48164913659521,
                    37.332017940342645,
                    37.51551255776179,
                    37.10966561099815,
                    37.24547672678249,
                    37.341537531896066,
                    37.74997777251088,
                    37.674927212819746,
                    38.08666081064195,
                    38.518923129677844,
                    38.907481270211974,
                    39.33704315974028,
                    39.18410904433679,
                    39.45832039885767,
                    39.40704444968223,
                    39.55442809278685,
                    39.64220797461636,
                    39.96944198147159,
                    39.472440310235655,
                    39.86659072565028,
                    40.127148997497585,
                    40.40712216501131,
                    40.715885720766,
                    41.06329140792977,
                    41.38638399252939,
                    40.96924981510064,
                    41.3045058800379,
                    41.00016318362212,
                    41.02598496699922,
                    41.423103794931286,
                    41.48918394028169,
                    41.56137376250157,
                    41.512870624362854,
                    41.502338479316215,
                    41.51647752943436,
                    41.0673012316763,
                    41.0707430965991,
                    41.56783872407212,
                    41.97614715711162,
                    41.581801808973815,
                    41.195708180612556,
                    41.03427195177484,
                    40.7555085708136,
                    40.64089973889358,
                    40.6848770145112,
                    40.73305482142643,
                    40.96137346206167,
                    40.76823764647142,
                    40.99577752581716
                  ]
                ]
              }
            },
            {
              "schema": {
                "refId": "D",
                "meta": {
                  "type": "timeseries-multi",
                  "typeVersion": [
                    0,
                    0
                  ],
                  "custom": {
                    "customStat": 10
                  }
                },
                "fields": [
                  {
                    "name": "time",
                    "type": "time",
                    "typeInfo": {
                      "frame": "time.Time"
                    },
                    "config": {
                      "interval": 300000
                    }
                  },
                  {
                    "name": "c",
                    "type": "number",
                    "typeInfo": {
                      "frame": "float64",
                      "nullable": true
                    },
                    "labels": {},
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    1756210045024,
                    1756210345024,
                    1756210645024,
                    1756210945024,
                    1756211245024,
                    1756211545024,
                    1756211845024,
                    1756212145024,
                    1756212445024,
                    1756212745024,
                    1756213045024,
                    1756213345024,
                    1756213645024,
                    1756213945024,
                    1756214245024,
                    1756214545024,
                    1756214845024,
                    1756215145024,
                    1756215445024,
                    1756215745024,
                    1756216045024,
                    1756216345024,
                    1756216645024,
                    1756216945024,
                    1756217245024,
                    1756217545024,
                    1756217845024,
                    1756218145024,
                    1756218445024,
                    1756218745024,
                    1756219045024,
                    1756219345024,
                    1756219645024,
                    1756219945024,
                    1756220245024,
                    1756220545024,
                    1756220845024,
                    1756221145024,
                    1756221445024,
                    1756221745024,
                    1756222045024,
                    1756222345024,
                    1756222645024,
                    1756222945024,
                    1756223245024,
                    1756223545024,
                    1756223845024,
                    1756224145024,
                    1756224445024,
                    1756224745024,
                    1756225045024,
                    1756225345024,
                    1756225645024,
                    1756225945024,
                    1756226245024,
                    1756226545024,
                    1756226845024,
                    1756227145024,
                    1756227445024,
                    1756227745024,
                    1756228045024,
                    1756228345024,
                    1756228645024,
                    1756228945024,
                    1756229245024,
                    1756229545024,
                    1756229845024,
                    1756230145024,
                    1756230445024,
                    1756230745024,
                    1756231045024,
                    1756231345024
                  ],
                  [
                    72.72788592400514,
                    72.53681954647,
                    72.40950155346496,
                    72.20026703501512,
                    72.33214535936938,
                    72.63326648002388,
                    72.38605882604772,
                    71.91655648754363,
                    72.034677993473,
                    71.73161275781801,
                    71.63285777466301,
                    71.29404809744916,
                    71.06569802293902,
                    70.76051765568177,
                    70.37288796378165,
                    70.72837902219266,
                    70.27182932589328,
                    70.58531403807625,
                    70.85884184722156,
                    70.77262417736024,
                    70.54797436207274,
                    70.86759703384904,
                    71.09017661485574,
                    71.20018512866098,
                    70.91012399181551,
                    71.15664796574941,
                    71.28961492561857,
                    71.03457653705162,
                    71.00809461212847,
                    70.96488273722089,
                    71.01997774940398,
                    71.44065143544898,
                    71.31558630317858,
                    70.96842972680109,
                    70.64970302576884,
                    70.35177154703483,
                    70.52122538894788,
                    70.41350830510038,
                    70.2874541052934,
                    70.13505053355024,
                    69.8956361522653,
                    70.24863850461016,
                    70.24275620944091,
                    69.94782465866024,
                    70.0029563884945,
                    70.45575590934932,
                    70.28898057673211,
                    69.94081704548556,
                    69.77458915954988,
                    69.89501426030873,
                    70.05826757349051,
                    70.39962240130953,
                    70.03803687951329,
                    70.45217176000095,
                    70.43010129998169,
                    70.80040101111794,
                    71.01556213227516,
                    71.22826190757819,
                    70.78202218669925,
                    70.34473635232197,
                    70.21371846326517,
                    70.6448242406832,
                    70.44059968610766,
                    70.04187133646973,
                    70.49936382578319,
                    70.35796157167447,
                    70.12489183157979,
                    69.96873883058448,
                    70.05967397020835,
                    69.71440404145675,
                    69.90220785863484,
                    69.51904590795296
                  ]
                ]
              }
            },
            {
              "schema": {
                "refId": "E",
                "meta": {
                  "type": "timeseries-multi",
                  "typeVersion": [
                    0,
                    0
                  ],
                  "custom": {
                    "customStat": 10
                  }
                },
                "fields": [
                  {
                    "name": "time",
                    "type": "time",
                    "typeInfo": {
                      "frame": "time.Time"
                    },
                    "config": {
                      "interval": 300000
                    }
                  },
                  {
                    "name": "d",
                    "type": "number",
                    "typeInfo": {
                      "frame": "float64",
                      "nullable": true
                    },
                    "labels": {},
                    "config": {}
                  }
                ]
              },
              "data": {
                "values": [
                  [
                    1756210045024,
                    1756210345024,
                    1756210645024,
                    1756210945024,
                    1756211245024,
                    1756211545024,
                    1756211845024,
                    1756212145024,
                    1756212445024,
                    1756212745024,
                    1756213045024,
                    1756213345024,
                    1756213645024,
                    1756213945024,
                    1756214245024,
                    1756214545024,
                    1756214845024,
                    1756215145024,
                    1756215445024,
                    1756215745024,
                    1756216045024,
                    1756216345024,
                    1756216645024,
                    1756216945024,
                    1756217245024,
                    1756217545024,
                    1756217845024,
                    1756218145024,
                    1756218445024,
                    1756218745024,
                    1756219045024,
                    1756219345024,
                    1756219645024,
                    1756219945024,
                    1756220245024,
                    1756220545024,
                    1756220845024,
                    1756221145024,
                    1756221445024,
                    1756221745024,
                    1756222045024,
                    1756222345024,
                    1756222645024,
                    1756222945024,
                    1756223245024,
                    1756223545024,
                    1756223845024,
                    1756224145024,
                    1756224445024,
                    1756224745024,
                    1756225045024,
                    1756225345024,
                    1756225645024,
                    1756225945024,
                    1756226245024,
                    1756226545024,
                    1756226845024,
                    1756227145024,
                    1756227445024,
                    1756227745024,
                    1756228045024,
                    1756228345024,
                    1756228645024,
                    1756228945024,
                    1756229245024,
                    1756229545024,
                    1756229845024,
                    1756230145024,
                    1756230445024,
                    1756230745024,
                    1756231045024,
                    1756231345024
                  ],
                  [
                    26.201446152294615,
                    26.061924817366513,
                    25.751470831398844,
                    25.289668527863128,
                    24.79001561456844,
                    24.52922727423791,
                    24.28520215983686,
                    23.904447367501596,
                    23.85198485446867,
                    23.859579255462652,
                    23.829368838291437,
                    23.810306667428765,
                    23.548627086022677,
                    23.26961526793923,
                    22.785357733086464,
                    22.34467206503066,
                    22.6024628922303,
                    23.062250151282143,
                    22.78813247442294,
                    22.429780790891133,
                    22.306816597066355,
                    22.129069572084667,
                    21.875054636211757,
                    21.605537112651465,
                    22.012154181351253,
                    22.080180202623335,
                    21.755122360196548,
                    22.23356920146445,
                    21.817046840261977,
                    22.199499101302763,
                    21.816420182120705,
                    22.050027483302888,
                    21.963275250667717,
                    22.40317346398614,
                    22.764907297889504,
                    22.632892505702806,
                    22.809858239125084,
                    22.99296204166591,
                    22.868729552107574,
                    23.311542095609457,
                    23.737062360175912,
                    23.698191509208637,
                    23.77593527490456,
                    23.862783664430715,
                    24.202443736893176,
                    24.418161597752036,
                    23.96378288053412,
                    24.293579068853145,
                    24.52213842295796,
                    24.678704506370458,
                    24.363477331114108,
                    24.53511727560739,
                    24.81361002608325,
                    24.866890101578505,
                    24.54984310023011,
                    24.855741834574786,
                    24.87481117526726,
                    24.843001582962863,
                    24.44588295467229,
                    24.107957436880266,
                    24.297519832760837,
                    24.538196245099872,
                    24.315529205026294,
                    24.358429094474708,
                    24.138225808066917,
                    24.061814613801126,
                    24.123768940818938,
                    24.01012387047715,
                    23.87055728812659,
                    24.22148642279539,
                    23.99243243215828,
                    24.400317755237772
                  ]
                ]
              }
            }
          ]
        }
      ],
      "maxDataPoints": 100,
      "datasource": {
        "type": "grafana",
        "uid": "grafana"
      },
      "options": {
        "tooltip": {
          "mode": "single",
          "sort": "none",
          "hideZeros": false
        },
        "legend": {
          "showLegend": true,
          "displayMode": "list",
          "placement": "bottom",
          "calcs": []
        }
      }
    },
    {
      "gridPos": {
        "h": 7,
        "w": 9,
        "x": 15,
        "y": 0
      },
      "id": 5,
      "options": {
        "content": "<table width=\"100%\">\n    <tr>\n      <th width=\"2%\">Panel</th>\n      <td >timeseries @ 12.2.0-pre</td>\n    </tr>\n    <tr>\n      <th>Queries</th>\n      <td>A[grafana-testdata-datasource], B[grafana-testdata-datasource], C[grafana-testdata-datasource], D[grafana-testdata-datasource], E[grafana-testdata-datasource]</td>\n    </tr>\n    <tr>\n      <th>Transform</th>\n      <td>fieldNameMapping</td>\n  </tr>\n    <tr><th>Data</th><td> 5 frames, 10 fields, 292 rows </td></tr>\n    \n    <tr>\n      <th>Grafana</th>\n      <td>Grafana v12.2.0-pre (7097baf68d) // Open Source</td>\n    </tr>\n  </table>",
        "mode": "html"
      },
      "title": "Debug info",
      "type": "text"
    },
    {
      "id": 6,
      "title": "Original Panel JSON",
      "type": "text",
      "gridPos": {
        "h": 13,
        "w": 9,
        "x": 15,
        "y": 7
      },
      "options": {
        "content": "{\n  \"id\": 1,\n  \"type\": \"timeseries\",\n  \"title\": \"Rename Fields By Mapping Example\",\n  \"gridPos\": {\n    \"x\": 0,\n    \"y\": 0,\n    \"h\": 8,\n    \"w\": 12\n  },\n  \"fieldConfig\": {\n    \"defaults\": {\n      \"custom\": {\n        \"drawStyle\": \"line\",\n        \"lineInterpolation\": \"linear\",\n        \"barAlignment\": 0,\n        \"barWidthFactor\": 0.6,\n        \"lineWidth\": 1,\n        \"fillOpacity\": 0,\n        \"gradientMode\": \"none\",\n        \"spanNulls\": false,\n        \"insertNulls\": false,\n        \"showPoints\": \"auto\",\n        \"showValues\": false,\n        \"pointSize\": 5,\n        \"stacking\": {\n          \"mode\": \"none\",\n          \"group\": \"A\"\n        },\n        \"axisPlacement\": \"auto\",\n        \"axisLabel\": \"\",\n        \"axisColorMode\": \"text\",\n        \"axisBorderShow\": false,\n        \"scaleDistribution\": {\n          \"type\": \"linear\"\n        },\n        \"axisCenteredZero\": false,\n        \"hideFrom\": {\n          \"tooltip\": false,\n          \"viz\": false,\n          \"legend\": false\n        },\n        \"thresholdsStyle\": {\n          \"mode\": \"off\"\n        }\n      },\n      \"color\": {\n        \"mode\": \"palette-classic\"\n      },\n      \"mappings\": [],\n      \"thresholds\": {\n        \"mode\": \"absolute\",\n        \"steps\": [\n          {\n            \"color\": \"green\",\n            \"value\": null\n          },\n          {\n            \"color\": \"red\",\n            \"value\": 80\n          }\n        ]\n      }\n    },\n    \"overrides\": []\n  },\n  \"transformations\": [\n    {\n      \"id\": \"fieldNameMapping\",\n      \"options\": {\n        \"configRefId\": \"A\",\n        \"from\": \"letter\",\n        \"to\": \"name\"\n      }\n    }\n  ],\n  \"pluginVersion\": \"12.2.0-pre\",\n  \"targets\": [\n    {\n      \"scenarioId\": \"csv_content\",\n      \"refId\": \"A\",\n      \"csvContent\": \"letter,name\\na,alpha\\nb,beta\\nc,charlie\\nd,delta\",\n      \"datasource\": {\n        \"type\": \"grafana-testdata-datasource\",\n        \"uid\": \"PD8C576611E62080A\"\n      }\n    },\n    {\n      \"alias\": \"a\",\n      \"datasource\": {\n        \"type\": \"grafana-testdata-datasource\",\n        \"uid\": \"PD8C576611E62080A\"\n      },\n      \"hide\": false,\n      \"refId\": \"B\",\n      \"scenarioId\": \"random_walk\",\n      \"seriesCount\": 1\n    },\n    {\n      \"alias\": \"b\",\n      \"datasource\": {\n        \"type\": \"grafana-testdata-datasource\",\n        \"uid\": \"PD8C576611E62080A\"\n      },\n      \"hide\": false,\n      \"refId\": \"C\",\n      \"scenarioId\": \"random_walk\",\n      \"seriesCount\": 1\n    },\n    {\n      \"alias\": \"c\",\n      \"datasource\": {\n        \"type\": \"grafana-testdata-datasource\",\n        \"uid\": \"PD8C576611E62080A\"\n      },\n      \"hide\": false,\n      \"refId\": \"D\",\n      \"scenarioId\": \"random_walk\",\n      \"seriesCount\": 1\n    },\n    {\n      \"alias\": \"d\",\n      \"datasource\": {\n        \"type\": \"grafana-testdata-datasource\",\n        \"uid\": \"PD8C576611E62080A\"\n      },\n      \"hide\": false,\n      \"refId\": \"E\",\n      \"scenarioId\": \"random_walk\",\n      \"seriesCount\": 1\n    }\n  ],\n  \"maxDataPoints\": 100,\n  \"datasource\": {\n    \"type\": \"grafana-testdata-datasource\",\n    \"uid\": \"PD8C576611E62080A\"\n  },\n  \"options\": {\n    \"tooltip\": {\n      \"mode\": \"single\",\n      \"sort\": \"none\",\n      \"hideZeros\": false\n    },\n    \"legend\": {\n      \"showLegend\": true,\n      \"displayMode\": \"list\",\n      \"placement\": \"bottom\",\n      \"calcs\": []\n    }\n  }\n}",
        "mode": "code",
        "code": {
          "language": "json",
          "showLineNumbers": true,
          "showMiniMap": true
        }
      }
    },
    {
      "id": 3,
      "title": "Data from panel above (after transformations)",
      "type": "table",
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "gridPos": {
        "h": 7,
        "w": 15,
        "x": 0,
        "y": 13
      },
      "options": {
        "showTypeIcons": true
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 2,
          "withTransforms": true,
          "refId": "A"
        }
      ]
    },
    {
      "id": 100,
      "title": "Data (before transformations)",
      "type": "table",
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "gridPos": {
        "h": 7,
        "w": 24,
        "x": 0,
        "y": 13
      },
      "options": {
        "showTypeIcons": true
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 2,
          "withTransforms": false,
          "refId": "A"
        }
      ]
    }
  ],
  "schemaVersion": 37,
  "title": "Debug: Rename Fields By Mapping Example // 26/08/2025 13:09:23",
  "tags": [
    "debug",
    "debug-timeseries"
  ],
  "time": {
    "from": "2025-08-26T12:07:25.024Z",
    "to": "2025-08-26T18:07:25.024Z"
  }
}
```
</details>

I haven't generated an image for this transformer, and I'm not sure what should be done on localization side.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
