### PR TITLE
UI: Disable tabular numbers toggle by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -82,7 +82,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `alertingMigrationUI`                  | Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules                                                              | Yes                |
 | `alertingImportYAMLUI`                 | Enables a UI feature for importing rules from a Prometheus file to Grafana-managed rules                                                                      | Yes                |
 | `unifiedNavbars`                       | Enables unified navbars                                                                                                                                       |                    |
-| `tabularNumbers`                       | Use fixed-width numbers globally in the UI                                                                                                                    | Yes                |
+| `tabularNumbers`                       | Use fixed-width numbers globally in the UI                                                                                                                    |                    |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -999,7 +999,7 @@ export interface FeatureToggles {
   preferLibraryPanelTitle?: boolean;
   /**
   * Use fixed-width numbers globally in the UI
-  * @default true
+  * @default false
   */
   tabularNumbers?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1714,7 +1714,7 @@ var (
 			Description: "Use fixed-width numbers globally in the UI",
 			Stage:       FeatureStageGeneralAvailability,
 			Owner:       grafanaFrontendPlatformSquad,
-			Expression:  "true",
+			Expression:  "false",
 		},
 		{
 			Name:         "newInfluxDSConfigPageDesign",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2943,17 +2943,17 @@
     {
       "metadata": {
         "name": "tabularNumbers",
-        "resourceVersion": "1750754828442",
+        "resourceVersion": "1752078306230",
         "creationTimestamp": "2025-06-24T11:52:03Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-06-24 08:47:08.442537461 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-07-09 16:25:06.230922635 +0000 UTC"
         }
       },
       "spec": {
         "description": "Use fixed-width numbers globally in the UI",
         "stage": "GA",
         "codeowner": "@grafana/grafana-frontend-platform",
-        "expression": "true"
+        "expression": "false"
       }
     },
     {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/107036 we enabled tabular numbers globally in the UI. This caused issues with the measureText function, which isn't able to use the font feature.

The toggle was disabled in Cloud, but we should turn it off by default as well.