### PR TITLE
Log Line Details: Add inline mode for the Details component

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -8,13 +8,14 @@ import { createLogLine } from '../mocks/logRow';
 
 import { getGridTemplateColumns, getStyles, LogLine, Props } from './LogLine';
 import { LogListFontSize } from './LogList';
-import { LogListContextProvider } from './LogListContext';
+import { LogListContextProvider, LogListContext } from './LogListContext';
 import { LogListSearchContext } from './LogListSearchContext';
-import { defaultProps } from './__mocks__/LogListContext';
+import { defaultProps, defaultValue } from './__mocks__/LogListContext';
 import { LogListModel } from './processing';
 import { LogLineVirtualization } from './virtualization';
 
 jest.mock('./LogListContext');
+jest.mock('../LogDetails');
 
 const theme = createTheme();
 const virtualization = new LogLineVirtualization(theme, 'default');
@@ -422,6 +423,40 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
       expect(screen.queryByText('log message 1')).not.toBeInTheDocument();
       expect(screen.queryByText('luna')).not.toBeInTheDocument();
       expect(screen.getByText('un')).toBeInTheDocument();
+    });
+  });
+
+  describe('Inline details', () => {
+    test('Details are not rendered if details mode is not inline', () => {
+      render(
+        <LogListContext.Provider
+          value={{
+            ...defaultValue,
+            showDetails: [log],
+            detailsMode: 'sidebar',
+            detailsDisplayed: jest.fn().mockReturnValue(true),
+          }}
+        >
+          <LogLine {...defaultProps} />
+        </LogListContext.Provider>
+      );
+      expect(screen.queryByPlaceholderText('Search field names and values')).not.toBeInTheDocument();
+    });
+
+    test('Details are rendered if details mode is inline', () => {
+      render(
+        <LogListContext.Provider
+          value={{
+            ...defaultValue,
+            showDetails: [log],
+            detailsMode: 'inline',
+            detailsDisplayed: jest.fn().mockReturnValue(true),
+          }}
+        >
+          <LogLine {...defaultProps} />
+        </LogListContext.Provider>
+      );
+      expect(screen.getByPlaceholderText('Search field names and values')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -51,7 +51,7 @@ export const LogLine = ({
   wrapLogMessage,
 }: Props) => {
   return (
-    <div style={{ ...style, width: 'max-content' }}>
+    <div style={wrapLogMessage ? style : { ...style, width: 'max-content' }}>
       <LogLineComponent
         displayedFields={displayedFields}
         height={style.height}

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -10,6 +10,7 @@ import { Button, Icon, Tooltip } from '@grafana/ui';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogMessageAnsi } from '../LogMessageAnsi';
 
+import { InlineLogLineDetails } from './LogLineDetails';
 import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPermalinked, useLogIsPinned, useLogListContext } from './LogListContext';
 import { useLogListSearchContext } from './LogListSearchContext';
@@ -88,6 +89,7 @@ const LogLineComponent = memo(
   }: LogLineComponentProps) => {
     const {
       detailsDisplayed,
+      detailsMode,
       dedupStrategy,
       enableLogDetails,
       fontSize,
@@ -235,6 +237,7 @@ const LogLineComponent = memo(
             </Button>
           </div>
         )}
+        {detailsMode === 'inline' && detailsShown && <InlineLogLineDetails logs={[]} />}
       </>
     );
   }

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -51,7 +51,7 @@ export const LogLine = ({
   wrapLogMessage,
 }: Props) => {
   return (
-    <div style={wrapLogMessage ? style : { ...style, width: 'max-content' }}>
+    <div style={wrapLogMessage ? style : { ...style, width: 'max-content', minWidth: '100%' }}>
       <LogLineComponent
         displayedFields={displayedFields}
         height={style.height}

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -51,7 +51,7 @@ export const LogLine = ({
   wrapLogMessage,
 }: Props) => {
   return (
-    <div style={style}>
+    <div style={{ ...style, width: 'max-content' }}>
       <LogLineComponent
         displayedFields={displayedFields}
         height={style.height}

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -76,15 +76,22 @@ export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
   }
 
   return (
-    <div className={styles.container} style={{ height: '30vh' }}>
-      <div className={styles.scrollContainer}>
-        <LogLineDetailsComponent log={showDetails[0]} logs={logs} />
+    <div className={`${styles.inlineWrapper} log-line-inline-details`}>
+      <div className={styles.container}>
+        <div className={styles.scrollContainer}>
+          <LogLineDetailsComponent log={showDetails[0]} logs={logs} />
+        </div>
       </div>
     </div>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  inlineWrapper: css({
+    gridColumn: '1 / -1',
+    height: '30vh',
+    paddingBottom: theme.spacing(0.5),
+  }),
   container: css({
     overflow: 'auto',
     height: '100%',

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -17,6 +17,8 @@ export interface Props {
   onResize(): void;
 }
 
+export type LogLineDetailsMode = 'inline' | 'sidebar';
+
 export const LogLineDetails = ({ containerElement, focusLogLine, logs, onResize }: Props) => {
   const { detailsWidth, logOptionsStorageKey, setDetailsWidth, showDetails } = useLogListContext();
   const styles = useStyles2(getStyles);

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -86,10 +86,12 @@ export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
   );
 };
 
+export const LOG_LINE_DETAILS_HEIGHT = 30;
+
 const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
   inlineWrapper: css({
     gridColumn: '1 / -1',
-    height: '30vh',
+    height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
     paddingBottom: theme.spacing(0.5),
     marginRight: 1,
   }),

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -20,7 +20,7 @@ export interface Props {
 export type LogLineDetailsMode = 'inline' | 'sidebar';
 
 export const LogLineDetails = ({ containerElement, focusLogLine, logs, onResize }: Props) => {
-  const { detailsWidth, logOptionsStorageKey, setDetailsWidth, showDetails } = useLogListContext();
+  const { detailsWidth, setDetailsWidth, showDetails } = useLogListContext();
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -56,10 +56,31 @@ export const LogLineDetails = ({ containerElement, focusLogLine, logs, onResize 
     >
       <div className={styles.container} ref={containerRef}>
         <div className={styles.scrollContainer}>
-          <LogLineDetailsComponent log={showDetails[0]} logOptionsStorageKey={logOptionsStorageKey} logs={logs} />
+          <LogLineDetailsComponent log={showDetails[0]} logs={logs} />
         </div>
       </div>
     </Resizable>
+  );
+};
+
+export interface InlineLogLineDetailsProps {
+  logs: LogListModel[];
+}
+
+export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
+  const { showDetails } = useLogListContext();
+  const styles = useStyles2(getStyles);
+
+  if (!showDetails.length) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container} style={{ height: '30vh' }}>
+      <div className={styles.scrollContainer}>
+        <LogLineDetailsComponent log={showDetails[0]} logs={logs} />
+      </div>
+    </div>
   );
 };
 

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -21,7 +21,7 @@ export type LogLineDetailsMode = 'inline' | 'sidebar';
 
 export const LogLineDetails = ({ containerElement, focusLogLine, logs, onResize }: Props) => {
   const { detailsWidth, setDetailsWidth, showDetails } = useLogListContext();
-  const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles, 'sidebar');
   const dragStyles = useStyles2(getDragStyles);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -69,7 +69,7 @@ export interface InlineLogLineDetailsProps {
 
 export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
   const { showDetails } = useLogListContext();
-  const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles, 'inline');
 
   if (!showDetails.length) {
     return null;
@@ -86,18 +86,19 @@ export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
   inlineWrapper: css({
     gridColumn: '1 / -1',
     height: '30vh',
     paddingBottom: theme.spacing(0.5),
+    marginRight: 1,
   }),
   container: css({
     overflow: 'auto',
     height: '100%',
     boxShadow: theme.shadows.z1,
     border: `1px solid ${theme.colors.border.medium}`,
-    borderRight: 'none',
+    borderRight: mode === 'sidebar' ? 'none' : undefined,
   }),
   scrollContainer: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -86,7 +86,7 @@ export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
   );
 };
 
-export const LOG_LINE_DETAILS_HEIGHT = 30;
+export const LOG_LINE_DETAILS_HEIGHT = 35;
 
 const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
   inlineWrapper: css({

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -18,12 +18,11 @@ import { LogListModel } from './processing';
 
 interface LogLineDetailsComponentProps {
   log: LogListModel;
-  logOptionsStorageKey?: string;
   logs: LogListModel[];
 }
 
-export const LogLineDetailsComponent = ({ log, logOptionsStorageKey, logs }: LogLineDetailsComponentProps) => {
-  const { displayedFields, setDisplayedFields } = useLogListContext();
+export const LogLineDetailsComponent = ({ log, logs }: LogLineDetailsComponentProps) => {
+  const { displayedFields, logOptionsStorageKey, setDisplayedFields } = useLogListContext();
   const [search, setSearch] = useState('');
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -187,8 +187,8 @@ export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
         )}
         <IconButton
           name={detailsMode === 'inline' ? 'columns' : 'gf-layout-simple'}
-          aria-label={
-            detailsMode
+          tooltip={
+            detailsMode === 'inline'
               ? t('logs.log-line-details.sidebar-mode', 'Anchor to the right')
               : t('logs.log-line-details.inline-mode', 'Display inline')
           }

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -8,6 +8,7 @@ import { IconButton, Input, useStyles2 } from '@grafana/ui';
 import { copyText, handleOpenLogsContextClick } from '../../utils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
+import { LogLineDetailsMode } from './LogLineDetails';
 import { useLogIsPinned, useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
@@ -20,6 +21,7 @@ interface Props {
 export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
   const {
     closeDetails,
+    detailsMode,
     displayedFields,
     getRowContextQuery,
     logSupportsContext,
@@ -29,9 +31,10 @@ export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
     onPermalinkClick,
     onPinLine,
     onUnpinLine,
+    wrapLogMessage,
   } = useLogListContext();
   const pinned = useLogIsPinned(log);
-  const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles, detailsMode, wrapLogMessage);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -179,7 +182,7 @@ export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, wrapLogMessage: boolean) => ({
   container: css({
     overflow: 'auto',
     height: '100%',
@@ -192,7 +195,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     background: theme.colors.background.canvas,
     display: 'flex',
-    flexDirection: 'row',
+    flexDirection: !wrapLogMessage && mode === 'inline' ? 'row-reverse' : 'row',
     gap: theme.spacing(0.75),
     zIndex: theme.zIndex.navbarFixed,
     height: theme.spacing(5.5),

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CoreApp, getDefaultTimeRange, LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { CoreApp, getDefaultTimeRange, LogRowModel, LogsDedupStrategy, LogsSortOrder, store } from '@grafana/data';
 
 import { disablePopoverMenu, enablePopoverMenu, isPopoverMenuDisabled } from '../../utils';
 import { createLogRow } from '../mocks/logRow';
@@ -75,6 +75,12 @@ describe('LogList', () => {
   });
 
   test('Supports showing log details', async () => {
+    jest.spyOn(store, 'get').mockImplementation((option: string) => {
+      if (option === 'storage-key.detailsMode') {
+        return 'sidebar';
+      }
+      return undefined;
+    });
     const onClickFilterLabel = jest.fn();
     const onClickFilterOutLabel = jest.fn();
     const onClickShowField = jest.fn();
@@ -86,6 +92,50 @@ describe('LogList', () => {
         onClickFilterLabel={onClickFilterLabel}
         onClickFilterOutLabel={onClickFilterOutLabel}
         onClickShowField={onClickShowField}
+        logOptionsStorageKey="storage-key"
+      />
+    );
+
+    await userEvent.click(screen.getByText('log message 1'));
+    await screen.findByText('Fields');
+
+    expect(screen.getByText('name_of_the_label')).toBeInTheDocument();
+    expect(screen.getByText('value of the label')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Filter for value in query A'));
+    expect(onClickFilterLabel).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByLabelText('Filter out value in query A'));
+    expect(onClickFilterOutLabel).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByLabelText('Show this field instead of the message'));
+    expect(onClickShowField).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByLabelText('Close log details'));
+
+    expect(screen.queryByText('Fields')).not.toBeInTheDocument();
+    expect(screen.queryByText('Close log details')).not.toBeInTheDocument();
+  });
+
+  test('Supports showing inline log details', async () => {
+    jest.spyOn(store, 'get').mockImplementation((option: string) => {
+      if (option === 'storage-key.detailsMode') {
+        return 'inline';
+      }
+      return undefined;
+    });
+    const onClickFilterLabel = jest.fn();
+    const onClickFilterOutLabel = jest.fn();
+    const onClickShowField = jest.fn();
+
+    render(
+      <LogList
+        {...defaultProps}
+        enableLogDetails={true}
+        onClickFilterLabel={onClickFilterLabel}
+        onClickFilterOutLabel={onClickFilterOutLabel}
+        onClickShowField={onClickShowField}
+        logOptionsStorageKey="storage-key"
       />
     );
 

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -502,6 +502,9 @@ function getStyles(
       '& .unwrapped-log-line': {
         display: 'grid',
         gridTemplateColumns: getGridTemplateColumns(columns, displayedFields),
+        '& .field': {
+          overflow: 'hidden',
+        },
       },
     }),
     logListContainer: css({

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -222,6 +222,7 @@ const LogListComponent = ({
     app,
     displayedFields,
     dedupStrategy,
+    detailsMode,
     filterLevels,
     fontSize,
     forceEscape,
@@ -476,7 +477,7 @@ const LogListComponent = ({
           )}
         </InfiniteScroll>
       </div>
-      {showDetails.length > 0 && (
+      {detailsMode === 'sidebar' && showDetails.length > 0 && (
         <LogLineDetails
           containerElement={containerElement}
           focusLogLine={focusLogLine}

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -460,6 +460,7 @@ const LogListComponent = ({
                 hasLogsWithErrors,
                 hasSampledLogs,
                 showDuplicates: dedupStrategy !== LogsDedupStrategy.none,
+                showDetails,
                 showTime,
                 wrap: wrapLogMessage,
               })}

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -26,7 +26,7 @@ import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { InfiniteScroll } from './InfiniteScroll';
 import { getGridTemplateColumns } from './LogLine';
-import { LogLineDetails } from './LogLineDetails';
+import { LogLineDetails, LogLineDetailsMode } from './LogLineDetails';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
 import { LogListContextProvider, LogListState, useLogListContext } from './LogListContext';
 import { LogListControls } from './LogListControls';
@@ -41,6 +41,7 @@ export interface Props {
   app: CoreApp;
   containerElement: HTMLDivElement;
   dedupStrategy: LogsDedupStrategy;
+  detailsMode?: LogLineDetailsMode;
   displayedFields: string[];
   enableLogDetails: boolean;
   eventBus?: EventBus;
@@ -105,11 +106,12 @@ export const LogList = ({
   app,
   displayedFields,
   containerElement,
+  logOptionsStorageKey,
+  detailsMode = logOptionsStorageKey ? (store.get(`${logOptionsStorageKey}.detailsMode`) ?? 'sidebar') : 'sidebar',
   dedupStrategy,
   enableLogDetails,
   eventBus,
   filterLevels,
-  logOptionsStorageKey,
   fontSize = logOptionsStorageKey ? (store.get(`${logOptionsStorageKey}.fontSize`) ?? 'default') : 'default',
   getFieldLinks,
   getRowContextQuery,
@@ -152,6 +154,7 @@ export const LogList = ({
       app={app}
       containerElement={containerElement}
       dedupStrategy={dedupStrategy}
+      detailsMode={detailsMode}
       displayedFields={displayedFields}
       enableLogDetails={enableLogDetails}
       filterLevels={filterLevels}
@@ -457,6 +460,7 @@ const LogListComponent = ({
               height={listHeight}
               itemCount={itemCount}
               itemSize={getLogLineSize.bind(null, virtualization, filteredLogs, widthContainer, displayedFields, {
+                detailsMode,
                 hasLogsWithErrors,
                 hasSampledLogs,
                 showDuplicates: dedupStrategy !== LogsDedupStrategy.none,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -26,6 +26,7 @@ import { PopoverContent } from '@grafana/ui';
 
 import { DownloadFormat, checkLogsError, checkLogsSampled, downloadLogs as download } from '../../utils';
 
+import { LogLineDetailsMode } from './LogLineDetails';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
 import { LogListFontSize } from './LogList';
 import { LogListModel } from './processing';
@@ -34,6 +35,7 @@ import { LOG_LIST_MIN_WIDTH } from './virtualization';
 export interface LogListContextData extends Omit<Props, 'containerElement' | 'logs' | 'logsMeta' | 'showControls'> {
   closeDetails: () => void;
   detailsDisplayed: (log: LogListModel) => boolean;
+  detailsMode: LogLineDetailsMode;
   detailsWidth: number;
   downloadLogs: (format: DownloadFormat) => void;
   enableLogDetails: boolean;
@@ -43,6 +45,7 @@ export interface LogListContextData extends Omit<Props, 'containerElement' | 'lo
   hasUnescapedContent?: boolean;
   logLineMenuCustomItems?: LogLineMenuCustomItem[];
   setDedupStrategy: (dedupStrategy: LogsDedupStrategy) => void;
+  setDetailsMode: (mode: LogLineDetailsMode) => void;
   setDetailsWidth: (width: number) => void;
   setFilterLevels: (filterLevels: LogLevel[]) => void;
   setFontSize: (size: LogListFontSize) => void;
@@ -64,6 +67,7 @@ export const LogListContext = createContext<LogListContextData>({
   closeDetails: () => {},
   dedupStrategy: LogsDedupStrategy.none,
   detailsDisplayed: () => false,
+  detailsMode: 'sidebar',
   detailsWidth: 0,
   displayedFields: [],
   downloadLogs: () => {},
@@ -72,6 +76,7 @@ export const LogListContext = createContext<LogListContextData>({
   fontSize: 'default',
   hasUnescapedContent: false,
   setDedupStrategy: () => {},
+  setDetailsMode: () => {},
   setDetailsWidth: () => {},
   setFilterLevels: () => {},
   setFontSize: () => {},
@@ -230,6 +235,7 @@ export const LogListContextProvider = ({
   });
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
+  const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>('sidebar');
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.
@@ -480,6 +486,7 @@ export const LogListContextProvider = ({
         closeDetails,
         detailsDisplayed,
         dedupStrategy: logListState.dedupStrategy,
+        detailsMode,
         detailsWidth,
         displayedFields,
         downloadLogs,
@@ -511,6 +518,7 @@ export const LogListContextProvider = ({
         pinnedLogs: logListState.pinnedLogs,
         prettifyJSON: logListState.prettifyJSON,
         setDedupStrategy,
+        setDetailsMode,
         setDetailsWidth,
         setDisplayedFields,
         setFilterLevels,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -235,7 +235,7 @@ export const LogListContextProvider = ({
   });
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
-  const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>('sidebar');
+  const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>('inline');
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -137,6 +137,7 @@ export interface Props {
   children?: ReactNode;
   // Only ControlledLogRows can send an undefined containerElement. See LogList.tsx
   containerElement?: HTMLDivElement;
+  detailsMode?: LogLineDetailsMode;
   dedupStrategy: LogsDedupStrategy;
   displayedFields: string[];
   enableLogDetails: boolean;
@@ -181,6 +182,7 @@ export const LogListContextProvider = ({
   children,
   containerElement,
   enableLogDetails,
+  detailsMode: detailsModeProp,
   dedupStrategy,
   displayedFields,
   filterLevels,
@@ -235,7 +237,7 @@ export const LogListContextProvider = ({
   });
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
-  const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>('inline');
+  const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>(detailsModeProp ?? 'sidebar');
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -481,8 +481,6 @@ export const LogListContextProvider = ({
   const hasLogsWithErrors = useMemo(() => logs.some((log) => !!checkLogsError(log)), [logs]);
   const hasSampledLogs = useMemo(() => logs.some((log) => !!checkLogsSampled(log)), [logs]);
 
-  console.log(detailsWidth);
-
   return (
     <LogListContext.Provider
       value={{

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -481,6 +481,8 @@ export const LogListContextProvider = ({
   const hasLogsWithErrors = useMemo(() => logs.some((log) => !!checkLogsError(log)), [logs]);
   const hasSampledLogs = useMemo(() => logs.some((log) => !!checkLogsSampled(log)), [logs]);
 
+  console.log(detailsWidth);
+
   return (
     <LogListContext.Provider
       value={{
@@ -573,7 +575,9 @@ function getDetailsWidth(
   const defaultWidth = containerElement.clientWidth * 0.4;
   const detailsWidth =
     currentWidth ||
-    (logOptionsStorageKey ? parseInt(store.get(`${logOptionsStorageKey}.detailsWidth`), 10) : defaultWidth);
+    (logOptionsStorageKey
+      ? parseInt(store.get(`${logOptionsStorageKey}.detailsWidth`) ?? defaultWidth, 10)
+      : defaultWidth);
 
   const maxWidth = containerElement.clientWidth - LOG_LIST_MIN_WIDTH;
 

--- a/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react';
 import { CoreApp, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 import { checkLogsError, checkLogsSampled } from 'app/features/logs/utils';
 
+import { LogLineDetailsMode } from '../LogLineDetails';
 import { LogListContextData, Props } from '../LogListContext';
 import { LogListModel } from '../processing';
 
@@ -37,6 +38,10 @@ export const LogListContext = createContext<LogListContextData>({
   syntaxHighlighting: true,
   toggleDetails: () => {},
   wrapLogMessage: false,
+  detailsMode: 'sidebar',
+  setDetailsMode: function (mode: LogLineDetailsMode): void {
+    throw new Error('Function not implemented.');
+  },
 });
 
 export const useLogListContextData = (key: keyof LogListContextData) => {
@@ -59,6 +64,8 @@ export const useLogIsPermalinked = (log: LogListModel) => {
 };
 
 export const defaultValue: LogListContextData = {
+  detailsMode: 'sidebar',
+  setDetailsMode: jest.fn(),
   setDedupStrategy: jest.fn(),
   setFilterLevels: jest.fn(),
   setFontSize: jest.fn(),

--- a/public/app/features/logs/components/panel/virtualization.test.ts
+++ b/public/app/features/logs/components/panel/virtualization.test.ts
@@ -21,8 +21,10 @@ describe('Virtualization', () => {
   let TWO_LINES_OF_CHARACTERS: number;
 
   const defaultOptions: DisplayOptions = {
+    detailsMode: 'sidebar',
     wrap: false,
     showTime: false,
+    showDetails: [],
     showDuplicates: false,
     hasLogsWithErrors: false,
     hasSampledLogs: false,

--- a/public/app/features/logs/components/panel/virtualization.test.ts
+++ b/public/app/features/logs/components/panel/virtualization.test.ts
@@ -3,9 +3,9 @@ import { createTheme, LogsSortOrder } from '@grafana/data';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../mocks/logRow';
 
+import { LOG_LINE_DETAILS_HEIGHT } from './LogLineDetails';
 import { LogListModel, PreProcessOptions } from './processing';
 import { LogLineVirtualization, getLogLineSize, DisplayOptions, FIELD_GAP_MULTIPLIER } from './virtualization';
-import { LOG_LINE_DETAILS_HEIGHT } from './LogLineDetails';
 
 describe('Virtualization', () => {
   let log: LogListModel, container: HTMLDivElement;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -253,9 +253,10 @@ export function getLogLineSize(
     return 0;
   }
   const gap = virtualization.getGridSize() * FIELD_GAP_MULTIPLIER;
-  const detailsHeight = showDetails.includes(logs[index])
-    ? window.innerHeight * (LOG_LINE_DETAILS_HEIGHT / 100) + gap / 2
-    : 0;
+  const detailsHeight =
+    showDetails.findIndex((log) => log.uid === logs[index].uid) >= 0
+      ? window.innerHeight * (LOG_LINE_DETAILS_HEIGHT / 100) + gap / 2
+      : 0;
   // !logs[index] means the line is not yet loaded by infinite scrolling
   if (!wrap || !logs[index]) {
     return virtualization.getLineHeight() + virtualization.getPaddingBottom() + detailsHeight;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -2,7 +2,7 @@ import ansicolor from 'ansicolor';
 
 import { BusEventWithPayload, GrafanaTheme2 } from '@grafana/data';
 
-import { LOG_LINE_DETAILS_HEIGHT } from './LogLineDetails';
+import { LOG_LINE_DETAILS_HEIGHT, LogLineDetailsMode } from './LogLineDetails';
 import { LogListFontSize } from './LogList';
 import { LogListModel } from './processing';
 
@@ -233,6 +233,7 @@ export class LogLineVirtualization {
 }
 
 export interface DisplayOptions {
+  detailsMode: LogLineDetailsMode;
   hasLogsWithErrors?: boolean;
   hasSampledLogs?: boolean;
   showDetails: LogListModel[];
@@ -246,7 +247,7 @@ export function getLogLineSize(
   logs: LogListModel[],
   container: HTMLDivElement | null,
   displayedFields: string[],
-  { hasLogsWithErrors, hasSampledLogs, showDuplicates, showDetails, showTime, wrap }: DisplayOptions,
+  { detailsMode, hasLogsWithErrors, hasSampledLogs, showDuplicates, showDetails, showTime, wrap }: DisplayOptions,
   index: number
 ) {
   if (!container) {
@@ -254,7 +255,7 @@ export function getLogLineSize(
   }
   const gap = virtualization.getGridSize() * FIELD_GAP_MULTIPLIER;
   const detailsHeight =
-    showDetails.findIndex((log) => log.uid === logs[index].uid) >= 0
+    detailsMode === 'inline' && showDetails.findIndex((log) => log.uid === logs[index].uid) >= 0
       ? window.innerHeight * (LOG_LINE_DETAILS_HEIGHT / 100) + gap / 2
       : 0;
   // !logs[index] means the line is not yet loaded by infinite scrolling

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -313,14 +313,28 @@ export function hasUnderOrOverflow(
   if (collapsed !== undefined && calculatedHeight) {
     calculatedHeight -= virtualization.getLineHeight();
   }
+  const inlineDetails = element.parentElement
+    ? Array.from(element.parentElement.children).filter((element) =>
+        element.classList.contains('log-line-inline-details')
+      )
+    : undefined;
+  const detailsHeight = inlineDetails?.length ? inlineDetails[0].clientHeight : 0;
+
+  // Line overflows container
+  let measuredHeight = element.scrollHeight + detailsHeight;
   const height = calculatedHeight ?? element.clientHeight;
-  if (element.scrollHeight > height) {
-    return collapsed !== undefined ? element.scrollHeight + virtualization.getLineHeight() : element.scrollHeight;
+  if (measuredHeight > height) {
+    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
   }
+
+  // Line is smaller than container
   const child = element.children[1];
-  if (child instanceof HTMLDivElement && child.clientHeight < height) {
-    return collapsed !== undefined ? child.clientHeight + virtualization.getLineHeight() : child.clientHeight;
+  measuredHeight = child.clientHeight + detailsHeight;
+  if (child instanceof HTMLDivElement && measuredHeight < height) {
+    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
   }
+
+  // No overflow or undermeasurement
   return null;
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8726,6 +8726,7 @@
       },
       "fields-section": "Fields",
       "hide-log-line": "Hide log line",
+      "inline-mode": "Display inline",
       "links-section": "Links",
       "log-line-field": "Log line",
       "log-line-section": "Log line",
@@ -8738,6 +8739,7 @@
       "search-placeholder": "Search field names and values",
       "show-context": "Show context",
       "show-log-line": "Show log line",
+      "sidebar-mode": "Anchor to the right",
       "unpin-line": "Unpin log"
     },
     "log-line-menu": {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075
Follow up of https://github.com/grafana/grafana/pull/107466

This PR adds support for displaying the Log Details panel in inline mode, analog to the current visualization (not the new Logs Panel).

![imagen](https://github.com/user-attachments/assets/11194441-c1d6-45fa-84d0-676ee2b51827)

![imagen](https://github.com/user-attachments/assets/a42ccb2e-a702-424d-92fe-9e94cfdbd37a)

Demo:

https://github.com/user-attachments/assets/f3658e92-692b-46cf-8628-e3bda777f482

Additionally, it properly handles overflowing content in unwrapped mode.

### What to test

- Log details should work without issues and be resizable as a sidebar
- Log details should work without issues with a fixed height in inline mode.
- In unwrapped mode, with overflow, there should be a horizontal scroll.
- In unwrapped mode, icons are shifted to the left so they are not hidden by the scroll. This matches the behavior of the current panel.