### PR TITLE
DevEnv: Add jaegeronly container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,6 +263,7 @@
 /devenv/docker/blocks/influxdb/ @grafana/partner-datasources
 /devenv/docker/blocks/influxdb1/ @grafana/partner-datasources
 /devenv/docker/blocks/jaeger/ @grafana/oss-big-tent
+/devenv/docker/blocks/jaegeronly/ @grafana/grafana-operator-experience-squad
 /devenv/docker/blocks/maildev/ @grafana/alerting-frontend
 /devenv/docker/blocks/mariadb/ @grafana/oss-big-tent
 /devenv/docker/blocks/memcached/ @grafana/grafana-backend-group

--- a/devenv/docker/blocks/jaegeronly/docker-compose.yaml
+++ b/devenv/docker/blocks/jaegeronly/docker-compose.yaml
@@ -1,0 +1,12 @@
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686" # UI
+      - "14268:14268"
+      - "4317:4317" # OpenTelemetry Protocol (OTLP) over gRPC
+      - "4318:4318" # OpenTelemetry Protocol (OTLP) over HTTP
+    environment:
+      - MEMORY_MAX_TRACES=100000
+      - SPAN_STORAGE_TYPE=badger
+      - COLLECTOR_OTLP_ENABLED=true


### PR DESCRIPTION
**What is this feature?**

Adds a simple Jaeger dev container with OTLP collector enabled (grpc+http)

**Why do we need this feature?**

The current jaeger env requires some extra setup with Loki, so this is a more lean version.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
