### PR TITLE
Alerting: Fix route validation in provisioning service

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2034,7 +2034,7 @@ func createProvisioningSrvSut(t *testing.T) ProvisioningSrv {
 func createProvisioningSrvSutFromEnv(t *testing.T, env *testEnvironment) ProvisioningSrv {
 	t.Helper()
 	tracer := tracing.InitializeTracerForTest()
-	configStore := legacy_storage.NewAlertmanagerConfigStore(env.configs)
+	configStore := legacy_storage.NewAlertmanagerConfigStore(env.configs, notifier.NewExtraConfigsCrypto(env.secrets))
 	receiverSvc := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](env.ac, true),
 		configStore,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -412,7 +412,7 @@ func (ng *AlertNG) init() error {
 	ng.stateManager = stateManager
 	ng.schedule = scheduler
 
-	configStore := legacy_storage.NewAlertmanagerConfigStore(ng.store)
+	configStore := legacy_storage.NewAlertmanagerConfigStore(ng.store, notifier.NewExtraConfigsCrypto(ng.SecretsService))
 	receiverService := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, false),
 		configStore,

--- a/pkg/services/ngalert/notifier/crypto.go
+++ b/pkg/services/ngalert/notifier/crypto.go
@@ -242,10 +242,10 @@ func (c *alertmanagerCrypto) Decrypt(ctx context.Context, payload []byte) ([]byt
 }
 
 type ExtraConfigsCrypto struct {
-	secrets secrets.Service
+	secrets secretService
 }
 
-func NewExtraConfigsCrypto(secrets secrets.Service) *ExtraConfigsCrypto {
+func NewExtraConfigsCrypto(secrets secretService) *ExtraConfigsCrypto {
 	return &ExtraConfigsCrypto{
 		secrets: secrets,
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/config.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/config.go
@@ -31,9 +31,16 @@ type ConfigRevision struct {
 	ConcurrencyToken string
 	Version          string
 }
+type alertmanagerConfigStoreImpl struct {
+	store amConfigStore
+}
 
-func getLastConfiguration(ctx context.Context, orgID int64, store amConfigStore) (*ConfigRevision, error) {
-	alertManagerConfig, err := store.GetLatestAlertmanagerConfiguration(ctx, orgID)
+func NewAlertmanagerConfigStore(store amConfigStore) *alertmanagerConfigStoreImpl {
+	return &alertmanagerConfigStoreImpl{store: store}
+}
+
+func (a alertmanagerConfigStoreImpl) Get(ctx context.Context, orgID int64) (*ConfigRevision, error) {
+	alertManagerConfig, err := a.store.GetLatestAlertmanagerConfiguration(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,18 +60,6 @@ func getLastConfiguration(ctx context.Context, orgID int64, store amConfigStore)
 		ConcurrencyToken: concurrencyToken,
 		Version:          alertManagerConfig.ConfigurationVersion,
 	}, nil
-}
-
-type alertmanagerConfigStoreImpl struct {
-	store amConfigStore
-}
-
-func NewAlertmanagerConfigStore(store amConfigStore) *alertmanagerConfigStoreImpl {
-	return &alertmanagerConfigStoreImpl{store: store}
-}
-
-func (a alertmanagerConfigStoreImpl) Get(ctx context.Context, orgID int64) (*ConfigRevision, error) {
-	return getLastConfiguration(ctx, orgID, a.store)
 }
 
 func (a alertmanagerConfigStoreImpl) Save(ctx context.Context, revision *ConfigRevision, orgID int64) error {

--- a/pkg/services/ngalert/notifier/legacy_storage/config.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/config.go
@@ -83,16 +83,11 @@ func (a alertmanagerConfigStoreImpl) Save(ctx context.Context, revision *ConfigR
 	if err != nil {
 		return err
 	}
-	cmd := models.SaveAlertmanagerConfigurationCmd{
+	return a.store.UpdateAlertmanagerConfiguration(ctx, &models.SaveAlertmanagerConfigurationCmd{
 		AlertmanagerConfiguration: string(serialized),
 		ConfigurationVersion:      revision.Version,
 		FetchedConfigurationHash:  revision.ConcurrencyToken,
 		Default:                   false,
 		OrgID:                     orgID,
-	}
-	cfg := &definitions.PostableUserConfig{}
-	if err := json.Unmarshal([]byte(cmd.AlertmanagerConfiguration), cfg); err != nil {
-		return fmt.Errorf("change would result in an invalid configuration state: %w", err)
-	}
-	return a.store.UpdateAlertmanagerConfiguration(ctx, &cmd)
+	})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/config.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/config.go
@@ -90,14 +90,9 @@ func (a alertmanagerConfigStoreImpl) Save(ctx context.Context, revision *ConfigR
 		Default:                   false,
 		OrgID:                     orgID,
 	}
-	return a.PersistConfig(ctx, &cmd)
-}
-
-// PersistConfig validates to config before eventually persisting it if no error occurs
-func (a alertmanagerConfigStoreImpl) PersistConfig(ctx context.Context, cmd *models.SaveAlertmanagerConfigurationCmd) error {
 	cfg := &definitions.PostableUserConfig{}
 	if err := json.Unmarshal([]byte(cmd.AlertmanagerConfiguration), cfg); err != nil {
 		return fmt.Errorf("change would result in an invalid configuration state: %w", err)
 	}
-	return a.store.UpdateAlertmanagerConfiguration(ctx, cmd)
+	return a.store.UpdateAlertmanagerConfiguration(ctx, &cmd)
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/testing.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/testing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -56,6 +57,42 @@ func (a *AlertmanagerConfigStoreFake) Save(ctx context.Context, revision *Config
 	})
 	if a.SaveFn != nil {
 		return a.SaveFn(ctx, revision)
+	}
+	return nil
+}
+
+type fakeCrypto struct {
+	Calls                   []methodCall
+	EncryptExtraConfigsFunc func(context.Context, *definitions.PostableUserConfig) error
+	DecryptExtraConfigsFunc func(context.Context, *definitions.PostableUserConfig) error
+}
+
+func newFakeCrypto() *fakeCrypto {
+	return &fakeCrypto{
+		Calls: []methodCall{},
+	}
+}
+
+func (f *fakeCrypto) EncryptExtraConfigs(ctx context.Context, config *definitions.PostableUserConfig) error {
+	f.Calls = append(f.Calls, methodCall{
+		Method: "EncryptExtraConfigs",
+		Args:   []interface{}{ctx, config},
+	})
+
+	if f.EncryptExtraConfigsFunc != nil {
+		return f.EncryptExtraConfigsFunc(ctx, config)
+	}
+	return nil
+}
+
+func (f *fakeCrypto) DecryptExtraConfigs(ctx context.Context, config *definitions.PostableUserConfig) error {
+	f.Calls = append(f.Calls, methodCall{
+		Method: "DecryptExtraConfigs",
+		Args:   []interface{}{ctx, config},
+	})
+
+	if f.DecryptExtraConfigsFunc != nil {
+		return f.DecryptExtraConfigsFunc(ctx, config)
 	}
 	return nil
 }

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -275,7 +275,7 @@ func TestReceiverService_Delete(t *testing.T) {
 			deleteUID:        baseReceiver.UID,
 			callerProvenance: definitions.Provenance(models.ProvenanceFile),
 			existing:         util.Pointer(models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithProvenance(models.ProvenanceAPI))),
-			//expectedErr:      validation.MakeErrProvenanceChangeNotAllowed(models.ProvenanceAPI, models.ProvenanceFile),
+			// expectedErr:      validation.MakeErrProvenanceChangeNotAllowed(models.ProvenanceAPI, models.ProvenanceFile),
 		},
 		{
 			name:        "delete receiver with optimistic version mismatch fails",
@@ -673,7 +673,7 @@ func TestReceiverService_Update(t *testing.T) {
 			user:     writer,
 			receiver: models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithProvenance(models.ProvenanceAPI)),
 			existing: util.Pointer(models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithProvenance(models.ProvenanceFile))),
-			//expectedErr: validation.MakeErrProvenanceChangeNotAllowed(models.ProvenanceFile, models.ProvenanceAPI),
+			// expectedErr: validation.MakeErrProvenanceChangeNotAllowed(models.ProvenanceFile, models.ProvenanceAPI),
 			expectedUpdate: models.CopyReceiverWith(baseReceiver,
 				models.ReceiverMuts.WithProvenance(models.ProvenanceAPI),
 				rm.Encrypted(models.Base64Enrypt)),
@@ -1529,7 +1529,7 @@ func createReceiverServiceSut(t *testing.T, encryptSvc secretService) *ReceiverS
 
 	return NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](acimpl.ProvideAccessControl(featuremgmt.WithFeatures()), false),
-		legacy_storage.NewAlertmanagerConfigStore(store),
+		legacy_storage.NewAlertmanagerConfigStore(store, NewExtraConfigsCrypto(encryptSvc)),
 		provisioningStore,
 		&fakeAlertRuleNotificationStore{},
 		encryptSvc,

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -493,7 +493,7 @@ func createContactPointServiceSutWithConfigStore(t *testing.T, secretService sec
 
 	receiverService := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](acimpl.ProvideAccessControl(featuremgmt.WithFeatures()), true),
-		legacy_storage.NewAlertmanagerConfigStore(configStore),
+		legacy_storage.NewAlertmanagerConfigStore(configStore, notifier.NewExtraConfigsCrypto(secretService)),
 		provisioningStore,
 		&fakeAlertRuleNotificationStore{},
 		secretService,
@@ -504,7 +504,7 @@ func createContactPointServiceSutWithConfigStore(t *testing.T, secretService sec
 	)
 
 	return NewContactPointService(
-		legacy_storage.NewAlertmanagerConfigStore(configStore),
+		legacy_storage.NewAlertmanagerConfigStore(configStore, notifier.NewExtraConfigsCrypto(secretService)),
 		secretService,
 		provisioningStore,
 		xact,

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -37,6 +37,10 @@ var (
 		"Invalid format of the submitted route.",
 		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
 	)
+
+	ErrRouteConflictingMatchers = errutil.BadRequest("alerting.notifications.routes.conflictingMatchers").MustTemplate("Routing tree conflicts with the external configuration",
+		errutil.WithPublic("Cannot add\\update route: matchers conflict with an external routing tree merging matchers {{ .Public.Matchers }}, making the added\\updated route unreachable."),
+	)
 )
 
 // MakeErrTimeIntervalInvalid creates an error with the ErrTimeIntervalInvalid template
@@ -106,6 +110,14 @@ func MakeErrRouteInvalidFormat(err error) error {
 			"Error": err.Error(),
 		},
 		Error: err,
+	})
+}
+
+func MakeErrRouteConflictingMatchers(matchers string) error {
+	return ErrRouteConflictingMatchers.Build(errutil.TemplateData{
+		Public: map[string]any{
+			"Matchers": matchers,
+		},
 	})
 }
 

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -3,12 +3,14 @@ package provisioning
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
 	"slices"
 	"unsafe"
 
+	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/common/model"
 	"golang.org/x/exp/maps"
 
@@ -113,7 +115,11 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 
 	_, err = revision.Config.GetMergedAlertmanagerConfig()
 	if err != nil {
-		return definitions.Route{}, "", fmt.Errorf("new routing tree is not compatible with extra configuration: %w", err)
+		if errors.Is(err, definition.ErrSubtreeMatchersConflict) {
+			// TODO temporarily get the conflicting matchers
+			return definitions.Route{}, "", MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
+		}
+		nps.log.Warn("Unable to validate the combined routing tree because of an error during merging. This could be a sign of broken external configuration. Skipping", "error", err)
 	}
 
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -294,7 +294,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		ps.alertingStore,
 		ps.alertingStore,
 		ps.folderService,
-		//ps.dashboardService,
+		// ps.dashboardService,
 		ps.quotaService,
 		ps.SQLStore,
 		int64(ps.Cfg.UnifiedAlerting.DefaultRuleEvaluationInterval.Seconds()),
@@ -304,7 +304,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		notifier.NewCachedNotificationSettingsValidationService(ps.alertingStore),
 		alertingauthz.NewRuleService(ps.ac),
 	)
-	configStore := legacy_storage.NewAlertmanagerConfigStore(ps.alertingStore)
+	configStore := legacy_storage.NewAlertmanagerConfigStore(ps.alertingStore, notifier.NewExtraConfigsCrypto(ps.secretService))
 	receiverSvc := notifier.NewReceiverService(
 		alertingauthz.NewReceiverAccess[*ngmodels.Receiver](ps.ac, true),
 		configStore,


### PR DESCRIPTION
**What is this feature?**
Updates legacy_storage to decrpyt extra configurations on read and encrypt on write. 
Updated notification policies provisioning service to return better error on conflicts and ignore all other merging errors because they are not relevant to that API.

**Why do we need this feature?**
This is needed in notification policies service to check for conflicts. 

Related to https://github.com/grafana/alerting-squad/issues/1152
