### PR TITLE
K8s: allow anonymous in K8s apis when individual getAuthorizer allows it

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -93,6 +93,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			Context: web.FromContext(ctx),
 			SignedInUser: &user.SignedInUser{
 				Permissions: map[int64]map[string][]string{},
+				IsAnonymous: true,
 			},
 			IsSignedIn:                false,
 			AllowAnonymous:            false,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature is about allowing anonymous access for select routes of new K8s style APIs.

**Why do we need this feature?**

The new Ofrep API will offer the ability to view public feature flags as anonymous. Historically, Grafana has had an allowAnonymous feature but that's not what we want to require in this case.

The ofrep feature branch already has the necessary work to allow the routing the work for a non-signed in user. The authenticators fail and the [else](https://github.com/grafana/grafana/blob/b6ce0a658250d4317d5492dc02ca369f267ac529/pkg/services/contexthandler/contexthandler.go#L123) branch correctly triggers in contexthandler.

However, later down the chain, the namespace authorizer has an if to protect against unintended anonymous access for an API resource. If the identity type is anonymous, in this [if](https://github.com/grafana/grafana/blob/3503fc209e97946b22c1e4fe23c766bf341b4ddd/pkg/services/apiserver/auth/authorizer/namespace.go#L34), the decision is NoOpinion. All that is good, however that `if` won't pass unless `ident.GetIdentityType()` returned `types.Anonymous`. 

For SignedInUser, that depends on the `IsAnonymous` boolean as shown [here](https://github.com/grafana/grafana/blob/3503fc209e97946b22c1e4fe23c766bf341b4ddd/pkg/services/user/identity.go#L90). In my brief testing, this one line change introduced in this PR will be required.

Elsewhere in [slack](https://raintank-corp.slack.com/archives/C06PNGH5H28/p1747321824302399?thread_ts=1747237489.758879&cid=C06PNGH5H28), there was a mention of only populating the context if the user is indeed signed in. I think we want to stay away from that, because we don't want a `nil` (`, err`) requester return from `GetRequester` or the various authorizers will start failing, such as the namespace authorizer one, which wants to check for anonymous identity. In the same slack comment, there is a mention of some thing about namespace authorizer being awry. In my view, that's the MT namespace authorizer in enterprise which is missing [these 3 lines of code](https://github.com/grafana/grafana/blob/3503fc209e97946b22c1e4fe23c766bf341b4ddd/pkg/services/apiserver/auth/authorizer/namespace.go#L34-L36) like the ST namespace authorizer does.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
