### PR TITLE
Alerting: Use GRAFANA_ALERTS as the default state history metric name

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1477,7 +1477,7 @@ enabled = true
 
 # Select which pluggable state history backend to use. Either "annotations", "loki", "prometheus", or "multiple"
 # "loki" writes state history to an external Loki instance.
-# "prometheus" writes state history as ALERTS metrics to a Prometheus-compatible data source.
+# "prometheus" writes state history as GRAFANA_ALERTS metrics to a Prometheus-compatible data source.
 # "multiple" allows history to be written to multiple backends at once.
 # Defaults to "annotations".
 backend =
@@ -1529,15 +1529,15 @@ loki_max_query_length = 721h
 loki_max_query_size = 65536
 
 # For "prometheus" only.
-# Target datasource UID for writing ALERTS metrics.
+# Target datasource UID for writing GRAFANA_ALERTS metrics.
 prometheus_target_datasource_uid =
 
 # For "prometheus" only.
-# Metric name for the ALERTS metric. Default is "ALERTS".
-prometheus_metric_name = ALERTS
+# Metric name for the GRAFANA_ALERTS metric. Default is "GRAFANA_ALERTS".
+prometheus_metric_name = GRAFANA_ALERTS
 
 # For "prometheus" only.
-# Timeout for writing ALERTS metrics to the target datasource. Default is 10s.
+# Timeout for writing GRAFANA_ALERTS metrics to the target datasource. Default is 10s.
 prometheus_write_timeout = 10s
 
 [unified_alerting.state_history.external_labels]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1456,7 +1456,7 @@ disabled_labels =
 
 # Select which pluggable state history backend to use. Either "annotations", "loki", "prometheus", or "multiple"
 # "loki" writes state history to an external Loki instance.
-# "prometheus" writes state history as ALERTS metrics to a Prometheus-compatible data source.
+# "prometheus" writes state history as GRAFANA_ALERTS metrics to a Prometheus-compatible data source.
 # "multiple" allows history to be written to multiple backends at once.
 # Defaults to "annotations".
 ; backend = "multiple"
@@ -1508,15 +1508,15 @@ disabled_labels =
 ;loki_max_query_size = 65536
 
 # For "prometheus" only.
-# Target datasource UID for writing ALERTS metrics.
+# Target datasource UID for writing GRAFANA_ALERTS metrics.
 ; prometheus_target_datasource_uid = "my-prometheus-uid"
 
 # For "prometheus" only.
-# Metric name for the ALERTS metric. Default is "ALERTS".
-; prometheus_metric_name = "ALERTS"
+# Metric name for the GRAFANA_ALERTS metric. Default is "GRAFANA_ALERTS".
+; prometheus_metric_name = "GRAFANA_ALERTS"
 
 # For "prometheus" only.
-# Timeout for writing ALERTS metrics to the target datasource. Default is 10s.
+# Timeout for writing GRAFANA_ALERTS metrics to the target datasource. Default is 10s.
 ; prometheus_write_timeout = 10s
 
 [unified_alerting.state_history.external_labels]

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -68,7 +68,7 @@ const (
 	defaultRecordingRequestTimeout         = 10 * time.Second
 	lokiDefaultMaxQuerySize                = 65536 // 64kb
 	defaultHistorianPrometheusWriteTimeout = 10 * time.Second
-	defaultHistorianPrometheusMetricName   = "ALERTS"
+	defaultHistorianPrometheusMetricName   = "GRAFANA_ALERTS"
 )
 
 var (


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/104361 we added a new state history backend to write an `ALERTS` metric compatible with Prometheus `ALERTS`. This PR changes the default name for the metric to `GRAFANA_ALERTS` so that it does not clash with Prometheus metric if it exists. If needed, the metric name can be configured via config.ini