### PR TITLE
TimeSeries/Trend: Fix infinite loop

### DIFF
--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -394,13 +394,13 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
           else {
             // scan right
             let leftIdx = 0;
-            while (yData[leftIdx] == null) {
+            while (yData[leftIdx] === null) {
               leftIdx++;
             }
 
             // scan left
             let rightIdx = yData.length - 1;
-            while (rightIdx >= leftIdx && yData[rightIdx] == null) {
+            while (rightIdx >= leftIdx && yData[rightIdx] === null) {
               rightIdx--;
             }
 


### PR DESCRIPTION
**What is this feature?**

Fix infinite loop in time series panel.

**Why do we need this feature?**

https://raintank-corp.slack.com/archives/C060CMCT996/p1751617849581709

TL;DR; if the index reaches `yData.length`, `yData[leftIdx]` will be undefined. `yData[leftIdx] == null` matches undefined as well causing infinite loops. 

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
