### PR TITLE
Plugin Extensions: Mutable props for extension components

### DIFF
--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -333,7 +333,7 @@ describe('usePluginComponent()', () => {
     expect(log.warning).not.toHaveBeenCalled();
   });
 
-  it('should pass a read-only copy of the props (in dev mode)', async () => {
+  it('should pass a writable copy of the props (in dev mode)', async () => {
     config.buildInfo.env = 'development';
 
     type Props = {
@@ -378,11 +378,12 @@ describe('usePluginComponent()', () => {
     expect(rendered.getByText('Foo')).toBeVisible();
 
     // Should throw an error if it mutates the props
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => render(Component && <Component {...originalProps} override />)).toThrow(
-      TypeError("'set' on proxy: trap returned falsish for property 'c'")
-    );
-    jest.spyOn(console, 'error').mockRestore();
+    expect(() => render(Component && <Component {...originalProps} override />)).not.toThrow();
+
+    // Should log a warning
+    expect(log.warning).toHaveBeenCalledWith('Attempted to mutate object property "c"', {
+      stack: expect.any(String),
+    });
   });
 
   it('should pass a writable copy of the props (in production mode)', async () => {

--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -377,7 +377,7 @@ describe('usePluginComponent()', () => {
     const rendered = render(Component && <Component {...originalProps} />);
     expect(rendered.getByText('Foo')).toBeVisible();
 
-    // Should throw an error if it mutates the props
+    // Should not throw an error if it mutates the props
     expect(() => render(Component && <Component {...originalProps} override />)).not.toThrow();
 
     // Should log a warning
@@ -430,7 +430,7 @@ describe('usePluginComponent()', () => {
     const rendered = render(Component && <Component {...originalProps} />);
     expect(rendered.getByText('Foo')).toBeVisible();
 
-    // Should throw an error if it mutates the props
+    // Should not throw an error if it mutates the props
     expect(() => render(Component && <Component {...originalProps} override />)).not.toThrow();
 
     // Should log a warning

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -211,7 +211,7 @@ describe('usePluginComponents()', () => {
     });
   });
 
-  it('should pass a read only copy of the props to the components (in dev mode)', async () => {
+  it('should pass a copy of the props to the components (in dev mode)', async () => {
     config.buildInfo.env = 'development';
 
     type Props = {
@@ -264,9 +264,11 @@ describe('usePluginComponents()', () => {
     const rendered = render(<Component foo={originalFoo} />);
     expect(rendered.getByText('Foo')).toBeVisible();
 
-    // Check if it throws a TypeError due to trying to change the prop
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => render(<Component foo={originalFoo} override />)).toThrow(TypeError);
+    // Should also render the component if it wants to change the props
+    expect(() => render(<Component foo={originalFoo} override />)).not.toThrow();
+    expect(log.warning).toHaveBeenCalledWith(`Attempted to mutate object property "foo4"`, {
+      stack: expect.any(String),
+    });
 
     // Check if the original property hasn't been changed
     expect(originalFoo.foo2.foo3.foo4).toBe('bar');

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -295,11 +295,6 @@ export function readOnlyCopy<T>(value: T, _log: ExtensionsLog = log): T {
     return getReadOnlyProxy(value);
   }
 
-  // In dev mode: we return a read-only proxy (throws errors for any mutation), but with a deep-cloned version of the original object (so no interference with other call-sites)
-  if (isGrafanaDevMode()) {
-    return getReadOnlyProxy(cloneDeep(value));
-  }
-
   // Default: we return a proxy of a deep-cloned version of the original object, which logs warnings when mutation is attempted
   return getMutationObserverProxy(cloneDeep(value), _log);
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We've noticed that somewhere in RTK/Immer errors are thrown that aren't bubbled up correctly so we've decided to change our initial approach from returning a readonly proxy in Dev mode to always return a `getMutationObserverProxy` that will allow all mutations but will log them to the console and Faro.
![image](https://github.com/user-attachments/assets/015ab580-b916-48ae-933f-028e28ed2a39)

Related [slack thread](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750939811989159)

**Why do we need this feature?**

So plugin extensions work as expected

**Who is this feature for?**

Plugin extension developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
