### PR TITLE
UI: add now-14d to DateTimePickers options

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/options.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/options.ts
@@ -13,6 +13,7 @@ export const quickOptions: TimeOption[] = [
   { from: 'now-24h', to: 'now', display: 'Last 24 hours' },
   { from: 'now-2d', to: 'now', display: 'Last 2 days' },
   { from: 'now-7d', to: 'now', display: 'Last 7 days' },
+  { from: 'now-14d', to: 'now', display: 'Last 14 days' },
   { from: 'now-30d', to: 'now', display: 'Last 30 days' },
   { from: 'now-90d', to: 'now', display: 'Last 90 days' },
   { from: 'now-6M', to: 'now', display: 'Last 6 months' },


### PR DESCRIPTION
**What is this feature?**

Adds `now-14d` to the list of "absolute time ranges" you can choose from.

**Why do we need this feature?**

In my professional experience, a 14 day retention period for prometheus is very common. As well, looking at trends over a 2 week period is a common desire. This just removes the need to type `now-14d` into the box in the UI.

**Who is this feature for?**

end users

**Which issue(s) does this PR fix?**:

n/a
