### PR TITLE
Fix Zanzana Error "user field is malformed"

### DIFF
--- a/pkg/services/authn/clients/render.go
+++ b/pkg/services/authn/clients/render.go
@@ -47,6 +47,7 @@ func (c *Render) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		}
 		return &authn.Identity{
 			ID:              "0",
+			UID:             "0",
 			Type:            identityType,
 			OrgID:           renderUsr.OrgID,
 			OrgRoles:        map[int64]org.RoleType{renderUsr.OrgID: org.RoleType(renderUsr.OrgRole)},

--- a/pkg/services/authn/clients/render_test.go
+++ b/pkg/services/authn/clients/render_test.go
@@ -38,6 +38,7 @@ func TestRender_Authenticate(t *testing.T) {
 			},
 			expectedIdentity: &authn.Identity{
 				ID:              "0",
+				UID:             "0",
 				Type:            claims.TypeAnonymous,
 				OrgID:           1,
 				OrgRoles:        map[int64]org.RoleType{1: org.RoleViewer},
@@ -60,6 +61,7 @@ func TestRender_Authenticate(t *testing.T) {
 			},
 			expectedIdentity: &authn.Identity{
 				ID:              "0",
+				UID:             "0",
 				Type:            claims.TypeRenderService,
 				OrgID:           1,
 				OrgRoles:        map[int64]org.RoleType{1: org.RoleAdmin},


### PR DESCRIPTION
### Which issue(s) does this PR fix?

Fixes https://github.com/grafana/identity-access-team/issues/1468

### Special notes for your reviewer:

A middleware [sets the request subject](https://github.com/grafana/authlib/blob/54543efcfeeddd5bad9e343c98c2094496a9cf4d/authz/client.go#L112) using `GetUID()`.

The actual implementation of `GetUID()` can be found [here](https://github.com/grafana/grafana/blob/main/pkg/services/authn/identity.go#L94-L96):
```go
func (i *Identity) GetUID() string {
	return claims.NewTypeID(i.Type, i.UID)
}
```

When creating the authentication request, `UID` wasn't being set at all, causing `subject = "render:"` instead of `subject = "render:0"`

By setting `UID = 0` the issue is fixed.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
