### PR TITLE
TimeRangePicker: Use consistent format in date-time input fields

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -23,10 +23,10 @@ import { Icon } from '../../Icon/Icon';
 import { Input } from '../../Input/Input';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { WeekStart } from '../WeekStartPicker';
+import { commonFormat } from '../commonFormat';
 import { isValid } from '../utils';
 
 import TimePickerCalendar from './TimePickerCalendar';
-import { commonFormat } from '../commonFormat';
 
 interface Props {
   isFullscreen: boolean;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -26,6 +26,7 @@ import { WeekStart } from '../WeekStartPicker';
 import { isValid } from '../utils';
 
 import TimePickerCalendar from './TimePickerCalendar';
+import { commonFormat } from '../commonFormat';
 
 interface Props {
   isFullscreen: boolean;
@@ -92,7 +93,7 @@ export const TimeRangeContent = (props: Props) => {
     }
 
     const raw: RawTimeRange = { from: from.value, to: to.value };
-    const timeRange = rangeUtil.convertRawToRange(raw, timeZone, fiscalYearStartMonth);
+    const timeRange = rangeUtil.convertRawToRange(raw, timeZone, fiscalYearStartMonth, commonFormat);
 
     onApplyFromProps(timeRange);
   }, [from.invalid, from.value, onApplyFromProps, timeZone, to.invalid, to.value, fiscalYearStartMonth]);
@@ -237,7 +238,7 @@ export const TimeRangeContent = (props: Props) => {
 
 function isRangeInvalid(from: string, to: string, timezone?: string): boolean {
   const raw: RawTimeRange = { from, to };
-  const timeRange = rangeUtil.convertRawToRange(raw, timezone);
+  const timeRange = rangeUtil.convertRawToRange(raw, timezone, undefined, commonFormat);
   const valid = timeRange.from.isSame(timeRange.to) || timeRange.from.isBefore(timeRange.to);
 
   return !valid;
@@ -267,12 +268,12 @@ function valueToState(
 
 function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
   if (isDateTime(value)) {
-    return dateTimeFormat(value, { timeZone });
+    return dateTimeFormat(value, { timeZone, format: commonFormat });
   }
 
   if (value.endsWith('Z')) {
     const dt = dateTimeParse(value);
-    return dateTimeFormat(dt, { timeZone });
+    return dateTimeFormat(dt, { timeZone, format: commonFormat });
   }
 
   return value;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.ts
@@ -2,8 +2,9 @@ import { TimeOption, TimeRange, TimeZone, rangeUtil, dateTimeFormat } from '@gra
 import { formatDateRange } from '@grafana/i18n';
 
 import { getFeatureToggle } from '../../../utils/featureToggle';
+import { commonFormat } from '../commonFormat';
 export const mapOptionToTimeRange = (option: TimeOption, timeZone?: TimeZone): TimeRange => {
-  return rangeUtil.convertRawToRange({ from: option.from, to: option.to }, timeZone);
+  return rangeUtil.convertRawToRange({ from: option.from, to: option.to }, timeZone, undefined, commonFormat);
 };
 
 const rangeFormatShort: Intl.DateTimeFormatOptions = {
@@ -17,8 +18,8 @@ const rangeFormatFull: Intl.DateTimeFormatOptions = {
 };
 
 export const mapRangeToTimeOption = (range: TimeRange, timeZone?: TimeZone): TimeOption => {
-  const from = dateTimeFormat(range.from, { timeZone });
-  const to = dateTimeFormat(range.to, { timeZone });
+  const from = dateTimeFormat(range.from, { timeZone, format: commonFormat });
+  const to = dateTimeFormat(range.to, { timeZone, format: commonFormat });
 
   let display = `${from} to ${to}`;
 

--- a/packages/grafana-ui/src/components/DateTimePickers/commonFormat.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/commonFormat.ts
@@ -1,0 +1,6 @@
+import { getFeatureToggle } from '../../utils/featureToggle';
+
+// The format to use for datetime inputs when the regionalFormat option is set.
+const COMMON_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+export const commonFormat = getFeatureToggle('localeFormatPreference') ? COMMON_FORMAT : undefined;

--- a/packages/grafana-ui/src/components/DateTimePickers/commonFormat.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/commonFormat.ts
@@ -1,6 +1,6 @@
 import { getFeatureToggle } from '../../utils/featureToggle';
 
-// The format to use for datetime inputs when the regionalFormat option is set.
+// The moment.js format to use for datetime inputs when the regionalFormat option is set.
 const COMMON_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export const commonFormat = getFeatureToggle('localeFormatPreference') ? COMMON_FORMAT : undefined;

--- a/packages/grafana-ui/src/components/DateTimePickers/utils.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/utils.ts
@@ -1,15 +1,18 @@
 import { dateMath, dateTimeParse, isDateTime, TimeRange, TimeZone } from '@grafana/data';
 
+import { commonFormat } from './commonFormat';
+
 export function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
   if (isDateTime(value)) {
     return value.isValid();
   }
 
+  // handles `now` math
   if (dateMath.isMathString(value)) {
     return dateMath.isValid(value);
   }
 
-  const parsed = dateTimeParse(value, { roundUp, timeZone });
+  const parsed = dateTimeParse(value, { roundUp, timeZone, format: commonFormat });
   return parsed.isValid();
 }
 


### PR DESCRIPTION
when localeFormatPreference toggle is enabled, always use a common datetime format in TimeRangePicker

**What is this feature?**

(Toggle) Behavior change: When `localeFormatPreference` is enabled, TimeRangePicker date inputs use a fixed date format of `YYYY-MM-DD HH:mm:ss`.

**Why do we need this feature?**

With regionalFormat set, we'll be using the [browser date formatting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) which doesn't have an equivalent parsing function. For our user-editable datetime inputs, we'll shift to using a standardized (based on ISO 8601) input format.

**Who is this feature for?**

All users that adjust absolute date ranges.

**Which issue(s) does this PR fix?**:

Fixes #105384

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
