### PR TITLE
Extensions: Expose `getObservablePluginFunctions` function 

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -43,7 +43,7 @@ export type ComponentTypeWithExtensionMeta<Props = {}> = React.ComponentType<Pro
   meta: PluginExtensionComponentMeta;
 };
 
-export type PluginExtensionFunction<Signature = () => void> = PluginExtensionBase & {
+export type PluginExtensionFunction<Signature = unknown> = PluginExtensionBase & {
   type: PluginExtensionTypes.function;
   fn: Signature;
 };

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -25,5 +25,9 @@ export {
   setGetObservablePluginLinks,
   type GetObservablePluginLinks,
 } from '../services/pluginExtensions/getObservablePluginLinks';
+export {
+  setGetObservablePluginFunctions,
+  type GetObservablePluginFunctions,
+} from '../services/pluginExtensions/getObservablePluginFunctions';
 
 export { UserStorage } from '../utils/userStorage';

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -32,6 +32,7 @@ export {
 } from './pluginExtensions/usePluginFunctions';
 export { getObservablePluginLinks } from './pluginExtensions/getObservablePluginLinks';
 export { getObservablePluginComponents } from './pluginExtensions/getObservablePluginComponents';
+export { getObservablePluginFunctions } from './pluginExtensions/getObservablePluginFunctions';
 export {
   isPluginExtensionLink,
   isPluginExtensionComponent,

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginFunctions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginFunctions.ts
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs';
 import { PluginExtensionFunction } from '@grafana/data';
 
 type GetObservablePluginFunctionsOptions = {
-  context?: object | Record<string | symbol, unknown>;
   extensionPointId: string;
   limitPerPlugin?: number;
 };

--- a/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginFunctions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/getObservablePluginFunctions.ts
@@ -1,0 +1,34 @@
+import { Observable } from 'rxjs';
+
+import { PluginExtensionFunction } from '@grafana/data';
+
+type GetObservablePluginFunctionsOptions = {
+  context?: object | Record<string | symbol, unknown>;
+  extensionPointId: string;
+  limitPerPlugin?: number;
+};
+
+export type GetObservablePluginFunctions = (
+  options: GetObservablePluginFunctionsOptions
+) => Observable<PluginExtensionFunction[]>;
+
+let singleton: GetObservablePluginFunctions | undefined;
+
+export function setGetObservablePluginFunctions(fn: GetObservablePluginFunctions): void {
+  // We allow overriding the registry in tests
+  if (singleton && process.env.NODE_ENV !== 'test') {
+    throw new Error('setObservablePluginFunctions() function should only be called once, when Grafana is starting.');
+  }
+
+  singleton = fn;
+}
+
+export function getObservablePluginFunctions(
+  options: GetObservablePluginFunctionsOptions
+): Observable<PluginExtensionFunction[]> {
+  if (!singleton) {
+    throw new Error('getObservablePluginFunctions() can only be used after the Grafana instance has started.');
+  }
+
+  return singleton(options);
+}

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -126,8 +126,9 @@ type AddedComponent struct {
 }
 
 type AddedFunction struct {
-	Targets []string `json:"targets"`
-	Title   string   `json:"title"`
+	Targets     []string `json:"targets"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
 }
 
 type ExposedComponent struct {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -42,7 +42,6 @@ import {
   setFolderPicker,
   setCorrelationsService,
   setPluginFunctionsHook,
-  getObservablePluginFunctions,
 } from '@grafana/runtime';
 import {
   setGetObservablePluginComponents,
@@ -91,6 +90,7 @@ import { DatasourceSrv } from './features/plugins/datasource_srv';
 import {
   getObservablePluginComponents,
   getObservablePluginLinks,
+  getObservablePluginFunctions,
 } from './features/plugins/extensions/getPluginExtensions';
 import { usePluginComponent } from './features/plugins/extensions/usePluginComponent';
 import { usePluginComponents } from './features/plugins/extensions/usePluginComponents';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -42,9 +42,11 @@ import {
   setFolderPicker,
   setCorrelationsService,
   setPluginFunctionsHook,
+  getObservablePluginFunctions,
 } from '@grafana/runtime';
 import {
   setGetObservablePluginComponents,
+  setGetObservablePluginFunctions,
   setGetObservablePluginLinks,
   setPanelDataErrorView,
   setPanelRenderer,
@@ -249,6 +251,7 @@ export class GrafanaApp {
       setPluginFunctionsHook(usePluginFunctions);
       setGetObservablePluginLinks(getObservablePluginLinks);
       setGetObservablePluginComponents(getObservablePluginComponents);
+      setGetObservablePluginFunctions(getObservablePluginFunctions);
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -6,6 +6,7 @@ import {
   type PluginExtension,
   type PluginExtensionLink,
   type PluginExtensionComponent,
+  PluginExtensionFunction,
 } from '@grafana/data';
 import {
   type GetObservablePluginLinks,
@@ -202,6 +203,30 @@ export const getPluginExtensions: GetExtensions = ({
 
     extensions.push(extension);
     extensionsByPlugin[addedComponent.pluginId] += 1;
+  }
+
+  const addedFunctions = addedFunctionsRegistry?.[extensionPointId] ?? [];
+  for (const addedFunction of addedFunctions) {
+    // Only limit if the `limitPerPlugin` is set
+    if (limitPerPlugin && extensionsByPlugin[addedFunction.pluginId] >= limitPerPlugin) {
+      continue;
+    }
+
+    if (extensionsByPlugin[addedFunction.pluginId] === undefined) {
+      extensionsByPlugin[addedFunction.pluginId] = 0;
+    }
+
+    const extension: PluginExtensionFunction = {
+      id: generateExtensionId(addedFunction.pluginId, extensionPointId, addedFunction.title),
+      type: PluginExtensionTypes.function,
+      pluginId: addedFunction.pluginId,
+      title: addedFunction.title,
+      description: addedFunction.description ?? '',
+      fn: addedFunction.fn,
+    };
+
+    extensions.push(extension);
+    extensionsByPlugin[addedFunction.pluginId] += 1;
   }
 
   return { extensions };

--- a/public/app/features/plugins/extensions/registry/AddedFunctionsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedFunctionsRegistry.ts
@@ -11,10 +11,10 @@ import { PluginExtensionConfigs, Registry, RegistryType } from './Registry';
 
 const logPrefix = 'Could not register function extension. Reason:';
 
-export type AddedFunctionsRegistryItem = {
+export type AddedFunctionsRegistryItem<Signature = unknown> = {
   pluginId: string;
   title: string;
-  fn: unknown;
+  fn: Signature;
   description?: string;
 };
 

--- a/public/app/features/plugins/extensions/types.ts
+++ b/public/app/features/plugins/extensions/types.ts
@@ -1,6 +1,7 @@
 import { PluginExtension } from '@grafana/data';
 
 import { AddedComponentRegistryItem } from './registry/AddedComponentsRegistry';
+import { AddedFunctionsRegistryItem } from './registry/AddedFunctionsRegistry';
 import { AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { RegistryType } from './registry/Registry';
 
@@ -10,6 +11,7 @@ export type GetExtensionsOptions = {
   limitPerPlugin?: number;
   addedComponentsRegistry: RegistryType<AddedComponentRegistryItem[]> | undefined;
   addedLinksRegistry: RegistryType<AddedLinkRegistryItem[]> | undefined;
+  addedFunctionsRegistry: RegistryType<AddedFunctionsRegistryItem[]> | undefined;
 };
 
 export type GetExtensions = (options: GetExtensionsOptions) => { extensions: PluginExtension[] };


### PR DESCRIPTION
**What is this feature?**

Exposing a `getObservablePluginFunctions` function that returns an observable with registered plugin functions. This is done in a similar fashion than `getObservablePluginComponents` and `getObservablePluginLinks`. 
Currently consumers have to use a React hook, which - especially for extension functions - makes it hard to use.
