### PR TITLE
Alerting: Fix package types reference

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -42,7 +42,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/types/src/index.d.ts",
+    "types": "./dist/types/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -42,7 +42,7 @@
   "publishConfig": {
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",
-    "types": "./dist/types/index.d.ts",
+    "types": "./dist/types/src/index.d.ts",
     "access": "public"
   },
   "files": [

--- a/packages/grafana-alerting/tsconfig.build.json
+++ b/packages/grafana-alerting/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
-  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts*"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts*", "**/*.story.tsx"],
   "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
This would crash the levitate tool.

Ran ` yarn dlx publint && yarn dlx @arethetypeswrong/cli --pack --format=table` to validate the incorrect reference.

```
@grafana/alerting v12.1.0-pre

Build tools:                                                                                                                                                       
- typescript@5.7.3
- rollup@^4.22.4

🎭 Import resolved to a CommonJS type declaration file, but an ESM JavaScript file. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md


┌───────────────────┬──────────────────────────────────┬────────────────────────┬──────────────────────────────┐
│                   │ "@grafana/alerting/package.json" │ "@grafana/alerting"    │ "@grafana/alerting/unstable" │
├───────────────────┼──────────────────────────────────┼────────────────────────┼──────────────────────────────┤
│ node10            │ 🟢 (JSON)                        │ 🟢                     │ 🟢                           │
├───────────────────┼──────────────────────────────────┼────────────────────────┼──────────────────────────────┤
│ node16 (from CJS) │ 🟢 (JSON)                        │ 🟢 (CJS)               │ 🟢 (CJS)                     │
├───────────────────┼──────────────────────────────────┼────────────────────────┼──────────────────────────────┤
│ node16 (from ESM) │ 🟢 (JSON)                        │ 🎭 Masquerading as CJS │ 🎭 Masquerading as CJS       │
├───────────────────┼──────────────────────────────────┼────────────────────────┼──────────────────────────────┤
│ bundler           │ 🟢 (JSON)                        │ 🟢                     │ 🟢                           │
└───────────────────┴──────────────────────────────────┴────────────────────────┴──────────────────────────────┘
```