### PR TITLE
Documentation: Add SCIM to Public Preview Feature toggle list

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -114,6 +114,8 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `alertRuleRestore`                    | Enables the alert rule restore feature                                                                                                                        |
 | `azureMonitorLogsBuilderEditor`       | Enables the logs builder mode for the Azure Monitor data source                                                                                               |
 | `logsPanelControls`                   | Enables a control component for the logs panel in Explore                                                                                                     |
+| `enableSCIM`                          | Enables SCIM provisioning for SAML                                                                                                                            |
+
 
 ## Development feature toggles
 


### PR DESCRIPTION
The SCIM Feature is public preview and is missing from the FT list.

https://grafana.com/docs/grafana/next/setup-grafana/configure-security/configure-scim-provisioning/

https://grafana.com/blog/2025/05/14/introducing-scim-provisioning-in-grafana-enterprise-grade-user-management-made-simple/

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
