### PR TITLE
Dashboards: Fix history list for dashboard uids that end in `-`

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -226,11 +226,13 @@ func (s *Service) getHistoryThroughK8s(ctx context.Context, orgID int64, dashboa
 	// generation id in unified storage, so we cannot query for the dashboard version directly, and we cannot use search as history is not indexed.
 	// use batches to make sure we don't load too much data at once.
 	const batchSize = 50
-	labelSelector := utils.LabelKeyGetHistory + "=" + dashboardUID
+	labelSelector := utils.LabelKeyGetHistory + "=true"
+	fieldSelector := "metadata.name=" + dashboardUID
 	var continueToken string
 	for {
 		out, err := s.k8sclient.List(ctx, orgID, v1.ListOptions{
 			LabelSelector: labelSelector,
+			FieldSelector: fieldSelector,
 			Limit:         int64(batchSize),
 			Continue:      continueToken,
 		})
@@ -260,8 +262,11 @@ func (s *Service) getHistoryThroughK8s(ctx context.Context, orgID int64, dashboa
 }
 
 func (s *Service) listHistoryThroughK8s(ctx context.Context, orgID int64, dashboardUID string, limit int64, continueToken string) (*dashver.DashboardVersionResponse, error) {
+	labelSelector := utils.LabelKeyGetHistory + "=true"
+	fieldSelector := "metadata.name=" + dashboardUID
 	out, err := s.k8sclient.List(ctx, orgID, v1.ListOptions{
-		LabelSelector: utils.LabelKeyGetHistory + "=" + dashboardUID,
+		LabelSelector: labelSelector,
+		FieldSelector: fieldSelector,
 		Limit:         limit,
 		Continue:      continueToken,
 	})

--- a/pkg/storage/unified/apistore/util_test.go
+++ b/pkg/storage/unified/apistore/util_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/storage"
@@ -153,7 +154,8 @@ func TestToListRequest(t *testing.T) {
 			},
 			opts: storage.ListOptions{
 				Predicate: storage.SelectionPredicate{
-					Label: labels.SelectorFromSet(labels.Set{utils.LabelKeyGetHistory: "test-name"}),
+					Label: labels.SelectorFromSet(labels.Set{utils.LabelKeyGetHistory: "true"}),
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": "test-name"}),
 				},
 			},
 			want: &resourcepb.ListRequest{

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -431,6 +431,31 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			err = adminClient.Resource.Delete(context.Background(), dashUID, v1.DeleteOptions{})
 			require.NoError(t, err)
 		})
+
+		t.Run("dashboard version history available, even for UIDs ending in hyphen", func(t *testing.T) {
+			dashboardUID := "test-dashboard-"
+			dash, err := createDashboard(t, adminClient, "Dashboard with uid ending in hyphen", nil, &dashboardUID)
+			require.NoError(t, err)
+
+			updatedDash, err := updateDashboard(t, adminClient, dash, "Updated dashboard with uid ending in hyphen", nil)
+			require.NoError(t, err)
+			require.NotNil(t, updatedDash)
+
+			labelSelector := utils.LabelKeyGetHistory + "=true"
+			fieldSelector := "metadata.name=" + dashboardUID
+			versions, err := adminClient.Resource.List(context.Background(), v1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fieldSelector,
+				Limit:         10,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, versions)
+			// one from initial save, one from update
+			require.Equal(t, len(versions.Items), 2)
+
+			err = adminClient.Resource.Delete(context.Background(), dashboardUID, v1.DeleteOptions{})
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("Dashboard provisioning validations", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This PR fixes getting history on dashboard uids that fail the label validation by k8s [here](https://github.com/kubernetes/kubernetes/blob/ccf291b50166ce82204486aae6a626a30b469182/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L165). This label validation doesn't allow for values to end in `-` or `.`, unlike the name validation [here](https://github.com/kubernetes/kubernetes/blob/ccf291b50166ce82204486aae6a626a30b469182/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L41). 

Since we do allow uids in grafana to end with `-`, we cannot use labels to specify the uids.

Therefore, this PR changes the get-history request from:
```
http://localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards?labelSelector=grafana.app/get-history=fb034c5e-9445-4415-8917-17cad2c5b296
```

to

```
http://localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards?labelSelector=grafana.app/get-history=true&fieldSelector=metadata.name=fb034c5e-9445-4415-8917-17cad2c5b296
```

Where we now instead use the field selector to specify the metadata.name (i.e. the uid).

**Why do we need this feature?**

We need to be able to support getting the history of objects with valids uids.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/support-escalations/issues/16827
