### PR TITLE
Dashboard: POC for adding to dashboard with grafana/runtime from external drilldown app

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -67,3 +67,8 @@ export {
   getCorrelationsService,
   setCorrelationsService,
 } from './services/CorrelationsService';
+export {
+  type AddToDashboardService,
+  getAddToDashboardService,
+  setAddToDashboardService,
+} from './services/AddToDashboardService';

--- a/packages/grafana-runtime/src/services/AddToDashboardService.ts
+++ b/packages/grafana-runtime/src/services/AddToDashboardService.ts
@@ -1,5 +1,6 @@
-import { Panel } from '@grafana/schema';
 import { ComponentType } from 'react';
+
+import { Panel } from '@grafana/schema';
 
 /**
  * Used to work with user defined addToDashboard.

--- a/packages/grafana-runtime/src/services/AddToDashboardService.ts
+++ b/packages/grafana-runtime/src/services/AddToDashboardService.ts
@@ -1,0 +1,42 @@
+import { Panel } from '@grafana/schema';
+import { ComponentType } from 'react';
+
+/**
+ * Used to work with user defined addToDashboard.
+ * Should be accessed via {@link getAddToDashboardService} function.
+ *
+ * @alpha
+ */
+export interface AddToDashboardService {
+  /**
+   * Returns a React component for the add to dashboard modal
+   *
+   * @returns ExploreToDashboardPanel component
+   */
+  getExploreToDashboardPanel: () => ComponentType<{
+    onClose: () => void;
+    exploreId: string;
+    panel?: Panel;
+  }>;
+}
+
+let singletonInstance: AddToDashboardService;
+
+/**
+ * Used during startup by Grafana to set the AddToDashboardService so it is available
+ * via {@link getAddToDashboardService} to the rest of the application.
+ *
+ * @internal
+ */
+export function setAddToDashboardService(instance: AddToDashboardService) {
+  singletonInstance = instance;
+}
+
+/**
+ * Used to retrieve the {@link AddToDashboardService}.
+ *
+ * @alpha
+ */
+export function getAddToDashboardService(): AddToDashboardService {
+  return singletonInstance;
+}

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -71,6 +71,7 @@ import { loadTranslations } from './core/internationalization/loadTranslations';
 import { postInitTasks, preInitTasks } from './core/lifecycle-hooks';
 import { setMonacoEnv } from './core/monacoEnv';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
+import { AddToDashboardService } from './core/services/AddToDashboardService';
 import { CorrelationsService } from './core/services/CorrelationsService';
 import { NewFrontendAssetsChecker } from './core/services/NewFrontendAssetsChecker';
 import { backendSrv } from './core/services/backend_srv';
@@ -114,7 +115,6 @@ import { createQueryVariableAdapter } from './features/variables/query/adapter';
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
-import { AddToDashboardService } from './core/services/AddToDashboardService';
 
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -42,6 +42,7 @@ import {
   setFolderPicker,
   setCorrelationsService,
   setPluginFunctionsHook,
+  setAddToDashboardService,
 } from '@grafana/runtime';
 import {
   setGetObservablePluginComponents,
@@ -113,6 +114,7 @@ import { createQueryVariableAdapter } from './features/variables/query/adapter';
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
+import { AddToDashboardService } from './core/services/AddToDashboardService';
 
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
@@ -168,6 +170,8 @@ export class GrafanaApp {
       setTimeZoneResolver(() => config.bootData.user.timezone);
       initGrafanaLive();
       setCurrentUser(contextSrv.user);
+      // set the singleton that exposes the add to dashboard component
+      setAddToDashboardService(new AddToDashboardService());
 
       initAuthConfig();
 

--- a/public/app/core/services/AddToDashboardService.ts
+++ b/public/app/core/services/AddToDashboardService.ts
@@ -1,0 +1,9 @@
+import { type AddToDashboardService as AddToDashboardServiceInterface } from '@grafana/runtime';
+import { ExploreToDashboardPanel } from 'app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel';
+
+export class AddToDashboardService implements AddToDashboardServiceInterface {
+  // Expose the AddToDashboardForm component here
+  getExploreToDashboardPanel() {
+    return ExploreToDashboardPanel;
+  }
+}

--- a/public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx
@@ -41,7 +41,7 @@ export interface Props<TOptions = undefined> {
   children?: React.ReactNode;
 }
 
-export function AddToDashboardForm<TOptions = undefined>({
+export function AddToDashboardForm<TOptions extends string | undefined = undefined>({
   onClose,
   buildPanel,
   timeRange,
@@ -90,8 +90,14 @@ export function AddToDashboardForm<TOptions = undefined>({
       saveTarget: data.saveTarget,
       queries: panel.targets,
     });
-
-    const error = addToDashboard({ dashboardUid, panel, openInNewTab, timeRange });
+    // simple type assertion to make TS happy
+    const error = addToDashboard({
+      dashboardUid,
+      panel,
+      openInNewTab,
+      timeRange,
+      options,
+    });
     if (error) {
       setSubmissionError(error);
       return;

--- a/public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx
@@ -90,7 +90,6 @@ export function AddToDashboardForm<TOptions extends string | undefined = undefin
       saveTarget: data.saveTarget,
       queries: panel.targets,
     });
-    // simple type assertion to make TS happy
     const error = addToDashboard({
       dashboardUid,
       panel,

--- a/public/app/features/dashboard-scene/addToDashboard/addToDashboard.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addToDashboard.ts
@@ -87,7 +87,7 @@ export function addToDashboard({
   }
   let navigateToDashboardUrl = locationUtil.stripBaseFromUrl(dashboardURL);
 
-  if (options && options === 'external-app') {
+  if (options === 'external-app') {
     navigateToDashboardUrl = '/' + navigateToDashboardUrl;
   }
 

--- a/public/app/features/dashboard-scene/addToDashboard/addToDashboard.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addToDashboard.ts
@@ -26,6 +26,8 @@ interface AddPanelToDashboardOptions {
   dashboardUid?: string;
   openInNewTab?: boolean;
   timeRange?: TimeRange;
+  // placeholder for external app options, which is only necessary for navigation to the correct URL at the moment
+  options?: string;
 }
 
 export function addToDashboard({
@@ -33,6 +35,7 @@ export function addToDashboard({
   dashboardUid,
   openInNewTab,
   timeRange,
+  options,
 }: AddPanelToDashboardOptions): SubmissionError | undefined {
   let dto: DashboardDTO = {
     meta: {},
@@ -82,8 +85,14 @@ export function addToDashboard({
 
     return;
   }
+  let navigateToDashboardUrl = locationUtil.stripBaseFromUrl(dashboardURL);
 
-  locationService.push(locationUtil.stripBaseFromUrl(dashboardURL));
+  if (options && options === 'external-app') {
+    navigateToDashboardUrl = '/' + navigateToDashboardUrl;
+  }
+
+  locationService.push(navigateToDashboardUrl);
+
   return;
 }
 

--- a/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
@@ -2,6 +2,8 @@ import { type ReactElement } from 'react';
 
 import { AddToDashboardForm } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardForm';
 import { useSelector } from 'app/types';
+import { TimeRange } from '@grafana/data';
+import { Panel } from '@grafana/schema';
 
 import { getExploreItemSelector } from '../../state/selectors';
 
@@ -10,22 +12,42 @@ import { buildDashboardPanelFromExploreState } from './addToDashboard';
 interface Props {
   onClose: () => void;
   exploreId: string;
+  // explore apps can send a panel and time range for now
+  panelData?: { panel: Panel; range: TimeRange };
 }
 
 export function ExploreToDashboardPanel(props: Props): ReactElement {
-  const { exploreId, onClose } = props;
-  const exploreItem = useSelector(getExploreItemSelector(exploreId))!;
+  const { exploreId, onClose, panelData } = props;
+
+  // the props can include a prebuilt panel json object to use over the explore item
+  const exploreItem = panelData ? undefined : useSelector(getExploreItemSelector(exploreId));
 
   const buildPanel = () => {
-    return buildDashboardPanelFromExploreState({
-      datasource: exploreItem.datasourceInstance?.getRef(),
-      queries: exploreItem.queries,
-      queryResponse: exploreItem.queryResponse,
-      panelState: exploreItem?.panelsState,
-    });
-  };
+    if (panelData) {
+      return panelData.panel;
+    }
 
-  return (
-    <AddToDashboardForm onClose={onClose} buildPanel={buildPanel} timeRange={exploreItem.range} options={undefined} />
-  );
+    if (exploreItem) {
+      return buildDashboardPanelFromExploreState({
+        datasource: exploreItem.datasourceInstance?.getRef(),
+        queries: exploreItem.queries,
+        queryResponse: exploreItem.queryResponse,
+        panelState: exploreItem.panelsState,
+      });
+    }
+
+    // Return a default panel if neither panelData nor exploreItem exist
+    return {
+      type: 'timeseries',
+      title: 'New Panel',
+      gridPos: { x: 0, y: 0, w: 12, h: 8 },
+      targets: [],
+    };
+  };
+  // if explore item time range is undefined, then make a default time range
+  const timeRange = panelData?.range || exploreItem?.range;
+  // this is used eventually to navigate correctly to dashboard and not use the explore app url
+  const options = panelData ? 'external-app' : undefined;
+
+  return <AddToDashboardForm onClose={onClose} buildPanel={buildPanel} timeRange={timeRange} options={options} />;
 }

--- a/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
@@ -1,9 +1,9 @@
 import { type ReactElement } from 'react';
 
-import { AddToDashboardForm } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardForm';
-import { useSelector } from 'app/types';
 import { TimeRange } from '@grafana/data';
 import { Panel } from '@grafana/schema';
+import { AddToDashboardForm } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardForm';
+import { useSelector } from 'app/types';
 
 import { getExploreItemSelector } from '../../state/selectors';
 

--- a/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react';
 
 import { TimeRange } from '@grafana/data';
+import { t } from '@grafana/i18n/internal';
 import { Panel } from '@grafana/schema';
 import { AddToDashboardForm } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardForm';
 import { useSelector } from 'app/types';
@@ -39,7 +40,7 @@ export function ExploreToDashboardPanel(props: Props): ReactElement {
     // Return a default panel if neither panelData nor exploreItem exist
     return {
       type: 'timeseries',
-      title: 'New Panel',
+      title: t('dashboard.new-panel-title', 'New panel'),
       gridPos: { x: 0, y: 0, w: 12, h: 8 },
       targets: [],
     };

--- a/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/ExploreToDashboardPanel.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
 
 import { TimeRange } from '@grafana/data';
-import { t } from '@grafana/i18n/internal';
+import { t } from '@grafana/i18n';
 import { Panel } from '@grafana/schema';
 import { AddToDashboardForm } from 'app/features/dashboard-scene/addToDashboard/AddToDashboardForm';
 import { useSelector } from 'app/types';

--- a/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
+++ b/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
@@ -24,6 +24,7 @@ export function getExploreExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
         icon: 'apps',
         category: 'Dashboards',
         configure: () => {
+          // moving this and the ui to runtime
           const canAddPanelToDashboard =
             contextSrv.hasPermission(AccessControlAction.DashboardsCreate) ||
             contextSrv.hasPermission(AccessControlAction.DashboardsWrite);


### PR DESCRIPTION
Related PR https://github.com/grafana/metrics-drilldown/pull/510

## **What is this feature?**

This is a POC to expose "Add to dashboard" so that it can be used in the drilldown apps.


https://github.com/user-attachments/assets/794a205a-10e8-4774-8e78-1fc069a3d58b

![Screenshot 2025-06-24 at 12 15 31 PM](https://github.com/user-attachments/assets/85f8d40e-3e0d-4695-b25a-076ee305aeea)
![Screenshot 2025-06-24 at 12 16 17 PM](https://github.com/user-attachments/assets/03dbf9cc-ec8a-42ef-8b77-c62c9ebc37f7)
![Screenshot 2025-06-24 at 12 16 25 PM](https://github.com/user-attachments/assets/05e58bc0-5c3e-4cc0-aaac-b6469bded477)


## **Why do we need this feature?**

This will improve consumption and adoption by allowing external drilldown apps to add panels to a dashboard. We need to expose `ExploreToDashboardPanel` from grafana in runtime because it has access to context server and dashboard schema. 

## **Who is this feature for?**

This is for users of drilldown apps or other plugins.

## **More information**

### 📖 Summary of the changes

1. `AddToDashboardService` exposes the `ExploreToDashboardPanel` component for drilldown app.
2. This is accessible via grafana/runtime so that we have access to user permissions through the context server, to dashboard schema, and all the logic in the Explore Add to Dashboard feature.
3. `ExploreToDashboardPanel` now accepts a panel from an external app (query, visualization, query options, max data points, legend, etc)
4. We adjust the URL for the dashboard because external drilldown apps have their own URLs. 

### 🧪 How to test?

1. Run both Grafana and Metrics Drilldown locally
3. Use this `bohandley/add-to-dashboard-poc` in Metrics Drilldown app which uses the service. [PR here](https://github.com/grafana/metrics-drilldown/pull/510).
5. In Grafana, use the feature toggle so that you can use your local metric drilldown app. Otherwise, it will preinstall metrics drilldown from the plugin library into your `./plugins` directory.
```
[plugins]
preinstall_disabled = true
```
6. Navigate to metrics drilldown.
7. Select a metric
8. In the metric scene, click the 'Add to dashboard button' which is next to the 'Open in explore' button.
![Screenshot 2025-06-24 at 12 15 31 PM](https://github.com/user-attachments/assets/f1af2898-19b4-4bb4-bc23-968d889d0d44)
9. Select a new dashboard or add to a previously created dashboard.
10. Confirm that the panel JSON is the same from the drilldown app with the following panel fields (and time range)
  - datasource
  - query
  - visualization
  - query options
  - legend for the panel



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
