### PR TITLE
Prometheus: Reinstate variable interpolation for getTagKeys() and getTagValues()

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -825,6 +825,21 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
       expect(result).toEqual(['label1', 'label2']);
     });
 
+    it('queryLabelKeys should interpolate variables', async () => {
+      const provider = new PrometheusLanguageProvider({
+        ...defaultDatasource,
+        interpolateString: (string: string) => string.replace(/\$/g, 'interpolated_'),
+      } as PrometheusDatasource);
+      const resourceClientSpy = jest
+        .spyOn(provider['resourceClient'], 'queryLabelKeys')
+        .mockResolvedValue(['label1', 'label2']);
+
+      const result = await provider.queryLabelKeys(timeRange, '{job="$job"}');
+
+      expect(resourceClientSpy).toHaveBeenCalledWith(timeRange, '{job="interpolated_job"}', undefined);
+      expect(result).toEqual(['label1', 'label2']);
+    });
+
     it('should delegate to resource client queryLabelValues', async () => {
       const provider = new PrometheusLanguageProvider(defaultDatasource);
       const resourceClientSpy = jest
@@ -835,6 +850,26 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
 
       expect(resourceClientSpy).toHaveBeenCalledWith(timeRange, 'job', '{job="grafana"}', undefined);
       expect(result).toEqual(['value1', 'value2']);
+    });
+
+    it('queryLabelValues should interpolate variables', async () => {
+      const provider = new PrometheusLanguageProvider({
+        ...defaultDatasource,
+        interpolateString: (string: string) => string.replace(/\$/g, 'interpolated_'),
+      } as PrometheusDatasource);
+      const resourceClientSpy = jest
+        .spyOn(provider['resourceClient'], 'queryLabelValues')
+        .mockResolvedValue(['label1', 'label2']);
+
+      const result = await provider.queryLabelValues(timeRange, '$label', '{job="$job"}');
+
+      expect(resourceClientSpy).toHaveBeenCalledWith(
+        timeRange,
+        'interpolated_label',
+        '{job="interpolated_job"}',
+        undefined
+      );
+      expect(result).toEqual(['label1', 'label2']);
     });
   });
 

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -682,7 +682,8 @@ export class PrometheusLanguageProvider extends PromQlLanguageProvider implement
    * @returns {Promise<string[]>} Array of matching label key names, sorted alphabetically
    */
   public queryLabelKeys = async (timeRange: TimeRange, match?: string, limit?: number): Promise<string[]> => {
-    return await this.resourceClient.queryLabelKeys(timeRange, match, limit);
+    const interpolatedMatch = match ? this.datasource.interpolateString(match) : match;
+    return await this.resourceClient.queryLabelKeys(timeRange, interpolatedMatch, limit);
   };
 
   /**
@@ -716,7 +717,13 @@ export class PrometheusLanguageProvider extends PromQlLanguageProvider implement
     match?: string,
     limit?: number
   ): Promise<string[]> => {
-    return await this.resourceClient.queryLabelValues(timeRange, labelKey, match, limit);
+    const interpolatedMatch = match ? this.datasource.interpolateString(match) : match;
+    return await this.resourceClient.queryLabelValues(
+      timeRange,
+      this.datasource.interpolateString(labelKey),
+      interpolatedMatch,
+      limit
+    );
   };
 }
 


### PR DESCRIPTION
Prometheus frontend datasource `getTagKeys()` and `getTagValues()` used to support variable interpolation. This is no longer the case after https://github.com/grafana/grafana/pull/106277 and https://github.com/grafana/grafana/pull/105818. This broke a feature in App o11y plugin.

This PR adds variable interpolation to prom language provider `queryLabelValues()` and `queryLabelKeys()`

fixes #107169 