### PR TITLE
Hackathon(GrafanaQL): Removes prefixes from GraphQL query names

### DIFF
--- a/apps/playlist/README.md
+++ b/apps/playlist/README.md
@@ -150,7 +150,7 @@ These examples use HTTP Basic Authentication with `admin:admin`. In production e
 
 ```graphql
 query GetPlaylists {
-  playlist_playlists(namespace: "default") {
+  playlists(namespace: "default") {
     items {
       metadata {
         name
@@ -177,7 +177,7 @@ query GetPlaylists {
 
 ```graphql
 query GetPlaylists {
-  playlist_playlists(namespace: "default") {
+  playlists(namespace: "default") {
     items {
       metadata {
         name
@@ -194,7 +194,7 @@ query GetPlaylists {
 
 ```graphql
 query GetPlaylist {
-  playlist_playlist(namespace: "default", name: "my-playlist") {
+  playlist(namespace: "default", name: "my-playlist") {
     metadata {
       name
     }
@@ -224,7 +224,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetPlaylists { playlist_playlists(namespace: \"default\") { items { metadata { name namespace creationTimestamp } uid name interval items { id playlistUid type value order title } } } }"
+    "query": "query GetPlaylists { playlists(namespace: \"default\") { items { metadata { name namespace creationTimestamp } uid name interval items { id playlistUid type value order title } } } }"
   }'
 ```
 
@@ -235,7 +235,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetPlaylist { playlist_playlist(namespace: \"default\", name: \"my-playlist\") { metadata { name } uid name interval } }"
+    "query": "query GetPlaylist { playlist(namespace: \"default\", name: \"my-playlist\") { metadata { name } uid name interval } }"
   }'
 ```
 
@@ -246,7 +246,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetPlaylists { playlist_playlists(namespace: \"default\") { items { metadata { name } uid name interval } } }"
+    "query": "query GetPlaylists { playlists(namespace: \"default\") { items { metadata { name } uid name interval } } }"
   }'
 ```
 

--- a/pkg/registry/apps/investigations/README.md
+++ b/pkg/registry/apps/investigations/README.md
@@ -212,7 +212,7 @@ These examples use HTTP Basic Authentication with `admin:admin`. In production e
 
 ```graphql
 query GetInvestigations {
-  investigations_investigations(namespace: "default") {
+  investigations(namespace: "default") {
     items {
       metadata {
         name
@@ -263,7 +263,7 @@ query GetInvestigations {
 
 ```graphql
 query GetInvestigations {
-  investigations_investigations(namespace: "default") {
+  investigations(namespace: "default") {
     items {
       metadata {
         name
@@ -283,7 +283,7 @@ query GetInvestigations {
 
 ```graphql
 query GetInvestigation {
-  investigations_investigation(namespace: "default", name: "my-investigation") {
+  investigation(namespace: "default", name: "my-investigation") {
     metadata {
       name
     }
@@ -326,7 +326,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetInvestigations { investigations_investigations(namespace: \"default\") { items { metadata { name namespace creationTimestamp } title createdByProfile { uid name gravatarUrl } hasCustomName isFavorite collectables { id title origin type } } } }"
+    "query": "query GetInvestigations { investigations(namespace: \"default\") { items { metadata { name namespace creationTimestamp } title createdByProfile { uid name gravatarUrl } hasCustomName isFavorite collectables { id title origin type } } } }"
   }'
 ```
 
@@ -337,7 +337,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetInvestigation { investigations_investigation(namespace: \"default\", name: \"my-investigation\") { metadata { name } title createdByProfile { name uid } overviewNote } }"
+    "query": "query GetInvestigation { investigation(namespace: \"default\", name: \"my-investigation\") { metadata { name } title createdByProfile { name uid } overviewNote } }"
   }'
 ```
 
@@ -348,7 +348,7 @@ curl -X POST http://localhost:3000/api/graphql \
   -u admin:admin \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "query GetInvestigations { investigations_investigations(namespace: \"default\") { items { metadata { name } title createdByProfile { name } hasCustomName isFavorite } } }"
+    "query": "query GetInvestigations { investigations(namespace: \"default\") { items { metadata { name } title createdByProfile { name } hasCustomName isFavorite } } }"
   }'
 ```
 


### PR DESCRIPTION
## Overview

This PR is part of a Hackathon project.

This PR complements https://github.com/grafana/grafana-app-sdk/pull/853 by updating docs to reflect the simplification of query names in the GraphQL API.