### PR TITLE
Alert rules: Increase adoption with link from alerts to metrics drilldown app

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -185,6 +185,7 @@ export enum PluginExtensionPoints {
   AlertingHomePage = 'grafana/alerting/home',
   AlertingAlertingRuleAction = 'grafana/alerting/alertingrule/action',
   AlertingRecordingRuleAction = 'grafana/alerting/recordingrule/action',
+  AlertingRuleQueryEditor = 'grafana/alerting/alertingrule/queryeditor',
   CommandPalette = 'grafana/commandpalette/action',
   DashboardPanelMenu = 'grafana/dashboard/panel/menu',
   DataSourceConfig = 'grafana/datasources/config',

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -27,6 +27,7 @@ import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 import { RuleFormValues } from '../../types/rule-form';
 import { msToSingleUnitDuration } from '../../utils/time';
 import { ExpressionStatusIndicator } from '../expressions/ExpressionStatusIndicator';
+import { AlertingRuleQueryExtentionPoint } from '../rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint';
 
 import { QueryOptions } from './QueryOptions';
 import { VizWrapper } from './VizWrapper';
@@ -169,6 +170,11 @@ export const QueryWrapper = ({
     return (
       <Stack direction="row" alignItems="center" gap={1}>
         <SelectingDataSourceTooltip />
+        <AlertingRuleQueryExtentionPoint
+          query={Object.assign({}, query.model)}
+          ruleFormValues={getValues()}
+          extensionsToShow="queryless"
+        />
         <QueryOptions
           onChangeTimeRange={onChangeTimeRange}
           query={query}

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
@@ -1,0 +1,61 @@
+import { ReactElement } from 'react';
+
+import { PluginExtensionPoints } from '@grafana/data';
+import { usePluginLinks } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+
+type Props = {
+  extensionsToShow: 'queryless';
+  query: DataQuery;
+};
+
+const QUERYLESS_APPS = [
+  'grafana-pyroscope-app',
+  'grafana-lokiexplore-app',
+  'grafana-exploretraces-app',
+  'grafana-metricsdrilldown-app',
+];
+
+export function AlertingRuleQueryExtentionPoint(props: Props): ReactElement | null {
+  const { extensionsToShow, query } = props;
+  // for opeining the modal
+  // const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
+  // const [isOpen, setIsOpen] = useState<boolean>(false);
+  const context = { targets: [query] };
+
+  const { links } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.AlertingRuleQueryEditor,
+    context: context,
+    limitPerPlugin: 3,
+  });
+
+  // Filter queryless links if needed
+  const querylessLinks = links.filter((link) => QUERYLESS_APPS.includes(link.pluginId));
+
+  return (
+    <>
+      {extensionsToShow === 'queryless' && querylessLinks.length > 0 && (
+        <div>
+          {/* Render queryless extensions here */}
+          {querylessLinks.map((link) => (
+            // the links should be html links
+            <a key={link.id} href={link.path}>
+              {link.title}
+            </a>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+export type PluginExtensionAlertingRuleContext = {
+  targets: DataQuery[];
+};
+
+function useExtensionPointContext(props: Props): PluginExtensionAlertingRuleContext {
+  const { query } = props;
+  return {
+    targets: [query],
+  };
+}

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
@@ -42,33 +42,6 @@ export function AlertingRuleQueryExtentionPoint({
   ruleFormValues,
 }: Props): ReactElement | null {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  // Just fix contactPoints to avoid ZodError
-  const cleanRuleFormValues = (values: RuleFormValues): RuleFormValues => {
-    const cleaned = { ...values };
-
-    // Fix contactPoints if it exists
-    if (cleaned.contactPoints) {
-      Object.keys(cleaned.contactPoints).forEach((alertManagerName) => {
-        const contactPoint = cleaned.contactPoints![alertManagerName];
-        if (contactPoint) {
-          // Add missing fields with correct types
-          cleaned.contactPoints![alertManagerName] = {
-            selectedContactPoint: contactPoint.selectedContactPoint || '',
-            overrideGrouping: contactPoint.overrideGrouping ?? false,
-            groupBy: contactPoint.groupBy || [],
-            overrideTimings: contactPoint.overrideTimings ?? false,
-            groupWaitValue: contactPoint.groupWaitValue || '',
-            groupIntervalValue: contactPoint.groupIntervalValue || '',
-            repeatIntervalValue: contactPoint.repeatIntervalValue || '',
-            muteTimeIntervals: contactPoint.muteTimeIntervals || [],
-            activeTimeIntervals: contactPoint.activeTimeIntervals || [],
-          };
-        }
-      });
-    }
-
-    return cleaned;
-  };
 
   const cleanedValues = cleanRuleFormValues(ruleFormValues);
   const context: PluginExtensionAlertingRuleContext = {
@@ -138,3 +111,31 @@ export function AlertingRuleQueryExtentionPoint({
     </>
   );
 }
+
+// Just fix contactPoints to avoid ZodError
+const cleanRuleFormValues = (values: RuleFormValues): RuleFormValues => {
+  const cleaned = { ...values };
+
+  // Fix contactPoints if it exists
+  if (cleaned.contactPoints) {
+    Object.keys(cleaned.contactPoints).forEach((alertManagerName) => {
+      const contactPoint = cleaned.contactPoints![alertManagerName];
+      if (contactPoint) {
+        // Add missing fields with correct types
+        cleaned.contactPoints![alertManagerName] = {
+          selectedContactPoint: contactPoint.selectedContactPoint || '',
+          overrideGrouping: contactPoint.overrideGrouping ?? false,
+          groupBy: contactPoint.groupBy || [],
+          overrideTimings: contactPoint.overrideTimings ?? false,
+          groupWaitValue: contactPoint.groupWaitValue || '',
+          groupIntervalValue: contactPoint.groupIntervalValue || '',
+          repeatIntervalValue: contactPoint.repeatIntervalValue || '',
+          muteTimeIntervals: contactPoint.muteTimeIntervals || [],
+          activeTimeIntervals: contactPoint.activeTimeIntervals || [],
+        };
+      }
+    });
+  }
+
+  return cleaned;
+};

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
@@ -1,8 +1,12 @@
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 
 import { PluginExtensionPoints } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
 import { usePluginLinks } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
+import { ToolbarButton } from '@grafana/ui';
+
+import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
 
 type Props = {
   extensionsToShow: 'queryless';
@@ -18,9 +22,8 @@ const QUERYLESS_APPS = [
 
 export function AlertingRuleQueryExtentionPoint(props: Props): ReactElement | null {
   const { extensionsToShow, query } = props;
-  // for opeining the modal
-  // const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
-  // const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
   const context = { targets: [query] };
 
   const { links } = usePluginLinks({
@@ -32,18 +35,39 @@ export function AlertingRuleQueryExtentionPoint(props: Props): ReactElement | nu
   // Filter queryless links if needed
   const querylessLinks = links.filter((link) => QUERYLESS_APPS.includes(link.pluginId));
 
+  // Use the first available queryless link
+  const selectedQuerylessLink = querylessLinks[0];
+
+  const handleGoQuerylessClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleModalDismiss = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <>
-      {extensionsToShow === 'queryless' && querylessLinks.length > 0 && (
+      {extensionsToShow === 'queryless' && (
         <div>
-          {/* Render queryless extensions here */}
-          {querylessLinks.map((link) => (
-            // the links should be html links
-            <a key={link.id} href={link.path}>
-              {link.title}
-            </a>
-          ))}
+          <ToolbarButton
+            aria-label={t('alerting.rule-editor.go-queryless.aria-label', 'Go queryless')}
+            disabled={querylessLinks.length === 0}
+            variant="canvas"
+            isOpen={isModalOpen}
+            onClick={handleGoQuerylessClick}
+          >
+            <Trans i18nKey="alerting.rule-editor.go-queryless">Go queryless</Trans>
+          </ToolbarButton>
         </div>
+      )}
+
+      {isModalOpen && selectedQuerylessLink && selectedQuerylessLink.path && selectedQuerylessLink.title && (
+        <ConfirmNavigationModal
+          onDismiss={handleModalDismiss}
+          path={selectedQuerylessLink.path}
+          title={selectedQuerylessLink.title}
+        />
       )}
     </>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint.tsx
@@ -5,8 +5,8 @@ import { Trans, t } from '@grafana/i18n';
 import { usePluginLinks } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Button } from '@grafana/ui';
+import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 
-import { RuleFormValues } from '../../../types/rule-form';
 import { ConfirmNavigationModal } from './ConfirmationNavigationModal';
 
 type Props = {
@@ -44,6 +44,7 @@ export function AlertingRuleQueryExtentionPoint({
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const cleanedValues = cleanRuleFormValues(ruleFormValues);
+
   const context: PluginExtensionAlertingRuleContext = {
     targets: [query],
     ruleFormValues: cleanedValues,

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/ConfirmationNavigationModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/ConfirmationNavigationModal.tsx
@@ -1,0 +1,44 @@
+import { ReactElement } from 'react';
+
+import { locationUtil } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { Button, Modal, Stack } from '@grafana/ui';
+
+type Props = {
+  onDismiss: () => void;
+  path: string;
+  title: string;
+};
+
+export function ConfirmNavigationModal(props: Props): ReactElement {
+  const { onDismiss, path, title } = props;
+  const openInNewTab = () => {
+    global.open(locationUtil.assureBaseUrl(path), '_blank');
+    onDismiss();
+  };
+  const openInCurrentTab = () => locationService.push(path);
+
+  return (
+    <Modal title={title} isOpen onDismiss={onDismiss}>
+      <Stack direction="column" gap={1}>
+        <p>
+          <Trans i18nKey="explore.confirm-navigation-modal.new-tab">
+            Do you want to proceed in the current tab or open a new tab?
+          </Trans>
+        </p>
+      </Stack>
+      <Modal.ButtonRow>
+        <Button onClick={onDismiss} fill="outline" variant="secondary">
+          <Trans i18nKey="explore.confirm-navigation-modal.cancel">Cancel</Trans>
+        </Button>
+        <Button type="submit" variant="secondary" onClick={openInNewTab} icon="external-link-alt">
+          <Trans i18nKey="explore.confirm-navigation-modal.open-in-new-tab">Open in new tab</Trans>
+        </Button>
+        <Button type="submit" variant="primary" onClick={openInCurrentTab} icon="apps">
+          <Trans i18nKey="explore.confirm-navigation-modal.open">Open</Trans>
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/getAlertingExtensionConfigs.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/getAlertingExtensionConfigs.tsx
@@ -1,0 +1,127 @@
+import { PluginExtensionAddedLinkConfig } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
+import { log } from 'app/features/plugins/extensions/logs/log';
+import { createAddedLinkConfig } from 'app/features/plugins/extensions/utils';
+
+// TODO: Add other scenes drilldownapps here
+export const metricsDrilldownPluginId = 'grafana-metricsdrilldown-app';
+export const extensionPointId = `${metricsDrilldownPluginId}/alerting/alertingrule/queryeditor/v1`;
+
+export type MetricsDrilldownExternsionAlertingRuleContext = {
+  targets: RuleFormValues;
+};
+
+export function getAlertingExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
+  try {
+    return [
+      createAddedLinkConfig<MetricsDrilldownExternsionAlertingRuleContext>({
+        // This is called at the top level, so will break if we add a translation here 😱
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        title: 'Navigate to Alert rule form',
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        description: 'Return to the alert rule form.',
+        targets: [extensionPointId],
+        icon: 'apps',
+        category: 'Alerting',
+        onClick: (_, { context }) => {
+          if (!context) {
+            console.warn('Extension context is undefined');
+            return;
+          }
+
+          const url = encodeURL(context.targets);
+
+          locationService.push(url);
+        },
+      }),
+    ];
+  } catch (error) {
+    log.warning(`Could not configure extensions for Alerting due to: "${error}"`);
+    return [];
+  }
+}
+
+/**
+ * Encodes the ruleFormValues into a URL
+ * @param ruleFormValues - The ruleFormValues to encode
+ * @returns The encoded URL
+ */
+function encodeURL(ruleFormValues: RuleFormValues) {
+  const jsonString = JSON.stringify(ruleFormValues);
+  const urlEncodedTargets = encodeURIComponent(jsonString);
+  const url = '/alerting/new/alerting?defaults=' + urlEncodedTargets;
+  return url;
+}
+
+// Saving for tests
+// const url = '/alerting/new/alerting?defaults=%7B%22name%22%3A%22Image%20Provider%20Latency%20P50%20Alert%22%2C%22type%22%3A%22grafana%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22queryType%22%3A%22%22%2C%22datasourceUid%22%3A%22fenlcp4kzo4jke%22%2C%22model%22%3A%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22histogram_quantile(0.5%2C%20sum%20by(le%2C%20cloud_availability_zone)%20(rate(traces_spanmetrics_latency_bucket%7Bjob%3D%5C%22imageprovider%5C%22%7D%5B%24__rate_interval%5D)))%22%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22fenlcp4kzo4jke%22%7D%7D%2C%22relativeTimeRange%22%3A%7B%22from%22%3A600%2C%22to%22%3A0%7D%7D%2C%7B%22refId%22%3A%22B%22%2C%22queryType%22%3A%22expression%22%2C%22datasourceUid%22%3A%22__expr__%22%2C%22model%22%3A%7B%22refId%22%3A%22B%22%2C%22type%22%3A%22reduce%22%2C%22expression%22%3A%22A%22%2C%22reducer%22%3A%22max%22%2C%22settings%22%3A%7B%22mode%22%3A%22strict%22%7D%7D%7D%2C%7B%22refId%22%3A%22C%22%2C%22queryType%22%3A%22expression%22%2C%22datasourceUid%22%3A%22__expr__%22%2C%22model%22%3A%7B%22refId%22%3A%22C%22%2C%22type%22%3A%22threshold%22%2C%22expression%22%3A%22B%22%2C%22conditions%22%3A%5B%7B%22evaluator%22%3A%7B%22params%22%3A%5B0.5%5D%2C%22type%22%3A%22gt%22%7D%7D%5D%7D%7D%5D%2C%22condition%22%3A%22C%22%7D'
+// return {url: '/alerting/new/alerting?defaults=%7B%22name%22%3A%22Image%20Provider%20Latency%20P50%20Alert%22%2C%22type%22%3A%22grafana%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22queryType%22%3A%22%22%2C%22datasourceUid%22%3A%22fenlcp4kzo4jke%22%2C%22model%22%3A%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22histogram_quantile(0.5%2C%20sum%20by(le%2C%20cloud_availability_zone)%20(rate(traces_spanmetrics_latency_bucket%7Bjob%3D%5C%22imageprovider%5C%22%7D%5B%24__rate_interval%5D)))%22%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22fenlcp4kzo4jke%22%7D%7D%2C%22relativeTimeRange%22%3A%7B%22from%22%3A600%2C%22to%22%3A0%7D%7D%2C%7B%22refId%22%3A%22B%22%2C%22queryType%22%3A%22expression%22%2C%22datasourceUid%22%3A%22__expr__%22%2C%22model%22%3A%7B%22refId%22%3A%22B%22%2C%22type%22%3A%22reduce%22%2C%22expression%22%3A%22A%22%2C%22reducer%22%3A%22max%22%2C%22settings%22%3A%7B%22mode%22%3A%22strict%22%7D%7D%7D%2C%7B%22refId%22%3A%22C%22%2C%22queryType%22%3A%22expression%22%2C%22datasourceUid%22%3A%22__expr__%22%2C%22model%22%3A%7B%22refId%22%3A%22C%22%2C%22type%22%3A%22threshold%22%2C%22expression%22%3A%22B%22%2C%22conditions%22%3A%5B%7B%22evaluator%22%3A%7B%22params%22%3A%5B0.5%5D%2C%22type%22%3A%22gt%22%7D%7D%5D%7D%7D%5D%2C%22condition%22%3A%22C%22%7D'};
+// const url = '/alerting/new/alerting?defaults=' + urlEncodedTargets
+
+// Successfully tested
+// const histogramAlert: RuleFormValues = {
+//   name: 'Image Provider Latency P50 Alert',
+//   queries: [
+//     {
+//       refId: 'A',
+//       queryType: '',
+//       datasourceUid: 'fenlcp4kzo4jke',
+//       model: {
+//         refId: 'A',
+//         expr: 'histogram_quantile(0.5, sum by(le, cloud_availability_zone) (rate(traces_spanmetrics_latency_bucket{job="imageprovider"}[$__rate_interval])))',
+//         instant: true,
+//         datasource: {
+//           type: 'prometheus',
+//           uid: 'fenlcp4kzo4jke'
+//         },
+//         interval: '',
+//         legendFormat: 'P50 Latency by AZ',
+//         intervalMs: 60000,
+//         maxDataPoints: 500
+//       },
+//       relativeTimeRange: { from: 600, to: 0 }
+//     },
+//     {
+//       refId: 'B',
+//       queryType: 'expression',
+//       datasourceUid: '__expr__',
+//       model: {
+//         refId: 'B',
+//         type: 'reduce',
+//         expression: 'A',
+//         reducer: 'max',
+//         settings: { mode: 'strict' }
+//       }
+//     },
+//     {
+//       refId: 'C',
+//       queryType: 'expression',
+//       datasourceUid: '__expr__',
+//       model: {
+//         refId: 'C',
+//         type: 'threshold',
+//         expression: 'B',
+//         conditions: [
+//           {
+//             evaluator: {
+//               params: [0.5],
+//               type: 'gt'
+//             }
+//           }
+//         ]
+//       }
+//     }
+//   ],
+//   condition: 'C',
+//   folder: { uid: 'benldbkcq3gg0f', title: '"WeirdPermissionFolder' },
+//   annotations: [
+//     { key: 'summary', value: 'Image Provider P50 latency is high' },
+//     { key: 'description', value: 'The 50th percentile latency for imageprovider service has exceeded 500ms' }
+//   ],
+//   labels: [
+//     { key: 'severity', value: 'warning' },
+//     { key: 'service', value: 'imageprovider' },
+//     { key: 'metric_type', value: 'latency' }
+//   ]
+// };

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/getAlertingExtensionConfigs.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/getAlertingExtensionConfigs.tsx
@@ -9,7 +9,7 @@ export const metricsDrilldownPluginId = 'grafana-metricsdrilldown-app';
 export const extensionPointId = `${metricsDrilldownPluginId}/alerting/alertingrule/queryeditor/v1`;
 
 export type MetricsDrilldownExternsionAlertingRuleContext = {
-  targets: RuleFormValues;
+  ruleFormValues: RuleFormValues;
 };
 
 export function getAlertingExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
@@ -29,8 +29,7 @@ export function getAlertingExtensionConfigs(): PluginExtensionAddedLinkConfig[] 
             console.warn('Extension context is undefined');
             return;
           }
-
-          const url = encodeURL(context.targets);
+          const url = encodeURL(context.ruleFormValues);
 
           locationService.push(url);
         },

--- a/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
+++ b/public/app/features/plugins/extensions/getCoreExtensionConfigurations.ts
@@ -1,6 +1,7 @@
 import { PluginExtensionAddedLinkConfig } from '@grafana/data';
+import { getAlertingExtensionConfigs } from 'app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/getAlertingExtensionConfigs';
 import { getExploreExtensionConfigs } from 'app/features/explore/extensions/getExploreExtensionConfigs';
 
 export function getCoreExtensionConfigurations(): PluginExtensionAddedLinkConfig[] {
-  return [...getExploreExtensionConfigs()];
+  return [...getExploreExtensionConfigs(), ...getAlertingExtensionConfigs()];
 }

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -6,7 +6,6 @@ import { DataQuery, DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/d
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { FieldValidationMessage, Icon, Input, useStyles2 } from '@grafana/ui';
-import { AlertingRuleQueryExtentionPoint } from 'app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 export interface Props<TQuery extends DataQuery = DataQuery> {
@@ -151,8 +150,6 @@ const renderDataSource = <TQuery extends DataQuery>(
         current={dataSource.name}
         onChange={onChangeDataSource}
       />
-      {/* Only show the extensions in alerting. This data source picker is also used in dashboard panel mixed data source editor */}
-      {alerting && <AlertingRuleQueryExtentionPoint query={query} extensionsToShow="queryless" />}
     </div>
   );
 };

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -6,6 +6,7 @@ import { DataQuery, DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/d
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { FieldValidationMessage, Icon, Input, useStyles2 } from '@grafana/ui';
+import { AlertingRuleQueryExtentionPoint } from 'app/features/alerting/unified/components/rule-editor/alert-rule-form/extensions/AlertingRuleQueryExtentionPoint';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 export interface Props<TQuery extends DataQuery = DataQuery> {
@@ -135,7 +136,7 @@ const renderDataSource = <TQuery extends DataQuery>(
   props: Props<TQuery>,
   styles: ReturnType<typeof getStyles>
 ): ReactNode => {
-  const { alerting, dataSource, onChangeDataSource } = props;
+  const { alerting, dataSource, onChangeDataSource, query } = props;
 
   if (!onChangeDataSource) {
     return <em className={styles.contextInfo}>({dataSource.name})</em>;
@@ -150,6 +151,8 @@ const renderDataSource = <TQuery extends DataQuery>(
         current={dataSource.name}
         onChange={onChangeDataSource}
       />
+      {/* Only show the extensions in alerting. This data source picker is also used in dashboard panel mixed data source editor */}
+      {alerting && <AlertingRuleQueryExtentionPoint query={query} extensionsToShow="queryless" />}
     </div>
   );
 };


### PR DESCRIPTION
Related issues and PR
[Issue: Link from Alert Rule to GMD](https://github.com/grafana/metrics-drilldown/issues/467)
[PR to make this work in GMD app](https://github.com/grafana/metrics-drilldown/pull/522)

**What is this feature?**

This is a link from creating an alert rule to Grafana Metrics Drilldown App.


https://github.com/user-attachments/assets/dc6aabb2-46ff-4448-a112-e47a115a5a04


**Why do we need this feature?**

We want to increase adoption of GMD so we are adding it to spots where people may want to explore their data more.

This work is extendable so that the other drilldown apps can get linked to via the alert rule. This work is similar to the "Go queryless" button in Explore.

**Who is this feature for?**

This feature is currently for Prometheus users who are creating an alert rule but want to see the queryless experience, and break down their metric to see data without using the query editor, before building the query for the alert rule.

**Special notes for your reviewer:**
1. Run both Grafana and Metrics Drilldown locally
2. Use this branch in GMD, `bohandley/link-from-alert-rule-to-GMD-POC` which adds the extension point in metrics drilldown plugin.json and link "Open in Grafana Metrics Drilldown
3. In Grafana, use the feature toggle so that you can use your local metric drilldown app. Otherwise, it will preinstall metrics drilldown from the plugin library into your ./plugins directory.
```
[plugins]
preinstall_disabled = true
```
4. Build grafana, `make run` and `make run-frontend
5. Build GMD (make sure this is in your plugins directory)
6. Create an alert rule in grafana
7. Select a prometheus data source in the alert rule query editor row.
8. Select a metric. 
9. See the "Go queryless" button pop up. Click this.
10. Open a modal to allow you to navigate to GMD.

Notes: There will be one button per query editor row. This is different than go queryless in explore. The alert rule form allows for multiple query editors with multiple data sources. For each editor row, we can show the button to a queryless app if the link is configured.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
