### PR TITLE
Prometheus: Fix populating label names in sum operation on query builder

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx
@@ -71,9 +71,9 @@ async function loadGroupByLabels(
   }
 
   const expr = modeller.renderLabels(labels);
-  const result = await datasource.languageProvider.queryLabelKeys(timeRange, expr);
+  const result: string[] = await datasource.languageProvider.queryLabelKeys(timeRange, expr);
 
-  return Object.keys(result).map((x) => ({
+  return result.map((x) => ({
     label: x,
     value: x,
   }));


### PR DESCRIPTION
**What is this feature?**

This is fixing the problem with the sum operator on query builder. There was an API change and we won't need `Object.keys` anymore. 

Problem:
![grafik](https://github.com/user-attachments/assets/02740272-007f-48d4-9a77-4a5bb58897c6)

After Fix: 

![grafik](https://github.com/user-attachments/assets/260d952d-bf5c-4d1b-96bd-e2922db7a85c)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
