### PR TITLE
Prometheus: Fallback to series endpoint when labels endpoint is not available

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -437,8 +437,7 @@ exports[`better eslint`] = {
     "packages/grafana-prometheus/src/language_provider.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "packages/grafana-prometheus/src/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -754,22 +754,6 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
       const result = await provider.start();
       expect(result).toEqual([]);
     });
-
-    it('should use resource client and metricsMetadata is available', async () => {
-      const provider = new PrometheusLanguageProvider(defaultDatasource);
-      const mockMetadata = { metric1: { type: 'counter', help: 'help text' } };
-
-      // Mock the resource client's start method
-      const resourceClientStartSpy = jest.spyOn(provider['resourceClient'], 'start');
-      const queryMetadataSpy = jest.spyOn(provider as any, '_queryMetadata').mockResolvedValue(mockMetadata);
-
-      await provider.start();
-
-      expect(resourceClientStartSpy).toHaveBeenCalled();
-      expect(queryMetadataSpy).toHaveBeenCalled();
-      expect(provider.retrieveMetricsMetadata()).toEqual(mockMetadata);
-      expect(provider.metricsMetadata).toEqual(mockMetadata); // Check backward compatibility
-    });
   });
 
   describe('queryMetricsMetadata', () => {
@@ -815,8 +799,9 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
 
     it('should delegate to resource client queryLabelKeys', async () => {
       const provider = new PrometheusLanguageProvider(defaultDatasource);
+      await provider.initializeResourceClient();
       const resourceClientSpy = jest
-        .spyOn(provider['resourceClient'], 'queryLabelKeys')
+        .spyOn(provider['_resourceClient']!, 'queryLabelKeys')
         .mockResolvedValue(['label1', 'label2']);
 
       const result = await provider.queryLabelKeys(timeRange, '{job="grafana"}');
@@ -827,8 +812,9 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
 
     it('should delegate to resource client queryLabelValues', async () => {
       const provider = new PrometheusLanguageProvider(defaultDatasource);
+      await provider.initializeResourceClient();
       const resourceClientSpy = jest
-        .spyOn(provider['resourceClient'], 'queryLabelValues')
+        .spyOn(provider['_resourceClient']!, 'queryLabelValues')
         .mockResolvedValue(['value1', 'value2']);
 
       const result = await provider.queryLabelValues(timeRange, 'job', '{job="grafana"}');

--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -763,11 +763,11 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
         hasLabelsMatchAPISupport: () => false,
         metadataRequest: jest.fn(), // Mock to ensure it's not called
       } as unknown as PrometheusDatasource;
-      
+
       const provider = new PrometheusLanguageProvider(datasourceWithoutLabelsAPI);
-      
+
       await provider.initializeResourceClient();
-      
+
       expect(provider['_resourceClient']).toBeDefined();
       expect(provider['_resourceClient']!.constructor.name).toBe('SeriesApiClient');
       expect(datasourceWithoutLabelsAPI.metadataRequest).not.toHaveBeenCalled();
@@ -779,12 +779,16 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
         hasLabelsMatchAPISupport: () => true,
         metadataRequest: jest.fn().mockResolvedValue({ data: { data: [] } }),
       } as unknown as PrometheusDatasource;
-      
+
       const provider = new PrometheusLanguageProvider(datasourceWithLabelsAPI);
-      
+
       await provider.initializeResourceClient();
-      
-      expect(datasourceWithLabelsAPI.metadataRequest).toHaveBeenCalledWith('/api/v1/labels', { limit: 1 }, { showErrorAlert: false });
+
+      expect(datasourceWithLabelsAPI.metadataRequest).toHaveBeenCalledWith(
+        '/api/v1/labels',
+        { limit: 1 },
+        { showErrorAlert: false }
+      );
       expect(provider['_resourceClient']!.constructor.name).toBe('LabelsApiClient');
     });
 
@@ -794,16 +798,19 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
         hasLabelsMatchAPISupport: () => true,
         metadataRequest: jest.fn().mockRejectedValue({ status: 404, message: '404 Not Found' }),
       } as unknown as PrometheusDatasource;
-      
+
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
       const provider = new PrometheusLanguageProvider(datasourceWithFailingLabelsAPI);
-      
+
       await provider.initializeResourceClient();
-      
-      expect(datasourceWithFailingLabelsAPI.metadataRequest).toHaveBeenCalledWith('/api/v1/labels', { limit: 1 }, { showErrorAlert: false });
+
+      expect(datasourceWithFailingLabelsAPI.metadataRequest).toHaveBeenCalledWith(
+        '/api/v1/labels',
+        { limit: 1 },
+        { showErrorAlert: false }
+      );
       expect(provider['_resourceClient']!.constructor.name).toBe('SeriesApiClient');
       expect(consoleSpy).toHaveBeenCalledWith('Labels endpoint is not available (404). Using series endpoint.');
-      
       consoleSpy.mockRestore();
     });
   });

--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -792,7 +792,7 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
       const datasourceWithFailingLabelsAPI = {
         ...defaultDatasource,
         hasLabelsMatchAPISupport: () => true,
-        metadataRequest: jest.fn().mockRejectedValue(new Error('404 Not Found')),
+        metadataRequest: jest.fn().mockRejectedValue({ status: 404, message: '404 Not Found' }),
       } as unknown as PrometheusDatasource;
       
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
@@ -802,7 +802,7 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
       
       expect(datasourceWithFailingLabelsAPI.metadataRequest).toHaveBeenCalledWith('/api/v1/labels', { limit: 1 }, { showErrorAlert: false });
       expect(provider['_resourceClient']!.constructor.name).toBe('SeriesApiClient');
-      expect(consoleSpy).toHaveBeenCalledWith('Labels endpoint is not available. Using series endpoint.');
+      expect(consoleSpy).toHaveBeenCalledWith('Labels endpoint is not available (404). Using series endpoint.');
       
       consoleSpy.mockRestore();
     });

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -564,6 +564,7 @@ export class PrometheusLanguageProvider extends PromQlLanguageProvider implement
     // Check if the datasource claims to support labels API
     if (!this.datasource.hasLabelsMatchAPISupport()) {
       this.start();
+      return;
     }
 
     // Try to make a test call to verify labels API actually works


### PR DESCRIPTION
**What is this feature?**

Enhanced Prometheus language provider with API endpoint fallback mechanism. Tests /api/v1/labels?limit=1 to verify actual API availability before selecting LabelsApiClient vs SeriesApiClient.

**Why do we need this feature?**

Some Prometheus instances report labels API support based on version but don't actually implement the endpoint (custom forks, special distributions). This causes 404 errors and breaks autocompletion. The fallback ensures reliable operation by testing actual API availability.

**Who is this feature for?**

Grafana users with Prometheus instances that have incomplete labels API implementations or custom distributions.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/105562

**Special notes for your reviewer:**


Use the script below to create a proxy server where labels api is unavailable.
Save it as test_proxy_server.js

```
node ./test_proxy_server.js
```
Then use `http://localhost:6060` as your datasource url.

<details><summary>Test server where labels api is unavailable</summary>

```js
const http = require('http');
const url = require('url');

const PORT = 6060;
const PROMETHEUS_TARGET = 'http://localhost:9090';

const server = http.createServer((req, res) => {
  const parsedUrl = url.parse(req.url, true);
  const path = parsedUrl.pathname;
  
  console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);

  // Return 404 for labels endpoints
  if (path === '/api/v1/labels' || path.match(/^\/api\/v1\/label\/[^\/]+\/values$/)) {
    console.log(`  -> Returning 404 for labels endpoint: ${path}`);
    res.writeHead(404, {
      'Content-Type': 'application/json',
      'Access-Control-Allow-Origin': '*',
      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
    });
    res.end(JSON.stringify({
      status: 'error',
      errorType: 'not_found',
      error: 'endpoint not found'
    }));
    return;
  }

  // Handle CORS preflight requests
  if (req.method === 'OPTIONS') {
    res.writeHead(200, {
      'Access-Control-Allow-Origin': '*',
      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
    });
    res.end();
    return;
  }

  // Proxy all other requests to the target Prometheus server
  console.log(`  -> Proxying to: ${PROMETHEUS_TARGET}${req.url}`);
  
  const targetUrl = new URL(req.url, PROMETHEUS_TARGET);
  
  const proxyOptions = {
    hostname: targetUrl.hostname,
    port: targetUrl.port || 80,
    path: targetUrl.pathname + targetUrl.search,
    method: req.method,
    headers: {
      ...req.headers,
      host: targetUrl.host
    }
  };

  const proxyReq = http.request(proxyOptions, (proxyRes) => {
    // Forward status and headers from target server
    res.writeHead(proxyRes.statusCode, {
      ...proxyRes.headers,
      'Access-Control-Allow-Origin': '*',
      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
    });
    
    // Pipe the response from target server to client
    proxyRes.pipe(res);
    
    console.log(`  <- Response: ${proxyRes.statusCode}`);
  });

  proxyReq.on('error', (err) => {
    console.error(`  <- Proxy error: ${err.message}`);
    res.writeHead(500, {
      'Content-Type': 'application/json',
      'Access-Control-Allow-Origin': '*'
    });
    res.end(JSON.stringify({
      status: 'error',
      errorType: 'internal',
      error: `Proxy error: ${err.message}`
    }));
  });

  // Forward request body if present
  if (req.method === 'POST' || req.method === 'PUT') {
    req.pipe(proxyReq);
  } else {
    proxyReq.end();
  }
});

server.listen(PORT, () => {
  console.log(`Test Prometheus server running on http://localhost:${PORT}`);
  console.log(`Proxying non-labels requests to: ${PROMETHEUS_TARGET}`);
  console.log('');
  console.log('Endpoints that return 404:');
  console.log('  - /api/v1/labels');
  console.log('  - /api/v1/label/<label_name>/values');
  console.log('');
  console.log('All other /api/v1/* endpoints will be proxied to the target server.');
  console.log('');
  console.log('Press Ctrl+C to stop the server');
});

// Graceful shutdown
process.on('SIGINT', () => {
  console.log('\nShutting down server...');
  server.close(() => {
    console.log('Server stopped');
    process.exit(0);
  });
}); 
```
</details> 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
