### PR TITLE
CloudMigrations: Add Mute Timings as dependency for Notification Policies

### DIFF
--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -109,7 +109,7 @@ After connecting to the cloud stack, this is the empty state of the migration as
    | Folders | Nothing else |
    | All Alert rule groups | All other resources |
    | Alert Rules | <ul><li>Dashboards</li> <li>Library Elements</li> <li>Data Sources</li> <li>Plugins</li> <li>Folders</li> <li>Notification Policies</li> <li>Notification Templates</li> <li>Contact Points</li> <li>Mute Timings</li></ul> |
-   | Notification Policies | <ul><li>Notification Templates</li> <li>Contact Points</li></ul> |
+   | Notification Policies | <ul><li>Notification Templates</li> <li>Contact Points</li> <li>Mute Timings</li></ul> |
    | Notification Templates | Nothing else |
    | Contact Points | Notification Templates |
    | Mute Timings | Nothing else |

--- a/pkg/services/cloudmigration/resource_dependency.go
+++ b/pkg/services/cloudmigration/resource_dependency.go
@@ -24,7 +24,7 @@ var ResourceDependency = DependencyMap{
 	MuteTimingType:           nil,
 	NotificationTemplateType: nil,
 	ContactPointType:         {NotificationTemplateType},
-	NotificationPolicyType:   {ContactPointType},
+	NotificationPolicyType:   {ContactPointType, MuteTimingType},
 	AlertRuleType:            {DatasourceDataType, FolderDataType, DashboardDataType, MuteTimingType, ContactPointType, NotificationPolicyType},
 	AlertRuleGroupType:       {AlertRuleType},
 }

--- a/pkg/services/cloudmigration/resource_dependency_test.go
+++ b/pkg/services/cloudmigration/resource_dependency_test.go
@@ -144,10 +144,11 @@ func TestResourceDependencyParse(t *testing.T) {
 				NotificationPolicyType,
 				ContactPointType,
 				NotificationTemplateType,
+				MuteTimingType,
 			}
 			result, err := ResourceDependency.Parse(input)
 			require.NoError(t, err)
-			require.Len(t, result, 3)
+			require.Len(t, result, len(input))
 		})
 	})
 


### PR DESCRIPTION
**What is this feature?**

Enforces that to migrate Notification Policies, you need to migrate Mute Timings.


https://github.com/user-attachments/assets/673a7413-04d2-4a7b-9fdb-bfd93222ea5d


**Why do we need this feature?**

If you create a Mute Timing and attach it to a Notification Policy and attempt to migrate only the Notification Policy, it wouldn't automatically select Mute Timings and cause the migration to fail with the error:
```
Invalid format of the submitted route: mute time interval '<mute-timing>' does not exist. Correct the payload and try again.
```

**Who is this feature for?**

Cloud Migration users.

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1426

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
