### PR TITLE
Plugins: Fix and encode invalid gRPC header values

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -52,7 +52,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		if gotVal == "" {
 			continue
 		}
-		gotVal = sanitizeGrpcHeaderValue(gotVal)
+		gotVal = sanitizeHTTPHeaderValueForGRPC(gotVal)
 		req.SetHTTPHeader(headerName, gotVal)
 	}
 }
@@ -106,11 +106,11 @@ func (m *TracingHeaderMiddleware) RunStream(ctx context.Context, req *backend.Ru
 	return m.BaseHandler.RunStream(ctx, req, sender)
 }
 
-// sanitizeGrpcHeaderValue sanitizes header values according to HTTP/2 gRPC specification.
+// sanitizeHTTPHeaderValueForGRPC sanitizes header values according to HTTP/2 gRPC specification.
 // The spec defines ASCII-Value as 1*( %x20-%x7E ) ; space and printable ASCII
 // Control characters (0x00-0x1F) are percent-encoded.
 // Allows printable ASCII (0x20-0x7E) and extended characters (> 0x7F).
-func sanitizeGrpcHeaderValue(value string) string {
+func sanitizeHTTPHeaderValueForGRPC(value string) string {
 	var sanitized strings.Builder
 	sanitized.Grow(len(value)) // Pre-allocate reasonable capacity
 

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -110,9 +110,8 @@ func (m *TracingHeaderMiddleware) RunStream(ctx context.Context, req *backend.Ru
 }
 
 // sanitizeHTTPHeaderValueForGRPC sanitizes header values according to HTTP/2 gRPC specification.
-// The spec defines ASCII-Value as 1*( %x20-%x7E ) ; space and printable ASCII
-// Control characters (0x00-0x1F) are percent-encoded.
-// Allows printable ASCII (0x20-0x7E) and extended characters (> 0x7F).
+// The spec defines that header values must §consist of printable ASCII characters 0x20 (space) - 0x7E(tilde) inclusive.
+// Other characters are percent-encoded.
 func sanitizeHTTPHeaderValueForGRPC(value string) string {
 	// Can we use something from utf8 package to do this?
 	var sanitized strings.Builder
@@ -120,11 +119,9 @@ func sanitizeHTTPHeaderValueForGRPC(value string) string {
 
 	for _, r := range value {
 		code := int(r)
-		// Allow printable ASCII (space to ~) and extended characters
-		if (code >= 0x20 && code <= 0x7E) || code > 0x7F {
+		if code >= 0x20 && code <= 0x7E {
 			sanitized.WriteRune(r)
 		} else {
-			// Control characters (0x00-0x1F) need percent encoding
 			sanitized.WriteString(fmt.Sprintf("%%%02X", code))
 		}
 	}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -115,8 +115,6 @@ func (m *TracingHeaderMiddleware) RunStream(ctx context.Context, req *backend.Ru
 // The spec defines that header values must consist of printable ASCII characters 0x20 (space) - 0x7E(tilde) inclusive.
 // First attempts to decode any percent-encoded characters, then encodes invalid characters.
 func sanitizeHTTPHeaderValueForGRPC(value string) string {
-	var sanitized strings.Builder
-	sanitized.Grow(len(value)) // Pre-allocate reasonable capacity
 	// First try to decode characters that were encoded by the frontend
 	decoder := charmap.ISO8859_1.NewDecoder()
 	decoded, _, err := transform.Bytes(decoder, []byte(value))
@@ -124,6 +122,8 @@ func sanitizeHTTPHeaderValueForGRPC(value string) string {
 	if err != nil {
 		decoded = []byte(value)
 	}
+	var sanitized strings.Builder
+	sanitized.Grow(len(decoded)) // Pre-allocate reasonable capacity
 	// Then encode invalid characters
 	for _, b := range decoded {
 		if b >= 0x20 && b <= 0x7E {

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -301,8 +301,8 @@ func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 		},
 		{
 			name:     "Extended characters remain unchanged",
-			input:    "café résumé naïve",
-			expected: "café résumé naïve",
+			input:    "naïve",
+			expected: "na%EFve",
 		},
 		{
 			name:     "Control characters are percent-encoded",
@@ -327,7 +327,7 @@ func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 		{
 			name:     "Mixed valid and invalid characters",
 			input:    "Valid text\x00invalid\x1Fmore valid 🚀",
-			expected: "Valid text%00invalid%1Fmore valid 🚀",
+			expected: "Valid text%00invalid%1Fmore valid %1F680",
 		},
 		{
 			name:     "Empty string remains empty",

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -276,8 +276,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			require.NoError(t, err)
 
 			// Invalid UTF-8 should be sanitized
-			require.Equal(t, "dash%FFFD%FFFDuid", cdt.QueryDataReq.GetHTTPHeader(`X-Dashboard-Title`))
-			require.Equal(t, "panel%FFFDid", cdt.QueryDataReq.GetHTTPHeader(`X-Panel-Title`))
+			require.Equal(t, "dash%C3%BF%C3%BEuid", cdt.QueryDataReq.GetHTTPHeader(`X-Dashboard-Title`))
+			require.Equal(t, "panel%C2%80id", cdt.QueryDataReq.GetHTTPHeader(`X-Panel-Title`))
 
 			// Valid characters should remain unchanged
 			require.Equal(t, "valid-text-123", cdt.QueryDataReq.GetHTTPHeader(`X-Query-Group-Id`))

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -293,11 +293,6 @@ func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 			expected: "café résumé naïve",
 		},
 		{
-			name:     "Invalid characters are percent-encoded",
-			input:    "Ó",
-			expected: "Ó",
-		},
-		{
 			name:     "Control characters are percent-encoded",
 			input:    "hello\x00\x01\x1Fworld",
 			expected: "hello%00%01%1Fworld",

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -276,7 +276,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 	})
 }
 
-func TestSanitizeGrpcHeaderValue(t *testing.T) {
+func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    string
@@ -331,7 +331,7 @@ func TestSanitizeGrpcHeaderValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sanitizeGrpcHeaderValue(tc.input)
+			result := sanitizeHTTPHeaderValueForGRPC(tc.input)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -291,61 +291,61 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    []byte
+		input    string
 		expected string
 	}{
 		{
 			name:     "Valid printable ASCII characters remain unchanged",
-			input:    []byte("Hello World! 123 @#$%^&*()"),
+			input:    "Hello World! 123 @#$%^&*()",
 			expected: "Hello World! 123 @#$%^&*()",
 		},
 		{
 			name: "Extended characters remain unchanged",
 			// %C3%A9 is encoded é
-			input:    []byte("naiv%C3%A9"),
+			input:    "naiv%C3%A9",
 			expected: "naiv%C3%A9",
 		},
 		{
 			name:     "naivé coming in as an iso8859-1 string",
-			input:    []byte{110, 97, 105, 118, 233},
+			input:    string([]byte{110, 97, 105, 118, 233}),
 			expected: "naiv%C3%A9",
 		},
 		{
 			name:     "Control characters are percent-encoded",
-			input:    []byte("hello\x00\x01\x1Fworld"),
+			input:    "hello\x00\x01\x1Fworld",
 			expected: "hello%00%01%1Fworld",
 		},
 		{
 			name:     "Tab character is percent-encoded",
-			input:    []byte("hello\tworld"),
+			input:    "hello\tworld",
 			expected: "hello%09world",
 		},
 		{
 			name:     "Newline character is percent-encoded",
-			input:    []byte("hello\nworld"),
+			input:    "hello\nworld",
 			expected: "hello%0Aworld",
 		},
 		{
 			name:     "Carriage return is percent-encoded",
-			input:    []byte("hello\rworld"),
+			input:    "hello\rworld",
 			expected: "hello%0Dworld",
 		},
 		{
 			name: "Mixed valid and invalid characters",
 			// %F0%9F%9A%80 is encoded 🚀
-			input:    []byte("Valid text\x00invalid\x1Fmore valid %F0%9F%9A%80"),
+			input:    "Valid text\x00invalid\x1Fmore valid %F0%9F%9A%80",
 			expected: "Valid text%00invalid%1Fmore valid %F0%9F%9A%80",
 		},
 		{
 			name:     "Empty string remains empty",
-			input:    []byte(""),
+			input:    "",
 			expected: "",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sanitizeHTTPHeaderValueForGRPC(string(tc.input))
+			result := sanitizeHTTPHeaderValueForGRPC(tc.input)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -300,9 +300,10 @@ func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 			expected: "Hello World! 123 @#$%^&*()",
 		},
 		{
-			name:     "Extended characters remain unchanged",
-			input:    "naïve",
-			expected: "na%EFve",
+			name: "Extended characters remain unchanged",
+			// %C3%A9 is encoded é
+			input:    "naiv%C3%A9",
+			expected: "naiv%C3%A9",
 		},
 		{
 			name:     "Control characters are percent-encoded",
@@ -325,9 +326,10 @@ func TestSanitizeHTTPHeaderValueForGRPC(t *testing.T) {
 			expected: "hello%0Dworld",
 		},
 		{
-			name:     "Mixed valid and invalid characters",
-			input:    "Valid text\x00invalid\x1Fmore valid 🚀",
-			expected: "Valid text%00invalid%1Fmore valid %1F680",
+			name: "Mixed valid and invalid characters",
+			// %F0%9F%9A%80 is encoded 🚀
+			input:    "Valid text\x00invalid\x1Fmore valid %F0%9F%9A%80",
+			expected: "Valid text%00invalid%1Fmore valid %F0%9F%9A%80",
 		},
 		{
 			name:     "Empty string remains empty",


### PR DESCRIPTION
This PR fixes and encode invalid gRPC header values. We encode headers on frontend based on http spec, but grpc is ore strict. Therefore before sending headers through grpc, we need to ensure that values are valid. 

Related to [this](https://github.com/grafana/support-escalations/issues/17026#issuecomment-3013244920). More info in [here](https://raintank-corp.slack.com/archives/C06TNNEKAHL/p1751035356778639).

Here is fixed behavior:

https://github.com/user-attachments/assets/be8b0fdf-3181-42b7-b674-9fab5843bd1d

Current (broken) behavior on main:

https://github.com/user-attachments/assets/d1f3ac58-a1a4-46f1-a022-1e59497591c2


