### PR TITLE
Auth: Move POST login API to /api/login

### DIFF
--- a/devenv/docker/loadtest/modules/client.js
+++ b/devenv/docker/loadtest/modules/client.js
@@ -8,7 +8,7 @@ export const UIEndpoint = class UIEndpoint {
 
   login(username, pwd) {
     const payload = { user: username, password: pwd };
-    return this.httpClient.post('/login', JSON.stringify(payload));
+    return this.httpClient.post('/api/login', JSON.stringify(payload));
   }
 };
 

--- a/e2e/old-arch/utils/flows/login.ts
+++ b/e2e/old-arch/utils/flows/login.ts
@@ -7,7 +7,7 @@ const DEFAULT_PASSWORD = 'admin';
 const loginApi = (username: string, password: string) => {
   cy.request({
     method: 'POST',
-    url: fromBaseUrl('/login'),
+    url: fromBaseUrl('/api/login'),
     body: {
       user: username,
       password,

--- a/e2e/utils/flows/login.ts
+++ b/e2e/utils/flows/login.ts
@@ -7,7 +7,7 @@ const DEFAULT_PASSWORD = 'admin';
 const loginApi = (username: string, password: string) => {
   cy.request({
     method: 'POST',
-    url: fromBaseUrl('/login'),
+    url: fromBaseUrl('/api/login'),
     body: {
       user: username,
       password,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -79,7 +79,11 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// not logged in views
 	r.Get("/logout", hs.Logout)
+
+	// Login POST API is moved to /api/ for better routing, but old one left for backwards compatibility
 	r.Post("/login", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.LoginPost))
+	r.Post("/api/login", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.LoginPost))
+
 	r.Get("/login/:name", quota(string(auth.QuotaTargetSrv)), hs.OAuthLogin)
 
 	r.Get("/login", hs.LoginView)

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -111,7 +111,7 @@ export class LoginCtrl extends PureComponent<Props, State> {
     });
 
     getBackendSrv()
-      .post<LoginDTO>('/login', formModel, { showErrorAlert: false })
+      .post<LoginDTO>('/api/login', formModel, { showErrorAlert: false })
       .then((result) => {
         this.result = result;
         if (formModel.password !== 'admin' || config.ldapEnabled || config.authProxyEnabled) {


### PR DESCRIPTION
Moves the Login API to `/api/login` route for more consistent routing. 

Leaves the `POST /login` in place for compatibility, but we probably should deprecate it. Not sure they best way to go about this.

Part of https://github.com/grafana/grafana/issues/104503