### PR TITLE
TableNG: cache calculations that renderCell needs at column level

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/AutoCell.tsx
@@ -4,10 +4,11 @@ import { useState } from 'react';
 
 import { GrafanaTheme2, formattedValueToString } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { TableCellDisplayMode, TableCellOptions } from '@grafana/schema';
+import { TableCellDisplayMode } from '@grafana/schema';
 
 import { useStyles2 } from '../../../../themes/ThemeContext';
 import { DataLinksActionsTooltip, renderSingleLink } from '../../DataLinksActionsTooltip';
+import { TableCellOptions } from '../../types';
 import { DataLinksActionsTooltipCoords, getDataLinksActionsTooltipUtils } from '../../utils';
 import { AutoCellProps } from '../types';
 import { getCellLinks } from '../utils';
@@ -60,7 +61,6 @@ const getStyles = (theme: GrafanaTheme2, justifyContent: Property.JustifyContent
   cell: css({
     display: 'flex',
     justifyContent: justifyContent,
-
     a: {
       color: 'inherit',
     },

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -82,7 +82,7 @@ export const SparklineCell = (props: SparklineCellProps) => {
     },
   };
 
-  const hideValue = field.config.custom?.cellOptions?.hideValue;
+  const hideValue = cellOptions.hideValue;
   let valueWidth = 0;
   let valueElement: React.ReactNode = null;
   if (!hideValue) {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1375,8 +1375,8 @@ describe('TableNG', () => {
       expect(cells.length).toBeGreaterThan(0);
 
       // Check the first div inside the cell for style attributes
-      const div = cells[0].querySelectorAll('div')[0];
-      const styleAttr = window.getComputedStyle(div);
+      const cell = cells[0];
+      const styleAttr = window.getComputedStyle(cell);
 
       // Expected color is red
       expect(styleAttr.background).toBe('rgb(255, 0, 0)');
@@ -1412,8 +1412,8 @@ describe('TableNG', () => {
       expect(cells.length).toBeGreaterThan(0);
 
       // Check the first div inside the cell for style attributes
-      const div = cells[0].querySelectorAll('div')[0];
-      const computedStyle = window.getComputedStyle(div);
+      const cell = cells[0];
+      const computedStyle = window.getComputedStyle(cell);
 
       // Expected color is red
       expect(computedStyle.color).toBe('rgb(255, 0, 0)');

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { SortColumn } from 'react-data-grid';
 
 import { Field, fieldReducers, FieldType, formattedValueToString } from '@grafana/data';
-import { TableCellDisplayMode, TableCellOptions } from '@grafana/schema';
+import { TableCellDisplayMode } from '@grafana/schema';
 
 import { useTheme2 } from '../../../themes/ThemeContext';
 
@@ -16,6 +16,7 @@ import {
   getFooterItem,
   getColumnTypes,
   applySort,
+  getCellOptions,
 } from './utils';
 
 // Helper function to get displayed value
@@ -270,13 +271,12 @@ export function useFooterCalcs(
 export function useTextWraps(fields: Field[]): Record<string, boolean> {
   return useMemo(
     () =>
-      fields.reduce<{ [key: string]: boolean }>(
-        (acc, field) => ({
-          ...acc,
-          [getDisplayName(field)]: field.config?.custom?.cellOptions?.wrapText ?? false,
-        }),
-        {}
-      ),
+      fields.reduce<{ [key: string]: boolean }>((acc, field) => {
+        const cellOptions = getCellOptions(field);
+        const displayName = getDisplayName(field);
+        const wrapText = 'wrapText' in cellOptions && cellOptions.wrapText;
+        return { ...acc, [displayName]: !!wrapText };
+      }, {}),
     [fields]
   );
 }
@@ -321,9 +321,9 @@ export function useRowHeight(
           return false;
         }
 
-        const cellOptions: TableCellOptions = field.config?.custom?.cellOptions ?? {};
+        const cellOptions = getCellOptions(field);
         const wrapText = 'wrapText' in cellOptions && cellOptions.wrapText;
-        const type = cellOptions.type ?? TableCellDisplayMode.Auto;
+        const type = cellOptions.type;
         const result = !!wrapText && type !== TableCellDisplayMode.Image;
         if (result === true) {
           hasWrappedCols = true;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -1,5 +1,5 @@
 import { Property } from 'csstype';
-import { SyntheticEvent } from 'react';
+import { ReactNode, SyntheticEvent } from 'react';
 import { Column } from 'react-data-grid';
 
 import {
@@ -15,9 +15,10 @@ import {
   DataFrameWithValue,
   SelectableValue,
 } from '@grafana/data';
-import { TableCellOptions, TableCellHeight, TableFieldOptions } from '@grafana/schema';
+import { TableCellHeight, TableFieldOptions } from '@grafana/schema';
 
 import { TableCellInspectorMode } from '../TableCellInspector';
+import { TableCellOptions } from '../types';
 
 export const FILTER_FOR_OPERATOR = '=';
 export const FILTER_OUT_OPERATOR = '!=';
@@ -149,10 +150,10 @@ export interface BaseTableProps {
 export interface TableNGProps extends BaseTableProps {}
 
 export interface TableCellNGProps {
+  actions?: ActionModel[];
+  cellOptions: TableCellOptions;
+  displayName: string;
   field: Field;
-  frame: DataFrame;
-  getActions?: GetActionsFunction;
-  height: number;
   justifyContent: Property.JustifyContent;
   rowIdx: number;
   setContextMenuProps: (props: { value: string; top?: number; left?: number; mode?: TableCellInspectorMode }) => void;
@@ -160,10 +161,11 @@ export interface TableCellNGProps {
   theme: GrafanaTheme2;
   timeRange?: TimeRange;
   value: TableCellValue;
-  rowBg: Function | undefined;
   onCellFilterAdded?: TableFilterActionCallback;
-  replaceVariables?: InterpolateFunction;
+  children: ReactNode;
   width: number;
+  height: number;
+  frame: DataFrame;
 }
 
 /* ------------------------- Specialized Cell Props ------------------------- */
@@ -178,7 +180,7 @@ export interface SparklineCellProps {
   justifyContent: Property.JustifyContent;
   rowIdx: number;
   theme: GrafanaTheme2;
-  timeRange: TimeRange;
+  timeRange?: TimeRange;
   value: TableCellValue;
   width: number;
 }
@@ -190,7 +192,6 @@ export interface BarGaugeCellProps extends ActionCellProps {
   theme: GrafanaTheme2;
   value: TableCellValue;
   width: number;
-  timeRange: TimeRange;
 }
 
 export interface ImageCellProps extends ActionCellProps {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -20,10 +20,10 @@ import {
   TableCellBackgroundDisplayMode,
   TableCellDisplayMode,
   TableCellHeight,
-  TableCellOptions,
 } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../../utils/colors';
+import { TableCellOptions, TableCustomCellOptions } from '../types';
 
 import { COLUMN, TABLE } from './constants';
 import {
@@ -216,6 +216,7 @@ export function getCellColors(
   cellOptions: TableCellOptions,
   displayValue: DisplayValue
 ): CellColors {
+  // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = theme.isDark ? 1 : -0.7;
 
   // Setup color variables
@@ -567,17 +568,20 @@ export function computeColWidths(fields: Field[], availWidth: number) {
 
 export function getRowBgFn(fields: Field[], theme: GrafanaTheme2): ((rowIndex: number) => CellColors) | void {
   for (const field of fields) {
-    const cellOptions: TableCellOptions | void = field.config.custom?.cellOptions;
+    const cellOptions = getCellOptions(field);
     const fieldDisplay = field.display;
     if (
       fieldDisplay !== undefined &&
-      cellOptions !== undefined &&
       cellOptions.type === TableCellDisplayMode.ColorBackground &&
       cellOptions.applyToRow === true
     ) {
       return (rowIndex: number) => getCellColors(theme, cellOptions, fieldDisplay(field.values[rowIndex]));
     }
   }
+}
+
+export function isCustomCellOptions(options: TableCellOptions): options is TableCustomCellOptions {
+  return options.type === TableCellDisplayMode.Custom;
 }
 
 /**


### PR DESCRIPTION
- removes an intermediate `div` which isn't necessary, and cleans up some styles and tests as a result of this.
- pulls the logic for selecting which Cell rendering component to use up to the TableNG layer.
  - I left the code to pick this in TableCellNG, but it is exported and then used in the other file. we could consider whether this is the best way to organize the code or if there's a better setup.  
- cleans up some of the accessors for the cellOptions