### PR TITLE
Alerting: Document label sanitization in GRAFANA_ALERTS

### DIFF
--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -80,6 +80,8 @@ Instead, Grafana Alerting writes alert state data to the `GRAFANA_ALERTS` metric
 GRAFANA_ALERTS{alertname="", alertstate="", grafana_alertstate="", grafana_rule_uid="", <additional alert labels>}
 ```
 
+Alert labels are automatically converted to ensure compatibility. Prometheus requires label names to start with a letter or underscore (`_`), followed only by letters, numbers, or additional underscores. Invalid characters are replaced during conversion. For example, `1my-label` becomes `_my_label`.
+
 The following steps describe a basic configuration:
 
 1. **Configure Prometheus**

--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -80,8 +80,6 @@ Instead, Grafana Alerting writes alert state data to the `GRAFANA_ALERTS` metric
 GRAFANA_ALERTS{alertname="", alertstate="", grafana_alertstate="", grafana_rule_uid="", <additional alert labels>}
 ```
 
-Alert labels are automatically converted to ensure compatibility. Prometheus requires label names to start with a letter or underscore (`_`), followed only by letters, numbers, or additional underscores. Invalid characters are replaced during conversion. For example, `1my-label` becomes `_my_label`.
-
 The following steps describe a basic configuration:
 
 1. **Configure Prometheus**

--- a/docs/sources/alerting/set-up/meta-monitoring.md
+++ b/docs/sources/alerting/set-up/meta-monitoring.md
@@ -56,14 +56,16 @@ This `GRAFANA_ALERTS` metric is compatible with the `ALERTS` metric used by Prom
 1. A new `grafana_rule_uid` label for the UID of the Grafana rule.
 2. A new `grafana_alertstate` label for the Grafana alert state, which differs slightly from the equivalent Prometheus state included in the `alertstate` label.
 
-   | Grafana state  | `alertstate`          | `grafana_alertstate`  |
-   | -------------- | --------------------- | --------------------- |
-   | **Alerting**   | `firing`              | `alerting`            |
-   | **Recovering** | `firing`              | `recovering`          |
-   | **Pending**    | `pending`             | `pending`             |
-   | **Error**      | `firing`              | `error`               |
-   | **NoData**     | `firing`              | `nodata`              |
-   | **Normal**     | _(no metric emitted)_ | _(no metric emitted)_ |
+Alert labels are automatically converted before being written to Prometheus to ensure compatibility. Prometheus requires label names to start with a letter or underscore (`_`), followed only by letters, numbers, or additional underscores. Invalid characters are replaced during conversion. For example, `1my-label` becomes `_my_label`.
+
+| Grafana state  | `alertstate`          | `grafana_alertstate`  |
+| -------------- | --------------------- | --------------------- |
+| **Alerting**   | `firing`              | `alerting`            |
+| **Recovering** | `firing`              | `recovering`          |
+| **Pending**    | `pending`             | `pending`             |
+| **Error**      | `firing`              | `error`               |
+| **NoData**     | `firing`              | `nodata`              |
+| **Normal**     | _(no metric emitted)_ | _(no metric emitted)_ |
 
 You can then query this metric like any other Prometheus metric:
 


### PR DESCRIPTION
**What is this feature?**

A follow-up for https://github.com/grafana/grafana/pull/107181: document label sanitization in `GRAFANA_ALERTS` metric.

Prometheus requires label names to [satisfy a few requirements](https://github.com/prometheus/common/blob/75c3814dc66c571cc82cee2d3a6bf5f37ee73f1a/model/labels.go#L94). In Grafana, users can add static labels that don't meet these requirements. To ensure compatibility, we sanitize the label names before writing the `GRAFANA_ALERTS` metric.

Preview:

- [Configure alert state history page](https://deploy-preview-grafana-107285-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/configure-alert-state-history/#configure-prometheus-for-alert-state-grafana_alerts-metric)
- [Meta monitoring](https://deploy-preview-grafana-107285-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/meta-monitoring/#grafana_alerts-metric)

Part of https://github.com/grafana/alerting-squad/issues/1024