### PR TITLE
[WIP] StateTimeline: Add state filter option

### DIFF
--- a/packages/grafana-schema/src/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen.ts
@@ -30,6 +30,10 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   rowHeight: number;
   /**
+   * Optional list of states to display (all states shown if empty)
+   */
+  selectedStates?: Array<string>;
+  /**
    * Show timeline values on chart
    */
   showValue: ui.VisibilityMode;
@@ -40,6 +44,7 @@ export const defaultOptions: Partial<Options> = {
   mergeValues: true,
   perPage: 20,
   rowHeight: 0.9,
+  selectedStates: [],
   showValue: ui.VisibilityMode.Auto,
 };
 

--- a/public/app/plugins/panel/state-timeline/StateSelector.tsx
+++ b/public/app/plugins/panel/state-timeline/StateSelector.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+
+import { StandardEditorProps, SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { MultiSelect } from '@grafana/ui';
+
+interface StateSelectorSettings {
+  // Future: could add options here for filtering which states to show
+}
+
+interface StateSelectorProps extends StandardEditorProps<string[], StateSelectorSettings> {
+  // Additional props if needed
+}
+
+export const StateSelector: React.FC<StateSelectorProps> = ({ value = [], onChange, context }) => {
+  // Extract available states from the current data
+  const availableStates = useMemo(() => {
+    if (!context.data) {
+      return [];
+    }
+
+    const stateSet = new Set<string>();
+
+    // Iterate through all frames and non-time fields to collect unique values
+    context.data.forEach((frame) => {
+      frame.fields.forEach((field) => {
+        if (field.type !== 'time') {
+          field.values.forEach((val) => {
+            if (val != null && val !== '') {
+              // Convert to string to handle different value types
+              stateSet.add(String(val));
+            }
+          });
+        }
+      });
+    });
+
+    // Convert to SelectableValue array and sort
+    return Array.from(stateSet)
+      .sort()
+      .map(
+        (state): SelectableValue<string> => ({
+          label: state,
+          value: state,
+        })
+      );
+  }, [context.data]);
+
+  const selectedStates = useMemo(() => {
+    return value.map(
+      (state): SelectableValue<string> => ({
+        label: state,
+        value: state,
+      })
+    );
+  }, [value]);
+
+  const handleChange = (selections: Array<SelectableValue<string>>) => {
+    const newStates = selections.map((selection) => selection.value!).filter(Boolean);
+    onChange(newStates);
+  };
+
+  return (
+    <MultiSelect
+      options={availableStates}
+      value={selectedStates}
+      onChange={handleChange}
+      placeholder={t('state-timeline.state-selector.placeholder', 'Select states')}
+      isClearable
+      closeMenuOnSelect={false}
+      maxVisibleValues={5}
+    />
+  );
+};

--- a/public/app/plugins/panel/state-timeline/module.tsx
+++ b/public/app/plugins/panel/state-timeline/module.tsx
@@ -13,6 +13,7 @@ import { InsertNullsEditor } from '../timeseries/InsertNullsEditor';
 import { SpanNullsEditor } from '../timeseries/SpanNullsEditor';
 import { NullEditorSettings } from '../timeseries/config';
 
+import { StateSelector } from './StateSelector';
 import { StateTimelinePanel } from './StateTimelinePanel';
 import { timelinePanelChangedHandler } from './migrations';
 import { defaultFieldConfig, defaultOptions, FieldConfig, Options } from './panelcfg.gen';
@@ -152,6 +153,15 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(StateTimelinePanel)
           step: 1,
           integer: true,
         },
+      })
+      .addCustomEditor({
+        id: 'selectedStates',
+        path: 'selectedStates',
+        name: t('state-timeline.name-selected-states', 'Filter'),
+        description: t('state-timeline.description-selected-states', 'States to display. Leave empty to show all.'),
+        category,
+        editor: StateSelector,
+        defaultValue: defaultOptions.selectedStates,
       });
 
     commonOptionsBuilder.addLegendOptions(builder, false);

--- a/public/app/plugins/panel/state-timeline/panelcfg.cue
+++ b/public/app/plugins/panel/state-timeline/panelcfg.cue
@@ -39,6 +39,8 @@ composableKinds: PanelCfg: {
 					alignValue?: ui.TimelineValueAlignment & (*"left" | _)
 					//Enables pagination when > 0
 					perPage?: number & >=1 | *20
+					//Optional list of states to display (all states shown if empty)
+					selectedStates?: [...string]
 				} @cuetsy(kind="interface")
 				FieldConfig: {
 					ui.AxisConfig

--- a/public/app/plugins/panel/state-timeline/panelcfg.gen.ts
+++ b/public/app/plugins/panel/state-timeline/panelcfg.gen.ts
@@ -28,6 +28,10 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   rowHeight: number;
   /**
+   * Optional list of states to display (all states shown if empty)
+   */
+  selectedStates?: Array<string>;
+  /**
    * Show timeline values on chart
    */
   showValue: ui.VisibilityMode;
@@ -38,6 +42,7 @@ export const defaultOptions: Partial<Options> = {
   mergeValues: true,
   perPage: 20,
   rowHeight: 0.9,
+  selectedStates: [],
   showValue: ui.VisibilityMode.Auto,
 };
 


### PR DESCRIPTION
Putting up this PR for visibility. This is just a WIP for building out a mechanism (outside of transformations) to toggle states on/off through the legend. Currently this only scaffolds the option controls and does not handle legend click events.

On hold pending a design doc.

After:
![Jul-02-2025 16-24-11](https://github.com/user-attachments/assets/7b5a82b9-c3e0-439a-89bd-8f80e938e036)
