### PR TITLE
Air: Send interrupt signal for graceful server shutdown

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,8 +7,7 @@ exclude_unchanged = true
 follow_symlink = true
 include_dir = ["apps", "conf", "devenv/dev-dashboards", "pkg", "public/views"]
 include_ext = ["go", "ini", "toml", "html", "json"]
-pre_cmd = ["make gen-go", "make gen-jsonnet"]
-rerun_delay = 1000
+pre_cmd = ["make gen-go"]
 stop_on_error = true
 
 [log]

--- a/.air.toml
+++ b/.air.toml
@@ -9,6 +9,8 @@ include_dir = ["apps", "conf", "devenv/dev-dashboards", "pkg", "public/views"]
 include_ext = ["go", "ini", "toml", "html", "json"]
 pre_cmd = ["make gen-go"]
 stop_on_error = true
+send_interrupt = true
+kill_delay = 500
 
 [log]
 time = true


### PR DESCRIPTION
Small change as this can prevent plugins from properly removing themselves, and stays in the background running as a ghost process forever.

Also removes `rerun_delay = 1000` as it does nothing, and gets rid of running `make gen-jsonnet`.

I'm keeping `make gen-go` for now, as it doesn't seem to take more than 10s and it provides a decent experience when you make wire changes, not having to stop the air process, run the command, then start again.