### PR TITLE
SecretsManager: Add distributed tracing for async worker flow

### DIFF
--- a/pkg/registry/apis/secret/tracectx/carrier.go
+++ b/pkg/registry/apis/secret/tracectx/carrier.go
@@ -1,0 +1,57 @@
+package tracectx
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const (
+	kvSeparator   = "="
+	pairSeparator = "#"
+)
+
+func HexEncodeTraceFromContext(ctx context.Context) string {
+	carrier := propagation.MapCarrier(make(map[string]string))
+
+	propagation.TraceContext{}.Inject(ctx, carrier)
+
+	// no trace in context
+	if len(carrier) == 0 {
+		return ""
+	}
+
+	pairs := make([]string, 0, len(carrier))
+	for k, v := range carrier {
+		pairs = append(pairs, k+kvSeparator+v)
+	}
+
+	return hex.EncodeToString([]byte(strings.Join(pairs, pairSeparator)))
+}
+
+func HexDecodeTraceIntoContext(ctx context.Context, encoded string) (context.Context, error) {
+	if encoded == "" {
+		return ctx, nil
+	}
+
+	decoded, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	pairs := strings.Split(string(decoded), pairSeparator)
+
+	carrier := make(propagation.MapCarrier, len(pairs))
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, kvSeparator, 2)
+		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
+			return nil, fmt.Errorf("invalid key-value pair: %s", pair)
+		}
+		carrier[kv[0]] = kv[1]
+	}
+
+	return propagation.TraceContext{}.Extract(ctx, carrier), nil
+}

--- a/pkg/registry/apis/secret/tracectx/carrier_test.go
+++ b/pkg/registry/apis/secret/tracectx/carrier_test.go
@@ -1,0 +1,88 @@
+package tracectx
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestHexEncodeTraceFromContext(t *testing.T) {
+	t.Run("when no trace is present in context, it returns empty string", func(t *testing.T) {
+		ctx := context.Background()
+
+		encoded := HexEncodeTraceFromContext(ctx)
+		require.Empty(t, encoded)
+	})
+
+	t.Run("when trace is present in context, it returns hex-encoded string", func(t *testing.T) {
+		carrier := propagation.MapCarrier{
+			"traceparent": "00-446e31681d64f9dcefd947c95ef321d0-009e2f3d8ded1892-01",
+			"tracestate":  "first=abc1234,second=xyz7890",
+		}
+		ctx := propagation.TraceContext{}.Extract(context.Background(), carrier)
+
+		encoded := HexEncodeTraceFromContext(ctx)
+		require.NotEmpty(t, encoded)
+
+		traceCtx, err := HexDecodeTraceIntoContext(context.Background(), encoded)
+		require.NoError(t, err)
+
+		span := trace.SpanFromContext(traceCtx)
+		require.True(t, span.SpanContext().IsValid())
+
+		carrier = propagation.MapCarrier(make(map[string]string))
+		propagation.TraceContext{}.Inject(traceCtx, carrier)
+		require.Contains(t, carrier, "traceparent")
+		require.Contains(t, carrier, "tracestate")
+	})
+}
+
+func TestHexDecodeTraceIntoContext(t *testing.T) {
+	t.Run("when encoded string is empty, it returns original context", func(t *testing.T) {
+		ctx := context.Background()
+
+		result, err := HexDecodeTraceIntoContext(ctx, "")
+		require.NoError(t, err)
+		require.Equal(t, ctx, result)
+	})
+
+	t.Run("when encoded string is valid hex, it returns context with trace", func(t *testing.T) {
+		encoded := hex.EncodeToString([]byte("traceparent=00-446e31681d64f9dcefd947c95ef321d0-009e2f3d8ded1892-01#tracestate=first=abc1234,second=xyz7890"))
+
+		ctx, err := HexDecodeTraceIntoContext(context.Background(), encoded)
+		require.NoError(t, err)
+
+		span := trace.SpanFromContext(ctx)
+		require.True(t, span.SpanContext().IsValid())
+	})
+
+	t.Run("when encoded string has invalid hex encoding, it returns an error", func(t *testing.T) {
+		invalidHex := "invalid-hex-zzz"
+
+		result, err := HexDecodeTraceIntoContext(context.Background(), invalidHex)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("when decoded string has invalid key-value pair format, it returns an error", func(t *testing.T) {
+		// missing key
+		encoded := hex.EncodeToString([]byte("00-446e31681d64f9dcefd947c95ef321d0-009e2f3d8ded1892-01"))
+
+		result, err := HexDecodeTraceIntoContext(context.Background(), encoded)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("when decoded string has key without value, it returns error", func(t *testing.T) {
+		// missing value
+		encoded := hex.EncodeToString([]byte("traceparent="))
+
+		result, err := HexDecodeTraceIntoContext(context.Background(), encoded)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}

--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -133,8 +133,8 @@ func (*SecretDB) AddMigration(mg *migrator.Migrator) {
 	tables = append(tables, migrator.Table{
 		Name: TableNameSecureValueOutbox,
 		Columns: []*migrator.Column{
-			{Name: "request_id", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},
-			{Name: "uid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
+			{Name: "request_id", Type: migrator.DB_NVarchar, Length: 1024, Nullable: false}, // Safer upper limit because we hex-encode traceparent+tracestate to form the request_id.
+			{Name: "uid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},       // Fixed size of a UUID.
 			{Name: "message_type", Type: migrator.DB_NVarchar, Length: 16, Nullable: false},
 			{Name: "name", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},      // Limit enforced by K8s.
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.


### PR DESCRIPTION
**What is this feature?**

Stores the trace context in the `requestID` for the outbox queue, and extract that when processing the message.

This will let us directly correlate an HTTP request (create,update,delete) to its processing by the outbox worker.

Here is an example for create, zooom!

![trac](https://github.com/user-attachments/assets/0056f710-025c-4ce9-ab6f-ebe716d75b4a)

**Why do we need this feature?**

Better debugging!

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1416

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
