### PR TITLE
Actions: set -euo pipefail on multi-cmd runs

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
         run: |
+          set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
           go test -short -timeout=30m "${PACKAGES[@]}"
 
@@ -117,6 +118,7 @@ jobs:
           bucket: grafana-test-results
       - if: github.repository == 'grafana/grafana' && (success() || failure())
         run: |
+          set -euo pipefail
           BUCKET_PATH="go-unit-tests/$(echo "${REF_NAME}" | sed 's/\//-/g')"
           echo "BUCKET_PATH=$BUCKET_PATH" >> "$GITHUB_ENV"
         env:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build E2E test runner
         id: artifact
         run: |
+          set -euo pipefail
           # We want a static binary, so we need to set CGO_ENABLED=0
           CGO_ENABLED=0 go build -o ./e2e-runner ./e2e/
           echo "artifact=e2e-runner-${{github.run_number}}" >> "$GITHUB_OUTPUT"
@@ -127,6 +128,7 @@ jobs:
         env:
           SUITE: ${{ matrix.path }}
         run: |
+          set -euo pipefail
           echo "suite=$(echo "$SUITE" | sed 's/\//-/g')" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
         run: |
+          set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           go test -tags=sqlite -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
   mysql:
@@ -94,6 +95,7 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
         run: |
+          set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           go test -p=1 -tags=mysql -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
   postgres:
@@ -140,5 +142,6 @@ jobs:
         env:
           SHARD: ${{ matrix.shard }}
         run: |
+          set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"


### PR DESCRIPTION
When this isn't the case, and a prerequisite to some other command fails, we won't exit immediately. This can lead to the final command exiting with code 0; e.g. `go test` with no packages tested does this.