### PR TITLE
Fix organization deletion error messages

### DIFF
--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -292,16 +292,16 @@ func (hs *HTTPServer) DeleteOrgByID(c *contextmodel.ReqContext) response.Respons
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "orgId is invalid", err)
 	}
-	// before deleting an org, check if user does not belong to the current org
+	// before deleting an org, check if user is not active in the org
 	if c.GetOrgID() == orgID {
-		return response.Error(http.StatusBadRequest, "Can not delete org for current user", nil)
+		return response.Error(http.StatusBadRequest, "Cannot delete your active organization. Please switch to a different organization first.", nil)
 	}
 
 	if err := hs.orgDeletionService.Delete(c.Req.Context(), &org.DeleteOrgCommand{ID: orgID}); err != nil {
 		if errors.Is(err, org.ErrOrgNotFound) {
 			return response.Error(http.StatusNotFound, "Failed to delete organization. ID not found", nil)
 		}
-		return response.Error(http.StatusInternalServerError, "Failed to update organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to delete organization", err)
 	}
 	return response.Success("Organization deleted")
 }

--- a/pkg/services/org/orgimpl/org_delete_svc.go
+++ b/pkg/services/org/orgimpl/org_delete_svc.go
@@ -3,6 +3,7 @@ package orgimpl
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -59,7 +60,7 @@ func (s *DeletionService) Delete(ctx context.Context, cmd *org.DeleteOrgCommand)
 	ctx, _ = identity.WithServiceIdentity(ctx, cmd.ID)
 	err = s.dashSvc.DeleteAllDashboards(ctx, cmd.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete dashboards for org %d: %w", cmd.ID, err)
 	}
 
 	return s.store.Delete(ctx, cmd)

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -136,7 +136,7 @@ func (c authzLimitedClient) Check(ctx context.Context, id claims.AuthInfo, req c
 
 	if !claims.NamespaceMatches(id.GetNamespace(), req.Namespace) {
 		span.SetAttributes(attribute.Bool("allowed", false))
-		span.SetStatus(codes.Error, "Namespace missmatch")
+		span.SetStatus(codes.Error, "Namespace mismatch")
 		span.RecordError(claims.ErrNamespaceMissmatch)
 		return claims.CheckResponse{Allowed: false}, claims.ErrNamespaceMissmatch
 	}
@@ -185,7 +185,7 @@ func (c authzLimitedClient) Compile(ctx context.Context, id claims.AuthInfo, req
 	}
 	if !claims.NamespaceMatches(id.GetNamespace(), req.Namespace) {
 		span.SetAttributes(attribute.Bool("allowed", false))
-		span.SetStatus(codes.Error, "Namespace missmatch")
+		span.SetStatus(codes.Error, "Namespace mismatch")
 		span.RecordError(claims.ErrNamespaceMissmatch)
 		return nil, claims.ErrNamespaceMissmatch
 	}


### PR DESCRIPTION
Fixes #92792

**Problem:**
Admin users encountered confusing and incorrect error messages when attempting to delete organizations. Additionally, several error handling and messaging improvements were identified across the codebase.

**Changes:**

**1. Organization Deletion API Error Messages (pkg/api/org.go):**
- Improved error message when trying to delete active organization: "Cannot delete your active organization. Please switch to a different organization first."
- Fixed incorrect "Failed to update organization" message to "Failed to delete organization" in deletion error handling
- Updated code comment for accuracy

**2. Organization Deletion Service Error Handling (pkg/services/org/orgimpl/org_delete_svc.go):**
- Enhanced error handling with contextual messages when dashboard deletion fails during org deletion
- Added organization ID to error messages for better debugging and troubleshooting
- Improved error formatting with proper error wrapping

**3. Typo Fix (pkg/storage/unified/resource/access.go):**
- Fixed spelling error: "Namespace missmatch" → "Namespace mismatch"

**Impact:**
- Clearer guidance for administrators during organization management
- Better error messages that accurately reflect failed operations
- Improved debugging capability with contextual error information
- Enhanced user experience with more descriptive and accurate error text

**Testing:**
- Backward compatible - only affects error message text and error handling
- No functional behavior changes to core deletion logic
- Error scenarios now provide clearer, more actionable feedback to users