### PR TITLE
Fix canvas connection point z-indexing bug

### DIFF
--- a/public/app/features/canvas/runtime/root.tsx
+++ b/public/app/features/canvas/runtime/root.tsx
@@ -54,6 +54,7 @@ export class RootElement extends FrameState {
         {this.elements.map((v) => (
           <Fragment key={v.UID}>{v.render()}</Fragment>
         ))}
+        {this.scene.connections.render()}
       </div>
     );
   }

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -366,7 +366,6 @@ export class Scene {
 
     const sceneDiv = (
       <>
-        {this.connections.render()}
         {this.root.render()}
         {this.isEditingEnabled && (
           <Portal>

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionAnchors.tsx
@@ -137,7 +137,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     cursor: 'cursor',
     width: `calc(5px + 2 * ${ANCHOR_PADDING}px)`,
     height: `calc(5px + 2 * ${ANCHOR_PADDING}px)`,
-    zIndex: 100,
   }),
   highlightElement: css({
     backgroundColor: '#00ff00',


### PR DESCRIPTION
This is meant to fix the bug we discovered in z-indexing for Canvas element connection points: https://github.com/grafana/grafana/issues/106028

🐞 🔍 :shipit: _It seems that this bug was caused by nesting the connection points in a parent component that resulted in a DOM hierarchy where their z-index was constrained by that of the parent element._

<img width="1417" alt="Screenshot 2025-06-25 at 7 54 29 PM" src="https://github.com/user-attachments/assets/18626bcd-2cba-48b7-b758-7c44627a2121" />