### PR TITLE
Test Data Source: Allow inputs to render `0` values

### DIFF
--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RandomWalkEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RandomWalkEditor.tsx
@@ -47,7 +47,7 @@ export const RandomWalkEditor = ({ onChange, query }: EditorProps) => {
               id={`randomWalk-${id}-${query.refId}`}
               min={min}
               step={step}
-              value={(query as any)[id as keyof TestDataDataQuery] || placeholder}
+              value={(query as any)[id as keyof TestDataDataQuery] ?? placeholder}
               placeholder={placeholder}
               onChange={onChange}
             />


### PR DESCRIPTION
**What is this feature?**

The test data source's Random Walk editor currently does not render values if they are `0`. `0` is false-ish and thus the condition will fall back to the placeholder. Using `??` to fix.