### PR TITLE
fix: set withHistory flag to true for non-interactive mode

### DIFF
--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage.go
@@ -85,6 +85,7 @@ func ToUnifiedStorage(c utils.CommandLine, cfg *setting.Cfg, sqlStore db.DB) err
 	if c.Bool("non-interactive") {
 		opts.Store = client
 		opts.BlobStore = client
+		opts.WithHistory = true // always include history in non-interactive mode
 		rsp, err := migrator.Migrate(ctx, opts)
 		if exitErr := handleMigrationError(err, rsp); exitErr != nil {
 			return exitErr

--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -13,25 +13,25 @@ SELECT
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
   {{ if .Query.UseHistoryTable }}
-    dashboard_version.created,
-    updated_user.uid       as updated_by,
-    updated_user.id        as created_by_id,
-    dashboard_version.version,
-    dashboard_version.message,
-    dashboard_version.data,
-    dashboard_version.api_version
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
   {{ else }}
-    dashboard.updated,
-    updated_user.uid       as updated_by,
-    dashboard.updated_by   as updated_by_id,
-    dashboard.version,
-    '' as message,
-    dashboard.data,
-    dashboard.api_version
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
   {{ end }}
 FROM {{ .Ident .DashboardTable }} as dashboard
 {{ if .Query.UseHistoryTable }}
-  LEFT OUTER JOIN {{ .Ident .VersionTable }} as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+LEFT OUTER JOIN {{ .Ident .VersionTable }} as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 {{ end }}
 LEFT OUTER JOIN {{ .Ident .ProvisioningTable }} as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN {{ .Ident .UserTable }} as created_user ON dashboard.created_by = created_user.id
@@ -39,28 +39,28 @@ LEFT OUTER JOIN {{ .Ident .UserTable }} as updated_user ON {{ if .Query.UseHisto
 WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
   AND dashboard.org_id = {{ .Arg .Query.OrgID }}
   {{ if .Query.UseHistoryTable }}
-    {{ if .Query.UID }}
-      AND dashboard.uid = {{ .Arg .Query.UID }}
-    {{ end }}
-    {{ if .Query.Version }}
-      AND dashboard_version.version = {{ .Arg .Query.Version }}
-    {{ else if .Query.LastID }}
-      AND dashboard_version.version < {{ .Arg .Query.LastID }}
-    {{ end }}
-    ORDER BY
-      dashboard_version.created {{ .Query.Order }},
-      dashboard_version.version {{ .Query.Order }},
-      dashboard.uid ASC
+  {{ if .Query.UID }}
+  AND dashboard.uid = {{ .Arg .Query.UID }}
+  {{ end }}
+  {{ if .Query.Version }}
+  AND dashboard_version.version = {{ .Arg .Query.Version }}
+  {{ else if .Query.LastID }}
+  AND dashboard_version.version < {{ .Arg .Query.LastID }}
+  {{ end }}
+  ORDER BY
+    dashboard_version.created {{ .Query.Order }},
+    dashboard_version.version {{ .Query.Order }},
+    dashboard.uid ASC
   {{ else }}
-    {{ if .Query.UID }}
-      AND dashboard.uid = {{ .Arg .Query.UID }}
-    {{ else if .Query.LastID }}
-      AND dashboard.id < {{ .Arg .Query.LastID }}
-    {{ end }}
-    {{ if .Query.GetTrash }}
-      AND dashboard.deleted IS NOT NULL
-    {{ else }}
-      AND dashboard.deleted IS NULL
-    {{ end }}
-    ORDER BY dashboard.id DESC
+  {{ if .Query.UID }}
+  AND dashboard.uid = {{ .Arg .Query.UID }}
+  {{ else if .Query.LastID }}
+  AND dashboard.id < {{ .Arg .Query.LastID }}
+  {{ end }}
+  {{ if .Query.GetTrash }}
+  AND dashboard.deleted IS NOT NULL
+  {{ else }}
+  AND dashboard.deleted IS NULL
+  {{ end }}
+  ORDER BY dashboard.id DESC
   {{ end }}

--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -1,24 +1,37 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
   {{ if .Query.UseHistoryTable }}
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+    dashboard_version.created,
+    updated_user.uid       as updated_by,
+    updated_user.id        as created_by_id,
+    dashboard_version.version,
+    dashboard_version.message,
+    dashboard_version.data,
+    dashboard_version.api_version
   {{ else }}
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+    dashboard.updated,
+    updated_user.uid       as updated_by,
+    dashboard.updated_by   as updated_by_id,
+    dashboard.version,
+    '' as message,
+    dashboard.data,
+    dashboard.api_version
   {{ end }}
 FROM {{ .Ident .DashboardTable }} as dashboard
 {{ if .Query.UseHistoryTable }}
-LEFT OUTER JOIN {{ .Ident .VersionTable }} as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+  LEFT OUTER JOIN {{ .Ident .VersionTable }} as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 {{ end }}
 LEFT OUTER JOIN {{ .Ident .ProvisioningTable }} as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN {{ .Ident .UserTable }} as created_user ON dashboard.created_by = created_user.id
@@ -26,28 +39,28 @@ LEFT OUTER JOIN {{ .Ident .UserTable }} as updated_user ON {{ if .Query.UseHisto
 WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
   AND dashboard.org_id = {{ .Arg .Query.OrgID }}
   {{ if .Query.UseHistoryTable }}
-  {{ if .Query.UID }}
-  AND dashboard.uid = {{ .Arg .Query.UID }}
-  {{ end }}
-  {{ if .Query.Version }}
-  AND dashboard_version.version = {{ .Arg .Query.Version }}
-  {{ else if .Query.LastID }}
-  AND dashboard_version.version < {{ .Arg .Query.LastID }}
-  {{ end }}
-  ORDER BY
-    dashboard_version.created {{ .Query.Order }},
-    dashboard_version.version {{ .Query.Order }},
-    dashboard.uid ASC
+    {{ if .Query.UID }}
+      AND dashboard.uid = {{ .Arg .Query.UID }}
+    {{ end }}
+    {{ if .Query.Version }}
+      AND dashboard_version.version = {{ .Arg .Query.Version }}
+    {{ else if .Query.LastID }}
+      AND dashboard_version.version < {{ .Arg .Query.LastID }}
+    {{ end }}
+    ORDER BY
+      dashboard_version.created {{ .Query.Order }},
+      dashboard_version.version {{ .Query.Order }},
+      dashboard.uid ASC
   {{ else }}
     {{ if .Query.UID }}
-    AND dashboard.uid = {{ .Arg .Query.UID }}
+      AND dashboard.uid = {{ .Arg .Query.UID }}
     {{ else if .Query.LastID }}
-    AND dashboard.id < {{ .Arg .Query.LastID }}
+      AND dashboard.id < {{ .Arg .Query.LastID }}
     {{ end }}
     {{ if .Query.GetTrash }}
-    AND dashboard.deleted IS NOT NULL
+      AND dashboard.deleted IS NOT NULL
     {{ else }}
-    AND dashboard.deleted IS NULL
+      AND dashboard.deleted IS NULL
     {{ end }}
-  ORDER BY dashboard.id DESC
+    ORDER BY dashboard.id DESC
   {{ end }}

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-dashboard_next_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id < 22
-    AND dashboard.deleted IS NULL
+  AND dashboard.id < 22
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-folders.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-folders.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = TRUE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_second_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_second_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-dashboard_next_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id < 22
-    AND dashboard.deleted IS NULL
+  AND dashboard.id < 22
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-folders.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-folders.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = TRUE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_second_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_second_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard_next_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-dashboard_next_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.id < 22
-    AND dashboard.deleted IS NULL
+  AND dashboard.id < 22
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-folders.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-folders.sql
@@ -1,20 +1,29 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = TRUE
   AND dashboard.org_id = 2
-    AND dashboard.deleted IS NULL
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
@@ -1,15 +1,24 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard_version.created, updated_user.uid as updated_by,updated_user.id as created_by_id,
-  dashboard_version.version, dashboard_version.message, 
-  dashboard_version.data, dashboard_version.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard_version.created,
+  updated_user.uid       as updated_by,
+  updated_user.id        as created_by_id,
+  dashboard_version.version,
+  dashboard_version.message,
+  dashboard_version.data,
+  dashboard_version.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_second_page.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_second_page.sql
@@ -1,21 +1,30 @@
 SELECT
-  dashboard.org_id, dashboard.id,
-  dashboard.uid, dashboard.folder_uid,
-  dashboard.deleted, plugin_id,
+  dashboard.org_id,
+  dashboard.id,
+  dashboard.uid,
+  dashboard.folder_uid,
+  dashboard.deleted,
+  plugin_id,
   provisioning.name        as repo_name,
   provisioning.external_id as repo_path,
   provisioning.check_sum   as repo_hash,
   provisioning.updated     as repo_ts,
-  dashboard.created, created_user.uid as created_by, dashboard.created_by   as created_by_id,
-  dashboard.updated, updated_user.uid as updated_by, dashboard.updated_by   as updated_by_id,
-  dashboard.version, '' as message, 
-  dashboard.data, dashboard.api_version
+  dashboard.created,
+  created_user.uid         as created_by,
+  dashboard.created_by     as created_by_id,
+  dashboard.updated,
+  updated_user.uid       as updated_by,
+  dashboard.updated_by   as updated_by_id,
+  dashboard.version,
+  '' as message,
+  dashboard.data,
+  dashboard.api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard.updated_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
-    AND dashboard.uid = 'UUU'
-    AND dashboard.deleted IS NULL
+  AND dashboard.uid = 'UUU'
+  AND dashboard.deleted IS NULL
   ORDER BY dashboard.id DESC


### PR DESCRIPTION
Set the `WithHistory` flag to true for the non-interactive mode. It is required for the migration controller.

I also formatted one of the queries used during the migration, it was very hard to reason through it. I did not touch the query logic itself.