### PR TITLE
Prometheus: Don't use empty matcher if there is no match parameter

### DIFF
--- a/packages/grafana-prometheus/src/constants.ts
+++ b/packages/grafana-prometheus/src/constants.ts
@@ -19,8 +19,9 @@ export const EMPTY_SELECTOR = '{}';
 
 export const DEFAULT_SERIES_LIMIT = 40000;
 
-export const MATCH_ALL_LABELS_STR = '__name__!=""';
-
+/**
+ * Only for /series endpoint. Don't use this anywhere else as it cause an expensive query
+ */
 export const MATCH_ALL_LABELS = '{__name__!=""}';
 
 export const METRIC_LABEL = '__name__';

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -1016,7 +1016,7 @@ describe('PrometheusDatasource', () => {
       ];
 
       const result = extractResourceMatcher(queries, filters);
-      expect(result).toBe('{__name__!="",instance="localhost"}');
+      expect(result).toBe('{instance="localhost"}');
     });
 
     it('should extract matcher from given filters only', () => {
@@ -1035,7 +1035,7 @@ describe('PrometheusDatasource', () => {
       ];
 
       const result = extractResourceMatcher(queries, filters);
-      expect(result).toBe('{__name__!="",instance="localhost",job!="testjob"}');
+      expect(result).toBe('{instance="localhost",job!="testjob"}');
     });
 
     it('should extract matcher as match-all from no query and filter', () => {
@@ -1043,7 +1043,7 @@ describe('PrometheusDatasource', () => {
       const filters: AdHocVariableFilter[] = [];
 
       const result = extractResourceMatcher(queries, filters);
-      expect(result).toBe('{__name__!=""}');
+      expect(result).toBeUndefined();
     });
 
     it('should extract the correct matcher for queries with `... or vector(0)`', () => {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -913,7 +913,10 @@ export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQ
  * adhocFilters={key:"instance", operator:"=", value:"localhost"}
  * returns {__name__=~"metricName", instance="localhost"}
  */
-export const extractResourceMatcher = (queries: PromQuery[], adhocFilters: AdHocVariableFilter[]): string => {
+export const extractResourceMatcher = (
+  queries: PromQuery[],
+  adhocFilters: AdHocVariableFilter[]
+): string | undefined => {
   // Extract metric names from queries we have already
   const metricMatch = populateMatchParamsFromQueries(queries);
   const labelFilters: QueryBuilderLabelFilter[] = adhocFilters.map((f) => ({
@@ -924,5 +927,9 @@ export const extractResourceMatcher = (queries: PromQuery[], adhocFilters: AdHoc
   // Extract label filters from the filters we have already
   const labelsMatch = renderLabelsWithoutBrackets(labelFilters);
   // Create a matcher using metric names and label filters
-  return `{${[metricMatch, ...labelsMatch].join(',')}}`;
+  if (metricMatch.length === 0 && labelsMatch.length === 0) {
+    return undefined;
+  }
+
+  return `{${[...metricMatch, ...labelsMatch].join(',')}}`;
 };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -926,10 +926,11 @@ export const extractResourceMatcher = (
   }));
   // Extract label filters from the filters we have already
   const labelsMatch = renderLabelsWithoutBrackets(labelFilters);
-  // Create a matcher using metric names and label filters
+
   if (metricMatch.length === 0 && labelsMatch.length === 0) {
     return undefined;
   }
 
+  // Create a matcher using metric names and label filters
   return `{${[...metricMatch, ...labelsMatch].join(',')}}`;
 };

--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -1042,18 +1042,18 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
         { expr: 'metric2', refId: '2' },
       ];
       const result = populateMatchParamsFromQueries(queries);
-      expect(result).toBe(`__name__=~"metric1|metric2"`);
+      expect(result).toEqual([`__name__=~"metric1|metric2"`]);
     });
 
     it('should handle binary queries', () => {
       const queries: PromQuery[] = [{ expr: 'binary{label="val"} + second{}', refId: '1' }];
       const result = populateMatchParamsFromQueries(queries);
-      expect(result).toBe(`__name__=~"binary|second"`);
+      expect(result).toEqual([`__name__=~"binary|second"`]);
     });
 
     it('should handle undefined queries', () => {
       const result = populateMatchParamsFromQueries(undefined);
-      expect(result).toBe('__name__!=""');
+      expect(result).toEqual([]);
     });
 
     it('should handle UTF8 metrics', () => {
@@ -1071,13 +1071,13 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
     it('should return match-all matcher if there is no expr in queries', () => {
       const queries: PromQuery[] = [{ expr: '', refId: '1' }];
       const result = populateMatchParamsFromQueries(queries);
-      expect(result).toBe('__name__!=""');
+      expect(result).toEqual([]);
     });
 
     it('should return match-all matcher if there is no query', () => {
       const queries: PromQuery[] = [];
       const result = populateMatchParamsFromQueries(queries);
-      expect(result).toBe('__name__!=""');
+      expect(result).toEqual([]);
     });
 
     it('should extract the correct matcher for queries with `... or vector(0)`', () => {
@@ -1088,7 +1088,7 @@ describe('PrometheusLanguageProvider with feature toggle', () => {
         },
       ];
       const result = populateMatchParamsFromQueries(queries);
-      expect(result).toBe('__name__=~"go_cpu_classes_idle_cpu_seconds_total"');
+      expect(result).toEqual(['__name__=~"go_cpu_classes_idle_cpu_seconds_total"']);
     });
   });
 });

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -796,7 +796,7 @@ function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token
  * Handles UTF8 metrics by properly escaping them.
  *
  * @param {PromQuery[]} queries - Array of Prometheus queries
- * @returns {string} Metric names as a regex matcher
+ * @returns {string[]} Metric names as a regex matcher inside the array for easy handling
  */
 export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string[] => {
   if (!queries) {

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -18,7 +18,7 @@ import { BackendSrvRequest } from '@grafana/runtime';
 
 import { buildCacheHeaders, getDaysToCacheMetadata, getDefaultCacheHeaders } from './caching';
 import { Label } from './components/monaco-query-field/monaco-completion-provider/situation';
-import { DEFAULT_SERIES_LIMIT, MATCH_ALL_LABELS_STR, EMPTY_SELECTOR, REMOVE_SERIES_LIMIT } from './constants';
+import { DEFAULT_SERIES_LIMIT, EMPTY_SELECTOR, REMOVE_SERIES_LIMIT } from './constants';
 import { PrometheusDatasource } from './datasource';
 import {
   extractLabelMatchers,
@@ -798,9 +798,9 @@ function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token
  * @param {PromQuery[]} queries - Array of Prometheus queries
  * @returns {string} Metric names as a regex matcher
  */
-export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string => {
+export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string[] => {
   if (!queries) {
-    return MATCH_ALL_LABELS_STR;
+    return [];
   }
 
   const metrics = (queries ?? []).reduce<string[]>((params, query) => {
@@ -818,5 +818,5 @@ export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string =>
     return params;
   }, []);
 
-  return metrics.length === 0 ? MATCH_ALL_LABELS_STR : `__name__=~"${metrics.join('|')}"`;
+  return metrics.length === 0 ? [] : [`__name__=~"${metrics.join('|')}"`];
 };


### PR DESCRIPTION
**What is this feature?**

When there is no matcher provided, prometheus data source fallbacks to use empty matcher for the sake of consistency. Because for series endpoint we have to provide at least one matcher. But that empty matcher creates very expensive queries in the end. So instead of using a default matcher here we omit the empty matcher where possible.

**Why do we need this feature?**

Better and cheaper resource queries

**Who is this feature for?**

Prometheus users


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
