### PR TITLE
SecureValues: Use util package to generate resource names for less collision

### DIFF
--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -36,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -698,10 +698,10 @@ func (b *SecretAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, o
 	if operation == admission.Create && a.GetName() == "" {
 		switch typedObj := obj.(type) {
 		case *secretv0alpha1.SecureValue:
-			typedObj.Name = names.SimpleNameGenerator.GenerateName(cmp.Or(typedObj.GenerateName, "sv-"))
+			typedObj.SetName(cmp.Or(typedObj.GetGenerateName(), "sv-") + util.GenerateShortUID())
 
 		case *secretv0alpha1.Keeper:
-			typedObj.Name = names.SimpleNameGenerator.GenerateName(cmp.Or(typedObj.GenerateName, "kp-"))
+			typedObj.SetName(cmp.Or(typedObj.GetGenerateName(), "kp-") + util.GenerateShortUID())
 		}
 	}
 


### PR DESCRIPTION
The previous method only generates 5 characters long IDs with a limited alphabet, which is useful for ephemeral resources like pods, but not so much for secrets which are more long lived.