### PR TITLE
BarChart/StateTimeline: Use noValue setting for error message when data is empty

### DIFF
--- a/public/app/core/components/TimelineChart/utils.test.ts
+++ b/public/app/core/components/TimelineChart/utils.test.ts
@@ -64,12 +64,14 @@ describe('prepare timeline graph', () => {
 
   it('errors with no frame', () => {
     const info = prepareTimelineFields(undefined, true, timeRange, theme);
-    expect(info.warn).toEqual('No data in response');
+    expect(info.frames).toBeUndefined();
+    expect(info.warn).toBe('');
   });
 
   it('errors with empty frame', () => {
     const info = prepareTimelineFields([], true, timeRange, theme);
-    expect(info.warn).toBeUndefined();
+    expect(info.frames).toBeUndefined();
+    expect(info.warn).toBe('');
   });
 
   it('will merge duplicate values', () => {

--- a/public/app/core/components/TimelineChart/utils.test.ts
+++ b/public/app/core/components/TimelineChart/utils.test.ts
@@ -62,6 +62,21 @@ describe('prepare timeline graph', () => {
     expect(info.warn).toEqual('No graphable fields');
   });
 
+  it('errors with no frame', () => {
+    const info = prepareTimelineFields(undefined, true, timeRange, theme);
+    expect(info.warn).toEqual('No data in response');
+  });
+
+  it('errors with empty frame', () => {
+    const info = prepareTimelineFields([], true, timeRange, theme);
+    expect(info.warn).toEqual('No data in response');
+  });
+
+  it('supports override text when no data is present', () => {
+    const info = prepareTimelineFields(undefined, true, timeRange, theme, "Well, that's awkward!");
+    expect(info.warn).toEqual("Well, that's awkward!");
+  });
+
   it('will merge duplicate values', () => {
     const frames = [
       toDataFrame({

--- a/public/app/core/components/TimelineChart/utils.test.ts
+++ b/public/app/core/components/TimelineChart/utils.test.ts
@@ -69,12 +69,7 @@ describe('prepare timeline graph', () => {
 
   it('errors with empty frame', () => {
     const info = prepareTimelineFields([], true, timeRange, theme);
-    expect(info.warn).toEqual('No data in response');
-  });
-
-  it('supports override text when no data is present', () => {
-    const info = prepareTimelineFields(undefined, true, timeRange, theme, "Well, that's awkward!");
-    expect(info.warn).toEqual("Well, that's awkward!");
+    expect(info.warn).toBeUndefined();
   });
 
   it('will merge duplicate values', () => {

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -308,11 +308,10 @@ export function prepareTimelineFields(
   series: DataFrame[] | undefined,
   mergeValues: boolean,
   timeRange: TimeRange,
-  theme: GrafanaTheme2,
-  noValue = t('timeline.no-value.default', 'No data in response')
+  theme: GrafanaTheme2
 ): { frames?: DataFrame[]; warn?: string } {
   if (!series?.length) {
-    return { warn: noValue };
+    return { warn: undefined };
   }
 
   cacheFieldDisplayNames(series);

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -310,8 +310,9 @@ export function prepareTimelineFields(
   timeRange: TimeRange,
   theme: GrafanaTheme2
 ): { frames?: DataFrame[]; warn?: string } {
+  // this allows PanelDataErrorView to show the default noValue message
   if (!series?.length) {
-    return { warn: undefined };
+    return { warn: '' };
   }
 
   cacheFieldDisplayNames(series);

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -23,6 +23,7 @@ import {
   SpecialValueMatch,
 } from '@grafana/data';
 import { maybeSortFrame, NULL_RETAIN } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
 import {
   VizLegendOptions,
   AxisPlacement,
@@ -307,10 +308,11 @@ export function prepareTimelineFields(
   series: DataFrame[] | undefined,
   mergeValues: boolean,
   timeRange: TimeRange,
-  theme: GrafanaTheme2
+  theme: GrafanaTheme2,
+  noValue = t('timeline.no-value.default', 'No data in response')
 ): { frames?: DataFrame[]; warn?: string } {
   if (!series?.length) {
-    return { warn: 'No data in response' };
+    return { warn: noValue };
   }
 
   cacheFieldDisplayNames(series);
@@ -436,10 +438,10 @@ export function prepareTimelineFields(
   }
 
   if (!hasTimeseries) {
-    return { warn: 'Data does not have a time field' };
+    return { warn: t('timeline.missing-field.time', 'Data does not have a time field') };
   }
   if (!frames.length) {
-    return { warn: 'No graphable fields' };
+    return { warn: t('timeline.missing-field.all', 'No graphable fields') };
   }
 
   return { frames };

--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -8,7 +8,7 @@ import {
   VisualizationSuggestion,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { PanelDataErrorViewProps, locationService } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
@@ -132,22 +132,22 @@ function getMessageFor(
   }
 
   if (!data.series || data.series.length === 0 || data.series.every((frame) => frame.length === 0)) {
-    return fieldConfig?.defaults.noValue ?? 'No data';
+    return fieldConfig?.defaults.noValue ?? t('panel.panel-data-error-view.no-value.default', 'No data');
   }
 
   if (needsStringField && !dataSummary.hasStringField) {
-    return 'Data is missing a string field';
+    return t('panel.panel-data-error-view.missing-value.string', 'Data is missing a string field');
   }
 
   if (needsNumberField && !dataSummary.hasNumberField) {
-    return 'Data is missing a number field';
+    return t('panel.panel-data-error-view.missing-value.number', 'Data is missing a number field');
   }
 
   if (needsTimeField && !dataSummary.hasTimeField) {
-    return 'Data is missing a time field';
+    return t('panel.panel-data-error-view.missing-value.time', 'Data is missing a time field');
   }
 
-  return 'Cannot visualize data';
+  return t('panel.panel-data-error-view.missing-value.unknown', 'Cannot visualize data');
 }
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -173,6 +173,18 @@ describe('BarChart utils', () => {
       expect(warning.warn).toEqual('No data in response');
     });
 
+    it('will warn when there is no frames in the response', () => {
+      const info = prepSeries(
+        [],
+        { ...fieldConfig, defaults: { noValue: 'Uh oh!' } },
+        StackingMode.None,
+        createTheme()
+      );
+      const warning = assertIsDefined('warn' in info ? info : null);
+
+      expect(warning.warn).toEqual('Uh oh!');
+    });
+
     it('will warn when there is no data in the response', () => {
       const info = prepSeries(
         [

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -166,26 +166,14 @@ describe('BarChart utils', () => {
   });
 
   describe('prepareGraphableFrames', () => {
-    it('will warn when there is no frames in the response', () => {
+    it('will return undefined when there is no frames in the response', () => {
       const info = prepSeries([], fieldConfig, StackingMode.None, createTheme());
-      const warning = assertIsDefined('warn' in info ? info : null);
 
-      expect(warning.warn).toEqual('No data in response');
+      expect(info.warn).toBe('');
+      expect(info.series).toHaveLength(0);
     });
 
-    it('will use a custom message for the no frames messages if provided', () => {
-      const info = prepSeries(
-        [],
-        { ...fieldConfig, defaults: { noValue: 'Uh oh!' } },
-        StackingMode.None,
-        createTheme()
-      );
-      const warning = assertIsDefined('warn' in info ? info : null);
-
-      expect(warning.warn).toEqual('Uh oh!');
-    });
-
-    it('will warn when there is no data in the response', () => {
+    it('will return undefined when there is no data in the response', () => {
       const info = prepSeries(
         [
           {
@@ -197,9 +185,9 @@ describe('BarChart utils', () => {
         StackingMode.None,
         createTheme()
       );
-      const warning = assertIsDefined('warn' in info ? info : null);
 
-      expect(warning.warn).toEqual('No data in response');
+      expect(info.warn).toBe('');
+      expect(info.series).toHaveLength(0);
     });
 
     it('will warn when there is no string or time field', () => {
@@ -213,7 +201,7 @@ describe('BarChart utils', () => {
 
       const info = prepSeries([df], fieldConfig, StackingMode.None, createTheme());
       const warning = assertIsDefined('warn' in info ? info : null);
-      expect(warning.warn).toEqual('Bar charts requires a string or time field');
+      expect(warning.warn).toEqual('Bar charts require a string or time field');
     });
 
     it('will warn when there are no numeric fields in the response', () => {

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -173,7 +173,7 @@ describe('BarChart utils', () => {
       expect(warning.warn).toEqual('No data in response');
     });
 
-    it('will warn when there is no frames in the response', () => {
+    it('will use a custom message for the no frames messages if provided', () => {
       const info = prepSeries(
         [],
         { ...fieldConfig, defaults: { noValue: 'Uh oh!' } },

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -166,14 +166,14 @@ describe('BarChart utils', () => {
   });
 
   describe('prepareGraphableFrames', () => {
-    it('will return undefined when there is no frames in the response', () => {
+    it('will return empty string when there are no frames in the response', () => {
       const info = prepSeries([], fieldConfig, StackingMode.None, createTheme());
 
       expect(info.warn).toBe('');
       expect(info.series).toHaveLength(0);
     });
 
-    it('will return undefined when there is no data in the response', () => {
+    it('will return empty string when there is no data in the response', () => {
       const info = prepSeries(
         [
           {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -61,7 +61,6 @@ export function prepSeries(
     return {
       series: [],
       _rest: [],
-      warn: fieldConfig.defaults.noValue ?? t('barchart.no-value.default-message', 'No data in response'),
     };
   }
 
@@ -125,7 +124,7 @@ export function prepSeries(
     let warn: string | null = null;
 
     if (fields.length === 1) {
-      warn = 'No numeric fields found';
+      warn = t('bar-chart.warn.missing-numeric', 'No numeric fields found');
     }
 
     frame.fields = fields;
@@ -146,7 +145,7 @@ export function prepSeries(
     series: [],
     _rest: [],
     color: null,
-    warn: 'Bar charts requires a string or time field',
+    warn: t('bar-chart.warn.missing-series', 'Bar charts require a string or time field'),
   };
 }
 

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -14,6 +14,7 @@ import {
   outerJoinDataFrames,
 } from '@grafana/data';
 import { decoupleHideFromState } from '@grafana/data/internal';
+import { t } from '@grafana/i18n';
 import {
   AxisColorMode,
   AxisPlacement,
@@ -57,7 +58,12 @@ export function prepSeries(
   colorFieldName?: string
 ): BarSeries {
   if (frames.length === 0 || frames.every((fr) => fr.length === 0)) {
-    return { series: [], _rest: [], warn: 'No data in response' };
+    // TODO this should be localized
+    return {
+      series: [],
+      _rest: [],
+      warn: fieldConfig.defaults.noValue ?? t('barchart.no-value.default-message', 'No data in response'),
+    };
   }
 
   cacheFieldDisplayNames(frames);

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -58,7 +58,6 @@ export function prepSeries(
   colorFieldName?: string
 ): BarSeries {
   if (frames.length === 0 || frames.every((fr) => fr.length === 0)) {
-    // TODO this should be localized
     return {
       series: [],
       _rest: [],

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -57,8 +57,10 @@ export function prepSeries(
   xFieldName?: string,
   colorFieldName?: string
 ): BarSeries {
+  // this allows PanelDataErrorView to show the default noValue message
   if (frames.length === 0 || frames.every((fr) => fr.length === 0)) {
     return {
+      warn: '',
       series: [],
       _rest: [],
     };

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { DashboardCursorSync, PanelProps } from '@grafana/data';
+import { PanelDataErrorView } from '@grafana/runtime';
 import {
   AxisPlacement,
   EventBusPlugin,
@@ -40,6 +41,7 @@ export const StateTimelinePanel = ({
   fieldConfig,
   replaceVariables,
   onChangeTimeRange,
+  id: panelId,
 }: TimelinePanelProps) => {
   const theme = useTheme2();
 
@@ -49,9 +51,8 @@ export const StateTimelinePanel = ({
   const cursorSync = sync?.() ?? DashboardCursorSync.Off;
 
   const { frames, warn } = useMemo(
-    () =>
-      prepareTimelineFields(data.series, options.mergeValues ?? true, timeRange, theme, fieldConfig.defaults.noValue),
-    [data.series, options.mergeValues, timeRange, theme, fieldConfig.defaults.noValue]
+    () => prepareTimelineFields(data.series, options.mergeValues ?? true, timeRange, theme),
+    [data.series, options.mergeValues, timeRange, theme]
   );
 
   const { paginatedFrames, paginationRev, paginationElement, paginationHeight } = usePagination(
@@ -67,11 +68,7 @@ export const StateTimelinePanel = ({
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
 
   if (!paginatedFrames || warn) {
-    return (
-      <div className="panel-empty">
-        <p>{warn ?? 'No data found in response'}</p>
-      </div>
-    );
+    return <PanelDataErrorView panelId={panelId} fieldConfig={fieldConfig} data={data} message={warn} needsTimeField />;
   }
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -37,6 +37,7 @@ export const StateTimelinePanel = ({
   options,
   width,
   height,
+  fieldConfig,
   replaceVariables,
   onChangeTimeRange,
 }: TimelinePanelProps) => {
@@ -48,8 +49,9 @@ export const StateTimelinePanel = ({
   const cursorSync = sync?.() ?? DashboardCursorSync.Off;
 
   const { frames, warn } = useMemo(
-    () => prepareTimelineFields(data.series, options.mergeValues ?? true, timeRange, theme),
-    [data.series, options.mergeValues, timeRange, theme]
+    () =>
+      prepareTimelineFields(data.series, options.mergeValues ?? true, timeRange, theme, fieldConfig.defaults.noValue),
+    [data.series, options.mergeValues, timeRange, theme, fieldConfig.defaults.noValue]
   );
 
   const { paginatedFrames, paginationRev, paginationElement, paginationHeight } = usePagination(

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -67,7 +67,7 @@ export const StateTimelinePanel = ({
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
 
-  if (!paginatedFrames || warn) {
+  if (!paginatedFrames || typeof warn === 'string') {
     return <PanelDataErrorView panelId={panelId} fieldConfig={fieldConfig} data={data} message={warn} needsTimeField />;
   }
 

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { DashboardCursorSync, PanelProps } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { PanelDataErrorView } from '@grafana/runtime';
 import {
   AxisPlacement,
   EventBusPlugin,
@@ -41,6 +42,7 @@ export const StatusHistoryPanel = ({
   fieldConfig,
   replaceVariables,
   onChangeTimeRange,
+  id: panelId,
 }: TimelinePanelProps) => {
   const theme = useTheme2();
 
@@ -51,9 +53,9 @@ export const StatusHistoryPanel = ({
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
 
-  const { frames, warn } = useMemo(
-    () => prepareTimelineFields(data.series, false, timeRange, theme, fieldConfig.defaults.noValue),
-    [data.series, timeRange, theme, fieldConfig.defaults.noValue]
+  const { warn, frames } = useMemo(
+    () => prepareTimelineFields(data.series, false, timeRange, theme),
+    [data.series, timeRange, theme]
   );
 
   const { paginatedFrames, paginationRev, paginationElement, paginationHeight } = usePagination(
@@ -69,11 +71,7 @@ export const StatusHistoryPanel = ({
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
 
   if (!paginatedFrames || warn) {
-    return (
-      <div className="panel-empty">
-        <p>{warn ?? 'No data found in response'}</p>
-      </div>
-    );
+    return <PanelDataErrorView panelId={panelId} fieldConfig={fieldConfig} data={data} message={warn} needsTimeField />;
   }
 
   // Status grid requires some space between values

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -38,6 +38,7 @@ export const StatusHistoryPanel = ({
   options,
   width,
   height,
+  fieldConfig,
   replaceVariables,
   onChangeTimeRange,
 }: TimelinePanelProps) => {
@@ -51,8 +52,8 @@ export const StatusHistoryPanel = ({
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
 
   const { frames, warn } = useMemo(
-    () => prepareTimelineFields(data.series, false, timeRange, theme),
-    [data.series, timeRange, theme]
+    () => prepareTimelineFields(data.series, false, timeRange, theme, fieldConfig.defaults.noValue),
+    [data.series, timeRange, theme, fieldConfig.defaults.noValue]
   );
 
   const { paginatedFrames, paginationRev, paginationElement, paginationHeight } = usePagination(

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -53,7 +53,7 @@ export const StatusHistoryPanel = ({
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
 
-  const { warn, frames } = useMemo(
+  const { frames, warn } = useMemo(
     () => prepareTimelineFields(data.series, false, timeRange, theme),
     [data.series, timeRange, theme]
   );

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -70,7 +70,7 @@ export const StatusHistoryPanel = ({
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
 
-  if (!paginatedFrames || warn) {
+  if (!paginatedFrames || typeof warn === 'string') {
     return <PanelDataErrorView panelId={panelId} fieldConfig={fieldConfig} data={data} message={warn} needsTimeField />;
   }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3255,6 +3255,12 @@
   "auth-config-auth-config-page-unconnected": {
     "subtitle": "Manage your auth settings and configure single sign-on. Find out more in our <2>documentation</2>."
   },
+  "bar-chart": {
+    "warn": {
+      "missing-numeric": "No numeric fields found",
+      "missing-series": "Bar charts require a string or time field"
+    }
+  },
   "barchart": {
     "config": {
       "category-thresholds": "Thresholds",
@@ -3295,9 +3301,6 @@
         "label-constant": "Constant",
         "label-negative-y": "Negative Y"
       }
-    },
-    "no-value": {
-      "default-message": "No data in response"
     },
     "tick-spacing-editor": {
       "content-require-space-from-the-right-side": "Require space from the right side",
@@ -11610,9 +11613,6 @@
     "missing-field": {
       "all": "No graphable fields",
       "time": "Data does not have a time field"
-    },
-    "no-value": {
-      "default": "No data in response"
     }
   },
   "timeseries": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3296,6 +3296,9 @@
         "label-negative-y": "Negative Y"
       }
     },
+    "no-value": {
+      "default-message": "No data in response"
+    },
     "tick-spacing-editor": {
       "content-require-space-from-the-right-side": "Require space from the right side",
       "gaps-options": {
@@ -9494,6 +9497,15 @@
       "view": "View"
     },
     "panel-data-error-view": {
+      "missing-value": {
+        "number": "Data is missing a number field",
+        "string": "Data is missing a string field",
+        "time": "Data is missing a time field",
+        "unknown": "Cannot visualize data"
+      },
+      "no-value": {
+        "default": "No data"
+      },
       "open-visualization-suggestions": "Open visualization suggestions",
       "switch-to-table": "Switch to table"
     },
@@ -11592,6 +11604,15 @@
     "zone": {
       "select-aria-label": "Time zone picker",
       "select-search-input": "Type to search (country, city, abbreviation)"
+    }
+  },
+  "timeline": {
+    "missing-field": {
+      "all": "No graphable fields",
+      "time": "Data does not have a time field"
+    },
+    "no-value": {
+      "default": "No data in response"
     }
   },
   "timeseries": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In PanelDataErrorView, [we use fieldConfig.defaults.noValue as the "no data" message if it is set](https://github.com/grafana/grafana/). Some visualizations do not use this, and so their messages were not overrideable with this config value. This PR updates BarChart and StateTimeline to use this value if it's set.

_Additionally, the default messages are hardcoded in utils files, which were not picked up in recent sweeps of values which needed translation. I've taken the liberty of adding them to the i18n config._

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #88004
Relates to https://github.com/grafana/support-escalations/issues/16514

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
