### PR TITLE
[release-11.6.2] InfluxDB: Fix variable interpolation on adhoc filters

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -404,5 +404,6 @@ describe('interpolateQueryExpr', () => {
     const adhocFilter: AdHocVariableFilter[] = [{ key: 'bar', value: templateVarName, operator: '=' }];
     const result = ds.applyTemplateVariables(mockInfluxQueryRequest() as unknown as InfluxQuery, {}, adhocFilter);
     expect(result.tags![0].value).toBe(templateVarValue);
+    expect(result.adhocFilters![0].value).toBe(templateVarValue);
   });
 });

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -47,14 +47,7 @@ import { buildMetadataQuery } from './influxql_query_builder';
 import { prepareAnnotation } from './migrations';
 import { buildRawQuery, removeRegexWrapper } from './queryUtils';
 import ResponseParser from './response_parser';
-import {
-  DEFAULT_POLICY,
-  InfluxOptions,
-  InfluxQuery,
-  InfluxQueryTag,
-  InfluxVariableQuery,
-  InfluxVersion,
-} from './types';
+import { DEFAULT_POLICY, InfluxOptions, InfluxQuery, InfluxVariableQuery, InfluxVersion } from './types';
 import { InfluxVariableSupport } from './variables';
 
 export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery, InfluxOptions> {
@@ -206,12 +199,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (this.version === InfluxVersion.SQL || this.isMigrationToggleOnAndIsAccessProxy()) {
       query = this.applyVariables(query, variables, filters);
       if (query.adhocFilters?.length) {
-        const adhocFiltersToTags: InfluxQueryTag[] = (query.adhocFilters ?? []).map((af) => {
+        query.adhocFilters = (query.adhocFilters ?? []).map((af) => {
           const { condition, ...asTag } = af;
           asTag.value = this.templateSrv.replace(asTag.value ?? '', variables);
           return asTag;
         });
-        query.tags = [...(query.tags ?? []), ...adhocFiltersToTags];
+        query.tags = [...(query.tags ?? []), ...query.adhocFilters];
       }
     }
 


### PR DESCRIPTION
Backport 02d977e1afcf1d35299a7aa05550371c7e34d3fb from #104931

---

Grafana frontend code sends adhoc filters to the backend in both the `tags` and `adhocFilters` params.

The values in `tags` have dashboard variables interpolated, while those in `adhocFilters` don't. This PR adds interpolation on the frontend to the `adhocFilters` param.

The duplicated data is left in `tags` in case some other code is using it there.

Fixes [#104835
](https://github.com/grafana/grafana/issues/104835)
