### PR TITLE
Table: Fix cell border visibility (#101759, #103564)

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -351,7 +351,9 @@ export const RowsList = (props: RowsListProps) => {
               rowStyled={rowBg !== undefined}
               rowExpanded={rowExpanded}
               textWrapped={textWrapFinal !== undefined}
-              height={Number(style.height)}
+              // VariableSizeList overrides calculated in buildCellContainerStyle height of the cell,
+              // so we need to subtract 1 to respect the row border
+              height={Number(style.height) - 1}
               getActions={getActions}
               replaceVariables={replaceVariables}
               setInspectCell={setInspectCell}


### PR DESCRIPTION
**What is this feature?**

It is a backport of a fix for #101759 from v12 to v11.6.x, as it seems that it was overlooked by developers.

**Why do we need this feature?**

The issue was introduced in v11.1.0 - and it would be better to have the fix in the latest v11.

**Who is this feature for?**

For those who rely on older dashboard JSON representation that has been changed in v12.

**Which issue(s) does this PR fix?**:

Fixes #101759, #103564
