### PR TITLE
CI: Remove test upload from backend unit tests

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -101,31 +101,7 @@ jobs:
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
           # This tee requires pipefail to be set, otherwise `go test`'s exit code is thrown away.
           # That means having no `-o pipefail` => failing tests => exit code 0, which is wrong.
-          go test -short -v -timeout=30m "${PACKAGES[@]}" | tee >(go-junit-report -set-exit-code > "$RESULTS_FILE")
-
-      # Upload results to GCS
-      - name: Log in to GCS
-        if: github.repository == 'grafana/grafana' && (success() || failure())
-        uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0
-        with:
-          service_account: github-junit-uploader@grafanalabs-workload-identity.iam.gserviceaccount.com
-          bucket: grafana-test-results
-      - if: github.repository == 'grafana/grafana' && (success() || failure())
-        run: |
-          set -euo pipefail
-          BUCKET_PATH="go-unit-tests/$(echo "${REF_NAME}" | sed 's/\//-/g')"
-          echo "BUCKET_PATH=$BUCKET_PATH" >> "$GITHUB_ENV"
-        env:
-          REF_NAME: ${{ github.ref_name }}
-      - name: Upload test results
-        if: github.repository == 'grafana/grafana' && (success() || failure())
-        uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.2.0
-        with:
-          bucket: grafana-test-results
-          service_account: github-junit-uploader@grafanalabs-workload-identity.iam.gserviceaccount.com
-          environment: "dev" # Can be dev/prod (defaults to dev)
-          path: ${{ env.RESULTS_FILE }}
-          bucket_path: ${{ env.BUCKET_PATH }}
+          go test -short -timeout=30m "${PACKAGES[@]}"
 
   # This is the job that is actually required by rulesets.
   # We need to require EITHER the OSS or the Enterprise job to pass.


### PR DESCRIPTION
We're not using the results atm anyways and trying to parse the output of `go test -v` is really annoying.