### PR TITLE
Chore: Remove migrated e2e tests from drone pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -258,78 +258,6 @@ steps:
   image: alpine:3.21.3
   name: grafana-server
 - commands:
-  - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-dashboards-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/dashboards-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/dashboards-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite smoke-tests-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-smoke-tests-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/smoke-tests-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/smoke-tests-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite panels-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-panels-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/panels-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/panels-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite various-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-various-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/various-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/various-suite
-- commands:
   - GITHUB_TOKEN=$(cat /github-app/token)
   - cd /
   - ./cpp-e2e/scripts/ci-run.sh azure ${DRONE_SOURCE_BRANCH}
@@ -417,8 +345,8 @@ steps:
     - failure
 - commands:
   - export GITHUB_TOKEN=$(cat /github-app/token)
-  - if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'missing videos';
-    false; fi
+  - if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'no e2e videos found
+    from remaining tests'; exit 0; fi
   - apt-get update
   - apt-get install -yq zip
   - printenv GCP_GRAFANA_UPLOAD_ARTIFACTS_KEY > /tmp/gcpkey_upload_artifacts.json
@@ -432,10 +360,8 @@ steps:
     \"description\": \"Click on the details to download e2e recording videos\", \"context\":
     \"e2e_artifacts\"}"'
   depends_on:
-  - end-to-end-tests-dashboards-suite
-  - end-to-end-tests-panels-suite
-  - end-to-end-tests-smoke-tests-suite
-  - end-to-end-tests-various-suite
+  - end-to-end-tests-cloud-plugins-suite-azure
+  - playwright-plugin-e2e
   - github-app-generate-token
   environment:
     E2E_TEST_ARTIFACTS_BUCKET: releng-pipeline-artifacts-dev
@@ -803,78 +729,6 @@ steps:
   image: alpine:3.21.3
   name: grafana-server
 - commands:
-  - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-dashboards-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/dashboards-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/dashboards-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite smoke-tests-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-smoke-tests-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/smoke-tests-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/smoke-tests-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite panels-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-panels-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/panels-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/panels-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite various-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-various-suite
-- commands:
-  - ./bin/build e2e-tests --port 3001 --suite old-arch/various-suite
-  depends_on:
-  - grafana-server
-  - build-test-plugins
-  environment:
-    HOST: grafana-server
-  image: cypress/included:14.3.2
-  name: end-to-end-tests-old-arch/various-suite
-- commands:
   - GITHUB_TOKEN=$(cat /github-app/token)
   - cd /
   - ./cpp-e2e/scripts/ci-run.sh azure ${DRONE_SOURCE_BRANCH}
@@ -962,8 +816,8 @@ steps:
     - failure
 - commands:
   - export GITHUB_TOKEN=$(cat /github-app/token)
-  - if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'missing videos';
-    false; fi
+  - if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'no e2e videos found
+    from remaining tests'; exit 0; fi
   - apt-get update
   - apt-get install -yq zip
   - printenv GCP_GRAFANA_UPLOAD_ARTIFACTS_KEY > /tmp/gcpkey_upload_artifacts.json
@@ -977,10 +831,8 @@ steps:
     \"description\": \"Click on the details to download e2e recording videos\", \"context\":
     \"e2e_artifacts\"}"'
   depends_on:
-  - end-to-end-tests-dashboards-suite
-  - end-to-end-tests-panels-suite
-  - end-to-end-tests-smoke-tests-suite
-  - end-to-end-tests-various-suite
+  - end-to-end-tests-cloud-plugins-suite-azure
+  - playwright-plugin-e2e
   - github-app-generate-token
   environment:
     E2E_TEST_ARTIFACTS_BUCKET: releng-pipeline-artifacts-dev
@@ -1027,10 +879,8 @@ steps:
   - ./bin/build store-storybook --deployment canary
   depends_on:
   - build-storybook
-  - end-to-end-tests-dashboards-suite
-  - end-to-end-tests-panels-suite
-  - end-to-end-tests-smoke-tests-suite
-  - end-to-end-tests-various-suite
+  - end-to-end-tests-cloud-plugins-suite-azure
+  - playwright-plugin-e2e
   environment:
     GCP_KEY:
       from_secret: gcp_grafanauploads
@@ -1086,10 +936,8 @@ steps:
   - apk add --update bash git
   - ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'
   depends_on:
-  - end-to-end-tests-dashboards-suite
-  - end-to-end-tests-panels-suite
-  - end-to-end-tests-smoke-tests-suite
-  - end-to-end-tests-various-suite
+  - end-to-end-tests-cloud-plugins-suite-azure
+  - playwright-plugin-e2e
   - build-frontend-packages
   environment:
     NPM_TOKEN:
@@ -3136,6 +2984,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: e6c1b534a4d8744e0290343b9bbb6932b0284cd422f53146fcdbbb2919aa8a20
+hmac: 6dad99efcf9a41b8964e347e66d4e33861d6d08871294ed70033e4b653963dfd
 
 ...

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
         with:
-          version: "0.13.6"
+          version: "8.0.0"
           verb: run
           args: go -C grafana run ./pkg/build/cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir="${PWD}/grafana" > out.txt
       - run: mv "$(cat out.txt)" grafana.tar.gz
@@ -119,7 +119,7 @@ jobs:
       - name: Run E2E tests
         uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
         with:
-          version: "0.13.6"
+          version: "8.0.0"
           verb: run
           args: go run ./pkg/build/e2e --package=grafana.tar.gz
             --suite=${{ matrix.path }}

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
           persist-credentials: false
       - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
         with:
+          version: "0.13.6"
           verb: run
           args: go -C grafana run ./pkg/build/cmd artifacts -a targz:grafana:linux/amd64 --grafana-dir="${PWD}/grafana" > out.txt
       - run: mv "$(cat out.txt)" grafana.tar.gz
@@ -118,6 +119,7 @@ jobs:
       - name: Run E2E tests
         uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e
         with:
+          version: "0.13.6"
           verb: run
           args: go run ./pkg/build/e2e --package=grafana.tar.gz
             --suite=${{ matrix.path }}

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -122,14 +122,8 @@ def build_e2e(trigger, ver_mode):
             publish_docker,
             build_test_plugins_step(),
             grafana_server_step(),
-            e2e_tests_step("dashboards-suite"),
-            e2e_tests_step("old-arch/dashboards-suite"),
-            e2e_tests_step("smoke-tests-suite"),
-            e2e_tests_step("old-arch/smoke-tests-suite"),
-            e2e_tests_step("panels-suite"),
-            e2e_tests_step("old-arch/panels-suite"),
-            e2e_tests_step("various-suite"),
-            e2e_tests_step("old-arch/various-suite"),
+            # Note: Main E2E test suites (dashboards, panels, smoke-tests, various) have been migrated to GitHub Actions
+            # Only keeping tests that are not yet covered by GitHub Actions
             cloud_plugins_e2e_tests_step(
                 "cloud-plugins-suite",
                 cloud = "azure",
@@ -138,7 +132,7 @@ def build_e2e(trigger, ver_mode):
             playwright_e2e_tests_step(),
             playwright_e2e_report_upload(),
             playwright_e2e_report_post_link(),
-            e2e_tests_artifacts(),
+            e2e_tests_artifacts(),  # Collects artifacts from remaining E2E tests
             build_storybook_step(ver_mode = ver_mode),
             test_a11y_frontend_step(ver_mode = ver_mode),
         ],

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -14,7 +14,6 @@ load(
     "compile_build_cmd",
     "download_grabpl_step",
     "e2e_tests_artifacts",
-    "e2e_tests_step",
     "enterprise_downstream_step",
     "frontend_metrics_step",
     "grafana_server_step",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -315,14 +315,16 @@ def store_storybook_step(ver_mode, trigger = None):
     return step
 
 def e2e_tests_artifacts():
+    # Note: This function is kept for backward compatibility but now only handles 
+    # artifacts from the remaining E2E tests that haven't been migrated to GitHub Actions
     return {
         "name": "e2e-tests-artifacts-upload",
         "image": images["cloudsdk"],
         "depends_on": [
-            "end-to-end-tests-dashboards-suite",
-            "end-to-end-tests-panels-suite",
-            "end-to-end-tests-smoke-tests-suite",
-            "end-to-end-tests-various-suite",
+            # Note: Main E2E tests have been migrated to GitHub Actions
+            # Only depend on remaining Drone E2E tests
+            "end-to-end-tests-cloud-plugins-suite-azure",
+            "playwright-plugin-e2e",
             github_app_generate_token_step()["name"],
         ],
         "failure": "ignore",
@@ -338,8 +340,8 @@ def e2e_tests_artifacts():
         },
         "commands": [
             "export GITHUB_TOKEN=$(cat /github-app/token)",
-            # if no videos found do nothing
-            "if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'missing videos'; false; fi",
+            # if no videos found do nothing (may be fewer videos now that main tests are in GitHub Actions)
+            "if [ -z `find ./e2e -type f -name *spec.ts.mp4` ]; then echo 'no e2e videos found from remaining tests'; exit 0; fi",
             "apt-get update",
             "apt-get install -yq zip",
             "printenv GCP_GRAFANA_UPLOAD_ARTIFACTS_KEY > /tmp/gcpkey_upload_artifacts.json",
@@ -970,10 +972,10 @@ def release_canary_npm_packages_step(trigger = None):
     return step
 
 def upload_packages_step(ver_mode, trigger = None, depends_on = [
-    "end-to-end-tests-dashboards-suite",
-    "end-to-end-tests-panels-suite",
-    "end-to-end-tests-smoke-tests-suite",
-    "end-to-end-tests-various-suite",
+    # Note: Main E2E tests have been migrated to GitHub Actions
+    # Updated dependencies to only include remaining Drone E2E tests
+    "end-to-end-tests-cloud-plugins-suite-azure",
+    "playwright-plugin-e2e",
 ]):
     """Upload packages to object storage.
 
@@ -1135,11 +1137,11 @@ def verify_gen_jsonnet_step():
     }
 
 def end_to_end_tests_deps():
+    # Note: Main E2E tests have been migrated to GitHub Actions
+    # Only return dependencies for E2E tests that still run in Drone
     return [
-        "end-to-end-tests-dashboards-suite",
-        "end-to-end-tests-panels-suite",
-        "end-to-end-tests-smoke-tests-suite",
-        "end-to-end-tests-various-suite",
+        "end-to-end-tests-cloud-plugins-suite-azure",
+        "playwright-plugin-e2e",
     ]
 
 def compile_build_cmd():

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -315,7 +315,7 @@ def store_storybook_step(ver_mode, trigger = None):
     return step
 
 def e2e_tests_artifacts():
-    # Note: This function is kept for backward compatibility but now only handles 
+    # Note: This function is kept for backward compatibility but now only handles
     # artifacts from the remaining E2E tests that haven't been migrated to GitHub Actions
     return {
         "name": "e2e-tests-artifacts-upload",
@@ -971,12 +971,15 @@ def release_canary_npm_packages_step(trigger = None):
 
     return step
 
-def upload_packages_step(ver_mode, trigger = None, depends_on = [
-    # Note: Main E2E tests have been migrated to GitHub Actions
-    # Updated dependencies to only include remaining Drone E2E tests
-    "end-to-end-tests-cloud-plugins-suite-azure",
-    "playwright-plugin-e2e",
-]):
+def upload_packages_step(
+        ver_mode,
+        trigger = None,
+        depends_on = [
+            # Note: Main E2E tests have been migrated to GitHub Actions
+            # Updated dependencies to only include remaining Drone E2E tests
+            "end-to-end-tests-cloud-plugins-suite-azure",
+            "playwright-plugin-e2e",
+        ]):
     """Upload packages to object storage.
 
     Args:


### PR DESCRIPTION
This PR completes the migration of core E2E test suites from Drone CI to GitHub Actions. The main E2E test suites (dashboards-suite, panels-suite, smoke-tests-suite, various-suite, and their old-arch variants) have been fully migrated to GitHub Actions via the existing `pr-e2e-tests.yml` workflow, so this PR removes the corresponding 8 test steps from the Drone pipeline in `scripts/drone/pipelines/build.star`.

The change also updates all related dependencies and artifact collection logic to reference only the remaining E2E tests that haven't been migrated yet (cloud plugins and playwright tests). Also, the Enterprise downstream trigger mechanism is preserved - the `main-build-e2e-publish` pipeline continues to exist and trigger Enterprise repo builds after completion.