### PR TITLE
Allow the docs plugin to use the sidebar

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -11,7 +11,12 @@ import { DEFAULT_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar';
 export const EXTENSION_SIDEBAR_EXTENSION_POINT_ID = 'grafana/extension-sidebar/v0-alpha';
 export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarDocked';
 export const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
-const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = ['grafana-investigations-app', 'grafana-assistant-app', 'grafana-dash-app'];
+const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
+  'grafana-investigations-app',
+  'grafana-assistant-app',
+  'grafana-dash-app',
+  'grafana-grafanadocsplugin-app',
+];
 
 type ExtensionSidebarContextType = {
   /**

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -72,7 +72,6 @@ export function ExtensionToolbarItem() {
                 setDockedComponentId(id);
               }
             }}
-            pluginId={dockedPluginId}
           />
         );
       })}

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -18,6 +18,7 @@ export function ExtensionToolbarItem() {
     const dockedComponent = getComponentMetaFromComponentId(dockedComponentId);
     if (dockedComponent) {
       dockedComponentTitle = dockedComponent.componentTitle;
+      dockedPluginId = dockedComponent.pluginId;
     }
   }
 
@@ -47,6 +48,7 @@ export function ExtensionToolbarItem() {
               setDockedComponentId(getComponentIdFromComponentMeta(components[0].pluginId, components[0]));
             }
           }}
+          pluginId={components[0].pluginId}
         />
         <NavToolbarSeparator />
       </>
@@ -69,6 +71,7 @@ export function ExtensionToolbarItem() {
                 setDockedComponentId(id);
               }
             }}
+            pluginId={dockedPluginId}
           />
         );
       })}
@@ -85,6 +88,7 @@ export function ExtensionToolbarItem() {
               setDockedComponentId(undefined);
             }
           }}
+          pluginId={dockedPluginId}
         />
       ) : (
         <Dropdown overlay={MenuItems} placement="bottom-end">

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -14,6 +14,7 @@ export function ExtensionToolbarItem() {
     useExtensionSidebarContext();
 
   let dockedComponentTitle = '';
+  let dockedPluginId = '';
   if (dockedComponentId) {
     const dockedComponent = getComponentMetaFromComponentId(dockedComponentId);
     if (dockedComponent) {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -9,13 +9,24 @@ interface ToolbarItemButtonProps {
   isOpen: boolean;
   title?: string;
   onClick?: () => void;
+  pluginId?: string;
+}
+
+function getPluginIcon(pluginId?: string): string {
+  switch (pluginId) {
+    case 'grafana-grafanadocsplugin-app':
+      return 'book';
+    default:
+      return 'ai-sparkle';
+  }
 }
 
 function ExtensionToolbarItemButtonComponent(
-  { isOpen, title, onClick }: ToolbarItemButtonProps,
+  { isOpen, title, onClick, pluginId }: ToolbarItemButtonProps,
   ref: React.ForwardedRef<HTMLButtonElement>
 ) {
   const styles = useStyles2(getStyles);
+  const icon = getPluginIcon(pluginId);
 
   if (isOpen) {
     // render button to close the sidebar
@@ -23,7 +34,7 @@ function ExtensionToolbarItemButtonComponent(
       <ToolbarButton
         ref={ref}
         className={cx(styles.button, styles.buttonActive)}
-        icon="ai-sparkle"
+        icon={icon}
         data-testid="extension-toolbar-button-close"
         variant="default"
         onClick={onClick}
@@ -40,7 +51,7 @@ function ExtensionToolbarItemButtonComponent(
     <ToolbarButton
       ref={ref}
       className={cx(styles.button)}
-      icon="ai-sparkle"
+      icon={icon}
       data-testid="extension-toolbar-button-open"
       variant="default"
       onClick={onClick}


### PR DESCRIPTION
The [#wg-docs-in-product](https://grafanalabs.enterprise.slack.com/archives/C08VB4WC64R) team has built an app plugin that uses a sidebar to display relevant learning journeys and documentation in the product.

You can see a demo of the functionality [in the Slack channel](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1750088620856909).

The purpose of this PR is to allow the plugin to use that sidebar in the same way that Investigations and Assistant plugins already do.

It also adds logic to display a different icon to the other plugins that use this sidebar to distinguish this plugin from Investigations and Assistant.
Should the component take the icon itself as a property rather than the `pluginId` which is used to derive the correct icon?

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
