### PR TITLE
Actions: Wait for all backend unit tests

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -132,3 +132,30 @@ jobs:
           environment: "dev" # Can be dev/prod (defaults to dev)
           path: ${{ env.RESULTS_FILE }}
           bucket_path: ${{ env.BUCKET_PATH }}
+
+  # This is the job that is actually required by rulesets.
+  # We need to require EITHER the OSS or the Enterprise job to pass.
+  # However, if one is skipped, GitHub won't flat-map the shards,
+  #   so they won't be accepted by a ruleset.
+  required-backend-unit-tests:
+    needs:
+      - grafana
+      - grafana-enterprise
+    # always() is the best function here.
+    # success() || failure() will skip this function if any need is also skipped.
+    # That means conditional test suites will fail the entire requirement check.
+    if: always()
+
+    name: All backend unit tests complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test suites
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure")) | map_values(.result)')"
+          echo "$FAILURES"
+          if [ "$(echo "$FAILURES" | jq '. | length')" != "0" ]; then
+            exit 1
+          fi
+          echo "All OK!"


### PR DESCRIPTION
We need to wait for all the unit tests to complete. However, if we require one test suite or the other, GitHub Actions will skip one and only report the job name, i.e. (literally) `Grafana (${{ matrix.shard }})`. That is not `Grafana (1/8)` etc.

Another bonus of doing this, though, is that we can change the shard numbering however we please without touching any rulesets, or even backports (ie different releases can have different sharding).