### PR TITLE
Data Sources: Fix namespace

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -45,7 +45,7 @@ var (
 
 	datasourceResponseGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "plugins",
+			Namespace: "grafana",
 			Name:      "datasource_response_size",
 			Help:      "gauge of external data source response sizes returned to Grafana in bytes",
 		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},


### PR DESCRIPTION
Follow up to #104394 - the namespace was wrong and it can cause a clash with the equivalent namespace in the plugin SDK.