### PR TITLE
Access: Disable role none option if advanced access control is not enabled

### DIFF
--- a/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
+++ b/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
@@ -1,15 +1,10 @@
 import { SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Icon, RadioButtonList, Tooltip, useStyles2, useTheme2, PopoverContent } from '@grafana/ui';
-import { contextSrv } from 'app/core/core';
 import { OrgRole } from 'app/types';
+import { contextSrv } from 'app/core/core';
 
 import { getStyles } from './styles';
-
-const BasicRoleOption: Array<SelectableValue<OrgRole>> = Object.values(OrgRole).map((r) => ({
-  label: r === OrgRole.None ? 'No basic role' : r,
-  value: r,
-}));
 
 interface Props {
   value?: OrgRole;
@@ -23,8 +18,19 @@ export const BuiltinRoleSelector = ({ value, onChange, disabled, disabledMesssag
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
 
-  // Disable OrgRole.None if access control is not licensed
-  const disabledOptions = contextSrv.licensedAccessControlEnabled() ? [] : [OrgRole.None];
+  // Create options dynamically to filter out OrgRole.None when access control is not licensed
+  const basicRoleOptions: Array<SelectableValue<OrgRole>> = Object.values(OrgRole)
+    .filter((r) => {
+      // Filter out OrgRole.None if access control is not licensed
+      if (r === OrgRole.None && !contextSrv.licensedAccessControlEnabled()) {
+        return false;
+      }
+      return true;
+    })
+    .map((r) => ({
+      label: r === OrgRole.None ? 'No basic role' : r,
+      value: r,
+    }));
 
   return (
     <>
@@ -46,11 +52,10 @@ export const BuiltinRoleSelector = ({ value, onChange, disabled, disabledMesssag
       <RadioButtonList
         name="Basic Role Selector"
         className={styles.basicRoleSelector}
-        options={BasicRoleOption}
+        options={basicRoleOptions}
         value={value}
         onChange={onChange}
         disabled={disabled}
-        disabledOptions={disabledOptions}
       />
     </>
   );

--- a/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
+++ b/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
@@ -1,6 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Icon, RadioButtonList, Tooltip, useStyles2, useTheme2, PopoverContent } from '@grafana/ui';
+import { contextSrv } from 'app/core/core';
 import { OrgRole } from 'app/types';
 
 import { getStyles } from './styles';
@@ -21,6 +22,9 @@ interface Props {
 export const BuiltinRoleSelector = ({ value, onChange, disabled, disabledMesssage, tooltipMessage }: Props) => {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
+
+  // Disable OrgRole.None if access control is not licensed
+  const disabledOptions = contextSrv.licensedAccessControlEnabled() ? [] : [OrgRole.None];
 
   return (
     <>
@@ -46,6 +50,7 @@ export const BuiltinRoleSelector = ({ value, onChange, disabled, disabledMesssag
         value={value}
         onChange={onChange}
         disabled={disabled}
+        disabledOptions={disabledOptions}
       />
     </>
   );

--- a/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
+++ b/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
@@ -1,8 +1,8 @@
 import { SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Icon, RadioButtonList, Tooltip, useStyles2, useTheme2, PopoverContent } from '@grafana/ui';
-import { OrgRole } from 'app/types';
 import { contextSrv } from 'app/core/core';
+import { OrgRole } from 'app/types';
 
 import { getStyles } from './styles';
 


### PR DESCRIPTION
**What is this feature?**

Disable frontend option to assign None role to users.

![image](https://github.com/user-attachments/assets/caa03115-7da9-418e-8ec2-93fdf37e8e1e)

**Why do we need this feature?**

None role currently provides no value if users don't have access to https://grafana.com/docs/grafana/latest/administration/data-source-management/#data-source-permissions or RBAC roles.

None role is not an enterprise feature and remains unblocked in the backend for advanced users but locking it in the frontend stops users from trying to setup a flow they don't have all pieces for.

Fixes https://github.com/grafana/grafana/issues/88227