### PR TITLE
Alerting: Return extra alertmanager config as a string for mimirtool

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -605,18 +605,14 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetAlertmanagerConfig(c *
 		return response.Error(http.StatusNotFound, "Alertmanager configuration not found", nil)
 	}
 
-	// Parse the configuration into our Gettable struct which will automatically
-	// sanitize secrets and exclude global settings when marshaled back to YAML.
-	var prometheusConfig amconfig.Config
-	if err := yaml.Unmarshal([]byte(extraCfg.AlertmanagerConfig), &prometheusConfig); err != nil {
+	sanitizedConfig, err := extraCfg.GetSanitizedAlertmanagerConfigYAML()
+	if err != nil {
 		return response.Error(http.StatusBadRequest, "Invalid Alertmanager configuration format", err)
 	}
 
-	respBody := apimodels.GettableAlertmanagerUserConfig{
-		AlertmanagerConfig: apimodels.GettableAlertmanagerConfig{
-			Config: prometheusConfig,
-		},
-		TemplateFiles: extraCfg.TemplateFiles,
+	respBody := apimodels.AlertmanagerUserConfig{
+		AlertmanagerConfig: sanitizedConfig,
+		TemplateFiles:      extraCfg.TemplateFiles,
 	}
 
 	resp := response.YAML(http.StatusOK, respBody)

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -1651,24 +1651,24 @@ receivers:
 
 		require.Equal(t, http.StatusOK, response.Status())
 
-		expectedResponse := `alertmanager_config:
+		expectedResponse := `alertmanager_config: |
   route:
-    receiver: webhook
-    continue: false
+      receiver: webhook
+      continue: false
   receivers:
-    - name: webhook
-      webhook_configs:
-        - url: "<secret>"
-          url_file: ""
-          http_config:
-            authorization:
-              type: "Bearer"
-              credentials: "<secret>"
-            enable_http2: true
-            follow_redirects: true
-          send_resolved: true
-          max_alerts: 0
-          timeout: "0s"
+      - name: webhook
+        webhook_configs:
+          - send_resolved: true
+            http_config:
+              authorization:
+                  type: Bearer
+                  credentials: <secret>
+              follow_redirects: true
+              enable_http2: true
+            url: <secret>
+            url_file: ""
+            max_alerts: 0
+            timeout: 0s
   templates: []
 template_files:
   test.tmpl: '{{ define "test" }}Hello{{ end }}'`

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -742,15 +742,9 @@
      "type": "array"
     },
     "mute_time_intervals": {
-     "description": "Deprecated. Remove before v1.0 release.",
+     "description": "MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.",
      "items": {
       "$ref": "#/definitions/MuteTimeInterval"
-     },
-     "type": "array"
-    },
-    "receivers": {
-     "items": {
-      "$ref": "#/definitions/Receiver"
      },
      "type": "array"
     },
@@ -1443,62 +1437,6 @@
    },
    "title": "Frames is a slice of Frame pointers.",
    "type": "array"
-  },
-  "GettableAlertmanagerConfig": {
-   "properties": {
-    "global": {
-     "$ref": "#/definitions/GlobalConfig"
-    },
-    "inhibit_rules": {
-     "items": {
-      "$ref": "#/definitions/InhibitRule"
-     },
-     "type": "array"
-    },
-    "mute_time_intervals": {
-     "description": "Deprecated. Remove before v1.0 release.",
-     "items": {
-      "$ref": "#/definitions/MuteTimeInterval"
-     },
-     "type": "array"
-    },
-    "receivers": {
-     "items": {
-      "$ref": "#/definitions/Receiver"
-     },
-     "type": "array"
-    },
-    "route": {
-     "$ref": "#/definitions/Route"
-    },
-    "templates": {
-     "items": {
-      "type": "string"
-     },
-     "type": "array"
-    },
-    "time_intervals": {
-     "items": {
-      "$ref": "#/definitions/TimeInterval"
-     },
-     "type": "array"
-    }
-   },
-   "type": "object"
-  },
-  "GettableAlertmanagerUserConfig": {
-   "properties": {
-    "alertmanager_config": {
-     "$ref": "#/definitions/GettableAlertmanagerConfig"
-    },
-    "template_files": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object"
-    }
-   },
-   "type": "object"
   },
   "GettableAlertmanagers": {
    "properties": {

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -1,9 +1,6 @@
 package definitions
 
 import (
-	"encoding/json"
-
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/model"
 )
 
@@ -352,31 +349,4 @@ type AlertmanagerUserConfig struct {
 	// in: body
 	AlertmanagerConfig string            `yaml:"alertmanager_config" json:"alertmanager_config"`
 	TemplateFiles      map[string]string `yaml:"template_files" json:"template_files"`
-}
-
-// GettableAlertmanagerUserConfig is like AlertmanagerUserConfig but uses the normal config structure
-// that automatically sanitizes secrets when marshaled to YAML/JSON.
-
-// swagger:model
-type GettableAlertmanagerUserConfig struct {
-	AlertmanagerConfig GettableAlertmanagerConfig `yaml:"alertmanager_config" json:"alertmanager_config"`
-	TemplateFiles      map[string]string          `yaml:"template_files" json:"template_files"`
-}
-
-type GettableAlertmanagerConfig struct {
-	config.Config `yaml:",inline" json:",inline"`
-}
-
-func (c GettableAlertmanagerConfig) MarshalYAML() (any, error) {
-	type base config.Config
-	cfg := base(c.Config)
-	cfg.Global = nil // not used in Grafana
-	return cfg, nil
-}
-
-func (c GettableAlertmanagerConfig) MarshalJSON() ([]byte, error) {
-	type base config.Config
-	cfg := base(c.Config)
-	cfg.Global = nil // not used in Grafana
-	return json.Marshal(cfg)
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1438,62 +1438,6 @@
    "title": "Frames is a slice of Frame pointers.",
    "type": "array"
   },
-  "GettableAlertmanagerConfig": {
-   "properties": {
-    "global": {
-     "$ref": "#/definitions/GlobalConfig"
-    },
-    "inhibit_rules": {
-     "items": {
-      "$ref": "#/definitions/InhibitRule"
-     },
-     "type": "array"
-    },
-    "mute_time_intervals": {
-     "description": "Deprecated. Remove before v1.0 release.",
-     "items": {
-      "$ref": "#/definitions/MuteTimeInterval"
-     },
-     "type": "array"
-    },
-    "receivers": {
-     "items": {
-      "$ref": "#/definitions/Receiver"
-     },
-     "type": "array"
-    },
-    "route": {
-     "$ref": "#/definitions/Route"
-    },
-    "templates": {
-     "items": {
-      "type": "string"
-     },
-     "type": "array"
-    },
-    "time_intervals": {
-     "items": {
-      "$ref": "#/definitions/TimeInterval"
-     },
-     "type": "array"
-    }
-   },
-   "type": "object"
-  },
-  "GettableAlertmanagerUserConfig": {
-   "properties": {
-    "alertmanager_config": {
-     "$ref": "#/definitions/GettableAlertmanagerConfig"
-    },
-    "template_files": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object"
-    }
-   },
-   "type": "object"
-  },
   "GettableAlertmanagers": {
    "properties": {
     "data": {
@@ -3765,6 +3709,7 @@
    "type": "object"
   },
   "Route": {
+   "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
    "properties": {
     "active_time_intervals": {
      "items": {
@@ -3806,6 +3751,12 @@
      },
      "type": "array"
     },
+    "object_matchers": {
+     "$ref": "#/definitions/ObjectMatchers"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
     "receiver": {
      "type": "string"
     },
@@ -3819,7 +3770,6 @@
      "type": "array"
     }
    },
-   "title": "A Route is a node that contains definitions of how to handle alerts.",
    "type": "object"
   },
   "RouteExport": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5727,62 +5727,6 @@
         "$ref": "#/definitions/Frame"
       }
     },
-    "GettableAlertmanagerConfig": {
-      "type": "object",
-      "properties": {
-        "global": {
-          "$ref": "#/definitions/GlobalConfig"
-        },
-        "inhibit_rules": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/InhibitRule"
-          }
-        },
-        "mute_time_intervals": {
-          "description": "Deprecated. Remove before v1.0 release.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MuteTimeInterval"
-          }
-        },
-        "receivers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Receiver"
-          }
-        },
-        "route": {
-          "$ref": "#/definitions/Route"
-        },
-        "templates": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "time_intervals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TimeInterval"
-          }
-        }
-      }
-    },
-    "GettableAlertmanagerUserConfig": {
-      "type": "object",
-      "properties": {
-        "alertmanager_config": {
-          "$ref": "#/definitions/GettableAlertmanagerConfig"
-        },
-        "template_files": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "GettableAlertmanagers": {
       "type": "object",
       "properties": {
@@ -8055,8 +7999,8 @@
       }
     },
     "Route": {
+      "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
-      "title": "A Route is a node that contains definitions of how to handle alerts.",
       "properties": {
         "active_time_intervals": {
           "type": "array",
@@ -8097,6 +8041,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "object_matchers": {
+          "$ref": "#/definitions/ObjectMatchers"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
         },
         "receiver": {
           "type": "string"

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -86,10 +86,9 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 		require.Contains(t, retrievedConfig.TemplateFiles, "test.tmpl")
 		require.Equal(t, `{{ define "test.template" }}Test template{{ end }}`, retrievedConfig.TemplateFiles["test.tmpl"])
 
-		require.Len(t, retrievedConfig.AlertmanagerConfig.Receivers, 1)
-		require.Equal(t, "webhook", retrievedConfig.AlertmanagerConfig.Receivers[0].Name)
-		require.Len(t, retrievedConfig.AlertmanagerConfig.Receivers[0].WebhookConfigs, 1)
-		require.Equal(t, "", retrievedConfig.AlertmanagerConfig.Receivers[0].WebhookConfigs[0].URL.String())
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "name: webhook")
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "receiver: webhook")
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "webhook_configs:")
 	})
 
 	t.Run("delete alertmanager configuration", func(t *testing.T) {
@@ -245,10 +244,9 @@ receivers:
 		retrievedConfig := apiClient.ConvertPrometheusGetAlertmanagerConfig(t, getHeaders)
 
 		require.NotEmpty(t, retrievedConfig.AlertmanagerConfig)
-		require.Len(t, retrievedConfig.AlertmanagerConfig.Receivers, 1)
-		require.Equal(t, "updated-webhook", retrievedConfig.AlertmanagerConfig.Receivers[0].Name)
-		require.Len(t, retrievedConfig.AlertmanagerConfig.Receivers[0].WebhookConfigs, 1)
-		require.Equal(t, "", retrievedConfig.AlertmanagerConfig.Receivers[0].WebhookConfigs[0].URL.String())
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "name: updated-webhook")
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "receiver: updated-webhook")
+		require.Contains(t, retrievedConfig.AlertmanagerConfig, "webhook_configs:")
 
 		require.Equal(t, `{{ define "updated.template" }}Updated Config{{ end }}`, retrievedConfig.TemplateFiles["updated.tmpl"])
 	})

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1300,7 +1300,7 @@ func (a apiClient) RawConvertPrometheusPostAlertmanagerConfig(t *testing.T, amCf
 	return sendRequestJSON[apimodels.ConvertPrometheusResponse](t, req, http.StatusAccepted)
 }
 
-func (a apiClient) ConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers map[string]string) apimodels.GettableAlertmanagerUserConfig {
+func (a apiClient) ConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers map[string]string) apimodels.AlertmanagerUserConfig {
 	t.Helper()
 
 	config, status, raw := a.RawConvertPrometheusGetAlertmanagerConfig(t, headers)
@@ -1309,7 +1309,7 @@ func (a apiClient) ConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers 
 	return config
 }
 
-func (a apiClient) RawConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers map[string]string) (apimodels.GettableAlertmanagerUserConfig, int, string) {
+func (a apiClient) RawConvertPrometheusGetAlertmanagerConfig(t *testing.T, headers map[string]string) (apimodels.AlertmanagerUserConfig, int, string) {
 	t.Helper()
 
 	path := "%s/api/convert/api/v1/alerts"
@@ -1321,7 +1321,7 @@ func (a apiClient) RawConvertPrometheusGetAlertmanagerConfig(t *testing.T, heade
 		req.Header.Set(key, value)
 	}
 
-	config, status, raw := sendRequestYAML[apimodels.GettableAlertmanagerUserConfig](t, req, http.StatusOK)
+	config, status, raw := sendRequestYAML[apimodels.AlertmanagerUserConfig](t, req, http.StatusOK)
 
 	return config, status, raw
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13895,16 +13895,10 @@
           }
         },
         "mute_time_intervals": {
-          "description": "Deprecated. Remove before v1.0 release.",
+          "description": "MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/MuteTimeInterval"
-          }
-        },
-        "receivers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Receiver"
           }
         },
         "route": {
@@ -15890,62 +15884,6 @@
         },
         "uid": {
           "type": "string"
-        }
-      }
-    },
-    "GettableAlertmanagerConfig": {
-      "type": "object",
-      "properties": {
-        "global": {
-          "$ref": "#/definitions/GlobalConfig"
-        },
-        "inhibit_rules": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/InhibitRule"
-          }
-        },
-        "mute_time_intervals": {
-          "description": "Deprecated. Remove before v1.0 release.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MuteTimeInterval"
-          }
-        },
-        "receivers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Receiver"
-          }
-        },
-        "route": {
-          "$ref": "#/definitions/Route"
-        },
-        "templates": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "time_intervals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TimeInterval"
-          }
-        }
-      }
-    },
-    "GettableAlertmanagerUserConfig": {
-      "type": "object",
-      "properties": {
-        "alertmanager_config": {
-          "$ref": "#/definitions/GettableAlertmanagerConfig"
-        },
-        "template_files": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3944,15 +3944,9 @@
             "type": "array"
           },
           "mute_time_intervals": {
-            "description": "Deprecated. Remove before v1.0 release.",
+            "description": "MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.",
             "items": {
               "$ref": "#/components/schemas/MuteTimeInterval"
-            },
-            "type": "array"
-          },
-          "receivers": {
-            "items": {
-              "$ref": "#/components/schemas/Receiver"
             },
             "type": "array"
           },
@@ -5940,62 +5934,6 @@
           },
           "uid": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "GettableAlertmanagerConfig": {
-        "properties": {
-          "global": {
-            "$ref": "#/components/schemas/GlobalConfig"
-          },
-          "inhibit_rules": {
-            "items": {
-              "$ref": "#/components/schemas/InhibitRule"
-            },
-            "type": "array"
-          },
-          "mute_time_intervals": {
-            "description": "Deprecated. Remove before v1.0 release.",
-            "items": {
-              "$ref": "#/components/schemas/MuteTimeInterval"
-            },
-            "type": "array"
-          },
-          "receivers": {
-            "items": {
-              "$ref": "#/components/schemas/Receiver"
-            },
-            "type": "array"
-          },
-          "route": {
-            "$ref": "#/components/schemas/Route"
-          },
-          "templates": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "time_intervals": {
-            "items": {
-              "$ref": "#/components/schemas/TimeInterval"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "GettableAlertmanagerUserConfig": {
-        "properties": {
-          "alertmanager_config": {
-            "$ref": "#/components/schemas/GettableAlertmanagerConfig"
-          },
-          "template_files": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
           }
         },
         "type": "object"


### PR DESCRIPTION
**What is this feature?**

Go back to returning alertmanager configuration as a string, returning a structured YAML didn't work well with mimirtool: it expects a proper string.

Part of https://github.com/grafana/alerting-squad/issues/1152