### PR TITLE
VizTooltip: Fix memory leak

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -144,6 +144,8 @@ export const TooltipPlugin2 = ({
   getLinksRef.current = getDataLinks;
 
   useLayoutEffect(() => {
+    sizeRef.current?.observer.disconnect();
+
     sizeRef.current = {
       width: 0,
       height: 0,
@@ -646,6 +648,8 @@ export const TooltipPlugin2 = ({
     window.addEventListener('scroll', onscroll, true);
 
     return () => {
+      sizeRef.current?.observer.disconnect();
+
       window.removeEventListener('resize', updateWinSize);
       window.removeEventListener('scroll', onscroll, true);
 
@@ -659,6 +663,7 @@ export const TooltipPlugin2 = ({
     const size = sizeRef.current!;
 
     if (domRef.current != null) {
+      size.observer.disconnect();
       size.observer.observe(domRef.current);
 
       // since the above observer is attached after container is in DOM, we need to manually update sizeRef


### PR DESCRIPTION
**What is this feature?**

Fix a memory leak in uPlot tooltip plugin. The `ResizeObserver` was never disconnected, meaning that it was growing over time, retaining the listeners for detached elements.

**Why do we need this feature?**

Fix memory leak.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/59139f6b-0e72-4e68-940e-af03b746261f



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
