### PR TITLE
Auth: Check SCIM dynamic settings when syncing users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -711,6 +711,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /pkg/services/anonymous/ @grafana/identity-access-team
 /pkg/services/auth/ @grafana/identity-squad
 /pkg/services/authn/ @grafana/identity-squad
+/pkg/services/scimutil/ @grafana/identity-squad
 /pkg/services/authz/ @grafana/access-squad
 /pkg/services/signingkeys/ @grafana/identity-squad
 /pkg/services/dashboards/accesscontrol.go @grafana/access-squad

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -131,7 +131,8 @@ func ProvideRegistration(
 	}
 
 	// FIXME (jguer): move to User package
-	userSync := sync.ProvideUserSync(userService, userProtectionService, authInfoService, quotaService, tracer, features, cfg)
+	// Pass nil for k8sClient - it will be handled gracefully in the SCIMSettingsUtil
+	userSync := sync.ProvideUserSync(userService, userProtectionService, authInfoService, quotaService, tracer, features, cfg, nil)
 	orgSync := sync.ProvideOrgSync(userService, orgService, accessControlService, cfg, tracer)
 	authnSvc.RegisterPostAuthHook(userSync.SyncUserHook, 10)
 	authnSvc.RegisterPostAuthHook(userSync.EnableUserHook, 20)

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -1453,8 +1453,9 @@ func TestUserSync_SCIMUtilIntegration(t *testing.T) {
 						"namespace": "default",
 					},
 					"spec": map[string]interface{}{
-						"enableUserSync":  mockCfg.userSyncEnabled,
-						"enableGroupSync": false, // Not used for this test
+						"enableUserSync":           mockCfg.userSyncEnabled,
+						"enableGroupSync":          false, // Not used for this test
+						"allowNonProvisionedUsers": mockCfg.nonProvisionedUsersAllowed,
 					},
 				},
 			}

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -1569,12 +1569,6 @@ func TestUserSync_SCIMUtilIntegration(t *testing.T) {
 				nonProvisionedAllowed = tt.staticConfig.AllowNonProvisionedUsers
 			}
 			assert.Equal(t, tt.expectedNonProvisionedAllowed, nonProvisionedAllowed, "Non-provisioned users allowed mismatch")
-
-			// Verify mock expectations if SCIM util was used
-			if tt.mockSCIMUtil != nil {
-				// The mock expectations would be verified here if we had access to the mock
-				// For now, we just verify the behavior is correct
-			}
 		})
 	}
 }

--- a/pkg/services/scimutil/README.md
+++ b/pkg/services/scimutil/README.md
@@ -136,7 +136,7 @@ spec:
 ## Error Handling
 
 The utility gracefully handles errors and falls back to static configuration when:
-- K8s client is not configured (`scim.ErrK8sClientNotConfigured`)
+- K8s client is not configured
 - SCIMConfig resource is not found
 - Network errors occur
 - Invalid configuration is encountered
@@ -147,16 +147,18 @@ All errors are logged for debugging purposes with appropriate log levels:
 - `Warn`: Fallback scenarios and non-critical errors
 - `Error`: Invalid configuration or unexpected errors
 
-## Constants
+## Implementation Details
 
-The utility uses the following constants from the SCIM API:
+This package is designed to work with the open-source Grafana build and does not depend on enterprise-only SCIM API types. It uses a simplified `SCIMConfigSpec` struct that contains only the essential configuration fields:
 
 ```go
-const (
-    UserSyncSetting  = "user"   // For checking user sync configuration
-    GroupSyncSetting = "group"  // For checking group sync configuration
-)
+type SCIMConfigSpec struct {
+    EnableUserSync  bool `json:"enableUserSync"`
+    EnableGroupSync bool `json:"enableGroupSync"`
+}
 ```
+
+The utility directly works with Kubernetes unstructured objects and extracts the configuration values without requiring the full SCIM API types.
 
 ## Testing
 

--- a/pkg/services/scimutil/README.md
+++ b/pkg/services/scimutil/README.md
@@ -38,6 +38,8 @@ Checks if non-provisioned users are allowed using dynamic configuration with sta
 func (s *SCIMUtil) AreNonProvisionedUsersAllowed(ctx context.Context, orgID int64, staticAllowed bool) bool
 ```
 
+**Note**: This field defaults to `false` when not present in the dynamic configuration.
+
 ## Usage
 
 ### Basic Usage
@@ -129,8 +131,9 @@ metadata:
   name: default
   namespace: <org-namespace>
 spec:
-  enableUserSync: true    # Controls user provisioning
-  enableGroupSync: false  # Controls group/team provisioning
+  enableUserSync: true              # Controls user provisioning
+  enableGroupSync: false            # Controls group/team provisioning
+  allowNonProvisionedUsers: false   # Controls whether non-provisioned users are allowed (optional)
 ```
 
 ## Error Handling
@@ -153,20 +156,24 @@ This package is designed to work with the open-source Grafana build and does not
 
 ```go
 type SCIMConfigSpec struct {
-    EnableUserSync  bool `json:"enableUserSync"`
-    EnableGroupSync bool `json:"enableGroupSync"`
+    EnableUserSync           bool  `json:"enableUserSync"`
+    EnableGroupSync          bool  `json:"enableGroupSync"`
+    AllowNonProvisionedUsers *bool `json:"allowNonProvisionedUsers,omitempty"`
 }
 ```
+
+The `AllowNonProvisionedUsers` field is optional and defaults to `false` when not present in the configuration.
 
 The utility directly works with Kubernetes unstructured objects and extracts the configuration values without requiring the full SCIM API types.
 
 ## Testing
 
 The package includes comprehensive tests covering:
-- All combinations of user sync and group sync settings (true/false, false/true, true/true, false/false)
+- All combinations of user sync, group sync, and non-provisioned users settings
 - Error scenarios and fallback behavior
 - Integration scenarios with both dynamic and static configurations
 - Mock implementations for the K8s client interface
+- Optional field handling for `allowNonProvisionedUsers`
 
 Run tests with:
 ```bash

--- a/pkg/services/scimutil/README.md
+++ b/pkg/services/scimutil/README.md
@@ -1,0 +1,172 @@
+# SCIM Utility
+
+This package provides utility functions for checking SCIM dynamic app platform settings using the `client.K8sHandler`. It allows both the `authimpl` and `saml` packages to check SCIM settings with dynamic configuration support and static fallback.
+
+## API Reference
+
+### SCIMUtil
+
+The main utility struct that provides methods for checking SCIM settings.
+
+```go
+type SCIMUtil struct {
+    k8sClient client.K8sHandler
+    logger    log.Logger
+}
+```
+
+### Methods
+
+#### NewSCIMUtil
+Creates a new SCIMUtil instance.
+
+```go
+func NewSCIMUtil(k8sClient client.K8sHandler) *SCIMUtil
+```
+
+#### IsUserSyncEnabled
+Checks if SCIM user sync is enabled using dynamic configuration with static fallback.
+
+```go
+func (s *SCIMUtil) IsUserSyncEnabled(ctx context.Context, orgID int64, staticEnabled bool) bool
+```
+
+#### AreNonProvisionedUsersAllowed
+Checks if non-provisioned users are allowed using dynamic configuration with static fallback.
+
+```go
+func (s *SCIMUtil) AreNonProvisionedUsersAllowed(ctx context.Context, orgID int64, staticAllowed bool) bool
+```
+
+## Usage
+
+### Basic Usage
+
+```go
+import (
+    "context"
+    "github.com/grafana/grafana/pkg/services/apiserver/client"
+    "github.com/grafana/grafana/pkg/services/scimutil"
+)
+
+// Create a new SCIM utility instance
+scimUtil := scimutil.NewSCIMUtil(k8sClient)
+
+// Check if user sync is enabled (with dynamic config support)
+userSyncEnabled := scimUtil.IsUserSyncEnabled(ctx, orgID, staticConfig.IsUserProvisioningEnabled)
+
+// Check if non-provisioned users are allowed (with dynamic config support)
+nonProvisionedAllowed := scimUtil.AreNonProvisionedUsersAllowed(ctx, orgID, staticConfig.AllowNonProvisionedUsers)
+```
+
+### In authimpl Package
+
+The `authimpl` package uses this utility in the `UserSync` struct to check SCIM settings during user provisioning validation:
+
+```go
+// In user_sync.go
+type UserSync struct {
+    // ... other fields ...
+    scimUtil     *scim_util.SCIMUtil
+    staticConfig *StaticSCIMConfig
+}
+
+func (s *UserSync) skipProvisioningValidation(ctx context.Context, currentIdentity *authn.Identity) bool {
+    // Use dynamic SCIM settings if available, otherwise fall back to static config
+    effectiveUserSyncEnabled := s.isUserProvisioningEnabled
+    effectiveAllowNonProvisionedUsers := s.allowNonProvisionedUsers
+
+    if s.scimUtil != nil {
+        orgID := currentIdentity.GetOrgID()
+        effectiveUserSyncEnabled = s.scimUtil.IsUserSyncEnabled(ctx, orgID, s.staticConfig.IsUserProvisioningEnabled)
+        effectiveAllowNonProvisionedUsers = s.scimUtil.AreNonProvisionedUsersAllowed(ctx, orgID, s.staticConfig.AllowNonProvisionedUsers)
+    }
+
+    // ... rest of validation logic ...
+}
+```
+
+### In SAML Package
+
+The SAML package can use this utility to check SCIM settings during authentication:
+
+```go
+// In saml package
+type SCIMHelper struct {
+    scimUtil *scim_util.SCIMUtil
+}
+
+func (h *SCIMHelper) CheckUserSyncEnabled(ctx context.Context, orgID int64, staticEnabled bool) bool {
+    if h.scimUtil == nil {
+        return staticEnabled
+    }
+    return h.scimUtil.IsUserSyncEnabled(ctx, orgID, staticEnabled)
+}
+```
+
+## Dynamic Configuration
+
+The utility supports dynamic SCIM configuration through the Kubernetes API. It will:
+
+1. First attempt to fetch SCIM settings from the dynamic configuration (SCIMConfig resource)
+2. If dynamic configuration is not available or fails, fall back to static configuration from `config.ini`
+3. Log the source of configuration being used for debugging
+
+### Configuration Sources
+
+- **Dynamic**: SCIMConfig resource in Kubernetes (org-specific)
+  - Resource name: `default`
+  - API Group: `scim.grafana.com/v0alpha1`
+  - Kind: `SCIMConfig`
+- **Static**: `auth.scim` section in `config.ini` (global)
+
+### SCIMConfig Resource Structure
+
+```yaml
+apiVersion: scim.grafana.com/v0alpha1
+kind: SCIMConfig
+metadata:
+  name: default
+  namespace: <org-namespace>
+spec:
+  enableUserSync: true    # Controls user provisioning
+  enableGroupSync: false  # Controls group/team provisioning
+```
+
+## Error Handling
+
+The utility gracefully handles errors and falls back to static configuration when:
+- K8s client is not configured (`scim.ErrK8sClientNotConfigured`)
+- SCIMConfig resource is not found
+- Network errors occur
+- Invalid configuration is encountered
+- Missing or malformed spec in SCIMConfig resource
+
+All errors are logged for debugging purposes with appropriate log levels:
+- `Debug`: Normal operation messages
+- `Warn`: Fallback scenarios and non-critical errors
+- `Error`: Invalid configuration or unexpected errors
+
+## Constants
+
+The utility uses the following constants from the SCIM API:
+
+```go
+const (
+    UserSyncSetting  = "user"   // For checking user sync configuration
+    GroupSyncSetting = "group"  // For checking group sync configuration
+)
+```
+
+## Testing
+
+The package includes comprehensive tests covering:
+- All combinations of user sync and group sync settings (true/false, false/true, true/true, false/false)
+- Error scenarios and fallback behavior
+- Integration scenarios with both dynamic and static configurations
+- Mock implementations for the K8s client interface
+
+Run tests with:
+```bash
+go test ./pkg/services/scimutil
+``` 

--- a/pkg/services/scimutil/scim_util.go
+++ b/pkg/services/scimutil/scim_util.go
@@ -97,7 +97,7 @@ func (s *SCIMUtil) getOrgSCIMConfig(ctx context.Context, orgID int64) (*SCIMConf
 		return nil, errors.New("k8s client not configured")
 	}
 
-	unstructuredObj, err := s.k8sClient.Get(ctx, "", orgID, metav1.GetOptions{})
+	unstructuredObj, err := s.k8sClient.Get(ctx, "default", orgID, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/scimutil/scim_util.go
+++ b/pkg/services/scimutil/scim_util.go
@@ -1,0 +1,142 @@
+package scimutil
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	scim "github.com/grafana/grafana/pkg/extensions/apis/scim/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/apiserver/client"
+)
+
+// SCIMUtil provides utility functions for checking SCIM dynamic app platform settings
+type SCIMUtil struct {
+	k8sClient client.K8sHandler
+	logger    log.Logger
+}
+
+// NewSCIMUtil creates a new SCIMUtil instance
+func NewSCIMUtil(k8sClient client.K8sHandler) *SCIMUtil {
+	return &SCIMUtil{
+		k8sClient: k8sClient,
+		logger:    log.New("scim.util"),
+	}
+}
+
+// IsUserSyncEnabled checks if SCIM user sync is enabled using dynamic configuration with static fallback
+func (s *SCIMUtil) IsUserSyncEnabled(ctx context.Context, orgID int64, staticEnabled bool) bool {
+	if s.k8sClient == nil {
+		s.logger.Debug("K8s client not configured, using static SCIM config for user sync")
+		return staticEnabled
+	}
+
+	userSyncEnabled, dynamicConfigFetched := s.fetchDynamicSCIMSetting(ctx, orgID, scim.UserSyncSetting)
+
+	if dynamicConfigFetched {
+		s.logger.Debug("Using dynamic SCIM config for user sync", "orgID", orgID, "enabled", userSyncEnabled)
+		return userSyncEnabled
+	}
+
+	// Fallback to static config if dynamic config wasn't fetched successfully
+	s.logger.Debug("Using static SCIM config for user sync", "orgID", orgID, "enabled", staticEnabled)
+	return staticEnabled
+}
+
+// AreNonProvisionedUsersAllowed checks if non-provisioned users are allowed using dynamic configuration with static fallback
+func (s *SCIMUtil) AreNonProvisionedUsersAllowed(ctx context.Context, orgID int64, staticAllowed bool) bool {
+	if s.k8sClient == nil {
+		s.logger.Debug("K8s client not configured, using static SCIM config for non-provisioned users")
+		return staticAllowed
+	}
+
+	scimConfig, err := s.getOrgSCIMConfig(ctx, orgID)
+	if err != nil {
+		s.logger.Warn("Failed to fetch SCIM config, using static config for non-provisioned users", "error", err)
+		return staticAllowed
+	}
+
+	// In dynamic configuration, we consider non-provisioned users allowed if user sync is enabled
+	// This matches the behavior in the EnterpriseSCIMSettings implementation
+	dynamicAllowed := scimConfig.Spec.EnableUserSync
+	s.logger.Debug("Using dynamic SCIM config for non-provisioned users", "orgID", orgID, "allowed", dynamicAllowed)
+	return dynamicAllowed
+}
+
+// fetchDynamicSCIMSetting attempts to retrieve a specific dynamic SCIM configuration setting
+func (s *SCIMUtil) fetchDynamicSCIMSetting(ctx context.Context, orgID int64, settingType string) (settingEnabled bool, dynamicConfigFetched bool) {
+	if s.k8sClient == nil {
+		s.logger.Warn("K8s client not configured, dynamic SCIM config lookup skipped", "orgID", orgID, "settingType", settingType)
+		return false, false
+	}
+
+	scimConfig, err := s.getOrgSCIMConfig(ctx, orgID)
+	if err != nil {
+		s.logger.Warn("Failed to fetch dynamic SCIMConfig resource, will attempt fallback to static config", "orgID", orgID, "error", err)
+		return false, false
+	}
+
+	var enabled bool
+	switch settingType {
+	case scim.UserSyncSetting:
+		enabled = scimConfig.Spec.EnableUserSync
+	case scim.GroupSyncSetting:
+		enabled = scimConfig.Spec.EnableGroupSync
+	default:
+		s.logger.Error("Invalid setting type provided to fetchDynamicSCIMSetting", "settingType", settingType)
+		return false, false
+	}
+
+	return enabled, true
+}
+
+// getOrgSCIMConfig fetches and converts the SCIMConfig for an org
+func (s *SCIMUtil) getOrgSCIMConfig(ctx context.Context, orgID int64) (*scim.SCIMConfig, error) {
+	if s.k8sClient == nil {
+		return nil, scim.ErrK8sClientNotConfigured
+	}
+
+	unstructuredObj, err := s.k8sClient.Get(ctx, "", orgID, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.unstructuredToSCIMConfig(unstructuredObj)
+}
+
+// unstructuredToSCIMConfig converts an unstructured object to a SCIMConfig
+func (s *SCIMUtil) unstructuredToSCIMConfig(obj *unstructured.Unstructured) (*scim.SCIMConfig, error) {
+	if obj == nil {
+		return nil, scim.ErrK8sClientNotConfigured
+	}
+
+	scimConfig := &scim.SCIMConfig{}
+	scimConfig.SetStaticMetadata(resource.StaticMetadata{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Group:     obj.GetAPIVersion(),
+		Version:   obj.GetAPIVersion(),
+		Kind:      obj.GetKind(),
+	})
+
+	// Convert spec
+	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, scim.ErrK8sClientNotConfigured
+	}
+
+	enableUserSync, _, _ := unstructured.NestedBool(spec, "enableUserSync")
+	enableGroupSync, _, _ := unstructured.NestedBool(spec, "enableGroupSync")
+
+	scimConfig.Spec = scim.SCIMConfigSpec{
+		EnableUserSync:  enableUserSync,
+		EnableGroupSync: enableGroupSync,
+	}
+
+	return scimConfig, nil
+}

--- a/pkg/services/scimutil/scim_util_test.go
+++ b/pkg/services/scimutil/scim_util_test.go
@@ -144,7 +144,7 @@ func TestSCIMUtil_IsUserSyncEnabled(t *testing.T) {
 			k8sClient:     &MockK8sHandler{},
 			staticEnabled: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(nil, errors.New("k8s error"))
 			},
 			expectedResult: true,
@@ -155,7 +155,7 @@ func TestSCIMUtil_IsUserSyncEnabled(t *testing.T) {
 			staticEnabled: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: true,
@@ -166,7 +166,7 @@ func TestSCIMUtil_IsUserSyncEnabled(t *testing.T) {
 			staticEnabled: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: false,
@@ -177,7 +177,7 @@ func TestSCIMUtil_IsUserSyncEnabled(t *testing.T) {
 			staticEnabled: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: false,
@@ -188,7 +188,7 @@ func TestSCIMUtil_IsUserSyncEnabled(t *testing.T) {
 			staticEnabled: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: true,
@@ -241,7 +241,7 @@ func TestSCIMUtil_AreNonProvisionedUsersAllowed(t *testing.T) {
 			k8sClient:     &MockK8sHandler{},
 			staticAllowed: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(nil, errors.New("k8s error"))
 			},
 			expectedResult: true,
@@ -252,7 +252,7 @@ func TestSCIMUtil_AreNonProvisionedUsersAllowed(t *testing.T) {
 			staticAllowed: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: true,
@@ -263,7 +263,7 @@ func TestSCIMUtil_AreNonProvisionedUsersAllowed(t *testing.T) {
 			staticAllowed: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: false,
@@ -274,7 +274,7 @@ func TestSCIMUtil_AreNonProvisionedUsersAllowed(t *testing.T) {
 			staticAllowed: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: false,
@@ -285,7 +285,7 @@ func TestSCIMUtil_AreNonProvisionedUsersAllowed(t *testing.T) {
 			staticAllowed: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 			expectedResult: true,
@@ -337,7 +337,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -348,7 +348,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedEnabled:        false,
 			expectedDynamicFetched: false,
 			setupMock: func(mockHandler *MockK8sHandler) {
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(nil, errors.New("k8s error"))
 			},
 		},
@@ -360,7 +360,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -372,7 +372,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -384,7 +384,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -396,7 +396,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -408,7 +408,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -420,7 +420,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -432,7 +432,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(false, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -444,7 +444,7 @@ func TestSCIMUtil_fetchDynamicSCIMSetting(t *testing.T) {
 			expectedDynamicFetched: true,
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, true)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -489,7 +489,7 @@ func TestSCIMUtil_getOrgSCIMConfig(t *testing.T) {
 			k8sClient:     &MockK8sHandler{},
 			expectedError: errors.New("k8s error"),
 			setupMock: func(mockHandler *MockK8sHandler) {
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(nil, errors.New("k8s error"))
 			},
 		},
@@ -498,7 +498,7 @@ func TestSCIMUtil_getOrgSCIMConfig(t *testing.T) {
 			k8sClient: &MockK8sHandler{},
 			setupMock: func(mockHandler *MockK8sHandler) {
 				obj := createMockSCIMConfig(true, false)
-				mockHandler.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+				mockHandler.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 					Return(obj, nil)
 			},
 		},
@@ -625,7 +625,7 @@ func TestSCIMUtil_Integration(t *testing.T) {
 	t.Run("full workflow with dynamic config", func(t *testing.T) {
 		mockClient := &MockK8sHandler{}
 		obj := createMockSCIMConfig(true, false)
-		mockClient.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+		mockClient.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 			Return(obj, nil)
 
 		util := NewSCIMUtil(mockClient)
@@ -643,7 +643,7 @@ func TestSCIMUtil_Integration(t *testing.T) {
 
 	t.Run("full workflow with static fallback", func(t *testing.T) {
 		mockClient := &MockK8sHandler{}
-		mockClient.On("Get", ctx, "", orgID, metav1.GetOptions{}, mock.Anything).
+		mockClient.On("Get", ctx, "default", orgID, metav1.GetOptions{}, mock.Anything).
 			Return(nil, errors.New("k8s error"))
 
 		util := NewSCIMUtil(mockClient)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR adds a new SCIM Utility package to allow for checking dynamic SCIM settings via the app platform API. 
- Created `pkg/services/scimutil` with `SCIMUtil` for checking dynamic SCIM settings via K8s API
- Modified `UserSync` to support both static and dynamic SCIM configuration with fallback to static if dynamic API is unavailable
- Added tests

**Why do we need this feature?**
Previously, packages were only checking the static SCIM settings in the config.ini file, but SCIM user/group sync can also be enabled via the app platform API. Services that check the static SCIM settings also need to check whether specific SCIM settings are enabled via the app platform API.

**Who is this feature for?**
Grafana Enterprise users with SCIM enabled.

**Which issue(s) does this PR fix?**:
Closes https://github.com/grafana/identity-access-team/issues/1450
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
