### PR TITLE
fix: migration cli pass in feature toggle management into unified client

### DIFF
--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
@@ -219,9 +219,14 @@ func promptYesNo(prompt string) (bool, error) {
 }
 
 func newUnifiedClient(cfg *setting.Cfg, sqlStore db.DB) (resource.ResourceClient, error) {
+	featureManager, err := featuremgmt.ProvideManagerService(cfg)
+	if err != nil {
+		return nil, err
+	}
+	featureToggles := featuremgmt.ProvideToggles(featureManager)
 	return unified.ProvideUnifiedStorageClient(&unified.Options{
 		Cfg:      cfg,
-		Features: featuremgmt.WithFeatures(), // none??
+		Features: featureToggles,
 		DB:       sqlStore,
 		Tracer:   tracing.NewNoopTracerService(),
 		Reg:      prometheus.NewPedanticRegistry(),


### PR DESCRIPTION
We are passing a null feature toggle manager into the unified client used in migration cli. This PR tackles this issue.