### PR TITLE
[WIP] RBAC: modify roles investigation

### DIFF
--- a/pkg/services/accesscontrol/actionset_bug.md
+++ b/pkg/services/accesscontrol/actionset_bug.md
@@ -1,0 +1,225 @@
+# RBAC Action Set Resolution Bug - Reproduction Steps
+
+This document provides a simple way to reproduce the bug where adding plugin permissions to built-in roles causes users to lose dashboard access after the June 13, 2024 upgrade.
+
+## Bug Summary
+
+The issue occurs in `pkg/services/accesscontrol/resourcepermissions/service.go` in the `GetPermissions()` method where action set resolution logic incorrectly filters out non-dashboard/folder actions, causing managed roles to lose their permissions.
+
+## Prerequisites
+
+- Grafana v12.1.0-89698 or later (contains the bug)
+- Admin access to Grafana
+- Ability to create users and assign roles
+
+## Step-by-Step Reproduction
+
+### 1. Create Test Environment
+
+```bash
+# Start Grafana in development mode
+make run
+
+# Or using Docker
+docker run -d -p 3000:3000 --name grafana-test grafana/grafana:latest
+```
+
+### 2. Create Test User with Editor Role
+
+```bash
+# Using Grafana API
+curl -X POST \
+  http://admin:admin@localhost:3000/api/admin/users \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Test User",
+    "email": "test@example.com",
+    "login": "testuser",
+    "password": "testpass",
+    "OrgId": 1
+  }'
+
+# Set user role to Editor
+curl -X PATCH \
+  http://admin:admin@localhost:3000/api/org/users/2 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "role": "Editor"
+  }'
+```
+
+### 3. Verify Dashboard Access (Before)
+
+```bash
+# Login as test user and verify dashboard access
+curl -u testuser:testpass \
+  http://localhost:3000/api/dashboards/home
+
+# Should return dashboard data successfully
+
+# Check folder permissions
+curl -u testuser:testpass \
+  http://localhost:3000/api/folders
+```
+
+### 4. Add Plugin Permission to Editor Role
+
+Using Terraform configuration:
+
+```hcl
+# main.tf
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}
+
+resource "grafana_builtin_role_assignment" "editor_plugin_access" {
+  builtin_role = "Editor"
+  
+  permissions {
+    action = "plugins.app:access"
+    scope  = "plugins:id:grafana-testdata-datasource"
+  }
+}
+```
+
+Or using API directly:
+
+```bash
+# Add plugin permission to Editor role
+curl -X POST \
+  http://admin:admin@localhost:3000/api/access-control/builtin-roles/Editor/role-permissions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "permissions": [
+      {
+        "action": "plugins.app:access",
+        "scope": "plugins:id:grafana-testdata-datasource"
+      }
+    ]
+  }'
+```
+
+### 5. Verify Dashboard Access Loss (After)
+
+```bash
+# Test dashboard access - should now fail
+curl -u testuser:testuser \
+  http://localhost:3000/api/dashboards/home
+
+# Check specific permission endpoint
+curl -u testuser:testuser \
+  http://localhost:3000/api/access-control/user/permissions
+
+# Check folder access
+curl -u testuser:testuser \
+  http://localhost:3000/api/folders
+```
+
+Expected result: Dashboard access should be denied even though the user still has Editor role.
+
+### 6. Debug: Check Managed Role Creation
+
+```bash
+# Check if managed role was created
+curl -X GET \
+  http://admin:admin@localhost:3000/api/access-control/roles \
+  | jq '.[] | select(.name | contains("managed:builtins:editor"))'
+
+# Check permissions on the managed role
+curl -X GET \
+  http://admin:admin@localhost:3000/api/access-control/roles/managed:builtins:editor:permissions/permissions
+```
+
+Expected result: Managed role should only contain plugin permission, missing dashboard/folder permissions.
+
+## Alternative UI Reproduction
+
+### 1. Use Grafana UI
+
+1. Login as admin (admin/admin)
+2. Go to Administration → Users and access → Roles
+3. Find "Editor" role and click on it
+4. Add a new permission:
+   - Action: `plugins.app:access`
+   - Scope: `plugins:id:grafana-testdata-datasource`
+5. Save changes
+
+### 2. Test with Editor User
+
+1. Login as the test user
+2. Try to access dashboards via the UI
+3. Navigate to Dashboards → Browse
+4. Should see no dashboards or get permission errors
+
+## Expected Behavior vs Actual Behavior
+
+### Expected (Correct) Behavior
+- Adding plugin permissions should **supplement** existing Editor permissions
+- User should retain dashboard and folder access from Editor role
+- Managed role should inherit or preserve built-in Editor permissions
+
+### Actual (Bug) Behavior
+- Adding plugin permissions **replaces** all permissions in managed role
+- User loses dashboard and folder access from Editor role
+- Managed role only contains explicitly added permissions
+
+## Code Investigation
+
+To investigate the bug, examine this code in `pkg/services/accesscontrol/resourcepermissions/service.go`:
+
+```go
+if isFolderOrDashboardAction(action) {
+    actionSetActions := s.actionSetSvc.ResolveActionSet(action)
+    if len(actionSetActions) > 0 {
+        // ... expansion logic
+        continue  // ← BUG: Original action is skipped
+    }
+}
+expandedActions = append(expandedActions, action)  // ← Never reached for some actions
+```
+
+## Workaround
+
+Until fixed, add explicit dashboard permissions when adding plugin permissions:
+
+```hcl
+resource "grafana_builtin_role_assignment" "editor_complete" {
+  builtin_role = "Editor"
+  
+  permissions {
+    action = "plugins.app:access"
+    scope  = "plugins:id:grafana-testdata-datasource"
+  }
+  
+  # Add missing dashboard permissions explicitly
+  permissions {
+    action = "dashboards:read"
+    scope  = "folders:uid:general"
+  }
+  
+  permissions {
+    action = "folders:read" 
+    scope  = "folders:uid:general"
+  }
+}
+```
+
+## Cleanup
+
+```bash
+# Remove test resources
+curl -X DELETE http://admin:admin@localhost:3000/api/admin/users/2
+docker stop grafana-test && docker rm grafana-test
+```
+
+This reproduction demonstrates how the action set resolution bug causes permission loss when plugin permissions are added to built-in roles.

--- a/pkg/services/accesscontrol/actionset_bug.md
+++ b/pkg/services/accesscontrol/actionset_bug.md
@@ -1,49 +1,55 @@
-# RBAC Action Set Resolution Bug - Reproduction Steps
+# RBAC Action Set Resolution Bug
 
-This document provides a simple way to reproduce the bug where adding plugin permissions to built-in roles causes users to lose dashboard access after the June 13, 2024 upgrade.
+This document is a investigation documentation for potentially reproducing the bug where adding plugin permissions to built-in roles causes users to lose dashboard access.
 
 ## theory
 
 The issue occurs in `pkg/services/accesscontrol/resourcepermissions/service.go` in the `GetPermissions()` method where action set resolution logic incorrectly filters out non-dashboard/folder actions, causing managed roles to lose their permissions.
 
+current status: NOT REPRODUCABLE
+
+
 ## Prerequisites
 
 - Grafana v12.1.0-89698 or later (contains the bug)
-- Admin access to Grafana
-- Ability to create users and assign roles
+- Modify Editor Role via API
 
- UI Reproduction
 
-### 1. Use Grafana UI
+## Workaround
 
-1. Login as admin (admin/admin)
-2. Go to Administration → Users and access → Roles
-3. Find "Editor" role and click on it
-4. Add a new permission:
-   - Action: `plugins.app:access`
-   - Scope: `plugins:id:grafana-testdata-datasource`
-5. Save changes
+Until fixed, add explicit dashboard permissions when adding plugin permissions:
 
-### 2. Test with Editor User
+```hcl
+resource "grafana_builtin_role_assignment" "editor_complete" {
+  builtin_role = "Editor"
+  
+  permissions {
+    action = "plugins.app:access"
+    scope  = "plugins:id:grafana-testdata-datasource"
+  }
+  
+  permissions {
+    action = "folders:read" 
+    scope  = "folders:uid:general"
+  }
+}
+```
 
-1. Login as the test user
-2. Try to access dashboards via the UI
-3. Navigate to Dashboards → Browse
-4. Should see no dashboards or get permission errors
+1. create folders and dashboards in grafana, parents and children, there should at least be one dashboard nested in a folder, both in general folder and in a sub-folder
+2. remove editor managed role for certain dashboards and others leave it. (expect that only editors are able to see the dashboards assigned)
+3. if the bug exist, we should see no dashboards or get permission errors
 
 ## Expected Behavior vs Actual Behavior
 
 ### Expected (Correct) Behavior
 - Adding plugin permissions should **supplement** existing Editor permissions
 - User should retain dashboard and folder access from Editor role
-- Managed role should inherit or preserve built-in Editor permissions
 
 ### Actual (Bug) Behavior
-- Adding plugin permissions **replaces** all permissions in managed role
+- Adding plugin permissions seems to have been **replacing** all permissions in managed role
 - User loses dashboard and folder access from Editor role
-- Managed role only contains explicitly added permissions
 
-## Code Investigation
+## Potential Code Investigation
 
 To investigate the bug, examine this code in `pkg/services/accesscontrol/resourcepermissions/service.go`:
 
@@ -58,7 +64,7 @@ if isFolderOrDashboardAction(action) {
 expandedActions = append(expandedActions, action)  // ← Never reached for some actions
 ```
 
-## Workaround
+## Workaround for the customer that worked.
 
 Until fixed, add explicit dashboard permissions when adding plugin permissions:
 

--- a/pkg/services/accesscontrol/resolvers_test.go
+++ b/pkg/services/accesscontrol/resolvers_test.go
@@ -2,12 +2,15 @@ package accesscontrol_test
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
@@ -121,4 +124,268 @@ func TestResolvers_AttributeScope(t *testing.T) {
 			assert.Equal(t, tt.wantCalls, calls, "cache has not been used")
 		})
 	}
+}
+
+// TestRBACActionSetBug demonstrates the bug where action set expansion logic
+// skips adding original actions when expanding dashboard/folder actions
+func TestRBACActionSetBug(t *testing.T) {
+	// This test demonstrates the problematic logic from the real codebase
+	// The bug occurs when expanding action sets - it skips adding the original action
+
+	// Mock action set service that demonstrates the bug
+	// The issue is when an individual action name conflicts with an action set name
+	actionSetSvc := &mockActionSetService{
+		actionSets: map[string][]string{
+			// Real action sets
+			"dashboards:edit": {"dashboards:read", "dashboards:write"},
+			"folders:edit":    {"folders:read", "folders:write"},
+			// BUG SCENARIO: An action conflicts with an action set name
+			// This should NOT happen, but when it does, it causes the bug
+			"dashboards:read": {"dashboards:view"}, // Incorrectly treats individual action as action set
+		},
+	}
+
+	// Test case: User has individual action that conflicts with action set name
+	inputActions := []string{
+		"dashboards:read",    // This will be lost due to bug (treated as action set)
+		"folders:read",       // This will be preserved (no action set conflict)
+		"plugins.app:access", // This will be preserved (not dashboard/folder action)
+	}
+
+	// Run the buggy logic
+	result := demonstrateBuggyLogic(inputActions, actionSetSvc)
+
+	t.Logf("Input actions: %v", inputActions)
+	t.Logf("Output actions: %v", result)
+
+	// BUG: The original "dashboards:read" action is lost and replaced with action set expansion
+	assert.NotContains(t, result, "dashboards:read",
+		"BUG: Original dashboard read action is lost")
+	assert.Contains(t, result, "dashboards:view",
+		"BUG: Action set expansion replaces original action")
+
+	// These should be preserved
+	assert.Contains(t, result, "folders:read",
+		"Folders read should be preserved (no action set conflict)")
+	assert.Contains(t, result, "plugins.app:access",
+		"Plugin permission should be preserved")
+
+	// Test case 2: Demonstrate the correct behavior
+	fixedResult := demonstrateFixedLogic(inputActions, actionSetSvc)
+
+	t.Logf("Fixed output actions: %v", fixedResult)
+
+	// The fixed logic should preserve all original actions AND add expansions
+	assert.Contains(t, fixedResult, "dashboards:read",
+		"Fixed: Original dashboard read action should be preserved")
+	assert.Contains(t, fixedResult, "dashboards:view",
+		"Fixed: Action set expansion should also be included")
+	assert.Contains(t, fixedResult, "folders:read",
+		"Fixed: Folders read should be preserved")
+	assert.Contains(t, fixedResult, "plugins.app:access",
+		"Fixed: Plugin permission should be preserved")
+}
+
+// TestRBACActionSetBugFailing demonstrates the bug by failing - it expects correct behavior
+// but the buggy implementation loses original actions during expansion
+func TestRBACActionSetBugFailing(t *testing.T) {
+	// Create a real action set service
+	actionSetSvc := resourcepermissions.NewActionSetService()
+
+	// Set up action sets that will trigger the bug
+	// Store action sets that conflict with individual actions
+	actionSetSvc.StoreActionSet("dashboards:read", []string{"dashboards:view"}) // This causes the bug
+	actionSetSvc.StoreActionSet("folders:edit", []string{"folders:read", "folders:write"})
+
+	// User has these permissions that should be preserved
+	userActions := []string{
+		"dashboards:read",    // This will be lost due to the bug (conflicts with action set name)
+		"folders:write",      // This should be preserved (no conflict)
+		"plugins.app:access", // This should be preserved (not dashboard/folder action)
+	}
+
+	// Run the REAL buggy logic from the codebase
+	result := realBuggyLogic(userActions, actionSetSvc, []string{"dashboards:read", "folders:write", "plugins.app:access"})
+
+	// THIS TEST WILL FAIL because the buggy implementation loses "dashboards:read"
+	// Expected: User should keep their original "dashboards:read" permission
+	// Actual: The permission gets replaced with "dashboards:view" from action set expansion
+	assert.Contains(t, result, "dashboards:read",
+		"FAILING TEST: Original dashboards:read permission should be preserved but is lost due to bug")
+
+	// These should pass (not affected by the bug)
+	assert.Contains(t, result, "folders:write",
+		"folders:write should be preserved")
+	assert.Contains(t, result, "plugins.app:access",
+		"plugins.app:access should be preserved")
+
+	// Show what we actually get instead
+	t.Logf("Expected to find 'dashboards:read' in result: %v", result)
+	t.Logf("Bug: 'dashboards:read' was replaced with 'dashboards:view'")
+}
+
+// Mock action set service for testing
+type mockActionSetService struct {
+	actionSets map[string][]string
+}
+
+func (m *mockActionSetService) ResolveActionSet(actionSet string) []string {
+	if actions, exists := m.actionSets[actionSet]; exists {
+		return actions
+	}
+	return nil
+}
+
+func (m *mockActionSetService) ResolveAction(action string) []string {
+	// This would return action sets that contain the given action
+	var result []string
+	for actionSet, actions := range m.actionSets {
+		for _, a := range actions {
+			if a == action {
+				result = append(result, actionSet)
+				break
+			}
+		}
+	}
+	return result
+}
+
+// Example of the problematic code from the real codebase (simplified)
+func demonstrateBuggyLogic(actions []string, actionSetSvc ActionSetService) []string {
+	var expandedActions []string
+
+	for _, action := range actions {
+		// This is the problematic logic from the real code
+		if isFolderOrDashboardAction(action) {
+			actionSetActions := actionSetSvc.ResolveActionSet(action)
+			if len(actionSetActions) > 0 {
+				for _, actionSetAction := range actionSetActions {
+					expandedActions = append(expandedActions, actionSetAction)
+				}
+				continue // ← BUG: This skips adding the original action!
+			}
+		}
+		expandedActions = append(expandedActions, action)
+	}
+
+	return expandedActions
+}
+
+// Fixed version of the logic
+func demonstrateFixedLogic(actions []string, actionSetSvc ActionSetService) []string {
+	var expandedActions []string
+
+	for _, action := range actions {
+		// Add the original action first
+		expandedActions = append(expandedActions, action)
+
+		// Then add any action set expansions
+		if isFolderOrDashboardAction(action) {
+			actionSetActions := actionSetSvc.ResolveActionSet(action)
+			for _, actionSetAction := range actionSetActions {
+				// Avoid duplicates
+				found := false
+				for _, existing := range expandedActions {
+					if existing == actionSetAction {
+						found = true
+						break
+					}
+				}
+				if !found {
+					expandedActions = append(expandedActions, actionSetAction)
+				}
+			}
+		}
+	}
+
+	return expandedActions
+}
+
+func isFolderOrDashboardAction(action string) bool {
+	return strings.HasPrefix(action, "dashboards:") || strings.HasPrefix(action, "folders:")
+}
+
+type ActionSetService interface {
+	ResolveActionSet(actionSet string) []string
+	ResolveAction(action string) []string
+}
+
+// TestActionSetExpansionBehavior tests the specific problematic behavior
+func TestActionSetExpansionBehavior(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputActions  []string
+		actionSets    map[string][]string
+		expectedBuggy []string // What the buggy logic produces
+		expectedFixed []string // What the fixed logic produces
+	}{
+		{
+			name:         "action name conflicts with action set name",
+			inputActions: []string{"dashboards:read", "plugins.app:access"},
+			actionSets: map[string][]string{
+				"dashboards:read": {"dashboards:view"}, // Conflict: action treated as action set
+			},
+			expectedBuggy: []string{"dashboards:view", "plugins.app:access"}, // Original lost
+			expectedFixed: []string{"dashboards:read", "dashboards:view", "plugins.app:access"},
+		},
+		{
+			name:         "normal action set expansion",
+			inputActions: []string{"dashboards:edit", "users:read"},
+			actionSets: map[string][]string{
+				"dashboards:edit": {"dashboards:read", "dashboards:write"},
+			},
+			expectedBuggy: []string{"dashboards:read", "dashboards:write", "users:read"},
+			expectedFixed: []string{"dashboards:edit", "dashboards:read", "dashboards:write", "users:read"},
+		},
+		{
+			name:          "no action set conflicts",
+			inputActions:  []string{"plugins.app:access", "users:read"},
+			actionSets:    map[string][]string{},
+			expectedBuggy: []string{"plugins.app:access", "users:read"},
+			expectedFixed: []string{"plugins.app:access", "users:read"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actionSetSvc := &mockActionSetService{
+				actionSets: tt.actionSets,
+			}
+
+			// Test buggy behavior
+			buggyResult := demonstrateBuggyLogic(tt.inputActions, actionSetSvc)
+			assert.ElementsMatch(t, tt.expectedBuggy, buggyResult,
+				"Buggy logic should produce expected result")
+
+			// Test fixed behavior
+			fixedResult := demonstrateFixedLogic(tt.inputActions, actionSetSvc)
+			assert.ElementsMatch(t, tt.expectedFixed, fixedResult,
+				"Fixed logic should produce expected result")
+		})
+	}
+}
+
+// realBuggyLogic implements the actual buggy logic from the GetPermissions method
+// This mirrors the code in pkg/services/accesscontrol/resourcepermissions/service.go lines 178-202
+func realBuggyLogic(actions []string, actionSetSvc resourcepermissions.ActionSetService, serviceActions []string) []string {
+	var expandedActions []string
+
+	for _, action := range actions {
+		if isFolderOrDashboardAction(action) {
+			actionSetActions := actionSetSvc.ResolveActionSet(action)
+			if len(actionSetActions) > 0 {
+				// This check is needed for resolving inherited permissions - we don't want to include
+				// actions that are not related to dashboards when expanding dashboard action sets
+				for _, actionSetAction := range actionSetActions {
+					if slices.Contains(serviceActions, actionSetAction) {
+						expandedActions = append(expandedActions, actionSetAction)
+					}
+				}
+				continue // ← BUG: This skips adding the original action!
+			}
+		}
+		expandedActions = append(expandedActions, action)
+	}
+
+	return expandedActions
 }

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -137,11 +137,9 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 	)
 
 	permDenialKey := userPermDenialCacheKey(checkReq.Namespace.Value, checkReq.UserUID, checkReq.Action, checkReq.Name, checkReq.ParentFolder)
-	var permDenyKey string
-	if keyFound, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
+	if _, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
 		s.metrics.permissionCacheUsage.WithLabelValues("true", checkReq.Action).Inc()
 		s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
-		permDenyKey = keyFound.(string)
 		return &authzv1.CheckResponse{Allowed: false}, nil
 	}
 

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -137,9 +137,11 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 	)
 
 	permDenialKey := userPermDenialCacheKey(checkReq.Namespace.Value, checkReq.UserUID, checkReq.Action, checkReq.Name, checkReq.ParentFolder)
-	if _, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
+	var permDenyKey string
+	if keyFound, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
 		s.metrics.permissionCacheUsage.WithLabelValues("true", checkReq.Action).Inc()
 		s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		permDenyKey = keyFound.(string)
 		return &authzv1.CheckResponse{Allowed: false}, nil
 	}
 


### PR DESCRIPTION
The issue seems to occur in `pkg/services/accesscontrol/resourcepermissions/service.go` in the `GetPermissions()` method where action set resolution logic incorrectly filters out non-dashboard/folder actions, causing managed roles to lose their permissions.

  Pull Request that introduced the bug:
  - PR #89046: https://github.com/grafana/grafana/pull/89046
  
    Helper function:
  - isFolderOrDashboardAction: https://github.com/grafana/grafana/blob/main/pkg/services/accesscon
  trol/resourcepermissions/service.go#L587