### PR TITLE
Tempo: Force service.name and name to strings

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -245,10 +245,15 @@ const SearchField = ({
               }
             }}
             onCreateOption={(val) => {
+              // For service.name and name fields, always use string type for manually entered values
+              const valueType = filter.tag === 'service.name' || filter.tag === 'name' 
+                ? 'string' 
+                : uniqueOptionType;
+              
               updateFilter({
                 ...filter,
                 value: Array.isArray(filter.value) ? filter.value?.concat(val) : val,
-                valueType: uniqueOptionType,
+                valueType: valueType,
                 isCustomValue: true,
               });
             }}

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -46,9 +46,12 @@ export const valueHelper = (f: TraceqlFilter) => {
   if (Array.isArray(value) && value.length > 1) {
     return `"${value.join('|')}"`;
   }
-  if (f.valueType === 'string') {
+  
+  // Always quote specific tag values and strings
+  if (f.tag === 'service.name' || f.tag === 'name' || f.valueType === 'string') {
     return `"${value}"`;
   }
+  
   return value;
 };
 
@@ -57,6 +60,16 @@ export const scopeHelper = (f: TraceqlFilter, lp: TempoLanguageProvider) => {
   if (lp.getIntrinsics().find((t) => t === f.tag)) {
     return '';
   }
+  
+  // Special cases for common fields to ensure correct scoping
+  if (f.tag === 'service.name') {
+    return 'resource.';
+  }
+  
+  if (f.tag === 'name') {
+    return 'span.';
+  }
+  
   return (
     (f.scope === TraceqlSearchScope.Event ||
     f.scope === TraceqlSearchScope.Instrumentation ||


### PR DESCRIPTION
## What's the issue?

When manually entering values for service name or span name filters (rather than selecting from a dropdown), the Tempo datasource generates incorrect TraceQL syntax:

- Service names appear as `{service.name=abcdefd}` instead of `{resource.service.name="abcdefd"}`
- Span names appear as `{name=hahaha}` instead of `{span.name="hahaha"}`

This creates invalid queries that don't return expected results since:

1. The correct scope prefixes are missing (`resource.` and `span.`)
2. String values are not properly quoted with double quotes

### related issue
https://github.com/grafana/grafana-tempo-datasource/issues/148

## What are the changes?

Fixed three aspects of TraceQL query generation:

1. __Added proper scope prefixes in the `scopeHelper` function__:

   - Added a special case for `service.name` to always use `resource.` prefix
   - Added a special case for `name` to always use `span.` prefix

2. __Enhanced string value handling in the `valueHelper` function__:

   - Added logic to always quote values for certain tag types, ensuring string values get proper quotes

3. __Fixed value type assignment in the `SearchField` component__:

   - Modified the `onCreateOption` handler to explicitly set `valueType: "string"` for manually entered values for service name and span name fields

## Testing

To reproduce and verify the fix:

1. Add a Service Name filter and manually type a value (don't select from dropdown)

2. Add a Span Name filter and manually type a value (don't select from dropdown)

3. Observe the generated TraceQL query at the bottom of the query editor now shows:

   - `{resource.service.name="value" && span.name="value"}`
   - Before it would incorrectly show: `{service.name=value && name=value}`

## Notes

The issue was identified when manually entering service names and span names resulted in syntax errors in the TraceQL queries, preventing users from finding traces with manually entered filters.
