### PR TITLE
fix: percentage-based heights were not applied in updated scrollable iframe container

### DIFF
--- a/public/app/plugins/panel/text/TextPanel.tsx
+++ b/public/app/plugins/panel/text/TextPanel.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import DangerouslySetHtmlContent from 'dangerously-set-html-content';
 import { useState } from 'react';
 import { useDebounce } from 'react-use';
@@ -56,7 +56,7 @@ export function TextPanel(props: Props) {
         <DangerouslySetHtmlContent
           allowRerender
           html={processed.content}
-          className="markdown-html"
+          className={cx('markdown-html', styles.markdownHtml)}
           data-testid="TextPanel-converted-content"
         />
       </ScrollContainer>
@@ -102,6 +102,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   containStrict: css({
     contain: 'strict',
+    height: '100%',
+    display: 'flex',
+  }),
+  markdownHtml: css({
     height: '100%',
   }),
 });


### PR DESCRIPTION
**What is this feature?**

Fixes an issue with the Text panel, where the contents within could not be resized via style attributes due to the container elements' styling.

**Which issue(s) does this PR fix?**:

Fixes an issue where elements within a Text panel in HTML mode could not be sized using percentage-based style overrides, due to an issue with flexbox interactions between the various container elements.

*note about testing: without viz regression tests, it's not possible to test this in an automated manner.*

### iframe with 100% height

```html
<iframe src="<your url>" style="height: 100%; width: 100%;" />
```

#### Before

<img width="1704" alt="Screenshot 2025-06-23 at 12 18 28 PM" src="https://github.com/user-attachments/assets/cba4541d-db34-4073-8c23-d9c7295753ee" />

#### After

<img width="1707" alt="Screenshot 2025-06-23 at 12 19 10 PM" src="https://github.com/user-attachments/assets/c6aa0d9d-3d19-417e-a0a0-36a4e3db851d" />

### very long html with height: 100% and overflow hidden

*the point of this test is just to see whether the reverse was also not working, e.g. an element much longer than the fixed height of the panel. it wasn't!*

```html
<div style="height: 100%; overflow: hidden;">
  <p>Lorem ipsum...</p>
  <!-- repeated lorem ipsum for 20 paragraphs or so  -->
<div>
```

#### Before

<img width="1728" alt="K2wDz" src="https://github.com/user-attachments/assets/04a74508-1902-4eee-b456-f295b4021b98" />

#### After

*scrollbar's gone with `overflow:hidden;`, appears if you get rid of that, as expected.*

<img width="1728" alt="JZxtw" src="https://github.com/user-attachments/assets/5c0c161b-5c51-442c-b26e-9547e91b139e" />


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
