### PR TITLE
[release-11.6.4] StateTimeline: Add endTime to tooltip

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -52,8 +52,9 @@ export const VizTooltipRow = ({
         overflowY: 'auto',
       }
     : {
-        whiteSpace: 'wrap',
+        whiteSpace: 'pre-line',
         wordBreak: 'break-word',
+        lineHeight: 1.2,
       };
 
   const [showLabelTooltip, setShowLabelTooltip] = useState(false);

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
@@ -43,6 +43,7 @@ export const StateTimelineTooltip2 = ({
   mode = isPinned ? TooltipDisplayMode.Single : mode;
 
   const contentItems = getContentItems(series.fields, xField, dataIdxs, seriesIdx, mode, sortOrder);
+  let endTime = null;
 
   // append duration in single mode
   if (withDuration && mode === TooltipDisplayMode.Single) {
@@ -58,9 +59,11 @@ export const StateTimelineTooltip2 = ({
 
     if (nextStateTs) {
       duration = nextStateTs && fmtDuration(nextStateTs - stateTs);
+      endTime = nextStateTs;
     } else {
       const to = timeRange.to.valueOf();
       duration = fmtDuration(to - stateTs);
+      endTime = to;
     }
 
     contentItems.push({ label: 'Duration', value: duration });
@@ -82,7 +85,7 @@ export const StateTimelineTooltip2 = ({
 
   const headerItem: VizTooltipItem = {
     label: xField.type === FieldType.time ? '' : (xField.state?.displayName ?? xField.name),
-    value: xVal,
+    value: endTime ? xVal + ' - \n' + xField.display!(endTime).text : xVal,
   };
 
   return (


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/182bff2555128195869252a59b01fccc6e910982 from https://github.com/grafana/grafana/pull/106582

(requested in https://github.com/grafana/support-escalations/issues/16651)