### PR TITLE
PoC: replace using testing.Short in storage/unified package with integration test skip method

### DIFF
--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
+	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
@@ -134,7 +135,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 		_, err = server.IsHealthy(ctx, &resourcepb.HealthCheckRequest{})
 		require.NoError(t, err)
 	case StorageTypeUnified:
-		if testing.Short() {
+		if tests.Short(t) {
 			t.Skip("skipping integration test")
 		}
 		dbstore := infraDB.InitTestDB(t)

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -135,9 +135,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 		_, err = server.IsHealthy(ctx, &resourcepb.HealthCheckRequest{})
 		require.NoError(t, err)
 	case StorageTypeUnified:
-		if tests.Short(t) {
-			t.Skip("skipping integration test")
-		}
+		tests.SkipIntegrationTestInShortMode(t)
 		dbstore := infraDB.InitTestDB(t)
 		cfg := setting.NewCfg()
 

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -189,7 +189,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 	return ctx, store, destroyFunc, nil
 }
 
-func TestWatch(t *testing.T) {
+func TestIntegrationWatch(t *testing.T) {
 	for _, s := range []StorageType{StorageTypeFile, StorageTypeUnified} {
 		t.Run(string(s), func(t *testing.T) {
 			ctx, store, destroyFunc, err := testSetup(t, withStorageType(s))

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestBleveSearchBackend(t *testing.T) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 
 	// Run the search backend test suite
 	unitest.RunSearchBackendTest(t, func(ctx context.Context) resource.SearchBackend {

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
-	"github.com/grafana/grafana/pkg/tests"
 )
 
 func TestBleveSearchBackend(t *testing.T) {
-	tests.SkipIntegrationTestInShortMode(t)
-
 	// Run the search backend test suite
 	unitest.RunSearchBackendTest(t, func(ctx context.Context) resource.SearchBackend {
 		tempDir := t.TempDir()

--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
+	"github.com/grafana/grafana/pkg/tests"
 )
 
 func TestBleveSearchBackend(t *testing.T) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test")
 	}
 

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	test "github.com/grafana/grafana/pkg/storage/unified/testing"
+	"github.com/grafana/grafana/pkg/tests"
 )
 
 func newTestBackend(b testing.TB) resource.StorageBackend {
@@ -38,7 +39,7 @@ func newTestBackend(b testing.TB) resource.StorageBackend {
 }
 
 func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test in short mode")
 	}
 	opts := test.DefaultBenchmarkOptions()
@@ -49,7 +50,7 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationBenchmarkResourceServer(t *testing.T) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -39,9 +39,7 @@ func newTestBackend(b testing.TB) resource.StorageBackend {
 }
 
 func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test in short mode")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 	opts := test.DefaultBenchmarkOptions()
 	if db.IsTestDbSQLite() {
 		opts.Concurrency = 1 // to avoid SQLite database is locked error
@@ -50,9 +48,7 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationBenchmarkResourceServer(t *testing.T) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test in short mode")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
 	opts := &test.BenchmarkOptions{

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -96,9 +96,7 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationSearchAndStorage(t *testing.T) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test in short mode")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
+	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -95,7 +96,7 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationSearchAndStorage(t *testing.T) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -44,9 +44,7 @@ func GenerateRandomKVPrefix() string {
 
 // RunKVTest runs the KV test suite
 func RunKVTest(t *testing.T, newKV NewKVFunc, opts *KVTestOptions) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 
 	if opts == nil {
 		opts = &KVTestOptions{}

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -44,8 +43,6 @@ func GenerateRandomKVPrefix() string {
 
 // RunKVTest runs the KV test suite
 func RunKVTest(t *testing.T, newKV NewKVFunc, opts *KVTestOptions) {
-	tests.SkipIntegrationTestInShortMode(t)
-
 	if opts == nil {
 		opts = &KVTestOptions{}
 	}

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -43,7 +44,7 @@ func GenerateRandomKVPrefix() string {
 
 // RunKVTest runs the KV test suite
 func RunKVTest(t *testing.T, newKV NewKVFunc, opts *KVTestOptions) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test")
 	}
 

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -25,8 +25,6 @@ type NewSearchBackendFunc func(ctx context.Context) resource.SearchBackend
 
 // RunSearchBackendTest runs the search backend test suite
 func RunSearchBackendTest(t *testing.T, newBackend NewSearchBackendFunc, opts *TestOptions) {
-	tests.SkipIntegrationTestInShortMode(t)
-
 	if opts == nil {
 		opts = &TestOptions{}
 	}

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -25,9 +25,7 @@ type NewSearchBackendFunc func(ctx context.Context) resource.SearchBackend
 
 // RunSearchBackendTest runs the search backend test suite
 func RunSearchBackendTest(t *testing.T, newBackend NewSearchBackendFunc, opts *TestOptions) {
-	if tests.Short(t) {
-		t.Skip("skipping integration test")
-	}
+	tests.SkipIntegrationTestInShortMode(t)
 
 	if opts == nil {
 		opts = &TestOptions{}

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -24,7 +25,7 @@ type NewSearchBackendFunc func(ctx context.Context) resource.SearchBackend
 
 // RunSearchBackendTest runs the search backend test suite
 func RunSearchBackendTest(t *testing.T, newBackend NewSearchBackendFunc, opts *TestOptions) {
-	if testing.Short() {
+	if tests.Short(t) {
 		t.Skip("skipping integration test")
 	}
 

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -24,13 +24,14 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func Short(t testing.TB) bool {
+func SkipIntegrationTestInShortMode(t testing.TB) {
 	t.Helper()
 	if strings.HasPrefix(t.Name(), "TestIntegration") {
-		return testing.Short()
+		if testing.Short() {
+			t.Skip("skipping integration test in short mode")
+		}
 	}
-	t.Fatal("Short called from non-integration test")
-	return false
+	t.Fatal("test is not an integration test")
 }
 
 func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -5,10 +5,13 @@ import (
 	"crypto/tls"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
@@ -19,8 +22,16 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/require"
 )
+
+func Short(t testing.TB) bool {
+	t.Helper()
+	if strings.HasPrefix(t.Name(), "TestIntegration") {
+		return testing.Short()
+	}
+	t.Fatal("Short called from non-integration test")
+	return false
+}
 
 func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -26,12 +26,12 @@ import (
 
 func SkipIntegrationTestInShortMode(t testing.TB) {
 	t.Helper()
-	if strings.HasPrefix(t.Name(), "TestIntegration") {
-		if testing.Short() {
-			t.Skip("skipping integration test in short mode")
-		}
+	if !strings.HasPrefix(t.Name(), "TestIntegration") {
+		t.Fatal("test is not an integration test")
 	}
-	t.Fatal("test is not an integration test")
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 }
 
 func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {


### PR DESCRIPTION
PoC: replace using testing.Short with integration test skip method that checks that it's really called from Grafana integration tests (ie. test has `TestIntegration` prefix)