### PR TITLE
unistore: index search references

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -103,7 +103,7 @@ type IndexableDocument struct {
 
 	// Maintain a list of resource references.
 	// Someday this will likely be part of https://github.com/grafana/gamma
-	References ResourceReferences `json:"reference,omitempty"`
+	References ResourceReferences `json:"references,omitempty"`
 
 	// When the resource is managed by an upstream repository
 	Manager *utils.ManagerProperties `json:"manager,omitempty"`
@@ -285,7 +285,8 @@ const SEARCH_FIELD_TITLE_NGRAM = "title_ngram"
 const SEARCH_FIELD_TITLE_PHRASE = "title_phrase" // filtering/sorting on title by full phrase
 const SEARCH_FIELD_DESCRIPTION = "description"
 const SEARCH_FIELD_TAGS = "tags"
-const SEARCH_FIELD_LABELS = "labels" // All labels, not a specific one
+const SEARCH_FIELD_LABELS = "labels"         // All labels, not a specific one
+const SEARCH_FIELD_REFERENCES = "references" // List of references to other resources
 
 const SEARCH_FIELD_FOLDER = "folder"
 const SEARCH_FIELD_CREATED = "created"
@@ -399,6 +400,10 @@ func StandardSearchFields() SearchableDocumentFields {
 				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
 				Description: "Type of manager, which is responsible for managing the resource",
 			},
+			// {
+			// 	Name: SEARCH_FIELD_REFERENCES,
+			// 	Type: resourcepb.ResourceTableColumnDefinition_STRING,
+			// },
 			// TODO: below fields only need to be returned from search, but do not need to be searchable
 			{
 				Name: SEARCH_FIELD_MANAGER_ID,

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -105,6 +105,9 @@ type IndexableDocument struct {
 	// Someday this will likely be part of https://github.com/grafana/gamma
 	References ResourceReferences `json:"references,omitempty"`
 
+	// internal sort field for references ( don't set this directly )
+	Reference map[string][]string `json:"reference,omitempty"` // map of kind to list of names
+
 	// When the resource is managed by an upstream repository
 	Manager *utils.ManagerProperties `json:"manager,omitempty"`
 
@@ -120,6 +123,12 @@ func (m *IndexableDocument) UpdateCopyFields() *IndexableDocument {
 	m.TitlePhrase = strings.ToLower(m.Title) // Lowercase for case-insensitive sorting ?? in the analyzer?
 	if m.Manager != nil {
 		m.ManagedBy = fmt.Sprintf("%s:%s", m.Manager.Kind, m.Manager.Identity)
+	}
+
+	m.Reference = make(map[string][]string)
+	for _, ref := range m.References {
+		// Group and Version are ignored for now. This could be revisited.
+		m.Reference[ref.Kind] = append(m.Reference[ref.Kind], ref.Name)
 	}
 	return m
 }
@@ -285,8 +294,7 @@ const SEARCH_FIELD_TITLE_NGRAM = "title_ngram"
 const SEARCH_FIELD_TITLE_PHRASE = "title_phrase" // filtering/sorting on title by full phrase
 const SEARCH_FIELD_DESCRIPTION = "description"
 const SEARCH_FIELD_TAGS = "tags"
-const SEARCH_FIELD_LABELS = "labels"         // All labels, not a specific one
-const SEARCH_FIELD_REFERENCES = "references" // List of references to other resources
+const SEARCH_FIELD_LABELS = "labels" // All labels, not a specific one
 
 const SEARCH_FIELD_FOLDER = "folder"
 const SEARCH_FIELD_CREATED = "created"

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -105,7 +105,7 @@ type IndexableDocument struct {
 	// Someday this will likely be part of https://github.com/grafana/gamma
 	References ResourceReferences `json:"references,omitempty"`
 
-	// internal sort field for references ( don't set this directly )
+	// internal field for mapping references to kind ( don't set this directly )
 	Reference map[string][]string `json:"reference,omitempty"` // map of kind to list of names
 
 	// When the resource is managed by an upstream repository

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -400,10 +400,6 @@ func StandardSearchFields() SearchableDocumentFields {
 				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
 				Description: "Type of manager, which is responsible for managing the resource",
 			},
-			// {
-			// 	Name: SEARCH_FIELD_REFERENCES,
-			// 	Type: resourcepb.ResourceTableColumnDefinition_STRING,
-			// },
 			// TODO: below fields only need to be returned from search, but do not need to be searchable
 			{
 				Name: SEARCH_FIELD_MANAGER_ID,

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -342,7 +342,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 				return fmt.Errorf("missing document")
 			}
 			doc := item.Doc.UpdateCopyFields()
-			doc.References = nil // remove references (for now!)
+			// doc.References = nil // remove references (for now!)
 
 			err := batch.Index(resource.SearchID(doc.Key), doc)
 			if err != nil {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -342,7 +342,6 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 				return fmt.Errorf("missing document")
 			}
 			doc := item.Doc.UpdateCopyFields()
-			// doc.References = nil // remove references (for now!)
 
 			err := batch.Index(resource.SearchID(doc.Key), doc)
 			if err != nil {

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -137,6 +137,49 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		IncludeInAll:       false,
 	})
 
+	referencesMapper := bleve.NewDocumentStaticMapping()
+	referencesMapper.AddFieldMappingsAt("name", &mapping.FieldMapping{
+		Name:               "name",
+		Type:               "text",
+		Analyzer:           keyword.Name,
+		Index:              true,
+		Store:              true,
+		IncludeTermVectors: false,
+		IncludeInAll:       false,
+	})
+
+	referencesMapper.AddFieldMappingsAt("kind", &mapping.FieldMapping{
+		Name:               "kind",
+		Type:               "text",
+		Analyzer:           keyword.Name,
+		Index:              true,
+		Store:              true,
+		IncludeTermVectors: false,
+		IncludeInAll:       false,
+	})
+
+	referencesMapper.AddFieldMappingsAt("relation", &mapping.FieldMapping{
+		Name:               "relation",
+		Type:               "text",
+		Analyzer:           keyword.Name,
+		Index:              true,
+		Store:              true,
+		IncludeTermVectors: false,
+		IncludeInAll:       false,
+	})
+
+	referencesMapper.AddFieldMappingsAt("group", &mapping.FieldMapping{
+		Name:               "group",
+		Type:               "text",
+		Analyzer:           keyword.Name,
+		Index:              true,
+		Store:              true,
+		IncludeTermVectors: false,
+		IncludeInAll:       false,
+	})
+
+	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_REFERENCES, referencesMapper)
+
 	labelMapper := bleve.NewDocumentMapping()
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)
 

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -143,7 +143,7 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		Type:               "text",
 		Analyzer:           keyword.Name,
 		Index:              true,
-		Store:              true,
+		Store:              false,
 		IncludeTermVectors: false,
 		IncludeInAll:       false,
 	})
@@ -153,7 +153,7 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		Type:               "text",
 		Analyzer:           keyword.Name,
 		Index:              true,
-		Store:              true,
+		Store:              false,
 		IncludeTermVectors: false,
 		IncludeInAll:       false,
 	})
@@ -163,7 +163,7 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		Type:               "text",
 		Analyzer:           keyword.Name,
 		Index:              true,
-		Store:              true,
+		Store:              false,
 		IncludeTermVectors: false,
 		IncludeInAll:       false,
 	})
@@ -173,7 +173,7 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		Type:               "text",
 		Analyzer:           keyword.Name,
 		Index:              true,
-		Store:              true,
+		Store:              false,
 		IncludeTermVectors: false,
 		IncludeInAll:       false,
 	})

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -137,48 +137,9 @@ func getBleveDocMappings(_ resource.SearchableDocumentFields) *mapping.DocumentM
 		IncludeInAll:       false,
 	})
 
-	referencesMapper := bleve.NewDocumentStaticMapping()
-	referencesMapper.AddFieldMappingsAt("name", &mapping.FieldMapping{
-		Name:               "name",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Index:              true,
-		Store:              false,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-	})
-
-	referencesMapper.AddFieldMappingsAt("kind", &mapping.FieldMapping{
-		Name:               "kind",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Index:              true,
-		Store:              false,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-	})
-
-	referencesMapper.AddFieldMappingsAt("relation", &mapping.FieldMapping{
-		Name:               "relation",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Index:              true,
-		Store:              false,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-	})
-
-	referencesMapper.AddFieldMappingsAt("group", &mapping.FieldMapping{
-		Name:               "group",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Index:              true,
-		Store:              false,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-	})
-
-	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_REFERENCES, referencesMapper)
+	referenceMapper := bleve.NewDocumentMapping()
+	referenceMapper.DefaultAnalyzer = keyword.Name
+	mapper.AddSubDocumentMapping("reference", referenceMapper)
 
 	labelMapper := bleve.NewDocumentMapping()
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)

--- a/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
@@ -40,7 +40,7 @@
     ],
     "schema_version": 38
   },
-  "reference": [
+  "references": [
     {
       "relation": "depends-on",
       "group": "my-custom-plugin",

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -312,12 +312,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 				},
 				Fields: []*resourcepb.Requirement{
 					{
-						Key:      "references.kind",
-						Operator: "=",
-						Values:   []string{"LibraryPanel"},
-					},
-					{
-						Key:      "references.name",
+						Key:      "reference.LibraryPanel",
 						Operator: "=",
 						Values:   []string{"lib-panel-1"},
 					},
@@ -336,28 +331,5 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 		row := resp.Results.Rows[0]
 		require.Equal(t, "dash1", row.Key.Name)
 		require.Equal(t, "Dashboard with Library Panel 1", string(row.Cells[0])) // title field
-
-		// Search for dashboards with any LibraryPanel reference
-		resp, err = index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
-			Options: &resourcepb.ListOptions{
-				Key: &resourcepb.ResourceKey{
-					Namespace: ns.Namespace,
-					Group:     ns.Group,
-					Resource:  ns.Resource,
-				},
-				Fields: []*resourcepb.Requirement{
-					{
-						Key:      "references.kind",
-						Operator: "=",
-						Values:   []string{"LibraryPanel"},
-					},
-				},
-			},
-			Fields: []string{"title"},
-			Limit:  10,
-		}, nil)
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, int64(2), resp.TotalHits) // Both dash1 and dash2 should have LibraryPanel references
 	})
 }

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -324,7 +324,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 				},
 			},
 			Query:  "",
-			Fields: []string{"title", "references"},
+			Fields: []string{"title"},
 			Limit:  10,
 		}, nil)
 		require.NoError(t, err)
@@ -353,7 +353,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 					},
 				},
 			},
-			Fields: []string{"title", "references"},
+			Fields: []string{"title"},
 			Limit:  10,
 		}, nil)
 		require.NoError(t, err)

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -107,7 +107,7 @@ func runTestSearchBackendTotalDocs(t *testing.T, backend resource.SearchBackend,
 }
 
 func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix string) {
-	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
+	ctx := testutil.NewTestContext(t, time.Now().Add(50*time.Second))
 	ns := resource.NamespacedResource{
 		Namespace: nsPrefix + "-ns1",
 		Group:     "group",
@@ -160,82 +160,82 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
-	// t.Run("Search", func(t *testing.T) {
-	// 	resp, err := index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
-	// 		Options: &resourcepb.ListOptions{
-	// 			Key: &resourcepb.ResourceKey{
-	// 				Namespace: ns.Namespace,
-	// 				Group:     ns.Group,
-	// 				Resource:  ns.Resource,
-	// 			},
-	// 		},
-	// 		Fields: []string{"title", "folder", "tags"},
-	// 		Query:  "tag3",
-	// 		Limit:  10,
-	// 	}, nil)
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, resp)
-	// 	require.Equal(t, int64(1), resp.TotalHits) // Only doc3 should have tag3 now
+	t.Run("Search", func(t *testing.T) {
+		resp, err := index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Fields: []string{"title", "folder", "tags"},
+			Query:  "tag3",
+			Limit:  10,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(1), resp.TotalHits) // Only doc3 should have tag3 now
 
-	// 	// Search for Document
-	// 	resp, err = index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
-	// 		Options: &resourcepb.ListOptions{
-	// 			Key: &resourcepb.ResourceKey{
-	// 				Namespace: ns.Namespace,
-	// 				Group:     ns.Group,
-	// 				Resource:  ns.Resource,
-	// 			},
-	// 		},
-	// 		Query:  "Document",
-	// 		Fields: []string{"title", "folder", "tags"},
-	// 		Limit:  10,
-	// 	}, nil)
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, resp)
-	// 	require.Equal(t, int64(2), resp.TotalHits) // Both doc1 and doc2 should have doc now
-	// })
+		// Search for Document
+		resp, err = index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Query:  "Document",
+			Fields: []string{"title", "folder", "tags"},
+			Limit:  10,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(2), resp.TotalHits) // Both doc1 and doc2 should have doc now
+	})
 
-	// t.Run("Add a new document", func(t *testing.T) {
-	// 	// Add a new document
-	// 	err := index.BulkIndex(&resource.BulkIndexRequest{
-	// 		Items: []*resource.BulkIndexItem{
-	// 			{
-	// 				Action: resource.ActionIndex,
-	// 				Doc: &resource.IndexableDocument{
-	// 					Key: &resourcepb.ResourceKey{
-	// 						Namespace: ns.Namespace,
-	// 						Group:     ns.Group,
-	// 						Resource:  ns.Resource,
-	// 						Name:      "doc3",
-	// 					},
-	// 					Title: "Document 3",
-	// 					Tags:  []string{"tag3", "tag4"},
-	// 					Fields: map[string]interface{}{
-	// 						"field1": 3,
-	// 						"field2": "value3",
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	})
-	// 	require.NoError(t, err)
-	// 	// Search for Document
-	// 	resp, err := index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
-	// 		Options: &resourcepb.ListOptions{
-	// 			Key: &resourcepb.ResourceKey{
-	// 				Namespace: ns.Namespace,
-	// 				Group:     ns.Group,
-	// 				Resource:  ns.Resource,
-	// 			},
-	// 		},
-	// 		Query:  "Document",
-	// 		Fields: []string{"title", "folder", "tags"},
-	// 		Limit:  10,
-	// 	}, nil)
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, resp)
-	// 	require.Equal(t, int64(3), resp.TotalHits) // Both doc1, doc2, and doc3 should have doc now
-	// })
+	t.Run("Add a new document", func(t *testing.T) {
+		// Add a new document
+		err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{
+					Action: resource.ActionIndex,
+					Doc: &resource.IndexableDocument{
+						Key: &resourcepb.ResourceKey{
+							Namespace: ns.Namespace,
+							Group:     ns.Group,
+							Resource:  ns.Resource,
+							Name:      "doc3",
+						},
+						Title: "Document 3",
+						Tags:  []string{"tag3", "tag4"},
+						Fields: map[string]interface{}{
+							"field1": 3,
+							"field2": "value3",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		// Search for Document
+		resp, err := index.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: ns.Namespace,
+					Group:     ns.Group,
+					Resource:  ns.Resource,
+				},
+			},
+			Query:  "Document",
+			Fields: []string{"title", "folder", "tags"},
+			Limit:  10,
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, int64(3), resp.TotalHits) // Both doc1, doc2, and doc3 should have doc now
+	})
 
 	t.Run("Search by LibraryPanel reference", func(t *testing.T) {
 		// Build index with dashboards that have LibraryPanel references


### PR DESCRIPTION
Add support for indexing the "references" in the search document. This is usued to answer the question : "what are the dahsboards using a specific LibraryPanel or a specific Datasource?". 

For now, the references are NOT stored into the index NOR returned in the search response. 