### PR TITLE
chore: fix typo in FlameGraph docs

### DIFF
--- a/packages/grafana-flamegraph/README.md
+++ b/packages/grafana-flamegraph/README.md
@@ -9,7 +9,7 @@ This is a Flamegraph component that is used in Grafana and Pyroscope web app to 
 Currently this library exposes single component `Flamegraph` that renders whole visualization used for profiling which contains a header, a table representation of the data and a flamegraph.
 
 ```tsx
-import { Flamegraph } from '@grafana/flamegraph';
+import { FlameGraph } from '@grafana/flamegraph';
 
 <FlameGraph
   getTheme={() => createTheme({ colors: { mode: 'dark' } })}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/162c07d0-ec03-4d4a-9797-60bbe676058b)

I copy/pasted the import from the docs and got this error in my editor. Swapping `g` for `G` did the trick!
