### PR TITLE
Plugin Extension: improves  mutation logs

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -989,10 +989,6 @@ export interface FeatureToggles {
   */
   alertingBulkActionsInUI?: boolean;
   /**
-  * Use proxy-based read-only objects for plugin extensions instead of deep cloning
-  */
-  extensionsReadOnlyProxy?: boolean;
-  /**
   * Registers AuthZ /apis endpoint
   */
   kubernetesAuthzApis?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1698,15 +1698,6 @@ var (
 			Expression:        "true", // enabled by default
 		},
 		{
-			Name:              "extensionsReadOnlyProxy",
-			Description:       "Use proxy-based read-only objects for plugin extensions instead of deep cloning",
-			Stage:             FeatureStageExperimental,
-			Owner:             grafanaPluginsPlatformSquad,
-			HideFromAdminPage: true,
-			HideFromDocs:      true,
-			FrontendOnly:      true,
-		},
-		{
 			Name:              "kubernetesAuthzApis",
 			Description:       "Registers AuthZ /apis endpoint",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -222,7 +222,6 @@ multiTenantFrontend,experimental,@grafana/grafana-frontend-platform,false,false,
 alertingListViewV2PreviewToggle,privatePreview,@grafana/alerting-squad,false,false,true
 alertRuleUseFiredAtForStartsAt,experimental,@grafana/alerting-squad,false,false,false
 alertingBulkActionsInUI,GA,@grafana/alerting-squad,false,false,true
-extensionsReadOnlyProxy,experimental,@grafana/plugins-platform-backend,false,false,true
 kubernetesAuthzApis,experimental,@grafana/identity-access-team,false,false,false
 restoreDashboards,experimental,@grafana/grafana-frontend-platform,false,false,false
 skipTokenRotationIfRecent,privatePreview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -899,10 +899,6 @@ const (
 	// Enables the alerting bulk actions in the UI
 	FlagAlertingBulkActionsInUI = "alertingBulkActionsInUI"
 
-	// FlagExtensionsReadOnlyProxy
-	// Use proxy-based read-only objects for plugin extensions instead of deep cloning
-	FlagExtensionsReadOnlyProxy = "extensionsReadOnlyProxy"
-
 	// FlagKubernetesAuthzApis
 	// Registers AuthZ /apis endpoint
 	FlagKubernetesAuthzApis = "kubernetesAuthzApis"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1110,7 +1110,8 @@
       "metadata": {
         "name": "extensionsReadOnlyProxy",
         "resourceVersion": "1750434297879",
-        "creationTimestamp": "2025-05-06T04:55:23Z"
+        "creationTimestamp": "2025-05-06T04:55:23Z",
+        "deletionTimestamp": "2025-06-30T08:24:11Z"
       },
       "spec": {
         "description": "Use proxy-based read-only objects for plugin extensions instead of deep cloning",

--- a/public/app/features/datasources/components/DataSourcePluginSettings.tsx
+++ b/public/app/features/datasources/components/DataSourcePluginSettings.tsx
@@ -1,7 +1,7 @@
 import { createElement, PureComponent } from 'react';
 
 import { DataSourcePluginMeta, DataSourceSettings } from '@grafana/data';
-import { readOnlyCopy } from 'app/features/plugins/extensions/utils';
+import { writableProxy } from 'app/features/plugins/extensions/utils';
 
 import { GenericDataSourcePlugin } from '../types';
 
@@ -34,7 +34,7 @@ export class DataSourcePluginSettings extends PureComponent<Props> {
       <div>
         {plugin.components.ConfigEditor &&
           createElement(plugin.components.ConfigEditor, {
-            options: readOnlyCopy(dataSource),
+            options: writableProxy(dataSource),
             onOptionsChange: this.onModelChanged,
           })}
       </div>

--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -380,8 +380,8 @@ describe('usePluginComponent()', () => {
     // Should not throw an error if it mutates the props
     expect(() => render(Component && <Component {...originalProps} override />)).not.toThrow();
 
-    // Should log a warning
-    expect(log.warning).toHaveBeenCalledWith('Attempted to mutate object property "c"', {
+    // Should log an error in dev mode
+    expect(log.error).toHaveBeenCalledWith('Attempted to mutate object property "c"', {
       stack: expect.any(String),
     });
   });

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -266,7 +266,7 @@ describe('usePluginComponents()', () => {
 
     // Should also render the component if it wants to change the props
     expect(() => render(<Component foo={originalFoo} override />)).not.toThrow();
-    expect(log.warning).toHaveBeenCalledWith(`Attempted to mutate object property "foo4"`, {
+    expect(log.error).toHaveBeenCalledWith(`Attempted to mutate object property "foo4"`, {
       stack: expect.any(String),
     });
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -21,7 +21,7 @@ import {
   getAppPluginDependencies,
   getExtensionPointPluginMeta,
   getMutationObserverProxy,
-  readOnlyCopy,
+  writableProxy,
   isMutationObserverProxy,
 } from './utils';
 
@@ -439,7 +439,7 @@ describe('Plugin Extensions / Utils', () => {
     });
   });
 
-  describe('readOnlyCopy()', () => {
+  describe('writableProxy()', () => {
     const originalEnv = config.buildInfo.env;
 
     beforeEach(() => {
@@ -452,19 +452,19 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should return the same value for primitive types', () => {
-      expect(readOnlyCopy(1)).toBe(1);
-      expect(readOnlyCopy('a')).toBe('a');
-      expect(readOnlyCopy(true)).toBe(true);
-      expect(readOnlyCopy(false)).toBe(false);
-      expect(readOnlyCopy(null)).toBe(null);
-      expect(readOnlyCopy(undefined)).toBe(undefined);
+      expect(writableProxy(1)).toBe(1);
+      expect(writableProxy('a')).toBe('a');
+      expect(writableProxy(true)).toBe(true);
+      expect(writableProxy(false)).toBe(false);
+      expect(writableProxy(null)).toBe(null);
+      expect(writableProxy(undefined)).toBe(undefined);
     });
 
     it('should return a writable deep-copy of the original object in dev mode', () => {
       config.buildInfo.env = 'development';
 
       const obj = { a: 'a' };
-      const copy = readOnlyCopy(obj);
+      const copy = writableProxy(obj);
 
       expect(copy).not.toBe(obj);
       expect(copy.a).toBe('a');
@@ -484,7 +484,7 @@ describe('Plugin Extensions / Utils', () => {
       config.buildInfo.env = 'production';
 
       const obj = { a: 'a' };
-      const copy = readOnlyCopy(obj);
+      const copy = writableProxy(obj);
 
       expect(copy).not.toBe(obj);
       expect(copy.a).toBe('a');
@@ -504,7 +504,7 @@ describe('Plugin Extensions / Utils', () => {
       config.buildInfo.env = 'production';
 
       const obj = { a: 'a', b: { c: 'c' } };
-      const copy = readOnlyCopy(obj);
+      const copy = writableProxy(obj);
 
       expect(() => {
         Object.freeze(copy);

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -22,7 +22,6 @@ import {
   getExtensionPointPluginMeta,
   getMutationObserverProxy,
   readOnlyCopy,
-  isReadOnlyProxy,
   isMutationObserverProxy,
 } from './utils';
 
@@ -445,7 +444,6 @@ describe('Plugin Extensions / Utils', () => {
 
     beforeEach(() => {
       jest.spyOn(console, 'warn').mockImplementation();
-      config.featureToggles.extensionsReadOnlyProxy = false;
     });
 
     afterEach(() => {
@@ -462,22 +460,7 @@ describe('Plugin Extensions / Utils', () => {
       expect(readOnlyCopy(undefined)).toBe(undefined);
     });
 
-    it('should return a read-only proxy of the original object if the feature flag is enabled', () => {
-      config.featureToggles.extensionsReadOnlyProxy = true;
-
-      const obj = { a: 'a' };
-      const copy = readOnlyCopy(obj);
-
-      expect(copy).not.toBe(obj);
-      expect(copy.a).toBe('a');
-      expect(isReadOnlyProxy(copy)).toBe(true);
-      expect(() => {
-        copy.a = 'b';
-      }).toThrow(TypeError);
-    });
-
     it('should return a writable deep-copy of the original object in dev mode', () => {
-      config.featureToggles.extensionsReadOnlyProxy = false;
       config.buildInfo.env = 'development';
 
       const obj = { a: 'a' };
@@ -498,7 +481,6 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should return a writable deep-copy of the original object in production mode', () => {
-      config.featureToggles.extensionsReadOnlyProxy = false;
       config.buildInfo.env = 'production';
 
       const obj = { a: 'a' };
@@ -519,7 +501,6 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should allow freezing the object in production mode', () => {
-      config.featureToggles.extensionsReadOnlyProxy = false;
       config.buildInfo.env = 'production';
 
       const obj = { a: 'a', b: { c: 'c' } };

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -401,7 +401,7 @@ describe('Plugin Extensions / Utils', () => {
       expect(proxy.a).toBe('b');
     });
 
-    it('should be possible to set new values, but logs a warning', () => {
+    it('should be possible to set new values, but logs a debug message', () => {
       const obj: { a: string; b?: string } = { a: 'a' };
       const proxy = getMutationObserverProxy(obj);
 
@@ -412,7 +412,7 @@ describe('Plugin Extensions / Utils', () => {
         });
       }).not.toThrow();
 
-      expect(log.warning).toHaveBeenCalledWith(`Attempted to define object property "b"`, {
+      expect(log.debug).toHaveBeenCalledWith(`Attempted to define object property "b"`, {
         stack: expect.any(String),
       });
 
@@ -534,7 +534,7 @@ describe('Plugin Extensions / Utils', () => {
       expect(Object.isFrozen(copy.b)).toBe(true);
       expect(copy.b).toEqual({ c: 'c' });
 
-      expect(log.warning).toHaveBeenCalledWith(`Attempted to define object property "a"`, {
+      expect(log.debug).toHaveBeenCalledWith(`Attempted to define object property "a"`, {
         stack: expect.any(String),
       });
     });
@@ -687,7 +687,7 @@ describe('Plugin Extensions / Utils', () => {
       expect(screen.getByText('Version: 1.0.0')).toBeVisible();
     });
 
-    it('should not be possible to mutate the props in development mode, but it logs a warning', async () => {
+    it('should not be possible to mutate the props in development mode, but it logs an error', async () => {
       config.buildInfo.env = 'development';
       const pluginId = 'grafana-worldmap-panel';
       const Component = wrapWithPluginContext(pluginId, ExampleComponent, log);
@@ -700,8 +700,8 @@ describe('Plugin Extensions / Utils', () => {
       expect(await screen.findByText('Hello Grafana!')).toBeVisible();
 
       // Logs a warning
-      expect(log.warning).toHaveBeenCalledTimes(1);
-      expect(log.warning).toHaveBeenCalledWith(`Attempted to mutate object property "c"`, {
+      expect(log.error).toHaveBeenCalledTimes(1);
+      expect(log.error).toHaveBeenCalledWith(`Attempted to mutate object property "c"`, {
         stack: expect.any(String),
       });
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -230,24 +230,25 @@ export function getMutationObserverProxy<T extends object>(obj: T, _log: Extensi
   }
 
   const cache = new WeakMap();
+  const logFunction = isGrafanaDevMode() ? _log.error.bind(_log) : _log.warning.bind(_log); // should show error during local development
 
   return new Proxy(obj, {
     deleteProperty(target, prop) {
-      _log.warning(`Attempted to delete object property "${String(prop)}"`, {
+      logFunction(`Attempted to delete object property "${String(prop)}"`, {
         stack: new Error().stack ?? '',
       });
       Reflect.deleteProperty(target, prop);
       return true;
     },
     defineProperty(target, prop, descriptor) {
-      _log.warning(`Attempted to define object property "${String(prop)}"`, {
+      _log.debug(`Attempted to define object property "${String(prop)}"`, {
         stack: new Error().stack ?? '',
       });
       Reflect.defineProperty(target, prop, descriptor);
       return true;
     },
     set(target, prop, newValue) {
-      _log.warning(`Attempted to mutate object property "${String(prop)}"`, {
+      logFunction(`Attempted to mutate object property "${String(prop)}"`, {
         stack: new Error().stack ?? '',
       });
       Reflect.set(target, prop, newValue);

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -85,7 +85,7 @@ export const wrapWithPluginContext = <T,>(pluginId: string, Component: React.Com
 
     return (
       <PluginContextProvider meta={pluginMeta}>
-        <Component {...readOnlyCopy(props, log)} />
+        <Component {...writableProxy(props, log)} />
       </PluginContextProvider>
     );
   };
@@ -241,6 +241,8 @@ export function getMutationObserverProxy<T extends object>(obj: T, _log: Extensi
       return true;
     },
     defineProperty(target, prop, descriptor) {
+      // because immer (used by RTK) calls Object.isFrozen and Object.freeze we know that defineProperty will be called
+      // behind the scenes as well so we only log message with debug level to minimize the noise and false positives
       _log.debug(`Attempted to define object property "${String(prop)}"`, {
         stack: new Error().stack ?? '',
       });
@@ -286,7 +288,7 @@ export function getMutationObserverProxy<T extends object>(obj: T, _log: Extensi
   });
 }
 
-export function readOnlyCopy<T>(value: T, _log: ExtensionsLog = log): T {
+export function writableProxy<T>(value: T, _log: ExtensionsLog = log): T {
   // Primitive types are read-only by default
   if (!value || typeof value !== 'object') {
     return value;

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -292,10 +292,6 @@ export function readOnlyCopy<T>(value: T, _log: ExtensionsLog = log): T {
     return value;
   }
 
-  if (config.featureToggles.extensionsReadOnlyProxy) {
-    return getReadOnlyProxy(value);
-  }
-
   // Default: we return a proxy of a deep-cloned version of the original object, which logs warnings when mutation is attempted
   return getMutationObserverProxy(cloneDeep(value), _log);
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Sorry in advance for the long ramblings below, :see_no_evil:

> [!IMPORTANT]
> The TLDR is we can't ever pass getReadOnlyProxy (https://github.com/grafana/grafana/blob/main/public/app/features/plugins/extensions/utils.tsx#L183) to plugins that use that proxy as an argument to RTK api's because that will blow up silently and no error will bubble up and any expected state changes will fail, so pretty much we can't pass a getReadOnlyProxy


Background [thread](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750939811989159), and the [PR](https://github.com/grafana/grafana/pull/107290) that fixed this.

I spent almost a whole day trying to hunt down the exact line that throws and it's `immer`  that uses both `Object.isFrozen`  and `Object.freeze`.  `Object.isFrozen` calls `isExtensible` [on objects ](https://github.com/immerjs/immer/blob/v9.0.21/src/utils/common.ts#L215) behind the scenes and the `getReadOnlyProxy`will return [false](https://github.com/grafana/grafana/blob/main/public/app/features/plugins/extensions/utils.tsx#L193) and and then an error is thrown from the framework. `immer`  also calls `Object.freeze` [on objects](https://github.com/immerjs/immer/blob/v9.0.21/src/utils/common.ts#L203) and that invokes `defineProperty` on on objects and the `getReadOnlyProxy` will return [false](https://github.com/grafana/grafana/blob/main/public/app/features/plugins/extensions/utils.tsx#L191) and then an error is thrown from the framework.

So in the `pdc-app` they use `dataSource` that is a readonly proxy [here](https://github.com/grafana/grafana-pdc-app/blob/main/src/feature/datasource-config/components/DataSourceExtensionConfig.tsx#L70), and `dataSource` unfortunately get's stored in to state by RTK [here](https://github.com/reduxjs/redux-toolkit/blob/v1.9.7/packages/toolkit/src/query/core/buildSlice.ts#L169) as part of `originalArgs` and now `immer` will do it's thing and an error will be thrown. 

But wait you say how come the thrown error isn't bubbled up? Then we have to look at [these lines](https://github.com/reduxjs/redux/blob/v4.2.1/src/createStore.js#L216-L221) in core redux.  I found this [explanation](https://github.com/reduxjs/redux-toolkit/issues/3795#issuecomment-1758585839) why not bubbling up is working and that really makes sense.

The moral of the story is that as long as we're using RTK ([they will never abandon immer](https://redux-toolkit.js.org/usage/immer-reducers#architecture-and-intent)) we can't pass any readonly proxies to plugins because we really don't know how they're going to use those proxies.

This PR changes the logging of `defineProperty` from the `getMutationObserverProxy` to limit the amount of `false positives` because we know now that `isExtensible`  and `defineProperty` will be called by `immer` anyway so there's not much we can do about that. The PR also removed the feature toggle that doesn't server any purpose

**Why do we need this feature?**

To reduce the mutation logging noise

**Who is this feature for?**

The plugin platform squad `grafana/plugins-platform-frontend`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
