### PR TITLE
Loki: Remove lokiSendDashboardPanelNames toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -661,10 +661,6 @@ export interface FeatureToggles {
   */
   tableNextGen?: boolean;
   /**
-  * Send dashboard and panel names to Loki when querying
-  */
-  lokiSendDashboardPanelNames?: boolean;
-  /**
   * Uses Prometheus rules as the primary source of truth for ruler-enabled data sources
   */
   alertingPrometheusRulesPrimary?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1131,12 +1131,6 @@ var (
 			FrontendOnly: true,
 		},
 		{
-			Name:        "lokiSendDashboardPanelNames",
-			Description: "Send dashboard and panel names to Loki when querying",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaObservabilityLogsSquad,
-		},
-		{
 			Name:         "alertingPrometheusRulesPrimary",
 			Description:  "Uses Prometheus rules as the primary source of truth for ruler-enabled data sources",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -146,7 +146,6 @@ alertingFilterV2,experimental,@grafana/alerting-squad,false,false,false
 dataplaneAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 newFiltersUI,GA,@grafana/dashboards-squad,false,false,false
 tableNextGen,preview,@grafana/dataviz-squad,false,false,true
-lokiSendDashboardPanelNames,experimental,@grafana/observability-logs,false,false,false
 alertingPrometheusRulesPrimary,experimental,@grafana/alerting-squad,false,false,true
 exploreLogsShardSplitting,experimental,@grafana/observability-logs,false,false,true
 exploreLogsAggregatedMetrics,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -595,10 +595,6 @@ const (
 	// Allows access to the new react-data-grid based table component.
 	FlagTableNextGen = "tableNextGen"
 
-	// FlagLokiSendDashboardPanelNames
-	// Send dashboard and panel names to Loki when querying
-	FlagLokiSendDashboardPanelNames = "lokiSendDashboardPanelNames"
-
 	// FlagAlertingPrometheusRulesPrimary
 	// Uses Prometheus rules as the primary source of truth for ruler-enabled data sources
 	FlagAlertingPrometheusRulesPrimary = "alertingPrometheusRulesPrimary"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2127,7 +2127,8 @@
       "metadata": {
         "name": "lokiSendDashboardPanelNames",
         "resourceVersion": "1743693517832",
-        "creationTimestamp": "2024-08-22T19:30:43Z"
+        "creationTimestamp": "2024-08-22T19:30:43Z",
+        "deletionTimestamp": "2025-06-19T13:40:02Z"
       },
       "spec": {
         "description": "Send dashboard and panel names to Loki when querying",

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
@@ -29,8 +28,7 @@ func TestIntegrationLoki(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
-		DisableAnonymous:     true,
-		EnableFeatureToggles: []string{featuremgmt.FlagLokiSendDashboardPanelNames},
+		DisableAnonymous: true,
 	})
 
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -27,13 +27,12 @@ import (
 )
 
 const (
-	flagLokiLogsDataplane           = "lokiLogsDataplane"
-	flagLokiSendDashboardPanelNames = "lokiSendDashboardPanelNames"
-	flagLokiRunQueriesInParallel    = "lokiRunQueriesInParallel"
-	flagLokiStructuredMetadata      = "lokiStructuredMetadata"
-	flagLogQLScope                  = "logQLScope"
-	flagLokiExperimentalStreaming   = "lokiExperimentalStreaming"
-	fromAlertHeaderName             = "FromAlert"
+	flagLokiLogsDataplane         = "lokiLogsDataplane"
+	flagLokiRunQueriesInParallel  = "lokiRunQueriesInParallel"
+	flagLokiStructuredMetadata    = "lokiStructuredMetadata"
+	flagLogQLScope                = "logQLScope"
+	flagLokiExperimentalStreaming = "lokiExperimentalStreaming"
+	fromAlertHeaderName           = "FromAlert"
 )
 
 type Service struct {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1811,7 +1811,6 @@ describe('LokiDatasource', () => {
   });
 
   describe('query', () => {
-    let featureToggleVal = config.featureToggles.lokiSendDashboardPanelNames;
     beforeEach(() => {
       setDashboardSrv({
         getCurrent: () => ({
@@ -1821,10 +1820,6 @@ describe('LokiDatasource', () => {
       } as unknown as DashboardSrv);
       const fetchMock = jest.fn().mockReturnValue(of({ data: testLogsResponse }));
       setBackendSrv({ ...origBackendSrv, fetch: fetchMock });
-      config.featureToggles.lokiSendDashboardPanelNames = true;
-    });
-    afterEach(() => {
-      config.featureToggles.lokiSendDashboardPanelNames = featureToggleVal;
     });
 
     it('adds dashboard headers', async () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -297,9 +297,6 @@ export class LokiDatasource
 
   private getQueryHeaders(request: DataQueryRequest<LokiQuery>): Record<string, string> {
     const headers: Record<string, string> = {};
-    if (!config.featureToggles.lokiSendDashboardPanelNames) {
-      return headers;
-    }
     // only add headers if we are in the context of a dashboard
     if (
       [CoreApp.Dashboard.toString(), CoreApp.PanelEditor.toString(), CoreApp.PanelViewer.toString()].includes(


### PR DESCRIPTION
Next part of https://github.com/grafana/grafana/pull/106829
Part of https://github.com/grafana/grafana/issues/106466

This PR removes `lokiSendDashboardPanelNames` feature toggle as it was enabled by default and we want to be sending those headers - more info in [here](https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go#L36) so they are passed to Loki.