### PR TITLE
Alerting: Sanitize Prometheus state history labels before writing

### DIFF
--- a/pkg/services/ngalert/state/historian/prometheus.go
+++ b/pkg/services/ngalert/state/historian/prometheus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/grafana/dataplane/sdata/numeric"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	promValue "github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/util/strutil"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -190,7 +190,10 @@ func (b *RemotePrometheusBackend) framesFor(ctx context.Context, rule history_mo
 
 	for i, sample := range samples {
 		labels := make(data.Labels, len(baseLabels)+2)
-		maps.Copy(labels, baseLabels)
+		for k, v := range baseLabels {
+			sanitizedKey := strutil.SanitizeFullLabelName(k)
+			labels[sanitizedKey] = v
+		}
 		labels[alertStateLabel] = sample.promState
 		labels[grafanaAlertStateLabel] = sample.grafanaState
 


### PR DESCRIPTION
**What is this feature?**

Sanitize state history (`GRAFANA_ALERTS`) labels before writing them to Prometheus.

**Why do we need this feature?**

Without this, writes are rejected because invalid labels can be added statically to a rule in Grafana. For example, a label `label-1=value` can  be added to a rule and it breaks writing the metric.

This PR changes such labels and replaces all unsupported characters with underscores: `label_1=value`.

**Who is this feature for?**

Users of Grafana Alerting and [GRAFANA_ALERTS](https://grafana.com/docs/grafana/next/alerting/set-up/configure-alert-state-history/#configure-prometheus-for-alert-state-grafana_alerts-metric) metric.

I will update documentation separately.