### PR TITLE
Alerting: Update error message for failed FetchError

### DIFF
--- a/public/app/core/utils/errors.ts
+++ b/public/app/core/utils/errors.ts
@@ -62,8 +62,8 @@ export function getMessageIdFromError(err: unknown): string | undefined {
 }
 
 export function getRequestConfigFromError(err: FetchError): string {
-  const method = err.config.method ?? 'GET';
-  const url = err.config.url;
+  const method = err.config?.method ?? 'GET';
+  const url = err.config?.url;
 
-  return `${method} ${url}`;
+  return method && url ? `${method} ${url}` : 'request';
 }

--- a/public/app/core/utils/errors.ts
+++ b/public/app/core/utils/errors.ts
@@ -1,4 +1,4 @@
-import { isFetchError } from '@grafana/runtime';
+import { FetchError, isFetchError } from '@grafana/runtime';
 
 export function getMessageFromError(err: unknown): string {
   if (typeof err === 'string') {
@@ -59,4 +59,11 @@ export function getMessageIdFromError(err: unknown): string | undefined {
   }
 
   return undefined;
+}
+
+export function getRequestConfigFromError(err: FetchError): string {
+  const method = err.config.method ?? 'GET';
+  const url = err.config.url;
+
+  return `${method} ${url}`;
 }

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -284,7 +284,7 @@ describe('NotificationPolicies', () => {
 
     renderNotificationPolicies();
     const alert = await screen.findByRole('alert', { name: /error loading alertmanager config/i });
-    expect(await within(alert).findByText(errMessage)).toBeInTheDocument();
+    expect(await within(alert).findByText(new RegExp(errMessage))).toBeInTheDocument();
     expect(ui.rootRouteContainer.query()).not.toBeInTheDocument();
   });
 

--- a/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
@@ -135,7 +135,7 @@ describe('GroupDetailsPage', () => {
 
       // Assert
       expect(await screen.findByText('Error loading the group')).toBeInTheDocument();
-      expect(await screen.findByText('Failed to fetch rule group')).toBeInTheDocument();
+      expect(await screen.findByText(/Failed to fetch rule group/)).toBeInTheDocument();
     });
 
     it('should render "not found" when group does not exist', async () => {

--- a/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
@@ -70,7 +70,7 @@ describe('pause rule', () => {
     await userEvent.click(byRole('button').get());
     expect(await byText(/loading/i).find()).toBeInTheDocument();
     expect(byText(/success/i).query()).not.toBeInTheDocument();
-    expect(await byText(/error: oops/i).find()).toBeInTheDocument();
+    expect(await byText(/error:(.+)oops/i).find()).toBeInTheDocument();
   });
 });
 

--- a/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/DataSourceSection.tsx
@@ -77,9 +77,9 @@ export const DataSourceSection = ({
                 {Boolean(error) && (
                   <Toggletip
                     title={t('alerting.rule-list.ds-error.title', 'Cannot load rules for this datasource')}
-                    content={<div>{stringifyErrorLike(error)}</div>}
+                    content={<Text color="error">{stringifyErrorLike(error)}</Text>}
                   >
-                    <Button variant="destructive" fill="outline" size="sm" icon="exclamation-circle">
+                    <Button variant="destructive" fill="text" size="sm" icon="exclamation-circle">
                       <Trans i18nKey="alerting.rule-list.error-button">Error</Trans>
                     </Button>
                   </Toggletip>

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -1,3 +1,4 @@
+import { FetchError } from '@grafana/runtime';
 import {
   createExploreLink,
   makeDashboardLink,
@@ -140,7 +141,7 @@ describe('stringifyErrorLike', () => {
 
   it('should stringify Fetch error with message embedded in HTTP response', () => {
     const error = { status: 404, data: { message: 'message from the API' } };
-    expect(stringifyErrorLike(error)).toBe('message from the API');
+    expect(stringifyErrorLike(error)).toBe('request failed with 404: message from the API');
   });
 
   it('should stringify Fetch error with status text as fallback', () => {
@@ -164,7 +165,7 @@ describe('stringifyErrorLike', () => {
       reason: 'Conflict',
     };
 
-    expect(stringifyErrorLike({ status: 409, data: error })).toBe('some message');
+    expect(stringifyErrorLike({ status: 409, data: error })).toBe('request failed with 409: some message');
   });
 
   it('should stringify ApiMachineryError with known code', () => {
@@ -179,5 +180,20 @@ describe('stringifyErrorLike', () => {
     };
 
     expect(stringifyErrorLike({ status: 409, data: error })).toBe(getErrorMessageFromCode(ERROR_NEWER_CONFIGURATION));
+  });
+
+  it('should stringify fetchh error with status code and URL', () => {
+    const error = {
+      status: 404,
+      data: {
+        message: 'not found',
+      },
+      config: {
+        url: '/my/url',
+        method: 'POST',
+      },
+    } satisfies FetchError;
+
+    expect(stringifyErrorLike(error)).toBe('POST /my/url failed with 404: not found');
   });
 });

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -312,14 +312,17 @@ export function stringifyErrorLike(error: unknown): string {
       return error.message;
     }
 
-    // @TODO translate
     if ('message' in error.data && typeof error.data.message === 'string') {
       const status = getStatusFromError(error);
       const message = getMessageFromError(error);
 
       const config = getRequestConfigFromError(error);
 
-      return `${config} ${t('alerting.errors.failedWith', `failed with`)} ${status}: ${message}`;
+      return t('alerting.errors.failedWith', '{{- config}} failed with {{status}}: {{message}}', {
+        config,
+        status,
+        message,
+      });
     }
 
     if (error.statusText) {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -318,7 +318,7 @@ export function stringifyErrorLike(error: unknown): string {
 
       const config = getRequestConfigFromError(error);
 
-      return t('alerting.errors.failedWith', '{{- config}} failed with {{status}}: {{message}}', {
+      return t('alerting.errors.failedWith', '{{-config}} failed with {{status}}: {{-message}}', {
         config,
         status,
         message,

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -2,9 +2,11 @@ import { sortBy } from 'lodash';
 
 import { Labels, UrlQueryMap } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
 import { config, isFetchError } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
+import { getMessageFromError, getRequestConfigFromError, getStatusFromError } from 'app/core/utils/errors';
 import { escapePathSeparators } from 'app/features/alerting/unified/utils/rule-id';
 import {
   alertInstanceKey,
@@ -309,9 +311,17 @@ export function stringifyErrorLike(error: unknown): string {
     if (error.message) {
       return error.message;
     }
+
+    // @TODO translate
     if ('message' in error.data && typeof error.data.message === 'string') {
-      return error.data.message;
+      const status = getStatusFromError(error);
+      const message = getMessageFromError(error);
+
+      const config = getRequestConfigFromError(error);
+
+      return `${config} ${t('alerting.errors.failedWith', `failed with`)} ${status}: ${message}`;
     }
+
     if (error.statusText) {
       return error.statusText;
     }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1066,7 +1066,7 @@
       "content-show-all-errors": "Show all errors"
     },
     "errors": {
-      "failedWith": "{{- config}} failed with {{status}}: {{message}}"
+      "failedWith": "{{-config}} failed with {{status}}: {{-message}}"
     },
     "evaluate-every-validation-options": {
       "message": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1065,6 +1065,9 @@
     "error-summary-button": {
       "content-show-all-errors": "Show all errors"
     },
+    "errors": {
+      "failedWith": "failed with"
+    },
     "evaluate-every-validation-options": {
       "message": {
         "required": "Required."

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1066,7 +1066,7 @@
       "content-show-all-errors": "Show all errors"
     },
     "errors": {
-      "failedWith": "failed with"
+      "failedWith": "{{- config}} failed with {{status}}: {{message}}"
     },
     "evaluate-every-validation-options": {
       "message": {


### PR DESCRIPTION
**What is this feature?**

Updates the error messages to include details about which URL requests have failed.

<img width="495" alt="image" src="https://github.com/user-attachments/assets/da6ce770-c47d-485e-85b9-79a92b0c4240" />

**Special notes for your reviewer:**

~Might need a test for the util function and I'll need to update some existing tests :)~