### PR TITLE
Fix all the old usage of admonition syntax

### DIFF
--- a/docs/sources/administration/data-source-management/_index.md
+++ b/docs/sources/administration/data-source-management/_index.md
@@ -31,9 +31,9 @@ You can configure data source permissions to allow or deny certain users the abi
 - The `edit` permission allows users to query the data source, edit the data source’s configuration and delete the data source.
 - The `admin` permission allows users to query and edit the data source, change permissions on the data source and enable or disable query caching for the data source.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 By default, data sources in an organization can be queried by any user in that organization. For example, a user with the `Viewer` role can issue any possible query to a data source, not just queries that exist on dashboards to which they have access. Additionally, by default, data sources can be edited by the user who created the data source, as well as users with the `Admin` role.
 
@@ -82,15 +82,15 @@ When using Grafana, a query pertains to a request for data frames to be modified
 
 The caching feature works for **all** backend data sources. You can enable the cache globally in Grafana's [configuration](../../setup-grafana/configure-grafana/enterprise-configuration/#caching), and configure a cache duration (also called Time to Live, or TTL) for each data source individually.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 The following cache backend options are available: in-memory, Redis, and Memcached.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Storing cached queries in-memory can increase Grafana's memory footprint. In production environments, a Redis or Memcached backend is highly recommended.
-{{% /admonition %}}
+{{< /admonition >}}
 
 When a panel queries a data source with cached data, it will either fetch fresh data or use cached data depending on the panel's **interval.** The interval is used to round the query time range to a nearby cached time range, increasing the likelihood of cache hits. Therefore, wider panels and dashboards with shorter time ranges fetch new data more often than narrower panels and dashboards with longer time ranges.
 
@@ -110,15 +110,15 @@ By reducing the number of queries and requests sent to data sources, caching can
 
 Query caching works for Grafana's [built-in data sources](../../datasources/#built-in-core-data-sources), and [backend data source plugins](https://grafana.com/grafana/plugins/?type=datasource) that extend the `DataSourceWithBackend` class in the plugins SDK.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Logs Insights for the CloudWatch data source does not support query caching due to the way logs are requested from AWS.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To verify that a data source works with query caching, follow the [instructions below](#enable-and-configure-query-caching) to **Enable and Configure query caching**. If caching is enabled in Grafana but the Caching tab is not visible for the given data source, then query caching is not available for that data source.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Some data sources, such as Elasticsearch, Prometheus, and Loki, cache queries themselves, so Grafana _query_ caching does not significantly improve performance. However, _resource_ caching may help. Refer to [plugin resources](https://grafana.com/developers/plugin-tools/key-concepts/backend-plugins/) for details.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Enable and configure query caching
 
@@ -137,9 +137,9 @@ You can optionally override a data source's configured TTL for individual dashbo
 
 {{< figure max-width="500px" src="/media/docs/grafana/per-panel-cache-ttl-9-4.png" caption="Set Cache TTL for a single panel" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If query caching is enabled and the Cache tab is not visible in a data source's settings, then query caching is not available for that data source.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To configure global settings for query caching, refer to the `caching` section of [Configure Grafana Enterprise](../../setup-grafana/configure-grafana/enterprise-configuration/#caching).
 
@@ -158,9 +158,9 @@ To disable query caching for an entire Grafana instance, set the `enabled` flag 
 
 If you experience performance issues or repeated queries become slower to execute, consider clearing your cache.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This action impacts all cache-enabled data sources. If you are using Memcached, the system clears all data from the Memcached instance.
-{{% /admonition %}}
+{{< /admonition >}}
 
 1. Click **Connections** in the left-side menu.
 1. Under Your Connections, click **Data sources**.

--- a/docs/sources/administration/data-source-management/teamlbac/_index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/_index.md
@@ -29,9 +29,9 @@ LBAC for data sources is currently generally available for `Loki` and in **exper
 | Loki        | GA            | GA (requires GEL - Grafana Enterprise Logs)               | ❌                         |
 | Prometheus  | PublicPreview | PublicPreview (requires GEM - Grafana Enterprise Metrics) | ❌                         |
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 For enterprise this feature requires Grafana Enterprise Metrics (GEM) or Grafana Enterprise Logs (GEL) to function.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **LBAC for data sources offers:**
 

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -52,13 +52,13 @@ To download your Grafana Enterprise license:
 
 You must install a Grafana Enterprise build to use the enterprise features, which you can [download](https://grafana.com/grafana/download?edition=enterprise).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 If you already use Grafana OSS, you can replace it with the same version of Grafana Enterprise.
 Ensure that you back up the configuration and database before proceeding.
 For more information, refer to [Back up Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/back-up-grafana/).
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 There is more than one way to add the license to a Grafana instance:
 

--- a/docs/sources/administration/organization-management/index.md
+++ b/docs/sources/administration/organization-management/index.md
@@ -88,9 +88,9 @@ For more information about adding users to an organization, refer to [Add a user
 
 This action permanently removes an organization from your Grafana server.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Deleting the organization also deletes all teams and dashboards associated the organization.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Before you begin
 

--- a/docs/sources/administration/organization-preferences/index.md
+++ b/docs/sources/administration/organization-preferences/index.md
@@ -208,9 +208,9 @@ Users with the Grafana Server Admin flag on their account or access to the confi
 default_home_dashboard_path = data/main-dashboard.json
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 On Linux, Grafana uses `/usr/share/grafana/public/dashboards/home.json` as the default home dashboard location.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Set the home dashboard for your organization
 

--- a/docs/sources/administration/plugin-management/_index.md
+++ b/docs/sources/administration/plugin-management/_index.md
@@ -222,7 +222,7 @@ All plugins are signed under a _signature level_. The signature level determines
 
 {{< admonition type="note" >}}
 Unsigned plugins are not supported in Grafana Cloud.
-{{% /admonition %}}
+{{< /admonition >}}
 
 We strongly recommend that you don't run unsigned plugins in your Grafana instance. However, if you're aware of the risks and you still want to load an unsigned plugin, refer to [Configuration](../../setup-grafana/configure-grafana/#allow_loading_unsigned_plugins).
 

--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -17,23 +17,23 @@ weight: 300
 
 # DEPRECATED Recorded queries
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Recorded queries are deprecated. Please use the new [Grafana Managed Recording Rules](/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules) instead.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Recorded queries allow you to see trends over time by taking a snapshot of a data point on a set interval. This can give you insight into historic trends.
 
 For our plugins that do not return time series, it might be useful to plot historical data. For example, you might want to query ServiceNow to see a history of request response times but it can only return current point-in-time metrics.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](https://grafana.com/docs/grafana-cloud/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## How recorded queries work
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 An administrator must configure a Prometheus data source and associate it with a [Remote write target](#remote-write-target) before recorded queries can be used.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded four types of queries:
 

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -25,9 +25,9 @@ You can assign a user one of three types of permissions:
 - Organization permissions: Manage access to dashboards, alerts, plugins, teams, playlists, and other resources for an entire organization. The available roles are Viewer, Editor, and Admin.
 - Dashboard and folder permission: Manage access to dashboards and folders
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are running Grafana Enterprise, you can also control access to data sources and use role-based access control to grant user access to read and write permissions to specific Grafana resources. For more information about access control options available with Grafana Enterprise, refer to [Grafana Enterprise user permissions features](#grafana-enterprise-user-permissions-features).
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< admonition type="note" >}}
 For Grafana Cloud users, Grafana Support is not authorised to make org role changes. Instead, contact your org administrator.
@@ -37,9 +37,9 @@ For Grafana Cloud users, Grafana Support is not authorised to make org role chan
 
 A Grafana server administrator manages server-wide settings and access to resources such as organizations, users, and licenses. Grafana includes a default server administrator that you can use to manage all of Grafana, or you can divide that responsibility among other server administrators that you create.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The server administrator role does not mean that the user is also a Grafana [organization administrator](#organization-roles).
-{{% /admonition %}}
+{{< /admonition >}}
 
 A server administrator can perform the following tasks:
 
@@ -49,9 +49,9 @@ A server administrator can perform the following tasks:
 - View Grafana server statistics, including total users and active sessions
 - Upgrade the server to Grafana Enterprise.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The server administrator role does not exist in Grafana Cloud.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To assign or remove server administrator privileges, see [Server user management](../user-management/server-user-management/assign-remove-server-admin-privileges/).
 

--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -102,9 +102,9 @@ refs:
 
 # Role-based access control (RBAC)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 RBAC provides a standardized way of granting, changing, and revoking access when it comes to viewing and modifying Grafana resources, such as dashboards, reports, and administrative settings.
 
@@ -151,9 +151,9 @@ Each basic role is comprised of a number of _permissions_. For example, the view
 - `Action: annotations:write, Scope: annotations:type:dashboard`: Enables the viewer to modify annotations of a dashboard.
 - `Action: annotations:delete, Scope: annotations:type:dashboard`: Enables the viewer to remove annotations from a dashboard.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can't have a Grafana user without a basic role assigned. The `None` role contains no permissions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Basic role modification
 
@@ -165,9 +165,9 @@ For example, if you modify Viewer basic role and grant additional permission, Ed
 For more information about the permissions associated with each basic role, refer to [Basic role definitions](ref:rbac-role-definitions-basic-role-assignments).
 To interact with the API and view or modify basic roles permissions, refer to [the table](ref:rbac-basic-role-uid-mapping) that maps basic role names to the associated UID.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot use a service account to modify basic roles via the RBAC API. To update basic roles, you must be a Grafana administrator and use basic authentication with the request.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For Cloud customers, contact Support to reset roles.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles/index.md
@@ -41,9 +41,9 @@ refs:
 
 # Assign RBAC roles
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 In this topic you'll learn how to use the role picker, provisioning, and the HTTP API to assign fixed and custom roles to users and teams.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/configure-rbac/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/configure-rbac/index.md
@@ -13,9 +13,9 @@ weight: 30
 
 # Configure RBAC in Grafana
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 The table below describes all RBAC configuration options. Like any other Grafana configuration, you can apply these options as [environment variables](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables).
 

--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
@@ -72,9 +72,9 @@ refs:
 
 # Manage RBAC roles
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 This section includes instructions for how to view permissions associated with roles, create custom roles, and update and delete roles.
 
@@ -255,9 +255,9 @@ roles:
 
 The following examples show you how to create a custom role using the Grafana HTTP API. For more information about the HTTP API, refer to [Create a new custom role](ref:api-rbac-create-a-new-custom-role).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot create a custom role with permissions that you do not have. For example, if you only have `users:create` permissions, then you cannot create a role that includes other permissions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The following example creates a `custom:users:admin` role and assigns the `users:create` action to it.
 
@@ -314,9 +314,9 @@ If the default basic role definitions do not meet your requirements, you can cha
 
 - Determine the permissions you want to add or remove from a basic role. For more information about the permissions associated with basic roles, refer to [RBAC role definitions](ref:rbac-fixed-basic-role-definitions-basic-role-assignments).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot modify the `No Basic Role` permissions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **To change permissions from a basic role:**
 
@@ -371,10 +371,10 @@ roles:
         scope: 'folder:*'
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can add multiple `fixed`, `basic` or `custom` roles to the `from` section. Their permissions will be copied and added to the basic role.
 Make sure to **increment** the role version for the changes to be accounted for.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can also change basic roles' permissions using the API. Refer to the [RBAC HTTP API](ref:api-rbac-update-a-role) for more details.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
@@ -41,9 +41,9 @@ refs:
 
 # Plan your RBAC rollout strategy
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 An RBAC rollout strategy helps you determine _how_ you want to implement RBAC prior to assigning RBAC roles to users and teams.
 
@@ -92,13 +92,13 @@ Consider the following guidelines when you determine if you should modify basic 
 
 - **Modify basic roles** when Grafana's definitions of what viewers, editors, and admins can do does not match your definition of these roles. You can add or remove permissions from any basic role.
 
-  {{% admonition type="note" %}}
+  {{< admonition type="note" >}}
   Changes that you make to basic roles impact the role definition for all [organizations](/docs/grafana/<GRAFANA_VERSION>/administration/organization-management/) in the Grafana instance. For example, when you add the `fixed:users:writer` role's permissions to the viewer basic role, all viewers in any org in the Grafana instance can create users within that org.
-  {{% /admonition %}}
+  {{< /admonition >}}
 
-  {{% admonition type="note" %}}
+  {{< admonition type="note" >}}
   You cannot modify the `No Basic Role` permissions.
-  {{% /admonition %}}
+  {{< /admonition >}}
 
 - **Create custom roles** when fixed role definitions don't meet you permissions requirements. For example, the `fixed:dashboards:writer` role allows users to delete dashboards. If you want some users or teams to be able to create and update but not delete dashboards, you can create a custom role with a name like `custom:dashboards:creator` that lacks the `dashboards:delete` permission.
 
@@ -115,9 +115,9 @@ Use any of the following methods to assign RBAC roles to users and teams.
 
 We've compiled the following permissions rollout scenarios based on current Grafana implementations.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have a use case that you'd like to share, feel free to contribute to this docs page. We'd love to hear from you!
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Provide internal viewer employees with the ability to use Explore, but prevent external viewer contractors from using Explore
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -46,9 +46,9 @@ refs:
 
 # RBAC role definitions
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 The following tables list permissions associated with basic and fixed roles. This does not include basic role assignments added by plugins or apps.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
@@ -36,9 +36,9 @@ refs:
 
 # RBAC for app plugins
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 RBAC can be used to manage access to [app plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#app-plugins).
 Each app plugin grants the basic Viewer, Editor and Admin organization roles a default set of plugin permissions.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -51,9 +51,9 @@ refs:
 
 # Provisioning RBAC with Grafana
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can create, change or remove [Custom roles](ref:manage-rbac-roles-create-custom-roles-using-provisioning) and create or remove [basic role assignments](ref:assign-rbac-roles-assign-a-fixed-role-to-a-basic-role-using-provisioning), by adding one or more YAML configuration files in the `provisioning/access-control/` directory.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
@@ -45,9 +45,9 @@ refs:
 
 # Provisioning RBAC with Terraform
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can create, change or remove [Custom roles](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role) and create or remove [basic and custom role assignments](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role_assignment), by using [Terraform's Grafana provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 

--- a/docs/sources/administration/roles-and-permissions/access-control/troubleshooting/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/troubleshooting/index.md
@@ -26,9 +26,9 @@ filters = accesscontrol:debug accesscontrol.evaluator:debug dashboard.permission
 
 ## Enable audit logging
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can enable auditing in the Grafana configuration file.
 
@@ -46,10 +46,10 @@ Learn more about [access control audit logs](/docs/grafana/<GRAFANA_VERSION>/set
 This happens when an instance is downgraded from a version that uses RBAC to a version that uses the legacy access control, and dashboard, folder or data source permissions are updated.
 These permission updates will not be applied to RBAC, so permissions will be out of sync when the instance is next upgraded to a version with RBAC.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 the steps provided below will set all dashboard, folder and data source permissions to what they are set to with the legacy access control.
 If you have made dashboard, folder or data source permission updates with RBAC enabled, these updates will be wiped.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To resynchronize the permissions:
 

--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -78,11 +78,11 @@ A common use case for creating a service account is to perform operations on aut
 
 In [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/), you can also use service accounts in combination with [role-based access control](ref:rbac) to grant very specific permissions to applications that interact with Grafana.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Service accounts can only act in the organization they are created for. If you have the same task that is needed for multiple organizations, we recommend creating service accounts in each organization.
 
 Service accounts can't be used for instance-wide operations, such as global user management and organization management. For these tasks, you need to use a user with [Grafana server administrator permissions](ref:roles-and-permissions).
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< vimeo 742056367 >}}
 
@@ -168,9 +168,9 @@ You can assign organization roles to a service account using the Grafana UI or v
 
 In [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/), you can also [assign RBAC roles](ref:rbac-assign-rbac-roles) to grant very specific permissions to applications that interact with Grafana.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Since Grafana 10.2.0, the `No Basic Role` is available for organization users or service accounts. This role has no permissions. Permissions can be granted with RBAC.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Before you begin
 
@@ -237,10 +237,10 @@ To list your token's permissions, use the `/api/access-control/user/permissions`
 
 #### Example
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The following command output is shortened to show only the relevant content.
 Authorize your request with the token whose permissions you want to check.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ```bash
 curl -H "Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7FDsNSLAa_54e2f8be" -X GET '<grafana_url>/api/access-control/user/permissions' | jq

--- a/docs/sources/administration/service-accounts/migrate-api-keys.md
+++ b/docs/sources/administration/service-accounts/migrate-api-keys.md
@@ -40,9 +40,9 @@ refs:
 
 # Migrate API keys to service account tokens
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 API keys are deprecated. [Service accounts](ref:service-accounts) now replace API keys for authenticating with the **HTTP APIs** and interacting with Grafana.
-{{% /admonition %}}
+{{< /admonition >}}
 
 API keys specify a role—either **Admin**, **Editor**, or **Viewer**—that determine the permissions associated with interacting with Grafana.
 
@@ -252,9 +252,9 @@ This section shows you how to migrate your Terraform configuration for Grafana c
 
 For migration your cloud stack api keys, use the `grafana_cloud_stack_service_account` and `gafana_cloud_stack_service_account_token` resources. For additional information, refer to [Grafana Cloud Stack Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This is only relevant for Grafana Cloud **Stack** API keys `grafana_cloud_stack_api_key`. Grafana Cloud API keys resource `grafana_cloud_api_key` are not deprecated and should be used for authentication for managing your Grafana cloud.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Steps
 

--- a/docs/sources/administration/user-management/manage-dashboard-permissions/index.md
+++ b/docs/sources/administration/user-management/manage-dashboard-permissions/index.md
@@ -41,9 +41,9 @@ When you grant folder permissions, that setting applies to all dashboards and su
 
 For example, if a user with the viewer organization role requires editor (or admin) access to a dashboard, you can assign those elevated permissions on an individual basis.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have assigned a user dashboard folder permissions, you cannot also assign the user permission to dashboards contained in the folder.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Grant dashboard permissions when you want to restrict or enhance dashboard access for users who do not have permissions defined in the associated folder.
 

--- a/docs/sources/administration/user-management/manage-org-users/index.md
+++ b/docs/sources/administration/user-management/manage-org-users/index.md
@@ -21,9 +21,9 @@ Organization administrators can invite users to join their organization. Organiz
 
 For more information about organization user permissions, refer to [Organization users and permissions](../../roles-and-permissions/#organization-users-and-permissions).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Users added at the organization level will have access to all stacks and services by default, without the ability to be filtered by stack unless Single Sign-On (SSO) or Role-Based Access Control (RBAC) is implemented.
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< section >}}
 
@@ -40,17 +40,17 @@ You can see a list of users with accounts in your Grafana organization. If neces
 1. Sign in to Grafana as an organization administrator.
 1. Navigate to **Administration > Users and access > Users**.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [server administrator](../../roles-and-permissions/#grafana-server-administrators) permissions, you can also [view a global list of users](../server-user-management/#view-a-list-of-users) in the Server Admin section of Grafana.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Change a user's organization permissions
 
 Update user permissions when you want to enhance or restrict a user's access to organization resources. For more information about organization permissions, refer to [Organization roles](../../roles-and-permissions/#organization-roles).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Organization roles sync from the authentication provider on user sign-in. To prevent synchronization of organization roles from the authentication provider regardless of their role in the authentication provider, then refer to the `skip_org_role_sync` setting in your Grafana configuration. Refer to [skip org role sync](../../../setup-grafana/configure-grafana/#authgrafana_com-skip_org_role_sync) for more information.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Before you begin
 
@@ -68,9 +68,9 @@ Organization roles sync from the authentication provider on user sign-in. To pre
 1. Select the role that you want to assign.
 1. Click **Update**.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [server administrator](../../roles-and-permissions/#grafana-server-administrators) permissions, you can also [change a user's organization permissions](../server-user-management/change-user-org-permissions/) in the Server Admin section.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Invite a user to join an organization
 
@@ -79,9 +79,9 @@ When you invite users to join an organization, you assign the **Admin**, **Edito
 - If you know that the user already has access Grafana and you know their user name, then you issue an invitation by entering their user name.
 - If the user is new to Grafana, then use their email address to issue an invitation. The system automatically creates the user account on first sign in.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [server administrator](../../roles-and-permissions/#grafana-server-administrators) permissions, you can also manually [add a user to an organization](../server-user-management/add-remove-user-to-org/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Before you begin
 
@@ -116,9 +116,9 @@ If the invitee is not already a user, the system adds them.
 
 Periodically review invitations you have sent so that you can see a list of users that have not yet accepted the invitation or cancel a pending invitation.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The **Pending Invites** button is only visible if there are unanswered invitations.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Before you begin
 

--- a/docs/sources/administration/user-management/server-user-management/_index.md
+++ b/docs/sources/administration/user-management/server-user-management/_index.md
@@ -41,9 +41,9 @@ You can see a list of users with accounts on your Grafana server. This action mi
 1. Sign in to Grafana as a server administrator.
 1. Click **Administration** in the left-side menu, **Users and access**, and then **Users**.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [organization administrator](../../roles-and-permissions/#organization-roles) permissions and _not_ [server administrator](../../roles-and-permissions/#grafana-server-administrators) permissions, you can still [view of list of users in a given organization](../manage-org-users/#view-a-list-of-organization-users).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## View user details
 
@@ -121,9 +121,9 @@ When you configure advanced authentication using Oauth, SAML, LDAP, or the Auth 
 
 When you create a user, the system assigns the user viewer permissions in a default organization, which you can change. You can now [add a user to a second organization](add-remove-user-to-org/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [organization administrator](../../roles-and-permissions/#organization-roles) permissions and _not_ [server administrator](../../roles-and-permissions/#grafana-server-administrators) permissions, you can still add users by [inviting a user to join an organization](../manage-org-users/#invite-a-user-to-join-an-organization).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Force a user to log out of Grafana
 

--- a/docs/sources/administration/user-management/server-user-management/add-remove-user-to-org/index.md
+++ b/docs/sources/administration/user-management/server-user-management/add-remove-user-to-org/index.md
@@ -42,9 +42,9 @@ You are required to specify an Admin role for each organization. The first user 
 
 The next time the user signs in, they will be able to navigate to their new organization using the Switch Organizations option in the user profile menu.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have [organization administrator](../../../roles-and-permissions/#organization-roles) permissions and _not_ [server administrator](../../../roles-and-permissions/#grafana-server-administrators) permissions, you can still [invite a user to join an organization](../../manage-org-users/#invite-a-user-to-join-an-organization).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Remove a user from an organization
 

--- a/docs/sources/administration/user-management/server-user-management/assign-remove-server-admin-privileges/index.md
+++ b/docs/sources/administration/user-management/server-user-management/assign-remove-server-admin-privileges/index.md
@@ -15,9 +15,9 @@ weight: 20
 
 Grafana server administrators are responsible for creating users, organizations, and managing permissions. For more information about the server administration role, refer to [Grafana server administrators](../../../roles-and-permissions/#grafana-server-administrators).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Server administrators are "super-admins" with full permissions to create, read, update, and delete all resources and users in all organizations, as well as update global settings such as licenses. Only grant this permission to trusted users.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Before you begin
 

--- a/docs/sources/administration/user-management/user-preferences/index.md
+++ b/docs/sources/administration/user-management/user-preferences/index.md
@@ -26,9 +26,9 @@ You can also view important information about your account, such as the organiza
 
 You can change your Grafana password at any time.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If your Grafana instance uses an external authentication provider, then you might not be able to change your password in Grafana. Contact your Grafana administrator for more information.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **To change your password**:
 

--- a/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
@@ -125,9 +125,9 @@ To backup and manage alert rules, you can [provision alerting resources](ref:sha
 
 Define a query to get the data you want to measure and a condition that needs to be met before an alert rule fires.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 By default, new alert rules are Grafana-managed. To switch to **Data source-managed**, follow these instructions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 1. Select a Prometheus-based data source from the drop-down list.
 

--- a/docs/sources/alerting/alerting-rules/link-alert-rules-to-panels.md
+++ b/docs/sources/alerting/alerting-rules/link-alert-rules-to-panels.md
@@ -81,9 +81,9 @@ You can then [view the alert state on the panel](ref:view-alert-state-on-panels)
 
 By default, notification messages include a link to the dashboard panel. Additionally, you can [enable displaying panel screenshots in notifications](ref:images-in-notifications).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Changes to panel and alert rule queries aren't synchronized. If you change a query, you have to update it in both the panel and the alert rule.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Access linked alert rules from panels
 
@@ -95,4 +95,4 @@ This option is available only in [time series panels](ref:time-series-visualizat
 
 {{< admonition type="tip" >}}
 For a practical example, refer to our [Getting started: Link alerts to visualizations tutorial](http://www.grafana.com/tutorials/alerting-get-started-pt6/).
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/alerting/alerting-rules/templates/language.md
+++ b/docs/sources/alerting/alerting-rules/templates/language.md
@@ -72,9 +72,9 @@ At the start of notification templates, dot (`.`) refers to [Notification Data](
 
 In annotation and label templates, dot (`.`) is initialized with all alert data. It’s recommended to use the [`$labels` and `$values` variables](ref:alert-rule-template-reference-variables) instead to directly access the alert labels and query values.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Dot (`.`) might refer to something else when used in a [range](#range), a [with](#with), or when writing [templates](#templates) used in other templates.
-{{% /admonition %}}
+{{< /admonition >}}
 
 [//]: <> (The above section is not included in the shared file because `refs` links are not supported in shared files.)
 

--- a/docs/sources/alerting/best-practices/dynamic-thresholds.md
+++ b/docs/sources/alerting/best-practices/dynamic-thresholds.md
@@ -120,13 +120,13 @@ In this example:
 
 The _Math_ expression works as long as each series in `$A` can be matched with exactly one series in `$B`. They must align in a way that produces a one-to-one match between series in `$A` and `$B`.
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 
 If a series in one query doesn’t match any series in the other, it’s excluded from the result and a warning message is displayed:
 
 _1 items **dropped from union(s)**: ["$A > $B": ($B: {service=payment-api})]_
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Labels in both series don’t need to be identical**. If labels are a subset of the other, they can join. For example:
 

--- a/docs/sources/alerting/configure-notifications/create-notification-policy.md
+++ b/docs/sources/alerting/configure-notifications/create-notification-policy.md
@@ -78,9 +78,9 @@ When an alert instance is assigned to a notification policy, the notification po
 - Controlling when notifications are sent using the [timing options](ref:policy-timing-options).
 - Determining the [contact points](ref:configure-contact-points) that receive the alert notification.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The default notification policy and its child policies are assigned to a [specific Alertmanager](ref:alertmanager-architecture), and they cannot use contact points or mute timings from other Alertmanagers.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Edit the default notification policy
 

--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -111,9 +111,9 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
   | `=~`     | Select labels that regex-match the value.          |
   | `!~`     | Select labels that do not regex-match the value.   |
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Label matching example**
 

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -128,9 +128,9 @@ On the **Contact Points** tab, you can:
 - Export individual contact points or all contact points in JSON, YAML, or Terraform format.
 - Delete contact points. Note that you cannot delete contact points that are in use by a notification policy. To proceed, either delete the notification policy or update it to use another contact point.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Contact points are assigned to a [specific Alertmanager](ref:configure-alertmanager) and cannot be used by notification policies in other Alertmanagers.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Supported contact point integrations
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/_index.md
@@ -85,11 +85,11 @@ The notification message would look like this:
   Description: This alert fires when a web server responds with more 5xx errors than is expected. This could be an issue with the web server or a backend service.
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Avoid adding extra information about alert instances in notification templates, as this information will only be visible in the notification message.
 
 Instead, you should [use annotations or labels](ref:template-annotations-and-labels) to add information directly to the alert, ensuring it's also visible in the alert state and alert history within Grafana. You can then print the new alert annotation or label in notification templates.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Select a notification template for a contact point
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/examples.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/examples.md
@@ -73,11 +73,11 @@ Notification templates allows you to change the default notification messages.
 
 You can modify the content and format of notification messages. For example, you can customize the content to show only specific information or adjust the format to suit a particular contact point, such as Slack or Email.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Avoid adding extra information about alert instances in notification templates, as this information is only visible in the notification message.
 
 Instead, you should [use annotations or labels](ref:template-annotations-and-labels) to add information directly to the alert, ensuring it's also visible in the alert state and alert history within Grafana. You can then print the new alert annotation or label in notification templates.
-{{% /admonition %}}
+{{< /admonition >}}
 
 This page provides various examples illustrating how to template common notification messages. For more details about notification templates, refer to:
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
@@ -20,15 +20,15 @@ weight: 105
 
 # Use images in notifications
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana Cloud users can request this feature by [opening a support ticket in the Cloud Portal](/profile/org#support).
-{{% /admonition %}}
+{{< /admonition >}}
 
 Images in notifications helps recipients of alert notifications better understand why an alert has fired or resolved by including a screenshot of the panel associated with the alert.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager.
-{{% /admonition %}}
+{{< /admonition >}}
 
 When an alert is fired or resolved Grafana takes a screenshot of the panel associated with the alert. This is determined via the Dashboard UID and Panel ID annotations of the rule. Grafana cannot take a screenshot for alerts that are not associated with a panel.
 
@@ -60,9 +60,9 @@ Refer to the table at the end of this page for a list of contact points and thei
 
 ## Configuration
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana Cloud users can request this feature by [opening a support ticket in the Cloud Portal](/profile/org#support).
-{{% /admonition %}}
+{{< /admonition >}}
 
 Having installed either the image rendering plugin, or set up Grafana to use a remote rendering service, set `capture` in `[unified_alerting.screenshots]` to `true`:
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/language.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/language.md
@@ -76,9 +76,9 @@ At the start of notification templates, dot (`.`) refers to [Notification Data](
 
 In annotation and label templates, dot (`.`) is initialized with all alert data. It’s recommended to use the [`$labels` and `$values` variables](ref:alert-rule-template-reference-variables) instead to directly access the alert labels and query values.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Dot (`.`) might refer to something else when used in a [range](#range), a [with](#with), or when writing [templates](#templates) used in other templates.
-{{% /admonition %}}
+{{< /admonition >}}
 
 [//]: <> (The above section is not included in the shared file because `refs` links are not supported in shared files.)
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/manage-notification-templates.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/manage-notification-templates.md
@@ -100,9 +100,9 @@ For more details on how to write notification templates, refer to the [template 
 
 Preview how your notification templates should look before using them in your contact points, helping you understand the result of the template you are creating as well as enabling you to fix any errors before saving it.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Notification template preview is only for Grafana Alertmanager.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To preview your notification templates:
 

--- a/docs/sources/alerting/fundamentals/notifications/notification-policies.md
+++ b/docs/sources/alerting/fundamentals/notifications/notification-policies.md
@@ -90,9 +90,9 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
   | `=~`     | Select labels that regex-match the value.          |
   | `!~`     | Select labels that do not regex-match the value.   |
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Label matching example**
 
@@ -138,13 +138,13 @@ If a matching policy is found, the system continues to evaluate its child polici
 
 By default, once a matching policy is found, the system does not continue to look for sibling policies. If you want sibling policies of one matching policy to handle the alert instance as well, then enable **Continue matching siblings** on the particular matching policy.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 The default notification policy matches all alert instances. It always handles alert instances if there are no child policies or if none of the child policies match the alert instance's labels—this prevents any alerts from being missed.
 
 If alerts use multiple labels, these labels must also be present in a notification policy to match and route notifications to a specific contact point.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< collapse title="Routing example" >}}
 
@@ -156,9 +156,9 @@ The `team=security` policy is not a match and **Continue matching siblings** was
 
 **Disk Usage – 80%** has both a `team` and `severity` label, and matches a child policy of the operations team.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When an alert matches both a parent policy and a child policy (like it does in this case), the routing follows the child policy (`severity`) as it provides a more specific match.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Unauthorized log entry** has a `team` label but does not match the first policy (`team=operations`) since the values are not the same, so it will continue searching and match the `team=security` policy. It does not have any child policies, so the additional `severity=high` label is ignored.
 

--- a/docs/sources/alerting/monitor-status/view-active-notifications.md
+++ b/docs/sources/alerting/monitor-status/view-active-notifications.md
@@ -89,11 +89,11 @@ If an alert does not contain labels specified either in the grouping of the defa
 
 ## View notification errors
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 Notification errors are only available with [pre-configured Grafana Alertmanagers](ref:alertmanager).
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 Notification errors provide information about why they failed to be sent or were not received.
 

--- a/docs/sources/alerting/monitor-status/view-alert-state-history.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state-history.md
@@ -24,13 +24,13 @@ An alert event is displayed each time an alert instance changes its state over a
 
 ## View from the History page
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 For Grafana Enterprise and OSS users:
 The feature is available starting with Grafana 11.2.
 To try out the new alert history page, enable the `alertingCentralAlertHistory` feature toggle and configure [Loki annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/).
 
 Users can only see the history and transitions of alert rules they have access to (RBAC).
-{{% /admonition %}}
+{{< /admonition >}}
 
 To access the History view, complete the following steps.
 
@@ -44,9 +44,9 @@ To access the History view, complete the following steps.
 3. Filter by current state and previous state by selecting a state from the drop-down or by clicking the states from the list of events.
    Zoom in by dragging on the chart or use the time picker.
 
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    If you exceed the 5000 alerts limit, you may see data missing from the chart. To see complete results, narrow the time frame.
-   {{% /admonition %}}
+   {{< /admonition >}}
 
 4. Under the chart, there is a list of events. Each event represents a state change on an alert instance. Expand a row to see the number of transitions for the alert instance, a state graph, and the value in the transition.
 5. Click the alert rule name to jump to the History tab in the Alert Rule view.
@@ -59,9 +59,9 @@ Use the State history view to get insight into how your individual alert instanc
 
 View information on when a state change occurred, what the previous state was, the current state, any other alert instances that changed their state at the same time as well as what the query value was that triggered the change.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Open source users must [configure alert state history](/docs/grafana/latest/alerting/set-up/configure-alert-state-history/) in order to be able to access the view.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To access the State history view, complete the following steps.
 

--- a/docs/sources/alerting/set-up/configure-alertmanager/_index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/_index.md
@@ -78,9 +78,9 @@ For provisioning instructions, refer to the [Alertmanager data source documentat
 
 After adding an Alertmanager, you can use the Grafana Alerting UI to manage notification policies, contact points, silences, and other alerting resources from within Grafana.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When using Prometheus, you can manage silences in the Grafana Alerting UI. However, other Alertmanager resources such as contact points, notification policies, and templates are read-only because the Prometheus Alertmanager HTTP API does not support updates for these resources.
-{{% /admonition %}}
+{{< /admonition >}}
 
 When using multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
 
@@ -96,9 +96,9 @@ After enabling **Receive Grafana Alerts** in the Data Source Settings, you must 
 
 All Grafana-managed alerts are forwarded to Alertmanagers marked as `Receiving Grafana-managed alerts`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana Alerting does not support forwarding Grafana-managed alerts to the AlertManager in Amazon Managed Service for Prometheus. For more details, refer to [this GitHub issue](https://github.com/grafana/grafana/issues/64064).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Manage Alertmanager configurations
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -69,11 +69,11 @@ For a demo, see this [example using Docker Compose](https://github.com/grafana/a
 
 As an alternative to Memberlist, you can configure Redis to enable high availability. Only **Redis Server** and **Redis Cluster** modes are supported.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 Memberlist is the preferred option for high availability. Use Redis only in environments where direct communication between Grafana servers is not possible, such as when TCP or UDP ports are blocked.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 1. Make sure you have a Redis server that supports pub/sub. If you use a proxy in front of your Redis cluster, make sure the proxy supports pub/sub.
 1. In your custom configuration file ($WORKING_DIR/conf/custom.ini), go to the `[unified_alerting]` section.
@@ -160,13 +160,13 @@ For a demo, see this [example using Docker Compose](https://github.com/grafana/a
 
 When running multiple Grafana instances, all alert rules are evaluated on every instance. This multiple evaluation of alert rules is visible in the [state history](ref:state-history) and provides a straightforward way to verify that your high availability configuration is working correctly.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 If using a mix of `execute_alerts=false` and `execute_alerts=true` on the HA nodes, since the alert state is not shared amongst the Grafana instances, the instances with `execute_alerts=false` do not show any alert status.
 
 The HA settings (`ha_peers`, etc.) apply only to communication between alertmanagers, synchronizing silences and attempting to avoid duplicate notifications, as described in the introduction.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can also confirm your high availability setup by monitoring Alertmanager metrics exposed by Grafana.
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -137,7 +137,7 @@ To export alert rules from the Grafana UI, complete the following steps.
 
 ### Modify alert rule and export rule group without saving changes
 
-{{% admonition type="note" %}} This feature is for Grafana-managed alert rules only. It is available to Admin, Viewer, and Editor roles. {{% /admonition %}}
+{{< admonition type="note" >}} This feature is for Grafana-managed alert rules only. It is available to Admin, Viewer, and Editor roles. {{< /admonition >}}
 
 Use the **Modify export** mode to edit and export an alert rule without updating it. The exported data includes all alert rules within the same alert group.
 
@@ -155,7 +155,7 @@ To export a modified alert rule without saving the modifications, complete the f
 
 ### Export a new alert rule definition without saving changes
 
-{{% admonition type="note" %}} You can only export in Terraform (HCL) format. {{% /admonition %}}
+{{< admonition type="note" >}} You can only export in Terraform (HCL) format. {{< /admonition >}}
 
 Add a new alert rule definition to an existing provisioned rule group rather than creating the code manually. You can then copy it to your Terraform pipeline, and quickly deploy and manage alert rules as part of your infrastructure as code.
 

--- a/docs/sources/breaking-changes/_index.md
+++ b/docs/sources/breaking-changes/_index.md
@@ -23,11 +23,11 @@ For our purposes, a breaking change is any change that requires users or operato
 - Changes that affect some plugins or functions of Grafana
 - Migrations that can’t be rolled back
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 To learn what's available in a Grafana release, refer to the [What's new ](../whatsnew/) page for each version. For the steps we recommend when you upgrade, check out the [Upgrade guide](../upgrade-guide/) for each version.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 Refer to any of the following breaking changes guides:
 

--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -39,9 +39,9 @@ To view the JSON of a dashboard:
 
 When a user creates a new dashboard, a new dashboard JSON object is initialized with the following fields:
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 In the following JSON, id is shown as null which is the default value assigned to it until a dashboard is saved. Once a dashboard is saved, an integer value is assigned to the `id` field.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ```json
 {

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -86,9 +86,9 @@ When you nest folders, you can do so up to four levels deep.
 
 When you save a dashboard, you can optionally select a folder to save the dashboard in.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Alerts can't be placed in folders with slashes (\ /) in the name. If you wish to place alerts in the folder, don't use slashes in the folder name.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **To edit the name of a folder:**
 

--- a/docs/sources/dashboards/search-dashboards/index.md
+++ b/docs/sources/dashboards/search-dashboards/index.md
@@ -46,9 +46,9 @@ The search is:
 - _Not_ case sensitive
 - Functional across stored _and_ file based dashboards and folders.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can use your keyboard arrow keys to navigate the results and press `Enter` to open the selected dashboard or folder.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The following images show:
 
@@ -64,9 +64,9 @@ Searching by dashboard name inside a folder.
 
 {{< figure src="/media/docs/grafana/dashboards/search-in-folder.png" width="700px" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When you search within a folder, its subfolders are not part of the results returned. You need to be on the **Dashboards** page (or the root level) to search for subfolders by name.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Search dashboards using panel title
 
@@ -120,6 +120,6 @@ To filter dashboard search result by a tag, complete one of the following steps:
 
   All tags will be shown, and when you select a tag, the dashboard search will be instantly filtered.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When using only a keyboard, press the `tab` key and navigate to the **Filter by tag** drop-down menu, press the down arrow key `▼` to activate the menu and locate a tag, and press `Enter` to select the tag.
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/dashboards/use-dashboards/index.md
+++ b/docs/sources/dashboards/use-dashboards/index.md
@@ -174,14 +174,14 @@ The following table provides example relative ranges:
 | This Year              | `now/Y`     | `now/Y`     |
 | Previous fiscal year   | `now-1y/fy` | `now-1y/fy` |
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 Grafana Alerting does not support the following syntaxes at this time:
 
 - now+n for future timestamps.
 - now-1n/n for "start of n until end of n" because this is an absolute timestamp.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Common time range controls
 
@@ -229,11 +229,11 @@ This section also displays recently used absolute ranges.
 
 #### Semi-relative time range
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 Grafana Alerting does not support semi-relative time ranges.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can also use the absolute time range settings to set a semi-relative time range. Semi-relative time range dashboards are useful when you need to monitor the progress of something over time, but you also want to see the entire history from a starting point.
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -84,9 +84,9 @@ For details on data source management, including instructions on how configure u
 
 Before you can create your first dashboard, you need to add your data source.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Only users with the organization admin role can add data sources.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **To add a data source:**
 

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -68,9 +68,9 @@ Administrators can also [provision the data source](#provision-the-data-source) 
 
 Once you've added the data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor](query-editor/) when they [build dashboards](ref:build-dashboards) and use [Explore](ref:explore).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To troubleshoot issues while setting up the CloudWatch data source, check the `/var/log/grafana/grafana.log` file.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Configure the data source
 
@@ -407,9 +407,9 @@ filter @message like /Exception/
     | sort exceptionCount desc
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you receive an error like `input data must be a wide series but got ...` when trying to alert on a query, make sure that your query returns valid numeric data that can be output to a Time series panel.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For more information on Grafana alerts, refer to [Alerting](ref:alerting).
 
@@ -420,10 +420,10 @@ Pricing for CloudWatch Logs is based on the amount of data ingested, archived, a
 Each time you select a dimension in the query editor, Grafana issues a `ListMetrics` API request.
 Each time you change queries in the query editor, Grafana issues a new request to the `GetMetricData` API.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana replaced all `GetMetricStatistics` API requests with calls to GetMetricData to provide better support for CloudWatch metric math, and enables the automatic generation of search expressions when using wildcards or disabling the `Match Exact` option.
 The `GetMetricStatistics` API qualified for the CloudWatch API free tier, but `GetMetricData` calls don't.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For more information, refer to the [CloudWatch pricing page](https://aws.amazon.com/cloudwatch/pricing/).
 

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -67,9 +67,9 @@ Open source Grafana enables the `AWS SDK Default`, `Credentials file`, and `Acce
 
 ## Assume a role
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Assume a role is required for the Grafana Assume Role.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can specify an IAM role to assume in the **Assume Role ARN** field.
 
@@ -87,9 +87,9 @@ To disable this feature in open source Grafana or Grafana Enterprise, refer to t
 
 ### Use an external ID
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot use an external ID for the Grafana Assume Role authentication provider.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To assume a role in another account that was created with an external ID, specify the external ID in the **External ID** field.
 
@@ -128,9 +128,9 @@ For more information on why and how to use service endpoints, refer to the [AWS 
 
 Create a file at `~/.aws/credentials`, the `HOME` path for the user running the `grafana-server` service.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you think you have the credentials file in the right location, but it's not working, try moving your `.aws` file to `/usr/share/grafana/` and grant your credentials file at most 0644 permissions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Credentials file example
 
@@ -159,13 +159,13 @@ securityContext:
 
 ## Use Grafana Assume Role
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana Assume Role is currently in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud.
 
 It's currently only available for Amazon CloudWatch.
 
 To gain early access to this feature, contact Customer Support and ask for the `awsDatasourcesTempCredentials` feature toggle to be enabled on your account.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The Grafana Assume Role authentication provider lets you authenticate with AWS without having to create and maintain long term AWS users or rotate their access and secret keys. Instead, you can create an IAM role that has permissions to access CloudWatch and a trust relationship with Grafana's AWS account. Grafana's AWS account then makes an STS request to AWS to create temporary credentials to access your AWS data. It makes this STS request by passing along an `externalID` that's unique per Cloud account, to ensure that Grafana Cloud users can only access their own AWS data. For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -111,9 +111,9 @@ For details on the available functions, refer to [AWS Metric Math](https://docs.
 
 For example, to apply arithmetic operations to a metric, apply a unique string id to the raw metric, then use this id and apply arithmetic operations to it in the Expression field of the new metric.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you use the expression field to reference another query, like `queryA * 2`, you can't create an alert rule based on that query.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Period macro
 
@@ -192,9 +192,9 @@ The suggestions appear after typing a space, comma, or dollar (`$`) character, o
 
 {{< figure src="/static/img/docs/cloudwatch/cloudwatch-code-editor-autocomplete-8.3.0.png" max-width="500px" class="docs-image--right" caption="Code editor autocomplete" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Template variables in the code editor can interfere with autocompletion.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To run the query, click **Run query** above the code editor.
 

--- a/docs/sources/datasources/azure-monitor/query-editor/index.md
+++ b/docs/sources/datasources/azure-monitor/query-editor/index.md
@@ -66,9 +66,9 @@ In contrast, Azure Monitor Logs can store a variety of data types, each with the
 1. Select a resource from which to query metrics by using the subscription, resource group, resource type, and resource fields. Multiple resources can also be selected as long as they belong to the same subscription, region and resource type. Note that only a limited amount of resource types support this feature.
 1. To select a different namespace than the default—for instance, to select resources like storage accounts that are organized under multiple namespaces—use the **Namespace** option.
 
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    Not all metrics returned by the Azure Monitor Metrics API have values.
-   {{% /admonition %}}
+   {{< /admonition >}}
 
    > The data source retrieves lists of supported metrics for each subscription and ignores metrics that never have values.
 
@@ -139,10 +139,10 @@ The Azure Monitor data source also supports querying of [Basic Logs](https://lea
 1. Select a resource to query. Multiple resources can be selected as long as they are of the same type.
 
    Alternatively, you can dynamically query all resources under a single resource group or subscription.
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    If a timespan is specified in the query, the overlap of the timespan between the query and the dashboard will be used as the query timespan. See the [API documentation for
    details.](https://learn.microsoft.com/en-us/rest/api/loganalytics/dataaccess/query/get?tabs=HTTP#uri-parameters)
-   {{% /admonition %}}
+   {{< /admonition >}}
 
 1. Enter your KQL query.
 
@@ -155,10 +155,10 @@ You can also augment queries by using [template variables](../template-variables
 1. Select the **Logs** service.
 1. Select a resource to query. Multiple resources can be selected as long as they are of the same type.
 1. Switch the `Logs` toggle from `Analytics` to `Basic`. A modal will display to notify users of potential additional costs.
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    Basic Logs queries do not support time-ranges specified in the query. The time-range will be hardcoded to the dashboard time-range. There are also other query limitations. See the
    [documentation for details.](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/basic-logs-query?tabs=portal-1#limitations)
-   {{% /admonition %}}
+   {{< /admonition >}}
 1. Enter your KQL query.
 
 You can also augment queries by using [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/azure-monitor/template-variables/).
@@ -348,17 +348,17 @@ Application Insights stores trace data in an underlying Log Analytics workspace 
 1. Select the **Traces** service.
 1. Select a resource to query. Multiple resources can be selected as long as they are of the same type.
 
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    This query type only supports Application Insights resources.
-   {{% /admonition %}}
+   {{< /admonition >}}
 
 Running a query of this kind will return all trace data within the timespan specified by the panel/dashboard.
 
 Optionally, you can apply further filtering or select a specific Operation ID to query. The result format can also be switched between a tabular format or the trace format which will return the data in a format that can be used with the Trace visualization.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Selecting the trace format will filter events with the `trace` type.
-{{% /admonition %}}
+{{< /admonition >}}
 
 1. Specify an Operation ID value.
 1. Specify event types to filter by.

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -65,11 +65,11 @@ Our maintenance policy for Elasticsearch data source is aligned with the [Elasti
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana](ref:provisioning-grafana).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The previously used `database` field has now been [deprecated](https://github.com/grafana/grafana/pull/58647).
 You should now use the `index` field in `jsonData` to store the index name.
 Please see the examples below.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Provisioning examples
 

--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -95,9 +95,9 @@ Select one of the following authentication methods from the dropdown menu.
 
 ### TLS settings
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use TLS (Transport Layer Security) for an additional layer of security when working with Elasticsearch. For information on setting up TLS encryption with Elasticsearch see [Configure TLS](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/configuring-tls.html#configuring-tls). You must add TLS settings to your Elasticsearch configuration file **prior** to setting these options in Grafana.
-{{% /admonition %}}
+{{< /admonition >}}
 
 - **Add self-signed certificate** - Check the box to authenticate with a CA certificate. Follow the instructions of the CA (Certificate Authority) to download the certificate file. Required for verifying self-signed TLS certificates.
 
@@ -166,9 +166,9 @@ You can also override this setting in a dashboard panel under its data source op
 
 - **Include frozen indices** - Toggle on when the `X-Pack enabled` setting is active. Includes frozen indices in searches. You can configure Grafana to include [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Frozen indices are [deprecated in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/frozen-indices.html) since v7.14.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Logs
 

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -32,9 +32,9 @@ refs:
 Grafana provides a query editor for Elasticsearch. Elasticsearch queries are in Lucene format.
 See [Lucene query syntax](https://www.elastic.co/guide/en/kibana/current/lucene-query.html) and [Query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax) if you are new to working with Lucene queries in Elasticsearch.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When composing Lucene queries, ensure that you use uppercase boolean operators: `AND`, `OR`, and `NOT`. Lowercase versions of these operators are not supported by the Lucene query syntax.
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< figure src="/static/img/docs/elasticsearch/elastic-query-editor-10.1.png" max-width="800px" class="docs-image--no-shadow" caption="Elasticsearch query editor" >}}
 
@@ -137,9 +137,9 @@ Run a raw data query to retrieve a table of all fields that are associated with 
 
 - **Raw data size** - Number of raw data documents. You can specify a different amount. The default is `500`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The option to run a **raw document query** is deprecated as of Grafana v10.1.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Use template variables
 

--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -68,9 +68,9 @@ These queries by default return results in term order (which can then be sorted 
 To produce a list of terms sorted by doc count (a top-N values list), add an `orderBy` property of "doc_count".
 This automatically selects a descending sort.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To use an ascending sort (`asc`) with doc_count (a bottom-N list), set `order: "asc"`. However, Elasticsearch [discourages this](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-order) because sorting by ascending doc count can return inaccurate results.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To keep terms in the doc count order, set the variable's Sort dropdown to **Disabled**.
 You can alternatively use other sorting criteria, such as **Alphabetical**, to re-sort them.

--- a/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
@@ -74,9 +74,9 @@ In the case that the metric value type is a distribution, the aggregation will b
 
 The various metrics are documented [here](https://cloud.google.com/monitoring/api/metrics_gcp) and further details on the kinds and types of metrics can be found [here](https://cloud.google.com/monitoring/api/v3/kinds-and-types).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Distribution metrics are typically best visualized as either a heatmap or histogram. When visualizing in this way, aggregation is not necessary. However, for other visualization types, performance degradation may be observed when attempting to query distribution metrics that are not aggregated due to the number of potential buckets that can be returned. For more information on how to visualize distribution metrics refer to [this page](https://cloud.google.com/monitoring/charts/charting-distribution-metrics).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Apply a filter
 

--- a/docs/sources/datasources/graphite/query-editor/index.md
+++ b/docs/sources/datasources/graphite/query-editor/index.md
@@ -71,9 +71,9 @@ Some functions like aliasByNode support an optional second argument. To add an a
 
 To learn more, refer to [Graphite's documentation on functions](https://graphite.readthedocs.io/en/latest/functions.html).
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Some functions take a second argument that may be a function that returns a series. If you are adding a second argument that is a function, it is suggested to use a series reference from a second query instead of the function itself. The query editor does not currently support parsing of a second argument that is a function when switching between the query editor and the code editor.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Sort labels
 
@@ -91,10 +91,10 @@ Grafana consolidates all Graphite metrics so that Graphite doesn't return more d
 By default, Grafana consolidates data points using the `avg` function.
 To control how Graphite consolidates metrics, use the Graphite `consolidateBy()` function.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Legend summary values (max, min, total) can't all be correct at the same time because they are calculated client-side by Grafana.
 Depending on your consolidation function, only one or two can be correct at the same time.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Combine time series
 
@@ -109,10 +109,10 @@ To select data, use the `seriesByTag` function, which takes tag expressions (`=`
 
 The Grafana query builder does this for you automatically when you select a tag.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The regular expression search can be slow on high-cardinality tags, so try to use other tags to reduce the scope first.
 To help reduce the results, start by filtering on a particular name or namespace.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Nest queries
 

--- a/docs/sources/datasources/influxdb/configure-influxdb-data-source/_index.md
+++ b/docs/sources/datasources/influxdb/configure-influxdb-data-source/_index.md
@@ -176,10 +176,10 @@ You can define and configure the data source in YAML files as part of Grafana's 
 For more information about provisioning, and for available configuration options, refer
 to [Provision Grafana](ref:provision-grafana).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The `database` [field is deprecated](https://github.com/grafana/grafana/pull/58647).
 Grafana recommends using the `dbName` field in `jsonData`. There is no need to change existing provisioning settings.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Provisioning examples
 

--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -109,9 +109,9 @@ You can also configure settings specific to the Jaeger data source. These option
 
 ![Trace to logs settings](/media/docs/tempo/tempo-trace-to-logs-9-4.png)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The **Trace to logs** setting configures the [trace to logs feature](ref:explore-trace-integration) that is available when you integrate Grafana with Jaeger.
 

--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -72,9 +72,9 @@ Administrators can also [configure the data source via YAML](#provision-the-data
 
 Once you've added the Loki data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor](query-editor/) when they [build dashboards](ref:build-dashboards), use [Explore](ref:explore), and [annotate visualizations](query-editor/#apply-annotations).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To troubleshoot configuration and other issues, check the log file located at `/var/log/grafana/grafana.log` on Unix systems, or in `<grafana_install_dir>/data/log` on other platforms and manual installations.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Provision the data source
 

--- a/docs/sources/datasources/loki/configure-loki-data-source.md
+++ b/docs/sources/datasources/loki/configure-loki-data-source.md
@@ -61,9 +61,9 @@ The first option to configure is the name of your connection:
 
 There are several authentication methods you can choose in the Authentication section.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use TLS (Transport Layer Security) for an additional layer of security when working with Loki. For information on setting up TLS encryption with Loki see [Grafana Loki configuration parameters](/docs/loki/latest/configuration/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 - **Basic authentication** - The most common authentication method. Use your `data source` user name and `data source` password to connect.
 
@@ -91,9 +91,9 @@ Use TLS (Transport Layer Security) for an additional layer of security when work
 
 - **Maximum lines** - Sets the maximum number of log lines returned by Loki. Increase the limit to have a bigger results set for ad-hoc analysis. Decrease the limit if your browser is sluggish when displaying log results. The default is `1000`.
 
-<!-- {{% admonition type="note" %}}
+<!-- {{< admonition type="note" >}}
 To troubleshoot configuration and other issues, check the log file located at `/var/log/grafana/grafana.log` on Unix systems, or in `<grafana_install_dir>/data/log` on other platforms and manual installations.
-{{% /admonition %}} -->
+{{< /admonition >}} -->
 
 ### Derived fields
 
@@ -104,9 +104,9 @@ These links appear in the [log details](ref:log-details).
 
 You can add multiple derived fields.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you use Grafana Cloud, you can request modifications to this feature by clicking **Open a Support Ticket** from the Grafana Cloud Portal.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Each derived field consists of the following:
 
@@ -114,9 +114,9 @@ Each derived field consists of the following:
 
 - **Type** - Defines the type of the derived field. It can be either:
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 Using complex regular expressions in either type can impact browser performance when processing large volumes of logs. Consider using simpler patterns when possible.
-{{% /admonition %}}
+{{< /admonition >}}
 
 - **Regex**: A regular expression to parse a part of the log message and capture it as the value of the new field. Can contain only one capture group.
 

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -55,9 +55,9 @@ To switch between the editor modes, select the corresponding **Builder** and **C
 
 To run a query, select **Run queries** located at the top of the editor.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To run Loki queries in [Explore](ref:explore), select **Run query**.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Each mode is synchronized, so you can switch between them without losing your work, although there are some limitations. Builder mode doesn't support some complex queries.
 When you switch from Code mode to Builder mode with such a query, the editor displays a warning message that explains how you might lose parts of the query if you continue.

--- a/docs/sources/datasources/mysql/query-editor/_index.md
+++ b/docs/sources/datasources/mysql/query-editor/_index.md
@@ -66,9 +66,9 @@ Grafana’s query editors are unique for each data source. For general informati
 
 The MySQL query editor is located on the [Explore page](ref:explore). You can also access the MySQL query editor from a dashboard panel. Click the ellipsis in the upper right of the panel and select **Edit**.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If a default database is configured in the **Data Source Configuration page**, or via a provisioning configuration file, users will be restricted to querying only that pre-configured database. This feature is behind a feature flag and is available once you enable `sqlDatasourceDatabaseSelection`.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## MySQL query editor components
 
@@ -76,9 +76,9 @@ The MySQL query editor has two modes: **Builder** and **Code**.
 
 Builder mode helps you build a query using a visual interface. Code mode allows for advanced querying and offers support for complex SQL query writing.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If your table or database name contains a reserved word or a [prohibited character](https://dev.mysql.com/doc/en/identifiers.html) the editor will put quotes around the name. For example, the name `table-name` will be quoted with backticks - `` `table-name` ``.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## MySQL Builder mode
 
@@ -121,9 +121,9 @@ To create advanced queries, switch to **Code mode** by clicking **Code** in the 
 
 Select **Table** or **Time Series** as the format. Click the **{}** in the bottom right to format the query. Click the **downward caret** to expand the Code mode editor. **CTRL/CMD + Return** serves as a keyboard shortcut to execute the query.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Changes made to a query in Code mode will not transfer to Builder mode and will be discarded. You will be prompted to copy your code to the clipboard to save any changes.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Macros
 
@@ -174,9 +174,9 @@ Table panel results:
 
 Set the **Format** option to **Time series** to create and run time series queries.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To run a time series query you must include a column named `time` that returns either a SQL datetime value or a numeric datatype representing the UNIX epoch time in seconds. Additionally, the query results must be sorted by the `time` column for proper visualization in panels.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The examples in this section refer to the data in the following table:
 
@@ -194,9 +194,9 @@ The examples in this section refer to the data in the following table:
 
 A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/key-concepts/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 For backward compatibility, an exception to the aforementioned rule applies to queries returning three columns, including a string column named `metric`. Instead of converting the metric column into field labels, it is used as the field name, and the series name is set to the value of the metric column. Refer to the following example with a metric column.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Example with `metric` column:**
 

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -94,13 +94,13 @@ can be used to query OpenTSDB. Fill Policy is also introduced in OpenTSDB 2.2.
 
 ![](/static/img/docs/v43/opentsdb_query_editor.png)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 While using OpenTSDB 2.2 data source, make sure you use either Filters or Tags as they are mutually exclusive. If used together, might give you weird results.
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When using OpenTSDB 2.4 with alerting, queries are executed with the parameter `arrays=true`. This causes OpenTSDB to return data points as an array of arrays instead of a map of key-value pairs. Grafana then converts this data into the appropriate data frame format.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Auto complete suggestions
 

--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -82,14 +82,14 @@ refs:
 
 Prometheus is an open source database that uses a telemetry collector agent to scrape and store metrics used for monitoring and alerting. Grafana provides native support for Prometheus. If you are just getting started with Prometheus, see [What is Prometheus?](ref:intro-to-prometheus).
 
-{{% admonition type="tip" %}}
+{{< admonition type="tip" >}}
 For instructions on downloading Prometheus see [Get started with Grafana and Prometheus](ref:get-started-prometheus).
 
 If you’re ready to start visualizing your metrics, check out our Prometheus Learning Journeys:
 
 - [Connect to a Prometheus data source in Grafana Cloud](https://www.grafana.com/docs/learning-journeys/prometheus/) to visualize your metrics directly from where they are stored.
 - [Send metrics to Grafana Cloud using Prometheus remote write](https://www.grafana.com/docs/learning-journeys/prom-remote-write/) to explore Grafana Cloud without making significant changes to your existing configuration.
-  {{% /admonition %}}
+  {{< /admonition >}}
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation](ref:administration-documentation).
 Only users with the organization `administrator` role can add data sources and edit existing data sources.
@@ -117,9 +117,9 @@ For more information on how to query other Prometheus-compatible projects from G
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana](ref:provisioning-data-sources).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Once you have provisioned a data source you cannot edit it.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Provisioning example
 
@@ -183,17 +183,17 @@ Add the following setting in the **[auth]** section :
 azure_auth_enabled = true
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are using Azure authentication settings do not enable `Forward OAuth identity`. Both use the same HTTP authorization headers. Azure settings will get overwritten by the Oauth token.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Exemplars
 
 Exemplars associate higher-cardinality metadata from a specific event with traditional time series data. See [Introduction to exemplars](ref:exemplars) in Prometheus documentation for detailed information on how they work.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in Prometheus v2.26 and higher with Grafana v7.4 and higher.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Grafana can show exemplars data alongside a metric both in Explore and in Dashboards.
 

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -92,11 +92,11 @@ You should use the IP address of the Prometheus container, or the hostname if yo
 
 There are several authentication methods you can choose in the Authentication section.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 Use TLS (Transport Layer Security) for an additional layer of security when working with Prometheus. For information on setting up TLS encryption with Prometheus see [Securing Prometheus API and UI Endpoints Using TLS Encryption](https://prometheus.io/docs/guides/tls-encryption/). You must add TLS settings to your Prometheus configuration file **prior** to setting these options in Grafana.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 - **Basic authentication** - The most common authentication method. Use your `data source` user name and `data source` password to connect.
 
@@ -130,11 +130,11 @@ Following are additional configuration options.
 
 - **Manage alerts via Alerting UI** - Toggle to enable [data source-managed rules in Grafana Alerting](ref:alerting-alert-rules) for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts, which are displayed as data source-managed.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 The **Manage alerts via Alerting UI** toggle is enabled by default. You can change this behavior by setting the [default_manage_alerts_ui_toggle](../../../setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle) option in the Grafana configuration file.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Interval behavior
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -120,18 +120,18 @@ The **Type** setting sets the query type. These include:
 
 For more information, refer to the [Time Series Transform option documentation](ref:time-series-transform).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana modifies the request dates for queries to align them with the dynamically calculated step.
 This ensures a consistent display of metrics data and Prometheus requires this for caching results. But, aligning the range with the step can result in a small gap of data at the right edge of a graph or change the start date of the range. For example, a 15s step aligns the range to Unix time divisible by 15s and a 1w minstep aligns the range to the start of the week on a Thursday.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Exemplars
 
 Toggle **Exemplars** to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus. For more information see [Introduction to exemplars](ref:exemplars).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 There is no option to add exemplars with an **Instant** query type.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Inspector
 
@@ -243,9 +243,9 @@ You can then select one or more labels shown in Step 2.
 Select one or more values in Step 3 for each label to tighten your query scope.
 In Step 4, you can select **Use query** to run the query, **Use as rate query** to add the rate operation to your query (`$__rate_interval`), **Validate selector** to verify the selector is valid and show the number of series found, or **Clear** to clear your selections and start over.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you do not remember a metric name, you can also select a few labels to narrow down the list, then find relevant label values.
-{{% /admonition %}}
+{{< /admonition >}}
 
 All lists in the metrics browser have a search field above them to quickly filter for metrics or labels that match a certain string.
 The values section has only one search field, and its filtering applies to all labels to help you find values across labels once selected.

--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -120,9 +120,9 @@ That makes it much easier for the developers to replicate and solve your issue.
 
 ## Use a custom version of TestData
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This feature is experimental and requires Grafana version 10.3.0 or later.
-{{% /admonition %}}
+{{< /admonition >}}
 
 If you want to use a version of TestData different from the one shipped with Grafana, follow these steps:
 

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -102,9 +102,9 @@ To configure basic settings for the data source, complete the following steps:
 
 ![Trace to logs settings](/media/docs/tempo/tempo-trace-to-logs-9-4.png)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The **Trace to logs** setting configures the [trace to logs feature](ref:trace-integration) that is available when you integrate Grafana with Zipkin.
 

--- a/docs/sources/developers/angular_deprecation/angular-plugins.md
+++ b/docs/sources/developers/angular_deprecation/angular-plugins.md
@@ -20,9 +20,9 @@ The use of AngularJS in Grafana has been [deprecated](../) in favor of React. Su
 
 This page explains how Grafana users might be impacted by the removal of Angular support based on plugins dependent on this legacy framework. You will also see if there is a migration option available for a given plugin.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 We are greatly appreciative of the developers who have contributed plugins to the Grafana ecosystem. Guidance on migrating a plugin to React can be found in our [migration guide](/developers/plugin-tools/migration-guides/migrate-angularjs-to-react).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## What should I do with the list of AngularJS plugins?
 
@@ -34,9 +34,9 @@ Refer to the [table below](#angularjs-based-plugins) and take the appropriate ac
 - Customers of Grafana Enterprise and users of Grafana Cloud can also leverage [usage insights](../../../dashboards/assess-dashboard-usage/) to prioritize any migration efforts.
 - Review the plugin source repositories to add your support to any migration issues or consider forking the repo.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you want to add any specific migration guidance for your plugin here or update our assessment, please open a PR by clicking **Suggest an edit** at the bottom of this page.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Private plugins
 

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -203,9 +203,9 @@ Content-Type: application/json
 
 `PUT /api/admin/settings`
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in Grafana Enterprise v8.0+.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Updates / removes and reloads database settings. You must provide either `updates`, `removals` or both.
 

--- a/docs/sources/developers/http_api/dashboard_public.md
+++ b/docs/sources/developers/http_api/dashboard_public.md
@@ -24,11 +24,11 @@ refs:
 
 # Shared Dashboards API
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 If you're running Grafana Enterprise, you'll need to have specific permissions for some endpoints. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Create a shared dashboard
 

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -25,9 +25,9 @@ title: Data source HTTP API
 
 `GET /api/datasources`
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API currently doesn't handle pagination. The default maximum number of data sources returned is 5000. You can change this value in the default.ini file.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Required permissions**
 
@@ -84,9 +84,9 @@ Content-Type: application/json
 
 `GET /api/datasources/:datasourceId`
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API is deprecated since Grafana v9.0.0 and will be removed in a future release. Refer to the [API for getting a single data source by UID](#get-a-single-data-source-by-uid) or to the [API for getting a single data source by its name](#get-a-single-data-source-by-name).
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Required permissions**
 
@@ -351,9 +351,9 @@ Content-Type: application/json
 }
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 By defining `password` and `basicAuthPassword` under `secureJsonData` Grafana encrypts them securely as an encrypted blob in the database. The response then lists the encrypted fields under `secureJsonFields`.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Example Graphite Request with basic auth enabled**:
 
@@ -440,9 +440,9 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 `PUT /api/datasources/:datasourceId`
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API is deprecated since Grafana v9.0.0 and will be removed in a future release. Refer to the [new data source update API](#update-an-existing-data-source).
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Required permissions**
 
@@ -519,9 +519,9 @@ Content-Type: application/json
 }
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Similar to [creating a data source](#create-a-data-source), `password` and `basicAuthPassword` should be defined under `secureJsonData` in order to be stored securely as an encrypted blob in the database. Then, the encrypted fields are listed under `secureJsonFields` section in the response.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Update an existing data source
 
@@ -603,17 +603,17 @@ Content-Type: application/json
 }
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Similar to [creating a data source](#create-a-data-source), `password` and `basicAuthPassword` should be defined under `secureJsonData` in order to be stored securely as an encrypted blob in the database. Then, the encrypted fields are listed under `secureJsonFields` section in the response.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Delete an existing data source by id
 
 `DELETE /api/datasources/:datasourceId`
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API is deprecated since Grafana v9.0.0 and will be removed in a future release. Refer to the [API for deleting an existing data source by UID](#delete-an-existing-data-source-by-uid) or to the [API for deleting an existing data source by its name](#delete-an-existing-data-source-by-name)
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Required permissions**
 
@@ -715,9 +715,9 @@ Content-Type: application/json
 
 ## Data source proxy calls by id
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API is deprecated since Grafana v9.0.0 and will be removed in a future release. Refer to the [new data source API for proxying requests](#data-source-proxy-calls).
-{{% /admonition %}}
+{{< /admonition >}}
 
 `GET /api/datasources/proxy/:datasourceId/*`
 
@@ -791,9 +791,9 @@ Content-Type: application/json
 
 ## Fetch data source resources by id
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 This API is deprecated since Grafana v9.0.0 and will be removed in a future release. Refer to the [new data source resources API](#fetch-data-source-resources).
-{{% /admonition %}}
+{{< /admonition >}}
 
 `GET /api/datasources/:datasourceId/resources/*`
 
@@ -893,9 +893,9 @@ Queries a data source having a backend implementation.
 
 `POST /api/ds/query`
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana's built-in data sources usually have a backend implementation.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Example request for the Test data source**:
 

--- a/docs/sources/developers/http_api/library_element.md
+++ b/docs/sources/developers/http_api/library_element.md
@@ -441,9 +441,9 @@ Status Codes:
 
 Deletes an existing library element as specified by the UID. This operation cannot be reverted.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot delete a library element that is connected. This operation cannot be reverted.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Example Request**:
 

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -75,9 +75,9 @@ Status codes:
 
 ## Add license
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in Grafana Enterprise v7.4+.
-{{% /admonition %}}
+{{< /admonition >}}
 
 `POST /api/licensing/token`
 
@@ -151,9 +151,9 @@ Status Codes:
 
 ## Manually force license refresh
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in Grafana Enterprise v7.4+.
-{{% /admonition %}}
+{{< /admonition >}}
 
 `POST /api/licensing/token/renew`
 
@@ -212,9 +212,9 @@ Status Codes:
 
 ## Remove license from database
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in Grafana Enterprise v7.4+.
-{{% /admonition %}}
+{{< /admonition >}}
 
 `DELETE /api/licensing/token`
 

--- a/docs/sources/developers/http_api/query_and_resource_caching.md
+++ b/docs/sources/developers/http_api/query_and_resource_caching.md
@@ -23,9 +23,9 @@ title: Query and Resource Caching HTTP API
 
 # Query and resource caching API
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Enable caching for a data source
 

--- a/docs/sources/developers/http_api/snapshot.md
+++ b/docs/sources/developers/http_api/snapshot.md
@@ -69,9 +69,9 @@ JSON Body schema:
 - **key** - Optional. Define the unique key. Required if **external** is `true`.
 - **deleteKey** - Optional. Unique key used to delete the snapshot. It is different from the **key** so that only the creator can delete the snapshot. Required if **external** is `true`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When creating a snapshot using the API, you have to provide the full dashboard payload including the snapshot data. This endpoint is designed for the Grafana UI.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Example Response**:
 

--- a/docs/sources/developers/http_api/sso-settings.md
+++ b/docs/sources/developers/http_api/sso-settings.md
@@ -22,9 +22,9 @@ title: SSO Settings API
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available since Grafana 11. SAML support is in public preview behind the `ssoSettingsSAML` feature flag.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The API can be used to create, update, delete, get, and list SSO Settings for OAuth2 and SAML.
 
@@ -167,11 +167,11 @@ Grafana verifies whether the given settings are allowed and valid.
 If they are, then Grafana stores the settings in the database and reloads
 Grafana services with no need to restart the instance.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you run Grafana in high availability mode, configuration changes
 may not get applied to all Grafana instances immediately. You may need
 to wait a few minutes for the configuration to propagate to all Grafana instances.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Required permissions**
 

--- a/docs/sources/explore/correlations-editor-in-explore.md
+++ b/docs/sources/explore/correlations-editor-in-explore.md
@@ -10,9 +10,9 @@ weight: 20
 
 # Correlations Editor in Explore
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The Explore editor is available in 10.1 and later versions. In the editor, transformations is available in Grafana 10.3 and later versions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Correlations allow users to build a link between any two data sources. For more information about correlations in general, please see the [correlations](/docs/grafana/<GRAFANA_VERSION>/administration/correlations/) topic in the administration page.
 

--- a/docs/sources/explore/get-started-with-explore.md
+++ b/docs/sources/explore/get-started-with-explore.md
@@ -127,10 +127,10 @@ Select **Mixed** from the data source dropdown to run queries across multiple da
 
 When using Explore, the URL in the browser address bar updates as you make changes to the queries. You can share or bookmark this URL.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Explore may generate long URLs, which some tools, like messaging or videoconferencing applications, might truncate due to fixed message lengths. In such cases, Explore displays a warning and loads a default state.
 If you encounter issues when sharing Explore links in these applications, you can generate shortened links. See [Share shortened link](#share-shortened-link) for more information.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Generate Explore URLs from external tools
 

--- a/docs/sources/explore/query-management.md
+++ b/docs/sources/explore/query-management.md
@@ -16,17 +16,17 @@ weight: 10
 
 Grafana Explore provides a variety of tools to help manage your queries.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 For help with debugging queries, Explore allows you to investigate query requests and responses, as well as query statistics, via the Query inspector. Refer to [Query inspector in Explore](/docs/grafana/<GRAFANA_VERSION>/explore/explore-inspector/) for more information.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Query history
 
 Query history contains the list of queries that you created in Explore. This history is stored in the Grafana database and isn't shared with other users. The retention period for a query history is **two weeks**. Queries older than two weeks are automatically deleted.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Starred queries aren't subject to the two-week retention period and aren't deleted.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To view your query history:
 
@@ -65,9 +65,9 @@ Filter query history in both the **Query history** and **Starred** tabs by data 
 1. Click the **Filter queries for specific data source(s)** field.
 1. Select the data source in the dropdown by which you want to filter your history. You can select multiple data sources.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Queries with the **Mixed** data source appear only when filtering for "Mixed" and not when filtering by individual data source.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can also filter queries by date using the vertical slider:
 
@@ -87,8 +87,8 @@ You can customize your query history in the **Settings** tab.
 
 Toggle **Change the default active tab from "Query history" to "Starred"** to make the **Starred tab** the default active tab.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Query history settings are global, and applied to both panels in split mode.
-{{% /admonition %}}
+{{< /admonition >}}
 
 <!-- All queries that have been starred in the Query history tab are displayed in the Starred tab. This allows you to access your favorite queries faster and to reuse these queries without typing them from scratch. -->

--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -100,14 +100,14 @@ If the query is updated to select and group by more than just one string column,
 
 In this case the labels that represent the dimensions will have two keys based on the two string typed columns `Location` and `Sensor`. This data results four series: `Temp {Location=LGA,Sensor=A}`, `Temp {Location=LGA,Sensor=B}`, `Temp {Location=BOS,Sensor=A}`, and `Temp {Location=BOS,Sensor=B}`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 More than one dimension is currently only supported in the Logs queries within the Azure Monitor service as of version 7.1.
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Multiple dimensions are not supported in a way that maps to multiple alerts in Grafana, but rather they are treated as multiple conditions to a single alert.
 For more information, see the documentation on [creating alerts with multiple series](ref:create-grafana-managed-rule).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Multiple values
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -16,12 +16,12 @@ weight: 300
 
 Prometheus is an open source monitoring system for which Grafana provides out-of-the-box support. This topic walks you through the steps to create a series of dashboards in Grafana to display system metrics for a server monitored by Prometheus.
 
-{{% admonition type="tip" %}}
+{{< admonition type="tip" >}}
 Check out our Prometheus **Learning Journeys**.
 
 - [Connect to a Prometheus data source in Grafana Cloud](https://www.grafana.com/docs/learning-journeys/prometheus/) to visualize your metrics directly from where they are stored.
 - [Send metrics to Grafana Cloud using Prometheus remote write](https://www.grafana.com/docs/learning-journeys/prom-remote-write/) to explore Grafana Cloud without making significant changes to your existing configuration.
-  {{% /admonition %}}
+  {{< /admonition >}}
 
 _Grafana and Prometheus_:
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -201,9 +201,9 @@ Variables in data links and actions let you send people to a detailed dashboard 
 
 To see a list of available variables, enter `$` in the data link or action **URL** field.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 These variables changed in 6.4 so if you have an older version of Grafana, then use the version picker to select docs for an older version of Grafana.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Azure Monitor, [CloudWatch](ref:cloudwatch), and [Google Cloud Monitoring](ref:google-cloud-monitoring) have pre-configured data links called _deep links_.
 

--- a/docs/sources/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/panels-visualizations/configure-legend/index.md
@@ -97,9 +97,9 @@ Legends are supported for the following visualizations:
 
 You can find the following options under the **Legend** section in the panel edit pane.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Not all of the options listed apply to all visualizations with legends.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Visibility
 
@@ -175,6 +175,6 @@ When you format a legend as a table and add values to it, you can sort series in
 
 ![Legend formatted as a table showing sorted values](/media/docs/grafana/panels-visualizations/screenshot-legend-sorted-10.3-v2.png)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This feature is only supported for the following visualizations: bar chart, histogram, time series.
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -152,9 +152,9 @@ This section explains all available standard options.
 
 To set these options, expand the **Standard options** section in the panel editor pane. Most field options won't affect the visualization until you click outside of the field option box you're editing or press Enter.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Not all of the options listed apply to all visualizations with standard options.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Unit
 

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -106,9 +106,9 @@ Some visualizations, for example [candlestick](ref:candlestick) and [flame graph
 
 You can find the following options under the **Tooltip** section in the panel edit pane.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Not all of the options listed apply to all visualizations with tooltips.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Tooltip mode
 

--- a/docs/sources/panels-visualizations/panel-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-overview/index.md
@@ -117,9 +117,9 @@ To get started adding panels, ensure that you have configured a data source:
 - For details about using data sources, refer to [Data sources](ref:data-sources).
 - For more information about managing data sources as an administrator, refer to [Data source management](ref:data-source-management).
 
-  {{% admonition type="note" %}}
+  {{< admonition type="note" >}}
   [Data source management](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/) is only available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](https://grafana.com/docs/grafana-cloud/).
-  {{% /admonition %}}
+  {{< /admonition >}}
 
 ## Panel feature overview
 

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -189,9 +189,9 @@ Panel data source query options include:
   If a data point is saved every 15 seconds, you don't benefit from having an interval lower than that.
   You can also set this to a higher minimum than the scrape interval to retrieve queries that are more coarse-grained and well-functioning.
 
-  {{% admonition type="note" %}}
+  {{< admonition type="note" >}}
   The **Min interval** corresponds to the min step in Prometheus. Changing the Prometheus interval can change the start and end of the query range because Prometheus aligns the range to the interval. Refer to [Min step](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#min-step) for more details.
-  {{% /admonition %}}
+  {{< /admonition >}}
 
 - **Interval:** Sets a time span that you can use when aggregating or grouping data points by time.
 

--- a/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
@@ -48,15 +48,15 @@ Server-side expressions allow you to manipulate data returned from queries with 
 
 Expressions are most commonly used for [Grafana Alerting](ref:grafana-alerting). The processing is done server-side, so expressions can operate without a browser session. However, expressions can also be used with backend data sources and visualization.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Expressions do not work with legacy dashboard alerts.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Expressions are meant to augment data sources by enabling queries from different data sources to be combined or by providing operations unavailable in a data source.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When possible, you should do data processing inside the data source. Copying data from storage to the Grafana server for processing is inefficient, so expressions are targeted at lightweight data processing.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Expressions work with data source queries that return time series or number data. They also operate on [multiple-dimensional data](ref:multiple-dimensional-data). For example, a query that returns multiple series, where each series is identified by labels or tags.
 
@@ -142,9 +142,9 @@ abs returns the absolute value of its argument which can be a number or a series
 
 is_inf takes a number or a series and returns `1` for `Inf` values (negative or positive) and `0` for other values. For example `is_inf($A)`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you need to specifically check for negative infinity for example, you can do a comparison like `$A == infn()`.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ###### is_nan
 

--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -157,7 +157,7 @@ Grafana offers a variety of visualizations to support different use cases. This 
 
 {{< youtube id="JwF6FgeotaU" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are unsure which visualization to pick, Grafana can provide visualization suggestions based on the panel query. When you select a visualization, Grafana will show a preview with that visualization applied.
 {{< /admonition >}}
 

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -116,9 +116,9 @@ The candlestick visualization attempts to map fields from your data to the appro
 - **Close** - Final (end) value of the given period.
 - **Volume** - Sample count in the given period (for example, number of trades).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The candlestick visualization legend doesn't display these values.
-{{% /admonition %}}
+{{< /admonition >}}
 
 If your data can't be mapped to these dimensions for some reason (for example, because the column names aren't the same), you can map them manually using the **Open**, **High**, **Low**, and **Close** fields under the **Candlestick** options in the panel editor:
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -63,9 +63,9 @@ Elements are the basic building blocks of a canvas and they help you visualize d
 
 Add elements in the [Layer](#layer-options) section of canvas options.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Element snapping and alignment only works when the canvas is not zoomed in.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Element types
 
@@ -136,9 +136,9 @@ The server element lets you easily represent a single server, a stack of servers
 
 The button element lets you add a basic button to the canvas. Button elements support triggering basic, unauthenticated API calls. [API settings](#button-api-options) are found in the button element editor. You can also pass template variables in the API editor.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 A button click will only trigger an API call when [inline editing](#inline-editing) is disabled.
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< video-embed src="/media/docs/grafana/2023-20-10-Canvas-Button-Element-Enablement-Video.mp4" max-width="650px" alt="Canvas button element demo" >}}
 
@@ -271,9 +271,9 @@ Use the following pointer and keyboard strokes:
 
 You can enable infinite panning in a canvas when pan and zoom is enabled. This allows you to pan and zoom the canvas and uncover larger designs.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Infinite panning is an experimental feature that may not work as expected in all scenarios. For example, elements that are not top-left constrained may experience unexpected movement when panning.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Layer options
 

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -221,9 +221,9 @@ There are seven map layer types to choose from in a geomap.
 - [ArcGIS MapServer](#arcgis-mapserver-layer) adds a layer from an ESRI ArcGIS MapServer.
 - [XYZ Tile layer](#xyz-tile-layer) adds a map from a generic tile layer.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Beta is equivalent to the [public preview](/docs/release-life-cycle/) release stage.
-{{% /admonition %}}
+{{< /admonition >}}
 
 There are also two experimental (or alpha) layer types.
 
@@ -358,9 +358,9 @@ The Night / Day layer displays night and day regions based on the current time r
 
 #### Route layer (Beta)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Route layer is currently in [public preview](/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The Route layer renders data points as a route.
 
@@ -387,9 +387,9 @@ The layer can also render a route with arrows.
 
 #### Photos layer (Beta)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Photos layer is currently in [public preview](/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The Photos layer renders a photo at each data point.
 
@@ -414,9 +414,9 @@ The Photos layer renders a photo at each data point.
 
 #### Network layer (Beta)
 
-{{% admonition type="caution" %}}
+{{< admonition type="caution" >}}
 The Network layer is currently in [public preview](/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The Network layer renders a network graph. This layer supports the same [data format supported by the node graph visualization](ref:data-format) with the addition of [geospatial data](#location-mode) included in the nodes data. The geospatial data is used to locate and render the nodes on the map.
 

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -24,9 +24,9 @@ The news visualization displays an RSS feed. By default, it displays articles fr
 
 {{< figure src="/static/img/docs/news/news-visualization.png" max-width="1025px" alt="A news visualization showing the latest Grafana news feed" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 In version 8.5, we discontinued the "Use Proxy" option for Grafana news visualizations. As a result, RSS feeds that are not configured for request by Grafana's frontend (with the appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)) may not load.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can use the news visualization to provide regular news and updates to your users.
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -92,9 +92,9 @@ Both nodes and edges can have associated metadata or statistics. The data source
 
 #### Nodes
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Node graphs can show only 1,500 nodes. If this limit is crossed a warning will be visible in upper right corner, and some nodes will be hidden. You can expand hidden parts of the graph by clicking on the "Hidden nodes" markers in the graph.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Usually, nodes show two statistical values inside the node and two identifiers just below the node, usually name and type. Nodes can also show another set of values as a color circle around the node, with sections of different color represents different values that should add up to 1.
 

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -36,9 +36,9 @@ For example, if you're monitoring the health status of different services, you c
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-status-history-v11.6.png" max-width="800px" alt="A status history panel showing the health status of different sensors" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 A status history is similar to a [state timeline](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/state-timeline/), but has different [configuration options](#status-history-options). Unlike state timelines, status histories don't merge consecutive values.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Use a status history when you need to:
 

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -13,13 +13,13 @@ weight: 10000
 Here you can find detailed release notes that list everything included in past releases,
 as well as notices about deprecations, breaking changes, and changes related to plugin development.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 As of Grafana v9.2 we no longer publish release notes, which are redundant with other release lists that we publish:
 
 - For details about new features, deprecations, and breaking changes in new Grafana releases, see [What's New in Grafana](../whatsnew/).
 - For lists of changes to Grafana, with links to pull requests and related issues when available, see the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 - [Release notes for 9.1.7](release-notes-9-1-7/)
 - [Release notes for 9.1.6](release-notes-9-1-6/)

--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
@@ -14,13 +14,13 @@ weight: 300
 
 Custom branding enables you to replace the Grafana Labs brand and logo with your corporate brand and logo.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../../introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud). For Cloud Advanced and Enterprise customers, please provide custom elements and logos to our Support team. We will help you host your images and update your custom branding.
 
 This feature is not available for Grafana Free and Pro tiers.
 For more information on feature availability across plans, refer to our [feature comparison page](/docs/grafana-cloud/cost-management-and-billing/understand-grafana-cloud-features/)
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 The `grafana.ini` file includes Grafana Enterprise custom branding. As with all configuration options, you can use environment variables to set custom branding.
 
@@ -103,9 +103,9 @@ GF_WHITE_LABELING_FOOTER_LINKS_EXTRACUSTOM_TEXT=Custom Text
 GF_WHITE_LABELING_FOOTER_LINKS_EXTRACUSTOM_URL=http://your.custom.site
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The following two links are always present in the footer:
-{{% /admonition %}}
+{{< /admonition >}}
 
 - Grafana edition
 - Grafana version with build number

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -35,9 +35,9 @@ side to be valid for a different number of users or a new duration,
 your Grafana instance will be updated with the new terms
 automatically. Defaults to `true`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The license only automatically updates once per day. To immediately update the terms for a license, use the Grafana UI to renew your license token.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### license_validation_type
 
@@ -408,9 +408,9 @@ Setting 'enabled' to `true` allows users to configure query caching for data sou
 
 This value is `true` by default.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This setting enables the caching feature, but it does not turn on query caching for any data source. To turn on query caching for a data source, update the setting on the data source configuration page. For more information, refer to the [query caching docs](../../../administration/data-source-management/#enable-and-configure-query-caching).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### ttl
 
@@ -422,9 +422,9 @@ The max duration that a query result is stored in the caching system before it i
 
 The default is `0s` (disabled).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Disabling this constraint is not recommended in production environments.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### max_value_mb
 
@@ -444,9 +444,9 @@ This setting defines the duration to wait for the caching backend to return a ca
 
 The default is `0s` (disabled).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Disabling this timeout is not recommended in production environments.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### write_timeout
 
@@ -454,9 +454,9 @@ This setting defines the number of seconds to wait for the caching backend to st
 
 The default is `0s` (disabled).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Disabling this timeout is not recommended in production environments.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## [caching.encryption]
 
@@ -488,9 +488,9 @@ To disable the maximum, set this value to `0`.
 
 The default is `25`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Disabling the maximum is not recommended in production environments.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## [caching.redis]
 
@@ -505,13 +505,13 @@ The default is `"redis://localhost:6379"`.
 A comma-separated list of Redis cluster members, either in `host:port` format or using the full Redis URLs (`redis://username:password@localhost:6379`). For example, `localhost:7000, localhost: 7001, localhost:7002`.
 If you use the full Redis URLs, then you can specify the scheme, username, and password only once. For example, `redis://username:password@localhost:0000,localhost:1111,localhost:2222`. You cannot specify a different username and password for each URL.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have specify `cluster`, the value for `url` is ignored.
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can enable TLS for cluster mode using the `rediss` scheme in Grafana Enterprise v8.5 and later versions.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### prefix
 
@@ -527,9 +527,9 @@ A space-separated list of memcached servers. Example: `memcached-server-1:11211 
 
 The default is `"localhost:11211"`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The following memcached configuration requires the `tlsMemcached` feature toggle.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### tls_enabled
 

--- a/docs/sources/setup-grafana/configure-grafana/settings-updates-at-runtime/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/settings-updates-at-runtime/index.md
@@ -16,9 +16,9 @@ weight: 500
 
 # Settings updates at runtime
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This functionality is deprecated and will be removed in a future release. For configuring SAML authentication, please use the new [SSO settings API](../../../developers/http_api/sso-settings/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 By updating settings at runtime, you can update Grafana settings without needing to restart the Grafana server.
 

--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -19,15 +19,15 @@ weight: 800
 
 Auditing allows you to track important changes to your Grafana instance. By default, audit logs are logged to file but the auditing feature also supports sending logs directly to Loki.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To enable sending Grafana Cloud audit logs to your Grafana Cloud Logs instance, please [file a support ticket](/profile/org/tickets/new). Note that standard ingest and retention rates apply for ingesting these audit logs.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Only API requests or UI actions that trigger an API request generate an audit log.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../../introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Audit logs
 
@@ -354,9 +354,9 @@ Furthermore, you can also record `GET` requests. See below how to configure it.
 
 ## Configuration
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The auditing feature is disabled by default.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Audit logs can be saved into files, sent to a Loki instance or sent to the Grafana default logger. By default, only the file exporter is enabled.
 You can choose which exporter to use in the [configuration file](../../configure-grafana/).
@@ -403,9 +403,9 @@ max_file_size_mb = 256
 
 Audit logs are sent to a [Loki](/oss/loki/) service, through HTTP or gRPC.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The HTTP option for the Loki exporter is available only in Grafana Enterprise version 7.4 and later.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ```ini
 [auditing.logs.loki]

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
@@ -240,9 +240,9 @@ use_refresh_token = true
 
 ## Configure team synchronization
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 By using Team Sync, you can map GitLab groups to teams within Grafana. This will automatically assign users to the appropriate teams.
 Teams for each user are synchronized when the user logs in.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/google/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/google/index.md
@@ -152,9 +152,9 @@ By default, Grafana includes the `access_type=offline` parameter in the authoriz
 
 Refresh token fetching and access token expiration check is enabled by default for the Google provider since Grafana v10.1.0. If you would like to disable access token expiration check then set the `use_refresh_token` configuration value to `false`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The `accessTokenExpirationCheck` feature toggle has been removed in Grafana v10.3.0 and the `use_refresh_token` configuration value will be used instead for configuring refresh token fetching and access token expiration check.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Configure automatic login
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -23,9 +23,9 @@ This method of authentication is useful for integrating with other systems that
 use JWKS but can't directly integrate with Grafana or if you want to use pass-through
 authentication in an app embedding Grafana.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana does not currently support refresh tokens.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Enable JWT
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak-multitenant/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak-multitenant/index.md
@@ -82,9 +82,9 @@ To authenticate with Azure AD, the Keycloak application needs a client ID and cl
    1. Paste the client secret you created in the previous step in the **Client secret** field.
    1. Click Add.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Up to this point, you have created an App Registration in Azure AD, assigned users to the application, created credentials for the application, and configured the application in Keycloak. In the Keycloak Client's section, the client with ID `account` Home URL can be used to test the configuration. This will open a new tab where you can login into the correct Keycloak realm with the Azure AD tenant you just configured.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Repeat this steps, for every Azure AD tenant you want to configure in Keycloak.
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
@@ -93,9 +93,9 @@ profile
 roles
 ```
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 These scopes do not add group claims to the `id_token`. Without group claims, teamsync will not work. Teamsync is covered further down in this document.
-{{% /admonition %}}
+{{< /admonition >}}
 
 3. For role mapping to work with the example configuration above,
    you need to create the following roles and assign them to users:
@@ -153,9 +153,9 @@ signout_redirect_url = https://<PROVIDER_DOMAIN>/realms/<REALM_NAME>/protocol/op
 As an example, `<PROVIDER_DOMAIN>` can be `keycloak-demo.grafana.org`,
 `<REALM_NAME>` can be `grafana` and `<GRAFANA_DOMAIN>` can be `play.grafana.org`.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana supports ID token hints for single logout. Grafana automatically adds the `id_token_hint` parameter to the logout request if it detects OAuth as the authentication method.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Allow assigning Grafana Admin
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/okta/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/okta/index.md
@@ -245,9 +245,9 @@ org_mapping = ["Group 1:org_foo:Viewer", "Group 2:org_bar:Editor", "*:3:Editor"]
 
 ### Configure team synchronization (Enterprise only)
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](../../../../introduction/grafana-cloud).
-{{% /admonition %}}
+{{< /admonition >}}
 
 By using Team Sync, you can link your Okta groups to teams within Grafana. This will automatically assign users to the appropriate teams.
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -307,9 +307,9 @@ Grafana supports user authentication through Okta, which is useful when you want
    - In the **Single sign on URL** field, use the `/saml/acs` endpoint URL of your Grafana instance, for example, `https://grafana.example.com/saml/acs`.
    - In the **Audience URI (SP Entity ID)** field, use the `/saml/metadata` endpoint URL, by default it is the `/saml/metadata` endpoint of your Grafana instance (for example `https://example.grafana.com/saml/metadata`). This could be configured differently, but the value here must match the `entity_id` setting of the SAML settings of Grafana.
    - Leave the default values for **Name ID format** and **Application username**.
-     {{% admonition type="note" %}}
+     {{< admonition type="note" >}}
      If you plan to enable SAML Single Logout, consider setting the **Name ID format** to `EmailAddress` or `Persistent`. This must match the `name_id_format` setting of the Grafana instance.
-     {{% /admonition %}}
+     {{< /admonition >}}
    - In the **ATTRIBUTE STATEMENTS (OPTIONAL)** section, enter the SAML attributes to be shared with Grafana. The attribute names in Okta need to match exactly what is defined within Grafana, for example:
 
      | Attribute name (in Grafana) | Name and value (in Okta profile)                     | Grafana configuration (under `auth.saml`) |
@@ -404,9 +404,9 @@ Additionally, Grafana did not support IdP sessions and could not include the `Se
 
 Starting from Grafana version 11.5, Grafana uses the `NameID` from the SAML assertion to create the logout request. If the `NameID` is not present in the assertion, Grafana defaults to using the user's `Login` attribute. Additionally, Grafana supports including the `SessionIndex` in the logout request if it is provided in the SAML assertion by the IdP.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 These improvements are available in public preview behind the `improvedExternalSessionHandlingSAML` feature toggle, starting from Grafana v11.5. To enable it, refer to the [Configure feature toggles](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/)
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Assertion mapping
 
@@ -480,7 +480,7 @@ auto_login = true
 
 To use SAML Team sync, set [`assertion_attribute_groups`](../../../configure-grafana/enterprise-configuration#assertion_attribute_groups) to the attribute name where you store user groups. Then Grafana will use attribute values extracted from SAML assertion to add user into the groups with the same name configured on the External group sync tab.
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Grafana requires the SAML groups attribute to be configured with distinct `AttributeValue` elements for each group. Do not include multiple groups within a single `AttributeValue` delimited by a comma or any other character. Failure to do so will prevent correct group parsing. Example:
 
 ```xml
@@ -490,11 +490,11 @@ Grafana requires the SAML groups attribute to be configured with distinct `Attri
 </saml2:Attribute>
 ```
 
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Teamsync allows you sync users from SAML to Grafana teams. It does not automatically create teams in Grafana. You need to create teams in Grafana before you can use this feature.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Given the following partial SAML assertion:
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
@@ -18,21 +18,21 @@ Grafana’s database contains secrets, which are used to query data sources, sen
 
 Grafana encrypts these secrets before they are written to the database, by using a symmetric-key encryption algorithm called Advanced Encryption Standard (AES). These secrets are signed using a [secret key](../../configure-grafana/#secret_key) that you can change when you configure a new Grafana instance.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Grafana v9.0 and newer use [envelope encryption](#envelope-encryption) by default, which adds a layer of indirection to the encryption process that introduces an [**implicit breaking change**](#implicit-breaking-change) for older versions of Grafana.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For further details about how to operate a Grafana instance with envelope encryption, see the [Operational work](#operational-work) section.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 In Grafana Enterprise, you can also [encrypt secrets in AES-GCM (Galois/Counter Mode)](#changing-your-encryption-mode-to-aes-gcm) instead of the default AES-CFB (Cipher FeedBack mode).
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Envelope encryption
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Since Grafana v9.0, you can turn envelope encryption off by adding the feature toggle `disableEnvelopeEncryption` to your [Grafana configuration](../../configure-grafana/#feature_toggles).
-{{% /admonition %}}
+{{< /admonition >}}
 
 Instead of encrypting all secrets with a single key, Grafana uses a set of keys called data encryption keys (DEKs) to encrypt them. These data encryption keys are themselves encrypted with a single key encryption key (KEK), configured through the `secret_key` attribute in your
 [Grafana configuration](../../configure-grafana/#secret_key) or by [Encrypting your database with a key from a key management service (KMS)](#encrypting-your-database-with-a-key-from-a-key-management-service-kms).
@@ -79,11 +79,11 @@ You can rotate data keys to disable the active data key and therefore stop using
 
 New data keys for encryption operations are generated on demand.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Data key rotation does **not** implicitly re-encrypt secrets. Grafana will continue to use rotated data keys to decrypt
 secrets still encrypted with them. To completely stop using
 rotated data keys for both encryption and decryption, see [secrets re-encryption](#re-encrypt-secrets).
-{{% /admonition %}}
+{{< /admonition >}}
 
 To rotate data keys, use the `/encryption/rotate-data-keys` endpoint of the Grafana [Admin API](../../../developers/http_api/admin/#rotate-data-encryption-keys). It's safe to call more than once, more recommended under maintenance mode.
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/index.md
@@ -15,14 +15,14 @@ weight: 500
 
 If you manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration](../../../configure-grafana/) and [Provisioning](../../../../administration/provisioning/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../../../introduction/grafana-enterprise/).
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you have Grafana [set up for high availability](../../../set-up-for-high-availability/), then we advise not to use dynamic secrets for provisioning files.
 Each Grafana instance is responsible for renewing its own leases. Your data source leases might expire when one of your Grafana servers shuts down.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Configuration
 

--- a/docs/sources/setup-grafana/configure-security/configure-request-security.md
+++ b/docs/sources/setup-grafana/configure-security/configure-request-security.md
@@ -18,13 +18,13 @@ Request security allows you to limit requests from the Grafana server by targeti
 
 This can be used to limit access to internal systems that the server Grafana runs on can access but that users of Grafana should not be able to access. This feature does not affect traffic from the Grafana users browser.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../../introduction/grafana-enterprise/) and [Grafana Cloud Pro and Advanced](/docs/grafana-cloud/).
-{{% /admonition %}}
+{{< /admonition >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Although request security works with backend plugins, you can create a backend plugin that bypasses this security.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## IP and hostname blocking
 

--- a/docs/sources/setup-grafana/configure-security/export-logs.md
+++ b/docs/sources/setup-grafana/configure-security/export-logs.md
@@ -17,9 +17,9 @@ weight: 900
 
 # Export logs of usage insights
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Available in [Grafana Enterprise](../../../introduction/grafana-enterprise/) and [Grafana Cloud Pro and Advanced](/docs/grafana-cloud/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 By exporting usage logs to Loki, you can directly query them and create dashboards of the information that matters to you most, such as dashboard errors, most active organizations, or your top-10 most-used queries. This configuration is done for you in Grafana Cloud, with provisioned dashboards. Read about them in the [Grafana Cloud documentation](/docs/grafana-cloud/usage-insights/).
 

--- a/docs/sources/setup-grafana/configure-security/secret-scan.md
+++ b/docs/sources/setup-grafana/configure-security/secret-scan.md
@@ -19,9 +19,9 @@ Grafana instances, whether on-premises or on the cloud, can use this service to 
 
 If the service detects a leaked token, it immediately revokes it, making it useless, and logs the event.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If the `revoke` option is disabled, the service only sends a notification to the configured webhook URL and logs the event. The token is not automatically revoked.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can also configure the service to send an outgoing webhook notification to a webhook URL.
 
@@ -39,9 +39,9 @@ Grafana has revoked this token",
 }
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Secret scanning is disabled by default. Outgoing connections are made once you enable it.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Before you begin
 

--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -32,9 +32,9 @@ Alert notifications can include images, but rendering many images at the same ti
 
 ## Install Grafana Image Renderer plugin
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 All PhantomJS support has been removed. Instead, use the Grafana Image Renderer plugin or remote rendering service.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To install the plugin, refer to the [Grafana Image Renderer Installation instructions](/grafana/plugins/grafana-image-renderer/?tab=installation#installation).
 
@@ -66,9 +66,9 @@ You can see a docker-compose example using a custom configuration file [here](ht
 
 ### Security
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 This feature is available in Image Renderer v3.6.1 and later.
-{{% /admonition %}}
+{{< /admonition >}}
 
 You can restrict access to the rendering endpoint by specifying a secret token. The token should be configured in the Grafana configuration file and the renderer configuration file. This token is important when you run the plugin in remote rendering mode.
 
@@ -104,9 +104,9 @@ You can instruct how headless browser instances are created by configuring a ren
 
 Default mode will create a new browser instance on each request. When handling multiple concurrent requests, this mode increases memory usage as it will launch multiple browsers at the same time. If you want to set a maximum number of browser to open, you'll need to use the [clustered mode](#clustered).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When using the `default` mode, it's recommended to not remove the default Chromium flag `--disable-gpu`. When receiving a lot of concurrent requests, not using this flag can cause Puppeteer `newPage` function to freeze, causing request timeouts and leaving browsers open.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ```bash
 RENDERING_MODE=default
@@ -177,9 +177,9 @@ To achieve better performance, monitor the machine on which your service is runn
 
 ### Other available settings
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Please note that not all settings are available using environment variables. If there is no example using environment variable below, it means that you need to update the configuration file.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### HTTP host
 
@@ -215,9 +215,9 @@ HTTP_PORT=0
 
 #### HTTP protocol
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 HTTPS protocol is supported in the image renderer v3.11.0 and later.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Change the protocol of the server, it can be `http` or `https`. Default is `http`.
 
@@ -370,9 +370,9 @@ RENDERING_DUMPIO=true
 If you already have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/)
 installed on your system, then you can use this instead of the pre-packaged version of Chromium.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Please note that this is not recommended, since you may encounter problems if the installed version of Chrome/Chromium is not compatible with the [Grafana Image renderer plugin](/grafana/plugins/grafana-image-renderer).
-{{% /admonition %}}
+{{< /admonition >}}
 
 You need to make sure that the Chrome/Chromium executable is available for the Grafana/image rendering service process.
 

--- a/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
@@ -155,10 +155,10 @@ As a last resort, if you already have [Chrome](https://www.google.com/chrome/) o
 installed on your system, then you can configure the Grafana Image renderer plugin to use this
 instead of the pre-packaged version of Chromium.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Please note that this is not recommended, since you may encounter problems if the installed version of Chrome/Chromium is not
 compatible with the [Grafana Image renderer plugin](/grafana/plugins/grafana-image-renderer).
-{{% /admonition %}}
+{{< /admonition >}}
 
 To override the path to the Chrome/Chromium executable in plugin mode, set an environment variable and make sure that it's available for the Grafana process. For example:
 

--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -16,9 +16,9 @@ This topic includes instructions for installing and running Grafana on Kubernete
 
 [Helm](https://helm.sh/) is an open-source command line tool used for managing Kubernetes applications. It is a graduate project in the [CNCF Landscape](https://www.cncf.io/projects/helm/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The Grafana open-source community offers Helm Charts for running it on Kubernetes. Please be aware that the code is provided without any warranties. If you encounter any problems, you can report them to the [Official GitHub repository](https://github.com/grafana/helm-charts/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 Watch this video to learn more about installing Grafana using Helm Charts: {{< youtube id="sgYrEleW24E">}}
 

--- a/docs/sources/setup-grafana/installation/kubernetes/index.md
+++ b/docs/sources/setup-grafana/installation/kubernetes/index.md
@@ -45,16 +45,16 @@ For a list of supported databases, refer to [supported databases](/docs/grafana/
 
 For a list of support web browsers, refer to [supported web browsers](/docs/grafana/latest/setup-grafana/installation#supported-web-browsers).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Enable port `3000` in your network environment, as this is the Grafana default port.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Deploy Grafana OSS on Kubernetes
 
 This section explains how to install Grafana OSS using Kubernetes.
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you want to install Grafana Enterprise on Kubernetes, refer to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes).
-{{% /admonition %}}
+{{< /admonition >}}
 
 If you deploy an application in Kubernetes, it will use the default namespace which may already have other applications running. This can result in conflicts and other issues.
 
@@ -346,9 +346,9 @@ Rolling updates enable deployment updates to take place with no downtime by incr
 
 The following steps use the `kubectl annotate` command to add the metadata and keep track of the deployment. For more information about `kubectl annotate`, refer to [kubectl annotate documentation](https://jamesdefabia.github.io/docs/user-guide/kubectl/kubectl_annotate/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Instead of using the `annotate` flag, you can still use the `--record` flag. However, it has been deprecated and will be removed in the future version of Kubernetes. See: https://github.com/kubernetes/kubernetes/issues/40422
-{{% /admonition %}}
+{{< /admonition >}}
 
 1. To view the current status of the rollout, run the following command:
 
@@ -457,9 +457,9 @@ Instead of using the `annotate` flag, you can still use the `--record` flag. How
 
 This means that `REVISION#2` is the current version.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The last line of the `kubectl rollout history deployment` command output is the one which is currently active and running on your Kubernetes environment.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Roll back a deployment
 
@@ -887,9 +887,9 @@ kubectl create configmap ge-config --from-file=/path/to/your/grafana.ini
      type: LoadBalancer
    ```
 
-   {{% admonition type="caution" %}}
+   {{< admonition type="caution" >}}
    If you use `LoadBalancer` in the Service and depending on your cloud platform and network configuration, doing so might expose your Grafana instance to the Internet. To eliminate this risk, use `ClusterIP` to restrict access from within the cluster Grafana is deployed to.
-   {{% /admonition %}}
+   {{< /admonition >}}
 
 1. To send the manifest to Kubernetes API Server, run the following command:
    `kubectl apply -f grafana.yaml`

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -23,9 +23,9 @@ Grafana Live is a real-time messaging engine you can use to push event data to a
 
 This could be notifications about dashboard changes, new frames for rendered data, and so on. Live features can help eliminate a page reload or polling in many places, it can stream Internet of things (IoT) sensors or any other real-time data to panels.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 By `real-time`, we indicate a soft real-time. Due to network latencies, garbage collection cycles, and so on, the delay of a delivered message can be up to several hundred milliseconds or higher.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Concepts
 

--- a/docs/sources/setup-grafana/set-up-https.md
+++ b/docs/sources/setup-grafana/set-up-https.md
@@ -107,9 +107,9 @@ This section shows you how to use `openssl` tooling to generate all necessary fi
 
 The examples in this section use LetsEncrypt because it is free.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The instructions provided in this section are for a Debian-based Linux system. For other distributions and operating systems, please refer to the [certbot instructions](https://certbot.eff.org/instructions). Also, these instructions require you to have a domain name that you are in control of. Dynamic domain names like those from Amazon EC2 or DynDNS providers will not function.
-{{% /admonition %}}
+{{< /admonition >}}
 
 #### Install `snapd` and `certbot`
 

--- a/docs/sources/shared/alerts/how_label_matching_works.md
+++ b/docs/sources/shared/alerts/how_label_matching_works.md
@@ -25,9 +25,9 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
   | `=~`     | Select labels that regex-match the value.          |
   | `!~`     | Select labels that do not regex-match the value.   |
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
-{{% /admonition %}}
+{{< /admonition >}}
 
 **Label matching example**
 

--- a/docs/sources/shared/alerts/template-language.md
+++ b/docs/sources/shared/alerts/template-language.md
@@ -165,9 +165,9 @@ This works because both `.Alerts` and `.Alerts.Firing` is a list of alerts.
 {{ end }}
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You cannot create independent, reusable templates for labels and annotations as you can with notification templates. In alert rule templates, you need to write each template inline within the label or annotation field.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Comments
 

--- a/docs/sources/shared/alerts/warning-provisioning-tree.md
+++ b/docs/sources/shared/alerts/warning-provisioning-tree.md
@@ -2,7 +2,7 @@
 title: 'Warning Provisioning Tree'
 ---
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 
 Since the policy tree is a single resource, provisioning it will overwrite all policies in the notification policy tree. However, it does not affect internal policies created when alert rules directly select a contact point.
 

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -22,10 +22,10 @@ The Grafana configuration files are located in the following directories:
 
 For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 If you installed Grafana using the `deb` or `rpm` packages, then your configuration file is located at
 `/etc/grafana/grafana.ini`. This path is specified in the Grafana `init.d` script using `--config` file parameter.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Back up plugin data
 
@@ -44,9 +44,9 @@ We recommend that you back up your Grafana database so that you can roll back to
 
 The default Grafana database is SQLite, which stores its data in a single file on disk. To back up this file, copy it to your backup repository.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 To ensure data integrity, shut down your Grafana service before backing up the SQLite database.
-{{% /admonition %}}
+{{< /admonition >}}
 
 The SQLite database file is located in one of the following directories:
 

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -104,10 +104,10 @@ To add a tag, follow these steps:
 
 ### Optional: Use Aggregate by
 
-{{% admonition type="warning" %}}
+{{< admonition type="warning" >}}
 Metrics summary API and the **Aggregate by** feature are deprecated in Grafana Cloud and Grafana 11.3 and later.
 It will be removed in a future release.
-{{% /admonition %}}
+{{< /admonition >}}
 
 Using **Aggregate by**, you can calculate RED metrics (total span count, percent erroring spans, and latency information) for spans of `kind=server` that match your filter criteria, grouped by one or more attributes.
 This capability is based on the [metrics summary API](/docs/grafana-cloud/monitor-infrastructure/traces/metrics-summary-api/).

--- a/docs/sources/shared/upgrade/intro.md
+++ b/docs/sources/shared/upgrade/intro.md
@@ -12,14 +12,14 @@ Because Grafana upgrades are backward compatible, the upgrade process is straigh
 
 In addition to common tasks you should complete for all versions of Grafana, there might be additional upgrade tasks to complete for a version.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 There might be breaking changes in some releases. We outline these changes in the [What's New ](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/whatsnew/) document for most releases or a separate [Breaking changes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/breaking-changes/) document for releases with many breaking changes.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For versions of Grafana prior to v9.2, we published additional information in the [Release Notes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/release-notes/).
 
 When available, we list all changes with links to pull requests or issues in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When possible, we recommend that you test the Grafana upgrade process in a test or development environment.
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/shared/upgrade/intro_2.md
+++ b/docs/sources/shared/upgrade/intro_2.md
@@ -12,14 +12,14 @@ Because Grafana upgrades are backward compatible, the upgrade process is straigh
 
 In addition to common tasks you should complete for all versions of Grafana, there might be additional upgrade tasks to complete for a version.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 There might be breaking changes in some releases. We outline all these changes in the [What's New](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/whatsnew/) document.
-{{% /admonition %}}
+{{< /admonition >}}
 
 For versions of Grafana prior to v9.2, we published additional information in the [Release Notes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/release-notes/).
 
 When available, we list all changes with links to pull requests or issues in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 When possible, we recommend that you test the Grafana upgrade process in a test or development environment.
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -90,9 +90,9 @@ To upgrade Grafana running in a Docker container, complete the following steps:
 
 1. Run a commands similar to the following commands.
 
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    This is an example. The parameters you enter depend on how you configured your Grafana container.
-   {{% /admonition %}}
+   {{< /admonition >}}
 
    ```bash
    docker pull grafana/grafana

--- a/docs/sources/tutorials/create-alerts-with-logs/index.md
+++ b/docs/sources/tutorials/create-alerts-with-logs/index.md
@@ -217,7 +217,7 @@ In this section, we use the default options for Grafana-managed alert rule creat
 
    <!-- INTERACTIVE ignore START -->
 
-   {{% admonition type="note" %}}
+   {{< admonition type="note" >}}
    If you're using your own logs, modify the LogQL query to match your own log message. Refer to the Loki docs to understand the [pattern parser](https://grafana.com/docs/loki/latest/logql/log_queries/#pattern).
    {{% / admonition %}}
    <!-- INTERACTIVE ignore END -->

--- a/docs/sources/tutorials/create-users-and-teams/index.md
+++ b/docs/sources/tutorials/create-users-and-teams/index.md
@@ -55,9 +55,9 @@ a global role, the default `admin` user has this role.
 - **Editor -** Create and edit dashboards.
 - **Viewer -** View dashboards.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can also configure Grafana to allow [anonymous access](/docs/grafana/latest/auth/overview/#anonymous-authentication), to make dashboards available even to those who don't have a Grafana user account. That's how Grafana Labs made https://play.grafana.org publicly available.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Exercise
 

--- a/docs/sources/upgrade-guide/upgrade-v10.4/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v10.4/index.md
@@ -32,6 +32,6 @@ You can disable this behavior using the feature flag `alertingUpgradeDryrunOnSta
 alertingUpgradeDryrunOnStart=false
 ```
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 We strongly encourage you to review the [upgrade guide](https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts/) and perform the necessary upgrade steps prior to v11.
-{{% /admonition %}}
+{{< /admonition >}}

--- a/docs/sources/upgrade-guide/upgrade-v8.1/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.1/index.md
@@ -30,8 +30,8 @@ This section describes technical changes associated with this release of Grafana
 
 As of Grafana v8.1, we no longer support unencrypted storage of passwords and basic auth passwords.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Since Grafana v6.2, new or updated data sources store passwords and basic auth passwords encrypted. However, unencrypted passwords and basic auth passwords were also allowed.
-{{% /admonition %}}
+{{< /admonition >}}
 
 To migrate to encrypted storage, use a `grafana-cli` command to migrate all of your data sources to use encrypted storage of secrets. See [migrate data and encrypt passwords](../../cli/#migrate-data-and-encrypt-passwords) for further instructions.

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -68,9 +68,9 @@ weight: 1
 
 For release highlights, deprecations, and breaking changes in Grafana releases, refer to these "What's new" pages for each version.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 For Grafana versions prior to v9.2, additional information might also be available in the archive of [release notes](../release-notes/).
-{{% /admonition %}}
+{{< /admonition >}}
 
 For a complete list of every change, with links to pull requests and related issues when available, see the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 

--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -26,9 +26,9 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Name of contributor -->
 <!-- [Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You must use relative references when linking to docs within the Grafana repo. Please do not use absolute URLs. For more information about relrefs, refer to [Links and references](/docs/writers-toolkit/writing-guide/references/).
-{{% /admonition %}}
+{{< /admonition >}}
 -->
 
 ## Breaking changes
@@ -249,11 +249,11 @@ We've also added a **Public dashboard users** tab in **Administration > Users** 
 
 To try it out, please contact customer support.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 This feature will have a cost by active users after being promoted into general availability.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 To learn more, refer to our [public dashboards documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/share-dashboards-panels/shared-dashboards/).
 
@@ -284,11 +284,11 @@ From now on, whether you type your username or email address in uppercase, lower
 
 To help you deal with potential user identity conflicts, we've built a [Grafana CLI user identity conflict resolver tool](https://grafana.com/blog/2022/12/12/guide-to-using-the-new-grafana-cli-user-identity-conflict-tool-in-grafana-9.3/), which is available from Grafana version 9.3.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 If you're running Grafana with MySQL as a database, this change doesn't have any impact as MySQL users were already treated as case-insensitive.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Tracing
 

--- a/docs/sources/whatsnew/whats-new-in-v10-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-1.md
@@ -26,9 +26,9 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Name of contributor -->
 <!-- _[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You must use relative references when linking to docs within the Grafana repo. Please do not use absolute URLs. For more information about relrefs, refer to [Links and references](/docs/writers-toolkit/writing-guide/references/).
-{{% /admonition %}}
+{{< /admonition >}}
 -->
 <!-- Add an image, GIF or video  as below
 

--- a/docs/sources/whatsnew/whats-new-in-v10-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-2.md
@@ -29,9 +29,9 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Name of contributor -->
 <!-- _[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".
-{{% /admonition %}}
+{{< /admonition >}}
 -->
 <!-- Add an image, GIF or video  as below
 
@@ -473,11 +473,11 @@ With the current release, we've introduced a new configuration option for each O
 
 For more information on how to set up refresh token handling, please refer to [the documentation of the particular OAuth provider.](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-security/configure-authentication/).
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 The `use_refresh_token` configuration must be used in conjunction with the `accessTokenExpirationCheck` [feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/). If you disable the `accessTokenExpirationCheck` feature toggle, Grafana won't check the expiration of the access token and won't automatically refresh the expired access token, even if the `use_refresh_token` configuration is set to `true`.
 
 The `accessTokenExpirationCheck` feature toggle will be removed in Grafana v10.3.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Permission validation on custom role creation and update
 

--- a/docs/sources/whatsnew/whats-new-in-v10-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-3.md
@@ -34,9 +34,9 @@ For Grafana v10.3, we've also provided a list of [breaking changes](https://graf
 <!-- Name of contributor -->
 <!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".
-{{% /admonition %}}
+{{< /admonition >}}
 
 <!--Add an image, GIF or video  as below-->
 
@@ -135,9 +135,9 @@ To try out the new tooltips, enable the `newVizTooltips` [feature toggle](https:
 - XY Chart
 - and more coming soon!
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 As this is an ongoing project, the dashboard shared cursor and annotations features are not yet fully supported.
-{{% /admonition %}}
+{{< /admonition >}}
 
 {{< youtube id="0Rp6FYfHu6Q" >}}
 
@@ -328,11 +328,11 @@ _Generally available in Grafana Enterprise, Grafana Cloud Advanced and Cloud Pro
 
 Introducing query caching for async queries in the Athena and Redshift data source plugins. We previously introduced async queries for the Athena and Redshift plugins, and this feature adds support for caching those queries. To use this, you must have query caching enabled for the Athena or Redshift data source you wish to cache. This feature was previously available behind a feature toggle and is now generally available and enabled by default.
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 
 The `useCachingService` feature toggle must also be enabled to use this feature.
 
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Loki data source improvements: "or" filter syntax, filter by label types, derived fields by labels
 

--- a/docs/sources/whatsnew/whats-new-in-v10-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-4.md
@@ -27,9 +27,9 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Name of contributor -->
 <!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".
-{{% /admonition %}}
+{{< /admonition >}}
 
 <!--Add an image, GIF or video  as below-->
 

--- a/docs/sources/whatsnew/whats-new-in-v11-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v11-0.md
@@ -37,9 +37,9 @@ For Grafana v11.0, we've also provided a list of [breaking changes](https://graf
 <!-- Name of contributor -->
 <!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".
-{{% /admonition %}}
+{{< /admonition >}}
 
 <!--Add an image, GIF or video  as below-->
 


### PR DESCRIPTION
https://grafana.com/docs/writers-toolkit/review/lint-prose/rules/#grafanashortcodes

Performed with:

```bash

set -euf -o pipefail

function usage {
  cat <<EOF
Replace all old syntax admonition shortcodes for all Markdown files in the specified directory.

Usage:
  $0 <DIRECTORY>

Examples:
  $0 docs/sources
EOF
}

if [[ $# -ne 1 ]]; then
  usage

  exit 2
fi

find "$1" -name '*.md' -type f | while read -r file; do
  sed -i '' -f - -- "${file}" <<EOF
s/{{% *admonition *type="*\([^"]*\)"* *%}}/{{< admonition type="\1" >}}/g
s/{{% *\/admonition *%}}/{{< \/admonition >}}/g
EOF
done
```
