### PR TITLE
SCIM: Update allow non-provisioned users dynamic config field

### DIFF
--- a/pkg/services/scimutil/scim_util.go
+++ b/pkg/services/scimutil/scim_util.go
@@ -83,11 +83,7 @@ func (s *SCIMUtil) fetchDynamicSCIMSetting(ctx context.Context, orgID int64, set
 	case "group":
 		enabled = scimConfig.EnableGroupSync
 	case "allowNonProvisionedUsers":
-		if scimConfig.AllowNonProvisionedUsers != nil {
-			enabled = *scimConfig.AllowNonProvisionedUsers
-		} else {
-			enabled = false
-		}
+		enabled = scimConfig.AllowNonProvisionedUsers
 	default:
 		s.logger.Error("Invalid setting type provided to fetchDynamicSCIMSetting", "settingType", settingType)
 		return false, false
@@ -112,9 +108,9 @@ func (s *SCIMUtil) getOrgSCIMConfig(ctx context.Context, orgID int64) (*SCIMConf
 
 // SCIMConfigSpec represents the spec part of a SCIMConfig resource
 type SCIMConfigSpec struct {
-	EnableUserSync           bool  `json:"enableUserSync"`
-	EnableGroupSync          bool  `json:"enableGroupSync"`
-	AllowNonProvisionedUsers *bool `json:"allowNonProvisionedUsers,omitempty"`
+	EnableUserSync           bool `json:"enableUserSync"`
+	EnableGroupSync          bool `json:"enableGroupSync"`
+	AllowNonProvisionedUsers bool `json:"allowNonProvisionedUsers"`
 }
 
 // unstructuredToSCIMConfig converts an unstructured object to a SCIMConfigSpec
@@ -139,6 +135,6 @@ func (s *SCIMUtil) unstructuredToSCIMConfig(obj *unstructured.Unstructured) (*SC
 	return &SCIMConfigSpec{
 		EnableUserSync:           enableUserSync,
 		EnableGroupSync:          enableGroupSync,
-		AllowNonProvisionedUsers: &allowNonProvisionedUsers,
+		AllowNonProvisionedUsers: allowNonProvisionedUsers,
 	}, nil
 }

--- a/pkg/services/scimutil/scim_util_test.go
+++ b/pkg/services/scimutil/scim_util_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 // MockK8sHandler is a mock implementation of client.K8sHandler for testing
@@ -573,7 +572,7 @@ func TestSCIMUtil_unstructuredToSCIMConfig(t *testing.T) {
 			expectedSpec: SCIMConfigSpec{
 				EnableUserSync:           true,
 				EnableGroupSync:          true,
-				AllowNonProvisionedUsers: util.Pointer(false),
+				AllowNonProvisionedUsers: false,
 			},
 		},
 		{
@@ -582,7 +581,7 @@ func TestSCIMUtil_unstructuredToSCIMConfig(t *testing.T) {
 			expectedSpec: SCIMConfigSpec{
 				EnableUserSync:           false,
 				EnableGroupSync:          false,
-				AllowNonProvisionedUsers: util.Pointer(false),
+				AllowNonProvisionedUsers: false,
 			},
 		},
 		{
@@ -591,7 +590,7 @@ func TestSCIMUtil_unstructuredToSCIMConfig(t *testing.T) {
 			expectedSpec: SCIMConfigSpec{
 				EnableUserSync:           true,
 				EnableGroupSync:          false,
-				AllowNonProvisionedUsers: util.Pointer(false),
+				AllowNonProvisionedUsers: false,
 			},
 		},
 		{
@@ -600,7 +599,7 @@ func TestSCIMUtil_unstructuredToSCIMConfig(t *testing.T) {
 			expectedSpec: SCIMConfigSpec{
 				EnableUserSync:           false,
 				EnableGroupSync:          false,
-				AllowNonProvisionedUsers: util.Pointer(true),
+				AllowNonProvisionedUsers: true,
 			},
 		},
 		{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Changes the `AllowNonProvisionedUsers` field in SCIMConfigSpec from a pointer to a direct bool value to match other SCIM dynamic settings.

**Why do we need this feature?**
The `AllowNonProvisionedUsers` field has been added to the SCIM dynamic config in https://github.com/grafana/grafana-enterprise/pull/9013

**Who is this feature for?**
enterprise SCIM users/admins

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/1544

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
