### PR TITLE
chore: ignore Grafana Enterprise source files from prettier checks in CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -40,3 +40,6 @@ public/mockServiceWorker.js
 
 /.nx/cache
 /.nx/workspace-data
+
+# Ignore enterprise source files
+public/app/extensions/


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We are experiencing build failures on OSS Grafana due to a source file which requires a Prettier run in Grafana Enterprise. In my opinion, we should prevent merge in Grafana Enterprise on Prettier failures (as we do in OSS) and we should just ignore the entire Enterprise folder when doing the Prettier check on CI.

