### PR TITLE
chore(datasources): Adding debug logging to datasource provisioning when resource is not found in SqlStore

### DIFF
--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -83,6 +83,7 @@ func (ss *SqlStore) getDataSource(_ context.Context, query *datasources.GetDataS
 		ss.logger.Error("Failed getting data source", "err", err, "uid", query.UID, "id", query.ID, "name", query.Name, "orgId", query.OrgID) // nolint:staticcheck
 		return nil, err
 	} else if !has {
+		ss.logger.Debug("Data source not found", "uid", query.UID, "id", query.ID, "name", query.Name, "orgId", query.OrgID) // nolint:staticcheck
 		return nil, datasources.ErrDataSourceNotFound
 	}
 

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -281,7 +281,10 @@ func TestIntegrationDataAccess(t *testing.T) {
 		t.Run("Can not delete datasource with wrong orgID", func(t *testing.T) {
 			db := db.InitTestDB(t)
 			ds := initDatasource(db)
-			ss := SqlStore{db: db}
+			ss := SqlStore{
+				db:     db,
+				logger: log.NewNopLogger(),
+			}
 
 			err := ss.DeleteDataSource(context.Background(),
 				&datasources.DeleteDataSourceCommand{ID: ds.ID, OrgID: 123123})
@@ -322,7 +325,10 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 	t.Run("does not fire an event when the datasource is not deleted", func(t *testing.T) {
 		db := db.InitTestDB(t)
-		ss := SqlStore{db: db}
+		ss := SqlStore{
+			db:     db,
+			logger: log.NewNopLogger(),
+		}
 
 		var called bool
 		db.Bus().AddEventListener(func(ctx context.Context, e *events.DataSourceDeleted) error {


### PR DESCRIPTION
**What is this feature?**

Adding debug logging to datasource provisioning when resource is not found in SqlStore

**Why do we need this feature?**

Ease datasource provisioning troubleshooting

**Who is this feature for?**

Datasource developers


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

