### PR TITLE
Git sync create folder flow refactor to use new hook

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1493,9 +1493,6 @@ exports[`better eslint`] = {
     "public/app/features/browse-dashboards/components/NewFolderForm.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],
-    "public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx:5381": [
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
-    ],
     "public/app/features/browse-dashboards/state/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1494,10 +1494,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],
     "public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx:5381": [
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "1"],
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "2"],
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "3"]
+      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],
     "public/app/features/browse-dashboards/state/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -107,11 +107,7 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
           size="sm"
         >
           {parentFolder?.managedBy === ManagerKind.Repo || isProvisionedInstance ? (
-            <NewProvisionedFolderForm
-              onSubmit={() => setShowNewFolderDrawer(false)}
-              onCancel={() => setShowNewFolderDrawer(false)}
-              parentFolder={parentFolder}
-            />
+            <NewProvisionedFolderForm onDismiss={() => setShowNewFolderDrawer(false)} parentFolder={parentFolder} />
           ) : (
             <NewFolderForm onConfirm={onCreateFolder} onCancel={() => setShowNewFolderDrawer(false)} />
           )}

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
@@ -33,8 +33,8 @@ jest.mock('./BrowseActions/DescendantCount', () => ({
   DescendantCount: () => <div data-testid="descendant-count">2 folders, 5 dashboards</div>,
 }));
 
-jest.mock('app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields', () => ({
-  DashboardEditFormSharedFields: () => <div data-testid="shared-fields" />,
+jest.mock('app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields', () => ({
+  ResourceEditFormSharedFields: () => <div data-testid="shared-fields" />,
 }));
 
 const mockUseDeleteRepositoryFilesMutation = useDeleteRepositoryFilesWithPathMutation as jest.MockedFunction<

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -8,7 +8,7 @@ import { Box, Button, Stack } from '@grafana/ui';
 import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView, useDeleteRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
-import { DashboardEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields';
+import { ResourceEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields';
 import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/shared';
 import { FolderDTO } from 'app/types';
 
@@ -121,7 +121,7 @@ function FormContent({
             />
           </Box>
 
-          <DashboardEditFormSharedFields
+          <ResourceEditFormSharedFields
             resourceType="folder"
             isNew={false}
             workflow={workflow}

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -1,73 +1,52 @@
 import { useEffect } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { AppEvents } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getAppEvents } from '@grafana/runtime';
-import { Alert, Button, Field, Input, RadioButtonGroup, Spinner, Stack, TextArea } from '@grafana/ui';
-import { useCreateRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
+import { Alert, Button, Field, Input, Stack } from '@grafana/ui';
+import { Folder } from 'app/api/clients/folder/v1beta1';
+import { RepositoryView, useCreateRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath, Resource } from 'app/features/apiserver/types';
-import { getDefaultWorkflow, getWorkflowOptions } from 'app/features/dashboard-scene/saving/provisioned/defaults';
+import { DashboardEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields';
+import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/shared';
 import { validationSrv } from 'app/features/manage-dashboards/services/ValidationSrv';
-import { BranchValidationError } from 'app/features/provisioning/Shared/BranchValidationError';
 import { PROVISIONING_URL } from 'app/features/provisioning/constants';
-import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
-import { WorkflowOption } from 'app/features/provisioning/types';
-import { validateBranchName } from 'app/features/provisioning/utils/git';
 import { FolderDTO } from 'app/types';
 
-type FormData = {
-  ref?: string;
-  path: string;
-  comment?: string;
-  repo: string;
-  workflow?: WorkflowOption;
-  title: string;
-};
-
+import { useProvisionedFolderFormData } from '../hooks/useProvisionedFolderFormData';
+interface FormProps extends Props {
+  initialValues: BaseProvisionedFormData;
+  repository?: RepositoryView;
+  workflowOptions: Array<{ label: string; value: string }>;
+  folder?: Folder;
+  isGitHub: boolean;
+}
 interface Props {
-  onSubmit: () => void;
-  onCancel: () => void;
   parentFolder?: FolderDTO;
+  onDismiss?: () => void;
 }
 
-const initialFormValues: Partial<FormData> = {
-  title: '',
-  comment: '',
-  ref: `folder/${Date.now()}`,
-};
-
-// TODO: use useProvisionedFolderFormData hook to manage form data and repository state
-export function NewProvisionedFolderForm({ onSubmit, onCancel, parentFolder }: Props) {
-  const { repository, folder, isLoading } = useGetResourceRepositoryView({ folderName: parentFolder?.uid });
+function FormContent({ initialValues, repository, workflowOptions, folder, isGitHub, onDismiss }: FormProps) {
   const prURL = usePullRequestParam();
   const navigate = useNavigate();
   const [create, request] = useCreateRepositoryFilesWithPathMutation();
 
-  const isGitHub = Boolean(repository?.type === 'github');
-
-  const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { errors },
-    control,
-    setValue,
-  } = useForm<FormData>({ defaultValues: { ...initialFormValues, workflow: getDefaultWorkflow(repository) } });
+  const methods = useForm<BaseProvisionedFormData>({
+    defaultValues: initialValues,
+    mode: 'onBlur', // Validates when user leaves the field
+  });
+  const { handleSubmit, watch, register, formState } = methods;
 
   const [workflow, ref] = watch(['workflow', 'ref']);
-
-  useEffect(() => {
-    setValue('workflow', getDefaultWorkflow(repository));
-  }, [repository, setValue]);
 
   // TODO: replace with useProvisionedRequestHandler hook
   useEffect(() => {
     const appEvents = getAppEvents();
     if (request.isSuccess && repository) {
-      onSubmit();
+      onDismiss?.();
 
       appEvents.publish({
         type: AppEvents.alertSuccess.name,
@@ -101,20 +80,7 @@ export function NewProvisionedFolderForm({ onSubmit, onCancel, parentFolder }: P
         ],
       });
     }
-  }, [request.isSuccess, request.isError, request.error, onSubmit, ref, request.data, workflow, navigate, repository]);
-
-  if (isLoading) {
-    return <Spinner />;
-  }
-
-  if (!repository) {
-    return (
-      <Alert
-        title={t('browse-dashboards.new-provisioned-folder-form.title-repository-not-found', 'Repository not found')}
-        severity="error"
-      />
-    );
-  }
+  }, [request.isSuccess, request.isError, request.error, ref, request.data, workflow, navigate, repository, onDismiss]);
 
   const validateFolderName = async (folderName: string) => {
     try {
@@ -128,7 +94,7 @@ export function NewProvisionedFolderForm({ onSubmit, onCancel, parentFolder }: P
     }
   };
 
-  const doSave = async ({ ref, title, workflow, comment }: FormData) => {
+  const doSave = async ({ ref, title, workflow, comment }: BaseProvisionedFormData) => {
     const repoName = repository?.name;
     if (!title || !repoName) {
       return;
@@ -163,107 +129,102 @@ export function NewProvisionedFolderForm({ onSubmit, onCancel, parentFolder }: P
   };
 
   return (
-    <form onSubmit={handleSubmit(doSave)}>
-      <Stack direction="column" gap={2}>
-        {!repository?.workflows?.length && (
-          <Alert
-            title={t(
-              'browse-dashboards.new-provisioned-folder-form.title-this-repository-is-read-only',
-              'This repository is read only'
-            )}
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(doSave)}>
+        <Stack direction="column" gap={2}>
+          {!repository?.workflows?.length && (
+            <Alert
+              title={t(
+                'browse-dashboards.new-provisioned-folder-form.title-this-repository-is-read-only',
+                'This repository is read only'
+              )}
+            >
+              <Trans i18nKey="browse-dashboards.text-this-repository-is-read-only">
+                If you have direct access to the target, copy the JSON and paste it there.
+              </Trans>
+            </Alert>
+          )}
+
+          <Field
+            label={t('browse-dashboards.new-provisioned-folder-form.label-folder-name', 'Folder name')}
+            invalid={!!formState.errors.title}
+            error={formState.errors.title?.message}
           >
-            <Trans i18nKey="browse-dashboards.text-this-repository-is-read-only">
-              If you have direct access to the target, copy the JSON and paste it there.
-            </Trans>
-          </Alert>
-        )}
+            <Input
+              {...register('title', {
+                required: t('browse-dashboards.new-provisioned-folder-form.error-required', 'Folder name is required'),
+                validate: validateFolderName,
+              })}
+              placeholder={t(
+                'browse-dashboards.new-provisioned-folder-form.folder-name-input-placeholder-enter-folder-name',
+                'Enter folder name'
+              )}
+              id="folder-name-input"
+            />
+          </Field>
 
-        <Field
-          label={t('browse-dashboards.new-provisioned-folder-form.label-folder-name', 'Folder name')}
-          invalid={!!errors.title}
-          error={errors.title?.message}
-        >
-          <Input
-            {...register('title', {
-              required: t('browse-dashboards.new-provisioned-folder-form.error-required', 'Folder name is required'),
-              validate: validateFolderName,
-            })}
-            placeholder={t(
-              'browse-dashboards.new-provisioned-folder-form.folder-name-input-placeholder-enter-folder-name',
-              'Enter folder name'
-            )}
-            id="folder-name-input"
+          <DashboardEditFormSharedFields
+            resourceType="folder"
+            isNew={false}
+            workflow={workflow}
+            workflowOptions={workflowOptions}
+            isGitHub={isGitHub}
+            hidePath
           />
-        </Field>
 
-        {/* TODO: use DashboardEditFormSharedFields to replace comment and workflow input*/}
-        <Field label={t('browse-dashboards.new-provisioned-folder-form.label-comment', 'Comment')}>
-          <TextArea
-            {...register('comment')}
-            placeholder={t(
-              'browse-dashboards.new-provisioned-folder-form.folder-comment-input-placeholder-describe-changes-optional',
-              'Add a note to describe your changes (optional)'
-            )}
-            id="folder-comment-input"
-            rows={5}
-          />
-        </Field>
+          {prURL && (
+            <Alert
+              severity="info"
+              title={t(
+                'browse-dashboards.new-provisioned-folder-form.title-pull-request-created',
+                'Pull request created'
+              )}
+            >
+              <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.text-pull-request-created">
+                A pull request has been created with changes to this folder:
+              </Trans>{' '}
+              <a href={prURL} target="_blank" rel="noopener noreferrer">
+                {prURL}
+              </a>
+            </Alert>
+          )}
 
-        {isGitHub && (
-          <>
-            <Field label={t('browse-dashboards.new-provisioned-folder-form.label-workflow', 'Workflow')}>
-              <Controller
-                control={control}
-                name="workflow"
-                render={({ field: { ref, ...field } }) => (
-                  <RadioButtonGroup {...field} options={getWorkflowOptions(repository)} id={'folder-workflow'} />
-                )}
-              />
-            </Field>
-            {workflow === 'branch' && (
-              <Field
-                label={t('browse-dashboards.new-provisioned-folder-form.label-branch', 'Branch')}
-                description={t(
-                  'browse-dashboards.new-provisioned-folder-form.description-branch-name-in-git-hub',
-                  'Branch name in GitHub'
-                )}
-                invalid={!!errors?.ref}
-                error={errors.ref ? <BranchValidationError /> : ''}
-              >
-                <Input {...register('ref', { validate: validateBranchName })} id="branch-name-input" />
-              </Field>
-            )}
-          </>
-        )}
-
-        {prURL && (
-          <Alert
-            severity="info"
-            title={t(
-              'browse-dashboards.new-provisioned-folder-form.title-pull-request-created',
-              'Pull request created'
-            )}
-          >
-            <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.text-pull-request-created">
-              A pull request has been created with changes to this folder:
-            </Trans>{' '}
-            <a href={prURL} target="_blank" rel="noopener noreferrer">
-              {prURL}
-            </a>
-          </Alert>
-        )}
-
-        <Stack gap={2}>
-          <Button variant="secondary" fill="outline" onClick={onCancel}>
-            <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.cancel">Cancel</Trans>
-          </Button>
-          <Button type="submit" disabled={request.isLoading}>
-            {request.isLoading
-              ? t('browse-dashboards.new-provisioned-folder-form.button-creating', 'Creating...')
-              : t('browse-dashboards.new-provisioned-folder-form.button-create', 'Create')}
-          </Button>
+          <Stack gap={2}>
+            <Button variant="secondary" fill="outline" onClick={onDismiss}>
+              <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.cancel">Cancel</Trans>
+            </Button>
+            <Button type="submit" disabled={request.isLoading}>
+              {request.isLoading
+                ? t('browse-dashboards.new-provisioned-folder-form.button-creating', 'Creating...')
+                : t('browse-dashboards.new-provisioned-folder-form.button-create', 'Create')}
+            </Button>
+          </Stack>
         </Stack>
-      </Stack>
-    </form>
+      </form>
+    </FormProvider>
+  );
+}
+
+export function NewProvisionedFolderForm({ parentFolder, onDismiss }: Props) {
+  const { workflowOptions, isGitHub, repository, folder, initialValues } = useProvisionedFolderFormData({
+    folderUid: parentFolder?.uid,
+    action: 'create',
+    title: parentFolder?.title,
+  });
+
+  if (!initialValues) {
+    return null;
+  }
+
+  return (
+    <FormContent
+      parentFolder={parentFolder}
+      onDismiss={onDismiss}
+      initialValues={initialValues}
+      repository={repository}
+      workflowOptions={workflowOptions}
+      folder={folder}
+      isGitHub={isGitHub}
+    />
   );
 }

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -145,7 +145,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, isGit
             </Alert>
           )}
 
-          <Field
+          <Field noMargin
             label={t('browse-dashboards.new-provisioned-folder-form.label-folder-name', 'Folder name')}
             invalid={!!formState.errors.title}
             error={formState.errors.title?.message}

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -9,7 +9,7 @@ import { Alert, Button, Field, Input, Stack } from '@grafana/ui';
 import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView, useCreateRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath, Resource } from 'app/features/apiserver/types';
-import { DashboardEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields';
+import { ResourceEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields';
 import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/shared';
 import { validationSrv } from 'app/features/manage-dashboards/services/ValidationSrv';
 import { PROVISIONING_URL } from 'app/features/provisioning/constants';
@@ -145,7 +145,8 @@ function FormContent({ initialValues, repository, workflowOptions, folder, isGit
             </Alert>
           )}
 
-          <Field noMargin
+          <Field
+            noMargin
             label={t('browse-dashboards.new-provisioned-folder-form.label-folder-name', 'Folder name')}
             invalid={!!formState.errors.title}
             error={formState.errors.title?.message}
@@ -163,7 +164,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, isGit
             />
           </Field>
 
-          <DashboardEditFormSharedFields
+          <ResourceEditFormSharedFields
             resourceType="folder"
             isNew={false}
             workflow={workflow}

--- a/public/app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields.tsx
+++ b/public/app/features/dashboard-scene/components/Provisioned/DashboardEditFormSharedFields.tsx
@@ -14,10 +14,11 @@ interface DashboardEditFormSharedFieldsProps {
   readOnly?: boolean;
   workflow?: WorkflowOption;
   isGitHub?: boolean;
+  hidePath?: boolean;
 }
 
 export const DashboardEditFormSharedFields = memo<DashboardEditFormSharedFieldsProps>(
-  ({ readOnly = false, workflow, workflowOptions, isGitHub, isNew, resourceType }) => {
+  ({ readOnly = false, workflow, workflowOptions, isGitHub, isNew, resourceType, hidePath = false }) => {
     const {
       control,
       register,
@@ -32,16 +33,18 @@ export const DashboardEditFormSharedFields = memo<DashboardEditFormSharedFieldsP
     return (
       <>
         {/* Path */}
-        <Field
-          noMargin
-          label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-path', 'Path')}
-          description={t(
-            'provisioned-resource-form.save-or-delete-resource-shared-fields.description-inside-repository',
-            pathText
-          )}
-        >
-          <Input id="dashboard-path" type="text" {...register('path')} readOnly={!isNew} />
-        </Field>
+        {!hidePath && (
+          <Field
+            noMargin
+            label={t('provisioned-resource-form.save-or-delete-resource-shared-fields.label-path', 'Path')}
+            description={t(
+              'provisioned-resource-form.save-or-delete-resource-shared-fields.description-inside-repository',
+              pathText
+            )}
+          >
+            <Input id="dashboard-path" type="text" {...register('path')} readOnly={!isNew} />
+          </Field>
+        )}
 
         {/* Comment */}
         <Field

--- a/public/app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields.test.tsx
+++ b/public/app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields.test.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { ProvisionedDashboardFormData } from '../../saving/shared';
 
-import { DashboardEditFormSharedFields } from './DashboardEditFormSharedFields';
+import { ResourceEditFormSharedFields } from './ResourceEditFormSharedFields';
 
 // Mock the i18n hook since it's used in the component
 jest.mock('@grafana/i18n', () => ({
@@ -65,13 +65,13 @@ function setup(options: SetupOptions = {}) {
     user,
     ...render(
       <FormWrapper>
-        <DashboardEditFormSharedFields {...componentProps} resourceType="dashboard" />
+        <ResourceEditFormSharedFields {...componentProps} resourceType="dashboard" />
       </FormWrapper>
     ),
   };
 }
 
-describe('DashboardEditFormSharedFields', () => {
+describe('ResourceEditFormSharedFields', () => {
   describe('Basic Rendering', () => {
     it('should render path and comment fields by default', () => {
       setup();
@@ -186,7 +186,7 @@ describe('DashboardEditFormSharedFields', () => {
 
         return (
           <FormProvider {...methods}>
-            <DashboardEditFormSharedFields
+            <ResourceEditFormSharedFields
               workflowOptions={[
                 { label: 'Write directly', value: 'write' },
                 { label: 'Create branch', value: 'branch' },

--- a/public/app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields.tsx
@@ -17,7 +17,7 @@ interface DashboardEditFormSharedFieldsProps {
   hidePath?: boolean;
 }
 
-export const DashboardEditFormSharedFields = memo<DashboardEditFormSharedFieldsProps>(
+export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsProps>(
   ({ readOnly = false, workflow, workflowOptions, isGitHub, isNew, resourceType, hidePath = false }) => {
     const {
       control,

--- a/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
@@ -14,7 +14,7 @@ import { validationSrv } from 'app/features/manage-dashboards/services/Validatio
 import { PROVISIONING_URL } from 'app/features/provisioning/constants';
 import { useCreateOrUpdateRepositoryFile } from 'app/features/provisioning/hooks/useCreateOrUpdateRepositoryFile';
 
-import { DashboardEditFormSharedFields } from '../../components/Provisioned/DashboardEditFormSharedFields';
+import { ResourceEditFormSharedFields } from '../../components/Provisioned/ResourceEditFormSharedFields';
 import { getDashboardUrl } from '../../utils/getDashboardUrl';
 import { useProvisionedRequestHandler } from '../../utils/useProvisionedRequestHandler';
 import { SaveDashboardFormCommonOptions } from '../SaveDashboardForm';
@@ -214,7 +214,7 @@ export function SaveProvisionedDashboardForm({
 
           {!isNew && !readOnly && <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />}
 
-          <DashboardEditFormSharedFields
+          <ResourceEditFormSharedFields
             resourceType="dashboard"
             readOnly={readOnly}
             workflow={workflow}

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.test.tsx
@@ -34,8 +34,8 @@ jest.mock('react-router-dom-v5-compat', () => ({
 const mockNavigate = jest.fn();
 
 // Mock shared form components
-jest.mock('../components/Provisioned/DashboardEditFormSharedFields', () => ({
-  DashboardEditFormSharedFields: ({ disabled }: { disabled: boolean }) => (
+jest.mock('../components/Provisioned/ResourceEditFormSharedFields', () => ({
+  ResourceEditFormSharedFields: ({ disabled }: { disabled: boolean }) => (
     <textarea data-testid="shared-fields" disabled={disabled} />
   ),
 }));

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
@@ -8,7 +8,7 @@ import { Alert, Button, Drawer, Stack } from '@grafana/ui';
 import { useDeleteRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { PROVISIONING_URL } from 'app/features/provisioning/constants';
 
-import { DashboardEditFormSharedFields } from '../components/Provisioned/DashboardEditFormSharedFields';
+import { ResourceEditFormSharedFields } from '../components/Provisioned/ResourceEditFormSharedFields';
 import { ProvisionedDashboardFormData } from '../saving/shared';
 import { DashboardScene } from '../scene/DashboardScene';
 import { useProvisionedRequestHandler } from '../utils/useProvisionedRequestHandler';
@@ -121,7 +121,7 @@ export function DeleteProvisionedDashboardForm({
               </Alert>
             )}
 
-            <DashboardEditFormSharedFields
+            <ResourceEditFormSharedFields
               resourceType="dashboard"
               isNew={isNew}
               readOnly={readOnly}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3473,18 +3473,12 @@
       "button-create": "Create",
       "button-creating": "Creating...",
       "cancel": "Cancel",
-      "description-branch-name-in-git-hub": "Branch name in GitHub",
       "error-invalid-folder-name": "Invalid folder name",
       "error-required": "Folder name is required",
-      "folder-comment-input-placeholder-describe-changes-optional": "Add a note to describe your changes (optional)",
       "folder-name-input-placeholder-enter-folder-name": "Enter folder name",
-      "label-branch": "Branch",
-      "label-comment": "Comment",
       "label-folder-name": "Folder name",
-      "label-workflow": "Workflow",
       "text-pull-request-created": "A pull request has been created with changes to this folder:",
       "title-pull-request-created": "Pull request created",
-      "title-repository-not-found": "Repository not found",
       "title-this-repository-is-read-only": "This repository is read only"
     },
     "no-results": {


### PR DESCRIPTION
**What is this feature?**

Refactor `NewProvisionedFolderForm` to use `useProvisionedFolderFormData` hook and `DashboardEditFormSharedFields`

**Why do we need this feature?**

less duplicate code

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/git-ui-sync-project/issues/304

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
