### PR TITLE
Docs: Clarify auth requirement for /api/ds/query

### DIFF
--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -903,6 +903,7 @@ Grafana's built-in data sources usually have a backend implementation.
 POST /api/ds/query HTTP/1.1
 Accept: application/json
 Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 {
    "queries":[
@@ -982,6 +983,7 @@ In addition, specific properties of each data source should be added in a reques
 | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 200  | All data source queries returned a successful response.                                                                                                                          |
 | 400  | Bad request due to invalid JSON, missing content type, missing or invalid fields, etc. Or one or more data source queries were unsuccessful. Refer to the body for more details. |
+| 401  | Unauthorized. |
 | 403  | Access denied.                                                                                                                                                                   |
 | 404  | Either the data source or plugin required to fulfil the request could not be found.                                                                                              |
 | 500  | Unexpected error. Refer to the body and/or server logs for more details.                                                                                                         |

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -983,7 +983,7 @@ In addition, specific properties of each data source should be added in a reques
 | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 200  | All data source queries returned a successful response.                                                                                                                          |
 | 400  | Bad request due to invalid JSON, missing content type, missing or invalid fields, etc. Or one or more data source queries were unsuccessful. Refer to the body for more details. |
-| 401  | Unauthorized. |
+| 401  | Unauthorized.                                                                                                                                                                    |
 | 403  | Access denied.                                                                                                                                                                   |
 | 404  | Either the data source or plugin required to fulfil the request could not be found.                                                                                              |
 | 500  | Unexpected error. Refer to the body and/or server logs for more details.                                                                                                         |


### PR DESCRIPTION
**What is this feature?**

A documentation update that clarifies the authentication requirement for the /api/ds/query endpoint when accessed via external clients.

**Why do we need this feature?**

The current docs suggest no authentication is needed, which causes confusion when external requests receive `401 Unauthorized`. This update makes the requirement clear.

**Who is this feature for?**

Developers and engineers using Grafana’s API programmatically via tools like `curl`, Postman, or scripts outside the web UI.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
