### PR TITLE
grpc: wrapContext should not replace existing metadata, but append to it.

### DIFF
--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -140,14 +140,14 @@ func wrapContext(ctx context.Context) (context.Context, error) {
 	}
 
 	// set grpc metadata into the context to pass to the grpc server
-	ctx = metadata.AppendToOutgoingContext(ctx, encodeIdentityInMetadata(user)...)
+	ctx = metadata.AppendToOutgoingContext(ctx, encodeIdentityInMetadataPairs(user)...)
 	return ctx, nil
 }
 
-func encodeIdentityInMetadata(user identity.Requester) []string {
+func encodeIdentityInMetadataPairs(user identity.Requester) []string {
 	id, _ := user.GetInternalID()
 
-	logger.Debug("encodeIdentityInMetadata", "user.id", user.GetID(), "user.Login", user.GetLogin(), "user.Name", user.GetName())
+	logger.Debug("encodeIdentityInMetadataPairs", "user.id", user.GetID(), "user.Login", user.GetLogin(), "user.Name", user.GetName())
 
 	return []string{
 		// This should be everything needed to recreate the user

--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -11,8 +11,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 const (
@@ -139,15 +140,16 @@ func wrapContext(ctx context.Context) (context.Context, error) {
 	}
 
 	// set grpc metadata into the context to pass to the grpc server
-	return metadata.NewOutgoingContext(ctx, encodeIdentityInMetadata(user)), nil
+	ctx = metadata.AppendToOutgoingContext(ctx, encodeIdentityInMetadata(user)...)
+	return ctx, nil
 }
 
-func encodeIdentityInMetadata(user identity.Requester) metadata.MD {
+func encodeIdentityInMetadata(user identity.Requester) []string {
 	id, _ := user.GetInternalID()
 
 	logger.Debug("encodeIdentityInMetadata", "user.id", user.GetID(), "user.Login", user.GetLogin(), "user.Name", user.GetName())
 
-	return metadata.Pairs(
+	return []string{
 		// This should be everything needed to recreate the user
 		mdToken, user.GetIDToken(),
 
@@ -161,5 +163,5 @@ func encodeIdentityInMetadata(user identity.Requester) metadata.MD {
 		// TODO, Remove after this is deployed to unified storage
 		"grafana-userid", strconv.FormatInt(id, 10),
 		"grafana-useruid", user.GetRawIdentifier(),
-	)
+	}
 }

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -40,7 +40,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 func TestWrapContext(t *testing.T) {
 	const key = "some-random-metadata"
 
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(key, "12345"))
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(key, "random-metadata"))
 	ctx, _ = identity.WithServiceIdentity(ctx, 12345)
 	var err error
 	ctx, err = wrapContext(ctx)
@@ -49,5 +49,16 @@ func TestWrapContext(t *testing.T) {
 	outmd, ok := metadata.FromOutgoingContext(ctx)
 	require.True(t, ok)
 	val := outmd.Get(key)
+	require.Equal(t, []string{"random-metadata"}, val)
+}
+
+func TestWrapContextWithNoPreviousMetadata(t *testing.T) {
+	ctx, _ := identity.WithServiceIdentity(context.Background(), 12345)
+	ctx, err := wrapContext(ctx)
+	require.NoError(t, err)
+
+	outmd, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	val := outmd.Get(mdOrgID)
 	require.Equal(t, []string{"12345"}, val)
 }

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -25,7 +25,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 
 	auth := &Authenticator{Tracer: noop.NewTracerProvider().Tracer("")}
 
-	md := encodeIdentityInMetadata(before)
+	md := encodeIdentityInMetadataPairs(before)
 	after, err := auth.decodeMetadata(metadata.Pairs(md...))
 	require.NoError(t, err)
 	require.Equal(t, before.GetID(), after.GetID())

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -1,13 +1,16 @@
 package grpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 
 	claims "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 func TestBasicEncodeDecode(t *testing.T) {
@@ -23,7 +26,7 @@ func TestBasicEncodeDecode(t *testing.T) {
 	auth := &Authenticator{Tracer: noop.NewTracerProvider().Tracer("")}
 
 	md := encodeIdentityInMetadata(before)
-	after, err := auth.decodeMetadata(md)
+	after, err := auth.decodeMetadata(metadata.Pairs(md...))
 	require.NoError(t, err)
 	require.Equal(t, before.GetID(), after.GetID())
 	require.Equal(t, before.GetUID(), after.GetUID())
@@ -32,4 +35,19 @@ func TestBasicEncodeDecode(t *testing.T) {
 	require.Equal(t, before.GetOrgID(), after.GetOrgID())
 	require.Equal(t, before.GetOrgName(), after.GetOrgName())
 	require.Equal(t, before.GetOrgRole(), after.GetOrgRole())
+}
+
+func TestWrapContext(t *testing.T) {
+	const key = "some-random-metadata"
+
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(key, "12345"))
+	ctx, _ = identity.WithServiceIdentity(ctx, 12345)
+	var err error
+	ctx, err = wrapContext(ctx)
+	require.NoError(t, err)
+
+	outmd, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	val := outmd.Get(key)
+	require.Equal(t, []string{"12345"}, val)
 }


### PR DESCRIPTION
`grpc.wrapContext` was previously replacing all metadata in the context with its own metadata, but this prevented use of metadata as a communication mechanism between client and server, eg. as used in `BulkProcess` call.