### PR TITLE
KBARResults: Add Cmd+Enter/Ctrl+Enter to open links in new tab

### DIFF
--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -71,7 +71,20 @@ export const KBarResults = (props: KBarResultsProps) => {
           }
           return nextIndex;
         });
-      } else if (event.key === 'Enter' && !event.metaKey) {
+      } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        // Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) - open in new tab
+        event.preventDefault();
+        const activeItem = itemsRef.current[activeIndex];
+
+        if (activeItem.url) {
+          const url = typeof activeItem.url === 'function' ? activeItem.url(search) : activeItem.url;
+          window.open(url, '_blank', 'noopener,noreferrer');
+          query.toggle(); // Close the command palette
+        } else {
+          // If no URL, execute the action normally
+          activeRef.current?.click();
+        }
+      } else if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
         event.preventDefault();
         // storing the active dom element in a ref prevents us from
         // having to calculate the current action to perform based
@@ -82,7 +95,7 @@ export const KBarResults = (props: KBarResultsProps) => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [query]);
+  }, [query, search, activeIndex]);
 
   // destructuring here to prevent linter warning to pass
   // entire rowVirtualizer in the dependencies array.

--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -74,14 +74,12 @@ export const KBarResults = (props: KBarResultsProps) => {
       } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
         // Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) - open in new tab
         event.preventDefault();
-        const activeItem = itemsRef.current[activeIndex];
 
-        if (activeItem.url) {
-          const url = typeof activeItem.url === 'function' ? activeItem.url(search) : activeItem.url;
-          window.open(url, '_blank', 'noopener,noreferrer');
-          query.toggle(); // Close the command palette
+        if (activeRef.current instanceof HTMLAnchorElement) {
+          window.open(activeRef.current.href, '_blank', 'noopener,noreferrer');
+          query.toggle();
         } else {
-          // If no URL, execute the action normally
+          // For action-based items (rendered as <div> tags), execute normally
           activeRef.current?.click();
         }
       } else if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
@@ -95,7 +93,7 @@ export const KBarResults = (props: KBarResultsProps) => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [query, search, activeIndex]);
+  }, [query]);
 
   // destructuring here to prevent linter warning to pass
   // entire rowVirtualizer in the dependencies array.


### PR DESCRIPTION
**What is this feature?**

Adds keyboard shortcut support to the `Command Palette -> KBarResults` for opening links in new tabs using **Cmd+Enter** (macOS) or **Ctrl+Enter** (Windows/Linux).

https://github.com/user-attachments/assets/afc6e905-13cc-49ab-a204-43680f15180c


**Why do we need this feature?**

To help user easily navigate search result into new tab

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes #96737 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
