### PR TITLE
GrafanaUI: Fix prevent RadioButtonGroup overflow

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -119,6 +119,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       border: `1px solid ${theme.components.input.borderColor}`,
       borderRadius: theme.shape.radius.default,
       padding: RADIO_GROUP_PADDING,
+      maxWidth: '100%', // Ensure it doesn't overflow its parent
       '&:hover': {
         borderColor: theme.components.input.borderHover,
       },
@@ -126,6 +127,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     fullWidth: css({
       display: 'flex',
       flexGrow: 1,
+      maxWidth: '100%', // Ensure it respects the parent's width
     }),
     icon: css({
       marginRight: '6px',

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -119,7 +119,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       border: `1px solid ${theme.components.input.borderColor}`,
       borderRadius: theme.shape.radius.default,
       padding: RADIO_GROUP_PADDING,
-      maxWidth: '100%', // Ensure it doesn't overflow its parent
+      maxWidth: '100%', 
       '&:hover': {
         borderColor: theme.components.input.borderHover,
       },
@@ -127,7 +127,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     fullWidth: css({
       display: 'flex',
       flexGrow: 1,
-      maxWidth: '100%', // Ensure it respects the parent's width
+      maxWidth: '100%', 
     }),
     icon: css({
       marginRight: '6px',

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -127,8 +127,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     fullWidth: css({
       display: 'flex',
       flexGrow: 1,
-      maxWidth: '100%', 
-    }),
+    }),  
     icon: css({
       marginRight: '6px',
     }),


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
This PR fixes an issue where the RadioButtonGroup component does not shrink to fit its parent container, causing option labels to overflow

Fixes #107037

