### PR TITLE
Dashboards: Prefer the library panel title instead of panel title set in the dashboard.

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1022,4 +1022,9 @@ export interface FeatureToggles {
   * @default false
   */
   alertingImportAlertmanagerAPI?: boolean;
+  /**
+  * Prefer library panel title over viz panel title
+  * @default false
+  */
+  preferLibraryPanelTitle?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1023,7 +1023,7 @@ export interface FeatureToggles {
   */
   alertingImportAlertmanagerAPI?: boolean;
   /**
-  * Prefer library panel title over viz panel title
+  * Prefer library panel title over viz panel title.
   * @default false
   */
   preferLibraryPanelTitle?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1756,6 +1756,13 @@ var (
 			HideFromDocs:      true,
 			Expression:        "false",
 		},
+		{
+			Name:        "preferLibraryPanelTitle",
+			Description: "Prefer library panel title over viz panel title.",
+			Stage:       FeatureStagePrivatePreview,
+			Owner:       grafanaDashboardsSquad,
+			Expression:  "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -229,3 +229,4 @@ restoreDashboards,experimental,@grafana/grafana-frontend-platform,false,false,fa
 skipTokenRotationIfRecent,privatePreview,@grafana/identity-access-team,false,false,false
 alertEnrichment,experimental,@grafana/alerting-squad,false,false,false
 alertingImportAlertmanagerAPI,experimental,@grafana/alerting-squad,false,false,false
+preferLibraryPanelTitle,privatePreview,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -928,6 +928,6 @@ const (
 	FlagAlertingImportAlertmanagerAPI = "alertingImportAlertmanagerAPI"
 
 	// FlagPreferLibraryPanelTitle
-	// Prefer library panel title over viz panel title
+	// Prefer library panel title over viz panel title.
 	FlagPreferLibraryPanelTitle = "preferLibraryPanelTitle"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -926,4 +926,8 @@ const (
 	// FlagAlertingImportAlertmanagerAPI
 	// Enables the API to import Alertmanager configuration
 	FlagAlertingImportAlertmanagerAPI = "alertingImportAlertmanagerAPI"
+
+	// FlagPreferLibraryPanelTitle
+	// Prefer library panel title over viz panel title
+	FlagPreferLibraryPanelTitle = "preferLibraryPanelTitle"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2611,11 +2611,14 @@
     {
       "metadata": {
         "name": "preferLibraryPanelTitle",
-        "resourceVersion": "1750150403415",
-        "creationTimestamp": "2025-06-17T08:53:23Z"
+        "resourceVersion": "1750152018442",
+        "creationTimestamp": "2025-06-17T08:53:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-06-17 09:20:18.442539 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Prefer library panel title over viz panel title",
+        "description": "Prefer library panel title over viz panel title.",
         "stage": "privatePreview",
         "codeowner": "@grafana/dashboards-squad",
         "expression": "false"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2610,6 +2610,19 @@
     },
     {
       "metadata": {
+        "name": "preferLibraryPanelTitle",
+        "resourceVersion": "1750150403415",
+        "creationTimestamp": "2025-06-17T08:53:23Z"
+      },
+      "spec": {
+        "description": "Prefer library panel title over viz panel title",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/dashboards-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "preinstallAutoUpdate",
         "resourceVersion": "1743693517832",
         "creationTimestamp": "2024-11-07T12:14:25Z"

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
@@ -2,7 +2,7 @@ import { of } from 'rxjs';
 
 import { FieldType, LoadingState, PanelData, getDefaultTimeRange, toDataFrame } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
-import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
+import { config, setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { SceneCanvasText, sceneGraph, SceneGridLayout, VizPanel } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
 import * as libpanels from 'app/features/library-panels/state/api';
@@ -139,6 +139,21 @@ describe('LibraryPanelBehavior', () => {
 
     expect(behavior.state._loadedPanel?.name).toBe('LibraryPanel A');
     expect(behavior.state._loadedPanel?.uid).toBe('111');
+  });
+
+  it('should set the title to the library panel title if the feature toggle is enabled', async () => {
+    config.featureToggles.preferLibraryPanelTitle = true;
+    const { gridItem } = await buildTestSceneWithLibraryPanel();
+
+    expect(gridItem.state.body.state.title).toBe('LibraryPanel A title');
+    config.featureToggles.preferLibraryPanelTitle = false;
+  });
+
+  it('should set the title to the panel title if the feature toggle is disabled', async () => {
+    config.featureToggles.preferLibraryPanelTitle = false;
+    const { gridItem } = await buildTestSceneWithLibraryPanel();
+
+    expect(gridItem.state.body.state.title).toBe('Panel A');
   });
 
   it('should not update panel if behavior not part of a vizPanel', async () => {

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -1,5 +1,6 @@
 import { PanelPlugin, PanelProps } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { SceneObject, SceneObjectBase, SceneObjectState, sceneUtils, VizPanel, VizPanelState } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
 import { Stack } from '@grafana/ui';
@@ -59,8 +60,15 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     );
     titleItems.push(new PanelNotices());
 
+    let title;
+    if (config.featureToggles.preferLibraryPanelTitle) {
+      title = libPanelModel.title ?? vizPanel.state.title;
+    } else {
+      title = vizPanel.state.title ?? libPanelModel.title;
+    }
+
     const vizPanelState: VizPanelState = {
-      title: vizPanel.state.title ?? libPanelModel.title,
+      title,
       options: libPanelModel.options ?? {},
       fieldConfig: libPanelModel.fieldConfig,
       pluginId: libPanelModel.type,


### PR DESCRIPTION
**What is this feature?**

This adds a feature toggle that sets the title of a viz panel created from a library panel to the library panel title. Without the feature toggle the title can be set in the dashboard.

**Why do we need this feature?**

Some users prefer to use the library panel title instead of a panel title specifically set in the dashboard.