### PR TITLE
unistore: fix delete and db closed in kv store

### DIFF
--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -68,6 +68,10 @@ func NewBadgerKV(db *badger.DB) *badgerKV {
 }
 
 func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObject, error) {
+	if k.db.IsClosed() {
+		return KVObject{}, fmt.Errorf("database is closed")
+	}
+
 	txn := k.db.NewTransaction(false)
 	defer txn.Discard()
 
@@ -101,6 +105,10 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (KVObjec
 }
 
 func (k *badgerKV) Save(ctx context.Context, section string, key string, value io.Reader) error {
+	if k.db.IsClosed() {
+		return fmt.Errorf("database is closed")
+	}
+
 	if section == "" {
 		return fmt.Errorf("section is required")
 	}
@@ -123,6 +131,10 @@ func (k *badgerKV) Save(ctx context.Context, section string, key string, value i
 }
 
 func (k *badgerKV) Delete(ctx context.Context, section string, key string) error {
+	if k.db.IsClosed() {
+		return fmt.Errorf("database is closed")
+	}
+
 	if section == "" {
 		return fmt.Errorf("section is required")
 	}
@@ -149,6 +161,11 @@ func (k *badgerKV) Delete(ctx context.Context, section string, key string) error
 }
 
 func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
+	if k.db.IsClosed() {
+		return func(yield func(string, error) bool) {
+			yield("", fmt.Errorf("database is closed"))
+		}
+	}
 	if section == "" {
 		return func(yield func(string, error) bool) {
 			yield("", fmt.Errorf("section is required"))

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -782,6 +782,11 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 		return nil, apierrors.NewBadRequest(
 			fmt.Sprintf("unable to read previous object, %v", err))
 	}
+	oldObj, err := utils.MetaAccessor(marker)
+	if err != nil {
+		return nil, err
+	}
+
 	obj, err := utils.MetaAccessor(marker)
 	if err != nil {
 		return nil, err
@@ -793,6 +798,8 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 	obj.SetUpdatedBy(user.GetUID())
 	obj.SetGeneration(utils.DeletedGeneration)
 	obj.SetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig, "") // clears it
+	event.ObjectOld = oldObj
+	event.Object = obj
 	event.Value, err = marker.MarshalJSON()
 	if err != nil {
 		return nil, apierrors.NewBadRequest(

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -72,6 +72,7 @@ func TestKvStorageBackend_WriteEvent_Success(t *testing.T) {
 				},
 				Value:      objectToJSONBytes(t, testObj),
 				Object:     metaAccessor,
+				ObjectOld:  metaAccessor,
 				PreviousRV: 100,
 			}
 
@@ -799,6 +800,8 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 	// Delete the resource
 	writeEvent.Type = resourcepb.WatchEvent_DELETED
 	writeEvent.PreviousRV = rv1
+	writeEvent.Object = metaAccessor
+	writeEvent.ObjectOld = metaAccessor
 
 	rv2, err := backend.WriteEvent(ctx, writeEvent)
 	require.NoError(t, err)
@@ -989,7 +992,11 @@ func writeObject(t *testing.T, backend *kvStorageBackend, obj *unstructured.Unst
 		},
 		Value:      objectToJSONBytes(t, obj),
 		Object:     metaAccessor,
+		ObjectOld:  metaAccessor,
 		PreviousRV: previousRV,
+	}
+	if eventType == resourcepb.WatchEvent_ADDED {
+		writeEvent.ObjectOld = nil
 	}
 
 	return backend.WriteEvent(context.Background(), writeEvent)

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestBadgerKVStorageBackend(t *testing.T) {
-	t.Skip("failing with 'panic: DB Closed'")
 	RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
 		opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 		db, err := badger.Open(opts)


### PR DESCRIPTION
Fix the delete path for the kv storage backend to ensure we have a folder.
Fix the [DB closed error](https://raintank-corp.slack.com/archives/C08BF6HSFHD/p1751536315331509)