### PR TITLE
VizColors: Use more named colors in the classic palette

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.test.ts
+++ b/packages/grafana-data/src/field/fieldColor.test.ts
@@ -47,7 +47,7 @@ describe('fieldColorModeRegistry', () => {
 
   it('Palette classic with series index 1', () => {
     const calcFn = getCalculator({ mode: FieldColorModeId.PaletteClassic, seriesIndex: 1, name: 'series2' });
-    expect(calcFn(70, 0, undefined)).toEqual('#F2CC0C');
+    expect(calcFn(70, 0, undefined)).toEqual('#FADE2A');
   });
 
   it('Palette uses name', () => {
@@ -113,8 +113,8 @@ describe('fieldColorModeRegistry', () => {
     const calcFn1 = mode.getCalculator(frames[0].fields[1], createTheme());
     const calcFn2 = mode.getCalculator(frames[1].fields[1], createTheme());
 
-    expect(calcFn1(0, 0)).toEqual('#82B5D8');
-    expect(calcFn2(0, 0)).toEqual('#FCE2DE');
+    expect(calcFn1(0, 0)).toEqual('#5195CE');
+    expect(calcFn2(0, 0)).toEqual('#37872D');
   });
 
   it('When color.seriesBy is set to last use that instead of v', () => {

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -388,7 +388,7 @@ describe('FieldDisplay', () => {
 
       const result = getFieldDisplayValues(options);
       expect(result[0].display.color).toEqual('#73BF69');
-      expect(result[1].display.color).toEqual('#F2CC0C');
+      expect(result[1].display.color).toEqual('#FADE2A');
     });
 
     it('When showing all values lookup color via an override', () => {
@@ -435,7 +435,7 @@ describe('FieldDisplay', () => {
 
       const result = getFieldDisplayValues(options);
       expect(result[0].display.color).toEqual('#AAA');
-      expect(result[1].display.color).toEqual('#F2CC0C');
+      expect(result[1].display.color).toEqual('#FADE2A');
     });
 
     it('Multiple other string fields', () => {

--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -260,16 +260,24 @@ function getClassicPalette() {
   // Todo replace these with named colors (as many as possible)
 
   return [
-    'green', // '#7EB26D', // 0: pale green
-    'semi-dark-yellow', // '#EAB839', // 1: mustard
-    'light-blue', // #6ED0E0', // 2: light blue
-    'semi-dark-orange', // '#EF843C', // 3: orange
-    'red', // '#E24D42', // 4: red
-    'blue', // #1F78C1', // 5: ocean
-    'purple', // '#BA43A9', // 6: purple
-    '#705DA0', // 7: violet
-    'dark-green', // '#508642', // 8: dark green
-    'yellow', //'#CCA300', // 9: dark sand
+    'green',
+    'yellow',
+    'blue',
+    'orange',
+    'red',
+    'purple',
+    'dark-green',
+    'dark-yellow',
+    'dark-blue',
+    'dark-orange',
+    'dark-red',
+    'dark-purple',
+    'super-light-green',
+    'super-light-yellow',
+    'super-light-blue',
+    'super-light-orange',
+    'super-light-red',
+    'super-light-purple',
     '#447EBC',
     '#C15C17',
     '#890F02',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- use more named colors in the classic palette
  - this will make it easier to define new themes with different color palettes
  - this makes the first 18 colors used by visualisations more consistent (and maybe boring? 🤷 appreciate thoughts here!)

|  |  |
| --- | --- |
| before | ![Image](https://github.com/user-attachments/assets/f23b4737-cb6c-4da4-a034-03787e1e0abd) |
| after | ![Image](https://github.com/user-attachments/assets/fd9fc834-4344-4d14-aa40-20a8efd33d0d) |


**Why do we need this feature?**

- groundwork for creating accessible themes (e.g. colorblind themes)

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/60856

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
