### PR TITLE
Dashboards: Add Drag&Drop capabilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -925,6 +925,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/dashboard/ @grafana/dashboards-squad
 /public/app/features/dashboard/components/TransformationsEditor/ @grafana/datapro
 /public/app/features/dashboard-scene/ @grafana/dashboards-squad
+/public/app/features/dropandpaste/ @grafana/dashboards-squad
 /public/app/features/scopes/ @grafana/grafana-operator-experience-squad
 /public/app/features/datasources/ @grafana/plugins-platform-frontend
 /public/app/features/dimensions/ @grafana/dataviz-squad

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -597,6 +597,7 @@ export {
   type PluginExtensionAddedFunctionConfig,
   type PluginExtensionResourceAttributesContext,
   type CentralAlertHistorySceneV1Props,
+  type PluginExtensionDropAndPasteResponse,
 } from './types/pluginExtensions';
 export {
   type ScopeDashboardBindingSpec,

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1235,4 +1235,9 @@ export interface FeatureToggles {
   * @default false
   */
   kubernetesAnnotations?: boolean;
+  /**
+  * Enables the drop and paste handlers on dashboards
+  * @default false
+  */
+  dashboardDropAndPaste?: boolean;
 }

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 
 import { ScopedVars } from './ScopedVars';
+import { PanelModel } from './dashboard';
 import { DataSourcePluginMeta, DataSourceSettings } from './datasource';
 import { IconName } from './icon';
 import { PanelData } from './panel';
@@ -218,6 +219,8 @@ export enum PluginExtensionPoints {
   LogsViewResourceAttributes = 'grafana/logsview/resource-attributes',
   AppChrome = 'grafana/app/chrome/v1',
   ExtensionSidebar = 'grafana/extension-sidebar/v0-alpha',
+  DashboardDropzone = 'grafana/dashboard/dropzone/v1',
+  DashboardPaste = 'grafana/dashboard/paste/v1',
 }
 
 // Don't use directly in a plugin!
@@ -280,6 +283,13 @@ export type PluginExtensionDataSourceConfigContext<
   setSecureJsonData: (secureJsonData: SecureJsonData) => void;
 };
 
+export type PluginExtensionDropAndPasteResponse = {
+  title: string;
+  icon: IconName;
+  confidence: number;
+  component?: React.ComponentType<{ addPanel: (p: PanelModel) => void }>;
+  panel?: PanelModel;
+};
 export type PluginExtensionCommandPaletteContext = {};
 
 export type PluginExtensionResourceAttributesContext = {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -163,6 +163,7 @@ export class GrafanaBootConfig {
     internalLoggerLevel: 0,
     botFilterEnabled: false,
   };
+  pluginEnableDropAndPasteHook: string[] = [];
   pluginCatalogURL = 'https://grafana.com/grafana/plugins/';
   pluginAdminEnabled = true;
   pluginAdminExternalManageEnabled = false;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -253,6 +253,7 @@ type FrontendSettingsDTO struct {
 	PluginCatalogManagedPlugins         []string                       `json:"pluginCatalogManagedPlugins"`
 	PluginCatalogPreinstalledPlugins    []setting.InstallPlugin        `json:"pluginCatalogPreinstalledPlugins"`
 	PluginCatalogPreinstalledAutoUpdate bool                           `json:"pluginCatalogPreinstalledAutoUpdate"`
+	PluginEnableDropAndPasteHook        []string                       `json:"pluginEnableDropAndPasteHook"`
 	ExpressionsEnabled                  bool                           `json:"expressionsEnabled"`
 	AwsAllowedAuthProviders             []string                       `json:"awsAllowedAuthProviders"`
 	AwsAssumeRoleEnabled                bool                           `json:"awsAssumeRoleEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -311,6 +311,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		AwsAllowedAuthProviders:             hs.Cfg.AWSAllowedAuthProviders,
 		AwsAssumeRoleEnabled:                hs.Cfg.AWSAssumeRoleEnabled,
 		SupportBundlesEnabled:               isSupportBundlesEnabled(hs),
+		PluginEnableDropAndPasteHook:        hs.Cfg.PluginEnableDropAndPasteHook,
 
 		Azure: dtos.FrontendSettingsAzureDTO{
 			Cloud:                                  hs.Cfg.Azure.Cloud,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2142,6 +2142,16 @@ var (
 			Owner:       grafanaBackendServicesSquad,
 			Expression:  "false",
 		},
+		{
+			Name:              "dashboardDropAndPaste",
+			Description:       "Enables the drop and paste handlers on dashboards",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaDashboardsSquad,
+			FrontendOnly:      true,
+			HideFromAdminPage: false,
+			HideFromDocs:      false,
+			Expression:        "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -275,3 +275,4 @@ onlyStoreActionSets,GA,@grafana/identity-access-team,false,false,false
 panelTimeSettings,experimental,@grafana/dashboards-squad,false,false,false
 dashboardTemplates,experimental,@grafana/sharing-squad,false,false,false
 kubernetesAnnotations,experimental,@grafana/grafana-backend-services-squad,false,false,false
+dashboardDropAndPaste,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -1109,4 +1109,8 @@ const (
 	// FlagKubernetesAnnotations
 	// Enables app platform API for annotations
 	FlagKubernetesAnnotations = "kubernetesAnnotations"
+
+	// FlagDashboardDropAndPaste
+	// Enables the drop and paste handlers on dashboards
+	FlagDashboardDropAndPaste = "dashboardDropAndPaste"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1058,6 +1058,20 @@
     },
     {
       "metadata": {
+        "name": "dashboardDropAndPaste",
+        "resourceVersion": "1760089664458",
+        "creationTimestamp": "2025-10-10T09:47:44Z"
+      },
+      "spec": {
+        "description": "Enables the drop and paste handlers on dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardDsAdHocFiltering",
         "resourceVersion": "1756814786992",
         "creationTimestamp": "2025-07-23T08:12:25Z",

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -211,6 +211,7 @@ type Cfg struct {
 	PluginAdminExternalManageEnabled bool
 	PluginForcePublicKeyDownload     bool
 	PluginSkipPublicKeyDownload      bool
+	PluginEnableDropAndPasteHook     []string
 	DisablePlugins                   []string
 	ForwardHostEnvVars               []string
 	PreinstallPluginsAsync           []InstallPlugin

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -138,6 +138,12 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	cfg.PluginSettings = extractPluginSettings(iniFile.Sections())
 	cfg.PluginSkipPublicKeyDownload = pluginsSection.Key("public_key_retrieval_disabled").MustBool(false)
 	cfg.PluginForcePublicKeyDownload = pluginsSection.Key("public_key_retrieval_on_startup").MustBool(false)
+	enabledDropAndPasteHooks := pluginsSection.Key("enable_drop_and_paste_hook").MustString("")
+	if enabledDropAndPasteHooks != "" {
+		cfg.PluginEnableDropAndPasteHook = strings.Split(enabledDropAndPasteHooks, ",")
+	} else {
+		cfg.PluginEnableDropAndPasteHook = []string{}
+	}
 
 	cfg.PluginsAllowUnsigned = util.SplitString(pluginsSection.Key("allow_loading_unsigned_plugins").MustString(""))
 	cfg.DisablePlugins = util.SplitString(pluginsSection.Key("disable_plugins").MustString(""))

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -7,6 +7,7 @@ import { config, useChromeHeaderHeight } from '@grafana/runtime';
 import { useSceneObjectState } from '@grafana/scenes';
 import { ElementSelectionContext, useStyles2 } from '@grafana/ui';
 import NativeScrollbar, { DivScrollElement } from 'app/core/components/NativeScrollbar';
+import { DropAndPasteWrapper } from 'app/features/dropandpaste/DropAndPasteWrapper';
 
 import { useSnappingSplitter } from '../panel-edit/splitter/useSnappingSplitter';
 import { DashboardScene } from '../scene/DashboardScene';
@@ -32,9 +33,11 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
     return (
       <NativeScrollbar onSetScrollRef={dashboard.onSetScrollRef}>
         <div className={styles.canvasWrappperOld}>
-          <NavToolbarActions dashboard={dashboard} />
-          <div className={styles.controlsWrapperSticky}>{controls}</div>
-          <div className={styles.body}>{body}</div>
+          <DropAndPasteWrapper dashboard={dashboard}>
+            <NavToolbarActions dashboard={dashboard} />
+            <div className={styles.controlsWrapperSticky}>{controls}</div>
+            <div className={styles.body}>{body}</div>
+          </DropAndPasteWrapper>
         </div>
       </NativeScrollbar>
     );
@@ -96,17 +99,19 @@ export function DashboardEditPaneSplitter({ dashboard, isEditing, body, controls
             editPane.clearSelection();
           }}
         >
-          <NavToolbarActions dashboard={dashboard} />
-          <div className={cx(!isEditing && styles.controlsWrapperSticky)}>{controls}</div>
-          <div className={styles.bodyWrapper}>
-            <div
-              className={cx(styles.body, isEditing && styles.bodyEditing)}
-              data-testid={selectors.components.DashboardEditPaneSplitter.primaryBody}
-              ref={onBodyRef}
-            >
-              {body}
+          <DropAndPasteWrapper dashboard={dashboard}>
+            <NavToolbarActions dashboard={dashboard} />
+            <div className={cx(!isEditing && styles.controlsWrapperSticky)}>{controls}</div>
+            <div className={styles.bodyWrapper}>
+              <div
+                className={cx(styles.body, isEditing && styles.bodyEditing)}
+                data-testid={selectors.components.DashboardEditPaneSplitter.primaryBody}
+                ref={onBodyRef}
+              >
+                {body}
+              </div>
             </div>
-          </div>
+          </DropAndPasteWrapper>
         </div>
         {isEditing && (
           <>

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -294,9 +294,9 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
   const scopeMeta =
     config.featureToggles.scopeFilters && oldModel.scopeMeta
       ? {
-          trait: oldModel.scopeMeta.trait,
-          groups: oldModel.scopeMeta.groups,
-        }
+        trait: oldModel.scopeMeta.trait,
+        groups: oldModel.scopeMeta.groups,
+      }
       : undefined;
 
   // Create profiler once and reuse to avoid duplicate metadata setting
@@ -402,14 +402,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
   return dashboardScene;
 }
 
-export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
-  const repeatOptions: Partial<{ variableName: string; repeatDirection: RepeatDirection }> = panel.repeat
-    ? {
-        variableName: panel.repeat,
-        repeatDirection: panel.repeatDirection === 'v' ? 'v' : 'h',
-      }
-    : {};
-
+export function buildVizPanelForPanel(panel: PanelModel): VizPanel {
   const titleItems: SceneObject[] = [];
 
   titleItems.push(
@@ -481,8 +474,18 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     });
   }
 
-  const body = new VizPanel(vizPanelState);
+  return new VizPanel(vizPanelState);
+}
 
+export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
+  const repeatOptions: Partial<{ variableName: string; repeatDirection: RepeatDirection }> = panel.repeat
+    ? {
+      variableName: panel.repeat,
+      repeatDirection: panel.repeatDirection === 'v' ? 'v' : 'h',
+    }
+    : {};
+
+  const body = buildVizPanelForPanel(panel);
   return new DashboardGridItem({
     key: `grid-item-${panel.id}`,
     x: panel.gridPos.x,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -294,9 +294,9 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel,
   const scopeMeta =
     config.featureToggles.scopeFilters && oldModel.scopeMeta
       ? {
-        trait: oldModel.scopeMeta.trait,
-        groups: oldModel.scopeMeta.groups,
-      }
+          trait: oldModel.scopeMeta.trait,
+          groups: oldModel.scopeMeta.groups,
+        }
       : undefined;
 
   // Create profiler once and reuse to avoid duplicate metadata setting
@@ -480,9 +480,9 @@ export function buildVizPanelForPanel(panel: PanelModel): VizPanel {
 export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
   const repeatOptions: Partial<{ variableName: string; repeatDirection: RepeatDirection }> = panel.repeat
     ? {
-      variableName: panel.repeat,
-      repeatDirection: panel.repeatDirection === 'v' ? 'v' : 'h',
-    }
+        variableName: panel.repeat,
+        repeatDirection: panel.repeatDirection === 'v' ? 'v' : 'h',
+      }
     : {};
 
   const body = buildVizPanelForPanel(panel);

--- a/public/app/features/dropandpaste/DashboardDropOverlay.tsx
+++ b/public/app/features/dropandpaste/DashboardDropOverlay.tsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { useStyles2, Text } from '@grafana/ui';
+
+import { AddFileIcon } from './add-file-icon';
+
+export function DashboardDropOverlay() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.dropOverlay}>
+      <div className={styles.dropHint}>
+        <div className={styles.icon}>
+          <AddFileIcon />
+        </div>
+        <Text variant="body" element="p">
+          <Trans i18nKey="dragndrop.drop-hover-text">Drop a file to bring your data into the dashboard</Trans>
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    dropOverlay: css({
+      display: 'flex',
+      backdropFilter: 'blur(2px)',
+      position: 'absolute',
+      zIndex: theme.zIndex.modal,
+      inset: 0,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingBottom: theme.spacing(10),
+    }),
+    dropHint: css({
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      p: {
+        fontSize: '1.5rem',
+      },
+    }),
+    icon: css({
+      width: '3rem',
+    }),
+  };
+}

--- a/public/app/features/dropandpaste/DropAndPasteWrapper.tsx
+++ b/public/app/features/dropandpaste/DropAndPasteWrapper.tsx
@@ -1,0 +1,140 @@
+import { css } from '@emotion/css';
+import React, { useCallback, ClipboardEvent, useState, ReactNode } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import { PluginExtensionPoints, PluginExtensionDropAndPasteResponse, GrafanaTheme2, PanelModel } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { Drawer, useStyles2 } from '@grafana/ui';
+import { PanelModel as DashboardPanelModel } from 'app/features/dashboard/state/PanelModel';
+import { usePluginFunctions } from 'app/features/plugins/extensions/usePluginFunctions';
+
+import { DashboardScene } from '../dashboard-scene/scene/DashboardScene';
+import { buildVizPanelForPanel } from '../dashboard-scene/serialization/transformSaveModelToScene';
+
+import { DashboardDropOverlay } from './DashboardDropOverlay';
+import { VizPanelAlternatives } from './VizPanelAlternatives';
+
+interface Props {
+  dashboard: DashboardScene;
+  children?: React.ReactNode;
+}
+
+export function DropAndPasteWrapper(props: Props) {
+  if (!config.featureToggles.dashboardDropAndPaste) {
+    return <>{props.children}</>;
+  }
+  return <DropAndPasteContainer {...props} />;
+}
+function DropAndPasteContainer({ dashboard, children }: Props) {
+  const styles = useStyles2(getStyles);
+  const { functions: fileHooks } = usePluginFunctions<
+    (data: File) => Promise<PluginExtensionDropAndPasteResponse[] | null>
+  >({
+    extensionPointId: PluginExtensionPoints.DashboardDropzone,
+    limitPerPlugin: 1,
+  });
+  const [editComponent, setEditComponent] = useState<ReactNode | null>(null);
+  const filteredFileHooks =
+    config.pluginEnableDropAndPasteHook.length > 0
+      ? fileHooks.filter((x) => x.pluginId in config.pluginEnableDropAndPasteHook)
+      : fileHooks;
+  const { functions: pasteHooks } = usePluginFunctions<
+    (data: DataTransfer) => Promise<PluginExtensionDropAndPasteResponse[] | null>
+  >({
+    extensionPointId: PluginExtensionPoints.DashboardPaste,
+    limitPerPlugin: 1,
+  });
+  const filteredPasteHooks =
+    config.pluginEnableDropAndPasteHook.length > 0
+      ? pasteHooks.filter((x) => x.pluginId in config.pluginEnableDropAndPasteHook)
+      : pasteHooks;
+
+  const addResults = useCallback(
+    (results: Array<PluginExtensionDropAndPasteResponse[] | null>) => {
+      const filteredResults = results
+        .filter((x) => x !== null)
+        .flat()
+        .sort((a, b) => a.confidence - b.confidence);
+      if (filteredResults.length === 0) {
+        return;
+      }
+      const firstPanel = filteredResults.find((x) => !!x.panel);
+      const firstComponent = filteredResults.find((x) => !!x.component);
+      const addPanel = (panel: PanelModel) => {
+        const vizPanel = buildVizPanelForPanel(new DashboardPanelModel(panel));
+        vizPanel.setState({
+          headerActions: [
+            new VizPanelAlternatives({
+              actions: filteredResults.map((p) => ({
+                name: p.title,
+                icon: p.icon,
+                onClick: () => {
+                  if (p.component) {
+                    setEditComponent(
+                      <p.component
+                        addPanel={(p) => {
+                          dashboard.removePanel(vizPanel);
+                          setEditComponent(null);
+                          addPanel(p);
+                        }}
+                      />
+                    );
+                  } else if (p.panel != null) {
+                    dashboard.removePanel(vizPanel);
+                    addPanel(p.panel);
+                  }
+                },
+              })),
+            }),
+          ],
+        });
+        dashboard.addPanel(vizPanel);
+      };
+      if (firstPanel) {
+        addPanel(firstPanel.panel!);
+      } else if (firstComponent?.component) {
+        setEditComponent(<firstComponent.component addPanel={addPanel} />);
+      }
+    },
+    [dashboard, setEditComponent]
+  );
+  const onImportFile = useCallback(
+    async (f: File) => {
+      const results = await Promise.all(filteredFileHooks.map((hook) => hook.fn(f)));
+      addResults(results);
+    },
+    [filteredFileHooks, addResults]
+  );
+  const onPaste = useCallback(
+    async (e: ClipboardEvent) => {
+      const results = await Promise.all(filteredPasteHooks.map((hook) => hook.fn(e.clipboardData)));
+      addResults(results);
+    },
+    [filteredPasteHooks, addResults]
+  );
+  const { getRootProps, isDragActive } = useDropzone({ onDrop: ([acceptedFile]) => onImportFile(acceptedFile) });
+  return (
+    <div {...getRootProps({ className: styles.wrapper })} onPaste={onPaste}>
+      {children}
+      {isDragActive && <DashboardDropOverlay />}
+      {editComponent != null && (
+        <Drawer
+          onClose={() => {
+            setEditComponent(null);
+          }}
+        >
+          {editComponent}
+        </Drawer>
+      )}
+    </div>
+  );
+}
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+    }),
+  };
+}

--- a/public/app/features/dropandpaste/VizPanelAlternatives.tsx
+++ b/public/app/features/dropandpaste/VizPanelAlternatives.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { IconName } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { Button, Stack, Toggletip, ToolbarButton } from '@grafana/ui';
+
+export interface AlternativeActions {
+  name: string;
+  icon?: IconName;
+  onClick?: () => void;
+}
+
+interface VizPanelAlternativesState extends SceneObjectState {
+  actions: AlternativeActions[];
+}
+
+export class VizPanelAlternatives extends SceneObjectBase<VizPanelAlternativesState> {
+  static Component = VizPanelMoreRenderer;
+}
+
+function VizPanelMoreRenderer({ model }: SceneComponentProps<VizPanelAlternatives>) {
+  const [isToggletipOpen, setIsToggletipOpen] = useState(true);
+  const { actions } = model.useState();
+
+  return (
+    <Toggletip
+      fitContent={true}
+      show={isToggletipOpen}
+      onClose={() => setIsToggletipOpen(false)}
+      onOpen={() => setIsToggletipOpen(true)}
+      content={
+        <Stack gap={1} direction="column">
+          <Trans i18nKey="dragndrop.alternative-cta">Want a different look? Select another visualization</Trans>
+          <Stack gap={3}>
+            {actions.map((item, idx) => (
+              <Button size="sm" key={idx} variant="secondary" icon={item.icon} onClick={item.onClick}>
+                {item.name}
+              </Button>
+            ))}
+          </Stack>
+        </Stack>
+      }
+    >
+      <ToolbarButton icon="ai" />
+    </Toggletip>
+  );
+}

--- a/public/app/features/dropandpaste/add-file-icon.tsx
+++ b/public/app/features/dropandpaste/add-file-icon.tsx
@@ -1,0 +1,54 @@
+export const AddFileIcon = () => {
+  return (
+    <svg width="100%" height="100%" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <linearGradient id="brandHorizontal" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#F55F3E" offset="0%" />
+        <stop stopColor="#FF8833" offset="100%" />
+      </linearGradient>
+      <path
+        d="M17.25 14.45V20.45"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.25 17.45H20.25"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M17.25 23.45C20.5637 23.45 23.25 20.7637 23.25 17.45C23.25 14.1362 20.5637 11.45 17.25 11.45C13.9363 11.45 11.25 14.1362 11.25 17.45C11.25 20.7637 13.9363 23.45 17.25 23.45Z"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3.75 6.94995V15.95H8.25"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3.75 12.95L6.439 10.261C6.72033 9.97946 7.10201 9.82129 7.5 9.82129C7.89799 9.82129 8.27967 9.97946 8.561 10.261L9.142 10.842C9.46862 11.1682 9.92728 11.3259 10.3855 11.2695C10.8437 11.213 11.2503 10.9487 11.488 10.553L11.846 9.95297"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7.5 20.45H2.25C1.42157 20.45 0.75 19.7784 0.75 18.95V2.44995C0.75 1.62152 1.42157 0.949951 2.25 0.949951H12.879C13.2765 0.950036 13.6578 1.10793 13.939 1.38895L16.811 4.26095C17.092 4.54215 17.2499 4.9234 17.25 5.32095V7.69995"
+        stroke="url(#brandHorizontal)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -397,7 +397,7 @@ export function createAddedLinkConfig<T extends object>(
 
 function assertLinkConfig<T extends object>(
   config: PluginExtensionAddedLinkConfig<T>
-): asserts config is PluginExtensionAddedLinkConfig { }
+): asserts config is PluginExtensionAddedLinkConfig {}
 
 export function truncateTitle(title: string, length: number): string {
   if (title.length < length) {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -397,7 +397,7 @@ export function createAddedLinkConfig<T extends object>(
 
 function assertLinkConfig<T extends object>(
   config: PluginExtensionAddedLinkConfig<T>
-): asserts config is PluginExtensionAddedLinkConfig {}
+): asserts config is PluginExtensionAddedLinkConfig { }
 
 export function truncateTitle(title: string, length: number): string {
   if (title.length < length) {
@@ -619,7 +619,8 @@ export const getExtensionPointPluginDependencies = (extensionPointId: string): s
     .filter(
       (app) =>
         app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)) ||
-        app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId))
+        app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId)) ||
+        app.extensions.addedFunctions.some((fn) => fn.targets.includes(extensionPointId))
     )
     .map((app) => app.id)
     .reduce((acc: string[], id: string) => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7008,6 +7008,10 @@
       "update": "Update"
     }
   },
+  "dragndrop": {
+    "alternative-cta": "Want a different look? Select another visualization",
+    "drop-hover-text": "Drop a file to bring your data into the dashboard"
+  },
   "embed": {
     "share": {
       "time-range-description": "Change the current relative time range to an absolute time range",


### PR DESCRIPTION
**What is this feature?**

This feature adds drop and paste capabilities to scene based dashboards. It is based on the Hackathon project with the same name.

**Why do we need this feature?**

Supporting drag & drop interactions significantly simplifies getting started with Grafana.

**Who is this feature for?**

End users and plugin developers alike. The conversion between dropped/pasted data to panels is dynamic and can be performed by plugins

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
