### PR TITLE
Plugin Extensions: Await extension registration when loading plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -213,19 +213,19 @@ export async function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
   plugin.meta = meta;
   plugin.setComponentsFromLegacyExports(pluginExports);
 
-  exposedComponentsRegistry.register({
+  await exposedComponentsRegistry.register({
     pluginId,
     configs: plugin.exposedComponentConfigs || [],
   });
-  addedComponentsRegistry.register({
+  await addedComponentsRegistry.register({
     pluginId,
     configs: plugin.addedComponentConfigs || [],
   });
-  addedLinksRegistry.register({
+  await addedLinksRegistry.register({
     pluginId,
     configs: plugin.addedLinkConfigs || [],
   });
-  addedFunctionsRegistry.register({
+  await addedFunctionsRegistry.register({
     pluginId,
     configs: plugin.addedFunctionConfigs || [],
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It is adding an update to the extensions registry, so the `.register()` can be awaited (to make sure that the extension has been "processed" by the registry), and awaits the registrations when loading a plugin.

**Why do we need this feature?**

There _might be_ cases when the loading finishes before the registry would actually process new extensions, which could result in discrepancies (e.g. the callsite receives `isLoading=false`, thinks that the relevant extensions are now available, but they are actually not).

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
