### PR TITLE
Alerting: Send merged configuration to the remote alertmanager

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -1051,21 +1051,9 @@ func (c *GettableApiAlertingConfig) UnmarshalYAML(value *yaml.Node) error {
 func (c *GettableApiAlertingConfig) validate() error {
 	receivers := make(map[string]struct{}, len(c.Receivers))
 
-	var hasGrafReceivers, hasAMReceivers bool
-	for _, r := range c.Receivers {
-		receivers[r.Name] = struct{}{}
-		switch r.Type() {
-		case GrafanaReceiverType:
-			hasGrafReceivers = true
-		case AlertmanagerReceiverType:
-			hasAMReceivers = true
-		default:
-			continue
-		}
-	}
-
-	if hasGrafReceivers && hasAMReceivers {
-		return fmt.Errorf("cannot mix Alertmanager & Grafana receiver types")
+	// Populate the receivers map with defined receiver names
+	for _, receiver := range c.Receivers {
+		receivers[receiver.Name] = struct{}{}
 	}
 
 	for _, receiver := range AllReceivers(c.Route.AsAMRoute()) {

--- a/pkg/services/ngalert/notifier/crypto.go
+++ b/pkg/services/ngalert/notifier/crypto.go
@@ -256,9 +256,11 @@ func (c *alertmanagerCrypto) EncryptExtraConfigs(ctx context.Context, config *de
 
 func (c *alertmanagerCrypto) DecryptExtraConfigs(ctx context.Context, config *definitions.PostableUserConfig) error {
 	for i := range config.ExtraConfigs {
+		// Check if the config is encrypted by trying to base64 decode it
 		encryptedValue, err := base64.StdEncoding.DecodeString(config.ExtraConfigs[i].AlertmanagerConfig)
 		if err != nil {
-			return fmt.Errorf("failed to base64 decode extra configuration: %w", err)
+			// If it can't be base64 decoded, assume it's already decrypted and skip
+			continue
 		}
 
 		decryptedValue, err := c.secrets.Decrypt(ctx, encryptedValue)

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -11,12 +11,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -559,6 +562,198 @@ func Test_isDefaultConfiguration(t *testing.T) {
 			require.Equal(tt, test.expected, am.isDefaultConfiguration(md5.Sum(raw)))
 		})
 	}
+}
+
+func TestApplyConfigWithExtraConfigs(t *testing.T) {
+	const tenantID = "test"
+
+	var configSent client.UserGrafanaConfig
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
+		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
+
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/config") {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&configSent))
+		}
+
+		w.Header().Add("content-type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"status": "success"}))
+	}))
+	defer server.Close()
+
+	var cfg apimodels.PostableUserConfig
+	require.NoError(t, json.Unmarshal([]byte(testGrafanaConfig), &cfg))
+
+	cfg.ExtraConfigs = []apimodels.ExtraConfiguration{
+		{
+			Identifier: "test-external",
+			MergeMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchEqual,
+					Name:  "test",
+					Value: "value",
+				},
+			},
+			TemplateFiles: map[string]string{},
+			AlertmanagerConfig: `global:
+  smtp_smarthost: localhost:587
+  smtp_from: alerts@grafana.com
+route:
+  receiver: extra-receiver
+receivers:
+  - name: extra-receiver
+    email_configs:
+      - to: alerts@grafana.com`,
+		},
+	}
+
+	secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(db.InitTestDB(t)))
+	tc := notifier.NewCrypto(secretsService, nil, log.NewNopLogger())
+	ctx := context.Background()
+
+	c := AlertmanagerConfig{
+		OrgID:         1,
+		TenantID:      tenantID,
+		URL:           server.URL,
+		DefaultConfig: defaultGrafanaConfig,
+		PromoteConfig: true,
+	}
+
+	store := ngfakes.NewFakeKVStore(t)
+	fstore := notifier.NewFileStore(1, store)
+	require.NoError(t, store.Set(ctx, c.OrgID, "alertmanager", notifier.SilencesFilename, ""))
+	require.NoError(t, store.Set(ctx, c.OrgID, "alertmanager", notifier.NotificationLogFilename, ""))
+
+	m := metrics.NewRemoteAlertmanagerMetrics(prometheus.NewRegistry())
+	am, err := NewAlertmanager(ctx, c, fstore, tc, NoopAutogenFn, m, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+
+	err = am.SaveAndApplyConfig(ctx, &cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, len(configSent.GrafanaAlertmanagerConfig.AlertmanagerConfig.Receivers), 2)
+
+	var extraReceiver *apimodels.PostableApiReceiver
+	for _, rcv := range configSent.GrafanaAlertmanagerConfig.AlertmanagerConfig.Receivers {
+		if rcv.Name == "extra-receiver" {
+			extraReceiver = rcv
+			break
+		}
+	}
+	require.NotNil(t, extraReceiver)
+	require.Len(t, extraReceiver.EmailConfigs, 1)
+	require.Equal(t, "alerts@grafana.com", extraReceiver.EmailConfigs[0].To)
+}
+
+func TestCompareAndSendConfigurationWithExtraConfigs(t *testing.T) {
+	const tenantID = "test"
+
+	var configSent client.UserGrafanaConfig
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
+		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
+
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/config") {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&configSent))
+		} else if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/config") {
+			// If this is a GET method, Grafana requests the current configuration to compare.
+			// Return an empty config to ensure it gets replaced
+			w.Header().Add("content-type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(client.UserGrafanaConfig{
+				GrafanaAlertmanagerConfig: &apimodels.PostableUserConfig{},
+			}))
+			return
+		}
+
+		w.Header().Add("content-type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"status": "success"}))
+	}))
+	defer server.Close()
+
+	cfg := apimodels.PostableUserConfig{
+		AlertmanagerConfig: apimodels.PostableApiAlertingConfig{
+			Config: apimodels.Config{
+				Route: &apimodels.Route{
+					Receiver: "grafana-default-email",
+				},
+			},
+			Receivers: []*apimodels.PostableApiReceiver{
+				{
+					Receiver: config.Receiver{Name: "grafana-default-email"},
+					PostableGrafanaReceivers: apimodels.PostableGrafanaReceivers{
+						GrafanaManagedReceivers: []*apimodels.PostableGrafanaReceiver{
+							{
+								Name:     "email receiver",
+								Type:     "email",
+								Settings: apimodels.RawMessage(`{"addresses":"<example@email.com>"}`),
+							},
+						},
+					},
+				},
+			},
+		},
+		ExtraConfigs: []apimodels.ExtraConfiguration{
+			{
+				Identifier: "test-external",
+				MergeMatchers: []*labels.Matcher{
+					{
+						Type:  labels.MatchEqual,
+						Name:  "test",
+						Value: "test",
+					},
+				},
+				AlertmanagerConfig: `global:
+  smtp_smarthost: localhost:587
+  smtp_from: alerts@grafana.com
+route:
+  receiver: extra-receiver
+receivers:
+  - name: extra-receiver
+    email_configs:
+      - to: alerts@grafana.com`,
+			},
+		},
+	}
+
+	secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(db.InitTestDB(t)))
+	tc := notifier.NewCrypto(secretsService, nil, log.NewNopLogger())
+	ctx := context.Background()
+
+	// Encrypt extra configs since this tests the database path
+	err := tc.EncryptExtraConfigs(ctx, &cfg)
+	require.NoError(t, err)
+
+	c := AlertmanagerConfig{
+		OrgID:         1,
+		TenantID:      tenantID,
+		URL:           server.URL,
+		DefaultConfig: defaultGrafanaConfig,
+		PromoteConfig: true,
+	}
+
+	store := ngfakes.NewFakeKVStore(t)
+	fstore := notifier.NewFileStore(1, store)
+	require.NoError(t, store.Set(ctx, c.OrgID, "alertmanager", notifier.SilencesFilename, ""))
+	require.NoError(t, store.Set(ctx, c.OrgID, "alertmanager", notifier.NotificationLogFilename, ""))
+
+	m := metrics.NewRemoteAlertmanagerMetrics(prometheus.NewRegistry())
+	am, err := NewAlertmanager(ctx, c, fstore, tc, NoopAutogenFn, m, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+
+	configJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	config := &ngmodels.AlertConfiguration{
+		AlertmanagerConfiguration: string(configJSON),
+	}
+
+	err = am.CompareAndSendConfiguration(ctx, config)
+	require.NoError(t, err)
+
+	require.Equal(t, len(configSent.GrafanaAlertmanagerConfig.AlertmanagerConfig.Receivers), 2)
+	found := slices.ContainsFunc(configSent.GrafanaAlertmanagerConfig.AlertmanagerConfig.Receivers, func(rcv *apimodels.PostableApiReceiver) bool {
+		return strings.Contains(rcv.Name, "extra-receiver")
+	})
+	require.True(t, found)
 }
 
 func TestIntegrationRemoteAlertmanagerConfiguration(t *testing.T) {

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -3,10 +3,10 @@ package client
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/grafana/alerting/definition"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
 
@@ -53,7 +53,7 @@ func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafana
 }
 
 func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, cfg *apimodels.PostableUserConfig, hash string, createdAt int64, isDefault bool) error {
-	payload, err := json.Marshal(&UserGrafanaConfig{
+	payload, err := definition.MarshalJSONWithSecrets(&UserGrafanaConfig{
 		GrafanaAlertmanagerConfig: cfg,
 		Hash:                      hash,
 		CreatedAt:                 createdAt,

--- a/pkg/tests/alertmanager/alertmanager_scenario.go
+++ b/pkg/tests/alertmanager/alertmanager_scenario.go
@@ -43,6 +43,7 @@ type AlertmanagerScenario struct {
 	Webhook  *WebhookService
 	Postgres *PostgresService
 	Loki     *LokiService
+	Mimir    *MimirService
 }
 
 func NewAlertmanagerScenario() (*AlertmanagerScenario, error) {
@@ -380,4 +381,11 @@ func mapInstancePeers(is []string) map[string][]string {
 	}
 
 	return mIs
+}
+
+func (s *AlertmanagerScenario) NewMimirClient(tenantID string) (*MimirClient, error) {
+	if s.Mimir == nil {
+		return nil, fmt.Errorf("mimir service not started")
+	}
+	return NewMimirClient("http://"+s.Mimir.HTTPEndpoint(), tenantID)
 }

--- a/pkg/tests/alertmanager/alertmanager_scenario.go
+++ b/pkg/tests/alertmanager/alertmanager_scenario.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/e2e"
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana/pkg/services/ngalert/remote/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -383,7 +384,7 @@ func mapInstancePeers(is []string) map[string][]string {
 	return mIs
 }
 
-func (s *AlertmanagerScenario) NewMimirClient(tenantID string) (*MimirClient, error) {
+func (s *AlertmanagerScenario) NewMimirClient(tenantID string) (client.MimirClient, error) {
 	if s.Mimir == nil {
 		return nil, fmt.Errorf("mimir service not started")
 	}

--- a/pkg/tests/alertmanager/mimir.go
+++ b/pkg/tests/alertmanager/mimir.go
@@ -1,0 +1,133 @@
+package alertmanager
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/grafana/e2e"
+)
+
+const (
+	mimirImage = "grafana/mimir:r348-017076d8"
+
+	mimirBinary   = "/bin/mimir"
+	mimirHTTPPort = 8080
+)
+
+type MimirService struct {
+	*e2e.HTTPService
+}
+
+func NewMimirService(name string) *MimirService {
+	flags := map[string]string{
+		"-target":                                                  "alertmanager",
+		"-server.http-listen-port":                                 "8080",
+		"-server.grpc-listen-port":                                 "9095",
+		"-alertmanager.web.external-url":                           "http://localhost:8080/alertmanager",
+		"-alertmanager-storage.backend":                            "filesystem",
+		"-alertmanager-storage.filesystem.dir":                     "/tmp/mimir/alertmanager",
+		"-alertmanager.grafana-alertmanager-compatibility-enabled": "true",
+	}
+
+	return &MimirService{
+		HTTPService: e2e.NewHTTPService(
+			name,
+			mimirImage,
+			e2e.NewCommandWithoutEntrypoint(mimirBinary, e2e.BuildArgs(flags)...),
+			e2e.NewHTTPReadinessProbe(mimirHTTPPort, "/ready", 200, 299),
+			mimirHTTPPort,
+		),
+	}
+}
+
+type MimirClient struct {
+	*http.Client
+	baseURL  *url.URL
+	tenantID string
+}
+
+func NewMimirClient(mimirURL, tenantID string) (*MimirClient, error) {
+	pu, err := url.Parse(mimirURL)
+	if err != nil {
+		return nil, err
+	}
+	return &MimirClient{
+		Client:   &http.Client{Timeout: 30 * time.Second},
+		baseURL:  pu,
+		tenantID: tenantID,
+	}, nil
+}
+
+func (mc *MimirClient) GetGrafanaAlertmanagerConfig(ctx context.Context) (map[string]any, error) {
+	u := mc.baseURL.ResolveReference(&url.URL{Path: "/api/v1/grafana/config"})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Scope-OrgID", mc.tenantID)
+
+	resp, err := mc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var cfg map[string]any
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return nil, err
+		}
+		return cfg, nil
+
+	case http.StatusNotFound:
+		return map[string]any{}, nil
+
+	default:
+		return nil, fmt.Errorf("GET %s: %d %s", u, resp.StatusCode, string(body))
+	}
+}
+
+func (mc *MimirClient) SetGrafanaAlertmanagerConfig(ctx context.Context, cfg map[string]any) error {
+	u := mc.baseURL.ResolveReference(&url.URL{Path: "/alertmanager/api/v1/alerts"})
+
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scope-OrgID", mc.tenantID)
+
+	resp, err := mc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+
+	return fmt.Errorf("POST %s: %d %s", u, resp.StatusCode, string(body))
+}

--- a/pkg/tests/api/alerting/api_remote_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_remote_alertmanager_test.go
@@ -1,0 +1,281 @@
+package alerting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/tests/alertmanager"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+)
+
+// TestIntegrationRemoteAlertmanagerConfigUpload tests that when we post an alertmanager
+// configuration to Grafana with remote alertmanager enabled, it gets uploaded to the remote Mimir.
+func TestIntegrationRemoteAlertmanagerConfigUpload(t *testing.T) {
+	testinfra.SQLiteIntegrationTest(t)
+
+	s, err := alertmanager.NewAlertmanagerScenario()
+	require.NoError(t, err)
+	defer s.Close()
+
+	s.Mimir = alertmanager.NewMimirService("mimir")
+	require.NoError(t, s.StartAndWaitReady(s.Mimir))
+
+	mimirEndpoint := "http://" + s.Mimir.HTTPEndpoint()
+
+	dir, gpath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+		EnableFeatureToggles: []string{
+			"alertmanagerRemotePrimary",
+			"alertingImportAlertmanagerAPI",
+		},
+		RemoteAlertmanagerURL: mimirEndpoint,
+	})
+
+	grafanaListedAddr, _ := testinfra.StartGrafanaEnv(t, dir, gpath)
+
+	apiClient := newAlertingApiClient(grafanaListedAddr, "admin", "admin")
+	mimirClient, err := alertmanager.NewMimirClient(mimirEndpoint, "1")
+	require.NoError(t, err)
+
+	// Wait for Grafana to be ready
+	require.Eventually(t, func() bool {
+		_, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		return status == http.StatusOK
+	}, 30*time.Second, time.Second, "Grafana failed to start")
+
+	// Check that the initial Mimir config contains the default Grafana configuration
+	initialMimirConfig, err := mimirClient.GetGrafanaAlertmanagerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, initialMimirConfig) // Grafana automatically syncs default config to remote alertmanager
+
+	// Initially there is just the default grafana-default-email receiver
+	config := initialMimirConfig["data"].(map[string]any)["configuration"].(map[string]any)
+	alertmanagerConfig := config["alertmanager_config"].(map[string]any)
+	receivers := alertmanagerConfig["receivers"].([]any)
+	require.Len(t, receivers, 1)
+	defaultReceiver := receivers[0].(map[string]any)
+	require.Equal(t, "grafana-default-email", defaultReceiver["name"])
+
+	// Now upload a new extra config and check that it gets uploaded to Mimir
+	testAlertmanagerConfigYAML := `
+route:
+  group_by: ['alertname'] 
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: test-webhook
+
+receivers:
+- name: test-webhook
+  webhook_configs:
+  - url: 'http://127.0.0.1:5001/test'
+`
+
+	headers := map[string]string{
+		"Content-Type":                         "application/yaml",
+		"X-Grafana-Alerting-Config-Identifier": "external-system",
+		"X-Grafana-Alerting-Merge-Matchers":    "environment=production,team=backend",
+	}
+
+	amConfig := apimodels.AlertmanagerUserConfig{
+		AlertmanagerConfig: testAlertmanagerConfigYAML,
+		TemplateFiles: map[string]string{
+			"test.tmpl": `{{ define "test.template" }}Test template for remote sync{{ end }}`,
+		},
+	}
+
+	// Post the configuration to Grafana
+	response := apiClient.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+	require.Equal(t, "success", response.Status)
+
+	_, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+	require.Equal(t, http.StatusOK, status)
+
+	// Check that the configuration was successfully sent to Mimir and contains the new receiver
+	finalMimirConfig, err := mimirClient.GetGrafanaAlertmanagerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, finalMimirConfig)
+	cfg := finalMimirConfig["data"].(map[string]any)["configuration"].(map[string]any)
+	receivers = cfg["alertmanager_config"].(map[string]any)["receivers"].([]any)
+
+	require.ElementsMatch(t, receivers, []any{
+		map[string]any{
+			"name": "grafana-default-email",
+			"grafana_managed_receiver_configs": []any{
+				map[string]any{
+					"disableResolveMessage": false,
+					"name":                  "email receiver",
+					"settings": map[string]any{
+						"addresses": "<example@email.com>",
+					},
+					"type": "email",
+					"uid":  "",
+				},
+			},
+		},
+		map[string]any{
+			"name": "test-webhook",
+			"webhook_configs": []any{
+				map[string]any{
+					"http_config": map[string]any{
+						"enable_http2":     true,
+						"follow_redirects": true,
+						"proxy_url":        nil,
+						"tls_config": map[string]any{
+							"insecure_skip_verify": false,
+						},
+					},
+					"max_alerts":    float64(0),
+					"send_resolved": true,
+					"timeout":       float64(0),
+					"url":           "<secret>",
+					"url_file":      "",
+				},
+			},
+		},
+	})
+}
+
+// TestIntegrationRemoteAlertmanagerHistoricalConfigActivation tests that when we activate
+// a historical alertmanager configuration with extra configs, it gets properly decrypted
+// and uploaded to the remote Mimir.
+func TestIntegrationRemoteAlertmanagerHistoricalConfigActivation(t *testing.T) {
+	testinfra.SQLiteIntegrationTest(t)
+
+	s, err := alertmanager.NewAlertmanagerScenario()
+	require.NoError(t, err)
+	defer s.Close()
+
+	s.Mimir = alertmanager.NewMimirService("mimir")
+	require.NoError(t, s.StartAndWaitReady(s.Mimir))
+
+	mimirEndpoint := "http://" + s.Mimir.HTTPEndpoint()
+
+	dir, gpath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+		EnableFeatureToggles: []string{
+			"alertmanagerRemotePrimary",
+			"alertingImportAlertmanagerAPI",
+		},
+		RemoteAlertmanagerURL: mimirEndpoint,
+	})
+
+	grafanaListedAddr, _ := testinfra.StartGrafanaEnv(t, dir, gpath)
+
+	apiClient := newAlertingApiClient(grafanaListedAddr, "admin", "admin")
+	mimirClient, err := alertmanager.NewMimirClient(mimirEndpoint, "1")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		return status == http.StatusOK
+	}, 30*time.Second, time.Second, "Grafana failed to start")
+
+	// Upload configuration with extra configs
+	testAlertmanagerConfigYAML := `
+route:
+  group_by: ['alertname'] 
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: historical-webhook
+
+receivers:
+- name: historical-webhook
+  webhook_configs:
+  - url: 'http://127.0.0.1:5002/historical'
+`
+
+	headers := map[string]string{
+		"Content-Type":                         "application/yaml",
+		"X-Grafana-Alerting-Config-Identifier": "historical-system",
+		"X-Grafana-Alerting-Merge-Matchers":    "environment=test,team=platform",
+	}
+
+	amConfig := apimodels.AlertmanagerUserConfig{
+		AlertmanagerConfig: testAlertmanagerConfigYAML,
+		TemplateFiles: map[string]string{
+			"historical.tmpl": `{{ define "historical.template" }}Historical template{{ end }}`,
+		},
+	}
+
+	response := apiClient.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+	require.Equal(t, "success", response.Status)
+
+	// Get the configuration history to find the most recent config
+	historyResponse := getAlertmanagerConfigHistory(t, apiClient)
+	require.NotEmpty(t, historyResponse)
+
+	var mostRecentID int64
+	for _, entry := range historyResponse {
+		if entry.ID > mostRecentID {
+			mostRecentID = entry.ID
+		}
+	}
+	require.Greater(t, mostRecentID, int64(0), "Should have found a historical configuration")
+
+	// Activate the historical configuration
+	activateHistoricalConfiguration(t, apiClient, mostRecentID)
+
+	// Verify the configuration
+	finalMimirConfig, err := mimirClient.GetGrafanaAlertmanagerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, finalMimirConfig)
+
+	cfg := finalMimirConfig["data"].(map[string]any)["configuration"].(map[string]any)
+	receivers := cfg["alertmanager_config"].(map[string]any)["receivers"].([]any)
+
+	require.Len(t, receivers, 2)
+
+	found := false
+	for _, rcv := range receivers {
+		receiver := rcv.(map[string]any)
+		if receiver["name"] == "historical-webhook" {
+			found = true
+			webhookConfigs := receiver["webhook_configs"].([]any)
+			require.Len(t, webhookConfigs, 1)
+			break
+		}
+	}
+	require.True(t, found)
+}
+
+func getAlertmanagerConfigHistory(t *testing.T, client apiClient) []apimodels.GettableHistoricUserConfig {
+	t.Helper()
+	u, err := url.Parse(fmt.Sprintf("%s/api/alertmanager/grafana/config/history", client.url))
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(t, err)
+
+	history, _, _ := sendRequestJSON[[]apimodels.GettableHistoricUserConfig](t, req, http.StatusOK)
+	return history
+}
+
+func activateHistoricalConfiguration(t *testing.T, client apiClient, configID int64) {
+	t.Helper()
+	u, err := url.Parse(fmt.Sprintf("%s/api/alertmanager/grafana/config/history/%d/_activate", client.url, configID))
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	require.NoError(t, err)
+
+	response, statusCode, body := sendRequestJSON[map[string]string](t, req, http.StatusAccepted)
+	if statusCode != http.StatusAccepted {
+		t.Fatalf("Expected status code %d but got %d. Response body: %s", http.StatusAccepted, statusCode, body)
+	}
+	require.Equal(t, "configuration activated", response["message"])
+}

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -477,6 +477,17 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		_, err = grafanaComSection.NewKey("api_url", opts.GrafanaComAPIURL)
 		require.NoError(t, err)
 	}
+
+	if opts.RemoteAlertmanagerURL != "" {
+		remoteAlertmanagerSection, err := getOrCreateSection("remote.alertmanager")
+		require.NoError(t, err)
+		_, err = remoteAlertmanagerSection.NewKey("enabled", "true")
+		require.NoError(t, err)
+		_, err = remoteAlertmanagerSection.NewKey("url", opts.RemoteAlertmanagerURL)
+		require.NoError(t, err)
+		_, err = remoteAlertmanagerSection.NewKey("tenant", "1")
+		require.NoError(t, err)
+	}
 	if opts.GrafanaComSSOAPIToken != "" {
 		grafanaComSection, err := getOrCreateSection("grafana_com")
 		require.NoError(t, err)
@@ -571,6 +582,9 @@ type GrafanaOpts struct {
 
 	// When "unified-grpc" is selected it will also start the grpc server
 	APIServerStorageType options.StorageType
+
+	// Remote alertmanager configuration
+	RemoteAlertmanagerURL string
 }
 
 func CreateUser(t *testing.T, store db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) *user.User {


### PR DESCRIPTION
**What is this feature?**

This PR adds support for sending merged alertmanager configurations with extra configurations to a remote alertmanager.

- Templates are not supported yet.
- Added a simple integration test that uploads an extra config to Grafana and checks that it's in Mimir.
- When extra configurations are present, comparing old configurations doesn't work properly: secrets aren't being compared yet, so if they change the config is still not reuploaded. This will be fixed later, because additional changes in the Alertmanager are needed.

Part of https://github.com/grafana/alerting-squad/issues/1152

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
