### PR TITLE
Variables: Add support for custom delimiter format in variable interpolation

### DIFF
--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -204,3 +204,13 @@ servers = ["test1", "test2"]
 String to interpolate: '${servers:queryparam}'
 Interpolation result: "var-servers=test1&var-servers=test2"
 ```
+
+### Delimiter
+
+Formats variables with multiple values into a delimiter-separated string.
+
+```bash
+servers = ["test1", "test2"]
+String to interpolate: '${servers:delimiter:;}'
+Interpolation result: "test1;test2"
+```

--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -64,6 +64,16 @@ String to interpolate: '${servers:csv}'
 Interpolation result: 'test1,test2'
 ```
 
+### Delimiter
+
+Formats variables with multiple values into a delimiter-separated string.
+
+```bash
+servers = ["test1", "test2"]
+String to interpolate: '${servers:delimiter:;}'
+Interpolation result: "test1;test2"
+```
+
 ### Distributed - OpenTSDB
 
 Formats variables with multiple values in custom format for OpenTSDB.
@@ -203,14 +213,4 @@ Formats single- and multi-valued variables into their query parameter representa
 servers = ["test1", "test2"]
 String to interpolate: '${servers:queryparam}'
 Interpolation result: "var-servers=test1&var-servers=test2"
-```
-
-### Delimiter
-
-Formats variables with multiple values into a delimiter-separated string.
-
-```bash
-servers = ["test1", "test2"]
-String to interpolate: '${servers:delimiter:;}'
-Interpolation result: "test1;test2"
 ```

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -873,6 +873,7 @@ export enum VariableFormatID {
   SingleQuote = 'singlequote',
   Text = 'text',
   UriEncode = 'uriencode',
+  Delimiter = 'delimiter'
 }
 
 export interface DataSourceRef {

--- a/public/app/features/templating/formatVariableValue.test.ts
+++ b/public/app/features/templating/formatVariableValue.test.ts
@@ -39,6 +39,11 @@ describe('format variable to string values', () => {
     expect(result).toBe('test|test2');
   });
 
+  it('multi value and delimiter should render delimiter string', () => {
+    const result = formatVariableValue(['test', 'test2'], 'delimiter:;');
+    expect(result).toBe('test;test2');
+  });
+
   it('multi value and distributed should render distributed string', () => {
     const result = formatVariableValue(['test', 'test2'], 'distributed', {
       name: 'build',


### PR DESCRIPTION
**What is this feature?**

Adds support for a new `delimiter` variable format that allows users to join multi-valued variables using a custom delimiter. If no delimiter is specified, it defaults to a comma (`,`).

### Example usage

```bash
servers = ["test1", "test2"]
String to interpolate: '${servers:delimiter:;}'
Interpolation result: "test1;test2"
```

**Why do we need this feature?**

Currently, users are limited to predefined formats like CSV or pipe when interpolating multi-valued variables. This change provides greater flexibility for formatting variables, especially for integrations, templated queries, or display customization.

**Who is this feature for?**

Grafana users who create dashboards or queries that require specific value separators beyond the default ones (e.g., `;`, `|`, or `:`). This is especially helpful in templated alerts, or third-party integrations.

**Which issue(s) does this PR fix?**

Fixes [#91411](https://github.com/grafana/grafana/issues/91411)

Related to https://github.com/grafana/scenes/pull/1176


---

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
