### PR TITLE
Storybook: Bypass unmatched msw requests

### DIFF
--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -49,7 +49,9 @@ if (process.env.NODE_ENV === 'development') {
  * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
  * to learn how to customize it
  */
-initialize();
+initialize({
+  onUnhandledRequest: 'bypass',
+});
 
 const preview: Preview = {
   decorators: [withTheme(handleThemeChange), withTimeZone()],


### PR DESCRIPTION
**What is this feature?**

Super tiny PR to disable some warning in the console about unmatched handlers.
