### PR TITLE
Grafana live: Remove experimental language around redis

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1887,12 +1887,10 @@ allowed_origins =
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server.
 # Available options: "redis".
-# Setting ha_engine is an EXPERIMENTAL feature.
 ha_engine =
 
 # ha_engine_address sets a connection address for Live HA engine. Depending on engine type address format can differ.
 # For now we only support Redis connection address in "host:port" format.
-# This option is EXPERIMENTAL.
 ha_engine_address = "127.0.0.1:6379"
 
 # ha_engine_password allows setting an optional password to authenticate with the engine

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1824,12 +1824,10 @@ default_datasource_uid =
 
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server. Available options: "redis".
-# Setting ha_engine is an EXPERIMENTAL feature.
 ;ha_engine =
 
 # ha_engine_address sets a connection address for Live HA engine. Depending on engine type address format can differ.
 # For now we only support Redis connection address in "host:port" format.
-# This option is EXPERIMENTAL.
 ;ha_engine_address = "127.0.0.1:6379"
 
 # ha_engine_password allows setting an optional password to authenticate with the engine

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -201,7 +201,7 @@ In a high availability Grafana setup involving several Grafana server instances 
 - Streaming from Telegraf will deliver data only to clients connected to the same instance which received Telegraf data, active stream cache is not shared between different Grafana instances.
 - A separate unidirectional stream between Grafana and backend data source may be opened on different Grafana servers for the same channel.
 
-To bypass these limitations, Grafana v8.1 has an experimental Live HA engine that requires Redis to work.
+To bypass these limitations, Grafana has a Live HA engine that requires Redis to work.
 
 ### Configure Redis Live engine
 


### PR DESCRIPTION
This has been in grafana for awhile now - time to remove the experimental language :) 

[thread](https://raintank-corp.slack.com/archives/C04RVCAG9B5/p1750822776148889)