### PR TITLE
Plugin Extensions: Expose PluginMeta generic in usePluginContext

### DIFF
--- a/packages/grafana-data/src/context/plugins/DataSourcePluginContextProvider.tsx
+++ b/packages/grafana-data/src/context/plugins/DataSourcePluginContextProvider.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, ReactElement, useMemo } from 'react';
 
 import { DataSourceInstanceSettings } from '../../types/datasource';
 
-import { Context, DataSourcePluginContextType } from './PluginContext';
+import { PluginContext, DataSourcePluginContextType } from './PluginContext';
 
 export type DataSourcePluginContextProviderProps = {
   instanceSettings: DataSourceInstanceSettings;
@@ -16,5 +16,5 @@ export function DataSourcePluginContextProvider(
     return { instanceSettings, meta: instanceSettings.meta };
   }, [instanceSettings]);
 
-  return <Context.Provider value={value}>{children}</Context.Provider>;
+  return <PluginContext.Provider value={value}>{children}</PluginContext.Provider>;
 }

--- a/packages/grafana-data/src/context/plugins/PluginContext.tsx
+++ b/packages/grafana-data/src/context/plugins/PluginContext.tsx
@@ -1,14 +1,15 @@
 import { createContext } from 'react';
 
+import { KeyValue } from '../../types/data';
 import { DataSourceInstanceSettings } from '../../types/datasource';
 import { PluginMeta } from '../../types/plugin';
 
-export interface PluginContextType {
-  meta: PluginMeta;
+export interface PluginContextType<T extends KeyValue = KeyValue> {
+  meta: PluginMeta<T>;
 }
 
-export interface DataSourcePluginContextType extends PluginContextType {
+export interface DataSourcePluginContextType<T extends KeyValue = KeyValue> extends PluginContextType<T> {
   instanceSettings: DataSourceInstanceSettings;
 }
 
-export const Context = createContext<PluginContextType | undefined>(undefined);
+export const PluginContext = createContext<PluginContextType | undefined>(undefined);

--- a/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
+++ b/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, ReactElement } from 'react';
 
 import { PluginMeta } from '../../types/plugin';
 
-import { Context } from './PluginContext';
+import { PluginContext } from './PluginContext';
 
 export type PluginContextProviderProps = {
   meta: PluginMeta;
@@ -10,5 +10,5 @@ export type PluginContextProviderProps = {
 
 export function PluginContextProvider(props: PropsWithChildren<PluginContextProviderProps>): ReactElement {
   const { children, ...rest } = props;
-  return <Context.Provider value={rest}>{children}</Context.Provider>;
+  return <PluginContext.Provider value={rest}>{children}</PluginContext.Provider>;
 }

--- a/packages/grafana-data/src/context/plugins/guards.ts
+++ b/packages/grafana-data/src/context/plugins/guards.ts
@@ -1,5 +1,9 @@
+import { KeyValue } from '../../types/data';
+
 import { type DataSourcePluginContextType, type PluginContextType } from './PluginContext';
 
-export function isDataSourcePluginContext(context: PluginContextType): context is DataSourcePluginContextType {
+export function isDataSourcePluginContext<T extends KeyValue = KeyValue>(
+  context: PluginContextType<T>
+): context is DataSourcePluginContextType<T> {
   return 'instanceSettings' in context && 'meta' in context;
 }

--- a/packages/grafana-data/src/context/plugins/usePluginContext.tsx
+++ b/packages/grafana-data/src/context/plugins/usePluginContext.tsx
@@ -1,9 +1,12 @@
-import { useContext } from 'react';
+import { Context, useContext } from 'react';
 
-import { Context, PluginContextType } from './PluginContext';
+import { KeyValue } from '../../types/data';
 
-export function usePluginContext(): PluginContextType | null {
-  const context = useContext(Context);
+import { PluginContext, PluginContextType } from './PluginContext';
+
+export function usePluginContext<T extends KeyValue = KeyValue>(): PluginContextType<T> | null {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const context = useContext(PluginContext as Context<PluginContextType<T> | undefined>);
 
   // The extensions hooks (e.g. `usePluginLinks()`) are using this hook to check
   // if they are inside a plugin or not (core Grafana), so we should be able to return an empty state as well (`null`).

--- a/packages/grafana-data/src/context/plugins/usePluginContext.tsx
+++ b/packages/grafana-data/src/context/plugins/usePluginContext.tsx
@@ -1,12 +1,11 @@
-import { Context, useContext } from 'react';
+import { useContext } from 'react';
 
 import { KeyValue } from '../../types/data';
 
 import { PluginContext, PluginContextType } from './PluginContext';
 
 export function usePluginContext<T extends KeyValue = KeyValue>(): PluginContextType<T> | null {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const context = useContext(PluginContext as Context<PluginContextType<T> | undefined>);
+  const context = useContext(PluginContext);
 
   // The extensions hooks (e.g. `usePluginLinks()`) are using this hook to check
   // if they are inside a plugin or not (core Grafana), so we should be able to return an empty state as well (`null`).
@@ -14,5 +13,6 @@ export function usePluginContext<T extends KeyValue = KeyValue>(): PluginContext
     return null;
   }
 
-  return context;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return context as PluginContextType<T>;
 }

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -435,7 +435,7 @@ export { type GroupingToMatrixTransformerOptions } from './transformations/trans
 export {
   type PluginContextType,
   type DataSourcePluginContextType,
-  Context as PluginContext,
+  PluginContext,
 } from './context/plugins/PluginContext';
 export { type PluginContextProviderProps, PluginContextProvider } from './context/plugins/PluginContextProvider';
 export {


### PR DESCRIPTION
**What is this feature?**

When using `AppRootProps`, you can pass in a type that will be passed through to the generic for `PluginMeta`. However, when using `usePluginContext`, there was no way to pass a type through, and so `context.meta.jsonData` was always typed as an empty record. This updates the signature for `usePluginContext` to accept a generic to pass through to `PluginMeta`.

**Why do we need this feature?**

To allow `jsonData` to be consumed when using `usePluginContext` without needing to type-cast in the consumption of it.

**Who is this feature for?**

Anyone using `usePluginContext` in a plugin.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana-setupguide-app/pull/355 (🔐)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
