### PR TITLE
StateTimeline: Fix duration in tooltip

### DIFF
--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
@@ -56,11 +56,14 @@ export const StateTimelineTooltip2 = ({
       nextStateTs = xField.values[nextStateIdx!];
     }
 
-    const stateTs = xField.values[dataIdx!];
+    let stateTs = xField.values[dataIdx!];
+    stateTs = typeof stateTs === 'number' ? stateTs : new Date(stateTs).valueOf();
+
     let duration: string;
 
     if (nextStateTs) {
-      duration = nextStateTs && fmtDuration(nextStateTs - stateTs);
+      nextStateTs = typeof nextStateTs === 'number' ? nextStateTs : new Date(nextStateTs).valueOf();
+      duration = fmtDuration(nextStateTs - stateTs);
       endTime = nextStateTs;
     } else {
       const to = timeRange.to.valueOf();


### PR DESCRIPTION
Before:
![statetimeline_before](https://github.com/user-attachments/assets/92022ad0-8104-4ff1-a354-6e03019ad232)


After:
![statetimeline_after](https://github.com/user-attachments/assets/ae4216b3-774d-46ca-962f-34abdbd6e6e7)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
