### PR TITLE
[release-11.6.4] Table: Fix cell border visibility

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -351,7 +351,9 @@ export const RowsList = (props: RowsListProps) => {
               rowStyled={rowBg !== undefined}
               rowExpanded={rowExpanded}
               textWrapped={textWrapFinal !== undefined}
-              height={Number(style.height)}
+              // VariableSizeList overrides calculated in buildCellContainerStyle height of the cell,
+              // so we need to subtract 1 to respect the row border
+              height={Number(style.height) - 1}
               getActions={getActions}
               replaceVariables={replaceVariables}
               setInspectCell={setInspectCell}


### PR DESCRIPTION
Backport b2247513742f05cba9fdceeb3cc05026de37f0a7 from #101951

alternative to https://github.com/grafana/grafana/pull/106968 due to CI issues