### PR TITLE
Decrypt: Return base64-encoded secret from the storage

### DIFF
--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	claims "github.com/grafana/authlib/types"
@@ -53,6 +54,7 @@ type decryptStorage struct {
 }
 
 // Decrypt decrypts a secure value from the keeper.
+// The returned value is an ExposedSecureValue, which is a Base64 Std encoded string of the raw decrypted value.
 func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv0alpha1.ExposedSecureValue, decryptErr error) {
 	ctx, span := s.tracer.Start(ctx, "DecryptStorage.Decrypt", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
@@ -108,5 +110,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		return "", contracts.ErrDecryptFailed
 	}
 
-	return exposedValue, nil
+	return secretv0alpha1.NewExposedSecureValue(
+		base64.StdEncoding.EncodeToString([]byte(exposedValue.DangerouslyExposeAndConsumeValue())),
+	), nil
 }

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -131,7 +132,10 @@ func TestIntegrationDecrypt(t *testing.T) {
 		exposed, err := decryptSvc.Decrypt(authCtx, "default", "sv-test")
 		require.NoError(t, err)
 		require.NotEmpty(t, exposed)
-		require.Equal(t, "value", exposed.DangerouslyExposeAndConsumeValue())
+
+		decoded, err := base64.StdEncoding.DecodeString(exposed.DangerouslyExposeAndConsumeValue())
+		require.NoError(t, err)
+		require.Equal(t, "value", string(decoded))
 	})
 
 	t.Run("with permissions for a specific secure value but trying to decrypt another one, it returns unauthorized error", func(t *testing.T) {


### PR DESCRIPTION
We should base64 encode the raw secret to limit character space to printable ASCII.