### PR TITLE
Graphite: Fix date mutation

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3545,8 +3545,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "19"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
     ],
     "public/app/plugins/datasource/graphite/gfunc.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -961,7 +961,7 @@ describe('graphiteDatasource', () => {
 
   describe('translateTime', () => {
     it('does not mutate passed in date', async () => {
-      const date = new Date('2025-06-30T00:00:59Z');
+      const date = new Date('2025-06-30T00:00:59.000Z');
       const functionDate = moment(date);
       const updatedDate = ctx.ds.translateTime(
         dateMath.toDateTime(functionDate.toDate(), { roundUp: undefined, timezone: undefined })!,
@@ -970,6 +970,12 @@ describe('graphiteDatasource', () => {
 
       expect(functionDate.toDate()).toEqual(date);
       expect(updatedDate).not.toEqual(date.getTime());
+    });
+    it('does not mutate passed in relative date - string', async () => {
+      const date = 'now-1m';
+      const updatedDate = ctx.ds.translateTime(date, true);
+
+      expect(updatedDate).not.toEqual(date);
     });
     it('returns the input if the input is invalid', async () => {
       const updatedDate = ctx.ds.translateTime('', true);

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -971,6 +971,11 @@ describe('graphiteDatasource', () => {
       expect(functionDate.toDate()).toEqual(date);
       expect(updatedDate).not.toEqual(date.getTime());
     });
+    it('returns the input if the input is invalid', async () => {
+      const updatedDate = ctx.ds.translateTime('', true);
+
+      expect(updatedDate).toBe('');
+    });
   });
 });
 

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1,4 +1,5 @@
 import { isArray } from 'lodash';
+import moment from 'moment';
 import { of } from 'rxjs';
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
 
@@ -6,6 +7,7 @@ import {
   AbstractLabelMatcher,
   AbstractLabelOperator,
   DataQueryRequest,
+  dateMath,
   dateTime,
   getFrameDisplayName,
   MetricFindValue,
@@ -954,6 +956,20 @@ describe('graphiteDatasource', () => {
     it('does not extract metrics when the config does not match', async () => {
       await assertQueryExport('interpolate(alias(test.west.001.cpu))', []);
       await assertQueryExport('interpolate(alias(servers.west.001))', []);
+    });
+  });
+
+  describe('translateTime', () => {
+    it('does not mutate passed in date', async () => {
+      const date = new Date('2025-06-30T00:00:59Z');
+      const functionDate = moment(date);
+      const updatedDate = ctx.ds.translateTime(
+        dateMath.toDateTime(functionDate.toDate(), { roundUp: undefined, timezone: undefined })!,
+        true
+      );
+
+      expect(functionDate.toDate()).toEqual(date);
+      expect(updatedDate).not.toEqual(date.getTime());
     });
   });
 });

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -508,10 +508,7 @@ export class GraphiteDatasource
         if (date === 'now') {
           return 'now';
         } else if (date.indexOf('now-') >= 0 && date.indexOf('/') === -1) {
-          date = date.substring(3);
-          date = date.replace('m', 'min');
-          date = date.replace('M', 'mon');
-          return date;
+          return date.substring(3).replace('m', 'min').replace('M', 'mon');
         }
         const parsedDate = dateMath.toDateTime(date, { roundUp, timezone });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1,5 +1,5 @@
 import { map as _map, each, indexOf, isArray, isString } from 'lodash';
-import moment, { Moment } from 'moment';
+import moment from 'moment';
 import { lastValueFrom, merge, Observable, of, OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
@@ -503,27 +503,34 @@ export class GraphiteDatasource
   }
 
   translateTime(date: DateTime | string, roundUp?: boolean, timezone?: TimeZone) {
-    let dateCopy: Moment;
+    const parseDate = () => {
+      if (isString(date)) {
+        if (date === 'now') {
+          return 'now';
+        } else if (date.indexOf('now-') >= 0 && date.indexOf('/') === -1) {
+          date = date.substring(3);
+          date = date.replace('m', 'min');
+          date = date.replace('M', 'mon');
+          return date;
+        }
+        const parsedDate = dateMath.toDateTime(date, { roundUp, timezone });
 
-    if (isString(date)) {
-      if (date === 'now') {
-        return 'now';
-      } else if (date.indexOf('now-') >= 0 && date.indexOf('/') === -1) {
-        date = date.substring(3);
-        date = date.replace('m', 'min');
-        date = date.replace('M', 'mon');
-        return date;
+        // If the date is invalid return the original string
+        // e.g. if an empty string is passed in or if the roundng is invalid e.g. now/2y
+        if (!parsedDate || parsedDate.isValid() === false) {
+          return date;
+        }
+
+        return moment(parsedDate.toDate());
+      } else {
+        return moment(date.toDate());
       }
-      const parsedDate = dateMath.toDateTime(date, { roundUp, timezone });
+    };
 
-      // If the date is invalid return the original string
-      if (!parsedDate) {
-        return date;
-      }
+    const parsedDate = parseDate();
 
-      dateCopy = moment(parsedDate.toDate());
-    } else {
-      dateCopy = moment(date.toDate());
+    if (typeof parsedDate === 'string') {
+      return parsedDate;
     }
 
     // graphite' s from filter is exclusive
@@ -531,16 +538,16 @@ export class GraphiteDatasource
     // to guarantee that we get all the data that
     // exists for the specified range
     if (roundUp) {
-      if (dateCopy.get('s')) {
-        dateCopy.add(1, 's');
+      if (parsedDate.get('s')) {
+        parsedDate.add(1, 's');
       }
     } else if (roundUp === false) {
-      if (dateCopy.get('s')) {
-        dateCopy.subtract(1, 's');
+      if (parsedDate.get('s')) {
+        parsedDate.subtract(1, 's');
       }
     }
 
-    return dateCopy.unix();
+    return parsedDate.unix();
   }
 
   metricFindQuery(findQuery: string | GraphiteQuery, optionalOptions?: any): Promise<MetricFindValue[]> {


### PR DESCRIPTION
Data sources should not mutate the date object. If modifications need to be made when requesting data from the underlying data source, the date object should be cloned.

Fixes #107413