### PR TITLE
Internationalisation: don't load plugin translations in test environment

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/module.ts
+++ b/public/app/plugins/datasource/azuremonitor/module.ts
@@ -10,7 +10,13 @@ import { trackAzureMonitorDashboardLoaded } from './tracking';
 import { AzureMonitorQuery, AzureQueryType, ResultFormat } from './types/query';
 import { AzureMonitorDataSourceJsonData } from './types/types';
 
-initPluginTranslations(pluginJson.id);
+// top level await is fine in our bundlded code, but not in our test environment (yet)
+// TODO remove this when our test environment can handle top level await
+if (process.env.NODE_ENV === 'test') {
+  initPluginTranslations(pluginJson.id);
+} else {
+  await initPluginTranslations(pluginJson.id);
+}
 
 export const plugin = new DataSourcePlugin<Datasource, AzureMonitorQuery, AzureMonitorDataSourceJsonData>(Datasource)
   .setConfigEditor(ConfigEditor)

--- a/public/app/plugins/datasource/azuremonitor/module.ts
+++ b/public/app/plugins/datasource/azuremonitor/module.ts
@@ -10,11 +10,9 @@ import { trackAzureMonitorDashboardLoaded } from './tracking';
 import { AzureMonitorQuery, AzureQueryType, ResultFormat } from './types/query';
 import { AzureMonitorDataSourceJsonData } from './types/types';
 
-// top level await is fine in our bundlded code, but not in our test environment (yet)
-// TODO remove this when our test environment can handle top level await
-if (process.env.NODE_ENV === 'test') {
-  initPluginTranslations(pluginJson.id);
-} else {
+// don't load plugin translations in test environments
+// we don't use them anyway, and top-level await won't work currently in jest
+if (process.env.NODE_ENV !== 'test') {
   await initPluginTranslations(pluginJson.id);
 }
 

--- a/public/app/plugins/datasource/mssql/module.ts
+++ b/public/app/plugins/datasource/mssql/module.ts
@@ -8,7 +8,11 @@ import { MssqlDatasource } from './datasource';
 import pluginJson from './plugin.json';
 import { MssqlOptions } from './types';
 
-await initPluginTranslations(pluginJson.id, [loadSQLResources]);
+// don't load plugin translations in test environments
+// we don't use them anyway, and top-level await won't work currently in jest
+if (process.env.NODE_ENV !== 'test') {
+  await initPluginTranslations(pluginJson.id, [loadSQLResources]);
+}
 
 export const plugin = new DataSourcePlugin<MssqlDatasource, SQLQuery, MssqlOptions>(MssqlDatasource)
   .setQueryEditor(SqlQueryEditorLazy)

--- a/public/app/plugins/datasource/mssql/module.ts
+++ b/public/app/plugins/datasource/mssql/module.ts
@@ -8,7 +8,7 @@ import { MssqlDatasource } from './datasource';
 import pluginJson from './plugin.json';
 import { MssqlOptions } from './types';
 
-initPluginTranslations(pluginJson.id, [loadSQLResources]);
+await initPluginTranslations(pluginJson.id, [loadSQLResources]);
 
 export const plugin = new DataSourcePlugin<MssqlDatasource, SQLQuery, MssqlOptions>(MssqlDatasource)
   .setQueryEditor(SqlQueryEditorLazy)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- don't load plugin translations in test environments
- we don't use them anyway, and top-level `await` won't work currently in jest

**Why do we need this feature?**

- so we're properly `await`ing plugin translations, but tests will still work

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/107039

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
