### PR TITLE
Group sync: Deprecate group sync endpoints, unlink group sync frontend page

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -155,21 +155,6 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		})
 	}
 
-	if s.license.FeatureEnabled("groupsync") &&
-		s.features.IsEnabled(ctx, featuremgmt.FlagGroupAttributeSync) &&
-		hasAccess(ac.EvalAny(
-			ac.EvalPermission("groupsync.mappings:read"),
-			ac.EvalPermission("groupsync.mappings:write"),
-		)) {
-		accessNodeLinks = append(accessNodeLinks, &navtree.NavLink{
-			Text:     "External group sync",
-			Id:       "groupsync",
-			SubTitle: "Manage mappings of Identity Provider groups to Grafana Roles",
-			Icon:     "",
-			Url:      s.cfg.AppSubURL + "/admin/access/groupsync",
-		})
-	}
-
 	usersNode := &navtree.NavLink{
 		Text:     "Users and access",
 		SubTitle: "Configure access for individual users, teams, and service accounts",

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -990,39 +990,31 @@
     },
     "/groupsync/groups": {
       "get": {
+        "description": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "getMappedGroups",
+        "deprecated": true,
         "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
     },
     "/groupsync/groups/{group_id}": {
       "put": {
+        "description": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "updateGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "name": "body",
@@ -1040,30 +1032,20 @@
           }
         ],
         "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       },
       "post": {
+        "description": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "createGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "name": "body",
@@ -1081,30 +1063,20 @@
           }
         ],
         "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       },
       "delete": {
+        "description": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "deleteGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -1114,32 +1086,22 @@
           }
         ],
         "responses": {
-          "204": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
     },
     "/groupsync/groups/{group_id}/roles": {
       "get": {
+        "description": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "getGroupRoles",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -1149,23 +1111,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
@@ -5144,15 +5091,6 @@
         }
       }
     },
-    "Group": {
-      "type": "object",
-      "properties": {
-        "groupID": {
-          "type": "string"
-        },
-        "mappings": {}
-      }
-    },
     "GroupAttributes": {
       "type": "object",
       "properties": {
@@ -5487,6 +5425,7 @@
           "format": "int64"
         },
         "id": {
+          "description": "Deprecated: this field will be removed in the future",
           "type": "integer",
           "format": "int64"
         },
@@ -6128,14 +6067,14 @@
         "language": {
           "type": "string"
         },
-        "locale": {
-          "type": "string"
-        },
         "navbar": {
           "$ref": "#/definitions/NavbarPreference"
         },
         "queryHistory": {
           "$ref": "#/definitions/QueryHistoryPreference"
+        },
+        "regionalFormat": {
+          "type": "string"
         },
         "theme": {
           "type": "string",
@@ -6397,15 +6336,15 @@
           "description": "Selected language (beta)",
           "type": "string"
         },
-        "locale": {
-          "description": "Selected locale (beta)",
-          "type": "string"
-        },
         "navbar": {
           "$ref": "#/definitions/NavbarPreference"
         },
         "queryHistory": {
           "$ref": "#/definitions/QueryHistoryPreference"
+        },
+        "regionalFormat": {
+          "description": "Selected locale (beta)",
+          "type": "string"
         },
         "theme": {
           "description": "light, dark, empty is default",
@@ -8559,14 +8498,14 @@
         "language": {
           "type": "string"
         },
-        "locale": {
-          "type": "string"
-        },
         "navbar": {
           "$ref": "#/definitions/NavbarPreference"
         },
         "queryHistory": {
           "$ref": "#/definitions/QueryHistoryPreference"
+        },
+        "regionalFormat": {
+          "type": "string"
         },
         "theme": {
           "type": "string",
@@ -8972,21 +8911,6 @@
         }
       }
     },
-    "getGroupsResponse": {
-      "type": "object",
-      "properties": {
-        "groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "total": {
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
     "healthResponse": {
       "type": "object",
       "properties": {
@@ -9000,14 +8924,6 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
-        }
-      }
-    },
-    "messageResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
           "type": "string"
         }
       }
@@ -9154,12 +9070,6 @@
         "items": {
           "$ref": "#/definitions/UserToken"
         }
-      }
-    },
-    "apiResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/messageResponse"
       }
     },
     "badRequestError": {
@@ -9681,21 +9591,6 @@
         "items": {
           "$ref": "#/definitions/FolderSearchHit"
         }
-      }
-    },
-    "getGroupRolesResponse": {
-      "description": "",
-      "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/RoleDTO"
-        }
-      }
-    },
-    "getGroupsResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/getGroupsResponse"
       }
     },
     "getHomeDashboardResponse": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -5312,39 +5312,31 @@
     },
     "/groupsync/groups": {
       "get": {
+        "description": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "getMappedGroups",
+        "deprecated": true,
         "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
     },
     "/groupsync/groups/{group_id}": {
       "put": {
+        "description": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "updateGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "name": "body",
@@ -5362,30 +5354,20 @@
           }
         ],
         "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       },
       "post": {
+        "description": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "createGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "name": "body",
@@ -5403,30 +5385,20 @@
           }
         ],
         "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       },
       "delete": {
+        "description": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "deleteGroupMappings",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -5436,32 +5408,22 @@
           }
         ],
         "responses": {
-          "204": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
     },
     "/groupsync/groups/{group_id}/roles": {
       "get": {
+        "description": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ],
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "operationId": "getGroupRoles",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -5471,23 +5433,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
+          "410": {
+            "$ref": "#/responses/goneError"
           }
         }
       }
@@ -16424,15 +16371,6 @@
         }
       }
     },
-    "Group": {
-      "type": "object",
-      "properties": {
-        "groupID": {
-          "type": "string"
-        },
-        "mappings": {}
-      }
-    },
     "GroupAttributes": {
       "type": "object",
       "properties": {
@@ -23067,21 +23005,6 @@
         }
       }
     },
-    "getGroupsResponse": {
-      "type": "object",
-      "properties": {
-        "groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "total": {
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
     "gettableAlert": {
       "description": "GettableAlert gettable alert",
       "type": "object",
@@ -23327,14 +23250,6 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/matcher"
-      }
-    },
-    "messageResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        }
       }
     },
     "peerStatus": {
@@ -23706,12 +23621,6 @@
         "items": {
           "$ref": "#/definitions/UserToken"
         }
-      }
-    },
-    "apiResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/messageResponse"
       }
     },
     "badRequestError": {
@@ -24233,21 +24142,6 @@
         "items": {
           "$ref": "#/definitions/FolderSearchHit"
         }
-      }
-    },
-    "getGroupRolesResponse": {
-      "description": "(empty)",
-      "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/RoleDTO"
-        }
-      }
-    },
-    "getGroupsResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/getGroupsResponse"
       }
     },
     "getHomeDashboardResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -93,16 +93,6 @@
         },
         "description": "(empty)"
       },
-      "apiResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/messageResponse"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
       "badRequestError": {
         "content": {
           "application/json": {
@@ -831,29 +821,6 @@
                 "$ref": "#/components/schemas/FolderSearchHit"
               },
               "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupRolesResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/RoleDTO"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupsResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/getGroupsResponse"
             }
           }
         },
@@ -6469,15 +6436,6 @@
           "wechat_api_url": {
             "$ref": "#/components/schemas/URL"
           }
-        },
-        "type": "object"
-      },
-      "Group": {
-        "properties": {
-          "groupID": {
-            "type": "string"
-          },
-          "mappings": {}
         },
         "type": "object"
       },
@@ -13113,21 +13071,6 @@
         },
         "type": "object"
       },
-      "getGroupsResponse": {
-        "properties": {
-          "groups": {
-            "items": {
-              "$ref": "#/components/schemas/Group"
-            },
-            "type": "array"
-          },
-          "total": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
       "gettableAlert": {
         "description": "GettableAlert gettable alert",
         "properties": {
@@ -13372,14 +13315,6 @@
           "$ref": "#/components/schemas/matcher"
         },
         "type": "array"
-      },
-      "messageResponse": {
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "type": "object"
       },
       "peerStatus": {
         "description": "PeerStatus peer status",
@@ -19458,25 +19393,15 @@
     },
     "/groupsync/groups": {
       "get": {
+        "deprecated": true,
+        "description": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "operationId": "getMappedGroups",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
+          "410": {
+            "$ref": "#/components/responses/goneError"
           }
         },
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
@@ -19485,6 +19410,8 @@
     },
     "/groupsync/groups/{group_id}": {
       "delete": {
+        "deprecated": true,
+        "description": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "operationId": "deleteGroupMappings",
         "parameters": [
           {
@@ -19497,29 +19424,19 @@
           }
         ],
         "responses": {
-          "204": {
-            "$ref": "#/components/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
+          "410": {
+            "$ref": "#/components/responses/goneError"
           }
         },
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ]
       },
       "post": {
+        "deprecated": true,
+        "description": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "operationId": "createGroupMappings",
         "parameters": [
           {
@@ -19543,29 +19460,19 @@
           "x-originalParamName": "body"
         },
         "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
+          "410": {
+            "$ref": "#/components/responses/goneError"
           }
         },
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
         ]
       },
       "put": {
+        "deprecated": true,
+        "description": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "operationId": "updateGroupMappings",
         "parameters": [
           {
@@ -19589,23 +19496,11 @@
           "x-originalParamName": "body"
         },
         "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
+          "410": {
+            "$ref": "#/components/responses/goneError"
           }
         },
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "tags": [
           "group_attribute_sync",
           "enterprise"
@@ -19614,6 +19509,8 @@
     },
     "/groupsync/groups/{group_id}/roles": {
       "get": {
+        "deprecated": true,
+        "description": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
         "operationId": "getGroupRoles",
         "parameters": [
           {
@@ -19626,26 +19523,11 @@
           }
         ],
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/components/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
+          "410": {
+            "$ref": "#/components/responses/goneError"
           }
         },
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
+        "summary": "This endpoint has been deprecated and will not perform any logic.",
         "tags": [
           "group_attribute_sync",
           "enterprise"


### PR DESCRIPTION
**What is this feature?**

Group sync feature (which existed behind a private preview feature toggle) never took off, so we've decided to remove it. This PR starts the removal process by:
* deprecating group sync endpoints;
* changing the group sync endpoint logic to not perform any actions;
* unlinking group sync frontend page.

**Why do we need this feature?**

Feature removal.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/identity-access-team/issues/1117

**Special notes for your reviewer:**

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/8921
