### PR TITLE
extension-toolbar: make the sparkle-ai Toolbar button actually sparkle

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@grafana/data', () => ({
     get: jest.fn(),
     set: jest.fn(),
     delete: jest.fn(),
+    getBool: jest.fn(),
   },
 }));
 
@@ -81,6 +82,7 @@ describe('ExtensionToolbarItem', () => {
     (store.get as jest.Mock).mockClear();
     (store.set as jest.Mock).mockClear();
     (store.delete as jest.Mock).mockClear();
+    (store.getBool as jest.Mock).mockClear();
     jest.replaceProperty(config.featureToggles, 'extensionSidebar', true);
     setAppEvents(new EventBusSrv());
   });

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -1,5 +1,5 @@
-import { css, cx } from '@emotion/css';
-import React from 'react';
+import { css, cx, keyframes } from '@emotion/css';
+import React, { useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -16,14 +16,25 @@ function ExtensionToolbarItemButtonComponent(
   ref: React.ForwardedRef<HTMLButtonElement>
 ) {
   const styles = useStyles2(getStyles);
+  const [hasBeenOpened, setHasBeenOpened] = useState(() => {
+    const stored = localStorage.getItem('extension-sidebar-has-been-opened');
+    return stored === 'true';
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      setHasBeenOpened(true);
+      localStorage.setItem('extension-sidebar-has-been-opened', 'true');
+    }
+  }, [isOpen]);
 
   if (isOpen) {
-    // render button to close the sidebar
     return (
       <ToolbarButton
         ref={ref}
         className={cx(styles.button, styles.buttonActive)}
         icon="ai-sparkle"
+        id="extension-toolbar-button-ai-sparkle-close"
         data-testid="extension-toolbar-button-close"
         variant="default"
         onClick={onClick}
@@ -31,35 +42,46 @@ function ExtensionToolbarItemButtonComponent(
       />
     );
   }
-  // if a title is provided, use it in the tooltip
+
   let tooltip = t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
   if (title) {
     tooltip = t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title });
   }
+
   return (
-    <ToolbarButton
-      ref={ref}
-      className={cx(styles.button)}
-      icon="ai-sparkle"
-      data-testid="extension-toolbar-button-open"
-      variant="default"
-      onClick={onClick}
-      tooltip={tooltip}
-    />
+    <div className={styles.buttonWrapper}>
+      <ToolbarButton
+        ref={ref}
+        className={cx(styles.button)}
+        icon="ai-sparkle"
+        id="extension-toolbar-button-ai-sparkle-open"
+        data-testid="extension-toolbar-button-open"
+        variant="default"
+        onClick={onClick}
+        tooltip={tooltip}
+      />
+      {!hasBeenOpened && (
+        <>
+          <Sparkle delay={0.2} position="top" />
+          <Sparkle delay={0.7} position="bottom-right" />
+          <Sparkle delay={1.2} position="bottom-left" />
+        </>
+      )}
+    </div>
   );
 }
 
-// Wrapped the component with React.forwardRef to enable ref forwarding, which is required
-// for proper integration with the Dropdown component from @grafana/ui
 export const ExtensionToolbarItemButton = React.forwardRef<HTMLButtonElement, ToolbarItemButtonProps>(
   ExtensionToolbarItemButtonComponent
 );
 
 function getStyles(theme: GrafanaTheme2) {
   return {
+    buttonWrapper: css({
+      position: 'relative',
+      display: 'inline-block',
+    }),
     button: css({
-      // this is needed because with certain breakpoints the button will get `width: auto`
-      // and the icon will stretch
       aspectRatio: '1 / 1 !important',
       width: '28px',
       height: '28px',
@@ -73,6 +95,58 @@ function getStyles(theme: GrafanaTheme2) {
       backgroundColor: theme.colors.primary.transparent,
       border: `1px solid ${theme.colors.primary.borderTransparent}`,
       color: theme.colors.text.primary,
+    }),
+  };
+}
+
+const sparkleAnimation = keyframes`
+  0% { opacity: 0; transform: scale(0) rotate(0deg); }
+  50% { opacity: 1; transform: scale(1) rotate(180deg); }
+  100% { opacity: 0; transform: scale(0) rotate(360deg); }
+`;
+
+interface SparkleProps {
+  delay: number;
+  position: 'top' | 'bottom-right' | 'bottom-left';
+}
+
+const Sparkle = ({ delay, position }: SparkleProps) => {
+  const styles = useStyles2(getSparkleStyles);
+  return (
+    <span className={cx(styles.sparkle, styles[position])} style={{ animationDelay: `${delay}s` }}>
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <g>
+          <path d="M10 2 L11.5 8.5 L18 10 L11.5 11.5 L10 18 L8.5 11.5 L2 10 L8.5 8.5 Z" fill="currentColor"/>
+        </g>
+      </svg>
+    </span>
+  );
+};
+
+function getSparkleStyles() {
+  return {
+    sparkle: css({
+      position: 'absolute',
+      color: '#FFD700',
+      opacity: 0,
+      '@media (prefers-reduced-motion: no-preference)': {
+        animation: `${sparkleAnimation} 2s infinite`,
+      },
+      pointerEvents: 'none',
+      zIndex: 0,
+    }),
+    top: css({
+      top: '-10px',
+      left: '40%',
+      transform: 'translateX(-50%)',
+    }),
+    'bottom-right': css({
+      bottom: '-4px',
+      right: '-4px',
+    }),
+    'bottom-left': css({
+      bottom: '0',
+      left: '-4px',
     }),
   };
 }

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -1,7 +1,7 @@
 import { css, cx, keyframes } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
@@ -17,18 +17,19 @@ function ExtensionToolbarItemButtonComponent(
 ) {
   const styles = useStyles2(getStyles);
   const [hasBeenOpened, setHasBeenOpened] = useState(() => {
-    const stored = localStorage.getItem('extension-sidebar-has-been-opened');
-    return stored === 'true';
+    return store.getBool('extension-sidebar-has-been-opened', false);
   });
 
+  // if the sidebar is opened, store away that the sidebar has been opened to prevent consecutive animations
   useEffect(() => {
     if (isOpen) {
       setHasBeenOpened(true);
-      localStorage.setItem('extension-sidebar-has-been-opened', 'true');
+      store.set('extension-sidebar-has-been-opened', 'true');
     }
   }, [isOpen]);
 
   if (isOpen) {
+    // render button to close the sidebar
     return (
       <ToolbarButton
         ref={ref}
@@ -43,6 +44,7 @@ function ExtensionToolbarItemButtonComponent(
     );
   }
 
+  // if a title is provided, use it in the tooltip
   let tooltip = t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
   if (title) {
     tooltip = t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title });
@@ -71,6 +73,8 @@ function ExtensionToolbarItemButtonComponent(
   );
 }
 
+// Wrapped the component with React.forwardRef to enable ref forwarding, which is required
+// for proper integration with the Dropdown component from @grafana/ui
 export const ExtensionToolbarItemButton = React.forwardRef<HTMLButtonElement, ToolbarItemButtonProps>(
   ExtensionToolbarItemButtonComponent
 );
@@ -82,6 +86,8 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'inline-block',
     }),
     button: css({
+      // this is needed because with certain breakpoints the button will get `width: auto`
+      // and the icon will stretch
       aspectRatio: '1 / 1 !important',
       width: '28px',
       height: '28px',
@@ -116,7 +122,7 @@ const Sparkle = ({ delay, position }: SparkleProps) => {
     <span className={cx(styles.sparkle, styles[position])} style={{ animationDelay: `${delay}s` }}>
       <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <g>
-          <path d="M10 2 L11.5 8.5 L18 10 L11.5 11.5 L10 18 L8.5 11.5 L2 10 L8.5 8.5 Z" fill="currentColor"/>
+          <path d="M10 2 L11.5 8.5 L18 10 L11.5 11.5 L10 18 L8.5 11.5 L2 10 L8.5 8.5 Z" fill="currentColor" />
         </g>
       </svg>
     </span>


### PR DESCRIPTION
**What is this feature?**

This feature will make the `ai-sparkle` button within the extension-toolbar sparkle until the sidebar has been opened.

Screencast of how it'll look and behave
https://github.com/user-attachments/assets/7a82bb1d-5aa6-42dc-a98d-ff578eb7304d


**Why do we need this feature?**

As annoying as this might seem, but we want to increase the visibility of the Grafana Assistant hopefully resulting in more and more people using it - if it's accessible in their instance.

**Who is this feature for?**

Users that have the Grafana Assistant Plugin enabled in their instance but did not know about it, because the icon is kinda "hidden in plain sight"

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Bear in mind that this will only be temporary for private preview customers, hence the code ain't that pretty.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
