### PR TITLE
Panel edit: Panel edit dragging to zero breaks resize 

### DIFF
--- a/packages/grafana-ui/src/components/Splitter/useSplitter.ts
+++ b/packages/grafana-ui/src/components/Splitter/useSplitter.ts
@@ -111,7 +111,7 @@ export function useSplitter(options: UseSplitterOptions) {
 
       if (usePixels) {
         const newSize = clamp(secondPanePixels - diff, dims[minDimProp], dims[maxDimProp]);
-        secondPaneRef.current!.style.flexBasis = `${Math.max(newSize, 50)}px`
+        secondPaneRef.current!.style.flexBasis = `${Math.max(newSize, 50)}px`;
         splitterRef.current!.ariaValueNow = `${newSize}`;
         onResizing?.(newSize, firstPanePixels + diff, newSize);
       } else {

--- a/packages/grafana-ui/src/components/Splitter/useSplitter.ts
+++ b/packages/grafana-ui/src/components/Splitter/useSplitter.ts
@@ -111,12 +111,12 @@ export function useSplitter(options: UseSplitterOptions) {
 
       if (usePixels) {
         const newSize = clamp(secondPanePixels - diff, dims[minDimProp], dims[maxDimProp]);
-        secondPaneRef.current!.style.flexBasis = `${newSize}px`;
+        secondPaneRef.current!.style.flexBasis = `${Math.max(newSize, 50)}px`
         splitterRef.current!.ariaValueNow = `${newSize}`;
         onResizing?.(newSize, firstPanePixels + diff, newSize);
       } else {
         const newSize = clamp(primarySizeRef.current + diff, dims[minDimProp], dims[maxDimProp]);
-        const newFlex = newSize / (containerSize.current! - handleSize);
+        const newFlex = Math.max(newSize / (containerSize.current! - handleSize), 0.05);
         firstPaneRef.current!.style.flexGrow = `${newFlex}`;
         secondPaneRef.current!.style.flexGrow = `${1 - newFlex}`;
         splitterRef.current!.ariaValueNow = ariaValue(newSize, dims[minDimProp], dims[maxDimProp]);


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
This PR fixes an issue where the panel becomes unresizable after dragging the query drawer to fully collapse the panel (i.e., size reaches 0). Once the panel is collapsed, users are unable to drag it back open, effectively locking the panel in an unusable state.


Fixes #107200


