### PR TITLE
Doc: Remove dynamic dashboards section

### DIFF
--- a/docs/sources/dashboards/build-dashboards/_index.md
+++ b/docs/sources/dashboards/build-dashboards/_index.md
@@ -28,7 +28,3 @@ refs:
 This section includes the following topics:
 
 {{< section >}}
-
-## Dynamic dashboards
-
-You can create more interactive and dynamic dashboards by adding and using [variables](ref:variables). Instead of hard-coding things like server, application, and sensor names in your metric queries, you can use variables in their place. Read more about variables [here](ref:variables).


### PR DESCRIPTION
This heading is confusing now that we've released the dynamic dashboards feature.
In addition, this section doesn't make as a stand-alone CTA to use variables anymore.