### PR TITLE
Loki: Refactor getting of panel/dashboard title headers as part of decoupling

### DIFF
--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	q "github.com/grafana/grafana/pkg/services/query"
 )
 
 // Set of headers that we want to forward to the datasource api servers. Those are used i.e. for
@@ -12,6 +13,9 @@ import (
 //
 // The headers related to grafana alerting (x-rule-*), should match the list at
 // https://github.com/grafana/grafana/blob/f8ae71e4583499dd461ebaed31451966be04220b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go#L23
+//
+// The headers related to grafana query should match the list at
+// https://github.com/grafana/grafana/blob/f8ae71e4583499dd461ebaed31451966be04220b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go#L36
 //
 // The usage of strings.ToLower is because the server would convert `FromAlert` to `Fromalert`. So the make matching
 // easier, we just match all headers in lower case.
@@ -25,6 +29,14 @@ var expectedHeaders = map[string]string{
 	strings.ToLower("X-Rule-Type"):              "X-Rule-Type",
 	strings.ToLower("X-Rule-Version"):           "X-Rule-Version",
 	strings.ToLower("X-Grafana-Org-Id"):         "X-Grafana-Org-Id",
+	strings.ToLower(q.HeaderQueryGroupID):       q.HeaderQueryGroupID,
+	strings.ToLower(q.HeaderPanelID):            q.HeaderPanelID,
+	strings.ToLower(q.HeaderDashboardUID):       q.HeaderDashboardUID,
+	strings.ToLower(q.HeaderDatasourceUID):      q.HeaderDatasourceUID,
+	strings.ToLower(q.HeaderFromExpression):     q.HeaderFromExpression,
+	strings.ToLower(q.HeaderPanelPluginId):      q.HeaderPanelPluginId,
+	strings.ToLower(q.HeaderDashboardTitle):     q.HeaderDashboardTitle,
+	strings.ToLower(q.HeaderPanelTitle):         q.HeaderPanelTitle,
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {

--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	q "github.com/grafana/grafana/pkg/services/query"
+	queryService "github.com/grafana/grafana/pkg/services/query"
 )
 
 // Set of headers that we want to forward to the datasource api servers. Those are used i.e. for
@@ -20,23 +20,23 @@ import (
 // The usage of strings.ToLower is because the server would convert `FromAlert` to `Fromalert`. So the make matching
 // easier, we just match all headers in lower case.
 var expectedHeaders = map[string]string{
-	strings.ToLower(models.FromAlertHeaderName): models.FromAlertHeaderName,
-	strings.ToLower(models.CacheSkipHeaderName): models.CacheSkipHeaderName,
-	strings.ToLower("X-Rule-Name"):              "X-Rule-Name",
-	strings.ToLower("X-Rule-Uid"):               "X-Rule-Uid",
-	strings.ToLower("X-Rule-Folder"):            "X-Rule-Folder",
-	strings.ToLower("X-Rule-Source"):            "X-Rule-Source",
-	strings.ToLower("X-Rule-Type"):              "X-Rule-Type",
-	strings.ToLower("X-Rule-Version"):           "X-Rule-Version",
-	strings.ToLower("X-Grafana-Org-Id"):         "X-Grafana-Org-Id",
-	strings.ToLower(q.HeaderQueryGroupID):       q.HeaderQueryGroupID,
-	strings.ToLower(q.HeaderPanelID):            q.HeaderPanelID,
-	strings.ToLower(q.HeaderDashboardUID):       q.HeaderDashboardUID,
-	strings.ToLower(q.HeaderDatasourceUID):      q.HeaderDatasourceUID,
-	strings.ToLower(q.HeaderFromExpression):     q.HeaderFromExpression,
-	strings.ToLower(q.HeaderPanelPluginId):      q.HeaderPanelPluginId,
-	strings.ToLower(q.HeaderDashboardTitle):     q.HeaderDashboardTitle,
-	strings.ToLower(q.HeaderPanelTitle):         q.HeaderPanelTitle,
+	strings.ToLower(models.FromAlertHeaderName):        models.FromAlertHeaderName,
+	strings.ToLower(models.CacheSkipHeaderName):        models.CacheSkipHeaderName,
+	strings.ToLower("X-Rule-Name"):                     "X-Rule-Name",
+	strings.ToLower("X-Rule-Uid"):                      "X-Rule-Uid",
+	strings.ToLower("X-Rule-Folder"):                   "X-Rule-Folder",
+	strings.ToLower("X-Rule-Source"):                   "X-Rule-Source",
+	strings.ToLower("X-Rule-Type"):                     "X-Rule-Type",
+	strings.ToLower("X-Rule-Version"):                  "X-Rule-Version",
+	strings.ToLower("X-Grafana-Org-Id"):                "X-Grafana-Org-Id",
+	strings.ToLower(queryService.HeaderQueryGroupID):   queryService.HeaderQueryGroupID,
+	strings.ToLower(queryService.HeaderPanelID):        queryService.HeaderPanelID,
+	strings.ToLower(queryService.HeaderDashboardUID):   queryService.HeaderDashboardUID,
+	strings.ToLower(queryService.HeaderDatasourceUID):  queryService.HeaderDatasourceUID,
+	strings.ToLower(queryService.HeaderFromExpression): queryService.HeaderFromExpression,
+	strings.ToLower(queryService.HeaderPanelPluginId):  queryService.HeaderPanelPluginId,
+	strings.ToLower(queryService.HeaderDashboardTitle): queryService.HeaderDashboardTitle,
+	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -33,7 +33,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		return
 	}
 
-	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId}
+	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId, query.HeaderDashboardTitle, query.HeaderPanelTitle}
 
 	for _, headerName := range headersList {
 		gotVal := reqCtx.Req.Header.Get(headerName)

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -33,7 +33,17 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		return
 	}
 
-	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId, query.HeaderDashboardTitle, query.HeaderPanelTitle}
+	var headersList = []string{
+		query.HeaderQueryGroupID,
+		query.HeaderPanelID,
+		query.HeaderDashboardUID,
+		query.HeaderDatasourceUID,
+		query.HeaderFromExpression,
+		`X-Grafana-Org-Id`,
+		query.HeaderPanelPluginId,
+		query.HeaderDashboardTitle,
+		query.HeaderPanelTitle,
+	}
 
 	for _, headerName := range headersList {
 		gotVal := reqCtx.Req.Header.Get(headerName)

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -29,10 +29,12 @@ import (
 )
 
 const (
-	HeaderPluginID       = "X-Plugin-Id"      // can be used for routing
-	HeaderDatasourceUID  = "X-Datasource-Uid" // can be used for routing/ load balancing
-	HeaderDashboardUID   = "X-Dashboard-Uid"  // mainly useful for debugging slow queries
-	HeaderPanelID        = "X-Panel-Id"       // mainly useful for debugging slow queries
+	HeaderPluginID       = "X-Plugin-Id"       // can be used for routing
+	HeaderDatasourceUID  = "X-Datasource-Uid"  // can be used for routing/ load balancing
+	HeaderDashboardUID   = "X-Dashboard-Uid"   // mainly useful for debugging slow queries
+	HeaderPanelID        = "X-Panel-Id"        // mainly useful for debugging slow queries
+	HeaderDashboardTitle = "X-Dashboard-Title" // used for identifying the dashboard with heavy query load
+	HeaderPanelTitle     = "X-Panel-Title"     // used for identifying the panel with heavy query load
 	HeaderPanelPluginId  = "X-Panel-Plugin-Id"
 	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
 	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries


### PR DESCRIPTION
Part of https://github.com/grafana/data-sources/issues/1355
As a part of Loki data source decoupling effort, we need to remove import of `"github.com/grafana/grafana/pkg/services/contexthandler`.  This was used to get panel/dashboard title header that is then passed to Loki. More info in [here](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750087883608419?thread_ts=1723716243.322849&cid=C01C4K8DETW). 

As we need to keep these headers, the solution is to add them to [here](https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go#L36) so they are passed to Loki. 

The headers are still correctly sent to Loki:
<img width="1909" alt="image" src="https://github.com/user-attachments/assets/0e7b0d99-6ffd-4b55-873a-79bc855fedb8" />

