### PR TITLE
SQL Expressions: Move helper comment out of SQL editor into tooltip

### DIFF
--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -1,8 +1,9 @@
+import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef } from 'react';
 
-import { DataSourceApi, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { DataSourceApi, GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { InlineField, Select } from '@grafana/ui';
+import { IconButton, InlineField, Select, useStyles2 } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
 import { Math } from './components/Math';
@@ -19,6 +20,16 @@ const labelWidth = 15;
 
 type NonClassicExpressionType = Exclude<ExpressionQueryType, ExpressionQueryType.classic>;
 type ExpressionTypeConfigStorage = Partial<Record<NonClassicExpressionType, string>>;
+
+// Help text for each expression type - can be expanded with more detailed content
+const getExpressionHelpText = (type: ExpressionQueryType): string => {
+  switch (type) {
+    case ExpressionQueryType.sql:
+      return 'Run MySQL-dialect SQL against the tables returned from your data sources. Data source queries (ie "A", "B") are available as tables and referenced by query-name. Fields are available as columns, as returned from the data source.';
+    default:
+      return '';
+  }
+};
 
 function useExpressionsCache() {
   const expressionCache = useRef<ExpressionTypeConfigStorage>({});
@@ -61,6 +72,7 @@ function useExpressionsCache() {
 export function ExpressionQueryEditor(props: Props) {
   const { query, queries, onRunQuery, onChange, app } = props;
   const { getCachedExpression, setCachedExpression } = useExpressionsCache();
+  const styles = useStyles2(getStyles);
 
   useEffect(() => {
     setCachedExpression(query.type, query.expression);
@@ -101,16 +113,31 @@ export function ExpressionQueryEditor(props: Props) {
   };
 
   const selected = expressionTypes.find((o) => o.value === query.type);
+  const helperText = getExpressionHelpText(query.type);
 
   return (
     <div>
-      <InlineField
-        label={t('expressions.expression-query-editor.label-operation', 'Operation')}
-        labelWidth={labelWidth}
-      >
-        <Select options={expressionTypes} value={selected} onChange={onSelectExpressionType} width={25} />
-      </InlineField>
+      <div className={styles.operationRow}>
+        <InlineField
+          label={t('expressions.expression-query-editor.label-operation', 'Operation')}
+          labelWidth={labelWidth}
+        >
+          <Select options={expressionTypes} value={selected} onChange={onSelectExpressionType} width={25} />
+        </InlineField>
+        {helperText && <IconButton className={styles.infoIcon} name="info-circle" tooltip={helperText} />}
+      </div>
       {renderExpressionType()}
     </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  operationRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  infoIcon: css({
+    marginBottom: theme.spacing(0.5), // Align with the select field
+  }),
+});

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { DataSourceApi, GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
-import { t } from '@grafana/i18n';
-import { IconButton, InlineField, Select, useStyles2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
+import { IconButton, InlineField, PopoverContent, Select, useStyles2 } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
 import { Math } from './components/Math';
@@ -22,10 +22,16 @@ type NonClassicExpressionType = Exclude<ExpressionQueryType, ExpressionQueryType
 type ExpressionTypeConfigStorage = Partial<Record<NonClassicExpressionType, string>>;
 
 // Help text for each expression type - can be expanded with more detailed content
-const getExpressionHelpText = (type: ExpressionQueryType): string => {
+const getExpressionHelpText = (type: ExpressionQueryType): PopoverContent | string => {
   switch (type) {
     case ExpressionQueryType.sql:
-      return 'Run MySQL-dialect SQL against the tables returned from your data sources. Data source queries (ie "A", "B") are available as tables and referenced by query-name. Fields are available as columns, as returned from the data source.';
+      return (
+        <Trans i18nKey="expressions.expression-query-editor.helper-text-sql">
+          Run MySQL-dialect SQL against the tables returned from your data sources. Data source queries (ie "A", "B")
+          are available as tables and referenced by query-name. Fields are available as columns, as returned from the
+          data source.
+        </Trans>
+      );
     default:
       return '';
   }

--- a/public/app/features/expressions/components/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpr.tsx
@@ -30,12 +30,10 @@ interface Props {
 
 export const SqlExpr = ({ onChange, refIds, query, alerting = false }: Props) => {
   const vars = useMemo(() => refIds.map((v) => v.value!), [refIds]);
-  const initialQuery = `-- Run MySQL-dialect SQL against the tables returned from your data sources.
--- Data source queries (ie "${vars[0]}") are available as tables and referenced by query-name
--- Fields are available as columns, as returned from the data source.
-SELECT *
+  const initialQuery = `SELECT *
 FROM ${vars[0]}
 LIMIT 10`;
+
   const styles = useStyles2(getStyles);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ height: 0 });


### PR DESCRIPTION
### What does this PR do? 📓 

It was suggested that the helper text _within_ the SQL editor led to both 1) interaction bugs with the editor, and 2) ends up in most saved SQL queries 😝 . 

This PR moves the helper text into a info icon hover tooltip. It's designed to be reusable across the other expressions as well. 

https://github.com/user-attachments/assets/1f5f6b97-7c59-40d1-9193-ade91d4d803d