### PR TITLE
SecureValues: Remove actor prefix from decrypters

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -22,7 +22,7 @@ func TestValidateSecureValue(t *testing.T) {
 				Description: "description",
 				Value:       "value",
 				Keeper:      &keeper,
-				Decrypters:  []string{"actor_app1", "actor_app2"},
+				Decrypters:  []string{"app1", "app2"},
 			},
 		}
 
@@ -187,8 +187,8 @@ func TestValidateSecureValue(t *testing.T) {
 				Description: "description", Ref: &ref,
 
 				Decrypters: []string{
-					"actor_app1",
-					"actor_app1",
+					"app1",
+					"app1",
 				},
 			},
 		}
@@ -198,33 +198,8 @@ func TestValidateSecureValue(t *testing.T) {
 		require.Equal(t, "spec.decrypters.[1]", errs[0].Field)
 	})
 
-	t.Run("`decrypters` must match the expected format", func(t *testing.T) {
-		ref := "ref"
-		sv := &secretv0alpha1.SecureValue{
-			Spec: secretv0alpha1.SecureValueSpec{
-				Description: "description", Ref: &ref,
-
-				Decrypters: []string{
-					"app1",
-					"_app1",
-					"actr_app1",
-					"actor_ ",
-					"actor_",
-				},
-			},
-		}
-
-		errs := ValidateSecureValue(sv, nil, admission.Create, nil)
-		require.Len(t, errs, len(sv.Spec.Decrypters))
-
-		for i, err := range errs {
-			require.Equal(t, fmt.Sprintf("spec.decrypters.[%d]", i), err.Field)
-			require.Contains(t, err.Error(), "a decrypter must have the format `actor_{name}`")
-		}
-	})
-
 	t.Run("when set, the `decrypters` must be one of the allowed in the allow list", func(t *testing.T) {
-		allowList := map[string]struct{}{"actor_app1": {}, "actor_app2": {}}
+		allowList := map[string]struct{}{"app1": {}, "app2": {}}
 		decrypters := slices.Collect(maps.Keys(allowList))
 
 		t.Run("no matches, returns an error", func(t *testing.T) {
@@ -233,7 +208,7 @@ func TestValidateSecureValue(t *testing.T) {
 				Spec: secretv0alpha1.SecureValueSpec{
 					Description: "description", Ref: &ref,
 
-					Decrypters: []string{"actor_app3"},
+					Decrypters: []string{"app3"},
 				},
 			}
 
@@ -284,10 +259,37 @@ func TestValidateSecureValue(t *testing.T) {
 		})
 	})
 
+	t.Run("`decrypters` must be a valid label value", func(t *testing.T) {
+		decrypters := []string{
+			"",              // invalid
+			"is/this/valid", // invalid
+			"is this valid", // invalid
+			"is.this.valid",
+			"is-this-valid",
+			"is_this_valid",
+			"0isthisvalid9",
+			"isthisvalid9",
+			"0isthisvalid",
+			"isthisvalid",
+		}
+
+		ref := "ref"
+		sv := &secretv0alpha1.SecureValue{
+			Spec: secretv0alpha1.SecureValueSpec{
+				Description: "description", Ref: &ref,
+
+				Decrypters: decrypters,
+			},
+		}
+
+		errs := ValidateSecureValue(sv, nil, admission.Create, nil)
+		require.Len(t, errs, 3)
+	})
+
 	t.Run("`decrypters` cannot have more than 64 items", func(t *testing.T) {
 		decrypters := make([]string, 0, 64+1)
 		for i := 0; i < 64+1; i++ {
-			decrypters = append(decrypters, fmt.Sprintf("actor_app%d", i))
+			decrypters = append(decrypters, fmt.Sprintf("app%d", i))
 		}
 
 		ref := "ref"

--- a/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-default-generate.yaml
@@ -11,5 +11,5 @@ spec:
   description: This is a secret
   value: this is super duper secure
   decrypters:
-    - actor_k6
-    - actor_synthetic-monitoring
+    - k6
+    - synthetic-monitoring

--- a/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
@@ -12,5 +12,5 @@ spec:
   keeper: my-keeper-1
   value: super duper secure
   decrypters:
-    - actor_k6
-    - actor_synthetic-monitoring
+    - k6
+    - synthetic-monitoring


### PR DESCRIPTION
Merging the code mostly as-is from the feature branch: `secret-service/feature-branch`

This adds:
- @macabu's work to limit to remove actor prefix from secure value decrypters

Part of: https://github.com/grafana/grafana-operator-experience-squad/issues/1469