### PR TITLE
Secrets: Skip allowlist check when decrypting if the list is empty

### DIFF
--- a/pkg/registry/apis/secret/decrypt/authorizer.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer.go
@@ -61,8 +61,10 @@ func (a *decryptAuthorizer) Authorize(ctx context.Context, secureValueName strin
 	// TEMPORARY: while we can't onboard every app into secrets, we can block them from decrypting
 	// securevalues preemptively here before even reaching out to the database.
 	// This check can be removed once we open the gates for any service to use secrets.
-	if _, exists := a.allowList[serviceIdentity]; !exists || serviceIdentity == "" {
-		return serviceIdentity, false
+	if len(a.allowList) > 0 {
+		if _, exists := a.allowList[serviceIdentity]; !exists || serviceIdentity == "" {
+			return serviceIdentity, false
+		}
 	}
 
 	// Checks whether the token has the permission to decrypt secure values.

--- a/pkg/registry/apis/secret/decrypt/authorizer_test.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer_test.go
@@ -108,6 +108,15 @@ func TestDecryptAuthorizer(t *testing.T) {
 		require.False(t, allowed)
 	})
 
+	t.Run("when the allow list is empty, it allows all identities", func(t *testing.T) {
+		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
+		authorizer := ProvideDecryptAuthorizer(tracer, nil)
+
+		identity, allowed := authorizer.Authorize(ctx, "", []string{"identity"})
+		require.NotEmpty(t, identity)
+		require.True(t, allowed)
+	})
+
 	t.Run("when the identity is not in the allow list, it returns false", func(t *testing.T) {
 		ctx := createAuthContext(context.Background(), "identity", []string{"secret.grafana.app/securevalues:decrypt"})
 		authorizer := ProvideDecryptAuthorizer(tracer, map[string]struct{}{"allowed1": {}})


### PR DESCRIPTION
**What is this feature?**

Only checks decrypter allow list if present.

**Why do we need this feature?**

In OSS the list is empty which means any decryptions would fail.

**Who is this feature for?**

Devs integrating with Secrets Manager.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
