### PR TITLE
fix(unified-storage): return empty list instead of nil

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -100,7 +100,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 	// This can happen, as unified storage iteration is doing paging not only based on the provided limit,
 	// but also based on the response size. This check prevents starting the new iteration again.
 	if options.Continue != "" && legacyToken == "" {
-		return nil, nil
+		return d.NewList(), nil
 	}
 
 	// In some cases, where the stores are not in sync yet, the unified storage continue token might already


### PR DESCRIPTION
The kubernetes API contract expect always to get an initialized object, even if no items are returned.

Should fix the `expected pointer, but got invalid kind` errors we are seeing.