### PR TITLE
Clean up metrics usage in dual writer syncer

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -102,6 +102,7 @@ func SetDualWritingMode(
 	ctx context.Context,
 	kvs NamespacedKVStore,
 	cfg *SyncerConfig,
+	metrics *DualWriterMetrics,
 ) (DualWriterMode, error) {
 	if cfg == nil {
 		return Mode0, errors.New("syncer config is nil")
@@ -167,7 +168,7 @@ func SetDualWritingMode(
 	// Before running the sync, set the syncer config to the current mode, as we have to run the syncer
 	// once in the current active mode before we can upgrade.
 	cfg.Mode = currentMode
-	syncOk, err := runDataSyncer(ctx, cfg)
+	syncOk, err := runDataSyncer(ctx, cfg, metrics)
 	// Once we are done with running the syncer, we can change the mode back on the config to the desired one.
 	cfg.Mode = cfgModeTmp
 	if err != nil {

--- a/pkg/apiserver/rest/dualwriter_syncer_test.go
+++ b/pkg/apiserver/rest/dualwriter_syncer_test.go
@@ -201,13 +201,12 @@ func TestLegacyToUnifiedStorage_DataSyncer(t *testing.T) {
 				LegacyStorage:     ls,
 				Storage:           us,
 				Kind:              "test.kind",
-				Reg:               p,
 				ServerLockService: &fakeServerLock{},
 				RequestInfo:       &request.RequestInfo{},
 
 				DataSyncerRecordsLimit: 1000,
 				DataSyncerInterval:     time.Hour,
-			})
+			}, NewDualWriterMetrics(nil))
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -241,13 +240,12 @@ func TestLegacyToUnifiedStorage_DataSyncer(t *testing.T) {
 				LegacyStorage:     ls,
 				Storage:           us,
 				Kind:              "test.kind",
-				Reg:               p,
 				ServerLockService: &fakeServerLock{},
 				RequestInfo:       &request.RequestInfo{},
 
 				DataSyncerRecordsLimit: 1000,
 				DataSyncerInterval:     time.Hour,
-			})
+			}, NewDualWriterMetrics(nil))
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -105,11 +105,10 @@ func TestSetDualWritingMode(t *testing.T) {
 			SkipDataSync:      tt.skipDataSync,
 			ServerLockService: serverLockSvc,
 			RequestInfo:       &request.RequestInfo{},
-			Reg:               p,
 
 			DataSyncerRecordsLimit: 1000,
 			DataSyncerInterval:     time.Hour,
-		})
+		}, NewDualWriterMetrics(nil))
 		require.NoError(t, err)
 		require.Equal(t, tt.expectedMode, dwMode)
 

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -6,47 +6,40 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog/v2"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type dualWriterMetrics struct {
-	syncer        *prometheus.HistogramVec
+type DualWriterMetrics struct {
+	// DualWriterSyncerDuration is a metric summary for dual writer sync duration per mode
+	syncer *prometheus.HistogramVec
+	// DualWriterDataSyncerOutcome is a metric summary for dual writer data syncer outcome comparison between the 2 stores per mode
 	syncerOutcome *prometheus.HistogramVec
 }
 
-// DualWriterSyncerDuration is a metric summary for dual writer sync duration per mode
-var DualWriterSyncerDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Name:                        "dual_writer_data_syncer_duration_seconds",
-	Help:                        "Histogram for the runtime of dual writer data syncer duration per mode",
-	Namespace:                   "grafana",
-	NativeHistogramBucketFactor: 1.1,
-}, []string{"is_error", "mode", "resource"})
+func NewDualWriterMetrics(reg prometheus.Registerer) *DualWriterMetrics {
+	return &DualWriterMetrics{
+		syncer: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "dual_writer_data_syncer_duration_seconds",
+			Help:                        "Histogram for the runtime of dual writer data syncer duration per mode",
+			Namespace:                   "grafana",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"is_error", "mode", "resource"}),
 
-// DualWriterDataSyncerOutcome is a metric summary for dual writer data syncer outcome comparison between the 2 stores per mode
-var DualWriterDataSyncerOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Name:                        "dual_writer_data_syncer_outcome",
-	Help:                        "Histogram for the runtime of dual writer data syncer outcome comparison between the 2 stores per mode",
-	Namespace:                   "grafana",
-	NativeHistogramBucketFactor: 1.1,
-}, []string{"mode", "resource"})
-
-func (m *dualWriterMetrics) init(reg prometheus.Registerer) {
-	log := klog.NewKlogr()
-	m.syncer = DualWriterSyncerDuration
-	m.syncerOutcome = DualWriterDataSyncerOutcome
-	errSyncer := reg.Register(m.syncer)
-	errSyncerOutcome := reg.Register(m.syncerOutcome)
-	if errSyncer != nil || errSyncerOutcome != nil {
-		log.Info("cloud migration metrics already registered")
+		syncerOutcome: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "dual_writer_data_syncer_outcome",
+			Help:                        "Histogram for the runtime of dual writer data syncer outcome comparison between the 2 stores per mode",
+			Namespace:                   "grafana",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"mode", "resource"}),
 	}
 }
 
-func (m *dualWriterMetrics) recordDataSyncerDuration(isError bool, mode DualWriterMode, resource string, startFrom time.Time) {
+func (m *DualWriterMetrics) recordDataSyncerDuration(isError bool, mode DualWriterMode, resource string, startFrom time.Time) {
 	duration := time.Since(startFrom).Seconds()
 	m.syncer.WithLabelValues(strconv.FormatBool(isError), fmt.Sprintf("%d", mode), resource).Observe(duration)
 }
 
-func (m *dualWriterMetrics) recordDataSyncerOutcome(mode DualWriterMode, resource string, synced bool) {
+func (m *DualWriterMetrics) recordDataSyncerOutcome(mode DualWriterMode, resource string, synced bool) {
 	var observeValue float64
 	if !synced {
 		observeValue = 1

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,8 +19,6 @@ var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta
 var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2", GenerateName: "foo"}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: now}}}
 var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListMeta: metav1.ListMeta{}, Items: []example.Pod{*exampleObj}}
 var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}
-
-var p = prometheus.NewRegistry()
 
 type storageMock struct {
 	*mock.Mock


### PR DESCRIPTION
This PR modifies how Dual Writer Metrics are created and used. We now create `DualWriterMetrics` object once and pass metrics around to places where they are used. This eliminates global metrics variables.