### PR TITLE
CI: use main, not my branch in release-build.yml

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -178,7 +178,7 @@ jobs:
           retention-days: 1
   publish-artifacts:
     name: Upload artifacts
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@km/prerelease-builds-gha
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
     permissions:
       id-token: write
     needs:


### PR DESCRIPTION
Missed a reference that needed to change from my branch to main :sweat_smile: 