### PR TITLE
fix: remove minWidth from #107145

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -226,7 +226,6 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
     display: 'flex',
     alignItems: 'center',
     flex: '2',
-    minWidth: 0,
   }),
   value: css({
     fontWeight: 500,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In #107145, a fix was introduced for tooltip sizing which better supports max tooltip widths, but a regression was introduced across tooltips with longer series names.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes issue introduced in #107145.

### Before and after: many series, limited tooltip width

#### Before

<img width="257" alt="Screenshot 2025-06-26 at 8 30 37 AM" src="https://github.com/user-attachments/assets/6c28ead3-5eef-464c-9d0d-18b9d8610889" />

#### After

<img width="267" alt="Screenshot 2025-06-26 at 8 30 54 AM" src="https://github.com/user-attachments/assets/bb36417f-2c27-48d1-a1cc-a5977d2d4feb" />

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
