### PR TITLE
No need to convert error responses

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -482,6 +482,11 @@ func (b *QueryAPIBuilder) convertQueryFromAlerting(ctx context.Context, req data
 		return nil, fmt.Errorf("refID '%s' does not exist", refID)
 	}
 	frames := qdr.Responses[refID].Frames
+	// if there are no frames or there is an error, we do not need to modify the response at all
+	if len(frames) == 0 || qdr.Responses[refID].Error != nil {
+		return qdr, nil
+	}
+	// convert changes the results so that alerting can use them (ex no need for time stamps, easier to math with)
 	_, results, err := b.converter.Convert(ctx, req.PluginId, frames, false)
 	if err != nil {
 		b.log.Error("issue converting query from alerting", "err", err)


### PR DESCRIPTION
**What is this feature?**

No need to convert responses that are empty or contain errors, part of https://github.com/grafana/grafana-enterprise/pull/8926/files

**Why do we need this feature?**

reworking error handling in the ds querier

**Who is this feature for?**

internal grafana developers

**Which issue(s) does this PR fix?**:

relates to https://github.com/grafana/grafana-enterprise/issues/8893

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
