### PR TITLE
New Logs Panel: Support multiple virtualization instances for different font sizes

### DIFF
--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -45,6 +45,7 @@ export const createLogLine = (
     escape: false,
     order: LogsSortOrder.Descending,
     timeZone: 'browser',
+    virtualization: undefined,
   }
 ): LogListModel => {
   const logs = preProcessLogs([createLogRow(overrides)], processOptions);

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -12,6 +12,7 @@ import { canScrollBottom, getVisibleRange, ScrollDirection, shouldLoadMore } fro
 import { getStyles, LogLine } from './LogLine';
 import { LogLineMessage } from './LogLineMessage';
 import { LogListModel } from './processing';
+import { LogLineVirtualization } from './virtualization';
 
 interface ChildrenProps {
   itemCount: number;
@@ -33,6 +34,7 @@ interface Props {
   sortOrder: LogsSortOrder;
   timeRange: TimeRange;
   timeZone: string;
+  virtualization: LogLineVirtualization;
   wrapLogMessage: boolean;
 }
 
@@ -51,6 +53,7 @@ export const InfiniteScroll = ({
   sortOrder,
   timeRange,
   timeZone,
+  virtualization,
   wrapLogMessage,
 }: Props) => {
   const [infiniteLoaderState, setInfiniteLoaderState] = useState<InfiniteLoaderState>('idle');
@@ -61,7 +64,7 @@ export const InfiniteScroll = ({
   const lastEvent = useRef<Event | WheelEvent | null>(null);
   const countRef = useRef(0);
   const lastLogOfPage = useRef<string[]>([]);
-  const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles, virtualization);
 
   useEffect(() => {
     // Logs have not changed, ignore effect
@@ -156,6 +159,7 @@ export const InfiniteScroll = ({
           style={style}
           styles={styles}
           variant={getLogLineVariant(logs, index, lastLogOfPage.current)}
+          virtualization={virtualization}
           wrapLogMessage={wrapLogMessage}
           onOverflow={handleOverflow}
         />
@@ -171,6 +175,7 @@ export const InfiniteScroll = ({
       showTime,
       sortOrder,
       styles,
+      virtualization,
       wrapLogMessage,
     ]
   );

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -12,13 +12,13 @@ import { LogListContextProvider } from './LogListContext';
 import { LogListSearchContext } from './LogListSearchContext';
 import { defaultProps } from './__mocks__/LogListContext';
 import { LogListModel } from './processing';
-import { getTruncationLength } from './virtualization';
+import { LogLineVirtualization } from './virtualization';
 
 jest.mock('./LogListContext');
-jest.mock('./virtualization');
 
 const theme = createTheme();
-const styles = getStyles(theme);
+const virtualization = new LogLineVirtualization(theme, 'default');
+const styles = getStyles(theme, virtualization);
 const contextProps = {
   ...defaultProps,
   app: CoreApp.Unknown,
@@ -34,7 +34,10 @@ const fontSizes: LogListFontSize[] = ['default', 'small'];
 describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
   let log: LogListModel, defaultProps: Props;
   beforeEach(() => {
-    log = createLogLine({ labels: { place: 'luna' }, entry: `log message 1` });
+    log = createLogLine(
+      { labels: { place: 'luna' }, entry: `log message 1` },
+      { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+    );
     contextProps.logs = [log];
     contextProps.fontSize = fontSize;
     defaultProps = {
@@ -49,7 +52,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
     };
   });
 
-  test('Renders a log line', () => {
+  test.only('Renders a log line', () => {
     render(
       <LogListContextProvider {...contextProps}>
         <LogLine {...defaultProps} />
@@ -219,8 +222,12 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
 
   describe('Collapsible log lines', () => {
     beforeEach(() => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: `log message 1` });
-      jest.mocked(getTruncationLength).mockReturnValue(5);
+      const virtualization = new LogLineVirtualization(theme, 'default');
+      jest.spyOn(virtualization, 'getTruncationLength').mockReturnValue(5);
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: `log message 1` },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
     });
 
     test('Logs are not collapsed by default', () => {

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -52,7 +52,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
     };
   });
 
-  test.only('Renders a log line', () => {
+  test('Renders a log line', () => {
     render(
       <LogListContextProvider {...contextProps}>
         <LogLine {...defaultProps} />

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -18,8 +18,8 @@ import {
   FIELD_GAP_MULTIPLIER,
   hasUnderOrOverflow,
   LogFieldDimension,
-  getTruncationLineCount,
   LogLineVirtualization,
+  DEFAULT_LINE_HEIGHT,
 } from './virtualization';
 
 export interface Props {
@@ -317,7 +317,7 @@ export function getGridTemplateColumns(dimensions: LogFieldDimension[]) {
 }
 
 export type LogLineStyles = ReturnType<typeof getStyles>;
-export const getStyles = (theme: GrafanaTheme2, virtualization: LogLineVirtualization) => {
+export const getStyles = (theme: GrafanaTheme2, virtualization?: LogLineVirtualization) => {
   const colors = {
     critical: '#B877D9',
     error: theme.colors.error.text,
@@ -410,7 +410,7 @@ export const getStyles = (theme: GrafanaTheme2, virtualization: LogLineVirtualiz
       backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
     }),
     menuIcon: css({
-      height: virtualization.getLineHeight(),
+      height: virtualization?.getLineHeight() ?? DEFAULT_LINE_HEIGHT,
       margin: 0,
       padding: theme.spacing(0, 0, 0, 0.5),
     }),
@@ -507,7 +507,7 @@ export const getStyles = (theme: GrafanaTheme2, virtualization: LogLineVirtualiz
     }),
     expandCollapseControlButton: css({
       fontWeight: theme.typography.fontWeightLight,
-      height: virtualization.getLineHeight(),
+      height: virtualization?.getLineHeight() ?? DEFAULT_LINE_HEIGHT,
       margin: 0,
     }),
   };

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -322,7 +322,7 @@ const LogListComponent = ({
   const handleOverflow = useCallback(
     (index: number, id: string, height?: number) => {
       if (height !== undefined) {
-        virtualization.storeLogLineSize(id, widthContainer, height, fontSize);
+        virtualization.storeLogLineSize(id, widthContainer, height);
       }
       if (index === overflowIndexRef.current) {
         return;
@@ -330,7 +330,7 @@ const LogListComponent = ({
       overflowIndexRef.current = index < overflowIndexRef.current ? index : overflowIndexRef.current;
       debouncedResetAfterIndex(overflowIndexRef.current);
     },
-    [debouncedResetAfterIndex, fontSize, virtualization, widthContainer]
+    [debouncedResetAfterIndex, virtualization, widthContainer]
   );
 
   const handleScrollPosition = useCallback(() => {
@@ -436,7 +436,6 @@ const LogListComponent = ({
               height={listHeight}
               itemCount={itemCount}
               itemSize={getLogLineSize.bind(null, virtualization, filteredLogs, widthContainer, displayedFields, {
-                fontSize,
                 hasLogsWithErrors,
                 hasSampledLogs,
                 showDuplicates: dedupStrategy !== LogsDedupStrategy.none,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -20,7 +20,7 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { ConfirmModal, Icon, PopoverContent, useTheme2 } from '@grafana/ui';
+import { ConfirmModal, Icon, PopoverContent, useStyles2, useTheme2 } from '@grafana/ui';
 import { PopoverMenu } from 'app/features/explore/Logs/PopoverMenu';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
@@ -255,7 +255,7 @@ const LogListComponent = ({
     () => (wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields)),
     [displayedFields, processedLogs, wrapLogMessage]
   );
-  const styles = getStyles(dimensions, { showTime }, theme);
+  const styles = useStyles2(getStyles, dimensions, { showTime });
   const widthContainer = wrapperRef.current ?? containerElement;
   const {
     closePopoverMenu,
@@ -476,7 +476,7 @@ const LogListComponent = ({
   );
 };
 
-function getStyles(dimensions: LogFieldDimension[], { showTime }: { showTime: boolean }, theme: GrafanaTheme2) {
+function getStyles(theme: GrafanaTheme2, dimensions: LogFieldDimension[], { showTime }: { showTime: boolean }) {
   const columns = showTime ? dimensions : dimensions.filter((_, index) => index > 0);
   return {
     logList: css({

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -35,15 +35,7 @@ import { LogListSearchContextProvider, useLogListSearchContext } from './LogList
 import { preProcessLogs, LogListModel } from './processing';
 import { useKeyBindings } from './useKeyBindings';
 import { usePopoverMenu } from './usePopoverMenu';
-import {
-  calculateFieldDimensions,
-  getLogLineSize,
-  init as initVirtualization,
-  LogFieldDimension,
-  resetLogLineSizes,
-  ScrollToLogsEvent,
-  storeLogLineSize,
-} from './virtualization';
+import { LogLineVirtualization, getLogLineSize, LogFieldDimension, ScrollToLogsEvent } from './virtualization';
 
 export interface Props {
   app: CoreApp;
@@ -251,9 +243,10 @@ const LogListComponent = ({
   const widthRef = useRef(containerElement.clientWidth);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const virtualization = useMemo(() => new LogLineVirtualization(theme, fontSize), [theme, fontSize]);
   const dimensions = useMemo(
-    () => (wrapLogMessage ? [] : calculateFieldDimensions(processedLogs, displayedFields)),
-    [displayedFields, processedLogs, wrapLogMessage]
+    () => (wrapLogMessage ? [] : virtualization.calculateFieldDimensions(processedLogs, displayedFields)),
+    [displayedFields, processedLogs, virtualization, wrapLogMessage]
   );
   const styles = useStyles2(getStyles, dimensions, { showTime });
   const widthContainer = wrapperRef.current ?? containerElement;
@@ -277,10 +270,6 @@ const LogListComponent = ({
   }, []);
 
   useEffect(() => {
-    initVirtualization(theme, fontSize);
-  }, [fontSize, theme]);
-
-  useEffect(() => {
     const subscription = eventBus.subscribe(ScrollToLogsEvent, (e: ScrollToLogsEvent) =>
       handleScrollToEvent(e, logs.length, listRef.current)
     );
@@ -292,11 +281,15 @@ const LogListComponent = ({
       return;
     }
     setProcessedLogs(
-      preProcessLogs(logs, { getFieldLinks, escape: forceEscape ?? false, order: sortOrder, timeZone }, grammar)
+      preProcessLogs(
+        logs,
+        { getFieldLinks, escape: forceEscape ?? false, order: sortOrder, timeZone, virtualization },
+        grammar
+      )
     );
-    resetLogLineSizes();
+    virtualization.resetLogLineSizes();
     listRef.current?.resetAfterIndex(0);
-  }, [forceEscape, getFieldLinks, grammar, loading, logs, sortOrder, timeZone]);
+  }, [forceEscape, getFieldLinks, grammar, loading, logs, sortOrder, timeZone, virtualization]);
 
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
@@ -329,7 +322,7 @@ const LogListComponent = ({
   const handleOverflow = useCallback(
     (index: number, id: string, height?: number) => {
       if (height !== undefined) {
-        storeLogLineSize(id, widthContainer, height, fontSize);
+        virtualization.storeLogLineSize(id, widthContainer, height, fontSize);
       }
       if (index === overflowIndexRef.current) {
         return;
@@ -337,7 +330,7 @@ const LogListComponent = ({
       overflowIndexRef.current = index < overflowIndexRef.current ? index : overflowIndexRef.current;
       debouncedResetAfterIndex(overflowIndexRef.current);
     },
-    [debouncedResetAfterIndex, fontSize, widthContainer]
+    [debouncedResetAfterIndex, fontSize, virtualization, widthContainer]
   );
 
   const handleScrollPosition = useCallback(() => {
@@ -434,6 +427,7 @@ const LogListComponent = ({
           timeRange={timeRange}
           timeZone={timeZone}
           setInitialScrollPosition={handleScrollPosition}
+          virtualization={virtualization}
           wrapLogMessage={wrapLogMessage}
         >
           {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
@@ -441,7 +435,7 @@ const LogListComponent = ({
               className={styles.logList}
               height={listHeight}
               itemCount={itemCount}
-              itemSize={getLogLineSize.bind(null, filteredLogs, widthContainer, displayedFields, {
+              itemSize={getLogLineSize.bind(null, virtualization, filteredLogs, widthContainer, displayedFields, {
                 fontSize,
                 hasLogsWithErrors,
                 hasSampledLogs,

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -5,7 +5,7 @@ import { createLogLine, createLogRow } from '../__mocks__/logRow';
 
 import { LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
-import { getTruncationLength, init } from './virtualization';
+import { LogLineVirtualization } from './virtualization';
 
 describe('preProcessLogs', () => {
   let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;
@@ -168,13 +168,16 @@ describe('preProcessLogs', () => {
   });
 
   describe.each(fontSizes)('Collapsible log lines', (fontSize: LogListFontSize) => {
-    let longLog: LogListModel, entry: string, container: HTMLDivElement;
+    let longLog: LogListModel, entry: string, container: HTMLDivElement, virtualization: LogLineVirtualization;
     beforeEach(() => {
-      init(createTheme(), fontSize);
+      virtualization = new LogLineVirtualization(createTheme(), fontSize);
       container = document.createElement('div');
       jest.spyOn(container, 'clientWidth', 'get').mockReturnValue(200);
-      entry = new Array(2 * getTruncationLength(null)).fill('e').join('');
-      longLog = createLogLine({ entry, labels: { field: 'value' } });
+      entry = new Array(2 * virtualization.getTruncationLength(null)).fill('e').join('');
+      longLog = createLogLine(
+        { entry, labels: { field: 'value' } },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
     });
 
     test('Long lines that are not truncated are not modified', () => {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -171,15 +171,16 @@ export interface PreProcessOptions {
   getFieldLinks?: GetFieldLinksFn;
   order: LogsSortOrder;
   timeZone: string;
+  virtualization?: LogLineVirtualization;
 }
 
 export const preProcessLogs = (
   logs: LogRowModel[],
-  { escape, getFieldLinks, order, timeZone }: PreProcessOptions,
+  { escape, getFieldLinks, order, timeZone, virtualization }: PreProcessOptions,
   grammar?: Grammar
 ): LogListModel[] => {
   const orderedLogs = sortLogRows(logs, order);
-  return orderedLogs.map((log) => preProcessLog(log, { escape, getFieldLinks, grammar, timeZone }));
+  return orderedLogs.map((log) => preProcessLog(log, { escape, getFieldLinks, grammar, timeZone, virtualization }));
 };
 
 interface PreProcessLogOptions {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -8,7 +8,9 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { FieldDef, getAllFields } from '../logParser';
 
 import { generateLogGrammar, generateTextMatchGrammar } from './grammar';
-import { getTruncationLength } from './virtualization';
+import { LogLineVirtualization } from './virtualization';
+
+const TRUNCATION_DEFAULT_LENGTH = 50000;
 
 export class LogListModel implements LogRowModel {
   collapsed: boolean | undefined = undefined;
@@ -44,11 +46,13 @@ export class LogListModel implements LogRowModel {
   private _highlightedBody: string | undefined = undefined;
   private _fields: FieldDef[] | undefined = undefined;
   private _getFieldLinks: GetFieldLinksFn | undefined = undefined;
+  private _virtualization?: LogLineVirtualization;
 
-  constructor(log: LogRowModel, { escape, getFieldLinks, grammar, timeZone }: PreProcessLogOptions) {
+  constructor(log: LogRowModel, { escape, getFieldLinks, grammar, timeZone, virtualization }: PreProcessLogOptions) {
     // LogRowModel
     this.datasourceType = log.datasourceType;
     this.dataFrame = log.dataFrame;
+    this.datasourceUid = log.datasourceUid;
     this.duplicates = log.duplicates;
     this.entry = log.entry;
     this.entryFieldIndex = log.entryFieldIndex;
@@ -68,7 +72,6 @@ export class LogListModel implements LogRowModel {
     this.timeUtc = log.timeUtc;
     this.uid = log.uid;
     this.uniqueLabels = log.uniqueLabels;
-    this.datasourceUid = log.datasourceUid;
 
     // LogListModel
     this.displayLevel = logLevelToDisplayLevel(log.logLevel);
@@ -78,6 +81,7 @@ export class LogListModel implements LogRowModel {
       timeZone,
       defaultWithMS: true,
     });
+    this._virtualization = virtualization;
 
     let raw = log.raw;
     if (escape && log.hasUnescapedContent) {
@@ -88,7 +92,9 @@ export class LogListModel implements LogRowModel {
 
   get body(): string {
     if (this._body === undefined) {
-      this._body = this.collapsed ? this.raw.substring(0, getTruncationLength(null)) : this.raw;
+      this._body = this.collapsed
+        ? this.raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
+        : this.raw;
     }
     return this._body;
   }
@@ -136,7 +142,10 @@ export class LogListModel implements LogRowModel {
       displayedFields.length > 0
         ? displayedFields.map((field) => this.getDisplayedFieldValue(field)).join('').length
         : this.raw.length;
-    const collapsed = lineLength >= getTruncationLength(container) ? true : undefined;
+    const collapsed =
+      lineLength >= (this._virtualization?.getTruncationLength(container) ?? TRUNCATION_DEFAULT_LENGTH)
+        ? true
+        : undefined;
     if (this.collapsed === undefined || collapsed === undefined) {
       this.collapsed = collapsed;
     }
@@ -178,6 +187,7 @@ interface PreProcessLogOptions {
   getFieldLinks?: GetFieldLinksFn;
   grammar?: Grammar;
   timeZone: string;
+  virtualization?: LogLineVirtualization;
 }
 const preProcessLog = (log: LogRowModel, options: PreProcessLogOptions): LogListModel => {
   return new LogListModel(log, options);

--- a/public/app/features/logs/components/panel/virtualization.test.ts
+++ b/public/app/features/logs/components/panel/virtualization.test.ts
@@ -1,55 +1,56 @@
-import { createTheme } from '@grafana/data';
+import { createTheme, LogsSortOrder } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../__mocks__/logRow';
 
 import { LogListModel } from './processing';
-import {
-  getLineHeight,
-  getLogLineSize,
-  init,
-  measureTextWidth,
-  getTruncationLineCount,
-  DisplayOptions,
-} from './virtualization';
-
-const PADDING_BOTTOM = 6;
-const LINE_HEIGHT = getLineHeight();
-const SINGLE_LINE_HEIGHT = LINE_HEIGHT + PADDING_BOTTOM;
-const TWO_LINES_HEIGHT = 2 * LINE_HEIGHT + PADDING_BOTTOM;
-const THREE_LINES_HEIGHT = 3 * LINE_HEIGHT + PADDING_BOTTOM;
-let LETTER_WIDTH: number;
-let CONTAINER_SIZE = 200;
-let TWO_LINES_OF_CHARACTERS: number;
-const defaultOptions: DisplayOptions = {
-  wrap: false,
-  showTime: false,
-  showDuplicates: false,
-  hasLogsWithErrors: false,
-  hasSampledLogs: false,
-  fontSize: 'default',
-};
+import { LogLineVirtualization, getLogLineSize, DisplayOptions } from './virtualization';
 
 describe('Virtualization', () => {
   let log: LogListModel, container: HTMLDivElement;
+
+  let virtualization = new LogLineVirtualization(createTheme(), 'default');
+
+  const PADDING_BOTTOM = 6;
+  const LINE_HEIGHT = virtualization.getLineHeight();
+  const SINGLE_LINE_HEIGHT = LINE_HEIGHT + PADDING_BOTTOM;
+  const TWO_LINES_HEIGHT = 2 * LINE_HEIGHT + PADDING_BOTTOM;
+  const THREE_LINES_HEIGHT = 3 * LINE_HEIGHT + PADDING_BOTTOM;
+  let LETTER_WIDTH: number;
+  let CONTAINER_SIZE = 200;
+  let TWO_LINES_OF_CHARACTERS: number;
+
+  const defaultOptions: DisplayOptions = {
+    wrap: false,
+    showTime: false,
+    showDuplicates: false,
+    hasLogsWithErrors: false,
+    hasSampledLogs: false,
+    fontSize: 'default',
+  };
+
   beforeEach(() => {
-    log = createLogLine({ labels: { place: 'luna' }, entry: `log message 1` });
+    log = createLogLine(
+      { labels: { place: 'luna' }, entry: `log message 1` },
+      { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+    );
+    //virtualization = new LogLineVirtualization(createTheme(), 'default');
     container = document.createElement('div');
     jest.spyOn(container, 'clientWidth', 'get').mockReturnValue(CONTAINER_SIZE);
-    init(createTheme(), 'default');
-    LETTER_WIDTH = measureTextWidth('e');
+    LETTER_WIDTH = virtualization.measureTextWidth('e');
     TWO_LINES_OF_CHARACTERS = (CONTAINER_SIZE / LETTER_WIDTH) * 1.5;
   });
 
   describe('getLogLineSize', () => {
     test('Returns the a single line if the display mode is unwrapped', () => {
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, showTime: true }, 0);
+      const size = getLogLineSize(virtualization, [log], container, [], { ...defaultOptions, showTime: true }, 0);
       expect(size).toBe(SINGLE_LINE_HEIGHT);
     });
 
     test('Returns the a single line if the line is not loaded yet', () => {
       const logs = [log];
       const size = getLogLineSize(
+        virtualization,
         logs,
         container,
         [],
@@ -63,42 +64,66 @@ describe('Virtualization', () => {
       // Very small container
       log.collapsed = true;
       jest.spyOn(container, 'clientWidth', 'get').mockReturnValue(10);
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, showTime: true }, 0);
-      expect(size).toBe((getTruncationLineCount() + 1) * LINE_HEIGHT);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, wrap: true, showTime: true },
+        0
+      );
+      expect(size).toBe((virtualization.getTruncationLineCount() + 1) * LINE_HEIGHT);
     });
 
     test.each([true, false])('Measures a log line with controls %s and displayed time %s', (showTime: boolean) => {
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, showTime }, 0);
+      const size = getLogLineSize(virtualization, [log], container, [], { ...defaultOptions, wrap: true, showTime }, 0);
       expect(size).toBe(SINGLE_LINE_HEIGHT);
     });
 
     test('Measures a multi-line log line with no displayed time', () => {
-      log = createLogLine({
-        labels: { place: 'luna' },
-        entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
-        logLevel: undefined,
-      });
+      log = createLogLine(
+        {
+          labels: { place: 'luna' },
+          entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
+          logLevel: undefined,
+        },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true }, 0);
+      const size = getLogLineSize(virtualization, [log], container, [], { ...defaultOptions, wrap: true }, 0);
       expect(size).toBe(TWO_LINES_HEIGHT);
     });
 
     test('Measures a multi-line log line with level, controls, and displayed time', () => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') });
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, showTime: true }, 0);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, wrap: true, showTime: true },
+        0
+      );
       // Two lines for the log and one extra for level and time
       expect(size).toBe(THREE_LINES_HEIGHT);
     });
 
     test('Measures a multi-line log line with displayed fields', () => {
-      log = createLogLine({
-        labels: { place: 'very very long value for the displayed field that causes a new line' },
-        entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
-        logLevel: undefined,
-      });
+      log = createLogLine(
+        {
+          labels: { place: 'very very long value for the displayed field that causes a new line' },
+          entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
+          logLevel: undefined,
+        },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
       const size = getLogLineSize(
+        virtualization,
         [log],
         container,
         ['place', LOG_LINE_BODY_FIELD_NAME],
@@ -110,34 +135,74 @@ describe('Virtualization', () => {
     });
 
     test('Measures displayed fields in a log line with level, controls, and displayed time', () => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') });
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
-      const size = getLogLineSize([log], container, ['place'], { ...defaultOptions, wrap: true, showTime: true }, 0);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        ['place'],
+        { ...defaultOptions, wrap: true, showTime: true },
+        0
+      );
       // Only renders a short displayed field, so a single line
       expect(size).toBe(SINGLE_LINE_HEIGHT);
     });
 
     test('Measures a multi-line log line with duplicates', () => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') });
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
       log.duplicates = 1;
 
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, showDuplicates: true }, 0);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, wrap: true, showDuplicates: true },
+        0
+      );
       // Two lines for the log and one extra for duplicates
       expect(size).toBe(THREE_LINES_HEIGHT);
     });
 
     test('Measures a multi-line log line with errors', () => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') });
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, hasLogsWithErrors: true }, 0);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, wrap: true, hasLogsWithErrors: true },
+        0
+      );
       // Two lines for the log and one extra for the error icon
       expect(size).toBe(THREE_LINES_HEIGHT);
     });
 
     test('Measures a multi-line sampled log line', () => {
-      log = createLogLine({ labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') });
+      log = createLogLine(
+        { labels: { place: 'luna' }, entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join('') },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true, hasSampledLogs: true }, 0);
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, wrap: true, hasSampledLogs: true },
+        0
+      );
       // Two lines for the log and one extra for the sampled icon
       expect(size).toBe(THREE_LINES_HEIGHT);
     });
@@ -145,29 +210,34 @@ describe('Virtualization', () => {
     test('Adds an extra line for the expand/collapse controls if present', () => {
       jest.spyOn(log, 'updateCollapsedState').mockImplementation(() => undefined);
       log.collapsed = false;
-      const size = getLogLineSize([log], container, [], { ...defaultOptions, wrap: true }, 0);
+      const size = getLogLineSize(virtualization, [log], container, [], { ...defaultOptions, wrap: true }, 0);
       expect(size).toBe(TWO_LINES_HEIGHT);
     });
   });
 
   describe('With small font size', () => {
+    const virtualization = new LogLineVirtualization(createTheme(), 'small');
+
     beforeEach(() => {
-      init(createTheme(), 'small');
-      LETTER_WIDTH = measureTextWidth('e');
+      LETTER_WIDTH = virtualization.measureTextWidth('e');
       TWO_LINES_OF_CHARACTERS = (CONTAINER_SIZE / LETTER_WIDTH) * 1.5;
     });
 
     test('Measures a multi-line log line with displayed fields', () => {
-      const SMALL_LINE_HEIGHT = getLineHeight();
+      const SMALL_LINE_HEIGHT = virtualization.getLineHeight();
       const SMALL_THREE_LINES_HEIGHT = 3 * SMALL_LINE_HEIGHT + PADDING_BOTTOM;
 
-      log = createLogLine({
-        labels: { place: 'very very long value for the displayed field that causes a new line' },
-        entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
-        logLevel: undefined,
-      });
+      log = createLogLine(
+        {
+          labels: { place: 'very very long value for the displayed field that causes a new line' },
+          entry: new Array(TWO_LINES_OF_CHARACTERS).fill('e').join(''),
+          logLevel: undefined,
+        },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization }
+      );
 
       const size = getLogLineSize(
+        virtualization,
         [log],
         container,
         ['place', LOG_LINE_BODY_FIELD_NAME],

--- a/public/app/features/logs/components/panel/virtualization.test.ts
+++ b/public/app/features/logs/components/panel/virtualization.test.ts
@@ -26,7 +26,6 @@ describe('Virtualization', () => {
     showDuplicates: false,
     hasLogsWithErrors: false,
     hasSampledLogs: false,
-    fontSize: 'default',
   };
 
   beforeEach(() => {

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -15,18 +15,21 @@ export const DEFAULT_LINE_HEIGHT = 22;
 
 export class LogLineVirtualization {
   private ctx: CanvasRenderingContext2D | null = null;
-  private gridSize = 8;
-  private paddingBottom = 8 * 0.75;
-  private lineHeight = DEFAULT_LINE_HEIGHT;
+  private gridSize;
+  private paddingBottom;
+  private lineHeight;
   private measurementMode: 'canvas' | 'dom' = 'canvas';
   private textWidthMap: Map<number, number>;
   private logLineSizesMap: Map<string, number>;
   private spanElement = document.createElement('span');
+  readonly fontSize: LogListFontSize;
 
   constructor(theme: GrafanaTheme2, fontSize: LogListFontSize) {
-    let fontSizePx = theme.typography.fontSize;
+    this.fontSize = fontSize;
 
+    let fontSizePx;
     if (fontSize === 'default') {
+      fontSizePx = theme.typography.fontSize;
       this.lineHeight = theme.typography.fontSize * theme.typography.body.lineHeight;
     } else {
       fontSizePx =
@@ -223,19 +226,18 @@ export class LogLineVirtualization {
     this.logLineSizesMap = new Map<string, number>();
   };
 
-  storeLogLineSize = (id: string, container: HTMLDivElement, height: number, fontSize: LogListFontSize) => {
-    const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
+  storeLogLineSize = (id: string, container: HTMLDivElement, height: number) => {
+    const key = `${id}_${getLogContainerWidth(container)}_${this.fontSize}`;
     this.logLineSizesMap.set(key, height);
   };
 
-  retrieveLogLineSize = (id: string, container: HTMLDivElement, fontSize: LogListFontSize) => {
-    const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
+  retrieveLogLineSize = (id: string, container: HTMLDivElement) => {
+    const key = `${id}_${getLogContainerWidth(container)}_${this.fontSize}`;
     return this.logLineSizesMap.get(key);
   };
 }
 
 export interface DisplayOptions {
-  fontSize: LogListFontSize;
   hasLogsWithErrors?: boolean;
   hasSampledLogs?: boolean;
   showDuplicates: boolean;
@@ -248,7 +250,7 @@ export function getLogLineSize(
   logs: LogListModel[],
   container: HTMLDivElement | null,
   displayedFields: string[],
-  { fontSize, hasLogsWithErrors, hasSampledLogs, showDuplicates, showTime, wrap }: DisplayOptions,
+  { hasLogsWithErrors, hasSampledLogs, showDuplicates, showTime, wrap }: DisplayOptions,
   index: number
 ) {
   if (!container) {
@@ -264,7 +266,7 @@ export function getLogLineSize(
     return (virtualization.getTruncationLineCount() + 1) * virtualization.getLineHeight();
   }
 
-  const storedSize = virtualization.retrieveLogLineSize(logs[index].uid, container, fontSize);
+  const storedSize = virtualization.retrieveLogLineSize(logs[index].uid, container);
   if (storedSize) {
     return storedSize;
   }

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -7,162 +7,228 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogListFontSize } from './LogList';
 import { LogListModel } from './processing';
 
-let ctx: CanvasRenderingContext2D | null = null;
-let gridSize = 8;
-let paddingBottom = gridSize * 0.75;
-let lineHeight = 22;
-let measurementMode: 'canvas' | 'dom' = 'canvas';
-const iconWidth = 24;
-
-export const LOG_LIST_MIN_WIDTH = 35 * gridSize;
-
+export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
 
-export const getLineHeight = () => lineHeight;
+export class LogLineVirtualization {
+  private ctx: CanvasRenderingContext2D | null = null;
+  private gridSize = 8;
+  private paddingBottom = 8 * 0.75;
+  private lineHeight = 22;
+  private measurementMode: 'canvas' | 'dom' = 'canvas';
+  private textWidthMap: Map<number, number>;
+  private logLineSizesMap: Map<string, number>;
+  private spanElement = document.createElement('span');
 
-export function init(theme: GrafanaTheme2, fontSize: LogListFontSize) {
-  let fontSizePx = theme.typography.fontSize;
+  constructor(theme: GrafanaTheme2, fontSize: LogListFontSize) {
+    let fontSizePx = theme.typography.fontSize;
 
-  if (fontSize === 'default') {
-    lineHeight = theme.typography.fontSize * theme.typography.body.lineHeight;
-  } else {
-    fontSizePx =
-      typeof theme.typography.bodySmall.fontSize === 'string' && theme.typography.bodySmall.fontSize.includes('rem')
-        ? theme.typography.fontSize * parseFloat(theme.typography.bodySmall.fontSize)
-        : parseInt(theme.typography.bodySmall.fontSize, 10);
-    lineHeight = fontSizePx * theme.typography.bodySmall.lineHeight;
-  }
-
-  const font = `${fontSizePx}px ${theme.typography.fontFamilyMonospace}`;
-  const letterSpacing = theme.typography.body.letterSpacing;
-
-  initDOMmeasurement(font, letterSpacing);
-  initCanvasMeasurement(font, letterSpacing);
-
-  gridSize = theme.spacing.gridSize;
-  paddingBottom = gridSize * 0.75;
-
-  widthMap = new Map<number, number>();
-  resetLogLineSizes();
-
-  determineMeasurementMode();
-
-  return true;
-}
-
-function determineMeasurementMode() {
-  if (!ctx) {
-    measurementMode = 'dom';
-    return;
-  }
-  const canvasCharWidth = ctx.measureText('e').width;
-  const domCharWidth = measureTextWidthWithDOM('e');
-  const diff = domCharWidth - canvasCharWidth;
-  if (diff >= 0.1) {
-    console.warn('Virtualized log list: falling back to DOM for measurement');
-    measurementMode = 'dom';
-  }
-}
-
-function initCanvasMeasurement(font: string, letterSpacing: string | undefined) {
-  const canvas = document.createElement('canvas');
-  ctx = canvas.getContext('2d');
-  if (!ctx) {
-    return;
-  }
-  ctx.font = font;
-  ctx.fontKerning = 'normal';
-  ctx.fontStretch = 'normal';
-  ctx.fontVariantCaps = 'normal';
-  ctx.textRendering = 'optimizeLegibility';
-  if (letterSpacing) {
-    ctx.letterSpacing = letterSpacing;
-  }
-}
-
-const span = document.createElement('span');
-function initDOMmeasurement(font: string, letterSpacing: string | undefined) {
-  span.style.font = font;
-  span.style.visibility = 'hidden';
-  span.style.position = 'absolute';
-  span.style.wordBreak = 'break-all';
-  if (letterSpacing) {
-    span.style.letterSpacing = letterSpacing;
-  }
-}
-
-let widthMap = new Map<number, number>();
-export function measureTextWidth(text: string): number {
-  if (!ctx) {
-    throw new Error(`Measuring context canvas is not initialized. Call init() before.`);
-  }
-  const key = text.length;
-
-  const storedWidth = widthMap.get(key);
-  if (storedWidth) {
-    return storedWidth;
-  }
-
-  const width = measurementMode === 'canvas' ? ctx.measureText(text).width : measureTextWidthWithDOM(text);
-  widthMap.set(key, width);
-
-  return width;
-}
-
-function measureTextWidthWithDOM(text: string) {
-  span.textContent = text;
-
-  document.body.appendChild(span);
-  const width = span.getBoundingClientRect().width;
-  document.body.removeChild(span);
-
-  return width;
-}
-
-export function measureTextHeight(text: string, maxWidth: number, beforeWidth = 0) {
-  let logLines = 0;
-  const charWidth = measureTextWidth('e');
-  let logLineCharsLength = Math.round(maxWidth / charWidth);
-  const firstLineCharsLength = Math.floor((maxWidth - beforeWidth) / charWidth) - 2 * charWidth;
-  const textLines = text.split('\n');
-
-  // Skip unnecessary measurements
-  if (textLines.length === 1 && text.length < firstLineCharsLength) {
-    return {
-      lines: 1,
-      height: getLineHeight() + paddingBottom,
-    };
-  }
-
-  const availableWidth = maxWidth - beforeWidth;
-  for (const textLine of textLines) {
-    for (let start = 0; start < textLine.length; ) {
-      let testLogLine: string;
-      let width = 0;
-      let delta = 0;
-      do {
-        testLogLine = textLine.substring(start, start + logLineCharsLength - delta);
-        let measuredLine = testLogLine;
-        if (logLines > 0) {
-          measuredLine.trimStart();
-        }
-        width = measureTextWidth(measuredLine);
-        delta += 1;
-      } while (width >= availableWidth);
-      if (beforeWidth) {
-        beforeWidth = 0;
-      }
-      logLines += 1;
-      start += testLogLine.length;
+    if (fontSize === 'default') {
+      this.lineHeight = theme.typography.fontSize * theme.typography.body.lineHeight;
+    } else {
+      fontSizePx =
+        typeof theme.typography.bodySmall.fontSize === 'string' && theme.typography.bodySmall.fontSize.includes('rem')
+          ? theme.typography.fontSize * parseFloat(theme.typography.bodySmall.fontSize)
+          : parseInt(theme.typography.bodySmall.fontSize, 10);
+      this.lineHeight = fontSizePx * theme.typography.bodySmall.lineHeight;
     }
+
+    this.gridSize = theme.spacing.gridSize;
+    this.paddingBottom = this.gridSize * 0.75;
+    this.logLineSizesMap = new Map<string, number>();
+    this.textWidthMap = new Map<number, number>();
+
+    const font = `${fontSizePx}px ${theme.typography.fontFamilyMonospace}`;
+    const letterSpacing = theme.typography.body.letterSpacing;
+
+    this.initDOMmeasurement(font, letterSpacing);
+    this.initCanvasMeasurement(font, letterSpacing);
+    this.determineMeasurementMode();
   }
 
-  const height = logLines * getLineHeight() + paddingBottom;
+  getLineHeight = () => this.lineHeight;
+  getGridSize = () => this.gridSize;
+  getPaddingBottom = () => this.paddingBottom;
 
-  return {
-    lines: logLines,
-    height,
+  // 2/3 of the viewport height
+  getTruncationLineCount = () => Math.round(window.innerHeight / this.getLineHeight() / 1.5);
+
+  getTruncationLength = (container: HTMLDivElement | null) => {
+    const availableWidth = container ? getLogContainerWidth(container) : window.innerWidth;
+    return (availableWidth / this.measureTextWidth('e')) * this.getTruncationLineCount();
+  };
+
+  determineMeasurementMode = () => {
+    if (!this.ctx) {
+      this.measurementMode = 'dom';
+      return;
+    }
+    const canvasCharWidth = this.ctx.measureText('e').width;
+    const domCharWidth = this.measureTextWidthWithDOM('e');
+    const diff = domCharWidth - canvasCharWidth;
+    if (diff >= 0.1) {
+      console.warn('Virtualized log list: falling back to DOM for measurement');
+      this.measurementMode = 'dom';
+    }
+  };
+
+  initCanvasMeasurement = (font: string, letterSpacing: string | undefined) => {
+    const canvas = document.createElement('canvas');
+    this.ctx = canvas.getContext('2d');
+    if (!this.ctx) {
+      return;
+    }
+    this.ctx.font = font;
+    this.ctx.fontKerning = 'normal';
+    this.ctx.fontStretch = 'normal';
+    this.ctx.fontVariantCaps = 'normal';
+    this.ctx.textRendering = 'optimizeLegibility';
+    if (letterSpacing) {
+      this.ctx.letterSpacing = letterSpacing;
+    }
+  };
+
+  initDOMmeasurement = (font: string, letterSpacing: string | undefined) => {
+    this.spanElement.style.font = font;
+    this.spanElement.style.visibility = 'hidden';
+    this.spanElement.style.position = 'absolute';
+    this.spanElement.style.wordBreak = 'break-all';
+    if (letterSpacing) {
+      this.spanElement.style.letterSpacing = letterSpacing;
+    }
+  };
+
+  measureTextWidth = (text: string): number => {
+    if (!this.ctx) {
+      throw new Error(`Measuring context canvas is not initialized. Call init() before.`);
+    }
+    const key = text.length;
+
+    const storedWidth = this.textWidthMap.get(key);
+    if (storedWidth) {
+      return storedWidth;
+    }
+
+    const width =
+      this.measurementMode === 'canvas' ? this.ctx.measureText(text).width : this.measureTextWidthWithDOM(text);
+    this.textWidthMap.set(key, width);
+
+    return width;
+  };
+
+  measureTextWidthWithDOM = (text: string) => {
+    this.spanElement.textContent = text;
+
+    document.body.appendChild(this.spanElement);
+    const width = this.spanElement.getBoundingClientRect().width;
+    document.body.removeChild(this.spanElement);
+
+    return width;
+  };
+
+  measureTextHeight = (text: string, maxWidth: number, beforeWidth = 0) => {
+    let logLines = 0;
+    const charWidth = this.measureTextWidth('e');
+    let logLineCharsLength = Math.round(maxWidth / charWidth);
+    const firstLineCharsLength = Math.floor((maxWidth - beforeWidth) / charWidth) - 2 * charWidth;
+    const textLines = text.split('\n');
+
+    // Skip unnecessary measurements
+    if (textLines.length === 1 && text.length < firstLineCharsLength) {
+      return {
+        lines: 1,
+        height: this.getLineHeight() + this.paddingBottom,
+      };
+    }
+
+    const availableWidth = maxWidth - beforeWidth;
+    for (const textLine of textLines) {
+      for (let start = 0; start < textLine.length; ) {
+        let testLogLine: string;
+        let width = 0;
+        let delta = 0;
+        do {
+          testLogLine = textLine.substring(start, start + logLineCharsLength - delta);
+          let measuredLine = testLogLine;
+          if (logLines > 0) {
+            measuredLine.trimStart();
+          }
+          width = this.measureTextWidth(measuredLine);
+          delta += 1;
+        } while (width >= availableWidth);
+        if (beforeWidth) {
+          beforeWidth = 0;
+        }
+        logLines += 1;
+        start += testLogLine.length;
+      }
+    }
+
+    const height = logLines * this.getLineHeight() + this.paddingBottom;
+
+    return {
+      lines: logLines,
+      height,
+    };
+  };
+
+  calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
+    if (!logs.length) {
+      return [];
+    }
+    let timestampWidth = 0;
+    let levelWidth = 0;
+    const fieldWidths: Record<string, number> = {};
+    for (let i = 0; i < logs.length; i++) {
+      let width = this.measureTextWidth(logs[i].timestamp);
+      if (width > timestampWidth) {
+        timestampWidth = Math.round(width);
+      }
+      width = this.measureTextWidth(logs[i].displayLevel);
+      if (width > levelWidth) {
+        levelWidth = Math.round(width);
+      }
+      for (const field of displayedFields) {
+        width = this.measureTextWidth(logs[i].getDisplayedFieldValue(field));
+        fieldWidths[field] = !fieldWidths[field] || width > fieldWidths[field] ? Math.round(width) : fieldWidths[field];
+      }
+    }
+    const dimensions: LogFieldDimension[] = [
+      {
+        field: 'timestamp',
+        width: timestampWidth,
+      },
+      {
+        field: 'level',
+        width: levelWidth,
+      },
+    ];
+    for (const field in fieldWidths) {
+      // Skip the log line when it's a displayed field
+      if (field === LOG_LINE_BODY_FIELD_NAME) {
+        continue;
+      }
+      dimensions.push({
+        field,
+        width: fieldWidths[field],
+      });
+    }
+    return dimensions;
+  };
+
+  resetLogLineSizes = () => {
+    this.logLineSizesMap = new Map<string, number>();
+  };
+
+  storeLogLineSize = (id: string, container: HTMLDivElement, height: number, fontSize: LogListFontSize) => {
+    const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
+    this.logLineSizesMap.set(key, height);
+  };
+
+  retrieveLogLineSize = (id: string, container: HTMLDivElement, fontSize: LogListFontSize) => {
+    const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
+    return this.logLineSizesMap.get(key);
   };
 }
 
@@ -176,6 +242,7 @@ export interface DisplayOptions {
 }
 
 export function getLogLineSize(
+  virtualization: LogLineVirtualization,
   logs: LogListModel[],
   container: HTMLDivElement | null,
   displayedFields: string[],
@@ -187,31 +254,31 @@ export function getLogLineSize(
   }
   // !logs[index] means the line is not yet loaded by infinite scrolling
   if (!wrap || !logs[index]) {
-    return getLineHeight() + paddingBottom;
+    return virtualization.getLineHeight() + virtualization.getPaddingBottom();
   }
   // If a long line is collapsed, we show the line count + an extra line for the expand/collapse control
-  logs[index].updateCollapsedState(displayedFields, container);
+  logs[index].updateCollapsedState(virtualization, displayedFields, container);
   if (logs[index].collapsed) {
-    return (getTruncationLineCount() + 1) * getLineHeight();
+    return (virtualization.getTruncationLineCount() + 1) * virtualization.getLineHeight();
   }
 
-  const storedSize = retrieveLogLineSize(logs[index].uid, container, fontSize);
+  const storedSize = virtualization.retrieveLogLineSize(logs[index].uid, container, fontSize);
   if (storedSize) {
     return storedSize;
   }
 
   let textToMeasure = '';
-  const gap = gridSize * FIELD_GAP_MULTIPLIER;
-  const iconsGap = gridSize * 0.5;
+  const gap = virtualization.getGridSize() * FIELD_GAP_MULTIPLIER;
+  const iconsGap = virtualization.getGridSize() * 0.5;
   let optionsWidth = 0;
   if (showDuplicates) {
-    optionsWidth += gridSize * 4.5 + iconsGap;
+    optionsWidth += virtualization.getGridSize() * 4.5 + iconsGap;
   }
   if (hasLogsWithErrors) {
-    optionsWidth += gridSize * 2 + iconsGap;
+    optionsWidth += virtualization.getGridSize() * 2 + iconsGap;
   }
   if (hasSampledLogs) {
-    optionsWidth += gridSize * 2 + iconsGap;
+    optionsWidth += virtualization.getGridSize() * 2 + iconsGap;
   }
   if (showTime) {
     optionsWidth += gap;
@@ -229,9 +296,9 @@ export function getLogLineSize(
     textToMeasure += ansicolor.strip(logs[index].body);
   }
 
-  const { height } = measureTextHeight(textToMeasure, getLogContainerWidth(container), optionsWidth);
+  const { height } = virtualization.measureTextHeight(textToMeasure, getLogContainerWidth(container), optionsWidth);
   // When the log is collapsed, add an extra line for the expand/collapse control
-  return logs[index].collapsed === false ? height + getLineHeight() : height;
+  return logs[index].collapsed === false ? height + virtualization.getLineHeight() : height;
 }
 
 export interface LogFieldDimension {
@@ -239,80 +306,31 @@ export interface LogFieldDimension {
   width: number;
 }
 
-export const calculateFieldDimensions = (logs: LogListModel[], displayedFields: string[] = []) => {
-  if (!logs.length) {
-    return [];
-  }
-  let timestampWidth = 0;
-  let levelWidth = 0;
-  const fieldWidths: Record<string, number> = {};
-  for (let i = 0; i < logs.length; i++) {
-    let width = measureTextWidth(logs[i].timestamp);
-    if (width > timestampWidth) {
-      timestampWidth = Math.round(width);
-    }
-    width = measureTextWidth(logs[i].displayLevel);
-    if (width > levelWidth) {
-      levelWidth = Math.round(width);
-    }
-    for (const field of displayedFields) {
-      width = measureTextWidth(logs[i].getDisplayedFieldValue(field));
-      fieldWidths[field] = !fieldWidths[field] || width > fieldWidths[field] ? Math.round(width) : fieldWidths[field];
-    }
-  }
-  const dimensions: LogFieldDimension[] = [
-    {
-      field: 'timestamp',
-      width: timestampWidth,
-    },
-    {
-      field: 'level',
-      width: levelWidth,
-    },
-  ];
-  for (const field in fieldWidths) {
-    // Skip the log line when it's a displayed field
-    if (field === LOG_LINE_BODY_FIELD_NAME) {
-      continue;
-    }
-    dimensions.push({
-      field,
-      width: fieldWidths[field],
-    });
-  }
-  return dimensions;
-};
-
-// 2/3 of the viewport height
-export const getTruncationLineCount = () => Math.round(window.innerHeight / getLineHeight() / 1.5);
-export function getTruncationLength(container: HTMLDivElement | null) {
-  const availableWidth = container ? getLogContainerWidth(container) : window.innerWidth;
-  return (availableWidth / measureTextWidth('e')) * getTruncationLineCount();
-}
-
 export function hasUnderOrOverflow(
+  virtualization: LogLineVirtualization,
   element: HTMLDivElement,
   calculatedHeight?: number,
   collapsed?: boolean
 ): number | null {
   if (collapsed !== undefined && calculatedHeight) {
-    calculatedHeight -= getLineHeight();
+    calculatedHeight -= virtualization.getLineHeight();
   }
   const height = calculatedHeight ?? element.clientHeight;
   if (element.scrollHeight > height) {
-    return collapsed !== undefined ? element.scrollHeight + getLineHeight() : element.scrollHeight;
+    return collapsed !== undefined ? element.scrollHeight + virtualization.getLineHeight() : element.scrollHeight;
   }
   const child = element.children[1];
   if (child instanceof HTMLDivElement && child.clientHeight < height) {
-    return collapsed !== undefined ? child.clientHeight + getLineHeight() : child.clientHeight;
+    return collapsed !== undefined ? child.clientHeight + virtualization.getLineHeight() : child.clientHeight;
   }
   return null;
 }
 
+const logLineMenuIconWidth = 24;
 const scrollBarWidth = getScrollbarWidth();
 
 export function getLogContainerWidth(container: HTMLDivElement) {
-  return container.clientWidth - scrollBarWidth - iconWidth;
+  return container.clientWidth - scrollBarWidth - logLineMenuIconWidth;
 }
 
 export function getScrollbarWidth() {
@@ -329,21 +347,6 @@ export function getScrollbarWidth() {
   document.body.removeChild(hiddenDiv);
 
   return width;
-}
-
-let logLineSizesMap = new Map<string, number>();
-export function resetLogLineSizes() {
-  logLineSizesMap = new Map<string, number>();
-}
-
-export function storeLogLineSize(id: string, container: HTMLDivElement, height: number, fontSize: LogListFontSize) {
-  const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
-  logLineSizesMap.set(key, height);
-}
-
-export function retrieveLogLineSize(id: string, container: HTMLDivElement, fontSize: LogListFontSize) {
-  const key = `${id}_${getLogContainerWidth(container)}_${fontSize}`;
-  return logLineSizesMap.get(key);
 }
 
 export interface ScrollToLogsEventPayload {

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -11,11 +11,13 @@ export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
 
+export const DEFAULT_LINE_HEIGHT = 22;
+
 export class LogLineVirtualization {
   private ctx: CanvasRenderingContext2D | null = null;
   private gridSize = 8;
   private paddingBottom = 8 * 0.75;
-  private lineHeight = 22;
+  private lineHeight = DEFAULT_LINE_HEIGHT;
   private measurementMode: 'canvas' | 'dom' = 'canvas';
   private textWidthMap: Map<number, number>;
   private logLineSizesMap: Map<string, number>;
@@ -257,7 +259,7 @@ export function getLogLineSize(
     return virtualization.getLineHeight() + virtualization.getPaddingBottom();
   }
   // If a long line is collapsed, we show the line count + an extra line for the expand/collapse control
-  logs[index].updateCollapsedState(virtualization, displayedFields, container);
+  logs[index].updateCollapsedState(displayedFields, container);
   if (logs[index].collapsed) {
     return (virtualization.getTruncationLineCount() + 1) * virtualization.getLineHeight();
   }


### PR DESCRIPTION
This PR is a follow up to https://github.com/grafana/grafana/pull/106376 where we introduced an alternative smaller font size to the Logs Panel. This change allowed not only the control of the current font size, but also the possibility to define the font size used by a Logs Panel instance.

This follow up allows the display of multiple Logs Panel instances with different font sizes, by updating the virtualization code to be instantiable by each individual Logs Panel with its particular settings.

Additional changes in this PR:
- Fixed a bug where changing the font size of unwrapped logs would not trigger a recalculation of field sizes.
  
  https://github.com/user-attachments/assets/03c62c81-2c2c-4764-8960-67e0b2dddc4e
  
- Added a missing memoization to `getStyles`.
- Split the LogLine component to optimize re-renders, specially while scrolling. The LogLine component is not a trivial component and each unnecessary re-render was a costly operation, which we now skip.
  
  Before:
  
    https://github.com/user-attachments/assets/1813cba9-3cb6-429a-b1c4-3a66ceab666a
  
  After:
  
  https://github.com/user-attachments/assets/35720ff5-97d2-4e03-9dbe-f83eee8f4111

Part of https://github.com/grafana/grafana/issues/99075