### PR TITLE
Plugin Loader: Wait for plugins to register their extensions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2671,6 +2671,11 @@ exports[`better eslint`] = {
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
+    "public/app/features/plugins/pluginPreloader.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
     "public/app/features/plugins/sandbox/distortion_map.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2671,11 +2671,6 @@ exports[`better eslint`] = {
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
-    "public/app/features/plugins/pluginPreloader.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/features/plugins/sandbox/distortion_map.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/plugins/pluginPreloader.test.ts
+++ b/public/app/features/plugins/pluginPreloader.test.ts
@@ -1,0 +1,194 @@
+import {
+  PluginLoadingStrategy,
+  PluginType,
+  type PluginMeta,
+  type PluginMetaInfo,
+  type AngularMeta,
+  type PluginDependencies,
+  type PluginExtensions,
+} from '@grafana/data';
+import type { AppPluginConfig } from '@grafana/runtime';
+import { getPluginSettings } from 'app/features/plugins/pluginSettings';
+
+import { preloadPlugins } from './pluginPreloader';
+import { importAppPlugin } from './plugin_loader';
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: {
+      orgRole: 'Admin',
+    },
+  },
+}));
+
+jest.mock('app/features/plugins/pluginSettings', () => ({
+  getPluginSettings: jest.fn(),
+}));
+
+jest.mock('./plugin_loader', () => ({
+  importAppPlugin: jest.fn(),
+}));
+
+const mockGetPluginSettings = jest.mocked(getPluginSettings);
+const mockImportAppPlugin = jest.mocked(importAppPlugin);
+
+const createMockAppPluginConfig = (overrides: Partial<AppPluginConfig> = {}): AppPluginConfig => ({
+  id: 'test-plugin',
+  path: '/path/to/plugin',
+  version: '1.0.0',
+  preload: true,
+  angular: { detected: false, hideDeprecation: false } as AngularMeta,
+  loadingStrategy: PluginLoadingStrategy.fetch,
+  dependencies: {
+    grafanaVersion: '*',
+    plugins: [],
+    extensions: { exposedComponents: [] },
+  } as PluginDependencies,
+  extensions: {
+    addedComponents: [],
+    addedLinks: [],
+    addedFunctions: [],
+    exposedComponents: [],
+    extensionPoints: [],
+  } as PluginExtensions,
+  ...overrides,
+});
+
+const createMockPluginMeta = (overrides: Partial<PluginMeta> = {}): PluginMeta => ({
+  id: 'test-plugin',
+  name: 'Test Plugin',
+  type: PluginType.app,
+  info: {
+    author: {
+      name: 'Test Author',
+      url: 'https://example.com',
+    },
+    description: 'Test plugin description',
+    links: [],
+    logos: {
+      small: 'small-logo.png',
+      large: 'large-logo.png',
+    },
+    screenshots: [],
+    updated: '2023-01-01',
+    version: '1.0.0',
+  } as PluginMetaInfo,
+  module: 'module.js',
+  baseUrl: 'base-url',
+  ...overrides,
+});
+
+describe('pluginPreloader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  describe('preloadPlugins', () => {
+    it('should return early when no apps are provided', async () => {
+      await preloadPlugins([]);
+
+      expect(mockGetPluginSettings).not.toHaveBeenCalled();
+      expect(mockImportAppPlugin).not.toHaveBeenCalled();
+    });
+
+    it('should return early when empty array is provided', async () => {
+      await preloadPlugins();
+
+      expect(mockGetPluginSettings).not.toHaveBeenCalled();
+      expect(mockImportAppPlugin).not.toHaveBeenCalled();
+    });
+
+    it('should preload a single plugin successfully', async () => {
+      const appConfig = createMockAppPluginConfig({
+        id: 'test-plugin',
+        path: '/path/to/plugin',
+        version: '1.0.0',
+      });
+
+      const mockPluginMeta = createMockPluginMeta({
+        id: 'test-plugin',
+        name: 'Test Plugin',
+        type: PluginType.app,
+      });
+
+      mockGetPluginSettings.mockResolvedValue(mockPluginMeta);
+      mockImportAppPlugin.mockResolvedValue({} as any);
+
+      await preloadPlugins([appConfig]);
+
+      expect(mockGetPluginSettings).toHaveBeenCalledWith('test-plugin', {
+        showErrorAlert: true,
+      });
+      expect(mockImportAppPlugin).toHaveBeenCalledWith(mockPluginMeta);
+    });
+
+    it('should preload multiple plugins successfully', async () => {
+      const appConfigs = [
+        createMockAppPluginConfig({
+          id: 'plugin-1',
+          path: '/path/to/plugin1',
+          version: '1.0.0',
+        }),
+        createMockAppPluginConfig({
+          id: 'plugin-2',
+          path: '/path/to/plugin2',
+          version: '2.0.0',
+        }),
+      ];
+
+      const mockPluginMeta1 = createMockPluginMeta({
+        id: 'plugin-1',
+        name: 'Plugin 1',
+        type: PluginType.app,
+      });
+
+      const mockPluginMeta2 = createMockPluginMeta({
+        id: 'plugin-2',
+        name: 'Plugin 2',
+        type: PluginType.app,
+      });
+
+      mockGetPluginSettings.mockResolvedValueOnce(mockPluginMeta1).mockResolvedValueOnce(mockPluginMeta2);
+      mockImportAppPlugin.mockResolvedValue({} as any);
+
+      await preloadPlugins(appConfigs);
+
+      expect(mockGetPluginSettings).toHaveBeenCalledTimes(2);
+      expect(mockGetPluginSettings).toHaveBeenNthCalledWith(1, 'plugin-1', {
+        showErrorAlert: true,
+      });
+      expect(mockGetPluginSettings).toHaveBeenNthCalledWith(2, 'plugin-2', {
+        showErrorAlert: true,
+      });
+      expect(mockImportAppPlugin).toHaveBeenCalledTimes(2);
+      expect(mockImportAppPlugin).toHaveBeenNthCalledWith(1, mockPluginMeta1);
+      expect(mockImportAppPlugin).toHaveBeenNthCalledWith(2, mockPluginMeta2);
+    });
+
+    it('should not preload already preloaded plugins', async () => {
+      const appConfigs = [
+        createMockAppPluginConfig({
+          id: 'plugin-1',
+          path: '/path/to/plugin1',
+          version: '1.0.0',
+        }),
+      ];
+
+      const mockPluginMeta = createMockPluginMeta({
+        id: 'plugin-1',
+        name: 'Plugin 1',
+        type: PluginType.app,
+      });
+
+      mockGetPluginSettings.mockResolvedValue(mockPluginMeta);
+      mockImportAppPlugin.mockResolvedValue({} as any);
+
+      await preloadPlugins(appConfigs);
+      await preloadPlugins(appConfigs);
+
+      expect(mockGetPluginSettings).toHaveBeenCalledTimes(1);
+      expect(mockImportAppPlugin).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -19,7 +19,6 @@ export type PluginPreloadResult = {
 
 const preloadedAppPlugins = new Set<string>();
 const isNotYetPreloaded = ({ id }: AppPluginConfig) => !preloadedAppPlugins.has(id);
-const markAsPreloaded = (apps: AppPluginConfig[]) => apps.forEach(({ id }) => preloadedAppPlugins.add(id));
 
 export async function preloadPlugins(apps: AppPluginConfig[] = []) {
   const appPluginsToPreload = apps.filter(isNotYetPreloaded);
@@ -29,8 +28,6 @@ export async function preloadPlugins(apps: AppPluginConfig[] = []) {
   }
 
   await Promise.all(appPluginsToPreload.map(preload));
-
-  markAsPreloaded(apps);
 }
 
 async function preload(config: AppPluginConfig) {
@@ -40,6 +37,8 @@ async function preload(config: AppPluginConfig) {
     });
 
     await importAppPlugin(meta);
+
+    preloadedAppPlugins.add(config.id);
   } catch (error) {
     console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
   }

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -28,9 +28,9 @@ export async function preloadPlugins(apps: AppPluginConfig[] = []) {
     return;
   }
 
-  markAsPreloaded(apps);
-
   await Promise.all(appPluginsToPreload.map(preload));
+
+  markAsPreloaded(apps);
 }
 
 async function preload(config: AppPluginConfig) {


### PR DESCRIPTION
[Related Slack discussion](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750239676766609)

**What is this feature?**

This PR fixes some race-conditions that happen during loading plugins.

**Why do we need this feature?**

In some cases - if the plugin preloading was called multiple times before the initial request was resolved - the extensions hooks tell the call-site that the loading has finished, however the extensions are not in the registry yet.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
