### PR TITLE
Auth: Session expiration warning notification 

### DIFF
--- a/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
+++ b/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
@@ -158,4 +158,4 @@ describe('SessionExpiryMonitor', () => {
     
     clearIntervalSpy.mockRestore();
   });
-}); 
+});

--- a/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
+++ b/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
@@ -27,7 +27,7 @@ jest.mock('app/core/copy/appNotification', () => ({
 }));
 
 describe('SessionExpiryMonitor', () => {
-  let store: any;
+  let store: ReturnType<typeof configureStore>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -38,7 +38,7 @@ describe('SessionExpiryMonitor', () => {
       },
     });
 
-    (contextSrv.isSignedIn as any) = true;
+    (contextSrv as { isSignedIn: boolean }).isSignedIn = true;
     (hasSessionExpiry as jest.Mock).mockReturnValue(true);
   });
 
@@ -66,7 +66,7 @@ describe('SessionExpiryMonitor', () => {
   });
 
   it('should not monitor when user is not signed in', () => {
-    (contextSrv.isSignedIn as any) = false;
+    (contextSrv as { isSignedIn: boolean }).isSignedIn = false;
     (getSessionExpiry as jest.Mock).mockReturnValue(Math.floor(Date.now() / 1000) + 10 * 60);
 
     renderComponent();

--- a/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
+++ b/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.test.tsx
@@ -1,0 +1,161 @@
+import { render, waitFor, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import { contextSrv } from 'app/core/core';
+import { appNotificationsReducer } from 'app/core/reducers/appNotification';
+import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
+
+import { SessionExpiryMonitor } from './SessionExpiryMonitor';
+
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    isSignedIn: true,
+  },
+}));
+
+jest.mock('app/core/utils/auth', () => ({
+  getSessionExpiry: jest.fn(),
+  hasSessionExpiry: jest.fn(),
+}));
+
+const mockWarning = jest.fn();
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    warning: mockWarning,
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+
+const mockGetSessionExpiry = getSessionExpiry as jest.MockedFunction<typeof getSessionExpiry>;
+const mockHasSessionExpiry = hasSessionExpiry as jest.MockedFunction<typeof hasSessionExpiry>;
+
+describe('SessionExpiryMonitor', () => {
+  let store: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    
+    store = configureStore({
+      reducer: {
+        appNotifications: appNotificationsReducer,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const renderComponent = (props?: { warningMinutes?: number; checkIntervalMs?: number }) => {
+    return render(
+      <Provider store={store}>
+        <SessionExpiryMonitor {...props} />
+      </Provider>
+    );
+  };
+
+  it('should not monitor session when user is not signed in', () => {
+    (contextSrv as any).isSignedIn = false;
+    mockHasSessionExpiry.mockReturnValue(true);
+
+    renderComponent();
+
+    expect(mockGetSessionExpiry).not.toHaveBeenCalled();
+  });
+
+  it('should not monitor session when session expiry is not available', () => {    
+    (contextSrv as any).isSignedIn = true;
+    mockHasSessionExpiry.mockReturnValue(false);
+
+    renderComponent();
+
+    expect(mockGetSessionExpiry).not.toHaveBeenCalled();
+  });
+
+  it('should show warning when session is about to expire', async () => {
+    
+    (contextSrv as any).isSignedIn = true;
+    mockHasSessionExpiry.mockReturnValue(true);
+    
+    const now = Date.now();
+    const expiryTime = Math.floor((now + 4 * 60 * 1000) / 1000); // 4 minutes from now
+    mockGetSessionExpiry.mockReturnValue(expiryTime);
+
+    renderComponent({ warningMinutes: 5, checkIntervalMs: 1000 });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(mockWarning).toHaveBeenCalledWith(
+        'Session Expiring Soon',
+        expect.stringContaining('Your session will expire in')
+      );
+    });
+  });
+
+  it('should not show warning when session is not close to expiry', async () => {
+    (contextSrv as any).isSignedIn = true;
+    mockHasSessionExpiry.mockReturnValue(true);
+    
+    const now = Date.now();
+    const expiryTime = Math.floor((now + 10 * 60 * 1000) / 1000); // 10 minutes from now
+    mockGetSessionExpiry.mockReturnValue(expiryTime);
+
+    renderComponent({ warningMinutes: 5, checkIntervalMs: 1000 });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(mockWarning).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not show warning again after already showing it', async () => {
+    (contextSrv as any).isSignedIn = true;
+    mockHasSessionExpiry.mockReturnValue(true);
+    
+    const now = Date.now();
+    const expiryTime = Math.floor((now + 4 * 60 * 1000) / 1000); // 4 minutes from now
+    mockGetSessionExpiry.mockReturnValue(expiryTime);
+
+    renderComponent({ warningMinutes: 5, checkIntervalMs: 1000 });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(mockWarning).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clean up interval on unmount', () => {
+    (contextSrv as any).isSignedIn = true;
+    mockHasSessionExpiry.mockReturnValue(true);
+    mockGetSessionExpiry.mockReturnValue(Math.floor((Date.now() + 10 * 60 * 1000) / 1000));
+    
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderComponent();
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    
+    clearIntervalSpy.mockRestore();
+  });
+}); 

--- a/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.tsx
+++ b/public/app/core/components/SessionExpiryMonitor/SessionExpiryMonitor.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { t } from '@grafana/i18n';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/core';
+import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
+
+interface SessionExpiryMonitorProps {
+  warningMinutes?: number; // Minutes before expiry to show warning
+  checkIntervalMs?: number; // How often to check session expiry
+}
+
+export function SessionExpiryMonitor({ 
+  warningMinutes = 5, 
+  checkIntervalMs = 30000 // Check every 30 seconds
+}: SessionExpiryMonitorProps) {
+  const notifyApp = useAppNotification();
+  const [hasShownWarning, setHasShownWarning] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const lastExpiryTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Only monitor if user is signed in and session expiry is available
+    if (!contextSrv.isSignedIn || !hasSessionExpiry()) {
+      return;
+    }
+
+    const checkSessionExpiry = () => {
+      const expiryTimestamp = getSessionExpiry();
+      if (!expiryTimestamp) {
+        return;
+      }
+
+      const now = Date.now();
+      const expiryTime = expiryTimestamp * 1000;
+      const warningTime = expiryTime - (warningMinutes * 60 * 1000);
+
+      // Reset warning flag if session is renewed (expiry time changed)
+      if (lastExpiryTimeRef.current && lastExpiryTimeRef.current !== expiryTime) {
+        setHasShownWarning(false);
+        lastExpiryTimeRef.current = expiryTime;
+      } else if (!lastExpiryTimeRef.current) {
+        lastExpiryTimeRef.current = expiryTime;
+      }
+
+      // Show warning if we've reached the warning threshold and haven't shown it yet
+      if (now >= warningTime && now < expiryTime && !hasShownWarning) {
+        const remainingMinutes = Math.ceil((expiryTime - now) / (60 * 1000));
+        
+        try {
+          notifyApp.warning(
+            t('session-expiry.warning-title', 'Session Expiring Soon'),
+            t('session-expiry.warning-message', 
+              'Your session will expire in {{minutes}} minute(s). Please make sure to finish up or save any changes.',
+              { minutes: remainingMinutes }
+            )
+          );
+          
+          setHasShownWarning(true);
+        } catch (error) {
+          console.error('Error showing session expiry notification:', error);
+        }
+      }
+    };
+
+    checkSessionExpiry();
+
+    intervalRef.current = setInterval(checkSessionExpiry, checkIntervalMs);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [warningMinutes, checkIntervalMs, notifyApp, hasShownWarning]);
+
+  return null;
+}

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -8,6 +8,7 @@ import { ModalRoot, Stack } from '@grafana/ui';
 import { AppChrome } from '../core/components/AppChrome/AppChrome';
 import { AppChromeExtensionPoint } from '../core/components/AppChrome/AppChromeExtensionPoint';
 import { AppNotificationList } from '../core/components/AppNotifications/AppNotificationList';
+import { SessionExpiryMonitor } from '../core/components/SessionExpiryMonitor/SessionExpiryMonitor';
 import { ModalsContextProvider } from '../core/context/ModalsContextProvider';
 import { QueriesDrawerContextProvider } from '../features/explore/QueriesDrawer/QueriesDrawerContext';
 
@@ -33,6 +34,7 @@ export function RouterWrapper(props: RouterWrapperProps) {
               <ModalsContextProvider>
                 <AppChrome>
                   <AppNotificationList />
+                  <SessionExpiryMonitor />
                   <Stack gap={0} grow={1} direction="column">
                     {props.pageBanners.map((Banner, index) => (
                       <Banner key={index.toString()} />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10976,6 +10976,10 @@
       "revoked-label": "Revoked"
     }
   },
+  "session-expiry": {
+    "warning-message": "Your session will expire in {{minutes}} minute(s). Please make sure to finish up or save any changes.",
+    "warning-title": "Session Expiring Soon"
+  },
   "share-dashboard": {
     "menu": {
       "export-json-title": "Export as JSON",


### PR DESCRIPTION

**What is this feature?**

The change implements a warning banner before user session expiration. With the current implementation, the warning appears before 5 minutes before the session expiry. We check every 30 seconds the session cookie to resolve expiration time.

For short sessions, there is a logic which will dynamically determine when to show the warning - it will use the half of the remaining session time, if the warning minutes is bigger than the session expiration time.

<img width="710" alt="Screenshot 2025-07-04 at 10 31 02" src="https://github.com/user-attachments/assets/def4d1cb-aae9-4098-be88-87d09e2a15b8" />

**Why do we need this feature?**

This will ensure that any unsaved changes can be saved before suddenly user gets logged out.