### PR TITLE
Remove use of prometheus.DefaultRegisterer from ProvideUnifiedStorageGrpcService.

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/dskit/services"
+
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/modules"
@@ -173,7 +174,7 @@ func (s *ModuleServer) Run() error {
 		if err != nil {
 			return nil, err
 		}
-		return sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, nil, s.log, nil, docBuilders, s.storageMetrics, s.indexMetrics, s.storageRing, s.MemberlistKVConfig)
+		return sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, nil, s.log, s.registerer, docBuilders, s.storageMetrics, s.indexMetrics, s.storageRing, s.MemberlistKVConfig)
 	})
 
 	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -7,10 +7,10 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -86,11 +86,6 @@ func ProvideUnifiedStorageGrpcService(
 	memberlistKVConfig kv.Config,
 ) (UnifiedStorageGrpcService, error) {
 	tracer := otel.Tracer("unified-storage")
-
-	// reg can be nil when running unified storage in standalone mode
-	if reg == nil {
-		reg = prometheus.DefaultRegisterer
-	}
 
 	// FIXME: This is a temporary solution while we are migrating to the new authn interceptor
 	// grpcutils.NewGrpcAuthenticator should be used instead.
@@ -279,31 +274,14 @@ func (f *authenticatorWithFallback) Authenticate(ctx context.Context) (context.C
 	return newCtx, err
 }
 
-const (
-	metricsNamespace = "grafana"
-	metricsSubSystem = "grpc_authenticator_with_fallback"
-)
-
-var once sync.Once
-
 func newMetrics(reg prometheus.Registerer) *metrics {
-	m := &metrics{
-		requestsTotal: prometheus.NewCounterVec(
+	return &metrics{
+		requestsTotal: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Name:      "requests_total",
-				Help:      "Number requests using the authenticator with fallback",
+				Name: "grafana_grpc_authenticator_with_fallback_requests_total",
+				Help: "Number requests using the authenticator with fallback",
 			}, []string{"fallback_used", "result"}),
 	}
-
-	if reg != nil {
-		once.Do(func() {
-			reg.MustRegister(m.requestsTotal)
-		})
-	}
-
-	return m
 }
 
 func ReadGrpcServerConfig(cfg *setting.Cfg) *grpcutils.AuthenticatorConfig {


### PR DESCRIPTION
Remove use of `prometheus.DefaultRegisterer` from codebase. Also simplified `newMetrics`, which is only called once.