### PR TITLE
Hackathon(GrafanaQL): Enhance GraphQL API with Dashboard & Datasource APIs

### DIFF
--- a/pkg/registry/apis/apis.go
+++ b/pkg/registry/apis/apis.go
@@ -1,6 +1,9 @@
 package apiregistry
 
 import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 	dashboardinternal "github.com/grafana/grafana/pkg/registry/apis/dashboard"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboardsnapshot"
 	"github.com/grafana/grafana/pkg/registry/apis/datasource"
@@ -12,24 +15,65 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/query"
 	"github.com/grafana/grafana/pkg/registry/apis/secret"
 	"github.com/grafana/grafana/pkg/registry/apis/userstorage"
+	"github.com/grafana/grafana/pkg/services/apiserver"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 )
 
 type Service struct{}
 
 // ProvideRegistryServiceSink is an entry point for each service that will force initialization
-// and give each builder the chance to register itself with the main server
+// and give each builder the chance to register itself with the main server.
+// This also discovers and registers any GraphQL-capable API builders with the GraphQL federation system.
 func ProvideRegistryServiceSink(
-	_ *dashboardinternal.DashboardsAPIBuilder,
-	_ *dashboardsnapshot.SnapshotsAPIBuilder,
-	_ *featuretoggle.FeatureFlagAPIBuilder,
-	_ *datasource.DataSourceAPIBuilder,
-	_ *folders.FolderAPIBuilder,
-	_ *iam.IdentityAccessManagementAPIBuilder,
-	_ *query.QueryAPIBuilder,
-	_ *userstorage.UserStorageAPIBuilder,
-	_ *secret.SecretAPIBuilder,
-	_ *provisioning.APIBuilder,
-	_ *ofrep.APIBuilder,
+	dashboardBuilder *dashboardinternal.DashboardsAPIBuilder,
+	snapshotsBuilder *dashboardsnapshot.SnapshotsAPIBuilder,
+	featureToggleBuilder *featuretoggle.FeatureFlagAPIBuilder,
+	datasourceBuilder *datasource.DataSourceAPIBuilder,
+	folderBuilder *folders.FolderAPIBuilder,
+	iamBuilder *iam.IdentityAccessManagementAPIBuilder,
+	queryBuilder *query.QueryAPIBuilder,
+	userStorageBuilder *userstorage.UserStorageAPIBuilder,
+	secretBuilder *secret.SecretAPIBuilder,
+	provisioningBuilder *provisioning.APIBuilder,
+	ofrepBuilder *ofrep.APIBuilder,
 ) *Service {
+	logger := log.New("api-registry")
+
+	// Collect all API builders for GraphQL discovery
+	builders := []builder.APIGroupBuilder{
+		dashboardBuilder,
+		snapshotsBuilder,
+		featureToggleBuilder,
+		datasourceBuilder,
+		folderBuilder,
+		iamBuilder,
+		queryBuilder,
+		userStorageBuilder,
+		secretBuilder,
+		provisioningBuilder,
+		ofrepBuilder,
+	}
+
+	// Remove nil builders (some are conditionally registered)
+	var validBuilders []builder.APIGroupBuilder
+	for _, b := range builders {
+		if b != nil {
+			validBuilders = append(validBuilders, b)
+		}
+	}
+
+	// Use GraphQL discovery to find GraphQL-capable builders
+	discovery := builder.NewGraphQLDiscovery()
+	graphqlProviders := discovery.DiscoverFromBuilders(validBuilders)
+
+	// Register GraphQL providers with the global registry
+	if len(graphqlProviders) > 0 {
+		apiserver.RegisterGraphQLProviders(graphqlProviders)
+		for _, provider := range graphqlProviders {
+			logger.Debug("Registered GraphQL provider from API builder", "provider", fmt.Sprintf("%T", provider))
+		}
+		logger.Info("GraphQL providers registered from API builders", "count", len(graphqlProviders))
+	}
+
 	return &Service{}
 }

--- a/pkg/registry/apis/dashboard/graphql_storage.go
+++ b/pkg/registry/apis/dashboard/graphql_storage.go
@@ -1,0 +1,226 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	claims "github.com/grafana/authlib/types"
+	graphqlsubgraph "github.com/grafana/grafana-app-sdk/graphql/subgraph"
+	"github.com/grafana/grafana-app-sdk/resource"
+	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
+	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	unifiedresource "github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// dashboardStorageAdapter bridges Dashboard legacy storage to GraphQL storage interface
+type dashboardStorageAdapter struct {
+	access     legacy.DashboardAccess
+	namespacer request.NamespaceMapper
+}
+
+// Ensure dashboardStorageAdapter implements GraphQL Storage interface
+var _ graphqlsubgraph.Storage = (*dashboardStorageAdapter)(nil)
+
+// NewDashboardStorageAdapter creates a new dashboard storage adapter
+func NewDashboardStorageAdapter(access legacy.DashboardAccess, namespacer request.NamespaceMapper) *dashboardStorageAdapter {
+	return &dashboardStorageAdapter{
+		access:     access,
+		namespacer: namespacer,
+	}
+}
+
+// Get implements graphqlsubgraph.Storage - fetches a single dashboard
+func (s *dashboardStorageAdapter) Get(ctx context.Context, namespace, name string) (resource.Object, error) {
+	// Parse namespace to get org ID
+	nsInfo, err := claims.ParseNamespace(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse namespace: %w", err)
+	}
+
+	// Get dashboard from legacy storage
+	dash, _, err := s.access.GetDashboard(ctx, nsInfo.OrgID, name, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard: %w", err)
+	}
+	if dash == nil {
+		return nil, fmt.Errorf("dashboard not found")
+	}
+
+	// Ensure TypeMeta is set for GraphQL resource handlers
+	if dash.TypeMeta.APIVersion == "" {
+		dash.TypeMeta.APIVersion = dashboardV1.DashboardResourceInfo.GroupVersion().String()
+	}
+	if dash.TypeMeta.Kind == "" {
+		dash.TypeMeta.Kind = "Dashboard"
+	}
+
+	return dash, nil
+}
+
+// List implements graphqlsubgraph.Storage - fetches multiple dashboards
+func (s *dashboardStorageAdapter) List(ctx context.Context, namespace string, options graphqlsubgraph.ListOptions) (resource.ListObject, error) {
+	// Parse namespace to get org ID
+	_, err := claims.ParseNamespace(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse namespace: %w", err)
+	}
+
+	// Build list request
+	req := &resourcepb.ListRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: namespace,
+				Group:     dashboardV1.DashboardResourceInfo.GroupResource().Group,
+				Resource:  dashboardV1.DashboardResourceInfo.GroupResource().Resource,
+			},
+		},
+		Limit: options.Limit,
+	}
+
+	// Set up the list callback to collect dashboards
+	var dashboards []resource.Object
+	listCallback := func(iter unifiedresource.ListIterator) error {
+		for {
+			if !iter.Next() {
+				break // End of list
+			}
+
+			// Parse the dashboard JSON
+			var dash dashboardV1.Dashboard
+			if err := json.Unmarshal(iter.Value(), &dash); err != nil {
+				return fmt.Errorf("failed to unmarshal dashboard: %w", err)
+			}
+
+			// Ensure TypeMeta is set for GraphQL resource handlers
+			if dash.TypeMeta.APIVersion == "" {
+				dash.TypeMeta.APIVersion = dashboardV1.DashboardResourceInfo.GroupVersion().String()
+			}
+			if dash.TypeMeta.Kind == "" {
+				dash.TypeMeta.Kind = "Dashboard"
+			}
+
+			dashboards = append(dashboards, &dash)
+		}
+		return iter.Error()
+	}
+
+	// Execute the list operation
+	_, err = s.access.ListIterator(ctx, req, listCallback)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dashboards: %w", err)
+	}
+
+	// Create the list result
+	list := &dashboardV1.DashboardList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dashboardV1.DashboardResourceInfo.GroupVersion().String(),
+			Kind:       "DashboardList",
+		},
+		Items: make([]dashboardV1.Dashboard, len(dashboards)),
+	}
+
+	// Convert to proper list items
+	for i, dashboard := range dashboards {
+		if dash, ok := dashboard.(*dashboardV1.Dashboard); ok {
+			list.Items[i] = *dash
+		}
+	}
+
+	return list, nil
+}
+
+// Create implements graphqlsubgraph.Storage - creates a new dashboard
+func (s *dashboardStorageAdapter) Create(ctx context.Context, namespace string, obj resource.Object) (resource.Object, error) {
+	// Parse namespace to get org ID
+	nsInfo, err := claims.ParseNamespace(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse namespace: %w", err)
+	}
+
+	// Type assertion to Dashboard
+	dash, ok := obj.(*dashboardV1.Dashboard)
+	if !ok {
+		return nil, fmt.Errorf("expected Dashboard, got %T", obj)
+	}
+
+	// Ensure namespace is set
+	if dash.GetNamespace() == "" {
+		dash.SetNamespace(namespace)
+	}
+
+	// Save dashboard using legacy storage
+	savedDash, _, err := s.access.SaveDashboard(ctx, nsInfo.OrgID, dash, true) // failOnExisting=true for create
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dashboard: %w", err)
+	}
+
+	// Ensure TypeMeta is set for GraphQL resource handlers
+	if savedDash.TypeMeta.APIVersion == "" {
+		savedDash.TypeMeta.APIVersion = dashboardV1.DashboardResourceInfo.GroupVersion().String()
+	}
+	if savedDash.TypeMeta.Kind == "" {
+		savedDash.TypeMeta.Kind = "Dashboard"
+	}
+
+	return savedDash, nil
+}
+
+// Update implements graphqlsubgraph.Storage - updates an existing dashboard
+func (s *dashboardStorageAdapter) Update(ctx context.Context, namespace, name string, obj resource.Object) (resource.Object, error) {
+	// Parse namespace to get org ID
+	nsInfo, err := claims.ParseNamespace(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse namespace: %w", err)
+	}
+
+	// Type assertion to Dashboard
+	dash, ok := obj.(*dashboardV1.Dashboard)
+	if !ok {
+		return nil, fmt.Errorf("expected Dashboard, got %T", obj)
+	}
+
+	// Ensure name and namespace match
+	if dash.GetName() != name {
+		dash.SetName(name)
+	}
+	if dash.GetNamespace() == "" {
+		dash.SetNamespace(namespace)
+	}
+
+	// Save dashboard using legacy storage
+	savedDash, _, err := s.access.SaveDashboard(ctx, nsInfo.OrgID, dash, false) // failOnExisting=false for update
+	if err != nil {
+		return nil, fmt.Errorf("failed to update dashboard: %w", err)
+	}
+
+	// Ensure TypeMeta is set for GraphQL resource handlers
+	if savedDash.TypeMeta.APIVersion == "" {
+		savedDash.TypeMeta.APIVersion = dashboardV1.DashboardResourceInfo.GroupVersion().String()
+	}
+	if savedDash.TypeMeta.Kind == "" {
+		savedDash.TypeMeta.Kind = "Dashboard"
+	}
+
+	return savedDash, nil
+}
+
+// Delete implements graphqlsubgraph.Storage - deletes a dashboard
+func (s *dashboardStorageAdapter) Delete(ctx context.Context, namespace, name string) error {
+	// Parse namespace to get org ID
+	nsInfo, err := claims.ParseNamespace(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to parse namespace: %w", err)
+	}
+
+	// Delete dashboard using legacy storage
+	_, _, err = s.access.DeleteDashboard(ctx, nsInfo.OrgID, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete dashboard: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/registry/apis/datasource/unified_storage.go
+++ b/pkg/registry/apis/datasource/unified_storage.go
@@ -1,0 +1,228 @@
+package datasource
+
+import (
+	"context"
+	"fmt"
+
+	graphqlsubgraph "github.com/grafana/grafana-app-sdk/graphql/subgraph"
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	datasourcev0alpha1 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// DataSourceConnectionKind returns a resource.Kind for DataSourceConnection to use with GraphQL
+func DataSourceConnectionKind() resource.Kind {
+	// Create a simple schema for DataSourceConnection using unstructured approach
+	schema := resource.NewSimpleSchema(
+		"datasource.grafana.app",
+		"v0alpha1",
+		&resource.UntypedObject{},
+		&resource.UntypedList{},
+		resource.WithKind("DataSourceConnection"),
+		resource.WithPlural("connections"),
+		resource.WithScope(resource.NamespacedScope),
+	)
+
+	return resource.Kind{
+		Schema: schema,
+		Codecs: map[resource.KindEncoding]resource.Codec{
+			resource.KindEncodingJSON: resource.NewJSONCodec(),
+		},
+	}
+}
+
+// unifiedDataSourceStorageAdapter provides access to ALL datasources across all plugin types
+type unifiedDataSourceStorageAdapter struct {
+	dsService       datasources.DataSourceService
+	dsCache         datasources.CacheService
+	namespaceMapper request.NamespaceMapper
+}
+
+// NewUnifiedDataSourceStorageAdapter creates a new unified DataSource storage adapter for GraphQL
+// that can access datasources across all plugin types
+func NewUnifiedDataSourceStorageAdapter(
+	dsService datasources.DataSourceService,
+	dsCache datasources.CacheService,
+	namespaceMapper request.NamespaceMapper,
+) graphqlsubgraph.Storage {
+	return &unifiedDataSourceStorageAdapter{
+		dsService:       dsService,
+		dsCache:         dsCache,
+		namespaceMapper: namespaceMapper,
+	}
+}
+
+// setupContextWithNamespace sets up the proper context with namespace information for DataSource APIs
+func (s *unifiedDataSourceStorageAdapter) setupContextWithNamespace(ctx context.Context, namespace string) (context.Context, error) {
+	// Get the user from context
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user from context: %w", err)
+	}
+
+	// Get the org ID from the user
+	orgID := user.GetOrgID()
+	if orgID <= 0 {
+		return nil, fmt.Errorf("invalid org ID: %d", orgID)
+	}
+
+	// Format the namespace using the namespace mapper
+	properNamespace := s.namespaceMapper(orgID)
+
+	// Set the namespace in the k8s request context
+	ctx = k8srequest.WithNamespace(ctx, properNamespace)
+
+	return ctx, nil
+}
+
+// Get implements graphqlsubgraph.Storage - fetches a single datasource connection by UID
+func (s *unifiedDataSourceStorageAdapter) Get(ctx context.Context, namespace, name string) (resource.Object, error) {
+	// Set up proper context with namespace information
+	ctx, err := s.setupContextWithNamespace(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the user from context for authorization
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user from context: %w", err)
+	}
+
+	// Get the datasource by UID using the cache
+	ds, err := s.dsCache.GetDatasourceByUID(ctx, name, user, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get datasource connection: %w", err)
+	}
+
+	// Get namespace info for conversion
+	info, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace info: %w", err)
+	}
+
+	// Convert to DataSourceConnection
+	conn, err := asConnection(ds, info.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert datasource to connection: %w", err)
+	}
+
+	// Convert to resource.Object format for GraphQL using UnstructuredWrapper
+	return resource.NewUnstructuredWrapper(s.connectionToUnstructured(conn)), nil
+}
+
+// List implements graphqlsubgraph.Storage - fetches ALL datasource connections across all plugin types
+func (s *unifiedDataSourceStorageAdapter) List(ctx context.Context, namespace string, options graphqlsubgraph.ListOptions) (resource.ListObject, error) {
+	// Set up proper context with namespace information
+	ctx, err := s.setupContextWithNamespace(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get namespace info
+	info, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace info: %w", err)
+	}
+
+	// Get ALL datasources for the organization (not filtered by plugin type!)
+	allDataSources, err := s.dsService.GetDataSources(ctx, &datasources.GetDataSourcesQuery{
+		OrgID: info.OrgID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list datasources: %w", err)
+	}
+
+	// Convert all datasources to connections
+	connections := make([]datasourcev0alpha1.DataSourceConnection, 0, len(allDataSources))
+	for _, ds := range allDataSources {
+		conn, err := asConnection(ds, info.Value)
+		if err != nil {
+			// Log the error but continue with other datasources
+			continue
+		}
+		connections = append(connections, *conn)
+	}
+
+	// Create the connection list
+	connList := &datasourcev0alpha1.DataSourceConnectionList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "datasource.grafana.app/v0alpha1",
+			Kind:       "DataSourceConnectionList",
+		},
+		Items: connections,
+	}
+
+	// Convert to resource.ListObject format for GraphQL using UntypedList
+	return s.connectionListToUntypedList(connList), nil
+}
+
+// Create implements graphqlsubgraph.Storage - creates a new datasource connection
+func (s *unifiedDataSourceStorageAdapter) Create(ctx context.Context, namespace string, obj resource.Object) (resource.Object, error) {
+	// DataSource connections are typically created through the datasource service, not directly
+	// For now, return not implemented - this would need to integrate with the actual datasource service
+	return nil, fmt.Errorf("datasource connection creation not implemented via GraphQL")
+}
+
+// Update implements graphqlsubgraph.Storage - updates an existing datasource connection
+func (s *unifiedDataSourceStorageAdapter) Update(ctx context.Context, namespace, name string, obj resource.Object) (resource.Object, error) {
+	// DataSource connections are typically updated through the datasource service, not directly
+	// For now, return not implemented - this would need to integrate with the actual datasource service
+	return nil, fmt.Errorf("datasource connection update not implemented via GraphQL")
+}
+
+// Delete implements graphqlsubgraph.Storage - deletes a datasource connection
+func (s *unifiedDataSourceStorageAdapter) Delete(ctx context.Context, namespace, name string) error {
+	// DataSource connections are typically deleted through the datasource service, not directly
+	// For now, return not implemented - this would need to integrate with the actual datasource service
+	return fmt.Errorf("datasource connection deletion not implemented via GraphQL")
+}
+
+// connectionToUnstructured converts a DataSourceConnection to an unstructured object
+func (s *unifiedDataSourceStorageAdapter) connectionToUnstructured(conn *datasourcev0alpha1.DataSourceConnection) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "datasource.grafana.app/v0alpha1",
+		"kind":       "DataSourceConnection",
+		"metadata": map[string]interface{}{
+			"name":              conn.Name,
+			"namespace":         conn.Namespace,
+			"uid":               string(conn.UID),
+			"resourceVersion":   conn.ResourceVersion,
+			"generation":        conn.Generation,
+			"creationTimestamp": conn.CreationTimestamp.Time.Format("2006-01-02T15:04:05Z"),
+			"labels":            conn.Labels,
+		},
+		"spec": map[string]interface{}{
+			"title":       conn.Title,
+			"description": conn.Description,
+		},
+	})
+	return obj
+}
+
+// connectionListToUntypedList converts a DataSourceConnectionList to resource.UntypedList
+func (s *unifiedDataSourceStorageAdapter) connectionListToUntypedList(connList *datasourcev0alpha1.DataSourceConnectionList) resource.ListObject {
+	items := make([]resource.Object, len(connList.Items))
+	for i, conn := range connList.Items {
+		// Create a copy to avoid pointer issues
+		connCopy := conn
+		items[i] = resource.NewUnstructuredWrapper(s.connectionToUnstructured(&connCopy))
+	}
+
+	list := &resource.UntypedList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "datasource.grafana.app/v0alpha1",
+			Kind:       "DataSourceConnectionList",
+		},
+		ListMeta: connList.ListMeta,
+		Items:    items,
+	}
+
+	return list
+}

--- a/pkg/registry/apps/playlist/graphql_handler.go
+++ b/pkg/registry/apps/playlist/graphql_handler.go
@@ -8,10 +8,24 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 	playlistv0alpha1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
 	"github.com/graphql-go/graphql"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // playlistGraphQLHandler implements ResourceGraphQLHandler for playlist resources
-type playlistGraphQLHandler struct{}
+type playlistGraphQLHandler struct {
+	// Add subgraph registry to enable cross-resource relationships
+	subgraphRegistry SubgraphRegistry
+}
+
+// SubgraphRegistry interface for finding other subgraphs
+type SubgraphRegistry interface {
+	GetSubgraphForKind(gvk schema.GroupVersionKind) (SubgraphInterface, error)
+}
+
+// SubgraphInterface represents a GraphQL subgraph
+type SubgraphInterface interface {
+	GetStorage(gvr schema.GroupVersionResource) graphqlsubgraph.Storage
+}
 
 // Ensure playlistGraphQLHandler implements ResourceGraphQLHandler
 var _ graphqlsubgraph.ResourceGraphQLHandler = (*playlistGraphQLHandler)(nil)
@@ -21,6 +35,13 @@ func NewPlaylistGraphQLHandler() graphqlsubgraph.ResourceGraphQLHandler {
 	return &playlistGraphQLHandler{}
 }
 
+// NewPlaylistGraphQLHandlerWithRegistry creates a new playlist GraphQL handler with subgraph registry for relationships
+func NewPlaylistGraphQLHandlerWithRegistry(registry SubgraphRegistry) graphqlsubgraph.ResourceGraphQLHandler {
+	return &playlistGraphQLHandler{
+		subgraphRegistry: registry,
+	}
+}
+
 // GetResourceKind returns the playlist resource kind
 func (h *playlistGraphQLHandler) GetResourceKind() resource.Kind {
 	return playlistv0alpha1.PlaylistKind()
@@ -28,7 +49,7 @@ func (h *playlistGraphQLHandler) GetResourceKind() resource.Kind {
 
 // GetGraphQLFields returns playlist-specific GraphQL fields
 func (h *playlistGraphQLHandler) GetGraphQLFields() graphql.Fields {
-	// Create playlist item type
+	// Create playlist item type with relationship support
 	playlistItemType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "PlaylistItem",
 		Fields: graphql.Fields{
@@ -38,6 +59,12 @@ func (h *playlistGraphQLHandler) GetGraphQLFields() graphql.Fields {
 			"value":       &graphql.Field{Type: graphql.String},
 			"order":       &graphql.Field{Type: graphql.Int},
 			"title":       &graphql.Field{Type: graphql.String},
+			// Add dashboard relationship field
+			"dashboard": &graphql.Field{
+				Type:        h.getDashboardTypeReference(),
+				Description: "Dashboard referenced by this playlist item (value matches dashboard metadata.name)",
+				Resolve:     h.createDashboardResolver(),
+			},
 		},
 	})
 
@@ -47,6 +74,119 @@ func (h *playlistGraphQLHandler) GetGraphQLFields() graphql.Fields {
 		"name":     &graphql.Field{Type: graphql.String},
 		"interval": &graphql.Field{Type: graphql.String},
 		"items":    &graphql.Field{Type: graphql.NewList(playlistItemType)},
+	}
+}
+
+// getDashboardTypeReference returns a reference to the Dashboard type from the dashboard subgraph
+func (h *playlistGraphQLHandler) getDashboardTypeReference() graphql.Type {
+	// In proper GraphQL federation, this would reference the Dashboard type from the dashboard subgraph
+	// For now, we'll create a minimal interface that represents the Dashboard structure
+	// without conflicting with the actual Dashboard type name
+	return graphql.NewObject(graphql.ObjectConfig{
+		Name: "DashboardReference",
+		Fields: graphql.Fields{
+			"uid":         &graphql.Field{Type: graphql.String},
+			"title":       &graphql.Field{Type: graphql.String},
+			"description": &graphql.Field{Type: graphql.String},
+			"metadata": &graphql.Field{
+				Type: graphql.NewObject(graphql.ObjectConfig{
+					Name: "DashboardReferenceMetadata",
+					Fields: graphql.Fields{
+						"name":              &graphql.Field{Type: graphql.String},
+						"uid":               &graphql.Field{Type: graphql.String},
+						"namespace":         &graphql.Field{Type: graphql.String},
+						"creationTimestamp": &graphql.Field{Type: graphql.String},
+					},
+				}),
+			},
+		},
+	})
+}
+
+// createDashboardResolver creates a resolver function for the dashboard relationship
+func (h *playlistGraphQLHandler) createDashboardResolver() graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		// Extract the playlist item from the source
+		playlistItem, ok := p.Source.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected playlist item, got %T", p.Source)
+		}
+
+		// Get the type and value from the playlist item
+		itemType, typeExists := playlistItem["type"].(string)
+		itemValue, valueExists := playlistItem["value"].(string)
+
+		if !typeExists || !valueExists {
+			return nil, nil // Return null if type or value is missing
+		}
+
+		// Only resolve dashboard relationship for dashboard_by_uid type
+		if itemType != "dashboard_by_uid" {
+			return nil, nil // Return null for other types
+		}
+
+		// If we don't have a subgraph registry, we can't resolve the relationship
+		if h.subgraphRegistry == nil {
+			// For demonstration, return a mock dashboard object
+			return h.createMockDashboard(itemValue), nil
+		}
+
+		// Find the dashboard subgraph
+		dashboardGVK := schema.GroupVersionKind{
+			Group:   "dashboard.grafana.app",
+			Version: "v1beta1",
+			Kind:    "Dashboard",
+		}
+
+		dashboardSubgraph, err := h.subgraphRegistry.GetSubgraphForKind(dashboardGVK)
+		if err != nil {
+			// Graceful degradation - return null if dashboard subgraph is not available
+			return nil, nil
+		}
+
+		// Get the dashboard storage
+		dashboardGVR := schema.GroupVersionResource{
+			Group:    "dashboard.grafana.app",
+			Version:  "v1beta1",
+			Resource: "dashboards",
+		}
+
+		storage := dashboardSubgraph.GetStorage(dashboardGVR)
+		if storage == nil {
+			return nil, nil
+		}
+
+		// Extract namespace from context
+		namespace := "default" // Default namespace
+		if p.Context != nil {
+			if ns, ok := p.Context.Value("namespace").(string); ok {
+				namespace = ns
+			}
+		}
+
+		// Fetch the dashboard by name (playlist item value matches metadata.name)
+		dashboard, err := storage.Get(p.Context, namespace, itemValue)
+		if err != nil {
+			// Return null if dashboard is not found (graceful degradation)
+			return nil, nil
+		}
+
+		return dashboard, nil
+	}
+}
+
+// createMockDashboard creates a mock dashboard object for demonstration
+func (h *playlistGraphQLHandler) createMockDashboard(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"uid":         fmt.Sprintf("uid-%s", name), // UID is different from name
+		"title":       fmt.Sprintf("Dashboard %s", name),
+		"description": fmt.Sprintf("Dashboard with name %s", name),
+		"metadata": map[string]interface{}{
+			"name":              name, // This is what the playlist item value matches
+			"uid":               fmt.Sprintf("uid-%s", name),
+			"namespace":         "default",
+			"creationTimestamp": "2024-01-01T00:00:00Z",
+		},
 	}
 }
 

--- a/pkg/services/apiserver/builder/graphql.go
+++ b/pkg/services/apiserver/builder/graphql.go
@@ -1,0 +1,57 @@
+package builder
+
+import (
+	graphqlsubgraph "github.com/grafana/grafana-app-sdk/graphql/subgraph"
+)
+
+// GraphQLCapableBuilder is an optional interface that API builders can implement
+// to provide GraphQL federation support. This allows APIs to expose their resources
+// through GraphQL without requiring changes to the core API builder interfaces.
+//
+// Any API builder that implements this interface will be automatically discovered
+// and registered with the GraphQL federation system.
+type GraphQLCapableBuilder interface {
+	APIGroupBuilder
+
+	// GetGraphQLSubgraph returns the GraphQL subgraph for this API.
+	// The subgraph includes auto-generated GraphQL schema and resolvers
+	// based on the API's managed resources.
+	GetGraphQLSubgraph() (graphqlsubgraph.GraphQLSubgraph, error)
+}
+
+// GraphQLDiscovery provides functionality to discover and register
+// GraphQL-capable API builders with the federation system.
+type GraphQLDiscovery struct {
+	providers []graphqlsubgraph.GraphQLSubgraphProvider
+}
+
+// NewGraphQLDiscovery creates a new GraphQL discovery instance
+func NewGraphQLDiscovery() *GraphQLDiscovery {
+	return &GraphQLDiscovery{
+		providers: make([]graphqlsubgraph.GraphQLSubgraphProvider, 0),
+	}
+}
+
+// DiscoverFromBuilders scans a list of API builders and extracts any that
+// implement GraphQLCapableBuilder
+func (d *GraphQLDiscovery) DiscoverFromBuilders(builders []APIGroupBuilder) []graphqlsubgraph.GraphQLSubgraphProvider {
+	var graphqlProviders []graphqlsubgraph.GraphQLSubgraphProvider
+
+	for _, builder := range builders {
+		if graphqlBuilder, ok := builder.(GraphQLCapableBuilder); ok {
+			graphqlProviders = append(graphqlProviders, graphqlBuilder)
+		}
+	}
+
+	return graphqlProviders
+}
+
+// RegisterProviders registers discovered GraphQL providers with the global registry
+func (d *GraphQLDiscovery) RegisterProviders(providers []graphqlsubgraph.GraphQLSubgraphProvider) {
+	d.providers = append(d.providers, providers...)
+}
+
+// GetProviders returns all discovered providers
+func (d *GraphQLDiscovery) GetProviders() []graphqlsubgraph.GraphQLSubgraphProvider {
+	return d.providers
+}


### PR DESCRIPTION
## Overview

This PR is part of a Hackathon project. It makes the following enhancements to the federated GraphQL API:

- Adds the scaffolding needed to support APIs defined in `pkg/registry/apis/apis.go` in the graph
- Implements a query for `dashboard` & `dashboards`
<img width="1505" alt="demo dashboards" src="https://github.com/user-attachments/assets/3abd94d3-2a4f-4ad0-b51a-ae40030b3013" />

- Implements a query for `datasourceconnection` & `datasourceconnections`
<img width="1508" alt="demo datasources" src="https://github.com/user-attachments/assets/58e77fd0-e526-4f87-904a-f1e186cac153" />

- Enables support for joining playlist and dashboard data in a single query:

<img width="1508" alt="demo-playlists-with-dashboard" src="https://github.com/user-attachments/assets/a9b37af2-dcab-4839-b5a7-71930fdd187e" />

## Extras

`grafanaql-v02.json` is a [Bruno](https://www.usebruno.com) request collection that contains the new queries:

[grafanaql-v02.json](https://github.com/user-attachments/files/21034346/grafanaql-v02.json)
