### PR TITLE
Alerting: idempotent decrypt\encrypt operations on extra configs

### DIFF
--- a/pkg/services/ngalert/notifier/crypto.go
+++ b/pkg/services/ngalert/notifier/crypto.go
@@ -279,7 +279,6 @@ func (c *alertmanagerCrypto) DecryptExtraConfigs(ctx context.Context, config *de
 		// Check if the config is encrypted by trying to base64 decode it
 		encryptedValue, err := base64.StdEncoding.DecodeString(config.ExtraConfigs[i].AlertmanagerConfig[len(cryptoPrefix):])
 		if err != nil {
-			// If it can't be base64 decoded, assume it's already decrypted and skip
 			return fmt.Errorf("failed to decode extra configuration: %w", err)
 		}
 

--- a/pkg/services/ngalert/notifier/crypto.go
+++ b/pkg/services/ngalert/notifier/crypto.go
@@ -6,12 +6,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/secrets"
+)
+
+const (
+	// encryptedContentPrefix is a marker that identifies encrypted Alertmanager configurations.
+	// When this prefix is present at the beginning of a configuration string:
+	// 1. During encryption: It indicates the content is already encrypted and should be skipped
+	// 2. During decryption: It indicates the content (minus this prefix) should be base64 decoded
+	//    and then decrypted using the secrets service
+	// This prefix helps maintain idempotency in encryption/decryption operations.
+	cryptoPrefix = "crypto_"
 )
 
 // Crypto allows decryption of Alertmanager Configuration and encryption of arbitrary payloads.
@@ -243,12 +254,17 @@ func (c *alertmanagerCrypto) Decrypt(ctx context.Context, payload []byte) ([]byt
 
 func (c *alertmanagerCrypto) EncryptExtraConfigs(ctx context.Context, config *definitions.PostableUserConfig) error {
 	for i := range config.ExtraConfigs {
+		// If it has prefix, consider it encrypted already
+		if strings.HasPrefix(config.ExtraConfigs[i].AlertmanagerConfig, cryptoPrefix) {
+			continue
+		}
+
 		encryptedValue, err := c.secrets.Encrypt(ctx, []byte(config.ExtraConfigs[i].AlertmanagerConfig), secrets.WithoutScope())
 		if err != nil {
 			return fmt.Errorf("failed to encrypt extra configuration: %w", err)
 		}
 
-		config.ExtraConfigs[i].AlertmanagerConfig = base64.StdEncoding.EncodeToString(encryptedValue)
+		config.ExtraConfigs[i].AlertmanagerConfig = cryptoPrefix + base64.StdEncoding.EncodeToString(encryptedValue)
 	}
 
 	return nil
@@ -256,11 +272,15 @@ func (c *alertmanagerCrypto) EncryptExtraConfigs(ctx context.Context, config *de
 
 func (c *alertmanagerCrypto) DecryptExtraConfigs(ctx context.Context, config *definitions.PostableUserConfig) error {
 	for i := range config.ExtraConfigs {
+		// If it does not have prefix, consider it decrypted already
+		if !strings.HasPrefix(config.ExtraConfigs[i].AlertmanagerConfig, cryptoPrefix) {
+			continue
+		}
 		// Check if the config is encrypted by trying to base64 decode it
-		encryptedValue, err := base64.StdEncoding.DecodeString(config.ExtraConfigs[i].AlertmanagerConfig)
+		encryptedValue, err := base64.StdEncoding.DecodeString(config.ExtraConfigs[i].AlertmanagerConfig[len(cryptoPrefix):])
 		if err != nil {
 			// If it can't be base64 decoded, assume it's already decrypted and skip
-			continue
+			return fmt.Errorf("failed to decode extra configuration: %w", err)
 		}
 
 		decryptedValue, err := c.secrets.Decrypt(ctx, encryptedValue)

--- a/pkg/services/ngalert/notifier/crypto_test.go
+++ b/pkg/services/ngalert/notifier/crypto_test.go
@@ -1,0 +1,106 @@
+package notifier
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+)
+
+func TestEncryptExtraConfigs(t *testing.T) {
+	config := "plain-text-config"
+	encryptedConfig := base64.StdEncoding.EncodeToString([]byte(config))
+	tests := []struct {
+		name           string
+		inputConfig    string
+		expectedConfig string
+	}{
+		{
+			name:           "Encrypts unencrypted configs",
+			inputConfig:    config,
+			expectedConfig: cryptoPrefix + encryptedConfig,
+		},
+		{
+			name:           "Skips already encrypted configs",
+			inputConfig:    cryptoPrefix + "very-encrypted-data",
+			expectedConfig: cryptoPrefix + "very-encrypted-data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := fakes.NewFakeSecretsService()
+
+			c := &alertmanagerCrypto{
+				secrets: m,
+			}
+
+			cfg := &definitions.PostableUserConfig{
+				ExtraConfigs: []definitions.ExtraConfiguration{
+					{AlertmanagerConfig: tt.inputConfig},
+				},
+			}
+
+			err := c.EncryptExtraConfigs(context.Background(), cfg)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedConfig, cfg.ExtraConfigs[0].AlertmanagerConfig)
+		})
+	}
+}
+
+func TestDecryptExtraConfigs(t *testing.T) {
+	decryptedData := "derypted-data"
+	decryptedDataBase64 := base64.StdEncoding.EncodeToString([]byte(decryptedData))
+	tests := []struct {
+		name           string
+		inputConfig    string
+		expectedError  string
+		expectedConfig string
+	}{
+		{
+			name:           "Decrypts encrypted configs",
+			inputConfig:    cryptoPrefix + decryptedDataBase64,
+			expectedConfig: decryptedData,
+		},
+		{
+			name:           "Skips already encrypted configs",
+			inputConfig:    "very-decrypted-data",
+			expectedConfig: "very-decrypted-data",
+		},
+		{
+			name:          "Fails if not base64 encoded",
+			inputConfig:   cryptoPrefix + "plain-text-config",
+			expectedError: "failed to decode extra configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := fakes.NewFakeSecretsService()
+			c := &alertmanagerCrypto{
+				secrets: m,
+			}
+
+			cfg := &definitions.PostableUserConfig{
+				ExtraConfigs: []definitions.ExtraConfiguration{
+					{AlertmanagerConfig: tt.inputConfig},
+				},
+			}
+
+			err := c.DecryptExtraConfigs(context.Background(), cfg)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedConfig, cfg.ExtraConfigs[0].AlertmanagerConfig)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new encryption/decryption prefix (`cryptoPrefix`) for handling extra configurations in a more idempotent and consistent manner. It also adds comprehensive unit tests to validate these changes. The most important updates include the implementation of the prefix logic, modifications to the encryption and decryption methods, and the addition of tests to ensure the correctness of these operations.
