### PR TITLE
PublicDashboardsBadge: Fix react warning

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
@@ -18,18 +18,13 @@ export const PublicDashboardBadge = ({ dashboard }: ToolbarActionProps) => {
 // Used in old architecture
 export const PublicDashboardBadgeLegacy = PublicDashboardBadgeInternal;
 
-function PublicDashboardBadgeInternal({ uid }: { uid?: string }) {
-  if (!uid) {
-    return null;
-  }
-
+function PublicDashboardBadgeInternal({ uid }: { uid: string }) {
   const { data: publicDashboard } = useGetPublicDashboardQuery(uid);
+  const styles = useStyles2(getStyles);
 
   if (!publicDashboard) {
     return null;
   }
-
-  const styles = useStyles2(getStyles);
 
   return (
     <Badge

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -212,7 +212,9 @@ export const DashNav = memo<Props>((props) => {
       );
     }
 
-    buttons.push(<PublicDashboardBadgeLegacy key="public-dashboard-badge" uid={dashboard.uid} />);
+    if (dashboard.uid) {
+      buttons.push(<PublicDashboardBadgeLegacy key="public-dashboard-badge" uid={dashboard.uid} />);
+    }
 
     if (isDevEnv && config.featureToggles.dashboardScene) {
       buttons.push(


### PR DESCRIPTION
When I merged https://github.com/grafana/grafana/pull/107638 i forgot to fix a react warning about hooks order. This fixes it.