### PR TITLE
APIServer: Exclude internal GroupVersionKind from openapi

### DIFF
--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -4,21 +4,23 @@ import (
 	"maps"
 	"strings"
 
-	common "k8s.io/kube-openapi/pkg/common"
+	openapi "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
 
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	secret "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 )
 
 // This should eventually live in grafana-app-sdk
-func GetOpenAPIDefinitions(builders []APIGroupBuilder) common.GetOpenAPIDefinitions {
-	return func(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
-		defs := v0alpha1.GetOpenAPIDefinitions(ref) // common grafana apis
+func GetOpenAPIDefinitions(builders []APIGroupBuilder) openapi.GetOpenAPIDefinitions {
+	return func(ref openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {
+		defs := common.GetOpenAPIDefinitions(ref) // common grafana apis
 		maps.Copy(defs, data.GetOpenAPIDefinitions(ref))
+		maps.Copy(defs, secret.GetOpenAPIDefinitions(ref)) // Expose secret reference to all resources
 		// TODO: add timerange to upstream SDK setup
-		maps.Copy(defs, map[string]common.OpenAPIDefinition{
+		maps.Copy(defs, map[string]openapi.OpenAPIDefinition{
 			"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.TimeRange": {
 				Schema: spec.Schema{
 					SchemaProps: spec.SchemaProps{
@@ -117,8 +119,29 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 
 					// Remove the growing list of kinds
 					for k, v := range copy.Components.Schemas {
-						if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") && v.Extensions != nil {
+						if v.Extensions == nil {
+							continue
+						}
+						if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") {
 							delete(v.Extensions, "x-kubernetes-group-version-kind") // a growing list of everything
+							continue
+						}
+
+						// Remove the internal annotations
+						val, ok := v.Extensions["x-kubernetes-group-version-kind"]
+						if ok {
+							gvks, ok := val.([]any)
+							if ok {
+								keep := make([]map[string]any, 0, len(gvks))
+								for _, val := range gvks {
+									gvk, ok := val.(map[string]any)
+									if ok && gvk["version"] == "__internal" {
+										continue
+									}
+									keep = append(keep, gvk)
+								}
+								v.Extensions["x-kubernetes-group-version-kind"] = keep
+							}
 						}
 					}
 

--- a/pkg/tests/apis/openapi_snapshots/advisor.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/advisor.grafana.app-v0alpha1.json
@@ -1743,11 +1743,6 @@
           {
             "group": "advisor.grafana.app",
             "kind": "Check",
-            "version": "__internal"
-          },
-          {
-            "group": "advisor.grafana.app",
-            "kind": "Check",
             "version": "v0alpha1"
           }
         ]
@@ -1807,11 +1802,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "advisor.grafana.app",
-            "kind": "CheckList",
-            "version": "__internal"
-          },
           {
             "group": "advisor.grafana.app",
             "kind": "CheckList",
@@ -1960,11 +1950,6 @@
           {
             "group": "advisor.grafana.app",
             "kind": "CheckType",
-            "version": "__internal"
-          },
-          {
-            "group": "advisor.grafana.app",
-            "kind": "CheckType",
             "version": "v0alpha1"
           }
         ]
@@ -2005,11 +1990,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "advisor.grafana.app",
-            "kind": "CheckTypeList",
-            "version": "__internal"
-          },
           {
             "group": "advisor.grafana.app",
             "kind": "CheckTypeList",

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
@@ -1046,11 +1046,6 @@
           {
             "group": "folder.grafana.app",
             "kind": "DescendantCounts",
-            "version": "__internal"
-          },
-          {
-            "group": "folder.grafana.app",
-            "kind": "DescendantCounts",
             "version": "v1beta1"
           }
         ]
@@ -1101,11 +1096,6 @@
           {
             "group": "folder.grafana.app",
             "kind": "Folder",
-            "version": "__internal"
-          },
-          {
-            "group": "folder.grafana.app",
-            "kind": "Folder",
             "version": "v1beta1"
           }
         ]
@@ -1146,11 +1136,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "folder.grafana.app",
-            "kind": "FolderAccessInfo",
-            "version": "__internal"
-          },
           {
             "group": "folder.grafana.app",
             "kind": "FolderAccessInfo",
@@ -1233,11 +1218,6 @@
           {
             "group": "folder.grafana.app",
             "kind": "FolderInfoList",
-            "version": "__internal"
-          },
-          {
-            "group": "folder.grafana.app",
-            "kind": "FolderInfoList",
             "version": "v1beta1"
           }
         ]
@@ -1278,11 +1258,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "folder.grafana.app",
-            "kind": "FolderList",
-            "version": "__internal"
-          },
           {
             "group": "folder.grafana.app",
             "kind": "FolderList",

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -1827,11 +1827,6 @@
           {
             "group": "iam.grafana.app",
             "kind": "SSOSetting",
-            "version": "__internal"
-          },
-          {
-            "group": "iam.grafana.app",
-            "kind": "SSOSetting",
             "version": "v0alpha1"
           }
         ]
@@ -1871,11 +1866,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "SSOSettingList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "SSOSettingList",
@@ -1937,11 +1927,6 @@
           {
             "group": "iam.grafana.app",
             "kind": "ServiceAccount",
-            "version": "__internal"
-          },
-          {
-            "group": "iam.grafana.app",
-            "kind": "ServiceAccount",
             "version": "v0alpha1"
           }
         ]
@@ -1981,11 +1966,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "ServiceAccountList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "ServiceAccountList",
@@ -2078,11 +2058,6 @@
           {
             "group": "iam.grafana.app",
             "kind": "Team",
-            "version": "__internal"
-          },
-          {
-            "group": "iam.grafana.app",
-            "kind": "Team",
             "version": "v0alpha1"
           }
         ]
@@ -2116,11 +2091,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "TeamBinding",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "TeamBinding",
@@ -2163,11 +2133,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "TeamBindingList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "TeamBindingList",
@@ -2234,11 +2199,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "TeamList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "TeamList",
@@ -2327,11 +2287,6 @@
           {
             "group": "iam.grafana.app",
             "kind": "TeamMemberList",
-            "version": "__internal"
-          },
-          {
-            "group": "iam.grafana.app",
-            "kind": "TeamMemberList",
             "version": "v0alpha1"
           }
         ]
@@ -2413,11 +2368,6 @@
           {
             "group": "iam.grafana.app",
             "kind": "User",
-            "version": "__internal"
-          },
-          {
-            "group": "iam.grafana.app",
-            "kind": "User",
             "version": "v0alpha1"
           }
         ]
@@ -2457,11 +2407,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "UserList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "UserList",
@@ -2548,11 +2493,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "iam.grafana.app",
-            "kind": "UserTeamList",
-            "version": "__internal"
-          },
           {
             "group": "iam.grafana.app",
             "kind": "UserTeamList",

--- a/pkg/tests/apis/openapi_snapshots/investigations.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/investigations.grafana.app-v0alpha1.json
@@ -1744,11 +1744,6 @@
           {
             "group": "investigations.grafana.app",
             "kind": "Investigation",
-            "version": "__internal"
-          },
-          {
-            "group": "investigations.grafana.app",
-            "kind": "Investigation",
             "version": "v0alpha1"
           }
         ]
@@ -1895,11 +1890,6 @@
           {
             "group": "investigations.grafana.app",
             "kind": "InvestigationIndex",
-            "version": "__internal"
-          },
-          {
-            "group": "investigations.grafana.app",
-            "kind": "InvestigationIndex",
             "version": "v0alpha1"
           }
         ]
@@ -2031,11 +2021,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "investigations.grafana.app",
-            "kind": "InvestigationIndexList",
-            "version": "__internal"
-          },
           {
             "group": "investigations.grafana.app",
             "kind": "InvestigationIndexList",
@@ -2218,11 +2203,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "investigations.grafana.app",
-            "kind": "InvestigationList",
-            "version": "__internal"
-          },
           {
             "group": "investigations.grafana.app",
             "kind": "InvestigationList",

--- a/pkg/tests/apis/openapi_snapshots/notifications.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/notifications.alerting.grafana.app-v0alpha1.json
@@ -3404,11 +3404,6 @@
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "Receiver",
-            "version": "__internal"
-          },
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "Receiver",
             "version": "v0alpha1"
           }
         ]
@@ -3481,11 +3476,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "ReceiverList",
-            "version": "__internal"
-          },
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "ReceiverList",
@@ -3617,11 +3607,6 @@
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "RoutingTree",
-            "version": "__internal"
-          },
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "RoutingTree",
             "version": "v0alpha1"
           }
         ]
@@ -3662,11 +3647,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "RoutingTreeList",
-            "version": "__internal"
-          },
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "RoutingTreeList",
@@ -3919,11 +3899,6 @@
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "TemplateGroup",
-            "version": "__internal"
-          },
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "TemplateGroup",
             "version": "v0alpha1"
           }
         ]
@@ -3964,11 +3939,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "TemplateGroupList",
-            "version": "__internal"
-          },
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "TemplateGroupList",
@@ -4093,11 +4063,6 @@
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "TimeInterval",
-            "version": "__internal"
-          },
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "TimeInterval",
             "version": "v0alpha1"
           }
         ]
@@ -4185,11 +4150,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "notifications.alerting.grafana.app",
-            "kind": "TimeIntervalList",
-            "version": "__internal"
-          },
           {
             "group": "notifications.alerting.grafana.app",
             "kind": "TimeIntervalList",

--- a/pkg/tests/apis/openapi_snapshots/playlist.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/playlist.grafana.app-v0alpha1.json
@@ -914,11 +914,6 @@
           {
             "group": "playlist.grafana.app",
             "kind": "Playlist",
-            "version": "__internal"
-          },
-          {
-            "group": "playlist.grafana.app",
-            "kind": "Playlist",
             "version": "v0alpha1"
           }
         ]
@@ -978,11 +973,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "playlist.grafana.app",
-            "kind": "PlaylistList",
-            "version": "__internal"
-          },
           {
             "group": "playlist.grafana.app",
             "kind": "PlaylistList",

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -2779,11 +2779,6 @@
           {
             "group": "provisioning.grafana.app",
             "kind": "Job",
-            "version": "__internal"
-          },
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "Job",
             "version": "v0alpha1"
           }
         ]
@@ -2823,11 +2818,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "JobList",
-            "version": "__internal"
-          },
           {
             "group": "provisioning.grafana.app",
             "kind": "JobList",
@@ -3088,11 +3078,6 @@
           {
             "group": "provisioning.grafana.app",
             "kind": "Repository",
-            "version": "__internal"
-          },
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "Repository",
             "version": "v0alpha1"
           }
         ]
@@ -3133,11 +3118,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "RepositoryList",
-            "version": "__internal"
-          },
           {
             "group": "provisioning.grafana.app",
             "kind": "RepositoryList",
@@ -3426,11 +3406,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "ResourceList",
-            "version": "__internal"
-          },
           {
             "group": "provisioning.grafana.app",
             "kind": "ResourceList",
@@ -3740,11 +3715,6 @@
           {
             "group": "provisioning.grafana.app",
             "kind": "ResourceWrapper",
-            "version": "__internal"
-          },
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "ResourceWrapper",
             "version": "v0alpha1"
           }
         ]
@@ -3890,11 +3860,6 @@
           {
             "group": "provisioning.grafana.app",
             "kind": "TestResults",
-            "version": "__internal"
-          },
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "TestResults",
             "version": "v0alpha1"
           }
         ]
@@ -3929,11 +3894,6 @@
           }
         },
         "x-kubernetes-group-version-kind": [
-          {
-            "group": "provisioning.grafana.app",
-            "kind": "WebhookResponse",
-            "version": "__internal"
-          },
           {
             "group": "provisioning.grafana.app",
             "kind": "WebhookResponse",


### PR DESCRIPTION
Extracted from https://github.com/grafana/grafana/pull/106996

This PR removes any references to `"version": "__internal"` from the generated OpenAPI specs