### PR TITLE
[Docs] Panel embedding not available in Cloud

### DIFF
--- a/docs/sources/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/_index.md
@@ -296,7 +296,7 @@ https://play.grafana.org/render/d-solo/ktMs4D6Mk?from=2024-09-03T11:55:44.442Z&t
 You can share a panel by embedding it on another website using an iframe. Users must be signed into Grafana to view the panel unless you have anonymous access permission enabled for your Grafana instance.
 
 {{< admonition type="note" >}}
-Anonymous access permission is no longer available for Grafana Cloud even for panels in [externally shared dashboards](ref:shared-dashboards). This feature is only supported for Grafana Enterprise and Grafana Open Source.
+Panel embedding and anonymous access permissions are not available in Grafana Cloud, even for panels in [externally shared dashboards](ref:shared-dashboards). These capabilities are only supported in Grafana Enterprise and Grafana Open Source.
 {{< /admonition >}}
 
 To create a panel that can be embedded, follow these steps:


### PR DESCRIPTION
Clarifies the statement that embedding AND anonymous access are not available in Grafana Cloud.
