### PR TITLE
K8s/Dashboards: Add mode 1, 2 to dashboard TestIntegrationValidation

### DIFF
--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -62,7 +62,7 @@ func TestIntegrationValidation(t *testing.T) {
 	}
 
 	// TODO: Skip mode3 - borken due to race conditions while setting default permissions across storage backends
-	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1}
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 			// Create a K8sTestHelper which will set up a real API server

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -62,7 +62,7 @@ func TestIntegrationValidation(t *testing.T) {
 	}
 
 	// TODO: Skip mode3 - borken due to race conditions while setting default permissions across storage backends
-	dualWriterModes := []rest.DualWriterMode{rest.Mode0}
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 			// Create a K8sTestHelper which will set up a real API server
@@ -378,40 +378,40 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			require.NoError(t, err)
 		})
 
-		// Test generation conflict when updating concurrently
-		t.Run("reject update with version conflict", func(t *testing.T) {
-			// Create a dashboard with admin
-			dash, err := createDashboard(t, adminClient, "Dashboard for Version Conflict Test", nil, nil)
-			require.NoError(t, err, "Failed to create dashboard for version conflict test")
-			dashUID := dash.GetName()
+		// // Test generation conflict when updating concurrently
+		// t.Run("reject update with version conflict", func(t *testing.T) {
+		// 	// Create a dashboard with admin
+		// 	dash, err := createDashboard(t, adminClient, "Dashboard for Version Conflict Test", nil, nil)
+		// 	require.NoError(t, err, "Failed to create dashboard for version conflict test")
+		// 	dashUID := dash.GetName()
 
-			// Get the dashboard twice (simulating two users getting it)
-			dash1, err := adminClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
-			require.NoError(t, err)
-			dash2, err := editorClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
-			require.NoError(t, err)
+		// 	// Get the dashboard twice (simulating two users getting it)
+		// 	dash1, err := adminClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
+		// 	require.NoError(t, err)
+		// 	dash2, err := editorClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
+		// 	require.NoError(t, err)
 
-			// Update with the first copy
-			updatedDash1, err := updateDashboard(t, adminClient, dash1, "Updated by first user", nil)
-			require.NoError(t, err)
-			require.NotNil(t, updatedDash1)
+		// 	// Update with the first copy
+		// 	updatedDash1, err := updateDashboard(t, adminClient, dash1, "Updated by first user", nil)
+		// 	require.NoError(t, err)
+		// 	require.NotNil(t, updatedDash1)
 
-			// Try to update with the second copy (should fail with version conflict for mode 0, 4 and 5, but not for mode 1, 2 and 3)
-			updatedDash2, err := updateDashboard(t, editorClient, dash2, "Updated by second user", nil)
-			if ctx.DualWriterMode == rest.Mode1 || ctx.DualWriterMode == rest.Mode2 || ctx.DualWriterMode == rest.Mode3 {
-				require.NoError(t, err)
-				require.NotNil(t, updatedDash2)
-				meta, _ := utils.MetaAccessor(updatedDash2)
-				require.Equal(t, "Updated by second user", meta.FindTitle(""), "Dashboard title should be updated")
-			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "the object has been modified", "Should fail with version conflict error")
-			}
+		// 	// Try to update with the second copy (should fail with version conflict for mode 0, 4 and 5, but not for mode 1, 2 and 3)
+		// 	updatedDash2, err := updateDashboard(t, editorClient, dash2, "Updated by second user", nil)
+		// 	if ctx.DualWriterMode == rest.Mode1 || ctx.DualWriterMode == rest.Mode2 || ctx.DualWriterMode == rest.Mode3 {
+		// 		require.NoError(t, err) // fix here
+		// 		require.NotNil(t, updatedDash2)
+		// 		meta, _ := utils.MetaAccessor(updatedDash2)
+		// 		require.Equal(t, "Updated by second user", meta.FindTitle(""), "Dashboard title should be updated")
+		// 	} else {
+		// 		require.Error(t, err)
+		// 		require.Contains(t, err.Error(), "the object has been modified", "Should fail with version conflict error")
+		// 	}
 
-			// Clean up
-			err = adminClient.Resource.Delete(context.Background(), dashUID, v1.DeleteOptions{})
-			require.NoError(t, err)
-		})
+		// 	// Clean up
+		// 	err = adminClient.Resource.Delete(context.Background(), dashUID, v1.DeleteOptions{})
+		// 	require.NoError(t, err)
+		// })
 
 		// Test setting an explicit generation
 		t.Run("explicit generation setting is validated", func(t *testing.T) {

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -378,40 +378,33 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			require.NoError(t, err)
 		})
 
-		// // Test generation conflict when updating concurrently
-		// t.Run("reject update with version conflict", func(t *testing.T) {
-		// 	// Create a dashboard with admin
-		// 	dash, err := createDashboard(t, adminClient, "Dashboard for Version Conflict Test", nil, nil)
-		// 	require.NoError(t, err, "Failed to create dashboard for version conflict test")
-		// 	dashUID := dash.GetName()
+		// Test generation conflict when updating concurrently
+		t.Run("reject update with version conflict", func(t *testing.T) {
+			// Create a dashboard with admin
+			dash, err := createDashboard(t, adminClient, "Dashboard for Version Conflict Test", nil, nil)
+			require.NoError(t, err, "Failed to create dashboard for version conflict test")
+			dashUID := dash.GetName()
 
-		// 	// Get the dashboard twice (simulating two users getting it)
-		// 	dash1, err := adminClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
-		// 	require.NoError(t, err)
-		// 	dash2, err := editorClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
-		// 	require.NoError(t, err)
+			// Get the dashboard twice (simulating two users getting it)
+			dash1, err := adminClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
+			require.NoError(t, err)
+			dash2, err := editorClient.Resource.Get(context.Background(), dashUID, v1.GetOptions{})
+			require.NoError(t, err)
 
-		// 	// Update with the first copy
-		// 	updatedDash1, err := updateDashboard(t, adminClient, dash1, "Updated by first user", nil)
-		// 	require.NoError(t, err)
-		// 	require.NotNil(t, updatedDash1)
+			// Update with the first copy
+			updatedDash1, err := updateDashboard(t, adminClient, dash1, "Updated by first user", nil)
+			require.NoError(t, err)
+			require.NotNil(t, updatedDash1)
 
-		// 	// Try to update with the second copy (should fail with version conflict for mode 0, 4 and 5, but not for mode 1, 2 and 3)
-		// 	updatedDash2, err := updateDashboard(t, editorClient, dash2, "Updated by second user", nil)
-		// 	if ctx.DualWriterMode == rest.Mode1 || ctx.DualWriterMode == rest.Mode2 || ctx.DualWriterMode == rest.Mode3 {
-		// 		require.NoError(t, err) // fix here
-		// 		require.NotNil(t, updatedDash2)
-		// 		meta, _ := utils.MetaAccessor(updatedDash2)
-		// 		require.Equal(t, "Updated by second user", meta.FindTitle(""), "Dashboard title should be updated")
-		// 	} else {
-		// 		require.Error(t, err)
-		// 		require.Contains(t, err.Error(), "the object has been modified", "Should fail with version conflict error")
-		// 	}
+			// Try to update with the second copy. Should fail with version conflict.
+			_, err = updateDashboard(t, editorClient, dash2, "Updated by second user", nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "the object has been modified", "Should fail with version conflict error")
 
-		// 	// Clean up
-		// 	err = adminClient.Resource.Delete(context.Background(), dashUID, v1.DeleteOptions{})
-		// 	require.NoError(t, err)
-		// })
+			// Clean up
+			err = adminClient.Resource.Delete(context.Background(), dashUID, v1.DeleteOptions{})
+			require.NoError(t, err)
+		})
 
 		// Test setting an explicit generation
 		t.Run("explicit generation setting is validated", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Support dashboard, folder migration efforts by improving integration testing in mode 1, 2.

**Who is this feature for?**

Search and Storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partial https://github.com/grafana/search-and-storage-team/issues/323

**Special notes for your reviewer:**
It doesn't make sense to me that we are expecting version conflict in Mode0 but not in Mode1 (or above). If an error is returned in mode0 then it's an error that will also occur in mode1 because mode1 builds on mode2. 

I don't think the logic [here](https://github.com/grafana/grafana/blob/de59956db4dfc840adec8a79404d4b68bc2451df/pkg/tests/apis/dashboard/integration/api_validation_test.go#L399-L406)  should depend on the mode.

Without this PR, when mode1 is enabled, we fail at that stage of the test. The error that gets returned is the same one as for mode0. It gets emitted from the [legacy Update](https://github.com/grafana/grafana/blob/de59956db4dfc840adec8a79404d4b68bc2451df/pkg/registry/apis/dashboard/legacy_storage.go#L102) (it calls the Update from /Users/arati/go/pkg/mod2/[k8s.io/apiserver@v0.33.1/pkg/registry/generic/registry/store.go](http://k8s.io/apiserver@v0.33.1/pkg/registry/generic/registry/store.go)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
