### PR TITLE
[InfluxDB] Change default HTTP method to POST

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -36,55 +36,55 @@ describe('UrlAndAuthenticationSection', () => {
     expect(onOptionsChangeMock).toHaveBeenCalled();
   });
 
-  it('renders DRBP warning for InfluxDB OSS 1.x and InfluxQL', () => {
-    const props = {
-      ...defaultProps,
-      options: {
-        ...defaultProps.options,
-        jsonData: { product: 'InfluxDB OSS 1.x', version: InfluxVersion.InfluxQL },
-      },
-    };
+  const productsRequiringDBRP = [
+    'InfluxDB OSS 1.x',
+    'InfluxDB OSS 2.x',
+    'InfluxDB Enterprise 1.x',
+    'InfluxDB Cloud (TSM)',
+    'InfluxDB Cloud Serverless',
+  ];
 
-    render(<UrlAndAuthenticationSection {...props} />);
-    expect(screen.getByText(/requires DRBP mapping/i)).toBeInTheDocument();
+  describe('UrlAndAuthenticationSection', () => {
+    it.each(productsRequiringDBRP)('renders DBRP warning for %s and InfluxQL', (product) => {
+      const props = {
+        ...defaultProps,
+        options: {
+          ...defaultProps.options,
+          jsonData: {
+            product,
+            version: InfluxVersion.InfluxQL,
+          },
+        },
+      };
+
+      render(<UrlAndAuthenticationSection {...props} />);
+      expect(screen.getByText(/requires DBRP mapping/i)).toBeInTheDocument();
+    });
   });
 
-  it('renders DRBP warning for InfluxDB OSS 2.x and InfluxQL', () => {
+  it('does not render DBRP warning for SQL', () => {
     const props = {
       ...defaultProps,
       options: {
         ...defaultProps.options,
-        jsonData: { product: 'InfluxDB OSS 2.x', version: InfluxVersion.InfluxQL },
+        jsonData: { version: InfluxVersion.SQL },
       },
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    expect(screen.getByText(/requires DRBP mapping/i)).toBeInTheDocument();
+    expect(screen.queryByText(/requires DBRP mapping/i)).not.toBeInTheDocument();
   });
 
-  it('does not render DRBP warning for InfluxDB OSS 1.x and Flux', () => {
+  it('does not render DBRP warning for Flux', () => {
     const props = {
       ...defaultProps,
       options: {
         ...defaultProps.options,
-        jsonData: { product: 'InfluxDB OSS 1.x', version: InfluxVersion.Flux },
+        jsonData: { version: InfluxVersion.Flux },
       },
     };
 
     render(<UrlAndAuthenticationSection {...props} />);
-    expect(screen.queryByText(/requires DRBP mapping/i)).not.toBeInTheDocument();
-  });
-
-  it('does not render DRBP warning for InfluxDB OSS 2.x and Flux', () => {
-    const props = {
-      ...defaultProps,
-      options: {
-        ...defaultProps.options,
-        jsonData: { product: 'InfluxDB OSS 2.x', version: InfluxVersion.Flux },
-      },
-    };
-
-    render(<UrlAndAuthenticationSection {...props} />);
-    expect(screen.queryByText(/requires DRBP mapping/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/requires DBRP mapping/i)).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -38,7 +38,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
     typeof v === 'string' && (v === InfluxVersion.Flux || v === InfluxVersion.InfluxQL || v === InfluxVersion.SQL);
 
   // Database + Retention Policy (DBRP) mapping is required for InfluxDB OSS 1.x and 2.x when using InfluxQL
-  const requiresDrbpMapping =
+  const requiresDbrpMapping =
     options.jsonData.product &&
     options.jsonData.version === InfluxVersion.InfluxQL &&
     [
@@ -119,8 +119,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
 
           <Space v={2} />
 
-          {requiresDrbpMapping && (
-            <Alert severity="warning" title="InfluxQL requires DRBP mapping">
+          {requiresDbrpMapping && (
+            <Alert severity="warning" title="InfluxQL requires DBRP mapping">
               InfluxDB OSS 1.x and 2.x users must configure a Database + Retention Policy (DBRP) mapping via the CLI or
               API before data can be queried.{' '}
               <TextLink href="https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/" external>

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/constants.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/constants.ts
@@ -30,8 +30,8 @@ export const CONFIG_SECTION_HEADERS_WITH_PDC = [
 ];
 
 export const HTTP_MODES: ComboboxOption[] = [
-  { label: 'GET', value: 'GET' },
   { label: 'POST', value: 'POST' },
+  { label: 'GET', value: 'GET' },
 ];
 
 export const getInlineLabelStyles = (theme: GrafanaTheme2, transparent = false, width?: number | 'auto') => {


### PR DESCRIPTION
Change the default HTTP method for InfluxQL Database settings from GET to POST. Also, fix a spelling error where DBRP was referred to as DRBP.