### PR TITLE
Unified Search: Remove resource-server-specific methods from distributor

### DIFF
--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -41,6 +41,7 @@ func ProvideSearchDistributorServer(cfg *setting.Cfg, features featuremgmt.Featu
 
 	grpcServer := grpcHandler.GetServer()
 
+	// resourcepb.RegisterBulkStoreServer(grpcServer, distributorServer)
 	resourcepb.RegisterResourceIndexServer(grpcServer, distributorServer)
 	resourcepb.RegisterManagedObjectIndexServer(grpcServer, distributorServer)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
@@ -102,6 +103,11 @@ func (ds *distributorServer) GetStats(ctx context.Context, r *resourcepb.Resourc
 
 	return client.GetStats(ctx, r)
 }
+
+// TODO implement this if we want to support it in cloud
+// func (ds *DistributorServer) BulkProcess(srv BulkStore_BulkProcessServer) error {
+// 	return nil
+// }
 
 func (ds *distributorServer) CountManagedObjects(ctx context.Context, r *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Namespace, "CountManagedObjects")

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -41,8 +41,6 @@ func ProvideSearchDistributorServer(cfg *setting.Cfg, features featuremgmt.Featu
 
 	grpcServer := grpcHandler.GetServer()
 
-	resourcepb.RegisterResourceStoreServer(grpcServer, distributorServer)
-	// resourcepb.RegisterBulkStoreServer(grpcServer, distributorServer)
 	resourcepb.RegisterResourceIndexServer(grpcServer, distributorServer)
 	resourcepb.RegisterManagedObjectIndexServer(grpcServer, distributorServer)
 	resourcepb.RegisterBlobStoreServer(grpcServer, distributorServer)
@@ -105,86 +103,6 @@ func (ds *distributorServer) GetStats(ctx context.Context, r *resourcepb.Resourc
 
 	return client.GetStats(ctx, r)
 }
-
-func (ds *distributorServer) Read(ctx context.Context, r *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Key.Namespace, "Read")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Read(ctx, r)
-}
-
-func (ds *distributorServer) Create(ctx context.Context, r *resourcepb.CreateRequest) (*resourcepb.CreateResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Key.Namespace, "Create")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Create(ctx, r)
-}
-
-func (ds *distributorServer) Update(ctx context.Context, r *resourcepb.UpdateRequest) (*resourcepb.UpdateResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Key.Namespace, "Update")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Update(ctx, r)
-}
-
-func (ds *distributorServer) Delete(ctx context.Context, r *resourcepb.DeleteRequest) (*resourcepb.DeleteResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Key.Namespace, "Delete")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Delete(ctx, r)
-}
-
-func (ds *distributorServer) List(ctx context.Context, r *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Options.Key.Namespace, "List")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.List(ctx, r)
-}
-
-func (ds *distributorServer) Watch(r *resourcepb.WatchRequest, srv resourcepb.ResourceStore_WatchServer) error {
-	// r -> consumer watch request
-	// srv -> stream connection with consumer
-	ctx := srv.Context()
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Options.Key.Namespace, "Watch")
-	if err != nil {
-		return err
-	}
-
-	// watchClient -> stream connection with storage-api pod
-	watchClient, err := client.Watch(ctx, r)
-	if err != nil {
-		return err
-	}
-
-	// WARNING
-	// in Watch, all messages flow from the resource server (watchClient) to the consumer (srv)
-	// but since this is a streaming connection, in theory the consumer could also send a message to the server
-	// however for the sake of simplicity we are not handling it here
-	// but if we decide to handle bi-directional message passing in this method, we will need to update this
-	// we also never handle EOF err, as the server never closes the connection willingly
-	for {
-		msg, err := watchClient.Recv()
-		if err != nil {
-			return err
-		}
-		_ = srv.Send(msg)
-	}
-}
-
-// TODO implement this if we want to support it in cloud
-// func (ds *DistributorServer) BulkProcess(srv BulkStore_BulkProcessServer) error {
-// 	return nil
-// }
 
 func (ds *distributorServer) CountManagedObjects(ctx context.Context, r *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Namespace, "CountManagedObjects")

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -43,7 +43,6 @@ func ProvideSearchDistributorServer(cfg *setting.Cfg, features featuremgmt.Featu
 
 	resourcepb.RegisterResourceIndexServer(grpcServer, distributorServer)
 	resourcepb.RegisterManagedObjectIndexServer(grpcServer, distributorServer)
-	resourcepb.RegisterBlobStoreServer(grpcServer, distributorServer)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
 	_, err = grpcserver.ProvideReflectionService(cfg, grpcHandler)
 	if err != nil {
@@ -120,24 +119,6 @@ func (ds *distributorServer) ListManagedObjects(ctx context.Context, r *resource
 	}
 
 	return client.ListManagedObjects(ctx, r)
-}
-
-func (ds *distributorServer) PutBlob(ctx context.Context, r *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Resource.Namespace, "PutBlob")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.PutBlob(ctx, r)
-}
-
-func (ds *distributorServer) GetBlob(ctx context.Context, r *resourcepb.GetBlobRequest) (*resourcepb.GetBlobResponse, error) {
-	ctx, client, err := ds.getClientToDistributeRequest(ctx, r.Resource.Namespace, "GetBlob")
-	if err != nil {
-		return nil, err
-	}
-
-	return client.GetBlob(ctx, r)
 }
 
 func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, namespace string, methodName string) (context.Context, ResourceClient, error) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Cleanup following split of resource server and resource index client configuration.

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/search-and-storage-team/issues/310

**Special notes for your reviewer:**
EDIT: Confirmed here: https://github.com/grafana/grafana/pull/107607#discussion_r2184717662
~~Looks to me like we can remove the BlobStoreServer interface implementation  as well:~~
* ~~My understanding is that the distributor doesn’t do any indexing work so we can remove get/put blob methods.~~
* ~~TestIntegrationDistributor doesn't reference get/put blob.~~
* ~~A look through the distributor code doesn't show references to the blob methods.~~

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
