### PR TITLE
InfluxDB: Handle `STRING_VIEW` datatype

### DIFF
--- a/pkg/tsdb/influxdb/fsql/arrow.go
+++ b/pkg/tsdb/influxdb/fsql/arrow.go
@@ -124,7 +124,7 @@ func newFrame(schema *arrow.Schema) *data.Frame {
 
 func newField(f arrow.Field) *data.Field {
 	switch f.Type.ID() {
-	case arrow.STRING:
+	case arrow.STRING, arrow.STRING_VIEW:
 		return newDataField[string](f)
 	case arrow.FLOAT32:
 		return newDataField[float32](f)
@@ -239,6 +239,8 @@ func copyData(field *data.Field, col arrow.Array) error {
 				return err
 			}
 		}
+	case arrow.STRING_VIEW:
+		copyBasic[string](field, array.NewStringViewData(colData))
 	case arrow.STRING:
 		copyBasic[string](field, array.NewStringData(colData))
 	case arrow.UINT8:


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/104957.

This PR fixes an error when reading `STRING_VIEW` columns by correctly mapping `STRING_VIEW` in the `newField` factory and by adding a dedicated test to validate `copyData`’s handling of both nullable and non‐nullable `STRING_VIEW` arrays. This enables the [Distinct Value Cache](https://docs.influxdata.com/influxdb3/enterprise/admin/distinct-value-cache/) feature of InfluxDB v3 Enterprise for use.