### PR TITLE
Plugin Configs: Fix Env types

### DIFF
--- a/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
+++ b/e2e/test-plugins/grafana-extensionstest-app/webpack.config.ts
@@ -1,5 +1,5 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
+import grafanaConfig, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
 import { type Configuration } from 'webpack';
 
@@ -19,7 +19,7 @@ function skipFiles(f: string): boolean {
   return true;
 }
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
   const customConfig = {
     plugins: [

--- a/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
+++ b/e2e/test-plugins/grafana-test-datasource/webpack.config.ts
@@ -1,5 +1,5 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
+import grafanaConfig, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 import { mergeWithCustomize, unique } from 'webpack-merge';
 import { type Configuration } from 'webpack';
 
@@ -19,7 +19,7 @@ function skipFiles(f: string): boolean {
   return true;
 }
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
   const customConfig = {
     plugins: [

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -31,7 +31,7 @@ function skipFiles(f: string): boolean {
   return true;
 }
 
-type Env = {
+export type Env = {
   [key: string]: true | string | Env;
 };
 

--- a/public/app/plugins/datasource/azuremonitor/webpack.config.ts
+++ b/public/app/plugins/datasource/azuremonitor/webpack.config.ts
@@ -1,9 +1,9 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
+import grafanaConfig, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/webpack.config.ts
@@ -1,6 +1,6 @@
-import config from '@grafana/plugin-configs/webpack.config.ts';
+import config, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 
-const configWithFallback = async (env: Record<string, unknown>) => {
+const configWithFallback = async (env: Env) => {
   const response = await config(env);
   if (response !== undefined && response.resolve !== undefined) {
     response.resolve.fallback = {

--- a/public/app/plugins/datasource/jaeger/webpack.config.ts
+++ b/public/app/plugins/datasource/jaeger/webpack.config.ts
@@ -1,10 +1,10 @@
 import { createRequire } from 'node:module';
 
-import config from '@grafana/plugin-configs/webpack.config.ts';
+import config, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 
 const require = createRequire(import.meta.url);
 
-const configWithFallback = async (env: Record<string, unknown>) => {
+const configWithFallback = async (env: Env) => {
   const response = await config(env);
   if (response !== undefined && response.resolve !== undefined) {
     response.resolve.fallback = {

--- a/public/app/plugins/datasource/mssql/webpack.config.ts
+++ b/public/app/plugins/datasource/mssql/webpack.config.ts
@@ -1,9 +1,9 @@
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 
-import grafanaConfig from '@grafana/plugin-configs/webpack.config.ts';
+import grafanaConfig, { type Env } from '@grafana/plugin-configs/webpack.config.ts';
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {


### PR DESCRIPTION
**What is this feature?**

Fixes the types being passed for the Webpack env.

**Why do we need this feature?**

These Webpack configs were passing in `Record<string, unknown>` as the env type, while the base config expects `Record<string, true | string | [recursive]>` following #107133. This was resulting in type-checking errors when running Webpack.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.