### PR TITLE
Assistant: Expose Dashboarding functions to the Assistant's function registry

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1586,6 +1586,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "1"]
     ],
+    "public/app/features/dashboard-scene/assistant/RegisterAssistantDashboardFunctions.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroupCondition.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@grafana/alerting": "workspace:*",
-    "@grafana/assistant": "file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant",
+    "@grafana/assistant": "0.0.1-alpha.2",
     "@grafana/aws-sdk": "0.7.1",
     "@grafana/azure-sdk": "0.0.7",
     "@grafana/data": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@grafana/alerting": "workspace:*",
+    "@grafana/assistant": "file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant",
     "@grafana/aws-sdk": "0.7.1",
     "@grafana/azure-sdk": "0.0.7",
     "@grafana/data": "workspace:*",
@@ -426,7 +427,8 @@
     "uplot": "1.6.32",
     "uuid": "11.1.0",
     "visjs-network": "4.25.0",
-    "whatwg-fetch": "3.6.20"
+    "whatwg-fetch": "3.6.20",
+    "zod": "3.24.2"
   },
   "resolutions": {
     "underscore": "1.13.7",

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -16,6 +16,7 @@ import { GrafanaContext } from './core/context/GrafanaContext';
 import { GrafanaRouteWrapper } from './core/navigation/GrafanaRoute';
 import { RouteDescriptor } from './core/navigation/types';
 import { ThemeProvider } from './core/utils/ConfigProvider';
+import { RegisterAssistantDashboardFunctions } from './features/dashboard-scene/assistant/RegisterAssistantDashboardFunctions';
 import { LiveConnectionWarning } from './features/live/LiveConnectionWarning';
 import { ExtensionRegistriesProvider } from './features/plugins/extensions/ExtensionRegistriesContext';
 import { pluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
@@ -123,6 +124,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
                       <ExtensionRegistriesProvider registries={pluginExtensionRegistries}>
                         <MaybeExtensionSidebarProvider>
                           <GlobalStylesWrapper />
+                          <RegisterAssistantDashboardFunctions />
                           <div className="grafana-app">
                             <RouterWrapper {...routerWrapperProps} />
                             <LiveConnectionWarning />

--- a/public/app/features/dashboard-scene/assistant/RegisterAssistantDashboardFunctions.tsx
+++ b/public/app/features/dashboard-scene/assistant/RegisterAssistantDashboardFunctions.tsx
@@ -1,0 +1,44 @@
+import { type AddCallbackFunction, type DashboardOperations } from '@grafana/assistant';
+import { usePluginFunctions } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+
+const getDashboardScene = (): DashboardScene | null =>
+  window.__grafanaSceneContext instanceof DashboardScene ? window.__grafanaSceneContext : null;
+
+export const RegisterAssistantDashboardFunctions = () => {
+  // get all exposed functions from the assistant plugin
+  const { functions: assistantFunctions } = usePluginFunctions<AddCallbackFunction>({
+    extensionPointId: 'grafana/grafana-assistant-app/add-callback-function/v0-alpha',
+  });
+
+  const dashboardActions: DashboardOperations = {
+    addPanel: (vizPanel: VizPanel) => getDashboardScene()?.addPanel(vizPanel),
+    duplicatePanel: (vizPanel: VizPanel) => getDashboardScene()?.duplicatePanel(vizPanel),
+    copyPanel: (vizPanel: VizPanel) => getDashboardScene()?.copyPanel(vizPanel),
+    pastePanel: () => getDashboardScene()?.pastePanel(),
+    removePanel: (panel: VizPanel) => getDashboardScene()?.removePanel(panel),
+    createNewPanel: () => getDashboardScene()?.onCreateNewPanel(),
+    createNewRow: () => getDashboardScene()?.onCreateNewRow(),
+    onEnterEditMode: () => getDashboardScene()?.onEnterEditMode(),
+    openSaveDrawer: (options?: { saveAsCopy?: boolean; onSaveSuccess?: () => void }) =>
+      getDashboardScene()?.openSaveDrawer(options || {}),
+    onStarDashboard: () => getDashboardScene()?.onStarDashboard(),
+    canEditDashboard: (): boolean => getDashboardScene()?.canEditDashboard() ?? false,
+    exitEditMode: (options: { skipConfirm: boolean; restoreInitialState?: boolean }) =>
+      getDashboardScene()?.exitEditMode(options),
+  };
+
+  const addCallbackFunction = assistantFunctions.find((func) => func.title === 'addCallbackFunction');
+
+  if (addCallbackFunction) {
+    // register all dashboard actions as callback functions in the `dashboarding` namespace
+    Object.keys(dashboardActions).forEach((actionName) => {
+      const action = dashboardActions[actionName as keyof typeof dashboardActions];
+      addCallbackFunction.fn('dashboarding', actionName, action);
+    });
+  }
+
+  return null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,6 +2984,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::locator=grafana%40workspace%3A.":
+  version: 1.0.0
+  resolution: "@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant#/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::hash=252e7b&locator=grafana%40workspace%3A."
+  checksum: 10/e3bd2ade78c64bb5868cf2e9fb2fdb0e4265dc1bc7b6ef12cfc01a5e2482caa1de1cbd7c8e0bb9c63309751aa57dbd0090a2ccf29c4aa8c85326c1c8cec13e1c
+  languageName: node
+  linkType: hard
+
 "@grafana/async-query-data@npm:0.4.1":
   version: 0.4.1
   resolution: "@grafana/async-query-data@npm:0.4.1"
@@ -3267,6 +3274,7 @@ __metadata:
     react-use: "npm:^17.6.0"
     semver: "npm:^7.6.3"
     uuid: "npm:^11.0.5"
+    zod: "npm:3.24.2"
   peerDependencies:
     "@grafana/data": ^10.4.0 ||^11 || ^12
     "@grafana/runtime": ^10.4.0 || ^11 || ^12
@@ -18140,6 +18148,7 @@ __metadata:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
     "@glideapps/glide-data-grid": "npm:^6.0.0"
     "@grafana/alerting": "workspace:*"
+    "@grafana/assistant": "file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant"
     "@grafana/aws-sdk": "npm:0.7.1"
     "@grafana/azure-sdk": "npm:0.0.7"
     "@grafana/data": "workspace:*"
@@ -33020,6 +33029,13 @@ __metadata:
   peerDependencies:
     zod: ^3.24.1
   checksum: 10/1af291b4c429945c9568c2e924bdb7c66ab8d139cbeb9a99b6e9fc9e1b02863f85d07759b9303714f07ceda3993dcaf0ebcb80d2c18bb2aaf5502b2c1016affd
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.24.2":
+  version: 3.24.2
+  resolution: "zod@npm:3.24.2"
+  checksum: 10/604c62a8cf8e330d78b106a557f4b44f5d14845d20b1360a423ccc09b58cb8525ccf7e4b40cf1bd4852d22393d2c67774b5817ec5a2fedab25f543b36ed15943
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,8 +2986,8 @@ __metadata:
 
 "@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::locator=grafana%40workspace%3A.":
   version: 1.0.0
-  resolution: "@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant#/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::hash=252e7b&locator=grafana%40workspace%3A."
-  checksum: 10/e3bd2ade78c64bb5868cf2e9fb2fdb0e4265dc1bc7b6ef12cfc01a5e2482caa1de1cbd7c8e0bb9c63309751aa57dbd0090a2ccf29c4aa8c85326c1c8cec13e1c
+  resolution: "@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant#/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::hash=0677d0&locator=grafana%40workspace%3A."
+  checksum: 10/14ed0fa59dd20677fc6d4c35f2fc4416be31230d459a22dc9b33981ff3a683ff4c22b957e03cde5c555a07c5c94a562211fcfaf2f0365d82d24ea409e06a799d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,10 +2984,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::locator=grafana%40workspace%3A.":
-  version: 1.0.0
-  resolution: "@grafana/assistant@file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant#/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant::hash=0677d0&locator=grafana%40workspace%3A."
-  checksum: 10/14ed0fa59dd20677fc6d4c35f2fc4416be31230d459a22dc9b33981ff3a683ff4c22b957e03cde5c555a07c5c94a562211fcfaf2f0365d82d24ea409e06a799d
+"@grafana/assistant@npm:0.0.1-alpha.2":
+  version: 0.0.1-alpha.2
+  resolution: "@grafana/assistant@npm:0.0.1-alpha.2"
+  peerDependencies:
+    "@grafana/scenes": ">=5.41.0"
+  checksum: 10/05153946e942b38ca21fd10816cfda2c1505bbfbef97fb4828978a64b3eadf05cf8e749202156e4812c9fd6a51ba6ab951762a63753dc334740cf4b6b43fdef5
   languageName: node
   linkType: hard
 
@@ -18148,7 +18150,7 @@ __metadata:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
     "@glideapps/glide-data-grid": "npm:^6.0.0"
     "@grafana/alerting": "workspace:*"
-    "@grafana/assistant": "file:/Users/sven/repos/00_work/plugins/grafana-assistant-app/packages/@grafana/assistant"
+    "@grafana/assistant": "npm:0.0.1-alpha.2"
     "@grafana/aws-sdk": "npm:0.7.1"
     "@grafana/azure-sdk": "npm:0.0.7"
     "@grafana/data": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

This PR suggests a way of exposing better dashboarding functions to Grafana Assistant. 
Currently the Assistant uses some "hacky" APIs, types and has a bunch of code copied over into the Assistant's repository. To minimize this effort and support better dashboarding tools, this PR passes some helper functions around dashboarding into the Assistant's scope.

See https://github.com/grafana/grafana-assistant-app/pull/629 for how it would be used.