### PR TITLE
Alerting: Fix flaky test

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -216,7 +216,7 @@ func TestRouteGetNamespaceRulesConfig(t *testing.T) {
 			folder := randFolder()
 			ruleStore := fakes.NewRuleStore(t)
 			ruleStore.Folders[orgID] = append(ruleStore.Folders[orgID], folder)
-			folderGen := gen.With(gen.WithOrgID(orgID), gen.WithNamespace(folder.ToFolderReference()))
+			folderGen := gen.With(gen.WithOrgID(orgID), gen.WithNamespace(folder.ToFolderReference()), gen.WithUpdatedBy(util.Pointer(models.UserUID("test-user"))))
 			queryAccessRules := folderGen.GenerateManyRef(2, 6)
 			ruleStore.PutRule(context.Background(), queryAccessRules...)
 			noQueryAccessRules := folderGen.GenerateManyRef(2, 6)


### PR DESCRIPTION
One of the tests in `TestRouteGetNamespaceRulesConfig` was flaky because rule generation [randomly](https://github.com/grafana/grafana/blob/cf8e3bf7d41f84ebb107ee0193605e049e1e087c/pkg/services/ngalert/models/testing.go#L102) set `UpdatedBy` to `nil`, causing the user service call assertion to fail when all rules do not have the field. Fixed by adding `WithUpdatedBy` to ensure all generated rules have it.