### PR TITLE
Dashboard: SchemaV2 - Fix stateless variable query with default datasource

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -9,12 +9,12 @@ jest.mock('@grafana/runtime', () => ({
     ...jest.requireActual('@grafana/runtime').config,
     bootData: {
       settings: {
-        defaultDatasource: 'default-ds-grafana',
+        defaultDatasource: 'default-ds-prometheus',
         datasources: {
-          'default-ds-grafana': {
-            uid: 'default-ds-uid',
-            name: 'Default DS',
-            meta: { id: 'default-ds-grafana' },
+          'default-ds-prometheus': {
+            uid: 'default-prometheus-uid',
+            name: 'Default Prometheus',
+            meta: { id: 'prometheus' },
             type: 'datasource',
           },
           prometheus: {
@@ -61,7 +61,7 @@ describe('getRuntimePanelDataSource', () => {
     });
   });
 
-  it('should infer datasource based on query kind when datasource is not specified', () => {
+  it('should prioritize default datasource when it matches the query kind', () => {
     const query: PanelQueryKind = {
       kind: 'PanelQuery',
       spec: {
@@ -78,8 +78,30 @@ describe('getRuntimePanelDataSource', () => {
     const result = getRuntimePanelDataSource(query);
 
     expect(result).toEqual({
-      uid: 'prometheus-uid',
+      uid: 'default-prometheus-uid',
       type: 'prometheus',
+    });
+  });
+
+  it('should fall back to first available datasource when default datasource type does not match query kind', () => {
+    const query: PanelQueryKind = {
+      kind: 'PanelQuery',
+      spec: {
+        refId: 'A',
+        hidden: false,
+        datasource: undefined,
+        query: {
+          kind: 'loki',
+          spec: {},
+        },
+      },
+    };
+
+    const result = getRuntimePanelDataSource(query);
+
+    expect(result).toEqual({
+      uid: 'loki-uid',
+      type: 'loki',
     });
   });
 
@@ -100,8 +122,8 @@ describe('getRuntimePanelDataSource', () => {
     const result = getRuntimePanelDataSource(query);
 
     expect(result).toEqual({
-      uid: 'default-ds-uid',
-      type: 'default-ds-grafana',
+      uid: 'default-prometheus-uid',
+      type: 'prometheus',
     });
   });
 
@@ -125,7 +147,7 @@ describe('getRuntimePanelDataSource', () => {
     const result = getRuntimePanelDataSource(query);
 
     expect(result).toEqual({
-      uid: 'prometheus-uid',
+      uid: 'default-prometheus-uid',
       type: 'prometheus',
     });
   });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -106,6 +106,7 @@ describe('getRuntimePanelDataSource', () => {
   });
 
   it('should use default datasource when no datasource is specified and query kind does not match any available datasource', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
     const query: PanelQueryKind = {
       kind: 'PanelQuery',
       spec: {
@@ -125,6 +126,10 @@ describe('getRuntimePanelDataSource', () => {
       uid: 'default-prometheus-uid',
       type: 'prometheus',
     });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Could not find datasource for query kind unknown-type, defaulting to prometheus'
+    );
   });
 
   it('should handle the case when datasource uid is empty string', () => {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -243,6 +243,10 @@ function getDataSourceForQuery(
     // Fallback to default datasource even if type doesn't match
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
+
+    console.warn(
+      `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
+    );
     return {
       uid: dsList[defaultDatasource].uid || dsList[defaultDatasource].name,
       type: dsList[defaultDatasource].meta.id,

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -224,12 +224,23 @@ function getDataSourceForQuery(
   const defaultDatasource = config.bootData.settings.defaultDatasource;
   const dsList = config.bootData.settings.datasources;
 
-  // Look up by query type/kind
+  // First check if the default datasource matches the query type
+  if (dsList && dsList[defaultDatasource] && dsList[defaultDatasource].meta.id === queryKind) {
+    // In the datasource list from bootData "id" is the type and the uid could be uid or the name
+    // in cases like grafana, dashboard or mixed datasource
+    return {
+      uid: dsList[defaultDatasource].uid || dsList[defaultDatasource].name,
+      type: dsList[defaultDatasource].meta.id,
+    };
+  }
+
+  // Look up by query type/kind from all available datasources
   const bestGuess = dsList && Object.values(dsList).find((ds) => ds.meta.id === queryKind);
 
   if (bestGuess) {
     return { uid: bestGuess.uid, type: bestGuess.meta.id };
   } else if (dsList && dsList[defaultDatasource]) {
+    // Fallback to default datasource even if type doesn't match
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
     return {


### PR DESCRIPTION
### Current Problem: 

Reported internally [slack](https://raintank-corp.slack.com/archives/C07QVGH37D4/p1748628706450199) 

In V1 dashboards with query variables using no explicit datasource would resolve to the instance's default datasource. In V2, the "bestGuess" logic picks the first available datasource of the required type.

### Approach to resolve this issue:

Refactor `getDataSourceForQuery()` to:
  1. First check if the default datasource matches the query type from the variable query - use it if it does
  2. Fall back to existing "bestGuess" logic (first available of that type) if default doesn't match
  3. Keep final fallback to default datasource regardless of type

Fixes: https://github.com/grafana/grafana/issues/106825

Tasks:
- [x]  Test with similar dashboard provided in the issue 
- [x] Fix logic
- [x] Add test

https://github.com/user-attachments/assets/795445d1-ef9c-401a-b120-3abbb2baeaac



