### PR TITLE
Actions: Add GOCACHEPROG support

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -53,7 +53,6 @@ jobs:
 
   grafana-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    # If it gets merged into `main` or `release-*`, then a junit test result is uploaded to GCS.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     strategy:
       matrix:
@@ -66,9 +65,43 @@ jobs:
     name: Grafana Enterprise (${{ matrix.shard }})
     runs-on: ubuntu-latest-8-cores
     permissions:
-      contents: read
-      id-token: write
+      contents: read # to clone repo
+      id-token: write # required for enterprise & AWS
+    env:
+      GOCACHE_HTTP: 'localhost:12345'
+      GOCACHE_MODPROXY: 'true'
+      GOCACHE_PLUGIN: '1234'
+      GOCACHE_S3_BUCKET: 'grafana-cicd-gha-cache-workloads-prod'
+      GOCACHE_S3_REGION: 'us-east-2'
+      GOCACHE_METRICS: 'true'
+      GOCACHE_DIR: '/tmp/gocache'
+      GOCACHEPROG: go-cache-plugin connect 1234
+      GOPROXY: 'http://localhost:12345/mod'
+      GOSUMDB: 'sum.golang.org http://localhost:12345/mod/sumdb/sum.golang.org'
     steps:
+      - name: Auth to AWS
+        uses: grafana/shared-workflows/actions/aws-auth@aws-auth/v1.0.2
+        with:
+          aws-region: "us-east-2"
+          pass-claims: "repository_owner, repository_name, job_workflow_ref, ref, event_name"
+          set-creds-in-environment: true
+          role-arn: 'arn:aws:iam::422075448034:role/github-actions/grafana-cicd'
+      - name: Install go-cache-plugin
+        env:
+          GOCP_VERSION: 'v0.1.1'
+          GOCP_OS: 'linux-amd64'
+          GOCP_HASH: 'b945e1b76e3020732be19561d161067535e55d12a0d222a2045ea8429bf8bc88'
+        run: |
+          set -xeuo pipefail
+          curl -LO https://github.com/grafana/go-cache-plugin/releases/download/"$GOCP_VERSION"/go-cache-plugin-"$GOCP_OS"
+          mv go-cache-plugin-"$GOCP_OS" go-cache-plugin
+          echo -e "$GOCP_HASH\tgo-cache-plugin" | sha256sum --check
+          chmod +x go-cache-plugin
+          file go-cache-plugin
+          sudo mv go-cache-plugin /bin/go-cache-plugin # move to PATH
+          go-cache-plugin version || true # success returns exit code 2
+          go-cache-plugin serve &
+
       # Set up repository clone
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,16 +111,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false # download Go from the action super quickly. use S3 cache for code & modules.
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
           github-app-name: 'grafana-ci-bot'
-
-      # Prepare what we need to upload test results
-      - run: echo "RESULTS_FILE=$(date --rfc-3339=seconds --utc | sed -s 's/ /-/g')_${SHARD/\//_}.xml" >> "$GITHUB_ENV"
-        env:
-          SHARD: ${{ matrix.shard }}
-      - run: go install github.com/jstemmer/go-junit-report/v2@85bf4716ac1f025f2925510a9f5e9f5bb347c009
 
       # Run code
       - name: Generate Go code
@@ -99,8 +127,6 @@ jobs:
           set -euo pipefail
 
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/shard.sh -N"$SHARD")"
-          # This tee requires pipefail to be set, otherwise `go test`'s exit code is thrown away.
-          # That means having no `-o pipefail` => failing tests => exit code 0, which is wrong.
           go test -short -timeout=30m "${PACKAGES[@]}"
 
   # This is the job that is actually required by rulesets.

--- a/pkg/build/daggerbuild/arguments/go_build_cache.go
+++ b/pkg/build/daggerbuild/arguments/go_build_cache.go
@@ -2,6 +2,7 @@ package arguments
 
 import (
 	"context"
+	"os"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana/pkg/build/daggerbuild/golang"
@@ -26,6 +27,12 @@ var GoModCache = pipeline.Argument{
 	Flags:        []cli.Flag{},
 	ValueFunc: func(ctx context.Context, opts *pipeline.ArgumentOpts) (any, error) {
 		vol := opts.Client.CacheVolume("go-mod-cache")
+
+		// If GOCACHE_S3_BUCKET is set, then don't pre-warm the cache with 'go mod download'
+		if _, ok := os.LookupEnv("GOCACHE_S3_BUCKET"); ok {
+			return vol, nil
+		}
+
 		goVersion, err := opts.State.String(ctx, GoVersion)
 		if err != nil {
 			return nil, err

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -176,7 +176,7 @@ func Builder(
 		WithDirectory("/src/pkg", src.WithoutDirectory("pkg/build").Directory("pkg")).
 		WithDirectory("/src/apps", src.Directory("apps")).
 		WithDirectory("/src/emails", src.Directory("emails")).
-		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag, goBuildCache)).
+		WithFile("/src/pkg/server/wire_gen.go", Wire(d, src, platform, goVersion, opts.WireTag)).
 		WithFile("/src/.buildinfo.commit", commitInfo.Commit).
 		WithWorkdir("/src")
 
@@ -192,9 +192,9 @@ func Builder(
 	return builder, nil
 }
 
-func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goVersion string, wireTag string, cache *dagger.CacheVolume) *dagger.File {
+func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goVersion string, wireTag string) *dagger.File {
 	// withCue is only required during `make gen-go` in 9.5.x or older.
-	c := golang.Container(d, platform, goVersion).
+	return golang.Container(d, platform, goVersion).
 		WithExec([]string{"apk", "add", "make"}).
 		WithDirectory("/src/", src, dagger.ContainerWithDirectoryOpts{
 			Include: []string{"**/*.mod", "**/*.sum", "**/*.work", ".git"},
@@ -204,13 +204,7 @@ func Wire(d *dagger.Client, src *dagger.Directory, platform dagger.Platform, goV
 		WithDirectory("/src/.bingo", src.Directory(".bingo")).
 		WithDirectory("/src/.citools", src.Directory(".citools")).
 		WithFile("/src/Makefile", src.File("Makefile")).
-		WithWorkdir("/src")
-
-	if _, ok := os.LookupEnv("GOCACHE_S3_BUCKET"); ok {
-		c = WithGoModProxy(d, platform, c, goVersion, cache)
-	}
-
-	return c.
+		WithWorkdir("/src").
 		WithExec([]string{"make", "gen-go", fmt.Sprintf("WIRE_TAGS=%s", wireTag)}).
 		File("/src/pkg/server/wire_gen.go")
 }

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"dagger.io/dagger"
 	"github.com/grafana/grafana/pkg/build/daggerbuild/containers"
@@ -102,7 +103,9 @@ func GolangContainer(
 		WithExec([]string{"wget", "-q", "http://dl.grafana.com/ci/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
 		WithExec([]string{"tar", "-xf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
 		WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
-		WithExec([]string{"tar", "-xf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"})
+		WithExec([]string{"tar", "-xf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"}).
+		WithExec([]string{"wget", "-q", fmt.Sprintf("https://github.com/grafana/go-cache-plugin/releases/download/v0.1.1/go-cache-plugin-%s", strings.ReplaceAll(string(platform), "/", "-")), "-O", "/bin/go-cache-plugin"}).
+		WithExec([]string{"chmod", "+x", "/bin/go-cache-plugin"})
 
 	return WithGoEnv(log, container, distro, opts)
 }
@@ -154,8 +157,6 @@ func Builder(
 	builder = builder.
 		WithMountedCache("/root/.cache/go", goBuildCache).
 		WithEnvVariable("GOCACHE", "/root/.cache/go")
-
-	builder = builder.WithExec([]string{"go", "install", "github.com/tailscale/go-cache-plugin/cmd/go-cache-plugin@latest"})
 
 	if prog := opts.GoCacheProg; prog != "" {
 		builder = builder.WithEnvVariable("GOCACHEPROG", prog)

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -155,6 +155,8 @@ func Builder(
 		WithMountedCache("/root/.cache/go", goBuildCache).
 		WithEnvVariable("GOCACHE", "/root/.cache/go")
 
+	builder = builder.WithExec([]string{"go", "install", "github.com/tailscale/go-cache-plugin/cmd/go-cache-plugin@latest"})
+
 	if prog := opts.GoCacheProg; prog != "" {
 		builder = builder.WithEnvVariable("GOCACHEPROG", prog)
 	}

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -81,7 +81,7 @@ func ViceroyContainer(
 
 func WithGoCachePlugin(c *dagger.Container, platform dagger.Platform) *dagger.Container {
 	return c.
-		WithExec([]string{"wget", "-q", fmt.Sprintf("https://github.com/grafana/go-cache-plugin/releases/download/v0.1.1/go-cache-plugin-%s", strings.ReplaceAll(string(platform), "/", "-")), "-O", "/bin/go-cache-plugin"}).
+		WithExec([]string{"wget", "-q", fmt.Sprintf("https://github.com/grafana/go-cache-plugin/releases/download/v0.1.3/go-cache-plugin-%s", strings.ReplaceAll(string(platform), "/", "-")), "-O", "/bin/go-cache-plugin"}).
 		WithExec([]string{"chmod", "+x", "/bin/go-cache-plugin"})
 }
 

--- a/pkg/build/daggerbuild/backend/gomodproxy.go
+++ b/pkg/build/daggerbuild/backend/gomodproxy.go
@@ -1,0 +1,63 @@
+package backend
+
+import (
+	"os"
+
+	"dagger.io/dagger"
+	"github.com/grafana/grafana/pkg/build/daggerbuild/containers"
+	"github.com/grafana/grafana/pkg/build/daggerbuild/golang"
+)
+
+// withInheritedEnv will inherit the specific environment variables (env) from the host in the container (c)
+func withInheritedEnv(c *dagger.Container, vars []string) *dagger.Container {
+	container := c
+	for _, key := range vars {
+		value, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+
+		container = container.WithEnvVariable(key, value)
+	}
+
+	return container
+}
+
+func WithGoModProxy(
+	d *dagger.Client,
+	platform dagger.Platform,
+	c *dagger.Container,
+	goVersion string,
+	goCacheVolume *dagger.CacheVolume,
+) *dagger.Container {
+	svc := WithGoCachePlugin(golang.Container(d, platform, goVersion), platform)
+
+	svc = containers.WithEnv(svc, []containers.Env{
+		{
+			Name:  "GOCACHE_HTTP",
+			Value: "localhost:12345",
+		}, {
+			Name:  "GOCACHE_MODPROXY",
+			Value: "true",
+		}, {
+			Name:  "GOCACHE_PLUGIN",
+			Value: "1234",
+		}, {
+			Name:  "GOCACHE_METRICS",
+			Value: "true",
+		}, {
+			Name:  "GOCACHE_DIR",
+			Value: "/tmp/gocache",
+		},
+	})
+
+	svc = svc.WithMountedCache("/tmp/gocache", goCacheVolume)
+	svc = withInheritedEnv(svc, []string{"GOCACHE_S3_BUCKET", "GOCACHE_S3_REGION"})
+
+	s := svc.WithExposedPort(1234).AsService(dagger.ContainerAsServiceOpts{
+		Args: []string{"go-cache-plugin", "serve"},
+	})
+	return c.WithFile("/bin/go-cache-plugin", svc.File("/bin/go-cache-plugin")).
+		WithServiceBinding("gocache", s).
+		WithEnvVariable("GOCACHEPROG", `go-cache-plugin connect gocache:1234`)
+}

--- a/pkg/build/daggerbuild/backend/gomodproxy.go
+++ b/pkg/build/daggerbuild/backend/gomodproxy.go
@@ -75,7 +75,7 @@ func WithGoModProxy(
 	})
 
 	return c.WithFile("/bin/go-cache-plugin", svc.File("/bin/go-cache-plugin")).
-		WithEnvVariable("GOPROXY", "http://localhost:12345/mod").
+		WithEnvVariable("GOPROXY", "http://gocache:12345/mod").
 		WithEnvVariable("GOSUMDB", "sum.golang.org http://localhost:12345/mod/sumdb/sum.golang.org").
 		WithEnvVariable("GOCACHEPROG", `go-cache-plugin connect gocache:1234`).
 		WithServiceBinding("gocache", s)


### PR DESCRIPTION
This implements GOCACHEPROG.

This PR is pretty exclusively used as a testing ground for [#hackathon-13-cicd-perf](https://grafanalabs.enterprise.slack.com/archives/C093LJYELU8)

See also Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/8904