### PR TITLE
Outbox: remove last insert id as it is not compatible with postgres nor used

### DIFF
--- a/pkg/registry/apis/secret/contracts/outbox_queue.go
+++ b/pkg/registry/apis/secret/contracts/outbox_queue.go
@@ -54,7 +54,7 @@ type OutboxMessage struct {
 
 type OutboxQueue interface {
 	// Appends a message to the outbox queue
-	Append(ctx context.Context, message AppendOutboxMessage) (int64, error)
+	Append(ctx context.Context, message AppendOutboxMessage) error
 	// Receives at most n messages from the outbox queue
 	ReceiveN(ctx context.Context, n uint) ([]OutboxMessage, error)
 	// Deletes a message from the outbox queue

--- a/pkg/registry/apis/secret/service/secure_value.go
+++ b/pkg/registry/apis/secret/service/secure_value.go
@@ -68,7 +68,7 @@ func (s *SecureValueService) Create(ctx context.Context, sv *secretv0alpha1.Secu
 		}
 		out = createdSecureValue
 
-		if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
+		if err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
 			RequestID:       requestID,
 			Type:            contracts.CreateSecretOutboxMessage,
 			Name:            sv.Name,
@@ -196,7 +196,7 @@ func (s *SecureValueService) Update(ctx context.Context, newSecureValue *secretv
 
 		// Only the value needs to be updated asynchronously by the outbox worker
 		if encryptedSecret != "" {
-			if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
+			if err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
 				RequestID:       requestID,
 				Type:            contracts.UpdateSecretOutboxMessage,
 				Name:            newSecureValue.Name,
@@ -246,7 +246,7 @@ func (s *SecureValueService) Delete(ctx context.Context, namespace xkube.Namespa
 			return fmt.Errorf("setting secure value status phase: %+w", err)
 		}
 
-		if _, err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
+		if err := s.outboxQueue.Append(ctx, contracts.AppendOutboxMessage{
 			RequestID:  requestID,
 			Type:       contracts.DeleteSecretOutboxMessage,
 			Name:       name,


### PR DESCRIPTION
Since we don't use the id, we can remove the `LastInsertId` method since it is not compatible with Postgres