### PR TITLE
TimeRangePicker: Parse regional format datetimes POC

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "7.0.1",
+    "@grafana/i18n": "12.1.0-pre",
     "@grafana/schema": "12.1.0-pre",
     "@leeoniya/ufuzzy": "1.0.18",
     "@types/d3-interpolate": "^3.0.0",

--- a/packages/grafana-data/src/datetime/formatter.ts
+++ b/packages/grafana-data/src/datetime/formatter.ts
@@ -1,6 +1,8 @@
 /* eslint-disable id-blacklist, no-restricted-imports */
 import moment, { Moment } from 'moment-timezone';
 
+import { formatDate } from '@grafana/i18n';
+
 import { TimeZone } from '../types/time';
 
 import { DateTimeOptions, getTimeZone } from './common';
@@ -23,6 +25,28 @@ export interface DateTimeOptionsWithFormat extends DateTimeOptions {
 
 type DateTimeFormatter<T extends DateTimeOptions = DateTimeOptions> = (dateInUtc: DateTimeInput, options?: T) => string;
 
+const localeFormatPreferenceEnabled = window.grafanaBootData?.settings.featureToggles.localeFormatPreference ?? false;
+
+function toDate(dateInUtc: DateTimeInput): Date {
+  if (dateInUtc instanceof Date) {
+    return dateInUtc;
+  }
+
+  if (typeof dateInUtc === 'string' || typeof dateInUtc === 'number') {
+    return new Date(dateInUtc);
+  }
+
+  return dateTimeAsMoment(dateInUtc).toDate();
+}
+
+function toIANATimezone(grafanaTimezone: string) {
+  if (grafanaTimezone === 'browser') {
+    return undefined;
+  }
+
+  return grafanaTimezone;
+}
+
 /**
  * Helper function to format date and time according to the specified options. If no options
  * are supplied, then default values are used. For more details, see {@link DateTimeOptionsWithFormat}.
@@ -32,8 +56,22 @@ type DateTimeFormatter<T extends DateTimeOptions = DateTimeOptions> = (dateInUtc
  *
  * @public
  */
-export const dateTimeFormat: DateTimeFormatter<DateTimeOptionsWithFormat> = (dateInUtc, options?) =>
-  toTz(dateInUtc, getTimeZone(options)).format(getFormat(options));
+export const dateTimeFormat: DateTimeFormatter<DateTimeOptionsWithFormat> = (dateInUtc, options?) => {
+  // If a custom format is provided (or the toggle isn't enabled), use the previous implementation
+  if (!localeFormatPreferenceEnabled || options?.format) {
+    return toTz(dateInUtc, getTimeZone(options)).format(getFormat(options));
+  }
+
+  const timeZone = getTimeZone(options);
+  const ianaTimezone = toIANATimezone(timeZone);
+
+  const dateAsDate = toDate(dateInUtc);
+  return formatDate(dateAsDate, {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+    timeZone: ianaTimezone,
+  });
+};
 
 /**
  * Helper function to format date and time according to the standard ISO format e.g. 2013-02-04T22:44:30.652Z.

--- a/packages/grafana-i18n/src/index.ts
+++ b/packages/grafana-i18n/src/index.ts
@@ -24,4 +24,4 @@ export {
 } from './constants';
 export { initPluginTranslations, t, Trans } from './i18n';
 export type { ResourceLoader, Resources, TFunction, TransProps } from './types';
-export { formatDate, formatDuration, formatDateRange } from './dates';
+export { formatDate, formatDuration, formatDateRange, parseFormat } from './dates';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,6 +3068,7 @@ __metadata:
   resolution: "@grafana/data@workspace:packages/grafana-data"
   dependencies:
     "@braintree/sanitize-url": "npm:7.0.1"
+    "@grafana/i18n": "npm:12.1.0-pre"
     "@grafana/schema": "npm:12.1.0-pre"
     "@grafana/tsconfig": "npm:^2.0.0"
     "@leeoniya/ufuzzy": "npm:1.0.18"


### PR DESCRIPTION
**What is this feature?**

_Proof of Concept for:_

When `localeFormatPreference` is enabled, TimeRangePicker will display and parse the format specified.

**Why do we need this feature?**

Consistently use the set regional format across the app, including inputs.

**Who is this feature for?**

Users that adjust absolute date ranges and set a regional format preference.

**Which issue(s) does this PR fix?**:

Fixes #105384

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
