### PR TITLE
E2E: Fix icons not loading consistently in e2e tests

### DIFF
--- a/e2e/cypress/support/e2e.js
+++ b/e2e/cypress/support/e2e.js
@@ -36,12 +36,6 @@ if (Cypress.env('SLOWMO')) {
   });
 }
 
-// @todo remove when possible: https://github.com/cypress-io/cypress/issues/95
-Cypress.on('window:before:load', (win) => {
-  // @ts-ignore
-  delete win.fetch;
-});
-
 // See https://github.com/quasarframework/quasar/issues/2233 for details
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
 Cypress.on('uncaught:exception', (err) => {


### PR DESCRIPTION
Quite the rabbit hole to spot this one line.

A bisect revealed that #97725 introduced an issue where icons would not load in Cypress under certain conditions. If icons don't load, Cypress will refuse to click on certain buttons because it (rightfully) doesn't think they're visible. When icons don't load, you would see a bunch of failed network requests to `/[Object%20object]`.

In e2e.js, `window.fetch` is deleted for some reason. We include a fetch polyfill in the app, which hid the fact that the e2e code was deleting the browser fetch api. The fetch polyfill polyfills the `fetch` method and the `Request` class.

[react-inlinesvg](https://github.com/gilbarbara/react-inlinesvg) calls [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache/add) `cache.add` to *request* icons and add them to a browser cache:

```ts
await this.cacheApi?.add(new Request(url, fetchOptions));
```

When the Cache.add would fire off the request, it would fail requesting `/[Object%20object]`. I'm pretty sure the problem is due to trying to supply a polyfilled `Request` instance to the native `cache.add` function - the browser doesn't think it's a proper `Request` instance and just attempts to convert it to a string - `[Object%20object]`.

I'm not sure why this problem doesn't happen in CI. In a [seperate PR/CI run](https://github.com/grafana/grafana/pull/106952), I confirmed that icons load correctly and that `fetch`/`Request` is polyfilled.