### PR TITLE
[release-11.3.9] [Docs] Panel embedding not available in Cloud

### DIFF
--- a/docs/sources/dashboards/share-dashboards-panels/index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/index.md
@@ -223,7 +223,7 @@ The snapshot is immediately deleted. You may need to clear your browser cache or
 You can embed a panel using an iframe on another web site. A viewer must be signed into Grafana to view the graph.
 
 {{< admonition type="note" >}}
-As of Grafana 8.0, anonymous access permission is no longer available for Grafana Cloud.
+Panel embedding and anonymous access permissions are not available in Grafana Cloud, even for panels in [public dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/dashboard-public/). These capabilities are only supported in Grafana Enterprise and Grafana Open Source.
 {{< /admonition >}}
 
 Here is an example of the HTML code:


### PR DESCRIPTION
Backport 069598c454d9f0874072342ed06830abfb231c9c from #107253

---

Clarifies the statement that embedding AND anonymous access are not available in Grafana Cloud.
