### PR TITLE
Plugins: Decoupled core plugins should use their root directory as base

### DIFF
--- a/pkg/plugins/manager/loader/assetpath/assetpath.go
+++ b/pkg/plugins/manager/loader/assetpath/assetpath.go
@@ -47,8 +47,10 @@ func DefaultService(cfg *config.PluginManagementCfg) *Service {
 // Base returns the base path for the specified plugin.
 func (s *Service) Base(n PluginInfo) (string, error) {
 	if n.class == plugins.ClassCore {
-		baseDir := getBaseDir(n.fs.Base())
-		return path.Join("public/app/plugins", string(n.pluginJSON.Type), baseDir), nil
+		idx := strings.Index(n.fs.Base(), "public/app/plugins")
+		if idx != -1 {
+			return n.fs.Base()[idx:], nil
+		}
 	}
 	if n.class == plugins.ClassCDN {
 		return n.fs.Base(), nil
@@ -76,8 +78,7 @@ func (s *Service) Module(n PluginInfo) (string, error) {
 		if filepath.Base(n.fs.Base()) == "dist" {
 			// The core plugin has been built externally, use the module from the dist folder
 		} else {
-			baseDir := getBaseDir(n.fs.Base())
-			return path.Join("core:plugin", baseDir), nil
+			return path.Join("core:plugin", filepath.Base(n.fs.Base())), nil
 		}
 	}
 	if n.class == plugins.ClassCDN {
@@ -143,15 +144,6 @@ func (s *Service) RelativeURL(n PluginInfo, pathStr string) (string, error) {
 // DefaultLogoPath returns the default logo path for the specified plugin type.
 func (s *Service) DefaultLogoPath(pluginType plugins.Type) string {
 	return path.Join("public/img", fmt.Sprintf("icn-%s.svg", string(pluginType)))
-}
-
-func getBaseDir(pluginDir string) string {
-	baseDir := filepath.Base(pluginDir)
-	// Decoupled core plugins will be suffixed with "dist" if they have been built
-	if baseDir == "dist" {
-		return filepath.Base(strings.TrimSuffix(pluginDir, baseDir))
-	}
-	return baseDir
 }
 
 func (s *Service) GetTranslations(n PluginInfo) (map[string]string, error) {

--- a/pkg/plugins/manager/loader/assetpath/assetpath_test.go
+++ b/pkg/plugins/manager/loader/assetpath/assetpath_test.go
@@ -78,7 +78,7 @@ func TestService(t *testing.T) {
 
 				base, err = svc.Base(NewPluginInfo(jsonData["table-old"], plugins.ClassCore, tableOldFS, nil))
 				require.NoError(t, err)
-				require.Equal(t, "public/app/plugins/table-old", base)
+				require.Equal(t, "public/app/plugins/panel/table-old", base)
 
 				parentFS := pluginFS(oneCDNURL)
 				parentFS.RelFunc = func(_ string) (string, error) {
@@ -252,7 +252,7 @@ func TestService_ChildPlugins(t *testing.T) {
 			name: "Local FS core plugin",
 			cfg:  &config.PluginManagementCfg{},
 			pluginInfo: func() PluginInfo {
-				return NewPluginInfo(plugins.JSONData{ID: "parent", Info: plugins.Info{Version: "1.0.0"}}, plugins.ClassCore, plugins.NewLocalFS("/plugins/parent"), nil)
+				return NewPluginInfo(plugins.JSONData{ID: "parent", Info: plugins.Info{Version: "1.0.0"}}, plugins.ClassCore, plugins.NewLocalFS("/public/app/plugins/parent"), nil)
 			},
 			expected: expected{
 				module:  "core:plugin/parent",
@@ -264,12 +264,12 @@ func TestService_ChildPlugins(t *testing.T) {
 			name: "Externally-built Local FS core plugin",
 			cfg:  &config.PluginManagementCfg{},
 			pluginInfo: func() PluginInfo {
-				return NewPluginInfo(plugins.JSONData{ID: "parent", Info: plugins.Info{Version: "1.0.0"}}, plugins.ClassCore, plugins.NewLocalFS("/plugins/parent/dist"), nil)
+				return NewPluginInfo(plugins.JSONData{ID: "parent", Info: plugins.Info{Version: "1.0.0"}}, plugins.ClassCore, plugins.NewLocalFS("/public/app/plugins/parent/dist"), nil)
 			},
 			expected: expected{
 				module:  "public/plugins/parent/module.js",
-				baseURL: "public/app/plugins/parent",
-				relURL:  "public/app/plugins/parent/path/to/file.txt",
+				baseURL: "public/app/plugins/parent/dist",
+				relURL:  "public/app/plugins/parent/dist/path/to/file.txt",
 			},
 		},
 		{


### PR DESCRIPTION
**What is this feature?**

Removes special treatment for decoupled core plugins by having their baseURL point to their own directory path instead of their parent (IE using the built `dist` directory instead of the parent)

**Why do we need this feature?**

It keeps things simpler, particularly as we make adjustments to serving core plugins from a CDN.
