### PR TITLE
Storybook: Deploy PR previews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -835,6 +835,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/i18n-crowdin-download.yml @grafana/grafana-frontend-platform
 /.github/workflows/i18n-crowdin-create-tasks.yml @grafana/grafana-frontend-platform
 /.github/workflows/i18n-verify.yml @grafana/grafana-frontend-platform
+/.github/workflows/deploy-storybook-preview.yml @grafana/grafana-frontend-platform
 /.github/workflows/scripts/crowdin/create-tasks.ts @grafana/grafana-frontend-platform
 /.github/workflows/pr-go-workspace-check.yml @grafana/grafana-app-platform-squad
 /.github/workflows/pr-dependabot-update-go-workspace.yml @grafana/grafana-app-platform-squad

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -67,5 +67,5 @@ jobs:
 
       - name: Write summary
         run: |
-          echo '### Storybook preview deployed! 🚀' >> $GITHUB_STEP_SUMMARY
-          echo 'Check it out at: https://storage.googleapis.com/$BUCKET_NAME/$DEPLOY_NAME/index.html' >> $GITHUB_STEP_SUMMARY
+          echo "## Storybook preview deployed! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "Check it out at https://storage.googleapis.com/${BUCKET_NAME}/${DEPLOY_NAME}/index.html" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -24,7 +24,6 @@ jobs:
 
     env:
       BUCKET_NAME: grafana-storybook-previews
-      DEPLOY_NAME: preview-${{ github.run_id }} # TODO: better path prefix - branch name or PR ID?
 
     steps:
       - name: Checkout code
@@ -56,17 +55,39 @@ jobs:
       - name: Build storybook
         run: yarn storybook:build
 
+      # Create the GCS folder name for the preview. Creates a consistent name for all deploys for the PR.
+      # Matches format of `pr_<PR_NUMBER>_<SANITIZED_BRANCH>`.
+      # Where `SANITIZED_BRANCH` is the branch name with only alphanumeric and hyphens, limited to 30 characters.
+      - name: Create deploy name
+        id: create-deploy-name
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Convert branch name to only contain alphanumeric and hyphens
+          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')
+
+          # Check if SANITIZED_BRANCH is empty and fail if it is
+          if [ -z "$SANITIZED_BRANCH" ]; then
+            echo "Error: Branch name resulted in empty string after sanitization"
+            exit 1
+          fi
+
+          echo "deploy-name=pr_${PR_NUMBER}_${SANITIZED_BRANCH:0:30}" >> $GITHUB_OUTPUT
+
       - name: Upload Storybook
         uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
           environment: prod
           bucket: ${{ env.BUCKET_NAME }}
-          bucket_path: ${{ env.DEPLOY_NAME }}
+          bucket_path: ${{ steps.create-deploy-name.outputs.deploy-name }}
           path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
 
       - name: Write summary
+        env:
+          DEPLOY_NAME: ${{ steps.create-deploy-name.outputs.deploy-name }}
         run: |
           echo "## Storybook preview deployed! 🚀" >> $GITHUB_STEP_SUMMARY
           echo "Check it out at https://storage.googleapis.com/${BUCKET_NAME}/${DEPLOY_NAME}/index.html" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -58,3 +58,4 @@ jobs:
           bucket_path: preview-${{ github.run_id }} # TODO: better path prefix - PR ID?
           path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
+          parent: false

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -22,6 +22,10 @@ jobs:
       contents: read
       id-token: write
 
+    env:
+      BUCKET_NAME: grafana-storybook-previews
+      DEPLOY_NAME: preview-${{ github.run_id }} # TODO: better path prefix - branch name or PR ID?
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,11 +55,17 @@ jobs:
       - name: Build storybook
         run: yarn storybook:build
 
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - name: Upload Storybook
+        uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
           environment: prod
-          bucket: grafana-storybook-previews
-          bucket_path: preview-${{ github.run_id }} # TODO: better path prefix - PR ID?
+          bucket: ${{ env.BUCKET_NAME }}
+          bucket_path: ${{ env.DEPLOY_NAME }}
           path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
+
+      - name: Write summary
+        run: |
+          echo '### Storybook preview deployed! 🚀' >> $GITHUB_STEP_SUMMARY
+          echo 'Check it out at: https://storage.googleapis.com/$BUCKET_NAME/$DEPLOY_NAME/index.html' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -25,23 +25,8 @@ jobs:
     env:
       BUCKET_NAME: grafana-storybook-previews
       DEPLOY_NAME: preview-${{ github.run_id }} # TODO: better path prefix - branch name or PR ID?
-      COMMENT_MARKER: "<!-- storybook-preview -->"
 
     steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: ${{ env.COMMENT_MARKER }}
-
-      - name: React to comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
-        if: steps.find-comment.outputs.comment-id != ''
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          reactions: eyes
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -80,33 +65,6 @@ jobs:
           path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
-
-      - name: Get short commit hash
-        id: commit-hash
-        run: echo "commit-hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Post new comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
-        if: steps.find-comment.outputs.comment-id == ''
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ${{ env.COMMENT_MARKER }}
-            :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)
-
-      - name: Update existing comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
-        if: steps.find-comment.outputs.comment-id != ''
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          reactions-edit-mode: replace # remove eyes reaction
-          reactions: ""
-          edit-mode: replace
-          body: |
-            ${{ env.COMMENT_MARKER }}
-            :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)
-
-            <sub>Updated to `${{ steps.commit-hash.outputs.commit-hash }}`</sub>
 
       - name: Write summary
         run: |

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -2,14 +2,8 @@ name: Deploy Storybook preview
 
 on:
   pull_request:
-  #   paths:
-  #     - 'packages/grafana-ui/**'
-  push:
-    branches:
-      # - main
-      - storybook-preview-deploys
-    # paths:
-    #   - 'packages/grafana-ui/**'
+    paths:
+      - 'packages/grafana-ui/**'
 
 permissions: {}
 
@@ -17,8 +11,9 @@ jobs:
   deploy-storybook-preview:
     name: Deploy Storybook preview
     runs-on: ubuntu-latest
-    # Only run on push, or on PRs NOT from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Don't run from forks for the moment. If we find this useful we can do the workflow_run dance
+    # to make it work for forks.
+    if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -81,6 +81,10 @@ jobs:
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
 
+      - name: Get short commit hash
+        id: commit-hash
+        run: echo "commit-hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Post new comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: steps.find-comment.outputs.comment-id == ''
@@ -101,7 +105,7 @@ jobs:
             ${{ env.COMMENT_MARKER }}
             :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)
 
-            <sub>Updated to `${{ github.sha.substring(0, 7) }}`</sub>
+            <sub>Updated to `${{ steps.commit-hash.outputs.commit-hash }}`</sub>
 
       - name: Write summary
         run: |

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -14,7 +14,7 @@ on:
 permissions: {}
 
 jobs:
-  verify-storybook:
+  deploy-storybook-preview:
     name: Deploy Storybook preview
     runs-on: ubuntu-latest
     # Only run on push, or on PRs NOT from forks
@@ -39,3 +39,10 @@ jobs:
 
       - name: Build storybook
         run: yarn storybook:build
+
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs/v0.2.1
+        with:
+          bucket: grafana-storybook-previews
+          bucket_path: preview-${{ github.run_id }}/ # TODO: better path prefix - PR ID?
+          path: packages/grafana-ui/dist/storybook/
+          service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -50,6 +50,7 @@ jobs:
 
       - uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
+          environment: prod
           bucket: grafana-storybook-previews
           bucket_path: preview-${{ github.run_id }}/ # TODO: better path prefix - PR ID?
           path: packages/grafana-ui/dist/storybook/

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       # - main
-      - jh/storybook-pr-previews
+      - storybook-preview-deploys
     # paths:
     #   - 'packages/grafana-ui/**'
 

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -21,6 +21,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy Storybook preview
 
 on:
-  # pull_request:
+  pull_request:
   #   paths:
   #     - 'packages/grafana-ui/**'
   push:
@@ -40,13 +40,6 @@ jobs:
 
       - name: Build storybook
         run: yarn storybook:build
-
-      - name: Log in to GCS
-        id: login-to-gcs
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
-        with:
-          environment: prod
-          service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       - uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Install dependencies
         env:
-          YARN_ENABLE_HARDENED_MODE: ${{ github.event.pull_request.head.repo.fork == true && '1' || '0' }}
+          # If the PR isn't from a fork then don't use the slower yarn checks
+          YARN_ENABLE_HARDENED_MODE: ${{ github.event.pull_request.head.repo.fork == false && '1' || '0' }}
         run: yarn install --immutable
 
       - name: Build storybook

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -1,4 +1,4 @@
-name: Verify Storybook
+name: Deploy Storybook preview
 
 on:
   # pull_request:
@@ -15,8 +15,10 @@ permissions: {}
 
 jobs:
   verify-storybook:
-    name: Verify Storybook
+    name: Deploy Storybook preview
     runs-on: ubuntu-latest
+    # Only run on push, or on PRs NOT from forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
 

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -89,6 +89,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: steps.find-comment.outputs.comment-id == ''
         with:
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
             ${{ env.COMMENT_MARKER }}
             :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -40,6 +40,6 @@ jobs:
         with:
           environment: prod
           bucket: grafana-storybook-previews
-          bucket_path: preview-${{ github.run_id }}/ # TODO: better path prefix - PR ID?
-          path: packages/grafana-ui/dist/storybook/
+          bucket_path: preview-${{ github.run_id }} # TODO: better path prefix - PR ID?
+          path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -65,7 +65,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Convert branch name to only contain alphanumeric and hyphens
-          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')
+          SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | tr -cs "[:alnum:]-" "-" | sed "s/^-//;s/-$//")
 
           # Check if SANITIZED_BRANCH is empty and fail if it is
           if [ -z "$SANITIZED_BRANCH" ]; then
@@ -73,7 +73,7 @@ jobs:
             exit 1
           fi
 
-          echo "deploy-name=pr_${PR_NUMBER}_${SANITIZED_BRANCH:0:30}" >> $GITHUB_OUTPUT
+          echo "deploy-name=pr_${PR_NUMBER}_${SANITIZED_BRANCH:0:30}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Storybook
         uses: grafana/shared-workflows/actions/push-to-gcs@main

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'packages/grafana-ui/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -30,7 +34,18 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            node_modules-
+
       - name: Install dependencies
+        env:
+          YARN_ENABLE_HARDENED_MODE: ${{ github.event.pull_request.head.repo.fork == true && '1' || '0' }}
         run: yarn install --immutable
 
       - name: Build storybook

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -1,0 +1,39 @@
+name: Verify Storybook
+
+on:
+  # pull_request:
+  #   paths:
+  #     - 'packages/grafana-ui/**'
+  push:
+    branches:
+      # - main
+      - jh/storybook-pr-previews
+    # paths:
+    #   - 'packages/grafana-ui/**'
+
+permissions: {}
+
+jobs:
+  verify-storybook:
+    name: Verify Storybook
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build storybook
+        run: yarn storybook:build

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -41,7 +41,14 @@ jobs:
       - name: Build storybook
         run: yarn storybook:build
 
-      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs/v0.2.1
+      - name: Log in to GCS
+        id: login-to-gcs
+        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        with:
+          environment: prod
+          service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
+
+      - uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
           bucket: grafana-storybook-previews
           bucket_path: preview-${{ github.run_id }}/ # TODO: better path prefix - PR ID?

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -25,8 +25,23 @@ jobs:
     env:
       BUCKET_NAME: grafana-storybook-previews
       DEPLOY_NAME: preview-${{ github.run_id }} # TODO: better path prefix - branch name or PR ID?
+      COMMENT_MARKER: "<!-- storybook-preview -->"
 
     steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: ${{ env.COMMENT_MARKER }}
+
+      - name: React to comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        if: steps.find-comment.outputs.comment-id != ''
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          reactions: eyes
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -65,6 +80,28 @@ jobs:
           path: packages/grafana-ui/dist/storybook
           service_account: github-gf-storybook-preview@grafanalabs-workload-identity.iam.gserviceaccount.com
           parent: false
+
+      - name: Post new comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        if: steps.find-comment.outputs.comment-id == ''
+        with:
+          body: |
+            ${{ env.COMMENT_MARKER }}
+            :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)
+
+      - name: Update existing comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        if: steps.find-comment.outputs.comment-id != ''
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          reactions-edit-mode: replace # remove eyes reaction
+          reactions: ""
+          edit-mode: replace
+          body: |
+            ${{ env.COMMENT_MARKER }}
+            :wave: Storybook for this PR has been deployed to preview changes - [check it out!](https://storage.googleapis.com/${{ env.BUCKET_NAME }}/${{ env.DEPLOY_NAME }}/index.html)
+
+            <sub>Updated to `${{ github.sha.substring(0, 7) }}`</sub>
 
       - name: Write summary
         run: |

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -52,6 +52,7 @@ if (process.env.NODE_ENV === 'development') {
 initialize({
   onUnhandledRequest: 'bypass',
   serviceWorker: {
+    // Important! The path must be relative to work when we deploy storybook to subpaths (e.g. /ui/canary)
     url: 'mockServiceWorker.js',
   },
 });


### PR DESCRIPTION
Adds preview deploys of Storybook to PRs that touch files in `packages/grafana-ui/**`. Storybook will be built and uploaded to a public GCS bucket from the PR. All deploys for a PR are uploaded to the same path, overwriting the last one. 

It doesn't yet post a comment to the PR - you'll have to go to the [GHA run summary](https://github.com/grafana/grafana/actions/runs/16050222546) to get the URL, such as https://storage.googleapis.com/grafana-storybook-previews/pr_107322_storybook-preview-deploys/index.html?path=/

At the moment this isn't available for PRs from forks.

If we find this highly useful, in the future we can:
 - make it post a comment with the link, so it's more obvious
 - tweak the action to make it work for external PRs from forks.