### PR TITLE
fix TestIntegrationFoldersGetAPIEndpointK8S

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -531,6 +531,9 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	_, err = dbSection.NewKey("max_idle_conn", "2")
 	require.NoError(t, err)
 
+	_, err = dbSection.NewKey("high_availability", "false")
+	require.NoError(t, err)
+
 	cfgPath := filepath.Join(cfgDir, "test.ini")
 	err = cfg.SaveTo(cfgPath)
 	require.NoError(t, err)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -526,9 +526,9 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	require.NoError(t, err)
 	_, err = dbSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
 	require.NoError(t, err)
-	_, err = dbSection.NewKey("max_open_conn", "2")
+	_, err = dbSection.NewKey("max_open_conn", "5")
 	require.NoError(t, err)
-	_, err = dbSection.NewKey("max_idle_conn", "2")
+	_, err = dbSection.NewKey("max_idle_conn", "5")
 	require.NoError(t, err)
 
 	_, err = dbSection.NewKey("high_availability", "false")


### PR DESCRIPTION
disable HA in the tests

The unistore poller is incompatible with max_open_conn=2 (we have a poller querying SQL every 100ms)
https://github.com/grafana/grafana/blob/6f2db15aa05a55142257fbf38b540f02a0b8f4b2/pkg/tests/testinfra/testinfra.go#L529-L532 