### PR TITLE
PublicDashboards: Use API to render public dashboard badge

### DIFF
--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -5,17 +5,7 @@ import { GrafanaTheme2, store } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
-import {
-  Badge,
-  Button,
-  ButtonGroup,
-  Dropdown,
-  Icon,
-  Menu,
-  ToolbarButton,
-  ToolbarButtonRow,
-  useStyles2,
-} from '@grafana/ui';
+import { Button, ButtonGroup, Dropdown, Icon, Menu, ToolbarButton, ToolbarButtonRow, useStyles2 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
 import grafanaConfig from 'app/core/config';
@@ -39,6 +29,7 @@ import { GoToSnapshotOriginButton } from './GoToSnapshotOriginButton';
 import ManagedDashboardNavBarBadge from './ManagedDashboardNavBarBadge';
 import { LeftActions } from './new-toolbar/LeftActions';
 import { RightActions } from './new-toolbar/RightActions';
+import { PublicDashboardBadge } from './new-toolbar/actions/PublicDashboardBadge';
 
 interface Props {
   dashboard: DashboardScene;
@@ -85,6 +76,7 @@ export function ToolbarActions({ dashboard }: Props) {
   const folderRepo = useSelector((state) => selectFolderRepository(state, meta.folderUid));
   const isManaged = Boolean(dashboard.isManagedRepository() || folderRepo);
 
+  console.log('navToolbar');
   // Internal only;
   // allows viewer editing without ability to save
   // used for grafana play
@@ -119,23 +111,13 @@ export function ToolbarActions({ dashboard }: Props) {
     },
   });
 
-  if (meta.publicDashboardEnabled) {
-    toolbarActions.push({
-      group: 'icon-actions',
-      condition: uid && Boolean(meta.canStar) && isShowingDashboard && !isEditing,
-      render: () => {
-        return (
-          <Badge
-            color="blue"
-            text={t('dashboard.toolbar.public-dashboard', 'Public')}
-            key="public-dashboard-button-badge"
-            className={styles.publicBadge}
-            data-testid={selectors.pages.Dashboard.DashNav.publicDashboardTag}
-          />
-        );
-      },
-    });
-  }
+  toolbarActions.push({
+    group: 'icon-actions',
+    condition: uid && Boolean(meta.canStar) && isShowingDashboard && !isEditing,
+    render: () => {
+      return <PublicDashboardBadge dashboard={dashboard} />;
+    },
+  });
 
   if (dashboard.isManaged() && meta.canEdit) {
     toolbarActions.push({

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -76,7 +76,6 @@ export function ToolbarActions({ dashboard }: Props) {
   const folderRepo = useSelector((state) => selectFolderRepository(state, meta.folderUid));
   const isManaged = Boolean(dashboard.isManagedRepository() || folderRepo);
 
-  console.log('navToolbar');
   // Internal only;
   // allows viewer editing without ability to save
   // used for grafana play

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -114,7 +114,7 @@ export function ToolbarActions({ dashboard }: Props) {
     group: 'icon-actions',
     condition: uid && Boolean(meta.canStar) && isShowingDashboard && !isEditing,
     render: () => {
-      return <PublicDashboardBadge dashboard={dashboard} />;
+      return <PublicDashboardBadge key="public-dashboard-badge" dashboard={dashboard} />;
     },
   });
 

--- a/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
@@ -16,7 +16,6 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
   const isViewingPanel = Boolean(viewPanelScene);
   const isEditingDashboard = Boolean(isEditing);
   const isEditingPanel = Boolean(editPanel);
-  const isPublicDashboard = Boolean(meta.publicDashboardEnabled);
   const hasUid = Boolean(uid);
   const canEdit = Boolean(meta.canEdit);
   const canStar = Boolean(meta.canStar);
@@ -37,7 +36,7 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
         key: 'public-dashboard-badge',
         component: PublicDashboardBadge,
         group: 'actions',
-        condition: isPublicDashboard && hasUid && canStar && isShowingDashboard && !isEditingDashboard,
+        condition: hasUid && canStar && isShowingDashboard && !isEditingDashboard,
       },
       {
         key: 'managed-dashboard-badge',
@@ -55,6 +54,7 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
     dashboard
   );
 
+  console.log('elements', elements);
   if (elements.length === 0) {
     return null;
   }

--- a/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/LeftActions.tsx
@@ -54,7 +54,6 @@ export const LeftActions = ({ dashboard }: { dashboard: DashboardScene }) => {
     dashboard
   );
 
-  console.log('elements', elements);
   if (elements.length === 0) {
     return null;
   }

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
@@ -3,10 +3,32 @@ import { css } from '@emotion/css';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Badge, useStyles2 } from '@grafana/ui';
+import { useGetPublicDashboardQuery } from 'app/features/dashboard/api/publicDashboardApi';
 
 import { ToolbarActionProps } from '../types';
 
-export const PublicDashboardBadge = ({}: ToolbarActionProps) => {
+export const PublicDashboardBadge = ({ dashboard }: ToolbarActionProps) => {
+  if (!dashboard.state.uid) {
+    return null;
+  }
+
+  return <PublicDashboardBadgeInternal uid={dashboard.state.uid} />;
+};
+
+// Used in old architecture
+export const PublicDashboardBadgeLegacy = PublicDashboardBadgeInternal;
+
+function PublicDashboardBadgeInternal({ uid }: { uid?: string }) {
+  if (!uid) {
+    return null;
+  }
+
+  const { data: publicDashboard } = useGetPublicDashboardQuery(uid);
+
+  if (!publicDashboard) {
+    return null;
+  }
+
   const styles = useStyles2(getStyles);
 
   return (
@@ -17,7 +39,7 @@ export const PublicDashboardBadge = ({}: ToolbarActionProps) => {
       data-testid={selectors.pages.Dashboard.DashNav.publicDashboardTag}
     />
   );
-};
+}
 
 const getStyles = () => ({
   badge: css({

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -4,7 +4,6 @@ import { connect, ConnectedProps } from 'react-redux';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { textUtil } from '@grafana/data';
-import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import {
@@ -14,7 +13,6 @@ import {
   useForceUpdate,
   ToolbarButtonRow,
   ConfirmModal,
-  Badge,
 } from '@grafana/ui';
 import { updateNavIndex } from 'app/core/actions';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
@@ -29,6 +27,7 @@ import AddPanelButton from 'app/features/dashboard/components/AddPanelButton/Add
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import { PublicDashboardBadgeLegacy } from 'app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
@@ -57,8 +56,6 @@ const mapStateToProps = (state: StoreState) => ({
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
-
-const selectors = e2eSelectors.pages.Dashboard.DashNav;
 
 export interface OwnProps {
   dashboard: DashboardModel;
@@ -215,18 +212,7 @@ export const DashNav = memo<Props>((props) => {
       );
     }
 
-    if (dashboard.meta.publicDashboardEnabled) {
-      // TODO: This will be replaced with the new badge component. Color is required but gets override by css
-      buttons.push(
-        <Badge
-          color="blue"
-          text={t('dashboard.dash-nav.render-left-actions.text-public', 'Public')}
-          key="public-dashboard-button-badge"
-          className={publicBadgeStyle}
-          data-testid={selectors.publicDashboardTag}
-        />
-      );
-    }
+    buttons.push(<PublicDashboardBadgeLegacy uid={dashboard.uid} />);
 
     if (isDevEnv && config.featureToggles.dashboardScene) {
       buttons.push(
@@ -376,10 +362,4 @@ export default connector(DashNav);
 const modalStyles = css({
   width: 'max-content',
   maxWidth: '80vw',
-});
-
-const publicBadgeStyle = css({
-  color: 'grey',
-  backgroundColor: 'transparent',
-  border: '1px solid',
 });

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -212,7 +212,7 @@ export const DashNav = memo<Props>((props) => {
       );
     }
 
-    buttons.push(<PublicDashboardBadgeLegacy uid={dashboard.uid} />);
+    buttons.push(<PublicDashboardBadgeLegacy key="public-dashboard-badge" uid={dashboard.uid} />);
 
     if (isDevEnv && config.featureToggles.dashboardScene) {
       buttons.push(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4348,7 +4348,6 @@
         }
       },
       "render-left-actions": {
-        "text-public": "Public",
         "tooltip-view-as-scene": "View as Scene"
       }
     },
@@ -5110,7 +5109,6 @@
       "playlist-next": "Go to next dashboard",
       "playlist-previous": "Go to previous dashboard",
       "playlist-stop": "Stop playlist",
-      "public-dashboard": "Public",
       "refresh": "Refresh dashboard",
       "save": "Save dashboard",
       "save-dashboard": {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/107621

This PR updates the logic for rendering the public dashboard badge. Instead of relying on local or static data (provided through `dashboard.metadata.publicDashboardEnabled`), the badge is now rendered using data fetched from the  public dashboards API. 

**Key changes:**

- Updated the badge rendering logic to use the API for public dashboards.
- Uses the same badge component for PublicDashboardsBadge in top nav.

**Why?**

When enabling `kubernetesDashboards` toggle (https://github.com/grafana/grafana/pull/107618) we disovered a e2e test failing. This is because the `metadata.publicDashboardEnabled` is not available in the v1 k8s response for dashboards API. I also consider this a unhealthy approach to provide such information through dashboard metadata going forward given we have an API for Public Dashboards available.

Of course this does not change the API response for the legacy API, it just changes how the badge gets information about dashboard being public or not.