### PR TITLE
Alerting: Separate configuration model for remote Alertmanager Mimir client

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -374,7 +374,7 @@ func (am *Alertmanager) sendConfiguration(ctx context.Context, decrypted *apimod
 	am.metrics.ConfigSyncsTotal.Inc()
 	if err := am.mimirClient.CreateGrafanaAlertmanagerConfig(
 		ctx,
-		decrypted,
+		PostableUserConfigToGrafanaAlertmanagerConfig(decrypted),
 		hash,
 		createdAt,
 		isDefault,

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -29,7 +29,7 @@ type MimirClient interface {
 	DeleteGrafanaAlertmanagerState(ctx context.Context) error
 
 	GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error)
-	CreateGrafanaAlertmanagerConfig(ctx context.Context, configuration *apimodels.PostableUserConfig, hash string, createdAt int64, isDefault bool) error
+	CreateGrafanaAlertmanagerConfig(ctx context.Context, configuration *GrafanaAlertmanagerConfig, hash string, createdAt int64, isDefault bool) error
 	DeleteGrafanaAlertmanagerConfig(ctx context.Context) error
 
 	TestTemplate(ctx context.Context, c alertingNotify.TestTemplatesConfigBodyParams) (*alertingNotify.TestTemplatesResults, error)

--- a/pkg/services/ngalert/remote/compat.go
+++ b/pkg/services/ngalert/remote/compat.go
@@ -1,0 +1,13 @@
+package remote
+
+import (
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/remote/client"
+)
+
+func PostableUserConfigToGrafanaAlertmanagerConfig(config *definitions.PostableUserConfig) *client.GrafanaAlertmanagerConfig {
+	return &client.GrafanaAlertmanagerConfig{
+		TemplateFiles:      config.TemplateFiles,
+		AlertmanagerConfig: config.AlertmanagerConfig,
+	}
+}

--- a/pkg/services/ngalert/remote/test-data/config-with-extra.json
+++ b/pkg/services/ngalert/remote/test-data/config-with-extra.json
@@ -1,0 +1,41 @@
+{
+  "template_files": {
+    "test": "{{ define \"my_templ\" }}TEST{{ end }}"
+  },
+  "alertmanager_config": {
+    "route": {
+      "receiver": "grafana-default-email",
+      "group_by": [
+        "grafana_folder",
+        "alertname"
+      ]
+    },
+    "receivers": [
+      {
+        "name": "grafana-default-email",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "some other name",
+            "type": "email",
+            "disableResolveMessage": false,
+            "settings": {
+              "addresses": "<example@email.com>"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "extra_config": [
+    {
+      "identifier": "imported",
+      "merge_matchers": ["imported=\"true\""],
+      "template_files":
+      {
+        "extra_template": "{{ define \"my_message\" }}TEST{{ end }}"
+      },
+      "alertmanager_config": "{\"receivers\":[{\"webhook_configs\":[{\"url\":\"http://localhost\"}],\"name\":\"webhook\"}],\"route\":{\"receiver\":\"webhook\"}}"
+    }
+  ]
+}


### PR DESCRIPTION
**What is this feature?**
This PR refactors Mimir client of remote Alertmanager to use its own type for configuration model. 
The new model's default marshaler is set to `definition.MarshalJSONWithSecrets` to make sure the secrets are not masked when the configuration is sent to remote Alertmanager.

**Why do we need this feature?**
- The current PostableUserConfig is not the correct model anymore because it incorporates more information that the [model ](https://github.com/grafana/mimir/blob/0e4f123f8dcb6ae3c33af0eea32333d188d99a97/pkg/alertmanager/api_grafana.go#L60-L66) of the Mimir API supports. 
- The PostableUserConfig bears many responsibilities: domain, storage and API models, and usage of it in the client request model would bring to much uncertainty. 
- This will allow updating the models independently, which will be needed for the new templates functionality.