### PR TITLE
Zanzana: add flag for running zanzana server insecurely

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -178,7 +178,7 @@ func (z *Zanzana) start(ctx context.Context) error {
 	}
 
 	var authenticatorInterceptor interceptors.Authenticator
-	if z.cfg.ZanzanaServer.AllowInsecure {
+	if z.cfg.ZanzanaServer.AllowInsecure && z.cfg.Env == setting.Dev {
 		z.logger.Info("Allowing insecure connections to OpenFGA HTTP server")
 		authenticatorInterceptor = noopAuthenticator{}
 	} else {

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -46,6 +46,8 @@ type ZanzanaServerSettings struct {
 	UseStreamedListObjects bool
 	// URL for fetching signing keys.
 	SigningKeysURL string
+	// Allow insecure connections to the server for development purposes.
+	AllowInsecure bool
 }
 
 func (cfg *Cfg) readZanzanaSettings() {
@@ -77,6 +79,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zs.ListObjectsMaxResults = uint32(serverSec.Key("list_objects_max_results").MustUint(1000))
 	zs.UseStreamedListObjects = serverSec.Key("use_streamed_list_objects").MustBool(false)
 	zs.SigningKeysURL = serverSec.Key("signing_keys_url").MustString("")
+	zs.AllowInsecure = serverSec.Key("allow_insecure").MustBool(false)
 
 	cfg.ZanzanaServer = zs
 }


### PR DESCRIPTION
**What is this feature?**

Adds a config flag to allow for allowing the OpenFTA HTTP server (Zanzana) to be accessed without authentication.  This simplifies local development.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1358