### PR TITLE
Jaeger: Decouple backend

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,8 @@ linters:
             - '**/pkg/tsdb/cloudwatch/**/*'
             - '**/pkg/tsdb/loki/*'
             - '**/pkg/tsdb/loki/**/*'
+            - '**/pkg/tsdb/jaeger/*'
+            - '**/pkg/tsdb/jaeger/**/*'
           deny:
             - pkg: github.com/grafana/grafana/pkg/api
               desc: Core plugins are not allowed to depend on Grafana core packages

--- a/pkg/tsdb/jaeger/jaeger.go
+++ b/pkg/tsdb/jaeger/jaeger.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
-
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 )
 
 var logger = backend.NewLoggerWith("logger", "tsdb.jaeger")
@@ -20,7 +19,7 @@ type Service struct {
 	im instancemgmt.InstanceManager
 }
 
-func ProvideService(httpClientProvider httpclient.Provider) *Service {
+func ProvideService(httpClientProvider *httpclient.Provider) *Service {
 	return &Service{
 		im: datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 	}
@@ -36,7 +35,7 @@ type datasourceJSONData struct {
 	} `json:"traceIdTimeParams"`
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		httpClientOptions, err := settings.HTTPClientOptions(ctx)
 		if err != nil {

--- a/pkg/tsdb/jaeger/standalone/datasource.go
+++ b/pkg/tsdb/jaeger/standalone/datasource.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+
+	jaeger "github.com/grafana/grafana/pkg/tsdb/jaeger"
+)
+
+var (
+	_ backend.QueryDataHandler    = (*Datasource)(nil)
+	_ backend.CheckHealthHandler  = (*Datasource)(nil)
+	_ backend.CallResourceHandler = (*Datasource)(nil)
+)
+
+func NewDatasource(context.Context, backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	return &Datasource{
+		Service: jaeger.ProvideService(httpclient.NewProvider()),
+	}, nil
+}
+
+type Datasource struct {
+	Service *jaeger.Service
+}
+
+func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return d.Service.QueryData(ctx, req)
+}
+
+func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	return d.Service.CallResource(ctx, req, sender)
+}
+
+func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return d.Service.CheckHealth(ctx, req)
+}

--- a/pkg/tsdb/jaeger/standalone/main.go
+++ b/pkg/tsdb/jaeger/standalone/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+func main() {
+	// Start listening to requests sent from Grafana. This call is blocking so
+	// it won't finish until Grafana shuts down the process or the plugin choose
+	// to exit by itself using os.Exit. Manage automatically manages life cycle
+	// of datasource instances. It accepts datasource instance factory as first
+	// argument. This factory will be automatically called on incoming request
+	// from Grafana to create different instances of SampleDatasource (per datasource
+	// ID). When datasource configuration changed Dispose method will be called and
+	// new datasource instance created using NewSampleDatasource factory.
+	if err := datasource.Manage("jaeger", NewDatasource, datasource.ManageOpts{}); err != nil {
+		log.DefaultLogger.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/public/app/plugins/datasource/jaeger/plugin.json
+++ b/public/app/plugins/datasource/jaeger/plugin.json
@@ -3,6 +3,7 @@
   "name": "Jaeger",
   "id": "jaeger",
   "category": "tracing",
+  "executable": "gpx_jaeger",
 
   "backend": true,
   "metrics": true,
@@ -47,6 +48,6 @@
     "version": "%VERSION%"
   },
   "dependencies": {
-    "grafanaDependency": ">=10.3.0-0"
+    "grafanaDependency": ">=10.4.0-0"
   }
 }

--- a/public/app/plugins/datasource/jaeger/plugin.json
+++ b/public/app/plugins/datasource/jaeger/plugin.json
@@ -48,6 +48,6 @@
     "version": "%VERSION%"
   },
   "dependencies": {
-    "grafanaDependency": ">=10.4.0-0"
+    "grafanaDependency": ">=10.3.0-0"
   }
 }


### PR DESCRIPTION
Jaeger data source was decoupled before we implemented backend. When we implemented backend, we forgot to add following changes mention in [here](https://docs.google.com/document/d/1Fh6NeI7mNQwmtzPMhawMnmHypWd_PD-ZJQ-bDseRy1g/edit?tab=t.0). This PR fixes it. 