### PR TITLE
Dashboards: Fix persisting repeated panels resize after edit

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -57,16 +57,30 @@ export class DashboardGridItem
   public constructor(state: DashboardGridItemState) {
     super(state);
 
+    this.addActivationHandler(() => this._handleGridSizeUnsubscribe());
     this.addActivationHandler(() => this.handleVariableName());
   }
 
-  private _handleGridResize(newState: DashboardGridItemState, prevState: DashboardGridItemState) {
-    const itemCount = this.state.repeatedPanels?.length ?? 1;
-    const stateChange: Partial<DashboardGridItemState> = {};
+  private _handleGridSizeSubscribe() {
+    if (!this._gridSizeSub) {
+      this._gridSizeSub = this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState));
+    }
+  }
 
+  private _handleGridSizeUnsubscribe() {
+    if (this._gridSizeSub) {
+      this._gridSizeSub.unsubscribe();
+      this._gridSizeSub = undefined;
+    }
+  }
+
+  private _handleGridResize(newState: DashboardGridItemState, prevState: DashboardGridItemState) {
     if (newState.height === prevState.height) {
       return;
     }
+
+    const itemCount = this.state.repeatedPanels?.length ?? 1;
+    const stateChange: Partial<DashboardGridItemState> = {};
 
     if (this.getRepeatDirection() === 'v') {
       stateChange.itemHeight = Math.ceil(newState.height! / itemCount);
@@ -203,16 +217,9 @@ export class DashboardGridItem
 
   public handleVariableName() {
     if (this.state.variableName) {
-      if (!this._gridSizeSub) {
-        this._gridSizeSub = this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState));
-        this._subs.add(this._gridSizeSub);
-      }
+      this._handleGridSizeSubscribe();
     } else {
-      if (this._gridSizeSub) {
-        this._gridSizeSub.unsubscribe();
-        this._subs.remove(this._gridSizeSub);
-        this._gridSizeSub = undefined;
-      }
+      this._handleGridSizeUnsubscribe();
     }
 
     this.performRepeat();

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -57,8 +57,15 @@ export class DashboardGridItem
   public constructor(state: DashboardGridItemState) {
     super(state);
 
-    this.addActivationHandler(() => this._handleGridSizeUnsubscribe());
-    this.addActivationHandler(() => this.handleVariableName());
+    this.addActivationHandler(() => this._activationHandler());
+  }
+
+  private _activationHandler() {
+    this.handleVariableName();
+
+    return () => {
+      this._handleGridSizeUnsubscribe();
+    };
   }
 
   private _handleGridSizeSubscribe() {


### PR DESCRIPTION
**What is this feature?**

Currently there is a bug in the dashboards for repeated panels: after changing the number of repeated items per row, the resize is not persisted until the dashboard is refreshed.

This is caused by the fact that the layout scene is deactivated and the resize subscription is destroyed due to it being assigned to `_subs` and it's not re-initialized.

**Why do we need this feature?**

Fix bugs

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/a57ac638-b779-472d-a290-8f3b389a79c2

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
