### PR TITLE
Prometheus: Refactoring in datasource.ts

### DIFF
--- a/packages/grafana-prometheus/src/constants.ts
+++ b/packages/grafana-prometheus/src/constants.ts
@@ -6,28 +6,42 @@ export const PROMETHEUS_QUERY_BUILDER_MAX_RESULTS = 1000;
 export const PROM_CONFIG_LABEL_WIDTH = 30;
 
 export const LIST_ITEM_SIZE = 25;
+
 export const LAST_USED_LABELS_KEY = 'grafana.datasources.prometheus.browser.labels';
 
-// single duration input
 export const DURATION_REGEX = /^$|^\d+(ms|[Mwdhmsy])$/;
 
-// multiple duration input
 export const MULTIPLE_DURATION_REGEX = /(\d+)(.+)/;
 
 export const NON_NEGATIVE_INTEGER_REGEX = /^(0|[1-9]\d*)(\.\d+)?(e\+?\d+)?$/; // non-negative integers, including scientific notation
 
 export const EMPTY_SELECTOR = '{}';
+
 export const DEFAULT_SERIES_LIMIT = 40000;
+
 export const MATCH_ALL_LABELS_STR = '__name__!=""';
+
 export const MATCH_ALL_LABELS = '{__name__!=""}';
+
 export const METRIC_LABEL = '__name__';
+
+export const durationError = 'Value is not valid, you can use number with time unit specifier: y, M, w, d, h, m, s';
+
+export const countError = 'Value is not valid, you can use non-negative integers, including scientific notation';
+
+export const seriesLimitError = 'Value is not valid, you can use only numbers or leave it empty to use default limit or set 0 to have no limit.';
+
+export const InstantQueryRefIdIndex = '-Instant';
+
+export const GET_AND_POST_METADATA_ENDPOINTS = [
+  'api/v1/query',
+  'api/v1/query_range',
+  'api/v1/series',
+  'api/v1/labels',
+  'suggestions',
+];
 
 /**
  * @deprecated
  */
 export const REMOVE_SERIES_LIMIT = 'none';
-
-export const durationError = 'Value is not valid, you can use number with time unit specifier: y, M, w, d, h, m, s';
-export const countError = 'Value is not valid, you can use non-negative integers, including scientific notation';
-export const seriesLimitError =
-  'Value is not valid, you can use only numbers or leave it empty to use default limit or set 0 to have no limit.';

--- a/packages/grafana-prometheus/src/constants.ts
+++ b/packages/grafana-prometheus/src/constants.ts
@@ -29,7 +29,8 @@ export const durationError = 'Value is not valid, you can use number with time u
 
 export const countError = 'Value is not valid, you can use non-negative integers, including scientific notation';
 
-export const seriesLimitError = 'Value is not valid, you can use only numbers or leave it empty to use default limit or set 0 to have no limit.';
+export const seriesLimitError =
+  'Value is not valid, you can use only numbers or leave it empty to use default limit or set 0 to have no limit.';
 
 export const InstantQueryRefIdIndex = '-Instant';
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -25,30 +25,27 @@ import { utf8Support, wrapUtf8Filters } from './utf8_support';
 import { PrometheusVariableSupport } from './variables';
 
 export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromOptions> implements DataSourceWithQueryImportSupport<PromQuery>, DataSourceWithQueryExportSupport<PromQuery> {
-  // DATA SOURCE PROPERTIES
-  cache: QueryCache<PromQuery>;
-  exemplarsAvailable: boolean;
-  languageProvider: PrometheusLanguageProviderInterface;
-  ruleMappings: RuleQueryMapping;
-  type: string;
-
-  // CONFIGURATION PROPERTIES
   access: 'direct' | 'proxy';
   basicAuth: any;
+  cache: QueryCache<PromQuery>;
   cacheLevel: PrometheusCacheLevel;
   customQueryParameters: URLSearchParams;
   datasourceConfigurationPrometheusFlavor?: PromApplication;
   datasourceConfigurationPrometheusVersion?: string;
   disableRecordingRules: boolean;
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
+  exemplarsAvailable: boolean;
   hasIncrementalQuery: boolean;
   httpMethod: string;
   id: number;
   interval: string;
+  languageProvider: PrometheusLanguageProviderInterface;
   lookupsDisabled: boolean;
   metricNamesAutocompleteSuggestionLimit: number;
+  ruleMappings: RuleQueryMapping;
   seriesEndpoint: boolean;
   seriesLimit: number;
+  type: string;
   url: string;
   withCredentials: boolean;
   defaultEditor?: QueryEditorMode;
@@ -56,29 +53,27 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   constructor(instanceSettings: DataSourceInstanceSettings<PromOptions>, private readonly templateSrv: TemplateSrv = getTemplateSrv(), languageProvider?: PrometheusLanguageProviderInterface) {
     super(instanceSettings);
 
-    // DATA SOURCE PROPERTIES
-    this.cache = new QueryCache({ getTargetSignature: this.getPrometheusTargetSignature.bind(this), overlapString: instanceSettings.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow, applyInterpolation: this.interpolateString.bind(this) });
-    this.exemplarsAvailable = true;
-    this.ruleMappings = {};
-    this.type = 'prometheus';
-
-    // CONFIGURATION PROPERTIES
+    // DATASOURCE CONFIGURATION PROPERTIES
     this.access = instanceSettings.access;
     this.basicAuth = instanceSettings.basicAuth;
+    this.cache = new QueryCache({ getTargetSignature: this.getPrometheusTargetSignature.bind(this), overlapString: instanceSettings.jsonData.incrementalQueryOverlapWindow ?? defaultPrometheusQueryOverlapWindow, applyInterpolation: this.interpolateString.bind(this) });
     this.cacheLevel = instanceSettings.jsonData.cacheLevel ?? PrometheusCacheLevel.Low;
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
     this.datasourceConfigurationPrometheusFlavor = instanceSettings.jsonData.prometheusType;
     this.datasourceConfigurationPrometheusVersion = instanceSettings.jsonData.prometheusVersion;
     this.disableRecordingRules = instanceSettings.jsonData.disableRecordingRules ?? false;
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
+    this.exemplarsAvailable = true;
     this.hasIncrementalQuery = instanceSettings.jsonData.incrementalQuerying ?? false;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
     this.id = instanceSettings.id;
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup ?? false;
     this.metricNamesAutocompleteSuggestionLimit = instanceSettings.jsonData.codeModeMetricNamesSuggestionLimit ?? SUGGESTIONS_LIMIT;
+    this.ruleMappings = {};
     this.seriesEndpoint = instanceSettings.jsonData.seriesEndpoint ?? false;
     this.seriesLimit = instanceSettings.jsonData.seriesLimit ?? DEFAULT_SERIES_LIMIT;
+    this.type = 'prometheus';
     this.url = instanceSettings.url!;
     this.withCredentials = Boolean(instanceSettings.withCredentials);
     this.defaultEditor = instanceSettings.jsonData.defaultEditor;

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -20,7 +20,7 @@ export { PromVariableQueryEditor } from './components/VariableQueryEditor';
 // Main export
 export { ConfigEditor } from './configuration/ConfigEditor';
 export { overhaulStyles, validateInput, docsTip } from './configuration/shared/utils';
-export { PROM_CONFIG_LABEL_WIDTH } from './constants';
+export { PROM_CONFIG_LABEL_WIDTH, InstantQueryRefIdIndex } from './constants';
 // The parts
 export { AlertingSettingsOverhaul } from './configuration/AlertingSettingsOverhaul';
 export { DataSourceHttpSettingsOverhaul } from './configuration/DataSourceHttpSettingsOverhaul';
@@ -54,7 +54,7 @@ export { MetricsModal } from './querybuilder/components/metrics-modal/MetricsMod
 
 // SRC/
 // Main export
-export { PrometheusDatasource, InstantQueryRefIdIndex } from './datasource';
+export { PrometheusDatasource } from './datasource';
 // The parts
 export { addLabelToQuery } from './add_label_to_query';
 export { type QueryEditorMode, type PromQueryFormat, type Prometheus } from './dataquery';


### PR DESCRIPTION
This pull request focuses on code refactoring and general cleanup to improve readability, update comments, and reduce ongoing maintenance overhead. No functional changes are intended. The aim is to make the codebase easier to understand and maintain for future development.

**Summary of Changes**
- Applied Prettier formatting to `datasource.ts`
- Marked `loadRules` and `areExemplarsAvailable` as private functions
- Moved `loadRules` and `areExemplarsAvailable` alongside init(), which calls them
- Added comments to init, loadRules, and areExemplarsAvailable for clarity
- Made minor refactoring improvements to `loadRules` and `areExemplarsAvailable`, such as explicitly defining params and options objects
