### PR TITLE
Docs: Clarify that log level critical is just an alias for error

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1121,7 +1121,7 @@ content_types = text/html
 # Use space to separate multiple modes, e.g. "console file"
 mode = console file
 
-# Either "debug", "info", "warn", "error", "critical", default is "info"
+# Either "debug", "info", "warn", "error". Default is "info"
 level = info
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1105,7 +1105,7 @@
 # Use space to separate multiple modes, e.g. "console file"
 ;mode = console file
 
-# Either "debug", "info", "warn", "error", "critical", default is "info"
+# Either "debug", "info", "warn", "error". Default is "info"
 ;level = info
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1547,7 +1547,7 @@ Use spaces to separate multiple modes, for example, `console file`.
 
 #### `level`
 
-Options are `debug`, `info`, `warn`, `error`, and `critical`. Default is `info`.
+Options are `debug`, `info`, `warn`, `error`. `critical` is an alias for `error`. Default is `info`.
 
 #### `filters`
 
@@ -1576,7 +1576,7 @@ Only applicable when `console` is used in `[log]` mode.
 
 #### `level`
 
-Options are `debug`, `info`, `warn`, `error`, and `critical`. Default is inherited from `[log]` level.
+See [`[log] level`](#level) for values. Default is inherited from `[log]` level.
 
 #### `format`
 
@@ -1590,7 +1590,7 @@ Only applicable when `file` used in `[log]` mode.
 
 #### `level`
 
-Options are `debug`, `info`, `warn`, `error`, and `critical`. Default is inherited from `[log]` level.
+See [`[log] level`](#level) for values. Default is inherited from `[log]` level.
 
 #### `format`
 
@@ -1625,7 +1625,7 @@ Only applicable when `syslog` used in `[log]` mode.
 
 #### `level`
 
-Options are `debug`, `info`, `warn`, `error`, and `critical`. Default is inherited from `[log]` level.
+See [`[log] level`](#level) for values. Default is inherited from `[log]` level.
 
 #### `format`
 


### PR DESCRIPTION
After reading the docs, I was expecting that setting `[log] level = critical` would silence log lines reported as `error`. Instead, I was surprised to discover that `critical` is just an alias for `error`.

 - Remove `critical` as an example from both `defaults.ini` and `sample.ini`. This isn't _critical_ information to include in the sample configs
 - Add `critical is an alias for error` to the docs for `[log] level`
 - Don't duplicate all values for `level` for all the type-specific loggers. Instead, link back to `[log] level`

https://github.com/grafana/grafana/blob/0e9d9d3b75cdd7350e19db0bbcaea53b362526d0/pkg/infra/log/log.go#L318