### PR TITLE
Postgres: Regroup config page for TLS related settings

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
@@ -153,7 +153,11 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
             onBlur={onUpdateDatasourceSecureJsonDataOption(props, 'password')}
           />
         </Field>
+      </ConfigSection>
 
+      <Divider />
+
+      <ConfigSection title="TLS/SSL Auth Details" isCollapsible>
         <Field
           label={
             <Label>
@@ -180,7 +184,6 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
             width={WIDTH_LONG}
           />
         </Field>
-
         {options.jsonData.sslmode !== PostgresTLSModes.disable ? (
           <Field
             label={
@@ -217,12 +220,8 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
             />
           </Field>
         ) : null}
-      </ConfigSection>
-
-      {jsonData.sslmode !== PostgresTLSModes.disable ? (
-        <>
-          <Divider />
-          <ConfigSection title="TLS/SSL Auth Details">
+        {jsonData.sslmode !== PostgresTLSModes.disable ? (
+          <>
             {jsonData.tlsConfigurationMethod === PostgresTLSMethods.fileContent ? (
               <TLSSecretsConfig
                 showCACert={
@@ -314,9 +313,9 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
                 </Field>
               </>
             )}
-          </ConfigSection>
-        </>
-      ) : null}
+          </>
+        ) : null}
+      </ConfigSection>
 
       <Divider />
 


### PR DESCRIPTION
This PR just regroups TLS related config in postgres datasource

## Before

<img width="659" alt="image" src="https://github.com/user-attachments/assets/493dc7e3-2871-4c6b-9b6b-65636a5883e8" />

## After

<img width="567" alt="image" src="https://github.com/user-attachments/assets/56a396ae-ebdf-4f20-b8f1-1e00d6aa077c" />
