### PR TITLE
Provisioning: Increase timeout for flaky CreateGithubRepository integration test

### DIFF
--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -289,7 +289,7 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 		found, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
 		assert.NoError(t, err, "can list values")
 		assert.Equal(collect, 0, len(found.Items), "expected dashboards to be deleted")
-	}, time.Second*10, time.Millisecond*10, "Expected dashboards to be deleted")
+	}, time.Second*20, time.Millisecond*10, "Expected dashboards to be deleted")
 
 	t.Run("github url cleanup", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Increase timeout to 20 seconds in flaky test.

**Why do we need this feature?**

CI is failing at times.

**Who is this feature for?**

Devs.
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

None.

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
