### PR TITLE
Hackathon: Codeowners Experiments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@
 /scripts/modowners/ @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
+/scripts/codeowners-tools @sarahzinger
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -434,3 +434,17 @@ If you are trying to run the server from VS code and get this error, run `go ins
 - Learn how to [create a pull request](/contribute/create-pull-request.md).
 - Read about the [architecture](architecture).
 - Read through the [backend documentation](/contribute/backend/README.md).
+
+### Got a failing test in a pr that is unrelated to your changes?
+
+If a test is failing unrelated to your changes, it's possible you found a flakey test. We have a make command that makes it easy to find the right code owner to reach out to for help. Here is an example to find the right code owner for a particular test file: 
+```
+make get-codeowner FILE="pkg/expr/graph_test.go"
+```
+
+Alternatively if you're only getting an error in a ci environment you might consider changing the ci temporarily to log out the code owner for a failing test:
+```
+make test-go-with-code-owners TEST_ARGS="./pkg/expr"
+```
+
+A note the above make command only works for backend go tests at the moment, but could be expanded on in the future.

--- a/scripts/codeowners-tools/get-owner.sh
+++ b/scripts/codeowners-tools/get-owner.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Code Owner CLI - Find code owners for file paths
+# Usage: ./get-owner.sh <repository_path> <file_path>
+# Example: ./get-owner.sh . pkg/api/api.go
+
+set -e
+
+# Check if correct number of arguments provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <repository_path> <file_path>"
+    exit 1
+fi
+
+REPO_PATH="$1"
+FILE_PATH="$2"
+
+# Path to CODEOWNERS file
+CODEOWNERS_FILE="$REPO_PATH/.github/CODEOWNERS"
+
+# Check if CODEOWNERS file exists
+if [ ! -f "$CODEOWNERS_FILE" ]; then
+    echo "Error: CODEOWNERS file not found at $CODEOWNERS_FILE"
+    exit 1
+fi
+
+# Function to check if a file path matches a pattern
+matches_pattern() {
+    local pattern="$1"
+    local file_path="$2"
+    
+    # Remove leading slash from pattern if present
+    pattern="${pattern#/}"
+    
+    # Handle exact matches
+    if [ "$pattern" = "$file_path" ]; then
+        return 0
+    fi
+    
+    # Handle directory patterns (ending with /)
+    if [[ "$pattern" == */ ]]; then
+        pattern="${pattern%/}"
+        if [[ "$file_path" == "$pattern"* ]]; then
+            return 0
+        fi
+    fi
+    
+    # Handle wildcard patterns
+    if [[ "$pattern" == *\** ]]; then
+        # Convert glob pattern to regex-like matching
+        if [[ "$file_path" == $pattern ]]; then
+            return 0
+        fi
+    fi
+    
+    # Handle prefix matching for directories
+    if [[ "$file_path" == "$pattern"/* ]]; then
+        return 0
+    fi
+    
+    return 1
+}
+
+# Parse CODEOWNERS file and find the most specific match
+best_match=""
+best_match_owners=""
+best_match_specificity=0
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and comments
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+    
+    # Parse line: first token is the pattern, rest are owners
+    read -r pattern owners <<< "$line"
+    
+    # Skip if no pattern or owners
+    if [[ -z "$pattern" || -z "$owners" ]]; then
+        continue
+    fi
+    
+    # Check if the file matches this pattern
+    if matches_pattern "$pattern" "$FILE_PATH"; then
+        # Calculate specificity (longer patterns are more specific)
+        specificity=${#pattern}
+        
+        # If this is more specific than our current best match, use it
+        if [ $specificity -gt $best_match_specificity ]; then
+            best_match="$pattern"
+            best_match_owners="$owners"
+            best_match_specificity=$specificity
+        fi
+    fi
+done < "$CODEOWNERS_FILE"
+
+# Output the result
+if [[ -n "$best_match_owners" ]]; then
+    echo "Code owner for $FILE_PATH: $best_match_owners"
+    exit 0
+else
+    echo "No code owner found for $FILE_PATH"
+    exit 1
+fi 

--- a/scripts/codeowners-tools/get-owner.sh
+++ b/scripts/codeowners-tools/get-owner.sh
@@ -47,7 +47,8 @@ matches_pattern() {
     
     # Handle wildcard patterns
     if [[ "$pattern" == *\** ]]; then
-        # Convert glob pattern to regex-like matching
+        # Intentionally use glob matching to match file paths against CODEOWNERS patterns like *.go, pkg/*/api.go, etc.
+        # shellcheck disable=SC2053
         if [[ "$file_path" == $pattern ]]; then
             return 0
         fi
@@ -62,7 +63,6 @@ matches_pattern() {
 }
 
 # Parse CODEOWNERS file and find the most specific match
-best_match=""
 best_match_owners=""
 best_match_specificity=0
 
@@ -86,8 +86,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         specificity=${#pattern}
         
         # If this is more specific than our current best match, use it
-        if [ $specificity -gt $best_match_specificity ]; then
-            best_match="$pattern"
+        if [ "$specificity" -gt "$best_match_specificity" ]; then
             best_match_owners="$owners"
             best_match_specificity=$specificity
         fi

--- a/scripts/codeowners-tools/test-with-owners.sh
+++ b/scripts/codeowners-tools/test-with-owners.sh
@@ -22,48 +22,46 @@ print_colored() {
 # Function to print header
 print_header() {
     echo
-    print_colored $BLUE "================================================================="
-    print_colored $BLUE "$1"
-    print_colored $BLUE "================================================================="
+    print_colored "$BLUE" "================================================================="
+    print_colored "$BLUE" "$1"
+    print_colored "$BLUE" "================================================================="
     echo
 }
 
 # Check if CODEOWNERS file exists
 if [ ! -f ".github/CODEOWNERS" ]; then
-    print_colored $YELLOW "⚠️  Warning: .github/CODEOWNERS file not found"
-    print_colored $YELLOW "   Code owner identification will be skipped"
+    print_colored "$YELLOW" "⚠️  Warning: .github/CODEOWNERS file not found"
+    print_colored "$YELLOW" "   Code owner identification will be skipped"
     echo
 fi
 
 # Default to running all tests if no arguments provided
 if [ $# -eq 0 ]; then
-    TEST_ARGS="./..."
-else
-    TEST_ARGS="$@"
+    set -- "./..."
 fi
 
 print_header "Running Go Tests"
-print_colored $BLUE "Command: go test -v $TEST_ARGS"
+print_colored "$BLUE" "Command: go test -v $*"
 echo
 
 # Create temporary file for test output
 TEST_OUTPUT=$(mktemp)
 
 # Run go test and capture output
-go test -v $TEST_ARGS 2>&1 | tee "$TEST_OUTPUT"
+go test -v "$@" 2>&1 | tee "$TEST_OUTPUT"
 TEST_EXIT_CODE=${PIPESTATUS[0]}
 
 echo
 
 # Check if tests failed
-if [ $TEST_EXIT_CODE -ne 0 ]; then
+if [ "$TEST_EXIT_CODE" -ne 0 ]; then
     print_header "❌ Tests Failed - Identifying Code Owners"
     
     # Check if we have CODEOWNERS file
     if [ ! -f ".github/CODEOWNERS" ]; then
-        print_colored $YELLOW "Cannot identify code owners without .github/CODEOWNERS file"
+        print_colored "$YELLOW" "Cannot identify code owners without .github/CODEOWNERS file"
         rm "$TEST_OUTPUT"
-        exit $TEST_EXIT_CODE
+        exit "$TEST_EXIT_CODE"
     fi
     
     # Parse test failures and identify owners
@@ -80,7 +78,7 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
             # Convert absolute path to relative path if needed
             if [[ "$full_path" == /* ]]; then
                 # Remove the current working directory from the absolute path
-                file_path="${full_path#$PWD/}"
+                file_path="${full_path#"$PWD"/}"
                 # If the path doesn't start with the current directory, try to extract just the relevant part
                 if [[ "$file_path" == "$full_path" ]]; then
                     # Try to extract everything after the last occurrence of the repository structure
@@ -94,8 +92,8 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
                 file_path="$full_path"
             fi
             
-            # Get the test context (look for the test name in surrounding lines)
-            test_name=$(grep -B 10 -A 5 "$line" "$TEST_OUTPUT" | grep -E "=== RUN|--- FAIL:" | tail -1 | sed -E 's/.*(Test[A-Za-z0-9_]*).*/\1/')
+            # Get the test context (extract test name from the current line if possible)
+            test_name=$(echo "$line" | sed -E 's/.*(Test[A-Za-z0-9_]*).*/\1/' 2>/dev/null || echo "Unknown")
             
             # Use our CLI tool to find the code owner
             owner_output=$(./scripts/codeowners-tools/get-owner.sh . "$file_path" 2>/dev/null)
@@ -114,14 +112,14 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
     done < "$TEST_OUTPUT"
     
     # Also look for panic/error messages
-    grep -E "panic:|runtime error:|fatal error:" "$TEST_OUTPUT" | while IFS= read -r line; do
+    while IFS= read -r line; do
         if [[ "$line" =~ ([^[:space:]]+\.go):([0-9]+) ]]; then
             full_path="${BASH_REMATCH[1]}"
             line_number="${BASH_REMATCH[2]}"
             
             # Convert absolute path to relative path if needed
             if [[ "$full_path" == /* ]]; then
-                file_path="${full_path#$PWD/}"
+                file_path="${full_path#"$PWD"/}"
                 if [[ "$file_path" == "$full_path" ]]; then
                     if [[ "$full_path" =~ .*/grafana/(.+)$ ]]; then
                         file_path="${BASH_REMATCH[1]}"
@@ -144,34 +142,34 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
                 fi
             fi
         fi
-    done
+    done < <(grep -E "panic:|runtime error:|fatal error:" "$TEST_OUTPUT")
     
     # Display results
     if [ "$failures_found" = true ]; then
-        print_colored $RED "📋 Code Owners for Failed Tests:"
+        print_colored "$RED" "📋 Code Owners for Failed Tests:"
         echo
         
         # Sort and display unique failures
         while IFS='|' read -r failure_key owner test_name; do
             IFS=':' read -r file_path line_number <<< "$failure_key"
             
-            print_colored $YELLOW "  • $file_path:$line_number"
+            print_colored "$YELLOW" "  • $file_path:$line_number"
             if [ "$test_name" != "PANIC/ERROR" ]; then
-                print_colored $BLUE "    Test: $test_name"
+                print_colored "$BLUE" "    Test: $test_name"
             else
-                print_colored $RED "    Issue: Panic/Runtime Error"
+                print_colored "$RED" "    Issue: Panic/Runtime Error"
             fi
-            print_colored $GREEN "    Owner: $owner"
+            print_colored "$GREEN" "    Owner: $owner"
             echo
         done < "$owners_found_file"
         
-        print_colored $BLUE "💡 Next Steps:"
+        print_colored "$BLUE" "💡 Next Steps:"
         echo "   1. Review if your code changes could have affected these files"
         echo "   2. If not create a new issue and assign the code owner to inform of a potentially flakey test"
         
     else
-        print_colored $YELLOW "No code owners found for failed tests"
-        print_colored $YELLOW "This might indicate:"
+        print_colored "$YELLOW" "No code owners found for failed tests"
+        print_colored "$YELLOW" "This might indicate:"
         echo "   • Test failures in files not covered by CODEOWNERS"
         echo "   • Issues with parsing test output"
         echo "   • Missing or incomplete CODEOWNERS file"
@@ -182,12 +180,12 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
     
 else
     print_header "✅ All Tests Passed"
-    print_colored $GREEN "Great job! No failing tests to analyze."
+    print_colored "$GREEN" "Great job! No failing tests to analyze."
 fi
 
 # Clean up
 rm "$TEST_OUTPUT"
 
 echo
-print_colored $BLUE "================================================================="
-exit $TEST_EXIT_CODE 
+print_colored "$BLUE" "================================================================="
+exit "$TEST_EXIT_CODE"

--- a/scripts/codeowners-tools/test-with-owners.sh
+++ b/scripts/codeowners-tools/test-with-owners.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+# Test runner with code owner identification
+# Usage: ./test-with-owners.sh [go test arguments]
+# Example: ./test-with-owners.sh -v ./...
+# Example: ./test-with-owners.sh -run TestSpecific ./pkg/auth
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_colored() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to print header
+print_header() {
+    echo
+    print_colored $BLUE "================================================================="
+    print_colored $BLUE "$1"
+    print_colored $BLUE "================================================================="
+    echo
+}
+
+# Check if CODEOWNERS file exists
+if [ ! -f ".github/CODEOWNERS" ]; then
+    print_colored $YELLOW "⚠️  Warning: .github/CODEOWNERS file not found"
+    print_colored $YELLOW "   Code owner identification will be skipped"
+    echo
+fi
+
+# Default to running all tests if no arguments provided
+if [ $# -eq 0 ]; then
+    TEST_ARGS="./..."
+else
+    TEST_ARGS="$@"
+fi
+
+print_header "Running Go Tests"
+print_colored $BLUE "Command: go test -v $TEST_ARGS"
+echo
+
+# Create temporary file for test output
+TEST_OUTPUT=$(mktemp)
+
+# Run go test and capture output
+go test -v $TEST_ARGS 2>&1 | tee "$TEST_OUTPUT"
+TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+echo
+
+# Check if tests failed
+if [ $TEST_EXIT_CODE -ne 0 ]; then
+    print_header "❌ Tests Failed - Identifying Code Owners"
+    
+    # Check if we have CODEOWNERS file
+    if [ ! -f ".github/CODEOWNERS" ]; then
+        print_colored $YELLOW "Cannot identify code owners without .github/CODEOWNERS file"
+        rm "$TEST_OUTPUT"
+        exit $TEST_EXIT_CODE
+    fi
+    
+    # Parse test failures and identify owners
+    failures_found=false
+    owners_found_file=$(mktemp)
+    
+    # Look for failed tests with file paths
+    while IFS= read -r line; do
+        # Look for file paths in test output (absolute or relative paths)
+        if [[ "$line" =~ ([^[:space:]]+\.go):([0-9]+) ]]; then
+            full_path="${BASH_REMATCH[1]}"
+            line_number="${BASH_REMATCH[2]}"
+            
+            # Convert absolute path to relative path if needed
+            if [[ "$full_path" == /* ]]; then
+                # Remove the current working directory from the absolute path
+                file_path="${full_path#$PWD/}"
+                # If the path doesn't start with the current directory, try to extract just the relevant part
+                if [[ "$file_path" == "$full_path" ]]; then
+                    # Try to extract everything after the last occurrence of the repository structure
+                    if [[ "$full_path" =~ .*/grafana/(.+)$ ]]; then
+                        file_path="${BASH_REMATCH[1]}"
+                    else
+                        file_path="$full_path"
+                    fi
+                fi
+            else
+                file_path="$full_path"
+            fi
+            
+            # Get the test context (look for the test name in surrounding lines)
+            test_name=$(grep -B 10 -A 5 "$line" "$TEST_OUTPUT" | grep -E "=== RUN|--- FAIL:" | tail -1 | sed -E 's/.*(Test[A-Za-z0-9_]*).*/\1/')
+            
+            # Use our CLI tool to find the code owner
+            owner_output=$(./scripts/codeowners-tools/get-owner.sh . "$file_path" 2>/dev/null)
+            
+            if [[ "$owner_output" =~ Code\ owner\ for\ .*:\ (.+) ]]; then
+                owner="${BASH_REMATCH[1]}"
+                
+                # Track unique failures (using a temp file instead of associative array)
+                failure_key="$file_path:$line_number"
+                if ! grep -q "^$failure_key|" "$owners_found_file" 2>/dev/null; then
+                    echo "$failure_key|$owner|$test_name" >> "$owners_found_file"
+                    failures_found=true
+                fi
+            fi
+        fi
+    done < "$TEST_OUTPUT"
+    
+    # Also look for panic/error messages
+    grep -E "panic:|runtime error:|fatal error:" "$TEST_OUTPUT" | while IFS= read -r line; do
+        if [[ "$line" =~ ([^[:space:]]+\.go):([0-9]+) ]]; then
+            full_path="${BASH_REMATCH[1]}"
+            line_number="${BASH_REMATCH[2]}"
+            
+            # Convert absolute path to relative path if needed
+            if [[ "$full_path" == /* ]]; then
+                file_path="${full_path#$PWD/}"
+                if [[ "$file_path" == "$full_path" ]]; then
+                    if [[ "$full_path" =~ .*/grafana/(.+)$ ]]; then
+                        file_path="${BASH_REMATCH[1]}"
+                    else
+                        file_path="$full_path"
+                    fi
+                fi
+            else
+                file_path="$full_path"
+            fi
+            
+            owner_output=$(./scripts/codeowners-tools/get-owner.sh . "$file_path" 2>/dev/null)
+            
+            if [[ "$owner_output" =~ Code\ owner\ for\ .*:\ (.+) ]]; then
+                owner="${BASH_REMATCH[1]}"
+                failure_key="$file_path:$line_number"
+                if ! grep -q "^$failure_key|" "$owners_found_file" 2>/dev/null; then
+                    echo "$failure_key|$owner|PANIC/ERROR" >> "$owners_found_file"
+                    failures_found=true
+                fi
+            fi
+        fi
+    done
+    
+    # Display results
+    if [ "$failures_found" = true ]; then
+        print_colored $RED "📋 Code Owners for Failed Tests:"
+        echo
+        
+        # Sort and display unique failures
+        while IFS='|' read -r failure_key owner test_name; do
+            IFS=':' read -r file_path line_number <<< "$failure_key"
+            
+            print_colored $YELLOW "  • $file_path:$line_number"
+            if [ "$test_name" != "PANIC/ERROR" ]; then
+                print_colored $BLUE "    Test: $test_name"
+            else
+                print_colored $RED "    Issue: Panic/Runtime Error"
+            fi
+            print_colored $GREEN "    Owner: $owner"
+            echo
+        done < "$owners_found_file"
+        
+        print_colored $BLUE "💡 Next Steps:"
+        echo "   1. Review if your code changes could have affected these files"
+        echo "   2. If not create a new issue and assign the code owner to inform of a potentially flakey test"
+        
+    else
+        print_colored $YELLOW "No code owners found for failed tests"
+        print_colored $YELLOW "This might indicate:"
+        echo "   • Test failures in files not covered by CODEOWNERS"
+        echo "   • Issues with parsing test output"
+        echo "   • Missing or incomplete CODEOWNERS file"
+    fi
+    
+    # Clean up temp file
+    rm -f "$owners_found_file"
+    
+else
+    print_header "✅ All Tests Passed"
+    print_colored $GREEN "Great job! No failing tests to analyze."
+fi
+
+# Clean up
+rm "$TEST_OUTPUT"
+
+echo
+print_colored $BLUE "================================================================="
+exit $TEST_EXIT_CODE 


### PR DESCRIPTION
**What is this feature?**

Adds 2 new make commands to make it easier to identify code owners of flakey tests

**Why do we need this feature?**

Flakey tests happen! It's a reality of working on a large project with lots of cool people doing lots of hard things. When they do, we want to make it as easy as possible to find the right people for help, so that we don't ignore the issue, letting things accumulate. Sure, you could find the file name of the test that is failing and then go find the code owners file and then try to parse it to identify which is the best match....or you could run a command line script and have a computer do all that for you. 

If this works well, I think we could consider using the test-go-with-code-owners in our ci process so that we can see the codeowner immediately when we see the test failure. And if that works well we could consider adding some kind of notification system, so that if a test fails in the main branch the code owners are immediately notified. 

**Who is this feature for?**

Grafana devs who care about getting cicd to green! 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
