### PR TITLE
[unified-storage/search] Don't expire file-based indexes, check for resource stats when building index on-demand

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -637,18 +637,12 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 
 		size := int64(0)
 		rv := int64(0)
-		found := false
 		for _, stat := range stats {
 			if stat.Namespace == key.Namespace && stat.Group == key.Group && stat.Resource == key.Resource {
 				size = stat.Count
 				rv = stat.ResourceVersion
-				found = true
 				break
 			}
-		}
-
-		if !found {
-			s.log.Warn("Failed to find resource stats for building index", "namespace", key.Namespace, "group", key.Group, "resource", key.Resource)
 		}
 
 		idx, _, err = s.build(ctx, key, size, rv)

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -81,28 +81,16 @@ type ResourceIndex interface {
 
 // SearchBackend contains the technology specific logic to support search
 type SearchBackend interface {
-	// This will return nil if the key does not exist
+	// GetIndex returns existing index, or nil.
 	GetIndex(ctx context.Context, key NamespacedResource) (ResourceIndex, error)
 
-	// Build an index from scratch
-	BuildIndex(ctx context.Context,
-		key NamespacedResource,
+	// BuildIndex builds an index from scratch.
+	// Depending on the size, the backend may choose different options (eg: memory vs disk).
+	// The last known resource version can be used to detect that nothing has changed, and existing on-disk index can be reused.
+	// The builder will write all documents before returning.
+	BuildIndex(ctx context.Context, key NamespacedResource, size int64, resourceVersion int64, nonStandardFields SearchableDocumentFields, builder func(index ResourceIndex) (int64, error)) (ResourceIndex, error)
 
-	// When the size is known, it will be passed along here
-	// Depending on the size, the backend may choose different options (eg: memory vs disk)
-		size int64,
-
-	// The last known resource version (can be used to know that nothing has changed)
-		resourceVersion int64,
-
-	// The non-standard index fields
-		fields SearchableDocumentFields,
-
-	// The builder will write all documents before returning
-		builder func(index ResourceIndex) (int64, error),
-	) (ResourceIndex, error)
-
-	// Gets the total number of documents across all indexes
+	// TotalDocs returns the total number of documents across all indexes.
 	TotalDocs() int64
 }
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -2,7 +2,9 @@ package resource
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/mock"
@@ -96,6 +98,7 @@ func (m *mockStorageBackend) ListHistory(ctx context.Context, req *resourcepb.Li
 
 // mockSearchBackend implements SearchBackend for testing with tracking capabilities
 type mockSearchBackend struct {
+	mu                   sync.Mutex
 	buildIndexCalls      []buildIndexCall
 	buildEmptyIndexCalls []buildEmptyIndexCall
 }
@@ -128,6 +131,9 @@ func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResour
 	if err != nil {
 		return nil, err
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	// Determine if this is an empty index based on size
 	// Empty indexes are characterized by size == 0
@@ -270,4 +276,59 @@ func TestBuildIndexes_MaxCountThreshold(t *testing.T) {
 			require.ElementsMatch(t, tt.expectedEmptyBuilds, actualEmptyBuilds)
 		})
 	}
+}
+
+func TestSearchGetOrCreateIndex(t *testing.T) {
+	// Setup mock implementations
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{
+			{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}, Count: 50, ResourceVersion: 11111111},
+		},
+	}
+	search := &mockSearchBackend{
+		buildIndexCalls:      []buildIndexCall{},
+		buildEmptyIndexCalls: []buildEmptyIndexCall{},
+	}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{
+			"group": "resource",
+		},
+	}
+
+	// Create search support with the specified initMaxSize
+	opts := SearchOptions{
+		Backend:       search,
+		Resources:     supplier,
+		WorkerThreads: 1,
+		InitMinCount:  1, // set min count to default for this test
+		InitMaxCount:  0,
+	}
+
+	support, err := newSearchSupport(opts, storage, nil, nil, noop.NewTracerProvider().Tracer("test"), nil)
+	require.NoError(t, err)
+	require.NotNil(t, support)
+
+	start := make(chan struct{})
+
+	const concurrency = 100
+	wg := sync.WaitGroup{}
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = support.getOrCreateIndex(context.Background(), NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"})
+		}()
+	}
+
+	// Wait a bit for goroutines to start (hopefully)
+	time.Sleep(10 * time.Millisecond)
+	// Unblock all goroutines.
+	close(start)
+	wg.Wait()
+
+	require.NotEmpty(t, search.buildIndexCalls)
+	require.Less(t, len(search.buildIndexCalls), concurrency, "Should not have built index more than a few times (ideally once)")
+	require.Equal(t, int64(50), search.buildIndexCalls[0].size)
+	require.Equal(t, int64(11111111), search.buildIndexCalls[0].resourceVersion)
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -56,7 +56,7 @@ type BleveOptions struct {
 	// ?? not totally sure the units
 	BatchSize int
 
-	// Index cache TTL for bleve indices. 0 disables expiration.
+	// Index cache TTL for bleve indices. 0 disables expiration for in-memory indexes.
 	IndexCacheTTL time.Duration
 }
 
@@ -219,7 +219,7 @@ func (b *bleveBackend) BuildIndex(
 
 		if index != nil {
 			build = false
-			logWithDetails.Info("Existing index found on filesystem", "directory", filepath.Join(resourceDir, fileIndexName))
+			logWithDetails.Debug("Existing index found on filesystem", "directory", filepath.Join(resourceDir, fileIndexName))
 		} else {
 			// Building index from scratch. Index name has a time component in it to be unique, but if
 			// we happen to create non-unique name, we bump the time and try again.

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -235,8 +235,8 @@ func (b *bleveBackend) BuildIndex(
 
 				index, err = bleve.New(indexDir, mapper)
 				if errors.Is(err, bleve.ErrorIndexPathExists) {
-					now.Add(time.Second) // Bump time for next try
-					index = nil          // Bleve actually returns non-nil value with ErrorIndexPathExists
+					now = now.Add(time.Second) // Bump time for next try
+					index = nil                // Bleve actually returns non-nil value with ErrorIndexPathExists
 					continue
 				}
 				if err != nil {
@@ -319,8 +319,8 @@ func (b *bleveBackend) BuildIndex(
 }
 
 func cleanFileSegment(input string) string {
-	input = strings.Replace(input, string(filepath.Separator), "_", -1)
-	input = strings.Replace(input, "..", "_", -1)
+	input = strings.ReplaceAll(input, string(filepath.Separator), "_")
+	input = strings.ReplaceAll(input, "..", "_")
 	return input
 }
 

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -13,10 +13,6 @@ import (
 )
 
 func TestBleveSearchBackend(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	// Run the search backend test suite
 	unitest.RunSearchBackendTest(t, func(ctx context.Context) resource.SearchBackend {
 		tempDir := t.TempDir()

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -949,9 +949,9 @@ func TestCleanOldIndexes(t *testing.T) {
 	b := setupBleveBackend(t, 5, time.Nanosecond, dir)
 
 	t.Run("with skip", func(t *testing.T) {
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-2/b"), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-3/c"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-2/b"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-3/c"), 0750))
 
 		b.cleanOldIndexes(dir, "index-2")
 		files, err := os.ReadDir(dir)
@@ -961,9 +961,9 @@ func TestCleanOldIndexes(t *testing.T) {
 	})
 
 	t.Run("without skip", func(t *testing.T) {
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-2/b"), 0755))
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-3/c"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-2/b"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-3/c"), 0750))
 
 		b.cleanOldIndexes(dir, "")
 		files, err := os.ReadDir(dir)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -673,65 +673,65 @@ func TestSafeInt64ToInt(t *testing.T) {
 	}
 }
 
-func Test_isValidPath(t *testing.T) {
+func Test_isPathWithinRoot(t *testing.T) {
 	tests := []struct {
-		name    string
-		dir     string
-		safeDir string
-		want    bool
+		name string
+		dir  string
+		root string
+		want bool
 	}{
 		{
-			name:    "valid path",
-			dir:     "/path/to/my-file/",
-			safeDir: "/path/to/",
-			want:    true,
+			name: "valid path",
+			dir:  "/path/to/my-file/",
+			root: "/path/to/",
+			want: true,
 		},
 		{
-			name:    "valid path without trailing slash",
-			dir:     "/path/to/my-file",
-			safeDir: "/path/to",
-			want:    true,
+			name: "valid path without trailing slash",
+			dir:  "/path/to/my-file",
+			root: "/path/to",
+			want: true,
 		},
 		{
-			name:    "path with double slashes",
-			dir:     "/path//to//my-file/",
-			safeDir: "/path/to/",
-			want:    true,
+			name: "path with double slashes",
+			dir:  "/path//to//my-file/",
+			root: "/path/to/",
+			want: true,
 		},
 		{
-			name:    "invalid path: ..",
-			dir:     "/path/../above/",
-			safeDir: "/path/to/",
+			name: "invalid path: ..",
+			dir:  "/path/../above/",
+			root: "/path/to/",
 		},
 		{
-			name:    "invalid path: \\",
-			dir:     "\\path/to",
-			safeDir: "/path/to/",
+			name: "invalid path: \\",
+			dir:  "\\path/to",
+			root: "/path/to/",
 		},
 		{
-			name:    "invalid path: not under safe dir",
-			dir:     "/path/to.txt",
-			safeDir: "/path/to/",
+			name: "invalid path: not under safe dir",
+			dir:  "/path/to.txt",
+			root: "/path/to/",
 		},
 		{
-			name:    "invalid path: empty paths",
-			dir:     "",
-			safeDir: "/path/to/",
+			name: "invalid path: empty paths",
+			dir:  "",
+			root: "/path/to/",
 		},
 		{
-			name:    "invalid path: different path",
-			dir:     "/other/path/to/my-file/",
-			safeDir: "/Some/other/path",
+			name: "invalid path: different path",
+			dir:  "/other/path/to/my-file/",
+			root: "/Some/other/path",
 		},
 		{
-			name:    "invalid path: empty safe path",
-			dir:     "/path/to/",
-			safeDir: "",
+			name: "invalid path: empty safe path",
+			dir:  "/path/to/",
+			root: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isValidPath(tt.dir, tt.safeDir))
+			require.Equal(t, tt.want, isPathWithinRoot(tt.dir, tt.root))
 		})
 	}
 }

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -24,10 +24,6 @@ type NewSearchBackendFunc func(ctx context.Context) resource.SearchBackend
 
 // RunSearchBackendTest runs the search backend test suite
 func RunSearchBackendTest(t *testing.T, newBackend NewSearchBackendFunc, opts *TestOptions) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
 	if opts == nil {
 		opts = &TestOptions{}
 	}


### PR DESCRIPTION
This PR primarly fixes problem with building of large indexes in memory, when index is created on-demand (not at startup). Before this PR, on-demand indexing didn't check for number of resources of given type, and passed size=10 to indexing, which caused that our Bleve backend always chose to create index in memory.

On-demand indexing happens when previous index was expired. Before this PR, expiration happened without closing the index, which was problematic for file-based indexes, because Bleve didn't release the lock, and reopening the index was blocked forever. This PR changes that in two ways:
* File-based indexes are not expired
* Expired indexes are always closed

`bleveBackend.BuildIndex` function builds index from scratch, and replaces existing cached index. It can however reuse previous file-based index during startup or when memory-based index has expired. (Previously we tried to reuse index always, if it had the right RV and documents count, but that doesn't work correctly for periodic index rebuilds introduced in #106422)

In addition to that, this PR also introduces singleflight when building the index for same namespace/group/resource.
