### PR TITLE
[release-10.4.20] Docs: Fix graph styles and axis options content

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -22,7 +22,22 @@ refs:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/time-series/
+  color-scheme:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/#color-scheme
+  configure-field-overrides:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/
+  add-a-field-override:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/#add-a-field-override
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/#add-a-field-override
 ---
 
 # Candlestick
@@ -137,7 +152,121 @@ The **Include** and **Ignore** options allow it to visualize other included data
 
 The options under the **Graph styles** section let you control the general appearance of [additional fields](#additional-fields) in the visualization, excluding [color](#standard-options).
 
-{{< docs/shared lookup="visualizations/graph-styles-options.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
+<!-- prettier-ignore-start -->
+
+| Option                                      | Description                                                                                    |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [Style](#style)                             | Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**. |
+| [Line interpolation](#line-interpolation)   | Choose how the graph interpolates the series line. |
+| Line width                                  | Set the thickness of the series lines or the outline for bars using the **Line width** slider. |
+| Fill opacity                                | Set the series area fill color using the **Fill opacity** slider. |
+| [Gradient mode](#gradient-mode)             | Choose a gradient mode to control the gradient fill, which is based on the series color. |
+| [Line style](#line-style)                   | Choose a solid, dashed, or dotted line style. |
+| [Connect null values](#connect-null-values) | Choose how null values, which are gaps in the data, appear on the graph. |
+| [Disconnect values](#disconnect-values)     | Choose whether to set a threshold above which values in the data should be disconnected. |
+| [Show points](#show-points)                 | Set whether to show data points to lines or bars. |
+| Point size                                  | Set the size of the points, from 1 to 40 pixels in diameter. |
+| [Stack series](#stack-series)               | Set whether Grafana displays series on top of each other. |
+| [Bar alignment](#bar-alignment)             | Set the position of the bar relative to a data point. |
+
+<!-- prettier-ignore-end -->
+
+#### Style
+
+Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**.
+You can use overrides to combine multiple styles in the same graph. Choose from the following:
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-style-v12.0.png" max-width="750px" alt="Graph styles" >}}
+
+#### Line interpolation
+
+Choose how the graph interpolates the series line:
+
+- **Linear** - Points are joined by straight lines.
+- **Smooth** - Points are joined by curved lines that smooths transitions between points.
+- **Step before** - The line is displayed as steps between points. Points are rendered at the end of the step.
+- **Step after** - The line is displayed as steps between points. Points are rendered at the beginning of the step.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-interpolation-v12.0.png" max-width="750px" alt="Line interpolation styles" >}}
+
+#### Gradient mode
+
+Choose a gradient mode to control the gradient fill, which is based on the series color. To change the color, use the standard color scheme field option. For more information, refer to [Color scheme](ref:color-scheme).
+
+- **None** - No gradient fill. This is the default setting.
+- **Opacity** - An opacity gradient where the opacity of the fill increases as y-axis values increase.
+- **Hue** - A subtle gradient that's based on the hue of the series color.
+- **Scheme** - A color gradient defined by your [Color scheme](ref:color-scheme). This setting is used for the fill area and line. For more information about scheme, refer to [Scheme gradient mode](#scheme-gradient-mode).
+
+Gradient appearance is influenced by the **Fill opacity** setting. The following image shows the **Fill opacity** set to 50.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-gradient-v12.0.png" max-width="750px" alt="Gradient modes" >}}
+
+##### Scheme gradient mode
+
+In **Scheme** gradient mode, the line or bar receives a gradient color defined from the selected **Color scheme** option in the visualization's **Standard** options.
+
+The following image shows a line chart with the **Green-Yellow-Red (by value)** color scheme option selected:
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-scheme-grad-1-v12.0.png" max-width="600px" alt="Gradient color scheme" >}}
+
+If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the line or bar color changes as it crosses the defined thresholds:
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-scheme-grad-2-v12.0.png" max-width="600px" alt="Gradient color scheme with thresholds" >}}
+
+#### Line style
+
+Choose a solid, dashed, or dotted line style:
+
+- **Solid** - Display a solid line. This is the default setting.
+- **Dash** - Display a dashed line. When you choose this option, a list appears for you to select the length and gap (length, gap) for the line dashes. Dash spacing is 10, 10 by default.
+- **Dots** - Display dotted lines. When you choose this option, a list appears for you to select the gap (length = 0, gap) for the dot spacing. Dot spacing is 0, 10 by default.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-candle-line-style-v12.0.png" max-width="750px" alt="Line styles" >}}
+
+{{< docs/shared lookup="visualizations/connect-null-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
+
+{{< docs/shared lookup="visualizations/disconnect-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
+
+To change the color, use the standard [color scheme](ref:color-scheme) field option.
+
+#### Show points
+
+Set whether to show data points as lines or bars. Choose from the following:
+
+- **Auto** - Grafana determines a point's visibility based on the density of the data. If the density is low, then points appear.
+- **Always** - Show the points regardless of how dense the dataset is.
+- **Never** - Don't show points.
+
+#### Stack series
+
+Set whether Grafana stacks or displays series on top of each other. Be cautious when using stacking because it can create misleading graphs. To read more about why stacking might not be the best approach, refer to [The issue with stacking](https://www.data-to-viz.com/caveat/stacking.html). Choose from the following:
+
+- **Off** - Turns off series stacking. When **Off**, all series share the same space in the visualization.
+- **Normal** - Stacks series on top of each other.
+- **100%** - Stack by percentage where all series add up to 100%.
+
+##### Stack series in groups
+
+The stacking group option is only available as an override. For more information about creating an override, refer to [Configure field overrides](ref:configure-field-overrides).
+
+1. Edit the panel and click **Overrides**.
+1. Create a field override for the **Stack series** option.
+1. In stacking mode, click **Normal**.
+1. Name the stacking group in which you want the series to appear.
+
+   The stacking group name option is only available when you create an override.
+
+#### Bar alignment
+
+Set the position of the bar relative to a data point. In the examples below, **Show points** is set to **Always** which makes it easier to see the difference this setting makes. The points don't change, but the bars change in relationship to the points. Choose from the following:
+
+- **Before** ![Bar alignment before icon](/static/img/docs/time-series-panel/bar-alignment-before.png)
+  The bar is drawn before the point. The point is placed on the trailing corner of the bar.
+- **Center** ![Bar alignment center icon](/static/img/docs/time-series-panel/bar-alignment-center.png)
+  The bar is drawn around the point. The point is placed in the center of the bar. This is the default.
+- **After** ![Bar alignment after icon](/static/img/docs/time-series-panel/bar-alignment-after.png)
+  The bar is drawn after the point. The point is placed on the leading corner of the bar.
 
 ### Axis options
 

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -34,48 +34,23 @@ title: Time series
 menuTitle: Time series
 weight: 10
 refs:
-  configure-standard-options:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#max
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/#max
-  color-scheme:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/#color-scheme
-  add-a-field-override:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/#add-a-field-override
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/#add-a-field-override
-  configure-field-overrides:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/
   link-alert:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#max
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
-  panel-editor-alerts:
+  panel-editor:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-editor-overview/#data-section
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-editor-overview/#panel-editor
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-editor-overview/#data-section
-  data-transformation:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-editor-overview/#data-section
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-editor-overview/#data-section
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-editor-overview/#panel-editor
 ---
 
 # Time series
 
 Time series visualizations are the default way to show the variations of a set of data values over time. Each data point is matched to a timestamp and this _time series_ is displayed as a graph. The visualization can render series as lines, points, or bars and it's versatile enough to display almost any type of [time-series data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/timeseries/).
 
-{{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" alt="Time series" >}}
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-time-series-v12.0.png" max-width="750px" alt="Time series visualization" >}}
 
 {{< admonition type="note" >}}
 You can migrate from the legacy Graph visualization to the time series visualization. To migrate, open the panel and click the **Migrate** button in the side pane.
@@ -116,7 +91,7 @@ In the following example, there are three numeric fields represented by three li
 
 ![Time series line chart with multiple numeric fields](/media/docs/grafana/panels-visualizations/screenshot-grafana-11.1-timeseries-example1v2.png 'Time series line chart with multiple numeric fields')
 
-If the time field isn't automatically detected, you might need to convert the data to a time format using a [data transformation](ref:data-transformation).
+If the time field isn't automatically detected, you might need to convert the data to a time format using a [data transformation](ref:panel-editor).
 
 ### Example 2
 
@@ -168,7 +143,7 @@ When you add the offset, the resulting visualization makes the datasets appear t
 
 ## Alert rules
 
-You can [link alert rules](ref:link-alert) to time series visualizations in the form of annotations to observe when alerts fire and are resolved. In addition, you can create alert rules from the **Alert** tab within the [panel editor](ref:panel-editor-alerts).
+You can [link alert rules](ref:link-alert) to time series visualizations in the form of annotations to observe when alerts fire and are resolved. In addition, you can create alert rules from the **Alert** tab within the [panel editor](ref:panel-editor).
 
 ## Special overrides
 
@@ -187,7 +162,7 @@ The **Graph styles > Fill below to** [override property](#field-overrides) fills
 
 The following example shows three series: Min, Max, and Value. The Min and Max series have **Line width** set to 0. Max has a **Fill below to** override set to Min, which fills the area between Max and Min with the Max line color.
 
-{{< figure src="/static/img/docs/time-series-panel/fill-below-to-7-4.png" max-width="600px" alt="Fill below to example" >}}
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-fill-below-to-v12.0.png" max-width="600px" alt="Fill below to example" >}}
 
 {{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+2" >}}
 

--- a/docs/sources/shared/visualizations/axis-options-1.md
+++ b/docs/sources/shared/visualizations/axis-options-1.md
@@ -33,7 +33,7 @@ Select the placement of the y-axis. Choose from the following:
 - **Auto** - Automatically assigns the y-axis to the series. When there are two or more series with different units, Grafana assigns the left axis to the first unit and the right axis to the units that follow.
 - **Left** - Display all y-axes on the left side.
 - **Right** - Display all y-axes on the right side.
-- **Hidden** - Hide all axes. To selectively hide axes, [Add a field override](ref:add-a-field-override) that targets specific fields.
+- **Hidden** - Hide all axes. To selectively hide axes, [Add a field override](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/#add-a-field-override) that targets specific fields.
 
 #### Scale
 
@@ -49,6 +49,6 @@ Set a **Soft min** or **soft max** option for better control of y-axis limits. B
 
 **Soft min** and **soft max** settings can prevent small variations in the data from being magnified when it's mostly flat. In contrast, hard min and max values help prevent obscuring useful detail in the data by clipping intermittent spikes past a specific point.
 
-To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](ref:configure-standard-options).
+To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#max).
 
-![Label example](/static/img/docs/time-series-panel/axis-soft-min-max-7-4.png)
+![Label example](/media/docs/grafana/panels-visualizations/screenshot-soft-min-max-v12.0.png)

--- a/docs/sources/shared/visualizations/axis-options-2.md
+++ b/docs/sources/shared/visualizations/axis-options-2.md
@@ -32,7 +32,7 @@ Select the placement of the y-axis. Choose from the following:
 - **Auto** - Automatically assigns the y-axis to the series. When there are two or more series with different units, Grafana assigns the left axis to the first unit and the right axis to the units that follow.
 - **Left** - Display all y-axes on the left side.
 - **Right** - Display all y-axes on the right side.
-- **Hidden** - Hide all axes. To selectively hide axes, [Add a field override](ref:add-a-field-override) that targets specific fields.
+- **Hidden** - Hide all axes. To selectively hide axes, [Add a field override](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/#add-a-field-override) that targets specific fields.
 
 #### Scale
 
@@ -48,6 +48,7 @@ Set a **Soft min** or **soft max** option for better control of y-axis limits. B
 
 **Soft min** and **soft max** settings can prevent small variations in the data from being magnified when it's mostly flat. In contrast, hard min and max values help prevent obscuring useful detail in the data by clipping intermittent spikes past a specific point.
 
-To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](ref:configure-standard-options).
+To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#max).
+The following examples shows how this option works in a time series visualization:
 
-![Label example](/static/img/docs/time-series-panel/axis-soft-min-max-7-4.png)
+![Label example](/media/docs/grafana/panels-visualizations/screenshot-soft-min-max-v12.0.png)

--- a/docs/sources/shared/visualizations/graph-styles-options.md
+++ b/docs/sources/shared/visualizations/graph-styles-options.md
@@ -1,33 +1,33 @@
 ---
 title: Graph styles options
 comments: |
-  This file is used in the following visualizations: candlestick, time series.
+  This file is used in the following visualizations: time series.
 ---
 
-<!-- prettier-start-ignore -->
+<!-- prettier-ignore-start -->
 
 | Option                                      | Description                                                                                    |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [Style](#style)                             | Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**.         |
-| [Line interpolation](#line-interpolation)   | Choose how the graph interpolates the series line.                                             |
+| [Style](#style)                             | Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**. |
+| [Line interpolation](#line-interpolation)   | Choose how the graph interpolates the series line. |
 | Line width                                  | Set the thickness of the series lines or the outline for bars using the **Line width** slider. |
-| [Fill opacity](#fill-opacity)               | Set the series area fill color using the **Fill opacity** slider.                              |
-| [Gradient mode](#gradient-mode)             | Choose a gradient mode to control the gradient fill, which is based on the series color.       |
-| [Line style](#line-style)                   | Choose a solid, dashed, or dotted line style.                                                  |
-| [Connect null values](#connect-null-values) | Choose how null values, which are gaps in the data, appear on the graph.                       |
-| [Disconnect values](#disconnect-values)     | Choose whether to set a threshold above which values in the data should be disconnected.       |
-| [Show points](#show-points)                 | Set whether to show data points to lines or bars.                                              |
-| Point size                                  | Set the size of the points, from 1 to 40 pixels in diameter.                                   |
-| [Stack series](#stack-series)               | Set whether Grafana displays series on top of each other.                                      |
-| [Bar alignment](#bar-alignment)             | Set the position of the bar relative to a data point.                                          |
+| Fill opacity                                | Set the series area fill color using the **Fill opacity** slider. |
+| [Gradient mode](#gradient-mode)             | Choose a gradient mode to control the gradient fill, which is based on the series color. |
+| [Line style](#line-style)                   | Choose a solid, dashed, or dotted line style. |
+| [Connect null values](#connect-null-values) | Choose how null values, which are gaps in the data, appear on the graph. |
+| [Disconnect values](#disconnect-values)     | Choose whether to set a threshold above which values in the data should be disconnected. |
+| [Show points](#show-points)                 | Set whether to show data points to lines or bars. |
+| Point size                                  | Set the size of the points, from 1 to 40 pixels in diameter. |
+| [Stack series](#stack-series)               | Set whether Grafana displays series on top of each other. |
+| [Bar alignment](#bar-alignment)             | Set the position of the bar relative to a data point. |
 
-<!-- prettier-end-ignore -->
+<!-- prettier-ignore-end -->
 
 #### Style
 
 Choose whether to display your time-series data as **Lines**, **Bars**, or **Points**. You can use overrides to combine multiple styles in the same graph. Choose from the following:
 
-![Style modes](/static/img/docs/time-series-panel/style-modes-v9.png)
+![Graph style examples](/media/docs/grafana/panels-visualizations/screenshot-time-style-v12.0.png)
 
 #### Line interpolation
 
@@ -38,44 +38,32 @@ Choose how the graph interpolates the series line:
 - **Step before** - The line is displayed as steps between points. Points are rendered at the end of the step.
 - **Step after** - The line is displayed as steps between points. Points are rendered at the beginning of the step.
 
-#### Line width
-
-Set the thickness of the series lines or the outline for bars using the **Line width** slider.
-
-#### Fill opacity
-
-Set the series area fill color using the **Fill opacity** slider.
-
-![Fill opacity examples](/static/img/docs/time-series-panel/fill-opacity.png)
+![Line interpolation examples](/media/docs/grafana/panels-visualizations/screenshot-time-interpolation-v12.0.png)
 
 #### Gradient mode
 
-Choose a gradient mode to control the gradient fill, which is based on the series color. To change the color, use the standard color scheme field option. For more information, refer to [Color scheme](ref:color-scheme).
+Choose a gradient mode to control the gradient fill, which is based on the series color. To change the color, use the standard color scheme field option. For more information, refer to [Color scheme](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme).
 
 - **None** - No gradient fill. This is the default setting.
 - **Opacity** - An opacity gradient where the opacity of the fill increases as y-axis values increase.
 - **Hue** - A subtle gradient that's based on the hue of the series color.
-- **Scheme** - A color gradient defined by your [Color scheme](ref:color-scheme). This setting is used for the fill area and line. For more information about scheme, refer to [Scheme gradient mode](#scheme-gradient-mode).
+- **Scheme** - A color gradient defined by your [Color scheme](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme). This setting is used for the fill area and line. For more information about scheme, refer to [Scheme gradient mode](#scheme-gradient-mode).
 
 Gradient appearance is influenced by the **Fill opacity** setting. The following image shows the **Fill opacity** set to 50.
 
-![Gradient mode examples](/static/img/docs/time-series-panel/gradient-modes-v9.png)
+![Gradient mode examples](/media/docs/grafana/panels-visualizations/screenshot-time-gradient-v12.0.png)
 
 ##### Scheme gradient mode
 
-The **Gradient mode** option located under the **Graph styles** section has a mode called **Scheme**. When you enable **Scheme**, the line or bar receives a gradient color defined from the selected **Color scheme**.
+In **Scheme** gradient mode, the line or bar receives a gradient color defined from the selected **Color scheme** option in the visualization's **Standard** options.
 
-###### From thresholds
+The following image shows a line chart with the **Green-Yellow-Red (by value)** color scheme option selected:
 
-If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the line or bar color changes as it crosses the defined thresholds.
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_line.png" max-width="600px" alt="Color scheme: Green-Yellow-Red" >}}
 
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_line.png" max-width="1200px" alt="Colors scheme: From thresholds" >}}
+If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the line or bar color changes as it crosses the defined thresholds:
 
-###### Gradient color schemes
-
-The following image shows a line chart with the **Green-Yellow-Red (by value)** color scheme option selected.
-
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_line.png" max-width="1200px" alt="Color scheme: Green-Yellow-Red" >}}
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_line.png" max-width="600px" alt="Colors scheme: From thresholds" >}}
 
 #### Line style
 
@@ -85,13 +73,13 @@ Choose a solid, dashed, or dotted line style:
 - **Dash** - Display a dashed line. When you choose this option, a list appears for you to select the length and gap (length, gap) for the line dashes. Dash spacing is 10, 10 by default.
 - **Dots** - Display dotted lines. When you choose this option, a list appears for you to select the gap (length = 0, gap) for the dot spacing. Dot spacing is 0, 10 by default.
 
-![Line styles examples](/static/img/docs/time-series-panel/line-styles-examples-v9.png)
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-time-line-style-v12.0.png" max-width="550px" alt="Line style examples" >}}
 
 {{< docs/shared lookup="visualizations/connect-null-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
 
 {{< docs/shared lookup="visualizations/disconnect-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
 
-To change the color, use the standard [color scheme](ref:color-scheme) field option.
+To change the color, use the standard [color scheme](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme) field option.
 
 #### Show points
 
@@ -111,7 +99,7 @@ Set whether Grafana stacks or displays series on top of each other. Be cautious 
 
 ##### Stack series in groups
 
-The stacking group option is only available as an override. For more information about creating an override, refer to [Configure field overrides](ref:configure-field-overrides).
+The stacking group option is only available as an override. For more information about creating an override, refer to [Configure field overrides](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/).
 
 1. Edit the panel and click **Overrides**.
 1. Create a field override for the **Stack series** option.

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -37,5 +37,6 @@ When you set the **Tooltip mode** to **All**, the **Values sort order** option i
 ### Hover proximity
 
 Set the hover proximity (in pixels) to control how close the cursor must be to a data point to trigger the tooltip to display.
+The following screen recording shows this option in a time series visualization:
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)


### PR DESCRIPTION
Backport 12d7b804eb6c61f318a01478bf1cd4e0f2481ae6 from #107008

---

This PR:

- Removes the graph styles shared file from the Candlestick page and replaces it with text
- Updates screenshots so they're specific to candlestick
- Updates time series screenshots to dark mode
- Updates soft min/max screenshots in axis shared files

Backporting notes:
11.2 - Bar width factor
