### PR TITLE
Alerting: Emit metrics from prometheus state history backend

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -708,7 +708,7 @@ func configureHistorianBackend(
 		if w == nil {
 			return nil, fmt.Errorf("failed to create alert state metrics writer")
 		}
-		backend := historian.NewRemotePrometheusBackend(pcfg, w, prometheusBackendLogger)
+		backend := historian.NewRemotePrometheusBackend(pcfg, w, prometheusBackendLogger, met)
 
 		return backend, nil
 	}

--- a/pkg/services/ngalert/state/historian/prometheus_test.go
+++ b/pkg/services/ngalert/state/historian/prometheus_test.go
@@ -1,6 +1,7 @@
 package historian
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"math"
@@ -9,12 +10,15 @@ import (
 
 	"github.com/grafana/dataplane/sdata/numeric"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	promValue "github.com/prometheus/prometheus/model/value"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
@@ -53,13 +57,15 @@ func TestNewRemotePrometheusBackend(t *testing.T) {
 
 	fakeWriter := new(fakeRemoteWriter)
 	logger := log.NewNopLogger()
+	met := metrics.NewHistorianMetrics(prometheus.NewRegistry(), "test")
 
-	backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger)
+	backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger, met)
 
 	require.NotNil(t, backend)
 	require.Equal(t, cfg.DatasourceUID, backend.cfg.DatasourceUID)
 	require.Equal(t, fakeWriter, backend.promWriter)
 	require.Equal(t, logger, backend.logger)
+	require.Equal(t, met, backend.metrics)
 }
 
 func createExpectedFrame(t *testing.T, ruleUID, ruleName, promState, grafanaState string, instanceLabels data.Labels, value float64) *data.Frame {
@@ -262,7 +268,8 @@ func TestPrometheusBackend_Record(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeWriter := new(fakeRemoteWriter)
-			backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger)
+			met := metrics.NewHistorianMetrics(prometheus.NewRegistry(), "test")
+			backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger, met)
 
 			if tc.expectedFrames != nil {
 				var extraLabels map[string]string
@@ -298,13 +305,101 @@ func TestPrometheusBackend_Query(t *testing.T) {
 	cfg := PrometheusConfig{DatasourceUID: "test-ds-uid", MetricName: testMetricName}
 	logger := log.NewNopLogger()
 	fakeWriter := new(fakeRemoteWriter)
+	met := metrics.NewHistorianMetrics(prometheus.NewRegistry(), "test")
 
-	backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger)
+	backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger, met)
 
 	frame, err := backend.Query(context.Background(), ngmodels.HistoryQuery{})
 	require.Error(t, err)
 	require.Nil(t, frame)
 	require.Contains(t, err.Error(), "prometheus historian backend does not support querying")
+}
+
+func TestPrometheusBackend_Record_Metrics(t *testing.T) {
+	cfg := PrometheusConfig{DatasourceUID: "test-ds-uid", MetricName: testMetricName}
+	logger := log.NewNopLogger()
+	ctx := context.Background()
+	orgID := int64(1)
+	now := time.Now()
+	ruleMeta := history_model.RuleMeta{Title: "test rule"}
+
+	t.Run("success metrics", func(t *testing.T) {
+		fakeWriter := new(fakeRemoteWriter)
+		fakeWriter.On("WriteDatasource", ctx, cfg.DatasourceUID, testMetricName, now, mock.Anything, orgID, mock.Anything).Return(nil).Once()
+
+		registry := prometheus.NewRegistry()
+		met := metrics.NewHistorianMetrics(registry, "test")
+		backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger, met)
+
+		states := []state.StateTransition{
+			{State: &state.State{AlertRuleUID: "rule-uid", OrgID: orgID, Labels: data.Labels{}, State: eval.Alerting, LastEvaluationTime: now}},
+			{State: &state.State{AlertRuleUID: "rule-uid-2", OrgID: orgID, Labels: data.Labels{}, State: eval.Pending, LastEvaluationTime: now}},
+			{State: &state.State{AlertRuleUID: "rule-uid-3", OrgID: orgID, Labels: data.Labels{}, State: eval.Normal, LastEvaluationTime: now}},
+		}
+
+		errCh := backend.Record(ctx, ruleMeta, states)
+		err, ok := <-errCh
+		require.True(t, ok)
+		require.NoError(t, err)
+
+		// Only 2 frames generated (Alerting + Pending), Normal state doesn't generate frames
+		expectedMetrics := `
+			# HELP grafana_test_state_history_writes_total The total number of state history batches that were attempted to be written.
+			# TYPE grafana_test_state_history_writes_total counter
+			grafana_test_state_history_writes_total{backend="prometheus",org="1"} 1
+			# HELP grafana_test_state_history_transitions_total The total number of state transitions processed.
+			# TYPE grafana_test_state_history_transitions_total counter
+			grafana_test_state_history_transitions_total{org="1"} 2
+		`
+
+		err = testutil.GatherAndCompare(registry, bytes.NewBufferString(expectedMetrics),
+			"grafana_test_state_history_writes_total",
+			"grafana_test_state_history_transitions_total")
+		require.NoError(t, err)
+		fakeWriter.AssertExpectations(t)
+	})
+
+	t.Run("failure metrics", func(t *testing.T) {
+		fakeWriter := new(fakeRemoteWriter)
+		expectedErr := errors.New("write failed")
+		fakeWriter.On("WriteDatasource", ctx, cfg.DatasourceUID, testMetricName, now, mock.Anything, orgID, mock.Anything).Return(expectedErr).Once()
+
+		registry := prometheus.NewRegistry()
+		met := metrics.NewHistorianMetrics(registry, "test")
+		backend := NewRemotePrometheusBackend(cfg, fakeWriter, logger, met)
+
+		states := []state.StateTransition{
+			{State: &state.State{AlertRuleUID: "rule-uid", OrgID: orgID, Labels: data.Labels{}, State: eval.Alerting, LastEvaluationTime: now}},
+		}
+
+		errCh := backend.Record(ctx, ruleMeta, states)
+		err, ok := <-errCh
+		require.True(t, ok)
+		require.Error(t, err)
+
+		expectedMetrics := `
+			# HELP grafana_test_state_history_writes_total The total number of state history batches that were attempted to be written.
+			# TYPE grafana_test_state_history_writes_total counter
+			grafana_test_state_history_writes_total{backend="prometheus",org="1"} 1
+			# HELP grafana_test_state_history_writes_failed_total The total number of failed writes of state history batches.
+			# TYPE grafana_test_state_history_writes_failed_total counter
+			grafana_test_state_history_writes_failed_total{backend="prometheus",org="1"} 1
+			# HELP grafana_test_state_history_transitions_total The total number of state transitions processed.
+			# TYPE grafana_test_state_history_transitions_total counter
+			grafana_test_state_history_transitions_total{org="1"} 1
+			# HELP grafana_test_state_history_transitions_failed_total The total number of state transitions that failed to be written - they are not retried.
+			# TYPE grafana_test_state_history_transitions_failed_total counter
+			grafana_test_state_history_transitions_failed_total{org="1"} 1
+		`
+
+		err = testutil.GatherAndCompare(registry, bytes.NewBufferString(expectedMetrics),
+			"grafana_test_state_history_writes_total",
+			"grafana_test_state_history_writes_failed_total",
+			"grafana_test_state_history_transitions_total",
+			"grafana_test_state_history_transitions_failed_total")
+		require.NoError(t, err)
+		fakeWriter.AssertExpectations(t)
+	})
 }
 
 func TestPrometheusBackend_Record_PanicRecovery(t *testing.T) {
@@ -320,7 +415,8 @@ func TestPrometheusBackend_Record_PanicRecovery(t *testing.T) {
 
 	panicWriter.On("WriteDatasource", ctx, cfg.DatasourceUID, testMetricName, now, mock.Anything, orgID, mock.Anything).Once()
 
-	backend := NewRemotePrometheusBackend(cfg, panicWriter, logger)
+	met := metrics.NewHistorianMetrics(prometheus.NewRegistry(), "test")
+	backend := NewRemotePrometheusBackend(cfg, panicWriter, logger, met)
 
 	states := []state.StateTransition{
 		{State: &state.State{


### PR DESCRIPTION
**What is this feature?**

A new state history backend was added in https://github.com/grafana/grafana/pull/104361. This PR adds metric to the backend, similar to already existing metrics in Loki backend.


Part of https://github.com/grafana/alerting-squad/issues/1024