### PR TITLE
StateTimeline: Display false and empty string values

### DIFF
--- a/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
@@ -986,6 +986,101 @@
       ],
       "title": "special null + NaN value mapping from data",
       "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "fieldMinMax": false,
+          "mappings": [
+            {
+              "options": {
+                "match": "false",
+                "result": {
+                  "color": "red",
+                  "index": 0
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "blue",
+                  "index": 1,
+                  "text": "null + NaN"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata",
+            "uid": "PD8C576611E62080A"
+          },
+          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time\",\n            \"nullable\": true\n          },\n          \"config\": {}\n        },\n        {\n          \"name\": \"value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"thresholds\": {\n              \"mode\": \"absolute\",\n              \"steps\": [\n                {\n                  \"color\": \"green\",\n                  \"value\": null\n                }\n              ]\n            }\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1674732835000,\n          1674736435000,\n          1674740035000,\n          1674743635000,\n          1674747235000,\n          1674750835000,\n          1674754235000,\n          1674757835000\n        ],\n        [\n          null,\n          null,\n          false,\n          true,\n          true,\n          false,\n          true,\n          null\n        ]\n      ],\n      \"entities\": [null, { \"NaN\": [0], \"Undefined\": [1]}]\n    }\n  }\n]",
+          "refId": "A",
+          "scenarioId": "raw_frame"
+        }
+      ],
+      "title": "boolean values from data",
+      "type": "state-timeline"
     }
   ],
   "preload": false,
@@ -1008,5 +1103,5 @@
   "timezone": "utc",
   "title": "StateTimeline - Thresholds & Mappings",
   "uid": "Kce7z9TVz",
-  "version": 13
+  "version": 18
 }

--- a/public/app/core/components/TimelineChart/timeline.test.ts
+++ b/public/app/core/components/TimelineChart/timeline.test.ts
@@ -280,15 +280,8 @@ describe('StateTimeline uPlot integration', () => {
       }
     );
 
-    describe.each([
-      [{}, undefined, undefined, true, 'object returns true'],
-      [[], undefined, undefined, true, 'array returns true'],
-      [new Date(), undefined, undefined, true, 'date returns true'],
-      [BigInt(0), undefined, undefined, false, 'bigint zero returns false'],
-    ])('non-scalar values', (yValue, mappedNull, mappedNaN, expected, testName) => {
-      it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
-      });
+    describe('non-supported values', () => {
+      it.todo(`TODO: this helper currently returns true for many non-supported truthy values, but should not`);
     });
   });
 });

--- a/public/app/core/components/TimelineChart/timeline.test.ts
+++ b/public/app/core/components/TimelineChart/timeline.test.ts
@@ -263,13 +263,22 @@ describe('StateTimeline uPlot integration', () => {
     });
 
     describe.each([
-      ['', undefined, undefined, false, 'empty string returns false'],
-      [undefined, undefined, undefined, false, 'undefined returns false'],
-    ])('falsy values', (yValue, mappedNull, mappedNaN, expected, testName) => {
+      ['', undefined, undefined, true, 'empty string returns true'],
+      ['to be or not to be', undefined, undefined, true, 'non-empty string returns true'],
+    ])('string values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
         expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
+
+    describe.each([[undefined, undefined, undefined, false, 'undefined returns false']])(
+      'falsy values',
+      (yValue, mappedNull, mappedNaN, expected, testName) => {
+        it(testName, () => {
+          expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
+        });
+      }
+    );
 
     describe.each([
       [{}, undefined, undefined, true, 'object returns true'],

--- a/public/app/core/components/TimelineChart/timeline.test.ts
+++ b/public/app/core/components/TimelineChart/timeline.test.ts
@@ -211,76 +211,74 @@ describe('StateTimeline uPlot integration', () => {
 
   describe('#shouldDrawYValue', () => {
     describe.each([
-      [true, undefined, true, 'boolean true returns true'],
-      [false, undefined, true, 'boolean false returns true'],
-    ])('boolean values', (yValue, mappings, expected, testName) => {
+      [true, undefined, undefined, true, 'boolean true returns true'],
+      [false, undefined, undefined, true, 'boolean false returns true'],
+    ])('boolean values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      [0, undefined, true, 'zero returns true'],
-      [1, undefined, true, 'positive integer returns true'],
-      [-2.71, undefined, true, 'negative float returns true'],
-      [Number.MAX_VALUE, undefined, true, 'max value returns true'],
-      [Number.MIN_VALUE, undefined, true, 'min value returns true'],
-    ])('finite numbers', (yValue, mappings, expected, testName) => {
+      [0, undefined, undefined, true, 'zero returns true'],
+      [1, undefined, undefined, true, 'positive integer returns true'],
+      [-2.71, undefined, undefined, true, 'negative float returns true'],
+      [Number.MAX_VALUE, undefined, undefined, true, 'max value returns true'],
+      [Number.MIN_VALUE, undefined, undefined, true, 'min value returns true'],
+    ])('finite numeric values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      [Infinity, undefined, true, 'positive infinity returns true'],
-      [-Infinity, undefined, true, 'negative infinity returns true'],
-      [Number.POSITIVE_INFINITY, undefined, true, 'Number.POSITIVE_INFINITY returns true'],
-      [Number.NEGATIVE_INFINITY, undefined, true, 'Number.NEGATIVE_INFINITY returns true'],
-    ])('non-finite numbers', (yValue, mappings, expected, testName) => {
+      [Infinity, undefined, undefined, true, 'positive infinity returns true'],
+      [-Infinity, undefined, undefined, true, 'negative infinity returns true'],
+      [Number.POSITIVE_INFINITY, undefined, undefined, true, 'Number.POSITIVE_INFINITY returns true'],
+      [Number.NEGATIVE_INFINITY, undefined, undefined, true, 'Number.NEGATIVE_INFINITY returns true'],
+    ])('non-finite numeric values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      [null, undefined, false, 'null without mappings returns false'],
-      [null, {}, false, 'null with empty mappings returns false'],
-      [null, { mappedNull: false, mappedNaN: true }, false, 'null with false mappedNull returns false'],
-      [null, { mappedNull: true }, true, 'null with ture mappedNull returns true'],
-    ])('null values', (yValue, mappings, expected, testName) => {
+      [null, undefined, undefined, false, 'null without mappings returns false'],
+      [null, false, true, false, 'null with false mappedNull returns false'],
+      [null, true, undefined, true, 'null with ture mappedNull returns true'],
+    ])('null values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      [NaN, undefined, false, 'NaN without mappings returns false'],
-      [NaN, {}, false, 'NaN with empty mappings returns false'],
-      [NaN, { mappedNull: true, mappedNaN: false }, false, 'NaN with false mappedNaN returns false'],
-      [NaN, { mappedNaN: true }, true, 'NaN with true mappedNaN returns true'],
-    ])('NaN values', (yValue, mappings, expected, testName) => {
+      [NaN, undefined, undefined, false, 'NaN without mappings returns false'],
+      [NaN, true, undefined, false, 'NaN with false mappedNaN returns false'],
+      [NaN, undefined, true, true, 'NaN with true mappedNaN returns true'],
+    ])('NaN values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      ['', undefined, false, 'empty string returns false'],
-      [undefined, undefined, false, 'undefined returns false'],
-    ])('falsy values', (yValue, mappings, expected, testName) => {
+      ['', undefined, undefined, false, 'empty string returns false'],
+      [undefined, undefined, undefined, false, 'undefined returns false'],
+    ])('falsy values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
 
     describe.each([
-      [{}, undefined, true, 'object returns true'],
-      [[], undefined, true, 'array returns true'],
-      [new Date(), undefined, true, 'date returns true'],
-      [BigInt(0), undefined, false, 'bigint zero returns false'],
-    ])('non-scalar values', (yValue, mappings, expected, testName) => {
+      [{}, undefined, undefined, true, 'object returns true'],
+      [[], undefined, undefined, true, 'array returns true'],
+      [new Date(), undefined, undefined, true, 'date returns true'],
+      [BigInt(0), undefined, undefined, false, 'bigint zero returns false'],
+    ])('non-scalar values', (yValue, mappedNull, mappedNaN, expected, testName) => {
       it(testName, () => {
-        expect(shouldDrawYValue(yValue, mappings)).toBe(expected);
+        expect(shouldDrawYValue(yValue, mappedNull, mappedNaN)).toBe(expected);
       });
     });
   });

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -59,6 +59,33 @@ export interface TimelineCoreOptions {
 /**
  * @internal
  */
+export interface YValueMappings {
+  mappedNull?: boolean;
+  mappedNaN?: boolean;
+}
+
+/**
+ * @internal
+ */
+export function shouldDrawYValue(yValue: unknown, mappings?: YValueMappings): boolean {
+  if (typeof yValue === 'boolean') {
+    return true;
+  }
+  if (typeof yValue === 'number' && !Number.isNaN(yValue)) {
+    return true;
+  }
+  if (Number.isNaN(yValue) && mappings?.mappedNaN) {
+    return true;
+  }
+  if (yValue === null && mappings?.mappedNull) {
+    return true;
+  }
+  return !!yValue;
+}
+
+/**
+ * @internal
+ */
 export function getConfig(opts: TimelineCoreOptions) {
   const {
     mode,
@@ -210,9 +237,7 @@ export function getConfig(opts: TimelineCoreOptions) {
           if (mode === TimelineMode.Changes) {
             for (let ix = 0; ix < dataY.length; ix++) {
               let yVal = dataY[ix];
-
-              const shouldDrawY =
-                !!yVal || yVal === 0 || (yVal === null && mappedNull) || (Number.isNaN(yVal) && mappedNaN);
+              const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
 
               if (shouldDrawY) {
                 let left = Math.round(valToPosX(dataX[ix], scaleX, xDim, xOff));
@@ -257,8 +282,7 @@ export function getConfig(opts: TimelineCoreOptions) {
 
             for (let ix = idx0; ix <= idx1; ix++) {
               let yVal = dataY[ix];
-              const shouldDrawY =
-                !!yVal || yVal === 0 || (yVal === null && mappedNull) || (Number.isNaN(yVal) && mappedNaN);
+              const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
 
               if (shouldDrawY) {
                 // TODO: all xPos can be pre-computed once for all series in aligned set
@@ -321,8 +345,7 @@ export function getConfig(opts: TimelineCoreOptions) {
 
               for (let ix = 0; ix < dataY.length; ix++) {
                 const yVal = dataY[ix];
-                const shouldDrawY =
-                  !!yVal || yVal === 0 || (yVal == null && mappedNull) || (Number.isNaN(yVal) && mappedNaN);
+                const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
 
                 if (shouldDrawY) {
                   const boxRect = boxRectsBySeries[sidx - 1][ix];

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -59,25 +59,17 @@ export interface TimelineCoreOptions {
 /**
  * @internal
  */
-export interface YValueMappings {
-  mappedNull?: boolean;
-  mappedNaN?: boolean;
-}
-
-/**
- * @internal
- */
-export function shouldDrawYValue(yValue: unknown, mappings?: YValueMappings): boolean {
+export function shouldDrawYValue(yValue: unknown, mappedNull?: boolean, mappedNaN?: boolean): boolean {
   if (typeof yValue === 'boolean') {
     return true;
   }
   if (typeof yValue === 'number' && !Number.isNaN(yValue)) {
     return true;
   }
-  if (Number.isNaN(yValue) && mappings?.mappedNaN) {
+  if (yValue === null && mappedNull) {
     return true;
   }
-  if (yValue === null && mappings?.mappedNull) {
+  if (Number.isNaN(yValue) && mappedNaN) {
     return true;
   }
   return !!yValue;
@@ -237,7 +229,7 @@ export function getConfig(opts: TimelineCoreOptions) {
           if (mode === TimelineMode.Changes) {
             for (let ix = 0; ix < dataY.length; ix++) {
               let yVal = dataY[ix];
-              const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
+              const shouldDrawY = shouldDrawYValue(yVal, mappedNull, mappedNaN);
 
               if (shouldDrawY) {
                 let left = Math.round(valToPosX(dataX[ix], scaleX, xDim, xOff));
@@ -282,7 +274,7 @@ export function getConfig(opts: TimelineCoreOptions) {
 
             for (let ix = idx0; ix <= idx1; ix++) {
               let yVal = dataY[ix];
-              const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
+              const shouldDrawY = shouldDrawYValue(yVal, mappedNull, mappedNaN);
 
               if (shouldDrawY) {
                 // TODO: all xPos can be pre-computed once for all series in aligned set
@@ -345,7 +337,7 @@ export function getConfig(opts: TimelineCoreOptions) {
 
               for (let ix = 0; ix < dataY.length; ix++) {
                 const yVal = dataY[ix];
-                const shouldDrawY = shouldDrawYValue(yVal, { mappedNull, mappedNaN });
+                const shouldDrawY = shouldDrawYValue(yVal, mappedNull, mappedNaN);
 
                 if (shouldDrawY) {
                   const boxRect = boxRectsBySeries[sidx - 1][ix];

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -63,6 +63,9 @@ export function shouldDrawYValue(yValue: unknown, mappedNull?: boolean, mappedNa
   if (typeof yValue === 'boolean') {
     return true;
   }
+  if (typeof yValue === 'string') {
+    return true;
+  }
   if (typeof yValue === 'number' && !Number.isNaN(yValue)) {
     return true;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This change fixes a bug where `false` values were no longer being displayed in StateTimeline.

As discussed in https://github.com/grafana/grafana/issues/106970 the regression was introduced in https://github.com/grafana/grafana/pull/105638

You can test the changes in this PR locally, via the minimum reprodoction case test data in `StateTimeline - Thresholds & Mappings` dashboard's new `boolean values from data` panel _(bottom right of dashboard)_:

![Screenshot 2025-06-20 at 1 55 48 PM](https://github.com/user-attachments/assets/86227589-2029-4b44-9368-4cab13ed55c6)
![Screenshot 2025-06-20 at 1 56 29 PM](https://github.com/user-attachments/assets/0b1a6ab0-3b46-4c73-a0de-2a4956b27bac)



**Why do we need this feature?**

Fixes 🐞 https://github.com/grafana/grafana/issues/106970


**Who is this feature for?**

Everyone


**Which issue(s) does this PR fix?**:

- https://github.com/grafana/grafana/issues/106970


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [ ] ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
