### PR TITLE
ProvisionedDashboard: Refactor to Eliminate 2-layer component pattern in provisioned dashboard forms

### DIFF
--- a/public/app/features/dashboard-scene/components/Provisioned/ProvisionedFormWrapper.tsx
+++ b/public/app/features/dashboard-scene/components/Provisioned/ProvisionedFormWrapper.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+
+import { LoadingPlaceholder } from '@grafana/ui';
+
+import { ProvisionedDashboardData, useProvisionedDashboardData } from '../../saving/provisioned/hooks';
+import { DashboardScene } from '../../scene/DashboardScene';
+
+interface ProvisionedFormWrapperProps {
+  dashboard: DashboardScene;
+  fallback?: ReactNode;
+  children: (
+    data: Omit<ProvisionedDashboardData, 'defaultValues' | 'isReady'> & {
+      defaultValues: NonNullable<ProvisionedDashboardData['defaultValues']>;
+    }
+  ) => ReactNode;
+}
+
+function isProvisionedDataReady(data: ProvisionedDashboardData): data is ProvisionedDashboardData & {
+  defaultValues: NonNullable<ProvisionedDashboardData['defaultValues']>;
+} {
+  return data.isReady && data.defaultValues !== null;
+}
+
+export function ProvisionedFormWrapper({ dashboard, fallback, children }: ProvisionedFormWrapperProps) {
+  const provisionedData = useProvisionedDashboardData(dashboard);
+
+  if (!isProvisionedDataReady(provisionedData)) {
+    return <>{fallback ?? <LoadingPlaceholder text="Loading provisioned dashboard data" />}</>;
+  }
+
+  // TypeScript now knows defaultValues is non-null
+  return <>{children(provisionedData)}</>;
+}

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardDrawer.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardDrawer.tsx
@@ -1,7 +1,18 @@
-import { useProvisionedDashboardData } from '../saving/provisioned/hooks';
-import { DashboardScene } from '../scene/DashboardScene';
+import { useForm, FormProvider } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { DeleteProvisionedDashboardForm } from './DeleteProvisionedDashboardForm';
+import { AppEvents } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { getAppEvents } from '@grafana/runtime';
+import { Alert, Button, Drawer, Stack } from '@grafana/ui';
+import { useDeleteRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
+import { PROVISIONING_URL } from 'app/features/provisioning/constants';
+
+import { DashboardEditFormSharedFields } from '../components/Provisioned/DashboardEditFormSharedFields';
+import { ProvisionedFormWrapper } from '../components/Provisioned/ProvisionedFormWrapper';
+import { ProvisionedDashboardFormData } from '../saving/shared';
+import { DashboardScene } from '../scene/DashboardScene';
+import { useProvisionedRequestHandler } from '../utils/useProvisionedRequestHandler';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -13,23 +24,120 @@ export interface Props {
  * Drawer component for deleting a git provisioned dashboard.
  */
 export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }: Props) {
-  const { defaultValues, loadedFromRef, readOnly, isGitHub, workflowOptions, isNew } =
-    useProvisionedDashboardData(dashboard);
-
-  if (!defaultValues) {
-    return null;
-  }
-
   return (
-    <DeleteProvisionedDashboardForm
-      dashboard={dashboard}
-      defaultValues={defaultValues}
-      loadedFromRef={loadedFromRef}
-      readOnly={readOnly}
-      isGitHub={isGitHub}
-      isNew={isNew}
-      workflowOptions={workflowOptions}
-      onDismiss={onDismiss}
-    />
+    <ProvisionedFormWrapper dashboard={dashboard} fallback={null}>
+      {({ defaultValues, loadedFromRef, readOnly, isGitHub, isNew, workflowOptions }) => {
+        const methods = useForm<ProvisionedDashboardFormData>({ defaultValues });
+        const { editPanel: panelEditor } = dashboard.useState();
+        const { handleSubmit, watch } = methods;
+
+        const [ref, workflow] = watch(['ref', 'workflow']);
+        const [deleteRepoFile, request] = useDeleteRepositoryFilesWithPathMutation();
+
+        const handleSubmitForm = async ({ repo, path, comment }: ProvisionedDashboardFormData) => {
+          if (!repo || !path) {
+            console.error('Missing required fields for deletion:', { repo, path });
+            return;
+          }
+
+          // If writing to the original branch, use the loaded reference; otherwise, use the selected ref.
+          const branchRef = workflow === 'write' ? loadedFromRef : ref;
+          const commitMessage = comment || `Delete dashboard: ${dashboard.state.title}`;
+
+          deleteRepoFile({
+            name: repo,
+            path: path,
+            ref: branchRef,
+            message: commitMessage,
+          });
+        };
+
+        const navigate = useNavigate();
+
+        const onRequestError = (error: unknown) => {
+          getAppEvents().publish({
+            type: AppEvents.alertError.name,
+            payload: [
+              t('dashboard-scene.delete-provisioned-dashboard-form.api-error', 'Failed to delete dashboard'),
+              error,
+            ],
+          });
+        };
+
+        const onWriteSuccess = () => {
+          panelEditor?.onDiscard();
+          onDismiss();
+          // TODO reset search state instead
+          window.location.href = '/dashboards';
+        };
+
+        const onBranchSuccess = (path: string, urls?: Record<string, string>) => {
+          panelEditor?.onDiscard();
+          onDismiss();
+          navigate(
+            `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}?pull_request_url=${urls?.newPullRequestURL}`
+          );
+        };
+
+        useProvisionedRequestHandler({
+          dashboard,
+          request,
+          workflow,
+          handlers: {
+            onBranchSuccess: ({ path, urls }) => onBranchSuccess(path, urls),
+            onWriteSuccess,
+            onError: onRequestError,
+          },
+        });
+
+        return (
+          <Drawer
+            title={t('dashboard-scene.delete-provisioned-dashboard-form.drawer-title', 'Delete Provisioned Dashboard')}
+            subtitle={dashboard.state.title}
+            onClose={onDismiss}
+          >
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(handleSubmitForm)}>
+                <Stack direction="column" gap={2}>
+                  {readOnly && (
+                    <Alert
+                      title={t(
+                        'dashboard-scene.delete-provisioned-dashboard-form.title-this-repository-is-read-only',
+                        'This repository is read only'
+                      )}
+                    >
+                      <Trans i18nKey="dashboard-scene.delete-provisioned-dashboard-form.delete-read-only-file-message">
+                        This dashboard cannot be deleted directly from Grafana because the repository is read-only. To
+                        delete this dashboard, please remove the file from your Git repository.
+                      </Trans>
+                    </Alert>
+                  )}
+
+                  <DashboardEditFormSharedFields
+                    isNew={isNew}
+                    readOnly={readOnly}
+                    workflow={workflow}
+                    workflowOptions={workflowOptions}
+                    isGitHub={isGitHub}
+                  />
+
+                  {/* Save / Cancel button */}
+                  <Stack gap={2}>
+                    <Button variant="destructive" type="submit" disabled={request.isLoading || readOnly}>
+                      {request.isLoading
+                        ? t('dashboard-scene.delete-provisioned-dashboard-form.deleting', 'Deleting...')
+                        : t('dashboard-scene.delete-provisioned-dashboard-form.delete-action', 'Delete dashboard')}
+                    </Button>
+                    <Button variant="secondary" onClick={onDismiss} fill="outline">
+                      <Trans i18nKey="dashboard-scene.delete-provisioned-dashboard-form.cancel-action">Cancel</Trans>
+                    </Button>
+                  </Stack>
+                </Stack>
+              </form>
+            </FormProvider>
+          </Drawer>
+        );
+      }}
+    </ProvisionedFormWrapper>
   );
 }

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.test.tsx
@@ -10,6 +10,7 @@ import { DashboardScene } from '../scene/DashboardScene';
 
 import { DeleteProvisionedDashboardDrawer, Props } from './DeleteProvisionedDashboardDrawer';
 
+// TODO: remove this
 // Mock the hooks and dependencies
 jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   useDeleteRepositoryFilesWithPathMutation: jest.fn(),

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
@@ -24,6 +24,7 @@ export interface Props {
   onDismiss: () => void;
 }
 
+// TODO: Remove this
 /**
  * @description
  * Drawer component for deleting a git provisioned dashboard.


### PR DESCRIPTION
**What is this feature?**

We had a repetitive pattern across 2+ provisioned dashboard drawer components where each consisted of two layers:
- A "Drawer" wrapper component that handled data fetching and null checks
- A "Form" component that rendered the actual form content
- New folder deletion flow will need to follow same pattern leading extra components


This pattern led to:
- Code duplication across multiple components
- Inconsistent null handling (return null pattern)
- Unnecessary component nesting


**Example of the old pattern:**
```
// DeleteProvisionedDashboardDrawer.tsx
export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }) {
  const { defaultValues, ...rest } = useProvisionedDashboardData(dashboard);
  
  if (!defaultValues) {
    return null; // 🚨 Problematic pattern
  }
  
  return <DeleteProvisionedDashboardForm {...props} />;
}
```

**Solution**
Created a reusable ProvisionedFormWrapper component that:
- Handles data loading and null checks consistently
- Uses render props pattern for flexibility
- Provides type-safe data to child components

**New pattern:** 
```
export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }) {
  return (
    <ProvisionedFormWrapper dashboard={dashboard} fallback={null}>
      {({ defaultValues, readOnly, isGitHub, ...data }) => {
        // All form logic here with guaranteed non-null data
        return <FormContent />
      }}
    </ProvisionedFormWrapper>
  );
}
```

**Why do we need this feature?**

Avoid redundant child component pattern

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes # N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
