### PR TITLE
[WIP] SQL Expressions: FE event tracking

### DIFF
--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -65,6 +65,9 @@ export function useSaveDashboard(isCopy = false) {
         //Update local storage dashboard to handle things like last used datasource
         updateDashboardUidLastUsedDatasource(resultData.uid);
 
+        // For analytics tracking, check if the dashboard has SQL expressions
+        const hasSQLExpression = scene.hasSQLExpressions(saveModel);
+
         if (isCopy) {
           reportInteraction('grafana_dashboard_copied', {
             name: saveModel.title,
@@ -74,6 +77,7 @@ export function useSaveDashboard(isCopy = false) {
           reportInteraction(`grafana_dashboard_${resultData.uid ? 'saved' : 'created'}`, {
             name: saveModel.title,
             url: resultData.url,
+            hasSQLExpression,
           });
         }
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -15,7 +15,7 @@ import {
   SceneVariableDependencyConfigLike,
   VizPanel,
 } from '@grafana/scenes';
-import { Dashboard, DashboardLink, LibraryPanel } from '@grafana/schema';
+import { Dashboard, DashboardLink, LibraryPanel, Panel } from '@grafana/schema';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
 import appEvents from 'app/core/app_events';
 import { ScrollRefElement } from 'app/core/components/NativeScrollbar';
@@ -732,6 +732,21 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public getDashboardPanels() {
     return dashboardSceneGraph.getVizPanels(this);
+  }
+
+  public hasSQLExpressions(saveModel?: Dashboard | DashboardV2Spec): boolean {
+    const model = saveModel ?? this.getSaveModel();
+
+    // Early return for non-V1 dashboards
+    if (!('panels' in model)) {
+      return false;
+    }
+
+    return (
+      model.panels?.some((panel: Panel) =>
+        panel.targets?.some((target: Record<string, unknown>) => target?.type === 'sql')
+      ) ?? false
+    );
   }
 
   public onSetScrollRef = (scrollElement: ScrollRefElement): void => {

--- a/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
+++ b/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { ReactElement, useCallback, useMemo, memo } from 'react';
 
 import { FeatureState, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Dropdown, FeatureBadge, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
 import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 
@@ -54,11 +55,26 @@ const ExpressionMenuItem = memo<ExpressionMenuItemProps>(({ item, onSelect }) =>
 ExpressionMenuItem.displayName = 'ExpressionMenuItem';
 
 export const ExpressionTypeDropdown = memo<ExpressionTypeDropdownProps>(({ handleOnSelect, children }) => {
-  const menuItems = useMemo(
-    () => expressionTypes.map((item) => <ExpressionMenuItem key={item.value} item={item} onSelect={handleOnSelect} />),
+  const selectWithEventTracking = useCallback(
+    (value: ExpressionQueryType) => {
+      const selectedExpression = expressionTypes.find((expr) => expr.value === value);
+
+      handleOnSelect(value);
+      reportInteraction('grafana_expressions_type_selected', {
+        expression_type: selectedExpression?.label ?? 'unknown',
+        context: 'dashboard_panel_editor',
+      });
+    },
     [handleOnSelect]
   );
 
+  const menuItems = useMemo(
+    () =>
+      expressionTypes.map((item) => (
+        <ExpressionMenuItem key={item.value} item={item} onSelect={selectWithEventTracking} />
+      )),
+    [selectWithEventTracking]
+  );
   const menuOverlay = useMemo(() => <Menu role="menu">{menuItems}</Menu>, [menuItems]);
 
   return (


### PR DESCRIPTION
## What does this PR do? 📓 

This PR adds FE event tracking for SQL Expressions. To determine usage and investment, we need to understand 1) how often users are engaging with the SQL expressions option from the expression dropdown, and 2) how often they actually _save_ a dashboard with a SQL expression. We feel it will give us strong signals regarding feature usage. 

> [!NOTE] 
> I understand the event tracking logic I added on dashboard save adds some cruft. Please let me know if there's a better way to achieve this, or if we can avoid it by passing metadata in some other way, perhaps? 😄 

Fixes #106796