### PR TITLE
unistore: Add kvstore interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -575,7 +575,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-require github.com/dgraph-io/badger/v4 v4.7.0
+require github.com/dgraph-io/badger/v4 v4.7.0 // @grafana/grafana-search-and-storage
 
 require (
 	github.com/dgraph-io/ristretto/v2 v2.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -575,7 +575,10 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+require github.com/dgraph-io/badger/v4 v4.7.0
+
 require (
+	github.com/dgraph-io/ristretto/v2 v2.2.0 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
 	github.com/jaegertracing/jaeger-idl v0.5.0 // indirect
 	github.com/sercand/kuberesolver/v6 v6.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1065,6 +1065,12 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
+github.com/dgraph-io/badger/v4 v4.7.0 h1:Q+J8HApYAY7UMpL8d9owqiB+odzEc0zn/aqOD9jhc6Y=
+github.com/dgraph-io/badger/v4 v4.7.0/go.mod h1:He7TzG3YBy3j4f5baj5B7Zl2XyfNe5bl4Udl0aPemVA=
+github.com/dgraph-io/ristretto/v2 v2.2.0 h1:bkY3XzJcXoMuELV8F+vS8kzNgicwQFAaGINAEJdWGOM=
+github.com/dgraph-io/ristretto/v2 v2.2.0/go.mod h1:RZrm63UmcBAaYWC1DotLYBmTvgkrs0+XhBd7Npn7/zI=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=

--- a/go.work.sum
+++ b/go.work.sum
@@ -2293,6 +2293,8 @@ go.opentelemetry.io/contrib/propagators/b3 v1.35.0 h1:DpwKW04LkdFRFCIgM3sqwTJA/Q
 go.opentelemetry.io/contrib/propagators/b3 v1.35.0/go.mod h1:9+SNxwqvCWo1qQwUpACBY5YKNVxFJn5mlbXg/4+uKBg=
 go.opentelemetry.io/contrib/samplers/jaegerremote v0.28.0/go.mod h1:iWS+NvC948FyfnJbVfPN9h/8+vr8CR2FPn6XsLRkvH8=
 go.opentelemetry.io/contrib/samplers/jaegerremote v0.29.0/go.mod h1:XAJmM2MWhiIoTO4LCLBVeE8w009TmsYk6hq1UNdXs5A=
+go.opentelemetry.io/contrib/zpages v0.60.0 h1:wOM9ie1Hz4H88L9KE6GrGbKJhfm+8F1NfW/Y3q9Xt+8=
+go.opentelemetry.io/contrib/zpages v0.60.0/go.mod h1:xqfToSRGh2MYUsfyErNz8jnNDPlnpZqWM/y6Z2Cx7xw=
 go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi/MArHo=
 go.opentelemetry.io/otel v1.26.0/go.mod h1:UmLkJHUAidDval2EICqBMbnAd0/m2vmpf/dAM+fvFs4=
 go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -83,8 +83,7 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObjec
 		return KVObject{}, err
 	}
 	out := KVObject{
-		Key:   string(item.Key())[len(section)+1:],
-		Value: []byte{},
+		Key: string(item.Key())[len(section)+1:],
 	}
 	err = item.Value(func(val []byte) error {
 		out.Value = make([]byte, len(val))

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -88,11 +88,14 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string, opts ...
 		Key:   string(item.Key())[len(section)+1:],
 		Value: []byte{},
 	}
-	item.Value(func(val []byte) error {
+	err = item.Value(func(val []byte) error {
 		out.Value = make([]byte, len(val))
 		copy(out.Value, val)
 		return nil
 	})
+	if err != nil {
+		return KVObject{}, err
+	}
 	return out, nil
 }
 
@@ -134,7 +137,6 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 	if section == "" {
 		return func(yield func(string, error) bool) {
 			yield("", fmt.Errorf("section is required"))
-			return
 		}
 	}
 
@@ -188,7 +190,6 @@ func (k *badgerKV) List(ctx context.Context, section string, opt ListOptions) it
 	if section == "" {
 		return func(yield func(KVObject, error) bool) {
 			yield(KVObject{}, fmt.Errorf("section is required"))
-			return
 		}
 	}
 

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -1,0 +1,277 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+var ErrNotFound = errors.New("key not found")
+
+type SortOrder int
+
+const (
+	SortOrderAsc SortOrder = iota
+	SortOrderDesc
+)
+
+type ListOptions struct {
+	Sort     SortOrder
+	StartKey string
+	EndKey   string
+	Limit    int64
+	// WithValues bool // Question: Should we always return the values? Or maybe never ?
+}
+
+type GetOptions struct{}
+
+type KVObject struct {
+	Key   string
+	Value []byte
+}
+
+type KV interface {
+	// Keys returns all the keys in the store
+	Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error]
+
+	// Get retrieves keys.
+	Get(ctx context.Context, section string, key string, opts ...GetOptions) (KVObject, error)
+
+	// List returns all the key-value pairs in the store
+	List(ctx context.Context, section string, opt ListOptions) iter.Seq2[KVObject, error]
+
+	// Save a new value
+	Save(ctx context.Context, section string, key string, value []byte) error
+
+	// Delete a value
+	Delete(ctx context.Context, section string, key string) error
+
+	// UnixTimestamp returns the current time in seconds since Epoch.
+	// This is used to ensure the server and client are not too far apart in time.
+	UnixTimestamp(ctx context.Context) (int64, error)
+}
+
+// Reference implementation of the KV interface using BadgerDB
+// This is only used for testing purposes, and will not work HA
+type badgerKV struct {
+	db *badger.DB
+}
+
+func NewBadgerKV(db *badger.DB) *badgerKV {
+	return &badgerKV{
+		db: db,
+	}
+}
+
+func (k *badgerKV) Get(ctx context.Context, section string, key string, opts ...GetOptions) (KVObject, error) {
+	txn := k.db.NewTransaction(false)
+	defer txn.Discard()
+
+	if section == "" {
+		return KVObject{}, fmt.Errorf("section is required")
+	}
+
+	key = section + "/" + key
+
+	item, err := txn.Get([]byte(key))
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return KVObject{}, ErrNotFound
+		}
+		return KVObject{}, err
+	}
+	out := KVObject{
+		Key:   string(item.Key())[len(section)+1:],
+		Value: []byte{},
+	}
+	item.Value(func(val []byte) error {
+		out.Value = make([]byte, len(val))
+		copy(out.Value, val)
+		return nil
+	})
+	return out, nil
+}
+
+func (k *badgerKV) Save(ctx context.Context, section string, key string, value []byte) error {
+	if section == "" {
+		return fmt.Errorf("section is required")
+	}
+
+	txn := k.db.NewTransaction(true)
+	defer txn.Discard()
+
+	key = section + "/" + key
+
+	err := txn.Set([]byte(key), value)
+	if err != nil {
+		return err
+	}
+	return txn.Commit()
+}
+
+func (k *badgerKV) Delete(ctx context.Context, section string, key string) error {
+	if section == "" {
+		return fmt.Errorf("section is required")
+	}
+
+	txn := k.db.NewTransaction(true)
+	defer txn.Discard()
+
+	key = section + "/" + key
+
+	err := txn.Delete([]byte(key))
+	if err != nil {
+		return err
+	}
+	return txn.Commit()
+}
+
+func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
+	if section == "" {
+		return func(yield func(string, error) bool) {
+			yield("", fmt.Errorf("section is required"))
+			return
+		}
+	}
+
+	txn := k.db.NewTransaction(false)
+
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchValues = false
+	opts.PrefetchSize = 100
+
+	start := section + "/" + opt.StartKey
+	end := section + "/" + opt.EndKey
+	if opt.EndKey == "" {
+		end = PrefixRangeEnd(section + "/")
+	}
+	if opt.Sort == SortOrderDesc {
+		start, end = end, start
+		opts.Reverse = true
+	}
+
+	isEnd := func(item *badger.Item) bool {
+		if opt.Sort == SortOrderDesc {
+			return string(item.Key()) <= end
+		}
+		return string(item.Key()) >= end
+	}
+
+	iter := txn.NewIterator(opts)
+	count := int64(0)
+
+	return func(yield func(string, error) bool) {
+		defer txn.Discard()
+		defer iter.Close()
+
+		for iter.Seek([]byte(start)); iter.Valid(); iter.Next() {
+			item := iter.Item()
+			if opt.Limit > 0 && count >= opt.Limit {
+				break
+			}
+			if isEnd(item) {
+				break
+			}
+			if !yield(string(item.Key())[len(section)+1:], nil) {
+				break
+			}
+			count++
+		}
+	}
+}
+
+func (k *badgerKV) List(ctx context.Context, section string, opt ListOptions) iter.Seq2[KVObject, error] {
+	if section == "" {
+		return func(yield func(KVObject, error) bool) {
+			yield(KVObject{}, fmt.Errorf("section is required"))
+			return
+		}
+	}
+
+	txn := k.db.NewTransaction(false)
+
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchValues = true
+	opts.PrefetchSize = 100
+
+	start := section + "/" + opt.StartKey
+	end := section + "/" + opt.EndKey
+	if opt.EndKey == "" {
+		end = PrefixRangeEnd(section + "/")
+	}
+	if opt.Sort == SortOrderDesc {
+		start, end = end, start
+		opts.Reverse = true
+	}
+
+	isEnd := func(item *badger.Item) bool {
+		if opt.Sort == SortOrderDesc {
+			return string(item.Key()) <= end
+		}
+		return string(item.Key()) >= end
+	}
+
+	iter := txn.NewIterator(opts)
+	count := int64(0)
+
+	return func(yield func(KVObject, error) bool) {
+		defer txn.Discard()
+		defer iter.Close()
+
+		for iter.Seek([]byte(start)); iter.Valid(); iter.Next() {
+			item := iter.Item()
+			if opt.Limit > 0 && count >= opt.Limit {
+				break
+			}
+			if isEnd(item) {
+				break
+			}
+
+			obj := KVObject{
+				Key:   string(item.Key())[len(section)+1:],
+				Value: []byte{},
+			}
+
+			err := item.Value(func(val []byte) error {
+				obj.Value = make([]byte, len(val))
+				copy(obj.Value, val)
+				return nil
+			})
+
+			if err != nil {
+				if !yield(KVObject{}, err) {
+					break
+				}
+				continue
+			}
+
+			if !yield(obj, nil) {
+				break
+			}
+			count++
+		}
+	}
+}
+
+func (k *badgerKV) UnixTimestamp(ctx context.Context) (int64, error) {
+	return time.Now().Unix(), nil
+}
+
+// PrefixRangeEnd returns the end key for the given prefix
+func PrefixRangeEnd(prefix string) string {
+	key := []byte(prefix)
+	end := make([]byte, len(key))
+	copy(end, key)
+	for i := len(end) - 1; i >= 0; i-- {
+		if end[i] < 0xff {
+			end[i] = end[i] + 1
+			end = end[:i+1]
+			return string(end)
+		}
+	}
+	return string(end)
+}

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -141,7 +141,6 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchValues = false
-	opts.PrefetchSize = 100
 
 	start := section + "/" + opt.StartKey
 	end := section + "/" + opt.EndKey

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -15,7 +15,8 @@ var ErrNotFound = errors.New("key not found")
 type SortOrder int
 
 const (
-	SortOrderAsc SortOrder = iota
+	SortOrderUndefined SortOrder = iota
+	SortOrderAsc
 	SortOrderDesc
 )
 
@@ -23,7 +24,7 @@ type ListOptions struct {
 	Sort     SortOrder // sort order of the results. Default is SortOrderAsc.
 	StartKey string    // lower bound of the range, included in the results
 	EndKey   string    // upper bound of the range, excluded from the results
-	Limit    int64     // maximum number of results to return
+	Limit    int64     // maximum number of results to return. 0 means no limit.
 }
 
 type KVObject struct {

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -41,8 +41,8 @@ type KV interface {
 	// Get retrieves a key-value pair from the store
 	Get(ctx context.Context, section string, key string) (KVObject, error)
 
-	// Save a new value from an io.Reader
-	Save(ctx context.Context, section string, key string, value io.Reader) error
+	// Save a new value
+	Save(ctx context.Context, section string, key string, value io.ReadCloser) error
 
 	// Delete a value
 	Delete(ctx context.Context, section string, key string) error
@@ -97,7 +97,7 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObjec
 	return out, nil
 }
 
-func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.Reader) error {
+func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.ReadCloser) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
 	}

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -17,8 +17,7 @@ var ErrNotFound = errors.New("key not found")
 type SortOrder int
 
 const (
-	SortOrderUndefined SortOrder = iota
-	SortOrderAsc
+	SortOrderAsc SortOrder = iota
 	SortOrderDesc
 )
 

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -137,8 +137,6 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 		}
 	}
 
-	txn := k.db.NewTransaction(false)
-
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchValues = false
 
@@ -159,10 +157,11 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 		return string(item.Key()) >= end
 	}
 
-	iter := txn.NewIterator(opts)
 	count := int64(0)
 
 	return func(yield func(string, error) bool) {
+		txn := k.db.NewTransaction(false)
+		iter := txn.NewIterator(opts)
 		defer txn.Discard()
 		defer iter.Close()
 
@@ -189,8 +188,6 @@ func (k *badgerKV) List(ctx context.Context, section string, opt ListOptions) it
 		}
 	}
 
-	txn := k.db.NewTransaction(false)
-
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchValues = true
 	opts.PrefetchSize = 100
@@ -212,10 +209,11 @@ func (k *badgerKV) List(ctx context.Context, section string, opt ListOptions) it
 		return string(item.Key()) >= end
 	}
 
-	iter := txn.NewIterator(opts)
 	count := int64(0)
 
 	return func(yield func(KVObject, error) bool) {
+		txn := k.db.NewTransaction(false)
+		iter := txn.NewIterator(opts)
 		defer txn.Discard()
 		defer iter.Close()
 

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -20,13 +20,11 @@ const (
 )
 
 type ListOptions struct {
-	Sort     SortOrder
-	StartKey string
-	EndKey   string
-	Limit    int64
+	Sort     SortOrder // sort order of the results. Default is SortOrderAsc.
+	StartKey string    // lower bound of the range, included in the results
+	EndKey   string    // upper bound of the range, excluded from the results
+	Limit    int64     // maximum number of results to return
 }
-
-type GetOptions struct{}
 
 type KVObject struct {
 	Key   string
@@ -38,7 +36,7 @@ type KV interface {
 	Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error]
 
 	// Get retrieves a key-value pair from the store
-	Get(ctx context.Context, section string, key string, opts ...GetOptions) (KVObject, error)
+	Get(ctx context.Context, section string, key string) (KVObject, error)
 
 	// List returns all the key-value pairs in the store
 	List(ctx context.Context, section string, opt ListOptions) iter.Seq2[KVObject, error]
@@ -66,7 +64,7 @@ func NewBadgerKV(db *badger.DB) *badgerKV {
 	}
 }
 
-func (k *badgerKV) Get(ctx context.Context, section string, key string, opts ...GetOptions) (KVObject, error) {
+func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObject, error) {
 	txn := k.db.NewTransaction(false)
 	defer txn.Discard()
 

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -37,7 +37,7 @@ type KV interface {
 	// Keys returns all the keys in the store
 	Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error]
 
-	// Get retrieves keys.
+	// Get retrieves a key-value pair from the store
 	Get(ctx context.Context, section string, key string, opts ...GetOptions) (KVObject, error)
 
 	// List returns all the key-value pairs in the store

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -1,9 +1,11 @@
 package resource
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"time"
 
@@ -27,9 +29,10 @@ type ListOptions struct {
 	Limit    int64     // maximum number of results to return. 0 means no limit.
 }
 
-type KVObject struct {
-	Key   string
-	Value []byte
+// KVReader represents a key-value pair with streaming value access
+type KVReader struct {
+	Key    string
+	Reader io.Reader
 }
 
 type KV interface {
@@ -37,13 +40,10 @@ type KV interface {
 	Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error]
 
 	// Get retrieves a key-value pair from the store
-	Get(ctx context.Context, section string, key string) (KVObject, error)
+	Get(ctx context.Context, section string, key string) (KVReader, error)
 
-	// List returns all the key-value pairs in the store
-	List(ctx context.Context, section string, opt ListOptions) iter.Seq2[KVObject, error]
-
-	// Save a new value
-	Save(ctx context.Context, section string, key string, value []byte) error
+	// Save a new value from an io.Reader
+	Save(ctx context.Context, section string, key string, value io.Reader) error
 
 	// Delete a value
 	Delete(ctx context.Context, section string, key string) error
@@ -65,12 +65,12 @@ func NewBadgerKV(db *badger.DB) *badgerKV {
 	}
 }
 
-func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObject, error) {
+func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVReader, error) {
 	txn := k.db.NewTransaction(false)
 	defer txn.Discard()
 
 	if section == "" {
-		return KVObject{}, fmt.Errorf("section is required")
+		return KVReader{}, fmt.Errorf("section is required")
 	}
 
 	key = section + "/" + key
@@ -78,35 +78,47 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObjec
 	item, err := txn.Get([]byte(key))
 	if err != nil {
 		if errors.Is(err, badger.ErrKeyNotFound) {
-			return KVObject{}, ErrNotFound
+			return KVReader{}, ErrNotFound
 		}
-		return KVObject{}, err
+		return KVReader{}, err
 	}
-	out := KVObject{
+
+	out := KVReader{
 		Key: string(item.Key())[len(section)+1:],
 	}
+
+	// Get the value and create a reader from it
+	var value []byte
 	err = item.Value(func(val []byte) error {
-		out.Value = make([]byte, len(val))
-		copy(out.Value, val)
+		value = make([]byte, len(val))
+		copy(value, val)
 		return nil
 	})
 	if err != nil {
-		return KVObject{}, err
+		return KVReader{}, err
 	}
+
+	out.Reader = bytes.NewReader(value)
+
 	return out, nil
 }
 
-func (k *badgerKV) Save(ctx context.Context, section string, key string, value []byte) error {
+func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.Reader) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
+	}
+
+	key = section + "/" + key
+
+	data, err := io.ReadAll(value)
+	if err != nil {
+		return fmt.Errorf("failed to read value: %w", err)
 	}
 
 	txn := k.db.NewTransaction(true)
 	defer txn.Discard()
 
-	key = section + "/" + key
-
-	err := txn.Set([]byte(key), value)
+	err = txn.Set([]byte(key), data)
 	if err != nil {
 		return err
 	}
@@ -174,77 +186,6 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 				break
 			}
 			if !yield(string(item.Key())[len(section)+1:], nil) {
-				break
-			}
-			count++
-		}
-	}
-}
-
-func (k *badgerKV) List(ctx context.Context, section string, opt ListOptions) iter.Seq2[KVObject, error] {
-	if section == "" {
-		return func(yield func(KVObject, error) bool) {
-			yield(KVObject{}, fmt.Errorf("section is required"))
-		}
-	}
-
-	opts := badger.DefaultIteratorOptions
-	opts.PrefetchValues = true
-	opts.PrefetchSize = 100
-
-	start := section + "/" + opt.StartKey
-	end := section + "/" + opt.EndKey
-	if opt.EndKey == "" {
-		end = PrefixRangeEnd(section + "/")
-	}
-	if opt.Sort == SortOrderDesc {
-		start, end = end, start
-		opts.Reverse = true
-	}
-
-	isEnd := func(item *badger.Item) bool {
-		if opt.Sort == SortOrderDesc {
-			return string(item.Key()) <= end
-		}
-		return string(item.Key()) >= end
-	}
-
-	count := int64(0)
-
-	return func(yield func(KVObject, error) bool) {
-		txn := k.db.NewTransaction(false)
-		iter := txn.NewIterator(opts)
-		defer txn.Discard()
-		defer iter.Close()
-
-		for iter.Seek([]byte(start)); iter.Valid(); iter.Next() {
-			item := iter.Item()
-			if opt.Limit > 0 && count >= opt.Limit {
-				break
-			}
-			if isEnd(item) {
-				break
-			}
-
-			obj := KVObject{
-				Key:   string(item.Key())[len(section)+1:],
-				Value: []byte{},
-			}
-
-			err := item.Value(func(val []byte) error {
-				obj.Value = make([]byte, len(val))
-				copy(obj.Value, val)
-				return nil
-			})
-
-			if err != nil {
-				if !yield(KVObject{}, err) {
-					break
-				}
-				continue
-			}
-
-			if !yield(obj, nil) {
 				break
 			}
 			count++

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -24,7 +24,6 @@ type ListOptions struct {
 	StartKey string
 	EndKey   string
 	Limit    int64
-	// WithValues bool // Question: Should we always return the values? Or maybe never ?
 }
 
 type GetOptions struct{}

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -182,6 +182,13 @@ func getIteratorTestCases() []iteratorTestCase {
 	}
 }
 
+func TestPrefixRangeEnd(t *testing.T) {
+	require.Equal(t, "b", PrefixRangeEnd("a"))
+	require.Equal(t, "a/c", PrefixRangeEnd("a/b"))
+	require.Equal(t, "a/b/d", PrefixRangeEnd("a/b/c"))
+	require.Equal(t, "", PrefixRangeEnd(""))
+}
+
 func TestBadgerKV_Keys(t *testing.T) {
 	for _, tc := range getIteratorTestCases() {
 		t.Run("Keys "+tc.name, func(t *testing.T) {

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -62,7 +62,7 @@ func TestBadgerKV_Save(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Save new key", func(t *testing.T) {
-		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
+		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("value1"))))
 		require.NoError(t, err)
 
 		// Verify the value was saved
@@ -77,11 +77,11 @@ func TestBadgerKV_Save(t *testing.T) {
 
 	t.Run("Save overwrite existing key", func(t *testing.T) {
 		// First save
-		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("oldvalue")))
+		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("oldvalue"))))
 		require.NoError(t, err)
 
 		// Overwrite
-		err = kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("newvalue")))
+		err = kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("newvalue"))))
 		require.NoError(t, err)
 
 		// Verify the value was updated
@@ -103,7 +103,7 @@ func TestBadgerKV_Delete(t *testing.T) {
 
 	t.Run("Delete existing key", func(t *testing.T) {
 		// First create a key
-		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
+		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("value1"))))
 		require.NoError(t, err)
 
 		// Delete it
@@ -136,7 +136,7 @@ func setupIteratorTestData(t *testing.T) (*badgerKV, context.Context) {
 	// Setup test data
 	keys := []string{"a1", "a2", "b1", "b2", "c1"}
 	for _, k := range keys {
-		err := kv.Save(ctx, "section", k, bytes.NewReader([]byte("value"+k)))
+		err := kv.Save(ctx, "section", k, io.NopCloser(bytes.NewReader([]byte("value"+k))))
 		require.NoError(t, err)
 	}
 
@@ -221,7 +221,7 @@ func TestBadgerKV_Concurrent(t *testing.T) {
 				value := []byte(fmt.Sprintf("value%d", i))
 
 				// Save
-				err := kv.Save(ctx, "section", key, bytes.NewReader(value))
+				err := kv.Save(ctx, "section", key, io.NopCloser(bytes.NewReader(value)))
 				require.NoError(t, err)
 
 				// Get

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -16,15 +16,15 @@ func setupTestBadgerDB(t *testing.T) *badger.DB {
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := db.Close()
+		require.NoError(t, err)
+	})
 	return db
 }
 
 func TestBadgerKV_Get(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer func() {
-		err := db.Close()
-		require.NoError(t, err)
-	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -51,10 +51,6 @@ func TestBadgerKV_Get(t *testing.T) {
 
 func TestBadgerKV_Save(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer func() {
-		err := db.Close()
-		require.NoError(t, err)
-	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -89,10 +85,6 @@ func TestBadgerKV_Save(t *testing.T) {
 
 func TestBadgerKV_Delete(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer func() {
-		err := db.Close()
-		require.NoError(t, err)
-	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -260,10 +252,6 @@ func TestBadgerKV_List(t *testing.T) {
 
 func TestBadgerKV_Concurrent(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer func() {
-		err := db.Close()
-		require.NoError(t, err)
-	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -43,7 +43,7 @@ func TestBadgerKV_Get(t *testing.T) {
 		assert.Equal(t, "key1", obj.Key)
 
 		// Read the value from the Reader
-		value, err := io.ReadAll(obj.Reader)
+		value, err := io.ReadAll(obj.Value)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("value1"), value)
 	})
@@ -70,7 +70,7 @@ func TestBadgerKV_Save(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "key1", obj.Key)
 
-		value, err := io.ReadAll(obj.Reader)
+		value, err := io.ReadAll(obj.Value)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("value1"), value)
 	})
@@ -89,7 +89,7 @@ func TestBadgerKV_Save(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "key1", obj.Key)
 
-		value, err := io.ReadAll(obj.Reader)
+		value, err := io.ReadAll(obj.Value)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("newvalue"), value)
 	})
@@ -229,7 +229,7 @@ func TestBadgerKV_Concurrent(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, key, obj.Key)
 
-				readValue, err := io.ReadAll(obj.Reader)
+				readValue, err := io.ReadAll(obj.Value)
 				require.NoError(t, err)
 				assert.Equal(t, value, readValue)
 

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -1,8 +1,10 @@
 package resource
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -39,7 +41,12 @@ func TestBadgerKV_Get(t *testing.T) {
 		obj, err := kv.Get(ctx, "section", "key1")
 		require.NoError(t, err)
 		assert.Equal(t, "key1", obj.Key)
-		assert.Equal(t, []byte("value1"), obj.Value)
+
+		// Read the value from the Reader
+		value, err := io.ReadAll(obj.Reader)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value1"), value)
+		assert.Equal(t, int64(6), obj.Size)
 	})
 
 	t.Run("Get non-existent key", func(t *testing.T) {
@@ -56,30 +63,36 @@ func TestBadgerKV_Save(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Save new key", func(t *testing.T) {
-		err := kv.Save(ctx, "section", "key1", []byte("value1"))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
 		require.NoError(t, err)
 
 		// Verify the value was saved
 		obj, err := kv.Get(ctx, "section", "key1")
 		require.NoError(t, err)
 		assert.Equal(t, "key1", obj.Key)
-		assert.Equal(t, []byte("value1"), obj.Value)
+
+		value, err := io.ReadAll(obj.Reader)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value1"), value)
 	})
 
 	t.Run("Save overwrite existing key", func(t *testing.T) {
 		// First save
-		err := kv.Save(ctx, "section", "key1", []byte("oldvalue"))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("oldvalue")))
 		require.NoError(t, err)
 
 		// Overwrite
-		err = kv.Save(ctx, "section", "key1", []byte("newvalue"))
+		err = kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("newvalue")))
 		require.NoError(t, err)
 
 		// Verify the value was updated
 		obj, err := kv.Get(ctx, "section", "key1")
 		require.NoError(t, err)
 		assert.Equal(t, "key1", obj.Key)
-		assert.Equal(t, []byte("newvalue"), obj.Value)
+
+		value, err := io.ReadAll(obj.Reader)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("newvalue"), value)
 	})
 }
 
@@ -91,7 +104,7 @@ func TestBadgerKV_Delete(t *testing.T) {
 
 	t.Run("Delete existing key", func(t *testing.T) {
 		// First create a key
-		err := kv.Save(ctx, "section", "key1", []byte("value1"))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
 		require.NoError(t, err)
 
 		// Delete it
@@ -124,7 +137,7 @@ func setupIteratorTestData(t *testing.T) (*badgerKV, context.Context) {
 	// Setup test data
 	keys := []string{"a1", "a2", "b1", "b2", "c1"}
 	for _, k := range keys {
-		err := kv.Save(ctx, "section", k, []byte("value"+k))
+		err := kv.Save(ctx, "section", k, bytes.NewReader([]byte("value"+k)))
 		require.NoError(t, err)
 	}
 
@@ -138,9 +151,15 @@ type iteratorTestCase struct {
 	expectedKeys []string
 }
 
-// getIteratorTestCases returns common test cases for both Keys and List methods
-func getIteratorTestCases() []iteratorTestCase {
-	return []iteratorTestCase{
+func TestPrefixRangeEnd(t *testing.T) {
+	require.Equal(t, "b", PrefixRangeEnd("a"))
+	require.Equal(t, "a/c", PrefixRangeEnd("a/b"))
+	require.Equal(t, "a/b/d", PrefixRangeEnd("a/b/c"))
+	require.Equal(t, "", PrefixRangeEnd(""))
+}
+
+func TestBadgerKV_Keys(t *testing.T) {
+	for _, tc := range []iteratorTestCase{
 		{
 			name:         "all items",
 			options:      ListOptions{},
@@ -171,18 +190,7 @@ func getIteratorTestCases() []iteratorTestCase {
 			options:      ListOptions{StartKey: "a", EndKey: PrefixRangeEnd("a"), Sort: SortOrderDesc},
 			expectedKeys: []string{"a2", "a1"},
 		},
-	}
-}
-
-func TestPrefixRangeEnd(t *testing.T) {
-	require.Equal(t, "b", PrefixRangeEnd("a"))
-	require.Equal(t, "a/c", PrefixRangeEnd("a/b"))
-	require.Equal(t, "a/b/d", PrefixRangeEnd("a/b/c"))
-	require.Equal(t, "", PrefixRangeEnd(""))
-}
-
-func TestBadgerKV_Keys(t *testing.T) {
-	for _, tc := range getIteratorTestCases() {
+	} {
 		t.Run("Keys "+tc.name, func(t *testing.T) {
 			kv, ctx := setupIteratorTestData(t)
 
@@ -194,60 +202,6 @@ func TestBadgerKV_Keys(t *testing.T) {
 			assert.Equal(t, tc.expectedKeys, keys)
 		})
 	}
-}
-
-func TestBadgerKV_List(t *testing.T) {
-	for _, tc := range getIteratorTestCases() {
-		t.Run("List "+tc.name, func(t *testing.T) {
-			kv, ctx := setupIteratorTestData(t)
-
-			var objects []KVObject
-			for obj, err := range kv.List(ctx, "section", tc.options) {
-				require.NoError(t, err)
-				objects = append(objects, obj)
-			}
-
-			// Verify we got the expected number of objects
-			assert.Len(t, objects, len(tc.expectedKeys))
-
-			// Verify keys and values match expectations
-			for i, expectedKey := range tc.expectedKeys {
-				assert.Equal(t, expectedKey, objects[i].Key)
-				assert.Equal(t, []byte("value"+expectedKey), objects[i].Value)
-			}
-		})
-	}
-
-	// Test edge cases with fresh setup
-	t.Run("List empty section", func(t *testing.T) {
-		kv, ctx := setupIteratorTestData(t)
-
-		var objects []KVObject
-		var errors []error
-		for obj, err := range kv.List(ctx, "emptysection", ListOptions{}) {
-			if err != nil {
-				errors = append(errors, err)
-			} else {
-				objects = append(objects, obj)
-			}
-		}
-		assert.Len(t, objects, 0)
-		assert.Len(t, errors, 0)
-	})
-
-	t.Run("List with empty section parameter", func(t *testing.T) {
-		kv, ctx := setupIteratorTestData(t)
-
-		var errors []error
-		for _, err := range kv.List(ctx, "", ListOptions{}) {
-			if err != nil {
-				errors = append(errors, err)
-				break
-			}
-		}
-		assert.Len(t, errors, 1)
-		assert.Contains(t, errors[0].Error(), "section is required")
-	})
 }
 
 func TestBadgerKV_Concurrent(t *testing.T) {
@@ -268,14 +222,17 @@ func TestBadgerKV_Concurrent(t *testing.T) {
 				value := []byte(fmt.Sprintf("value%d", i))
 
 				// Save
-				err := kv.Save(ctx, "section", key, value)
+				err := kv.Save(ctx, "section", key, bytes.NewReader(value))
 				require.NoError(t, err)
 
 				// Get
 				obj, err := kv.Get(ctx, "section", key)
 				require.NoError(t, err)
 				assert.Equal(t, key, obj.Key)
-				assert.Equal(t, value, obj.Value)
+
+				readValue, err := io.ReadAll(obj.Reader)
+				require.NoError(t, err)
+				assert.Equal(t, value, readValue)
 
 				// Delete
 				err = kv.Delete(ctx, "section", key)

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -1,0 +1,285 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestBadgerDB(t *testing.T) *badger.DB {
+	// Create a temporary directory for the test database
+	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	return db
+}
+
+func TestBadgerKV_Get(t *testing.T) {
+	db := setupTestBadgerDB(t)
+	defer db.Close()
+
+	kv := NewBadgerKV(db)
+	ctx := context.Background()
+
+	// Setup test data
+	err := db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte("section/key1"), []byte("value1"))
+	})
+	require.NoError(t, err)
+
+	t.Run("Get existing key", func(t *testing.T) {
+		obj, err := kv.Get(ctx, "section", "key1")
+		require.NoError(t, err)
+		assert.Equal(t, "key1", obj.Key)
+		assert.Equal(t, []byte("value1"), obj.Value)
+	})
+
+	t.Run("Get non-existent key", func(t *testing.T) {
+		_, err := kv.Get(ctx, "section", "nonexistent")
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, err)
+	})
+}
+
+func TestBadgerKV_Save(t *testing.T) {
+	db := setupTestBadgerDB(t)
+	defer db.Close()
+
+	kv := NewBadgerKV(db)
+	ctx := context.Background()
+
+	t.Run("Save new key", func(t *testing.T) {
+		err := kv.Save(ctx, "section", "key1", []byte("value1"))
+		require.NoError(t, err)
+
+		// Verify the value was saved
+		obj, err := kv.Get(ctx, "section", "key1")
+		require.NoError(t, err)
+		assert.Equal(t, "key1", obj.Key)
+		assert.Equal(t, []byte("value1"), obj.Value)
+	})
+
+	t.Run("Save overwrite existing key", func(t *testing.T) {
+		// First save
+		err := kv.Save(ctx, "section", "key1", []byte("oldvalue"))
+		require.NoError(t, err)
+
+		// Overwrite
+		err = kv.Save(ctx, "section", "key1", []byte("newvalue"))
+		require.NoError(t, err)
+
+		// Verify the value was updated
+		obj, err := kv.Get(ctx, "section", "key1")
+		require.NoError(t, err)
+		assert.Equal(t, "key1", obj.Key)
+		assert.Equal(t, []byte("newvalue"), obj.Value)
+	})
+}
+
+func TestBadgerKV_Delete(t *testing.T) {
+	db := setupTestBadgerDB(t)
+	defer db.Close()
+
+	kv := NewBadgerKV(db)
+	ctx := context.Background()
+
+	t.Run("Delete existing key", func(t *testing.T) {
+		// First create a key
+		err := kv.Save(ctx, "section", "key1", []byte("value1"))
+		require.NoError(t, err)
+
+		// Delete it
+		err = kv.Delete(ctx, "section", "key1")
+		require.NoError(t, err)
+
+		// Verify it's gone
+		_, err = kv.Get(ctx, "section", "key1")
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("Delete non-existent key", func(t *testing.T) {
+		err := kv.Delete(ctx, "section", "nonexistent")
+		require.NoError(t, err) // Badger doesn't return error for non-existent keys
+	})
+}
+
+// setupIteratorTestData creates a test environment with common test data
+func setupIteratorTestData(t *testing.T) (*badgerKV, context.Context) {
+	db := setupTestBadgerDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	kv := NewBadgerKV(db)
+	ctx := context.Background()
+
+	// Setup test data
+	keys := []string{"a1", "a2", "b1", "b2", "c1"}
+	for _, k := range keys {
+		err := kv.Save(ctx, "section", k, []byte("value"+k))
+		require.NoError(t, err)
+	}
+
+	return kv, ctx
+}
+
+// iteratorTestCase represents a test case for iteration methods
+type iteratorTestCase struct {
+	name         string
+	options      ListOptions
+	expectedKeys []string
+}
+
+// getIteratorTestCases returns common test cases for both Keys and List methods
+func getIteratorTestCases() []iteratorTestCase {
+	return []iteratorTestCase{
+		{
+			name:         "all items",
+			options:      ListOptions{},
+			expectedKeys: []string{"a1", "a2", "b1", "b2", "c1"},
+		},
+		{
+			name:         "with limit",
+			options:      ListOptions{Limit: 2},
+			expectedKeys: []string{"a1", "a2"},
+		},
+		{
+			name:         "with range",
+			options:      ListOptions{StartKey: "a", EndKey: "b"},
+			expectedKeys: []string{"a1", "a2"},
+		},
+		{
+			name:         "with prefix",
+			options:      ListOptions{StartKey: "a", EndKey: PrefixRangeEnd("a")},
+			expectedKeys: []string{"a1", "a2"},
+		},
+		{
+			name:         "in descending order",
+			options:      ListOptions{Sort: SortOrderDesc},
+			expectedKeys: []string{"c1", "b2", "b1", "a2", "a1"},
+		},
+		{
+			name:         "in descending order with prefix",
+			options:      ListOptions{StartKey: "a", EndKey: PrefixRangeEnd("a"), Sort: SortOrderDesc},
+			expectedKeys: []string{"a2", "a1"},
+		},
+	}
+}
+
+func TestBadgerKV_Keys(t *testing.T) {
+	for _, tc := range getIteratorTestCases() {
+		t.Run("Keys "+tc.name, func(t *testing.T) {
+			kv, ctx := setupIteratorTestData(t)
+
+			var keys []string
+			for k, err := range kv.Keys(ctx, "section", tc.options) {
+				require.NoError(t, err)
+				keys = append(keys, k)
+			}
+			assert.Equal(t, tc.expectedKeys, keys)
+		})
+	}
+}
+
+func TestBadgerKV_List(t *testing.T) {
+	for _, tc := range getIteratorTestCases() {
+		t.Run("List "+tc.name, func(t *testing.T) {
+			kv, ctx := setupIteratorTestData(t)
+
+			var objects []KVObject
+			for obj, err := range kv.List(ctx, "section", tc.options) {
+				require.NoError(t, err)
+				objects = append(objects, obj)
+			}
+
+			// Verify we got the expected number of objects
+			assert.Len(t, objects, len(tc.expectedKeys))
+
+			// Verify keys and values match expectations
+			for i, expectedKey := range tc.expectedKeys {
+				assert.Equal(t, expectedKey, objects[i].Key)
+				assert.Equal(t, []byte("value"+expectedKey), objects[i].Value)
+			}
+		})
+	}
+
+	// Test edge cases with fresh setup
+	t.Run("List empty section", func(t *testing.T) {
+		kv, ctx := setupIteratorTestData(t)
+
+		var objects []KVObject
+		var errors []error
+		for obj, err := range kv.List(ctx, "emptysection", ListOptions{}) {
+			if err != nil {
+				errors = append(errors, err)
+			} else {
+				objects = append(objects, obj)
+			}
+		}
+		assert.Len(t, objects, 0)
+		assert.Len(t, errors, 0)
+	})
+
+	t.Run("List with empty section parameter", func(t *testing.T) {
+		kv, ctx := setupIteratorTestData(t)
+
+		var errors []error
+		for _, err := range kv.List(ctx, "", ListOptions{}) {
+			if err != nil {
+				errors = append(errors, err)
+				break
+			}
+		}
+		assert.Len(t, errors, 1)
+		assert.Contains(t, errors[0].Error(), "section is required")
+	})
+}
+
+func TestBadgerKV_Concurrent(t *testing.T) {
+	db := setupTestBadgerDB(t)
+	defer db.Close()
+
+	kv := NewBadgerKV(db)
+	ctx := context.Background()
+
+	t.Run("Concurrent operations", func(t *testing.T) {
+		const numGoroutines = 10
+		done := make(chan struct{})
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer func() { done <- struct{}{} }()
+
+				key := fmt.Sprintf("key%d", i)
+				value := []byte(fmt.Sprintf("value%d", i))
+
+				// Save
+				err := kv.Save(ctx, "section", key, value)
+				require.NoError(t, err)
+
+				// Get
+				obj, err := kv.Get(ctx, "section", key)
+				require.NoError(t, err)
+				assert.Equal(t, key, obj.Key)
+				assert.Equal(t, value, obj.Value)
+
+				// Delete
+				err = kv.Delete(ctx, "section", key)
+				require.NoError(t, err)
+
+				// Verify deleted
+				_, err = kv.Get(ctx, "section", key)
+				assert.Error(t, err)
+			}(i)
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < numGoroutines; i++ {
+			<-done
+		}
+	})
+}

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -21,7 +21,10 @@ func setupTestBadgerDB(t *testing.T) *badger.DB {
 
 func TestBadgerKV_Get(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer db.Close()
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -48,7 +51,10 @@ func TestBadgerKV_Get(t *testing.T) {
 
 func TestBadgerKV_Save(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer db.Close()
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -83,7 +89,10 @@ func TestBadgerKV_Save(t *testing.T) {
 
 func TestBadgerKV_Delete(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer db.Close()
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -112,7 +121,10 @@ func TestBadgerKV_Delete(t *testing.T) {
 // setupIteratorTestData creates a test environment with common test data
 func setupIteratorTestData(t *testing.T) (*badgerKV, context.Context) {
 	db := setupTestBadgerDB(t)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() {
+		err := db.Close()
+		require.NoError(t, err)
+	})
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()
@@ -241,7 +253,10 @@ func TestBadgerKV_List(t *testing.T) {
 
 func TestBadgerKV_Concurrent(t *testing.T) {
 	db := setupTestBadgerDB(t)
-	defer db.Close()
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
 
 	kv := NewBadgerKV(db)
 	ctx := context.Background()

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -46,7 +46,6 @@ func TestBadgerKV_Get(t *testing.T) {
 		value, err := io.ReadAll(obj.Reader)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("value1"), value)
-		assert.Equal(t, int64(6), obj.Size)
 	})
 
 	t.Run("Get non-existent key", func(t *testing.T) {


### PR DESCRIPTION
Introduce the new kvstore interface and a reference implementation using [Badger](https://github.com/hypermodeinc/badger).

Size of the binary before/after is unchanged
```
echo "=== Binary sizes AFTER your changes ==="
ls -lh bin/grafana*
=== Binary sizes BEFORE your changes ===
-rwxr-xr-x@ 1 gc  staff   416M 24 jui 09:53 bin/grafana
-rwxr-xr-x@ 1 gc  staff   2,3M 24 jui 09:53 bin/grafana-cli
-rwxr-xr-x@ 1 gc  staff   2,3M 24 jui 09:53 bin/grafana-server

=== Binary sizes AFTER your changes ===
-rwxr-xr-x@ 1 gc  staff   416M 24 jui 09:53 bin/grafana
-rwxr-xr-x@ 1 gc  staff   2,3M 24 jui 09:53 bin/grafana-cli
-rwxr-xr-x@ 1 gc  staff   2,3M 24 jui 09:53 bin/grafana-server
```