### PR TITLE
SecretsManager: keepers with secure values credentials

### DIFF
--- a/pkg/storage/secret/metadata/keeper_model.go
+++ b/pkg/storage/secret/metadata/keeper_model.go
@@ -249,49 +249,33 @@ func toProvider(keeperType secretv0alpha1.KeeperType, payload string) secretv0al
 
 // extractSecureValues extracts unique securevalues referenced by the keeper, if any.
 func extractSecureValues(kp *secretv0alpha1.Keeper) map[string]struct{} {
-	secureValuesFromAWS := func(aws secretv0alpha1.AWSCredentials) map[string]struct{} {
+	switch {
+	case kp.Spec.AWS != nil:
 		secureValues := make(map[string]struct{}, 0)
 
-		if aws.AccessKeyID.SecureValueName != "" {
-			secureValues[aws.AccessKeyID.SecureValueName] = struct{}{}
+		if kp.Spec.AWS.AccessKeyID.SecureValueName != "" {
+			secureValues[kp.Spec.AWS.AccessKeyID.SecureValueName] = struct{}{}
 		}
 
-		if aws.SecretAccessKey.SecureValueName != "" {
-			secureValues[aws.SecretAccessKey.SecureValueName] = struct{}{}
+		if kp.Spec.AWS.SecretAccessKey.SecureValueName != "" {
+			secureValues[kp.Spec.AWS.SecretAccessKey.SecureValueName] = struct{}{}
 		}
 
 		return secureValues
-	}
-
-	secureValuesFromAzure := func(azure secretv0alpha1.AzureCredentials) map[string]struct{} {
-		if azure.ClientSecret.SecureValueName != "" {
-			return map[string]struct{}{azure.ClientSecret.SecureValueName: {}}
-		}
-
-		return nil
-	}
-
-	secureValuesFromHashiCorp := func(hashicorp secretv0alpha1.HashiCorpCredentials) map[string]struct{} {
-		if hashicorp.Token.SecureValueName != "" {
-			return map[string]struct{}{hashicorp.Token.SecureValueName: {}}
-		}
-
-		return nil
-	}
-
-	switch {
-	case kp.Spec.AWS != nil:
-		return secureValuesFromAWS(kp.Spec.AWS.AWSCredentials)
 
 	case kp.Spec.Azure != nil:
-		return secureValuesFromAzure(kp.Spec.Azure.AzureCredentials)
+		if kp.Spec.Azure.ClientSecret.SecureValueName != "" {
+			return map[string]struct{}{kp.Spec.Azure.ClientSecret.SecureValueName: {}}
+		}
 
 	// GCP does not reference secureValues.
 	case kp.Spec.GCP != nil:
 		return nil
 
 	case kp.Spec.HashiCorp != nil:
-		return secureValuesFromHashiCorp(kp.Spec.HashiCorp.HashiCorpCredentials)
+		if kp.Spec.HashiCorp.Token.SecureValueName != "" {
+			return map[string]struct{}{kp.Spec.HashiCorp.Token.SecureValueName: {}}
+		}
 	}
 
 	return nil

--- a/pkg/storage/secret/metadata/query.go
+++ b/pkg/storage/secret/metadata/query.go
@@ -21,7 +21,8 @@ var (
 	sqlKeeperList   = mustTemplate("keeper_list.sql")
 	sqlKeeperDelete = mustTemplate("keeper_delete.sql")
 
-	sqlKeeperListByName = mustTemplate("keeper_listByName.sql")
+	sqlKeeperListByName      = mustTemplate("keeper_listByName.sql")
+	sqlSecureValueListByName = mustTemplate("secure_value_listByName.sql")
 
 	sqlSecureValueRead             = mustTemplate("secure_value_read.sql")
 	sqlSecureValueList             = mustTemplate("secure_value_list.sql")
@@ -116,6 +117,18 @@ type listByNameKeeper struct {
 
 // Validate is only used if we use `dbutil` from `unifiedstorage`
 func (r listByNameKeeper) Validate() error {
+	return nil // TODO
+}
+
+// This is used at keeper store to validate create & update operations
+type listByNameSecureValue struct {
+	sqltemplate.SQLTemplate
+	Namespace        string
+	UsedSecureValues []string
+}
+
+// Validate is only used if we use `dbutil` from `unifiedstorage`
+func (r listByNameSecureValue) Validate() error {
 	return nil // TODO
 }
 

--- a/pkg/storage/secret/metadata/query_test.go
+++ b/pkg/storage/secret/metadata/query_test.go
@@ -105,6 +105,16 @@ func TestKeeperQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlSecureValueListByName: {
+				{
+					Name: "list",
+					Data: listByNameSecureValue{
+						SQLTemplate:      mocks.NewTestingSQLTemplate(),
+						Namespace:        "ns",
+						UsedSecureValues: []string{"a", "b"},
+					},
+				},
+			},
 		},
 	})
 }

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_listByName-list.sql
@@ -1,0 +1,9 @@
+SELECT
+  `name`,
+  `keeper`
+FROM
+  `secret_secure_value`
+WHERE  `namespace` = 'ns' AND
+  `name` IN ('a', 'b')
+FOR UPDATE
+;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_listByName-list.sql
@@ -1,0 +1,9 @@
+SELECT
+  "name",
+  "keeper"
+FROM
+  "secret_secure_value"
+WHERE  "namespace" = 'ns' AND
+  "name" IN ('a', 'b')
+FOR UPDATE
+;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_listByName-list.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_listByName-list.sql
@@ -1,0 +1,8 @@
+SELECT
+  "name",
+  "keeper"
+FROM
+  "secret_secure_value"
+WHERE  "namespace" = 'ns' AND
+  "name" IN ('a', 'b')
+;

--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -134,7 +134,6 @@ func TestIntegrationKeeper(t *testing.T) {
 		})
 
 		t.Run("and updating the keeper to reference securevalues that does not exist returns an error", func(t *testing.T) {
-			t.Skip("skipping because storing credentials as securevalues is not implemented yet")
 			newRaw := helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
 			newRaw.SetName(raw.GetName())
 			newRaw.Object["spec"].(map[string]any)["aws"] = map[string]any{
@@ -184,7 +183,6 @@ func TestIntegrationKeeper(t *testing.T) {
 	})
 
 	t.Run("creating a keeper that references securevalues that does not exist returns an error", func(t *testing.T) {
-		t.Skip("skipping because storing credentials as securevalues is not implemented yet")
 		testDataKeeper := helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
 		testDataKeeper.Object["spec"].(map[string]any)["aws"] = map[string]any{
 			"accessKeyId": map[string]any{


### PR DESCRIPTION
Merging the code mostly as-is from the feature branch: `secret-service/feature-branch`

This adds:
- template and tests to list secure values by name
- validation of keeper credentials as existing secure values

Still needed:
- 2 related integrations tests are yet to be added since they depend on async secure value status change


Part of: https://github.com/grafana/grafana-operator-experience-squad/issues/1404