### PR TITLE
SecureValues: Add limit of 24kiB for raw input

### DIFF
--- a/pkg/apis/secret/v0alpha1/secure_value.go
+++ b/pkg/apis/secret/v0alpha1/secure_value.go
@@ -59,7 +59,9 @@ type SecureValueSpec struct {
 
 	// The raw value is only valid for write. Read/List will always be empty.
 	// There is no support for mixing `value` and `ref`, you can't create a secret in a third-party keeper with a specified `ref`.
+	// Minimum and maximum lengths in bytes.
 	// +k8s:validation:minLength=1
+	// +k8s:validation:maxLength=24576
 	Value ExposedSecureValue `json:"value,omitempty"`
 
 	// When using a third-party keeper, the `ref` is used to reference a value inside the remote storage.

--- a/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
@@ -641,8 +641,9 @@ func schema_pkg_apis_secret_v0alpha1_SecureValueSpec(ref common.ReferenceCallbac
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The raw value is only valid for write. Read/List will always be empty. There is no support for mixing `value` and `ref`, you can't create a secret in a third-party keeper with a specified `ref`.",
+							Description: "The raw value is only valid for write. Read/List will always be empty. There is no support for mixing `value` and `ref`, you can't create a secret in a third-party keeper with a specified `ref`. Minimum and maximum lengths in bytes.",
 							MinLength:   ptr.To[int64](1),
+							MaxLength:   ptr.To[int64](24576),
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -8,6 +8,9 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
+// The maximum size of a secure value in bytes when written as raw input.
+const SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES = 24576 // 24 KiB
+
 type DecryptSecureValue struct {
 	Keeper     *string
 	Ref        string

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -283,6 +283,13 @@ func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admiss
 	}
 
 	// General validations.
+	if len(sv.Spec.Value) > 24576 {
+		errs = append(
+			errs,
+			field.TooLong(field.NewPath("spec", "value"), len(sv.Spec.Value), 24576),
+		)
+	}
+
 	if errs := validateDecrypters(sv.Spec.Decrypters, decryptersAllowList); len(errs) > 0 {
 		return errs
 	}

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -283,10 +283,10 @@ func ValidateSecureValue(sv, oldSv *secretv0alpha1.SecureValue, operation admiss
 	}
 
 	// General validations.
-	if len(sv.Spec.Value) > 24576 {
+	if len(sv.Spec.Value) > contracts.SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES {
 		errs = append(
 			errs,
-			field.TooLong(field.NewPath("spec", "value"), len(sv.Spec.Value), 24576),
+			field.TooLong(field.NewPath("spec", "value"), len(sv.Spec.Value), contracts.SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES),
 		)
 	}
 

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,16 @@ func TestValidateSecureValue(t *testing.T) {
 			errs = reststorage.ValidateSecureValue(sv, nil, admission.Create, nil)
 			require.Len(t, errs, 1)
 			require.Equal(t, "spec", errs[0].Field)
+		})
+
+		t.Run("`value` cannot exceed 24576 bytes", func(t *testing.T) {
+			sv := validSecureValue.DeepCopy()
+			sv.Spec.Value = secretv0alpha1.NewExposedSecureValue(strings.Repeat("a", 24576+1))
+			sv.Spec.Ref = nil
+
+			errs := reststorage.ValidateSecureValue(sv, nil, admission.Create, nil)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.value", errs[0].Field)
 		})
 	})
 

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -58,7 +58,7 @@ func TestValidateSecureValue(t *testing.T) {
 
 		t.Run("`value` cannot exceed 24576 bytes", func(t *testing.T) {
 			sv := validSecureValue.DeepCopy()
-			sv.Spec.Value = secretv0alpha1.NewExposedSecureValue(strings.Repeat("a", 24576+1))
+			sv.Spec.Value = secretv0alpha1.NewExposedSecureValue(strings.Repeat("a", contracts.SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES+1))
 			sv.Spec.Ref = nil
 
 			errs := reststorage.ValidateSecureValue(sv, nil, admission.Create, nil)


### PR DESCRIPTION
The lowest common denominator out of the providers we plan to support is 24kiB. 