### PR TITLE
CI: Unconditionally dispatch to GE

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -68,7 +68,6 @@ jobs:
       contents: read
       id-token: write
     name: Dispatch grafana-enterprise build
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - id: vault-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -39,6 +39,7 @@ jobs:
   setup:
     name: setup
     runs-on: github-hosted-ubuntu-x64-small
+    if: github.repository == 'grafana/grafana'
     outputs:
       version: ${{ steps.output.outputs.version }}
     permissions:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -42,6 +42,7 @@ jobs:
     if: github.repository == 'grafana/grafana'
     outputs:
       version: ${{ steps.output.outputs.version }}
+      grafana-commit: ${{ steps.output.outputs.grafana_commit }}
     permissions:
       contents: read
     steps:
@@ -60,7 +61,9 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           BUILD_ID: ${{ github.run_number }}
       - id: output
-        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+          echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
   # Triggers the same workflow in `grafana-enterprise` on the same ref
   downstream:
     runs-on: github-hosted-ubuntu-x64-small
@@ -89,10 +92,11 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
           BUILD_ID: ${{ github.run_number }}
           BUCKET: grafana-prerelease
+          GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            const {REF, VERSION, BUILD_ID, BUCKET} = process.env;
+            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT} = process.env;
 
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',
@@ -103,6 +107,7 @@ jobs:
                   "version": VERSION,
                   "build-id": String(BUILD_ID),
                   "bucket": BUCKET,
+                  "grafana-commit": GRAFANA_COMMIT,
                 }
             })
 


### PR DESCRIPTION
Apparently what I thought was a bug was just a lot of activity. There are a lot of merges to `main` in Grafana in one day.

I disabled it out of caution to investigate. Didn't want to completely explode our GitHub Actions bill.