### PR TITLE
Storybook: Serve msw worker from relative path

### DIFF
--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -51,6 +51,9 @@ if (process.env.NODE_ENV === 'development') {
  */
 initialize({
   onUnhandledRequest: 'bypass',
+  serviceWorker: {
+    url: 'mockServiceWorker.js',
+  },
 });
 
 const preview: Preview = {


### PR DESCRIPTION
Modifies the Storybook MSW worker location to serve relative from the index.html file.

This is required to serve it correctly from developers.grafana.com/ui/latest or /ui/canary. We don't want to use nginx redirects to serve it from the root path because we want each deployment to have its own version of the worker.

One important note is that MSW docs say you need to serve it with the `Service-Worker-Allowed: /` header in order to mock paths from the `/` root while serving the worker from the subdirectory. But, in my testing using nginx locally to simulate `/ui/latest` paths, this wasn't needed, even when serving from a non-localhost http domain

 - https://mswjs.io/docs/recipes/custom-worker-script-location/#option-2-service-worker-allowed-response-header
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Service-Worker-Allowed
 - https://developer.chrome.com/docs/workbox/service-worker-lifecycle#scope

![image](https://github.com/user-attachments/assets/fd6a7bfa-5811-4d4b-92db-392a7e452937)
