### PR TITLE
CI: Add GOCACHEPROG to the backend builder if GOCACHEPROG is set on the host

### DIFF
--- a/pkg/build/daggerbuild/artifacts/backend.go
+++ b/pkg/build/daggerbuild/artifacts/backend.go
@@ -3,6 +3,7 @@ package artifacts
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"dagger.io/dagger"
@@ -191,10 +192,17 @@ func NewBackendFromString(ctx context.Context, log *slog.Logger, artifact string
 		return nil, err
 	}
 
+	goCacheProg := ""
+	// If the caller has GOCACHEPROG set, then reuse it
+	if val, ok := os.LookupEnv("GOCACHEPROG"); ok {
+		goCacheProg = val
+	}
+
 	bopts := &backend.BuildOpts{
 		Version:           p.Version,
 		Enterprise:        p.Enterprise,
 		ExperimentalFlags: experiments,
+		GoCacheProg:       goCacheProg,
 		Static:            static,
 		WireTag:           wireTag,
 		Tags:              tags,

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -16,6 +16,7 @@ type BuildOpts struct {
 	ExperimentalFlags []string
 	Tags              []string
 	WireTag           string
+	GoCacheProg       string
 	Static            bool
 	Enterprise        bool
 }
@@ -153,6 +154,10 @@ func Builder(
 	builder = builder.
 		WithMountedCache("/root/.cache/go", goBuildCache).
 		WithEnvVariable("GOCACHE", "/root/.cache/go")
+
+	if prog := opts.GoCacheProg; prog != "" {
+		builder = builder.WithEnvVariable("GOCACHEPROG", prog)
+	}
 
 	commitInfo := GetVCSInfo(src, version, opts.Enterprise)
 


### PR DESCRIPTION
`GOCACHEPROG` will let us save lots of waste when building the backend.