### PR TITLE
Actions: Join on test suites

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -2,16 +2,10 @@ name: Backend Unit Tests
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   push:
     branches:
       - main
       - release-*.*.*
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -136,3 +136,28 @@ jobs:
           name: ${{ steps.set-suite-name.outputs.suite }}-${{ github.run_number }}
           path: videos
           retention-days: 1
+
+  # This is the job that is actually required by rulesets.
+  # We want to only require one job instead of all the individual tests.
+  # Future work also allows us to start skipping some tests based on changed files.
+  required-e2e-tests:
+    needs:
+      - run-e2e-tests
+    # always() is the best function here.
+    # success() || failure() will skip this function if any need is also skipped.
+    # That means conditional test suites will fail the entire requirement check.
+    if: always()
+
+    name: All E2E tests complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test suites
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure")) | map_values(.result)')"
+          echo "$FAILURES"
+          if [ "$(echo "$FAILURES" | jq '. | length')" != "0" ]; then
+            exit 1
+          fi
+          echo "All OK!"

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -69,3 +69,30 @@ jobs:
         TEST_MAX_WORKERS: 2
         TEST_SHARD: ${{ matrix.chunk }}
         TEST_SHARD_TOTAL: 8
+
+  # This is the job that is actually required by rulesets.
+  # We need to require EITHER the OSS or the Enterprise job to pass.
+  # However, if one is skipped, GitHub won't flat-map the shards,
+  #   so they won't be accepted by a ruleset.
+  required-frontend-unit-tests:
+    needs:
+      - frontend-unit-tests
+      - frontend-unit-tests-enterprise
+    # always() is the best function here.
+    # success() || failure() will skip this function if any need is also skipped.
+    # That means conditional test suites will fail the entire requirement check.
+    if: always()
+
+    name: All frontend unit tests complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test suites
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure")) | map_values(.result)')"
+          echo "$FAILURES"
+          if [ "$(echo "$FAILURES" | jq '. | length')" != "0" ]; then
+            exit 1
+          fi
+          echo "All OK!"

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -145,3 +145,30 @@ jobs:
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
           go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
+
+  # This is the job that is actually required by rulesets.
+  # We want to only require one job instead of all the individual tests and shards.
+  # Future work also allows us to start skipping some tests based on changed files.
+  required-backend-integration-tests:
+    needs:
+      - mysql
+      - postgres
+      - sqlite
+    # always() is the best function here.
+    # success() || failure() will skip this function if any need is also skipped.
+    # That means conditional test suites will fail the entire requirement check.
+    if: always()
+
+    name: All backend integration tests complete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test suites
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          FAILURES="$(echo "$NEEDS" | jq 'with_entries(select(.value.result == "failure")) | map_values(.result)')"
+          echo "$FAILURES"
+          if [ "$(echo "$FAILURES" | jq '. | length')" != "0" ]; then
+            exit 1
+          fi
+          echo "All OK!"


### PR DESCRIPTION
Like with [106927][1], we want to reduce the amount of tests we require. This allows us to do so.

Perk is that we can also start skipping tests in the future, e.g. if files aren't changed.

[1]: https://github.com/grafana/grafana/pull/106927
