### PR TITLE
ExposedSecureValue: base64 encode secret before creating wrapper

### DIFF
--- a/pkg/apis/secret/v0alpha1/exposed_secure_value.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value.go
@@ -1,6 +1,7 @@
 package v0alpha1
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -21,12 +22,12 @@ var (
 	_ yaml.Marshaler = (*ExposedSecureValue)(nil)
 )
 
-// NewExposedSecureValue creates a new exposed secure value wrapper.
+// NewExposedSecureValue creates a new base64 encoded exposed secure value wrapper.
 func NewExposedSecureValue(v string) ExposedSecureValue {
-	return ExposedSecureValue(v)
+	return ExposedSecureValue(base64.StdEncoding.EncodeToString([]byte(v)))
 }
 
-// DangerouslyExposeAndConsumeValue will move the decrypted secure value out of the wrapper and return it.
+// DangerouslyExposeAndConsumeValue will move the decrypted secure value out of the wrapper and return it as a bas64 encoded string.
 // Further attempts to call this method will panic.
 // The function name is intentionally kept long and weird because this is a dangerous operation and should be used carefully!
 func (s *ExposedSecureValue) DangerouslyExposeAndConsumeValue() string {

--- a/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
@@ -2,6 +2,7 @@ package v0alpha1_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -40,8 +41,10 @@ func TestExposedSecureValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "'"+expected+"'\n", string(bytes))
 
-	// DangerouslyExposeAndConsumeValue returns the raw value.
-	require.Equal(t, rawValue, esv.DangerouslyExposeAndConsumeValue())
+	// DangerouslyExposeAndConsumeValue returns the raw value base64 encoded.
+	decoded, err := base64.StdEncoding.DecodeString(esv.DangerouslyExposeAndConsumeValue())
+	require.NoError(t, err)
+	require.Equal(t, rawValue, string(decoded))
 
 	// Further calls to DangerouslyExposeAndConsumeValue will panic.
 	require.Panics(t, func() { esv.DangerouslyExposeAndConsumeValue() })


### PR DESCRIPTION
We should base64 encode the raw secret to limit character space to printable ASCII.