### PR TITLE
Library Elements: Fix side effects between integration tests

### DIFF
--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -531,6 +531,7 @@ func setupTestScenario(t *testing.T) scenarioContext {
 	features := featuremgmt.WithFeatures()
 	tracer := tracing.InitializeTracerForTest()
 	sqlStore, cfg := db.InitTestDBWithCfg(t)
+	t.Cleanup(db.CleanupTestDB)
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
 	require.NoError(t, err)


### PR DESCRIPTION
Side effects left over from the `TestIntegration_`  cause the `TestIntegrationLibraryElementPermissions` tests to fail with:

```
        	Error:      	Received unexpected error:
        	            	no such table: setting
```