### PR TITLE
apiserver/folders: use exact match on GetFolderByTitle in legacy

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -229,7 +229,15 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 				return nil, fmt.Errorf("only one repo name is supported")
 			}
 			query.ManagerIdentity = vals[0]
+		case resource.SEARCH_FIELD_TITLE_PHRASE:
+			if len(vals) != 1 {
+				return nil, fmt.Errorf("only one title supported")
+			}
+
+			query.Title = vals[0]
+			query.TitleExactMatch = true
 		}
+
 	}
 
 	columns := c.getColumns(sortByField, query)

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -237,7 +237,6 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 			query.Title = vals[0]
 			query.TitleExactMatch = true
 		}
-
 	}
 
 	columns := c.getColumns(sortByField, query)

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -882,7 +882,7 @@ func (d *dashboardStore) FindDashboards(ctx context.Context, query *dashboards.F
 	}
 
 	if len(query.Title) > 0 {
-		filters = append(filters, searchstore.TitleFilter{Dialect: d.store.GetDialect(), Title: query.Title})
+		filters = append(filters, searchstore.TitleFilter{Dialect: d.store.GetDialect(), Title: query.Title, TitleExactMatch: query.TitleExactMatch})
 	}
 
 	if len(query.Type) > 0 {

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -888,25 +888,47 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc           string
-		title          string
-		expectedResult res
-		typ            string
+		desc            string
+		title           string
+		titleExactMatch bool
+		expectedResult  *res
+		typ             string
 	}{
 		{
 			desc:           "find dashboard under general",
 			title:          "dashboard under general",
-			expectedResult: res{title: "dashboard under general"},
+			expectedResult: &res{title: "dashboard under general"},
 		},
 		{
 			desc:           "find dashboard under f0",
 			title:          "dashboard under f0",
-			expectedResult: res{title: "dashboard under f0", folderUID: f0.UID, folderTitle: f0.Title},
+			expectedResult: &res{title: "dashboard under f0", folderUID: f0.UID, folderTitle: f0.Title},
 		},
 		{
 			desc:           "find dashboard under subfolder",
 			title:          "dashboard under subfolder",
-			expectedResult: res{title: "dashboard under subfolder", folderUID: subfolder.UID, folderTitle: subfolder.Title},
+			expectedResult: &res{title: "dashboard under subfolder", folderUID: subfolder.UID, folderTitle: subfolder.Title},
+		},
+		{
+			desc:            "find folder 'sub' using partial match: 1 result found",
+			title:           "sub",
+			titleExactMatch: false,
+			typ:             "dash-folder",
+			expectedResult:  &res{title: "subfolder", folderUID: f0.UID, folderTitle: f0.Title},
+		},
+		{
+			desc:            "find folder 'sub' using exact match: no results",
+			title:           "sub",
+			titleExactMatch: true,
+			typ:             "dash-folder",
+			expectedResult:  nil,
+		},
+		{
+			desc:            "find folder 'subfolder' using exact match: 1 result",
+			title:           "subfolder",
+			titleExactMatch: true,
+			typ:             "dash-folder",
+			expectedResult:  &res{title: "subfolder", folderUID: f0.UID, folderTitle: f0.Title},
 		},
 	}
 
@@ -915,11 +937,18 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 			dashboardStore, err := ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
 			require.NoError(t, err)
 			res, err := dashboardStore.FindDashboards(context.Background(), &dashboards.FindPersistedDashboardsQuery{
-				SignedInUser: user,
-				Type:         tc.typ,
-				Title:        tc.title,
+				SignedInUser:    user,
+				Type:            tc.typ,
+				Title:           tc.title,
+				TitleExactMatch: tc.titleExactMatch,
 			})
 			require.NoError(t, err)
+
+			if tc.expectedResult == nil {
+				require.Equal(t, 0, len(res))
+				return
+			}
+
 			require.Equal(t, 1, len(res))
 
 			r := tc.expectedResult

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -430,12 +430,13 @@ type DashboardACLInfoDTO struct {
 }
 
 type FindPersistedDashboardsQuery struct {
-	Title         string
-	OrgId         int64
-	SignedInUser  identity.Requester
-	DashboardIds  []int64
-	DashboardUIDs []string
-	Type          string
+	Title           string
+	TitleExactMatch bool
+	OrgId           int64
+	SignedInUser    identity.Requester
+	DashboardIds    []int64
+	DashboardUIDs   []string
+	Type            string
 	// Deprecated: use FolderUIDs instead
 	FolderIds  []int64
 	FolderUIDs []string

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -310,11 +310,17 @@ func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64
 
 	request := &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{
-			Key:    folderkey,
-			Fields: []*resourcepb.Requirement{},
+			Key: folderkey,
+			Fields: []*resourcepb.Requirement{
+				{
+					Key:      resource.SEARCH_FIELD_TITLE_PHRASE, // nolint:staticcheck
+					Operator: string(selection.Equals),
+					Values:   []string{title},
+				},
+			},
 			Labels: []*resourcepb.Requirement{},
 		},
-		Query: title,
+		// Query: title,
 		Limit: folderSearchLimit}
 
 	if parentUID != nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -320,7 +320,6 @@ func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64
 			},
 			Labels: []*resourcepb.Requirement{},
 		},
-		// Query: title,
 		Limit: folderSearchLimit}
 
 	if parentUID != nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -792,11 +792,16 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 		service.unifiedStore = fakeFolderStore
 		fakeK8sClient.On("Search", mock.Anything, int64(1), &resourcepb.ResourceSearchRequest{
 			Options: &resourcepb.ListOptions{
-				Key:    folderkey,
-				Fields: []*resourcepb.Requirement{},
+				Key: folderkey,
+				Fields: []*resourcepb.Requirement{
+					&resourcepb.Requirement{
+						Key:      resource.SEARCH_FIELD_TITLE_PHRASE, // nolint:staticcheck
+						Operator: string(selection.Equals),
+						Values:   []string{"foo title"},
+					},
+				},
 				Labels: []*resourcepb.Requirement{},
 			},
-			Query: "foo title",
 			Limit: folderSearchLimit}).
 			Return(&resourcepb.ResourceSearchResponse{
 				Results: &resourcepb.ResourceTable{

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -43,11 +43,16 @@ func (f OrgFilter) Where() (string, []any) {
 }
 
 type TitleFilter struct {
-	Dialect migrator.Dialect
-	Title   string
+	Dialect         migrator.Dialect
+	Title           string
+	TitleExactMatch bool
 }
 
 func (f TitleFilter) Where() (string, []any) {
+	if f.TitleExactMatch {
+		return "dashboard.title = ?", []any{f.Title}
+	}
+
 	sql, params := f.Dialect.LikeOperator("dashboard.title", true, f.Title, true)
 	return sql, []any{params}
 }

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -91,3 +91,44 @@ func TestFolderUIDFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestTitleFilter(t *testing.T) {
+	testCases := []struct {
+		description    string
+		title          string
+		exactMatch     bool
+		expectedSql    string
+		expectedParams []any
+	}{
+		{
+			description:    "searching foo folder - partial match",
+			title:          "foo",
+			expectedSql:    "dashboard.title LIKE ?",
+			expectedParams: []any{"%foo%"},
+		},
+		{
+			description:    "searching foo folder - exact match",
+			title:          "foo",
+			exactMatch:     true,
+			expectedSql:    "dashboard.title = ?",
+			expectedParams: []any{"foo"},
+		},
+	}
+
+	store := setupTestEnvironment(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			f := searchstore.TitleFilter{
+				Dialect:         store.GetDialect(),
+				Title:           tc.title,
+				TitleExactMatch: tc.exactMatch,
+			}
+
+			sql, params := f.Where()
+
+			assert.Equal(t, tc.expectedSql, sql)
+			assert.Equal(t, tc.expectedParams, params)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an issue with the Folder Service in where GetFolderByTitle would return incorrect results when running with `kubernetesClientDashboardsFolders=true` and legacy storage. 

**Why do we need this feature?**

Consider that `kubernetesClientDashboardsFolders=true` and that we have the following folder structure:

```
- foo
- bar_foo
- qux
- fizz
```

If we call `folder.Get(title="foo")`, the expected result is to return just 1 item: the `foo` folder.

However, with the current implementation, the result is returning 2 items: `foo` and `bar_foo` too.

That happens because [the legacy implementation of `folder.Get(title=foo)`](https://github.com/grafana/grafana/blob/5448e8fb22e8f477556a6a3d531653719889732c/pkg/services/folder/folderimpl/sqlstore.go#L246) performs an exact match on folder title, while with the new apiserver implementation, we are relying on [k8s.Search](https://github.com/grafana/grafana/blob/5448e8fb22e8f477556a6a3d531653719889732c/pkg/services/folder/folderimpl/folder_unifiedstorage.go#L329) which is powered by the [legacy searcher](https://github.com/grafana/grafana/blob/5448e8fb22e8f477556a6a3d531653719889732c/pkg/registry/apis/dashboard/legacysearcher/search_client.go#L312) and finally `dashboardStore.FindDashboards`, which performs [partial matches on titles](https://github.com/grafana/grafana/blob/5448e8fb22e8f477556a6a3d531653719889732c/pkg/services/sqlstore/searchstore/filters.go#L51) 

To solve this, we need to modify the Folder apiserver, LegacySearcher and `searchstore` package to optionally support exact matches on FolderTitles.

![image](https://github.com/user-attachments/assets/c0cc8bf7-b28e-4ea2-b66f-f464173a344b)


**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
