### PR TITLE
Unistore: save should use a Reader not ReadCloser

### DIFF
--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -42,7 +42,7 @@ type KV interface {
 	Get(ctx context.Context, section string, key string) (KVObject, error)
 
 	// Save a new value
-	Save(ctx context.Context, section string, key string, value io.ReadCloser) error
+	Save(ctx context.Context, section string, key string, value io.Reader) error
 
 	// Delete a value
 	Delete(ctx context.Context, section string, key string) error
@@ -51,6 +51,8 @@ type KV interface {
 	// This is used to ensure the server and client are not too far apart in time.
 	UnixTimestamp(ctx context.Context) (int64, error)
 }
+
+var _ KV = &badgerKV{}
 
 // Reference implementation of the KV interface using BadgerDB
 // This is only used for testing purposes, and will not work HA
@@ -97,7 +99,7 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObjec
 	return out, nil
 }
 
-func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.ReadCloser) error {
+func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.Reader) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
 	}

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -62,7 +62,7 @@ func TestBadgerKV_Save(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Save new key", func(t *testing.T) {
-		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("value1"))))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
 		require.NoError(t, err)
 
 		// Verify the value was saved
@@ -77,11 +77,11 @@ func TestBadgerKV_Save(t *testing.T) {
 
 	t.Run("Save overwrite existing key", func(t *testing.T) {
 		// First save
-		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("oldvalue"))))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("oldvalue")))
 		require.NoError(t, err)
 
 		// Overwrite
-		err = kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("newvalue"))))
+		err = kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("newvalue")))
 		require.NoError(t, err)
 
 		// Verify the value was updated
@@ -103,7 +103,7 @@ func TestBadgerKV_Delete(t *testing.T) {
 
 	t.Run("Delete existing key", func(t *testing.T) {
 		// First create a key
-		err := kv.Save(ctx, "section", "key1", io.NopCloser(bytes.NewReader([]byte("value1"))))
+		err := kv.Save(ctx, "section", "key1", bytes.NewReader([]byte("value1")))
 		require.NoError(t, err)
 
 		// Delete it
@@ -136,7 +136,7 @@ func setupIteratorTestData(t *testing.T) (*badgerKV, context.Context) {
 	// Setup test data
 	keys := []string{"a1", "a2", "b1", "b2", "c1"}
 	for _, k := range keys {
-		err := kv.Save(ctx, "section", k, io.NopCloser(bytes.NewReader([]byte("value"+k))))
+		err := kv.Save(ctx, "section", k, bytes.NewReader([]byte("value"+k)))
 		require.NoError(t, err)
 	}
 
@@ -221,7 +221,7 @@ func TestBadgerKV_Concurrent(t *testing.T) {
 				value := []byte(fmt.Sprintf("value%d", i))
 
 				// Save
-				err := kv.Save(ctx, "section", key, io.NopCloser(bytes.NewReader(value)))
+				err := kv.Save(ctx, "section", key, bytes.NewReader(value))
 				require.NoError(t, err)
 
 				// Get


### PR DESCRIPTION
Small change to the kvstore to use a Reader instead of a ReadCloser