### PR TITLE
Include resource name in the event.

### DIFF
--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -305,7 +305,7 @@ func (b *batchRunner) Next() bool {
 
 		// Mention resource in the span.
 		attrs := []attribute.KeyValue{
-			attribute.String("key", k),
+			attribute.String("key", nsgrWithName(key)),
 		}
 		if b.err != nil {
 			attrs = append(attrs, attribute.String("error", b.err.Error()))

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -79,6 +79,11 @@ func ReadSearchID(x *resourcepb.ResourceKey, v string) error {
 // The namespace/group/resource
 func NSGR(x *resourcepb.ResourceKey) string {
 	var sb strings.Builder
+	appendNSGR(&sb, x)
+	return sb.String()
+}
+
+func appendNSGR(sb *strings.Builder, x *resourcepb.ResourceKey) string {
 	if x.Namespace == "" {
 		sb.WriteString(clusterNamespace)
 	} else {
@@ -88,5 +93,13 @@ func NSGR(x *resourcepb.ResourceKey) string {
 	sb.WriteString(x.Group)
 	sb.WriteString("/")
 	sb.WriteString(x.Resource)
+	return sb.String()
+}
+
+func nsgrWithName(x *resourcepb.ResourceKey) string {
+	var sb strings.Builder
+	appendNSGR(&sb, x)
+	sb.WriteString("/")
+	sb.WriteString(x.Name)
 	return sb.String()
 }


### PR DESCRIPTION
We've recently added events to the span that include namespace, group and resource of the bulk-processed resources. We would like to include name as well.

Before:

<img width="1788" alt="image" src="https://github.com/user-attachments/assets/c14eccf8-465e-4d9d-9632-e003bd202c41" />
