### PR TITLE
UI: Use tabular-numbers globally 

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -85,6 +85,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `alertingMigrationUI`                  | Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules                                   | Yes                |
 | `alertingImportYAMLUI`                 | Enables a UI feature for importing rules from a Prometheus file to Grafana-managed rules                                           | Yes                |
 | `unifiedNavbars`                       | Enables unified navbars                                                                                                            |                    |
+| `tabularNumbers`                       | Use fixed-width numbers globally in the UI                                                                                         | Yes                |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1032,4 +1032,8 @@ export interface FeatureToggles {
   * @default false
   */
   preferLibraryPanelTitle?: boolean;
+  /**
+  * Use fixed-width numbers globally in the UI
+  */
+  tabularNumbers?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1034,6 +1034,7 @@ export interface FeatureToggles {
   preferLibraryPanelTitle?: boolean;
   /**
   * Use fixed-width numbers globally in the UI
+  * @default true
   */
   tabularNumbers?: boolean;
 }

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 
 import { GrafanaTheme2, ThemeTypographyVariant } from '@grafana/data';
 
+import { getFeatureToggle } from '../../utils/featureToggle';
 import { getFocusStyles } from '../mixins';
 
 export function getElementStyles(theme: GrafanaTheme2, isExtensionSidebarOpen?: boolean) {
@@ -61,6 +62,7 @@ export function getElementStyles(theme: GrafanaTheme2, isExtensionSidebarOpen?: 
       fontVariantLigatures: 'no-contextual',
       ...theme.typography.body,
       ...bodyOverflow,
+      fontVariantNumeric: getFeatureToggle('tabularNumbers') ? 'tabular-nums' : 'initial',
     },
 
     'h1, .h1': getVariantStyles(theme.typography.h1),

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1773,6 +1773,12 @@ var (
 			Owner:       grafanaDashboardsSquad,
 			Expression:  "false",
 		},
+		{
+			Name:        "tabularNumbers",
+			Description: "Use fixed-width numbers globally in the UI",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaFrontendPlatformSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1776,8 +1776,9 @@ var (
 		{
 			Name:        "tabularNumbers",
 			Description: "Use fixed-width numbers globally in the UI",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStageGeneralAvailability,
 			Owner:       grafanaFrontendPlatformSquad,
+			Expression:  "true",
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -231,3 +231,4 @@ skipTokenRotationIfRecent,privatePreview,@grafana/identity-access-team,false,fal
 alertEnrichment,experimental,@grafana/alerting-squad,false,false,false
 alertingImportAlertmanagerAPI,experimental,@grafana/alerting-squad,false,false,false
 preferLibraryPanelTitle,privatePreview,@grafana/dashboards-squad,false,false,false
+tabularNumbers,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -231,4 +231,4 @@ skipTokenRotationIfRecent,privatePreview,@grafana/identity-access-team,false,fal
 alertEnrichment,experimental,@grafana/alerting-squad,false,false,false
 alertingImportAlertmanagerAPI,experimental,@grafana/alerting-squad,false,false,false
 preferLibraryPanelTitle,privatePreview,@grafana/dashboards-squad,false,false,false
-tabularNumbers,experimental,@grafana/grafana-frontend-platform,false,false,false
+tabularNumbers,GA,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -934,4 +934,8 @@ const (
 	// FlagPreferLibraryPanelTitle
 	// Prefer library panel title over viz panel title.
 	FlagPreferLibraryPanelTitle = "preferLibraryPanelTitle"
+
+	// FlagTabularNumbers
+	// Use fixed-width numbers globally in the UI
+	FlagTabularNumbers = "tabularNumbers"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3238,6 +3238,18 @@
     },
     {
       "metadata": {
+        "name": "tabularNumbers",
+        "resourceVersion": "1750421320919",
+        "creationTimestamp": "2025-06-20T12:08:40Z"
+      },
+      "spec": {
+        "description": "Use fixed-width numbers globally in the UI",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
         "name": "teamHttpHeadersMimir",
         "resourceVersion": "1749732225616",
         "creationTimestamp": "2025-01-13T10:42:47Z",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3239,13 +3239,17 @@
     {
       "metadata": {
         "name": "tabularNumbers",
-        "resourceVersion": "1750421320919",
-        "creationTimestamp": "2025-06-20T12:08:40Z"
+        "resourceVersion": "1750754828442",
+        "creationTimestamp": "2025-06-20T12:08:40Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-06-24 08:47:08.442537461 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use fixed-width numbers globally in the UI",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform"
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
**What is this feature?**

Enables monospaced/[tabular numbers](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric#numeric-spacing-values) globally in the UI where numbers always show the same size, for better alignment in tables and tooltips.

This change is behind the `tabularNumbers` feature toggle, but enabled by default in source.

_**Before:**_

![gif-1](https://github.com/user-attachments/assets/867d7803-f9c6-49ef-9d04-4f1a9af0c3cb)

_**After:**_

![gif-2](https://github.com/user-attachments/assets/4ddfbc0c-cf0d-4fbd-9120-734e376e482b)

(notice how the numbers in the tooltip stay the same width, and the tooltip width doesn't jitter about)

_**Comparison:**_

![output](https://github.com/user-attachments/assets/2f44b43d-ec73-4911-bbe2-1fd6de0e1905)



I think this is exceptionally suited for visualisations, but using it globally might be a bit iffy:

![image](https://github.com/user-attachments/assets/4b018298-f8be-446e-8588-f578507fa143)

The wider numbers in the recent ranges look quite different to me. I'm not sure if it's bad, or im just noticing the difference.

**Why do we need this feature?**

To help users scan rows and columns of numbers better.