### PR TITLE
IAM: Return 401 if identity type is not valid in GetUserPreferences

### DIFF
--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -74,7 +74,7 @@ func (hs *HTTPServer) SetHomeDashboard(c *contextmodel.ReqContext) response.Resp
 func (hs *HTTPServer) GetUserPreferences(c *contextmodel.ReqContext) response.Response {
 	userID, err := identity.UserIdentifier(c.GetID())
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to update user preferences", err)
+		return response.Error(http.StatusUnauthorized, "Not a valid identity", err)
 	}
 
 	return prefapi.GetPreferencesFor(c.Req.Context(), hs.DashboardService, hs.preferenceService, hs.Features, c.GetOrgID(), userID, 0)


### PR DESCRIPTION
The `GetUserPreferences` endpoint (`GET /api/user/preferences`) returns a 500 HTTP code when the request contains an invalid identity. This PR updates it to return a 401 instead.

When `identity.UserIdentifier(c.GetID())` returns an error, it's because it was given an invalid ID (wrong format, type, etc.) and it doesn't seem like `StatusInternalServerError` is the appropriate response. A 400 or 401 seem better-suited for it.