### PR TITLE
Alerting: API to delete extra Alertmanager configurations

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -412,8 +412,8 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 	return nil
 }
 
-// DeleteAndApplyExtraConfiguration deletes an ExtraConfiguration by its identifier while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) DeleteAndApplyExtraConfiguration(ctx context.Context, org int64, identifier string) error {
+// DeleteExtraConfiguration deletes an ExtraConfiguration by its identifier while preserving the main AlertmanagerConfig.
+func (moa *MultiOrgAlertmanager) DeleteExtraConfiguration(ctx context.Context, org int64, identifier string) error {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
 		filtered := make([]definitions.ExtraConfiguration, 0, len(configs))
 		for _, ec := range configs {

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -150,7 +150,7 @@ receivers:
 	})
 }
 
-func TestMultiOrgAlertmanager_DeleteAndApplyExtraConfiguration(t *testing.T) {
+func TestMultiOrgAlertmanager_DeleteExtraConfiguration(t *testing.T) {
 	orgID := int64(1)
 
 	t.Run("successfully delete existing extra configuration", func(t *testing.T) {
@@ -176,7 +176,7 @@ receivers:
 		require.NoError(t, err)
 		require.Len(t, gettableConfig.ExtraConfigs, 1)
 
-		err = mam.DeleteAndApplyExtraConfiguration(ctx, orgID, identifier)
+		err = mam.DeleteExtraConfiguration(ctx, orgID, identifier)
 		require.NoError(t, err)
 
 		gettableConfig, err = mam.GetAlertmanagerConfiguration(ctx, orgID, false)
@@ -189,7 +189,7 @@ receivers:
 		ctx := context.Background()
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
-		err := mam.DeleteAndApplyExtraConfiguration(ctx, orgID, "non-existent")
+		err := mam.DeleteExtraConfiguration(ctx, orgID, "non-existent")
 		require.NoError(t, err)
 	})
 
@@ -197,7 +197,7 @@ receivers:
 		mam := setupMam(t, nil)
 		ctx := context.Background()
 
-		err := mam.DeleteAndApplyExtraConfiguration(ctx, 999, "test-config")
+		err := mam.DeleteExtraConfiguration(ctx, 999, "test-config")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get current configuration")
 	})


### PR DESCRIPTION
**What is this feature?**

Implements the DELETE endpoint for deleting imported Mimir Alertmanager configurations:

- DELETE `/api/convert/api/v1/alerts`

The API endpoint deletes the extra Alertmanager configuration with the provided identifier.

Usage example:

```
mimirtool alertmanager delete \
    --key admin \
    --id admin \
    --address http://127.0.0.1:3000/api/convert/ \
    --extra-headers 'X-Grafana-Alerting-Config-Identifier=my-config'
```

Part of https://github.com/grafana/alerting-squad/issues/1152
