### PR TITLE
CI: Support large build IDs in artifact builds

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -30,7 +30,7 @@ inputs:
   build-id:
     type: string
     description: an identifier number which can be traced back to the workflow run.
-    default: ${{github.run_number}}
+    default: ${{github.run_id}}
     required: false
   patches-repo:
     type: string

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -59,7 +59,7 @@ jobs:
         run: jq -r .version package.json | sed -s "s/pre/${BUILD_ID}/g" > VERSION
         env:
           REF_NAME: ${{ github.ref_name }}
-          BUILD_ID: ${{ github.run_number }}
+          BUILD_ID: ${{ github.run_id }}
       - id: output
         run: |
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
@@ -90,7 +90,7 @@ jobs:
         env:
           REF: ${{ github.ref_name }}
           VERSION: ${{ needs.setup.outputs.version }}
-          BUILD_ID: ${{ github.run_number }}
+          BUILD_ID: ${{ github.run_id }}
           BUCKET: grafana-prerelease
           GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
         with:
@@ -163,7 +163,7 @@ jobs:
           version: ${{ needs.setup.outputs.version }}
           output: artifacts-${{ matrix.name }}.txt
           verify: true
-          build-id: ${{ github.run_number }}
+          build-id: ${{ github.run_id }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: artifacts-list-${{ matrix.name }}

--- a/pkg/build/daggerbuild/msi/wxs.go
+++ b/pkg/build/daggerbuild/msi/wxs.go
@@ -50,6 +50,9 @@ func WxsVersion(ersion string) string {
 			v = "0"
 		}
 
+		if len(v) > 5 {
+			v = v[len(v)-5:]
+		}
 		return fmt.Sprintf("%s.%s.%s.%s", major, minor, patch, v)
 	}
 	return fmt.Sprintf("%s.%s.%s.0", major, minor, patch)


### PR DESCRIPTION
If `build-id` was larger than `2147483647` (Which we're at with `github.run_id`: `15299923030`), then the MSI build would fail as it stores this value as a 32-bit integer.

While it's not perfect, we don't often insert the build ID into the version. We only do it for Windows because it expects a fourth digit in the version. In case we do, though, we still need to support large IDs.