### PR TITLE
Remote Alertmanager: Use the same struct for Grafana state and Mimir full state

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
@@ -108,7 +108,7 @@ func TestMultiorgAlertmanager_RemoteSecondaryMode(t *testing.T) {
 
 	// It should send config and state on startup.
 	var lastConfig *remoteClient.UserGrafanaConfig
-	var lastState *remoteClient.UserGrafanaState
+	var lastState *remoteClient.UserState
 	{
 		// We should start with no config and no state in the external Alertmanager.
 		require.Empty(t, fakeAM.config)
@@ -174,7 +174,7 @@ func newFakeRemoteAlertmanager(t *testing.T, user, pass string) *fakeRemoteAlert
 type fakeRemoteAlertmanager struct {
 	t        *testing.T
 	config   *remoteClient.UserGrafanaConfig
-	state    *remoteClient.UserGrafanaState
+	state    *remoteClient.UserState
 	username string
 	password string
 }
@@ -240,7 +240,7 @@ func (f *fakeRemoteAlertmanager) getConfig(w http.ResponseWriter) {
 }
 
 func (f *fakeRemoteAlertmanager) postState(w http.ResponseWriter, r *http.Request) {
-	var state remoteClient.UserGrafanaState
+	var state remoteClient.UserState
 	require.NoError(f.t, json.NewDecoder(r.Body).Decode(&state))
 
 	f.state = &state

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -12,12 +12,13 @@ const (
 	grafanaAlertmanagerStatePath = "/api/v1/grafana/state"
 )
 
-type UserGrafanaState struct {
+// UserState is used for both Grafana state and Mimir full state.
+type UserState struct {
 	State string `json:"state"`
 }
 
-func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaState, error) {
-	gs := &UserGrafanaState{}
+func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserState, error) {
+	gs := &UserState{}
 	response := successResponse{
 		Data: gs,
 	}
@@ -36,7 +37,7 @@ func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaS
 }
 
 func (mc *Mimir) CreateGrafanaAlertmanagerState(ctx context.Context, state string) error {
-	payload, err := json.Marshal(&UserGrafanaState{
+	payload, err := json.Marshal(&UserState{
 		State: state,
 	})
 	if err != nil {

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -24,7 +24,7 @@ import (
 
 // MimirClient contains all the methods to query the migration critical endpoints of Mimir instance, it's an interface to allow multiple implementations.
 type MimirClient interface {
-	GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaState, error)
+	GetGrafanaAlertmanagerState(ctx context.Context) (*UserState, error)
 	CreateGrafanaAlertmanagerState(ctx context.Context, state string) error
 	DeleteGrafanaAlertmanagerState(ctx context.Context) error
 


### PR DESCRIPTION
Change `UserGrafanaState` to `UserState`.
Part of https://github.com/grafana/grafana/pull/107710