### PR TITLE
PluginExtensions: fix `setJsonData()` race condition in EditDataSource extension point

### DIFF
--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -1,7 +1,8 @@
 import { screen, render } from '@testing-library/react';
+import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 
-import { PluginState } from '@grafana/data';
+import { DataSourceJsonData, PluginExtensionDataSourceConfigContext, PluginState } from '@grafana/data';
 import { setPluginComponentsHook } from '@grafana/runtime';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 import { configureStore } from 'app/store/configureStore';
@@ -11,6 +12,8 @@ import { getMockDataSource, getMockDataSourceMeta, getMockDataSourceSettingsStat
 import { missingRightsMessage } from './DataSourceMissingRightsMessage';
 import { readOnlyMessage } from './DataSourceReadOnlyMessage';
 import { EditDataSourceView, ViewProps } from './EditDataSource';
+
+const onOptionsChange = jest.fn();
 
 jest.mock('@grafana/runtime', () => {
   return {
@@ -38,7 +41,7 @@ const setup = (props?: Partial<ViewProps>) => {
         onDelete={jest.fn()}
         onDefaultChange={jest.fn()}
         onNameChange={jest.fn()}
-        onOptionsChange={jest.fn()}
+        onOptionsChange={onOptionsChange}
         onTest={jest.fn()}
         onUpdate={jest.fn()}
         {...props}
@@ -50,6 +53,7 @@ const setup = (props?: Partial<ViewProps>) => {
 describe('<EditDataSource>', () => {
   beforeEach(() => {
     setPluginComponentsHook(jest.fn().mockReturnValue({ isLoading: false, components: [] }));
+    onOptionsChange.mockClear();
   });
 
   describe('On loading errors', () => {
@@ -357,6 +361,51 @@ describe('<EditDataSource>', () => {
       expect(props.context.setJsonData).toBeDefined();
       expect(props.context.setSecureJsonData).toBeDefined();
       expect(props.context.testingStatus).toBeDefined();
+    });
+  });
+
+  it('should be possible to update the `jsonData` and `secureJsonData` at the same time from the extension component', () => {
+    const message = "I'm a UI extension component!";
+    const component = ({ context }: { context: PluginExtensionDataSourceConfigContext }) => {
+      useEffect(() => {
+        context.setJsonData({ test: 'test' } as unknown as DataSourceJsonData);
+        context.setSecureJsonData({ test: 'test' });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+
+      return <div>{message}</div>;
+    };
+
+    setPluginComponentsHook(
+      jest.fn().mockReturnValue({
+        isLoading: false,
+        components: [
+          createComponentWithMeta(
+            {
+              pluginId: 'grafana-pdc-app',
+              title: 'Example component',
+              description: 'Example description',
+              component: component as unknown as React.ComponentType<{}>,
+            },
+            '1'
+          ),
+        ],
+      })
+    );
+
+    setup({
+      dataSourceRights: {
+        readOnly: false,
+        hasDeleteRights: true,
+        hasWriteRights: true,
+      },
+    });
+
+    expect(onOptionsChange).toHaveBeenCalledTimes(2);
+    expect(onOptionsChange).toHaveBeenCalledWith({
+      ...getMockDataSource(),
+      jsonData: { ...getMockDataSource().jsonData, test: 'test' },
+      secureJsonData: { test: 'test' },
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -364,12 +364,57 @@ describe('<EditDataSource>', () => {
     });
   });
 
-  it('should be possible to update the `jsonData` and `secureJsonData` at the same time from the extension component', () => {
+  it('should be possible to update the `jsonData` first and `secureJsonData` directly afterwards from the extension component', () => {
     const message = "I'm a UI extension component!";
     const component = ({ context }: { context: PluginExtensionDataSourceConfigContext }) => {
       useEffect(() => {
         context.setJsonData({ test: 'test' } as unknown as DataSourceJsonData);
         context.setSecureJsonData({ test: 'test' });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+
+      return <div>{message}</div>;
+    };
+
+    setPluginComponentsHook(
+      jest.fn().mockReturnValue({
+        isLoading: false,
+        components: [
+          createComponentWithMeta(
+            {
+              pluginId: 'grafana-pdc-app',
+              title: 'Example component',
+              description: 'Example description',
+              component: component as unknown as React.ComponentType<{}>,
+            },
+            '1'
+          ),
+        ],
+      })
+    );
+
+    setup({
+      dataSourceRights: {
+        readOnly: false,
+        hasDeleteRights: true,
+        hasWriteRights: true,
+      },
+    });
+
+    expect(onOptionsChange).toHaveBeenCalledTimes(2);
+    expect(onOptionsChange).toHaveBeenCalledWith({
+      ...getMockDataSource(),
+      jsonData: { ...getMockDataSource().jsonData, test: 'test' },
+      secureJsonData: { test: 'test' },
+    });
+  });
+
+  it('should be possible to update the `secureJsonData` first and `jsonData` directly afterwards from the extension component', () => {
+    const message = "I'm a UI extension component!";
+    const component = ({ context }: { context: PluginExtensionDataSourceConfigContext }) => {
+      useEffect(() => {
+        context.setSecureJsonData({ test: 'test' });
+        context.setJsonData({ test: 'test' } as unknown as DataSourceJsonData);
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
 

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -121,6 +121,7 @@ export function EditDataSourceView({
   // Both those exposed functions are calling `onOptionsChange()` with the new jsonData and secureJsonData, and if they are called in the same tick, the Redux store
   // (which provides the `datasource` object) won't be updated yet, and they override each others `jsonData` value.
   let currentJsonData = dataSource.jsonData;
+  let currentSecureJsonData = dataSource.secureJsonData;
 
   const dsi = getDataSourceSrv()?.getInstanceSettings(dataSource.uid);
 
@@ -209,14 +210,16 @@ export function EditDataSourceView({
                   currentJsonData = { ...currentJsonData, ...jsonData };
                   onOptionsChange({
                     ...dataSource,
+                    secureJsonData: { ...currentSecureJsonData },
                     jsonData: currentJsonData,
                   });
                 },
                 setSecureJsonData: (secureJsonData) => {
+                  currentSecureJsonData = { ...currentSecureJsonData, ...secureJsonData };
                   onOptionsChange({
                     ...dataSource,
                     jsonData: { ...currentJsonData },
-                    secureJsonData: { ...dataSource.secureJsonData, ...secureJsonData },
+                    secureJsonData: currentSecureJsonData,
                   });
                 },
               }}


### PR DESCRIPTION
### What changed?

A [feedback](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750431277327449) from @dafydd-t highlighted a bug in the EditDataSource extension point. The problem is that we have exposed the `setJsonData()` and `setSecureJsonData()` functions independently to extensions, however under the hood they are working on the same data object stored in Redux (datasource). As [we are taking the `dataSource` object as the source of truth](https://github.com/grafana/grafana/blob/7c6e7deb09711f956671a1fcef60a769f7a5a09a/public/app/features/datasources/components/EditDataSource.tsx#L57), we have a race condition: 

```ts
  // This will trigger `onOptionsChange()` --> triggers a Redux update
  setJsonData({ test: 1 });

  // This will also trigger `onOptionsChange()` under the hood, but for the `jsonData: ` part it uses the value from Redux - which is not updated at this point -> it overrides the update
  setSecureJsonData({ secureTest: 1 });
```

Also pinging @jarben for visibility.


### Notes for the reviewer
I am aware that using a "normal variable" for holding state inside a React component is not an ideal approach, however in this case I am afraid we need a synchronous state. An other approach would be to change the exposed API - but I would like to avoid that if possible. Let me know though if you have a "nicer" idea!  