### PR TITLE
Transformations: Add RegexReplace to FormatString

### DIFF
--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -515,6 +515,7 @@ Use this transformation to customize the output of a string field. This transfor
 - **Kebab case** - Formats all characters in the string in lowercase and uses dashes instead of spaces between words.
 - **Trim** - Removes all leading and trailing spaces from the string.
 - **Substring** - Returns a substring of the string, using the specified start and end positions.
+- **Regex Replace** - Modifies the string to the specified format by regular expression replacement.
 
 This transformation provides a convenient way to standardize and tailor the presentation of string data for better visualization and analysis.`;
     },


### PR DESCRIPTION
### **What is this feature?**

Adds a new option to the existing FormatString transformer: "Regex Replace".  When this option is selected, fields for `Match` and `Replace` appear, and are used to re-format the values.  

<details><summary>Click to expand example</summary>
<p>
Given application log data...

![image](https://github.com/user-attachments/assets/5e8ed452-f13a-4006-a0a9-e3209ac3316d)

that data may be dynamically transformed to extract & perform analytics on an identifier.  

![image](https://github.com/user-attachments/assets/6d7d5ac4-7ba8-481b-b794-a72810e03b12)

</p>
</details> 

Other use cases include
- Extracting domains from websites or emails
- Creating a time-series graph of numbers reported in particular log messages
- Isolating important sections/cleaning up messy string data

### **Why do we need this feature?**

It is currently impossible to perform regular expression re-formatting or extract numeric values from string data via a dashboard transformation.  This change enables those capabilities.  (Yes, you can currently convert a string to a number, but it requires the string to *be* a number.  This change helps isolate the number before converting).  

### **Who is this feature for?**

- Dashboard maintainers performing string manipulation within transforms
- Anyone wanting to draw numeric metrics from string data

### **Which issue(s) does this PR fix?**:

Resolves #85083 by making the Format String transformer capable of the desired behavior.  
Fixes #82711 if you precede the Format String transformer with a type conversion transformer to convert a number to string.
Also relevant to #42819, as this would enable a workflow to prefix numbers with symbols.

### **Special notes for your reviewer:**

- This is my first Grafana PR - I've tried my best to follow conventions but let me know where I'm off-base.  
- It seems to me this is a borderline case for being mentioned in whats-new.  Someone with more familiarity with the project can help make that call.  
- There was little uniformity on when to apply changes or when to validate regex (on blur or update).  I made a choice that made sense to me, but I'm not sure where the project vision is for this.
- I'm not sure what the behavior should be for values that fail to match the regex.  Right now I'm just directly using the `.replace()` behavior, which leaves the input unchanged.  Perhaps it's better to replace it with an empty string, or filter out non-matching values (though this would muddy the purpose of a "FormatString" transformer)?  Leaving the entire panel in an error state seems excessive.  I'm open to suggestions.  
- I updated deprecated `Select` to `Combobox` in the tsx.  I'm not sure what the policy is on updating deprecated components when making tangentially-related changes like this.  
- I'm not very happy with the description I added in [content.ts](public/app/features/transformers/docs/content.ts).  I'll take any suggestions on phrasing.  


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
