### PR TITLE
Git UI Sync Create Dashboard: Fix update dashboard path field when folder selection changes

### DIFF
--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -19,7 +19,7 @@ interface RepositoryViewData {
 // This is safe to call as a viewer (you do not need full access to the Repository configs)
 export const useGetResourceRepositoryView = ({ name, folderName }: GetResourceRepositoryArgs): RepositoryViewData => {
   const { data: settingsData, isLoading: isSettingsLoading } = useGetFrontendSettingsQuery();
-  const skipFolderQuery = name || !folderName;
+  const skipFolderQuery = !folderName;
   const { data: folder, isLoading: isFolderLoading } = useGetFolderQuery(
     skipFolderQuery ? skipToken : { name: folderName }
   );


### PR DESCRIPTION
**What is this feature?**

Only skip the "get folder" query if no folder name is provided. This ensures we always fetch the latest folder path when a valid folder is selected.  

**Before:**  
https://github.com/user-attachments/assets/d78b0d15-0e44-4bf5-b9d7-db3954944d28

**After:**  
https://github.com/user-attachments/assets/c66f717d-38a5-4cb7-bfe3-cc8bb533daca



**Why do we need this feature?**

To allow users to easily save dashboards to different folders by keeping the folder path in sync.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/git-ui-sync-project/issues/310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
