### PR TITLE
CI: Prevent dispatch loop for building release artifacts

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -68,6 +68,7 @@ jobs:
       contents: read
       id-token: write
     name: Dispatch grafana-enterprise build
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main


### PR DESCRIPTION
If the enterprise repo dispatches this workflow, then this workflow is dispatching a workflow to enterprise, which dispatches a workflow to grafana ...