### PR TITLE
Revert "ToolTip: Fix flexbox bug with tooltip when `maxWidth` is set …

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
@@ -56,11 +56,9 @@ export const VizTooltipColorIndicator = ({
 const getStyles = (theme: GrafanaTheme2) => ({
   leading: css({
     marginRight: theme.spacing(0.5),
-    flex: 'none',
   }),
   trailing: css({
     marginLeft: theme.spacing(0.5),
-    flex: 'none',
   }),
   value: css({
     width: '12px',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -130,7 +130,7 @@ export const VizTooltipRow = ({
   return (
     <div className={styles.contentWrapper}>
       {(color || label) && (
-        <div className={styles.labelWrapper}>
+        <div className={styles.valueWrapper}>
           {color && colorPlacement === ColorPlacement.first && (
             <VizTooltipColorIndicator color={color} colorIndicator={colorIndicator} lineStyle={lineStyle} />
           )}
@@ -222,12 +222,6 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
     overflow: 'hidden',
     marginRight: theme.spacing(2),
   }),
-  labelWrapper: css({
-    display: 'flex',
-    alignItems: 'center',
-    flex: '2',
-    minWidth: 0,
-  }),
   value: css({
     fontWeight: 500,
     textOverflow: 'ellipsis',
@@ -236,7 +230,6 @@ const getStyles = (theme: GrafanaTheme2, justify: string, marginRight: string) =
   valueWrapper: css({
     display: 'flex',
     alignItems: 'center',
-    flex: '1',
   }),
   activeSeries: css({
     fontWeight: theme.typography.fontWeightBold,


### PR DESCRIPTION
…manually (#107145)"

This reverts commit cff743fcd56a2cf17b6e2e640dd6ffb53e8eba07.

The commit is being reverted because the change regresses the tooltip formatting when a tooltip label is relatively long.
