### PR TITLE
Actions(swagger-gen): Don't clone Enterprise on forks

### DIFF
--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -17,7 +17,7 @@ jobs:
   verify:
     name: Verify committed API specs match
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.repository == 'grafana/grafana' }}
+    if: ${{ github.repository == 'grafana/grafana' }}
     permissions:
       contents: read # clone the repository
       id-token: write # required for Vault access
@@ -32,14 +32,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Setup Enterprise
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
-
-      - name: Set go version
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
 
       - name: Generate Swagger specs
         run: make swagger-clean && make openapi3-gen


### PR DESCRIPTION
This should fix fork PRs by not cloning Enterprise. We already include code path for this case in the makefile, which should work fine here: we vendor and keep the Enterprise spec schema in the repo, and merge that with OSS. Forks can generate the OSS part, so we just use that to validate in the end.

Works on forks: https://github.com/grafana/grafana/actions/runs/15875908470/job/44763336085?pr=107178