### PR TITLE
TableNG: Fallback to AutoCell when cellType is unmapped

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.test.tsx
@@ -141,6 +141,14 @@ describe('TableNG Cells renderers', () => {
           expect(container).toBeInTheDocument();
           expect(container.childNodes).toHaveLength(1);
         });
+
+        it('should return AutoCell when cellOptions is unmapped', () => {
+          const field = createField(FieldType.string);
+
+          const { container } = renderCell(field, { type: 'number' } as unknown as TableCellOptions);
+          expect(container).toBeInTheDocument();
+          expect(container.childNodes).toHaveLength(1);
+        });
       });
     });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
@@ -109,7 +109,7 @@ export function getCellRenderer(field: Field, cellOptions: TableCellOptions): Ta
   if (cellType === TableCellDisplayMode.Auto) {
     return getAutoRendererResult(field);
   }
-  return CELL_RENDERERS[cellType];
+  return CELL_RENDERERS[cellType] ?? AUTO_RENDERER;
 }
 
 /** @internal */


### PR DESCRIPTION
TableNG users were experiencing an issue where a legacy cellOptions.type was causing issues when rendering the table.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
