### PR TITLE
Docs: Update min supported Loki version to v2.9+

### DIFF
--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -62,7 +62,7 @@ The following guides will help you get started with Loki:
 
 This data source supports these versions of Loki:
 
-- v2.8+
+- v2.9+
 
 ## Adding a data source
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1320,6 +1320,8 @@ var (
 			FrontendOnly: true,
 		},
 		{
+			// Remove this flag once Loki v4 is released and the min supported version is v3.0+,
+			// since users on v2.9 need it to disable the feature, as it doesn't work for them.
 			Name:        "lokiLabelNamesQueryApi",
 			Description: "Defaults to using the Loki `/labels` API instead of `/series`",
 			Stage:       FeatureStageGeneralAvailability,


### PR DESCRIPTION
Loki team currently supports v2.9 as last release. This PR updated documentation for Loki data source to reflect the change. 

I have also added a code comment to `lokiLabelNamesQueryApi` feature toggle to make it clear when can we remove it. More context in https://github.com/grafana/grafana/pull/107293#discussion_r2179620991. We got ✅ for this change from Loki team in [here](https://raintank-corp.slack.com/archives/C9T1FLN9K/p1751457186623359). 