### PR TITLE
unistore: use different ns for each test

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -228,37 +228,37 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 	}
 	// Create resources across different namespaces/groups
 	_, err := writeEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED,
-		WithNamespace(nsPrefix+"-ns1"),
+		WithNamespace(nsPrefix+"-stats-ns1"),
 		WithGroup("group"),
 		WithResource("resource1"))
 	require.NoError(t, err)
 
 	_, err = writeEvent(ctx, backend, "item2", resourcepb.WatchEvent_ADDED,
-		WithNamespace(nsPrefix+"-ns1"),
+		WithNamespace(nsPrefix+"-stats-ns1"),
 		WithGroup("group"),
 		WithResource("resource1"))
 	require.NoError(t, err)
 
 	_, err = writeEvent(ctx, backend, "item3", resourcepb.WatchEvent_ADDED,
-		WithNamespace(nsPrefix+"-ns1"),
+		WithNamespace(nsPrefix+"-stats-ns1"),
 		WithGroup("group"),
 		WithResource("resource2"))
 	require.NoError(t, err)
 
 	_, err = writeEvent(ctx, backend, "item4", resourcepb.WatchEvent_ADDED,
-		WithNamespace(nsPrefix+"-ns2"),
+		WithNamespace(nsPrefix+"-stats-ns2"),
 		WithGroup("group"),
 		WithResource("resource1"))
 	require.NoError(t, err)
 
 	_, err = writeEvent(ctx, backend, "item5", resourcepb.WatchEvent_ADDED,
-		WithNamespace(nsPrefix+"-ns2"),
+		WithNamespace(nsPrefix+"-stats-ns2"),
 		WithGroup("group"),
 		WithResource("resource1"))
 	require.NoError(t, err)
 
 	t.Run("Get stats for ns1", func(t *testing.T) {
-		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-ns1", 0)
+		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-stats-ns1", 0)
 		require.NoError(t, err)
 		require.Len(t, stats, 2)
 
@@ -266,14 +266,14 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 		slices.SortFunc(stats, sortFunc)
 
 		// Check first resource stats
-		require.Equal(t, nsPrefix+"-ns1", stats[0].Namespace)
+		require.Equal(t, nsPrefix+"-stats-ns1", stats[0].Namespace)
 		require.Equal(t, "group", stats[0].Group)
 		require.Equal(t, "resource1", stats[0].Resource)
 		require.Equal(t, int64(2), stats[0].Count)
 		require.Greater(t, stats[0].ResourceVersion, int64(0))
 
 		// Check second resource stats
-		require.Equal(t, nsPrefix+"-ns1", stats[1].Namespace)
+		require.Equal(t, nsPrefix+"-stats-ns1", stats[1].Namespace)
 		require.Equal(t, "group", stats[1].Group)
 		require.Equal(t, "resource2", stats[1].Resource)
 		require.Equal(t, int64(1), stats[1].Count)
@@ -281,11 +281,11 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 	})
 
 	t.Run("Get stats for ns2", func(t *testing.T) {
-		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-ns2", 0)
+		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-stats-ns2", 0)
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 
-		require.Equal(t, nsPrefix+"-ns2", stats[0].Namespace)
+		require.Equal(t, nsPrefix+"-stats-ns2", stats[0].Namespace)
 		require.Equal(t, "group", stats[0].Group)
 		require.Equal(t, "resource1", stats[0].Resource)
 		require.Equal(t, int64(2), stats[0].Count)
@@ -293,11 +293,11 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 	})
 
 	t.Run("Get stats with minimum count", func(t *testing.T) {
-		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-ns1", 1)
+		stats, err := backend.GetResourceStats(ctx, nsPrefix+"-stats-ns1", 1)
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 
-		require.Equal(t, nsPrefix+"-ns1", stats[0].Namespace)
+		require.Equal(t, nsPrefix+"-stats-ns1", stats[0].Namespace)
 		require.Equal(t, "group", stats[0].Group)
 		require.Equal(t, "resource1", stats[0].Resource)
 		require.Equal(t, int64(2), stats[0].Count)
@@ -314,7 +314,7 @@ func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.St
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 
 	// Create a few resources before initing the watch
-	_, err := writeEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED, WithNamespace(nsPrefix+"-ns1"))
+	_, err := writeEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED, WithNamespace(nsPrefix+"-watch-ns"))
 	require.NoError(t, err)
 
 	// Start the watch
@@ -322,7 +322,7 @@ func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.St
 	require.NoError(t, err)
 
 	// Create one more event
-	_, err = writeEvent(ctx, backend, "item2", resourcepb.WatchEvent_ADDED, WithNamespace(nsPrefix+"-ns1"))
+	_, err = writeEvent(ctx, backend, "item2", resourcepb.WatchEvent_ADDED, WithNamespace(nsPrefix+"-watch-ns"))
 	require.NoError(t, err)
 	require.Equal(t, "item2", (<-stream).Key.Name)
 
@@ -336,7 +336,7 @@ func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.St
 func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 	server := newServer(t, backend)
-	ns := nsPrefix + "-ns1"
+	ns := nsPrefix + "-list-ns"
 	// Create a few resources before starting the watch
 	rv1, err := writeEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
 	require.NoError(t, err)
@@ -367,8 +367,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 		res, err := server.List(ctx, &resourcepb.ListRequest{
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
-					Group:    "group",
-					Resource: "resource",
+					Namespace: ns,
+					Group:     "group",
+					Resource:  "resource",
 				},
 			},
 		})
@@ -390,8 +391,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 			Limit: 3,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
-					Group:    "group",
-					Resource: "resource",
+					Namespace: ns,
+					Group:     "group",
+					Resource:  "resource",
 				},
 			},
 		})
@@ -411,8 +413,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 			ResourceVersion: rv4,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
-					Group:    "group",
-					Resource: "resource",
+					Namespace: ns,
+					Group:     "group",
+					Resource:  "resource",
 				},
 			},
 		})
@@ -432,8 +435,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 			ResourceVersion: rv7,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
-					Group:    "group",
-					Resource: "resource",
+					Namespace: ns,
+					Group:     "group",
+					Resource:  "resource",
 				},
 			},
 		})
@@ -462,8 +466,9 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 			Limit:         2,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
-					Group:    "group",
-					Resource: "resource",
+					Namespace: ns,
+					Group:     "group",
+					Resource:  "resource",
 				},
 			},
 		})
@@ -484,7 +489,7 @@ func runTestIntegrationBackendList(t *testing.T, backend resource.StorageBackend
 func runTestIntegrationBackendListHistory(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
 	server := newServer(t, backend)
-	ns := nsPrefix + "-ns1"
+	ns := nsPrefix + "-history-ns"
 	rv1, _ := writeEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
 	require.Greater(t, rv1, int64(0))
 
@@ -985,12 +990,12 @@ func runTestIntegrationBackendCreateNewResource(t *testing.T, backend resource.S
 
 	request := &resourcepb.CreateRequest{
 		Key: &resourcepb.ResourceKey{
-			Namespace: "default",
+			Namespace: ns,
 			Group:     "test.grafana",
 			Resource:  "Test",
 			Name:      "test",
 		},
-		Value: []byte(`{"apiVersion":"test.grafana/v0alpha1","kind":"Test","metadata":{"name":"test","namespace":"default"}}`),
+		Value: []byte(`{"apiVersion":"test.grafana/v0alpha1","kind":"Test","metadata":{"name":"test","namespace":"` + ns + `","uid":"test-uid-123"}}`),
 	}
 
 	response, err := server.Create(ctx, request)


### PR DESCRIPTION
use different ns for reach test to allow running the tests multiple times with the same backend