### PR TITLE
Alerting: Fix notification policy conflicts originating from provenance mismatch

### DIFF
--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -277,7 +277,6 @@ func writeToHash(sum hash.Hash, r *definitions.Route) {
 	writeDuration(r.GroupWait)
 	writeDuration(r.GroupInterval)
 	writeDuration(r.RepeatInterval)
-	writeString(string(r.Provenance))
 	for _, route := range r.Routes {
 		writeToHash(sum, route)
 	}

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -434,7 +434,7 @@ func TestRoute_Fingerprint(t *testing.T) {
 	t.Run("unstable across field modification", func(t *testing.T) {
 		fingerprint := calculateRouteFingerprint(baseRouteGen())
 		excludedFields := map[string]struct{}{
-			"Routes": {},
+			"Routes":     {},
 			"Provenance": {},
 		}
 

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -428,13 +428,14 @@ func TestRoute_Fingerprint(t *testing.T) {
 	}
 
 	t.Run("stable across code changes", func(t *testing.T) {
-		expectedFingerprint := "7faba12778df93b8" // If this is a valid fingerprint generation change, update the expected value.
+		expectedFingerprint := "450c06a7f4a66675" // If this is a valid fingerprint generation change, update the expected value.
 		assert.Equal(t, expectedFingerprint, calculateRouteFingerprint(baseRouteGen()))
 	})
 	t.Run("unstable across field modification", func(t *testing.T) {
 		fingerprint := calculateRouteFingerprint(baseRouteGen())
 		excludedFields := map[string]struct{}{
 			"Routes": {},
+			"Provenance": {},
 		}
 
 		reflectVal := reflect.ValueOf(&completelyDifferentRoute).Elem()


### PR DESCRIPTION
Sometimes the provenance field on the notification policy route can mismatch with the actual provenance in the provenance store.

This leads to 409s when trying to update the notification policy via the k8s apis.

We fix this by ignoring the provenance field when calculating the fingerprint.
