### PR TITLE
OFREP:  Enable with standard aggregation

### DIFF
--- a/pkg/registry/apis/ofrep/noop.go
+++ b/pkg/registry/apis/ofrep/noop.go
@@ -54,6 +54,6 @@ func (r *NoopConnector) ProducesObject(verb string) interface{} {
 
 func (r *NoopConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte("NOOP"))
+		_, _ = w.Write([]byte("NOOP"))
 	}), nil
 }

--- a/pkg/registry/apis/ofrep/noop.go
+++ b/pkg/registry/apis/ofrep/noop.go
@@ -1,0 +1,59 @@
+package ofrep
+
+import (
+	"context"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+// This is a dummy connector that is not actually used for anything
+// EXCEPT -- k8s requires *something* to be registered so it will add the storage to discovery.
+// As a quick workaround, we register a noop storage; and then manually remove it from openapi
+type NoopConnector struct{}
+
+var (
+	_ rest.Connecter            = (*NoopConnector)(nil)
+	_ rest.StorageMetadata      = (*NoopConnector)(nil)
+	_ rest.Scoper               = (*NoopConnector)(nil)
+	_ rest.SingularNameProvider = (*NoopConnector)(nil)
+)
+
+func (r *NoopConnector) New() runtime.Object {
+	return &metav1.Status{}
+}
+
+func (r *NoopConnector) NamespaceScoped() bool {
+	return true // namespaced
+}
+
+func (r *NoopConnector) GetSingularName() string {
+	return "noop"
+}
+
+func (r *NoopConnector) Destroy() {
+}
+
+func (r *NoopConnector) ConnectMethods() []string {
+	return []string{"GET"}
+}
+
+func (r *NoopConnector) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (r *NoopConnector) ProducesMIMETypes(verb string) []string {
+	return nil
+}
+
+func (r *NoopConnector) ProducesObject(verb string) interface{} {
+	return r.New()
+}
+
+func (r *NoopConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("NOOP"))
+	}), nil
+}

--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -10,20 +10,22 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
+	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
-	"github.com/gorilla/mux"
+	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var _ builder.APIGroupBuilder = (*APIBuilder)(nil)
@@ -31,6 +33,11 @@ var _ builder.APIGroupRouteProvider = (*APIBuilder)(nil)
 var _ builder.APIGroupVersionProvider = (*APIBuilder)(nil)
 
 const ofrepPath = "/ofrep/v1/evaluate/flags"
+
+var groupVersion = schema.GroupVersion{
+	Group:   "features.grafana.app",
+	Version: "v0alpha1",
+}
 
 type APIBuilder struct {
 	providerType    string
@@ -66,18 +73,19 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 }
 
 func (b *APIBuilder) GetGroupVersion() schema.GroupVersion {
-	return schema.GroupVersion{
-		Group:   "features.grafana.app",
-		Version: "v0alpha1",
-	}
+	return groupVersion
 }
 
 func (b *APIBuilder) InstallSchema(scheme *runtime.Scheme) error {
-	metav1.AddToGroupVersion(scheme, b.GetGroupVersion())
-	return scheme.SetVersionPriority(b.GetGroupVersion())
+	metav1.AddToGroupVersion(scheme, groupVersion)
+	scheme.AddKnownTypes(groupVersion, &metav1.Status{}) // for noop
+	return scheme.SetVersionPriority(groupVersion)
 }
 
 func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
+	storage := map[string]rest.Storage{}
+	storage["noop"] = &NoopConnector{}
+	apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version] = storage
 	return nil
 }
 
@@ -91,20 +99,124 @@ func (b *APIBuilder) AllowedV0Alpha1Resources() []string {
 	return []string{builder.AllResourcesAllowed}
 }
 
+func (b *APIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
+	oas.Info.Description = "Proxy access to open feature flags"
+
+	// Remove the NOOP connector
+	delete(oas.Paths.Paths, "/apis/features.grafana.app/v0alpha1/namespaces/{namespace}/noop/{name}")
+	return oas, nil
+}
+
 func (b *APIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
+	evaluationContext := &spec3.RequestBody{
+		RequestBodyProps: spec3.RequestBodyProps{
+			Description: "EvaluationContext provides ambient information for the purposes of flag evaluation",
+			Content: map[string]*spec3.MediaType{
+				"application/json": {
+					MediaTypeProps: spec3.MediaTypeProps{
+						Schema: spec.MapProperty(nil),
+						Example: map[string]any{
+							"example": "aaa",
+							"yyy":     true,
+						},
+					},
+				},
+			},
+		}}
+
 	return &builder.APIRoutes{
 		Namespace: []builder.APIRouteHandler{
 			{
 				Path: "ofrep/v1/evaluate/flags/",
 				Spec: &spec3.PathProps{
-					Post: &spec3.Operation{},
+					Post: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Tags:        []string{"Evaluate"},
+							Description: "Evaluate all flags",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+							},
+							RequestBody: evaluationContext,
+							Responses: &spec3.Responses{
+								ResponsesProps: spec3.ResponsesProps{
+									StatusCodeResponses: map[int]*spec3.Response{
+										200: {
+											ResponseProps: spec3.ResponseProps{
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: spec.MapProperty(nil), // TODO... real type?
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				Handler: b.allFlagsHandler,
 			},
 			{
 				Path: "ofrep/v1/evaluate/flags/{flagKey}",
 				Spec: &spec3.PathProps{
-					Post: &spec3.Operation{},
+					Post: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Tags:        []string{"Evaluate"},
+							Description: "Evaluate a single flag",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "flagKey",
+										In:          "path",
+										Required:    true,
+										Example:     "unifiedStorageSearch", // ???
+										Description: "flag key",
+										Schema:      spec.StringProperty(),
+									},
+								},
+							},
+							RequestBody: evaluationContext,
+							Responses: &spec3.Responses{
+								ResponsesProps: spec3.ResponsesProps{
+									StatusCodeResponses: map[int]*spec3.Response{
+										200: {
+											ResponseProps: spec3.ResponseProps{
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: spec.MapProperty(nil), // anything
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				Handler: b.oneFlagHandler,
 			},

--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -112,15 +112,16 @@ func (b *APIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
 			Content: map[string]*spec3.MediaType{
 				"application/json": {
 					MediaTypeProps: spec3.MediaTypeProps{
-						Schema: spec.MapProperty(nil),
-						Example: map[string]any{
-							"example": "aaa",
-							"yyy":     true,
+						Schema: spec.MapProperty(spec.MapProperty(nil)),
+						Example: map[string]map[string]any{
+							"context": {
+								"targetingKey":    "1234",
+								"grafana_version": "12.0.0",
+							},
 						},
 					},
 				},
-			},
-		}}
+			}}}
 
 	return &builder.APIRoutes{
 		Namespace: []builder.APIRouteHandler{
@@ -189,7 +190,7 @@ func (b *APIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
 										Name:        "flagKey",
 										In:          "path",
 										Required:    true,
-										Example:     "unifiedStorageSearch", // ???
+										Example:     "testflag",
 										Description: "flag key",
 										Schema:      spec.StringProperty(),
 									},

--- a/pkg/tests/apis/features/features_test.go
+++ b/pkg/tests/apis/features/features_test.go
@@ -1,0 +1,53 @@
+package features
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+func TestIntegrationFeatures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Enable a random flag -- check that it is reported as enabled
+	flag := featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction: true,
+		DisableAnonymous:  false, // allow anon user
+		EnableFeatureToggles: []string{
+			flag, // used in test below
+		},
+	})
+
+	t.Run("Test evaluate flags", func(t *testing.T) {
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			Method: http.MethodPost,
+			Path:   "/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/" + flag,
+			User:   helper.Org1.Admin,
+		}, &map[string]any{})
+
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		require.JSONEq(t, `{
+			"Value": true,
+			"FlagKey": "`+flag+`",
+			"FlagType": 0,
+			"Variant": "enabled",
+			"Reason": "STATIC",
+			"ErrorCode": "",
+			"ErrorMessage": "",
+			"FlagMetadata": {}
+		}`, string(rsp.Body))
+	})
+}


### PR DESCRIPTION
This is a follow up to https://github.com/grafana/grafana/pull/105632 where a new features apiserver was added.

This PR makes sure it shows up in aggregation for single tenant grafana and adds a very basic integration test.

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/2441d0c6-8b0f-4579-bb4b-9299265b2a70" />
