### PR TITLE
datasources: querier: log empty refids

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -218,11 +218,16 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 }
 
 func logEmptyRefids(queries []v0alpha1.DataQuery, logger log.Logger) {
+	emptyCount := 0
+
 	for _, q := range queries {
 		if q.RefID == "" {
-			logger.Info("empty refid found", "query_count", len(queries))
-			break
+			emptyCount += 1
 		}
+	}
+
+	if emptyCount > 0 {
+		logger.Info("empty refid found", "empty_count", emptyCount, "query_count", len(queries))
 	}
 }
 

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -179,6 +179,8 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			return
 		}
 
+		logEmptyRefids(raw.Queries, b.log)
+
 		for i := range req.Requests {
 			req.Requests[i].Headers = ExtractKnownHeaders(httpreq.Header)
 		}
@@ -213,6 +215,15 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			QueryDataResponse: *rsp, // wrap the backend response as a QueryDataResponse
 		})
 	}), nil
+}
+
+func logEmptyRefids(queries []v0alpha1.DataQuery, logger log.Logger) {
+	for _, q := range queries {
+		if q.RefID == "" {
+			logger.Info("empty refid found", "query_count", len(queries))
+			break
+		}
+	}
 }
 
 func (b *QueryAPIBuilder) execute(ctx context.Context, req parsedRequestInfo, instanceConfig clientapi.InstanceConfigurationSettings) (qdr *backend.QueryDataResponse, err error) {


### PR DESCRIPTION
this PR will make the query service log every case where the request contains a query with an empty `refId`.

we are working on improving the handling of situations with empty refids.
one approach would be to forbid empty refIds.

problem is, the current query service allows empty refIds (so does the current `/api/ds/query` too)

this PR will log such cases, so we can get a picture about how often this happens in the query service currently.