### PR TITLE
fix: use database section for resource server db engine configuration

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/db_engine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db_engine.go
@@ -20,8 +20,9 @@ import (
 // driver.
 const tlsConfigName = "db_engine_tls"
 
-func getEngine(cfg *setting.Cfg, getter confGetter) (*xorm.Engine, error) {
-	dbType := getter.String("type")
+func getEngine(cfg *setting.Cfg) (*xorm.Engine, error) {
+	dbSection := cfg.SectionWithEnvOverrides("database")
+	dbType := dbSection.Key("type").String()
 	if dbType == "" {
 		return nil, fmt.Errorf("no database type specified")
 	}
@@ -38,9 +39,9 @@ func getEngine(cfg *setting.Cfg, getter confGetter) (*xorm.Engine, error) {
 			return nil, fmt.Errorf("open database: %w", err)
 		}
 
-		engine.SetMaxOpenConns(getter.Int("max_open_conn", 0))
-		engine.SetMaxIdleConns(getter.Int("max_idle_conn", 4))
-		maxLifetime := time.Duration(getter.Int("conn_max_lifetime", 14400)) * time.Second
+		engine.SetMaxOpenConns(dbSection.Key("max_open_conn").MustInt(0))
+		engine.SetMaxIdleConns(dbSection.Key("max_idle_conn").MustInt(4))
+		maxLifetime := time.Duration(dbSection.Key("conn_max_lifetime").MustInt(14400)) * time.Second
 		engine.SetConnMaxLifetime(maxLifetime)
 
 		return engine, nil

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -118,6 +118,7 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 	}
 
 	p.registerMetrics = true
+	p.logQueries = databaseGetter.Bool("log_queries")
 	p.engine, err = getEngine(cfg)
 	return p, err
 }

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -125,7 +125,18 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 }
 
 func (p *resourceDBProvider) init(ctx context.Context) (db.DB, error) {
-	p.log.Info("Initializing Resource DB", "db_type", p.engine.Dialect().DriverName())
+	p.log.Info("Initializing Resource DB",
+		"db_type",
+		p.engine.Dialect().DriverName(),
+		"open_conn",
+		p.engine.DB().DB.Stats().OpenConnections,
+		"in_use_conn",
+		p.engine.DB().DB.Stats().InUse,
+		"idle_conn",
+		p.engine.DB().DB.Stats().Idle,
+		"max_open_conn",
+		p.engine.DB().DB.Stats().MaxOpenConnections,
+	)
 
 	if p.registerMetrics {
 		err := prometheus.Register(sqlstats.NewStatsCollector("unified_storage", p.engine.DB().DB))

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -118,7 +118,7 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 	}
 
 	p.registerMetrics = true
-	p.engine, err = getEngine(cfg, databaseGetter)
+	p.engine, err = getEngine(cfg)
 	return p, err
 }
 

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -75,49 +75,51 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 	// we prefix them with "db_". We use the database config from core Grafana
 	// as fallback, and as it uses a dedicated INI section, then keys are not
 	// prefixed with "db_"
-	getter := newConfGetter(cfg.SectionWithEnvOverrides("resource_api"), "db_")
-	fallbackGetter := newConfGetter(cfg.SectionWithEnvOverrides("database"), "")
+	resourceAPIGetter := newConfGetter(cfg.SectionWithEnvOverrides("resource_api"), "db_")
+	databaseGetter := newConfGetter(cfg.SectionWithEnvOverrides("database"), "")
 
 	p = &resourceDBProvider{
 		cfg:         cfg,
 		log:         log.New("entity-db"),
-		logQueries:  getter.Bool("log_queries"),
+		logQueries:  resourceAPIGetter.Bool("log_queries"),
 		migrateFunc: migrations.MigrateResourceStore,
 		tracer:      tracer,
 	}
 
-	dbType := getter.String("type")
-	grafanaDBType := fallbackGetter.String("type")
-	switch {
-	// Deprecated: First try with the config in the "resource_api" section, which is specific to Unified Storage
-	case dbType == dbTypePostgres:
-		p.registerMetrics = true
-		p.engine, err = getEnginePostgres(getter)
-		return p, err
-
-	case dbType == dbTypeMySQL:
-		p.registerMetrics = true
-		p.engine, err = getEngineMySQL(getter)
-		return p, err
-
-	case dbType != "":
-		return p, fmt.Errorf("invalid db type specified: %s", dbType)
-
-	// If we have an empty Resource API db config, try with the core Grafana database config
-	case grafanaDBType != "":
-		p.registerMetrics = true
-		p.engine, err = getEngine(cfg)
-		return p, err
-	case grafanaDB != nil:
+	if grafanaDB != nil {
 		// try to use the grafana db connection (should only happen in tests)
-		if fallbackGetter.Bool(grafanaDBInstrumentQueriesKey) {
+		if databaseGetter.Bool(grafanaDBInstrumentQueriesKey) {
 			return nil, errGrafanaDBInstrumentedNotSupported
 		}
 		p.engine = grafanaDB.GetEngine()
 		return p, nil
-	default:
+	}
+
+	dbType := resourceAPIGetter.String("type")
+	switch {
+	// Deprecated: First try with the config in the "resource_api" section, which is specific to Unified Storage
+	case dbType == dbTypePostgres:
+		p.registerMetrics = true
+		p.engine, err = getEnginePostgres(resourceAPIGetter)
+		return p, err
+
+	case dbType == dbTypeMySQL:
+		p.registerMetrics = true
+		p.engine, err = getEngineMySQL(resourceAPIGetter)
+		return p, err
+
+	case dbType != "":
+		return p, fmt.Errorf("invalid db type specified: %s", dbType)
+	}
+
+	fallBackDBType := databaseGetter.String("type")
+	if fallBackDBType == "" {
 		return p, fmt.Errorf("no database type specified")
 	}
+
+	p.registerMetrics = true
+	p.engine, err = getEngine(cfg, databaseGetter)
+	return p, err
 }
 
 func (p *resourceDBProvider) init(ctx context.Context) (db.DB, error) {


### PR DESCRIPTION
This PR addresses the issue where the resource server utilises the same db engine configuration when either `resource_api` or `database` section is used.

**Note:** Be aware that this PR does not fully deprecate the `resource_api` section. We still preserve the support in this PR.

**Ticket:** https://github.com/grafana/search-and-storage-team/issues/341