### PR TITLE
Enable remote write receiver by default for the prometheus devenv block

### DIFF
--- a/devenv/docker/blocks/prometheus/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus/docker-compose.yaml
@@ -12,6 +12,7 @@
       --web.console.libraries=/usr/share/prometheus/console_libraries
       --web.console.templates=/usr/share/prometheus/consoles
       --web.config.file=/etc/prometheus/web.yml
+      --web.enable-remote-write-receiver
 
   node_exporter:
     image: prom/node-exporter
@@ -26,7 +27,7 @@
       FD_DATASOURCE: prom
 
   alertmanager:
-    image: prom/alertmanager 
+    image: prom/alertmanager
     volumes:
     - ${PWD}/docker/blocks/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml
     command: >


### PR DESCRIPTION
**What is this feature?**

This PR enables remote write by default for the Prometheus devenv block.

**Why do we need this feature?**

This feature is required to be enabled to test and develop the new `GRAFANA_ALERTS` alert notification history feature.

See https://grafana.com/docs/grafana/next/alerting/set-up/configure-alert-state-history/#configure-prometheus-for-alert-state-grafana_alerts-metric