### PR TITLE
Alerting: Fix crypto_test.go errors in CI

### DIFF
--- a/pkg/services/ngalert/notifier/crypto_test.go
+++ b/pkg/services/ngalert/notifier/crypto_test.go
@@ -36,7 +36,9 @@ func TestEncryptExtraConfigs(t *testing.T) {
 			m := fakes.NewFakeSecretsService()
 
 			c := &alertmanagerCrypto{
-				secrets: m,
+				ExtraConfigsCrypto: &ExtraConfigsCrypto{
+					secrets: m,
+				},
 			}
 
 			cfg := &definitions.PostableUserConfig{
@@ -83,7 +85,9 @@ func TestDecryptExtraConfigs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := fakes.NewFakeSecretsService()
 			c := &alertmanagerCrypto{
-				secrets: m,
+				ExtraConfigsCrypto: &ExtraConfigsCrypto{
+					secrets: m,
+				},
 			}
 
 			cfg := &definitions.PostableUserConfig{


### PR DESCRIPTION
CI is failing due to:
```
Error: pkg/services/ngalert/notifier/crypto_test.go:86:5: unknown field secrets in struct literal of type alertmanagerCrypto
```