### PR TITLE
K8s: Add cluster scope support in app runner

### DIFF
--- a/pkg/apimachinery/utils/resource.go
+++ b/pkg/apimachinery/utils/resource.go
@@ -9,35 +9,46 @@ import (
 
 // ResourceInfo helps define a k8s resource
 type ResourceInfo struct {
-	group        string
-	version      string
-	resourceName string
-	singularName string
-	shortName    string
-	kind         string
-	newObj       func() runtime.Object
-	newList      func() runtime.Object
-	columns      TableColumns
+	group         string
+	version       string
+	resourceName  string
+	singularName  string
+	shortName     string
+	kind          string
+	newObj        func() runtime.Object
+	newList       func() runtime.Object
+	columns       TableColumns
+	clusterScoped bool
 }
 
 func NewResourceInfo(group, version, resourceName, singularName, kind string,
 	newObj func() runtime.Object, newList func() runtime.Object, columns TableColumns) ResourceInfo {
-	shortName := "" // an optional alias helpful in kubectl eg ("sa" for serviceaccounts)
-	return ResourceInfo{group, version, resourceName, singularName, shortName, kind, newObj, newList, columns}
+	shortName := ""        // an optional alias helpful in kubectl eg ("sa" for serviceaccounts)
+	clusterScoped := false // if true, this resource is cluster scoped, otherwise it is namespace scoped
+	return ResourceInfo{group, version, resourceName, singularName, shortName, kind, newObj, newList, columns, clusterScoped}
 }
 
 func (info *ResourceInfo) WithGroupAndShortName(group string, shortName string) ResourceInfo {
 	return ResourceInfo{
-		group:        group,
-		version:      info.version,
-		resourceName: info.resourceName,
-		singularName: info.singularName,
-		kind:         info.kind,
-		shortName:    shortName,
-		newObj:       info.newObj,
-		newList:      info.newList,
-		columns:      info.columns,
+		group:         group,
+		version:       info.version,
+		resourceName:  info.resourceName,
+		singularName:  info.singularName,
+		kind:          info.kind,
+		shortName:     shortName,
+		newObj:        info.newObj,
+		newList:       info.newList,
+		columns:       info.columns,
+		clusterScoped: info.clusterScoped,
 	}
+}
+func (info *ResourceInfo) WithClusterScope() ResourceInfo {
+	info.clusterScoped = true
+	return *info
+}
+
+func (info *ResourceInfo) IsClusterScoped() bool {
+	return info.clusterScoped
 }
 
 func (info *ResourceInfo) GetName() string {

--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -12,6 +12,9 @@ func NewRegistryStore(scheme *runtime.Scheme, resourceInfo utils.ResourceInfo, o
 	gv := resourceInfo.GroupVersion()
 	gv.Version = runtime.APIVersionInternal
 	strategy := NewStrategy(scheme, gv)
+	if resourceInfo.IsClusterScoped() {
+		strategy = strategy.WithClusterScope()
+	}
 	store := &registry.Store{
 		NewFunc:                   resourceInfo.NewFunc,
 		NewListFunc:               resourceInfo.NewListFunc,

--- a/pkg/apiserver/registry/generic/strategy.go
+++ b/pkg/apiserver/registry/generic/strategy.go
@@ -22,17 +22,22 @@ type genericStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 
-	gv schema.GroupVersion
+	gv            schema.GroupVersion
+	clusterScoped bool
 }
 
 // NewStrategy creates and returns a genericStrategy instance.
 func NewStrategy(typer runtime.ObjectTyper, gv schema.GroupVersion) *genericStrategy {
-	return &genericStrategy{typer, names.SimpleNameGenerator, gv}
+	return &genericStrategy{typer, names.SimpleNameGenerator, gv, false}
 }
 
-// NamespaceScoped returns true because all Generic resources must be within a namespace.
 func (g *genericStrategy) NamespaceScoped() bool {
-	return true
+	return !g.clusterScoped
+}
+
+func (g *genericStrategy) WithClusterScope() *genericStrategy {
+	g.clusterScoped = true
+	return g
 }
 
 func (g *genericStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {

--- a/pkg/services/apiserver/builder/runner/resource_info.go
+++ b/pkg/services/apiserver/builder/runner/resource_info.go
@@ -9,7 +9,7 @@ import (
 )
 
 func KindToResourceInfo(kind resource.Kind) utils.ResourceInfo {
-	return utils.NewResourceInfo(
+	r := utils.NewResourceInfo(
 		kind.Group(),
 		kind.Version(),
 		kind.GroupVersionResource().Resource,
@@ -19,4 +19,8 @@ func KindToResourceInfo(kind resource.Kind) utils.ResourceInfo {
 		func() runtime.Object { return kind.ZeroListValue() },
 		utils.TableColumns{}, // TODO: this only supports the default columns
 	)
+	if kind.Scope() == resource.ClusterScope {
+		r = r.WithClusterScope()
+	}
+	return r
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds support for cluster scope resources in resourceInfo, strategy, and the app runner.

**Why do we need this feature?**

@grafana/plugins-platform-backend would like to add a resource that represents `plugin.json` at the cluster scope level.

**Who is this feature for?**

App authors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
