### PR TITLE
CloudWatch: Fix http client handling + assume role bug

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/clients"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
@@ -50,7 +50,7 @@ type DataQueryJson struct {
 
 type DataSource struct {
 	Settings          models.CloudWatchSettings
-	HTTPClient        *http.Client
+	ProxyOpts         *proxy.Options
 	AWSConfigProvider awsauth.ConfigProvider
 
 	logger          log.Logger
@@ -74,7 +74,10 @@ func (ds *DataSource) newAWSConfig(ctx context.Context, region string) (aws.Conf
 		Region:             region,
 		AccessKey:          ds.Settings.AccessKey,
 		SecretKey:          ds.Settings.SecretKey,
-		HTTPClient:         ds.HTTPClient,
+		HTTPClient:         &http.Client{},
+	}
+	if ds.Settings.GrafanaSettings.SecureSocksDSProxyEnabled && ds.Settings.SecureSocksProxyEnabled {
+		authSettings.ProxyOptions = ds.ProxyOpts
 	}
 	cfg, err := ds.AWSConfigProvider.GetConfig(ctx, authSettings)
 	if err != nil {
@@ -93,14 +96,11 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	if err != nil {
 		return nil, err
 	}
-	httpClient, err := httpclient.New(opts)
-	if err != nil {
-		return nil, err
-	}
 
 	ds := &DataSource{
-		Settings:          instanceSettings,
-		HTTPClient:        httpClient,
+		Settings: instanceSettings,
+		// this is used to build a custom dialer when secure socks proxy is enabled
+		ProxyOpts:         opts.ProxyOptions,
 		AWSConfigProvider: awsauth.NewConfigProvider(),
 		logger:            backend.NewLoggerWith("logger", "grafana-cloudwatch-datasource"),
 		tagValueCache:     cache.New(tagValueCacheExpiration, tagValueCacheExpiration*5),


### PR DESCRIPTION
**Why do we need this feature?**
The recent fix for the proxy configuration issue introduced an occasional panic deep inside the aws-sdk-go-v2. This fixes the proxy issue in a different way and avoids the panic.

This is effectively a revert of https://github.com/grafana/grafana/pull/107807, except for the grafana-aws-sdk bump, plus passing in a zero `*http.Client`, which addresses both the proxy configuration issue and the panic.