### PR TITLE
TableNG: Frames field range support + SparklineCell min/max

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -20,7 +20,6 @@ import {
   applyFieldOverrides,
   applyRawFieldOverrides,
   FieldOverrideEnv,
-  findNumericFieldMinMax,
   getLinksSupplier,
   setDynamicConfigValue,
   setFieldConfigDefaults,
@@ -79,68 +78,6 @@ locationUtil.initialize({
   config: { appSubUrl: '/subUrl' } as GrafanaConfig,
   getVariablesUrlParams: jest.fn(),
   getTimeRangeForUrl: jest.fn(),
-});
-
-describe('Global MinMax', () => {
-  it('find global min max', () => {
-    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
-      { title: 'AAA', value: 100, value2: 1234 },
-      { title: 'BBB', value: -20, value2: null },
-      { title: 'CCC', value: 200, value2: 1000 },
-    ]);
-
-    const minmax = findNumericFieldMinMax([f0]);
-    expect(minmax.min).toEqual(-20);
-    expect(minmax.max).toEqual(1234);
-  });
-
-  it('find global min max when all values are zero', () => {
-    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
-      { title: 'AAA', value: 0, value2: 0 },
-      { title: 'CCC', value: 0, value2: 0 },
-    ]);
-
-    const minmax = findNumericFieldMinMax([f0]);
-    expect(minmax.min).toEqual(0);
-    expect(minmax.max).toEqual(0);
-  });
-
-  describe('when value is null', () => {
-    it('then global min max should be null', () => {
-      const frame = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1] },
-          { name: 'Value', type: FieldType.number, values: [null] },
-        ],
-      });
-      const { min, max } = findNumericFieldMinMax([frame]);
-
-      expect(min).toBe(null);
-      expect(max).toBe(null);
-    });
-  });
-
-  describe('when values are zero', () => {
-    it('then global min max should be correct', () => {
-      const frame = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1, 2] },
-          { name: 'Value', type: FieldType.number, values: [1, 2] },
-        ],
-      });
-      const frame2 = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1, 2] },
-          { name: 'Value', type: FieldType.number, values: [0, 0] },
-        ],
-      });
-
-      const { min, max } = findNumericFieldMinMax([frame, frame2]);
-
-      expect(min).toBe(0);
-      expect(max).toBe(2);
-    });
-  });
 });
 
 describe('applyFieldOverrides', () => {

--- a/packages/grafana-data/src/field/scale.test.ts
+++ b/packages/grafana-data/src/field/scale.test.ts
@@ -1,9 +1,11 @@
+import { ArrayDataFrame } from '../dataframe/ArrayDataFrame';
+import { toDataFrame } from '../dataframe/processDataFrame';
 import { createTheme } from '../themes/createTheme';
 import { Field, FieldType } from '../types/dataFrame';
 import { FieldColorModeId } from '../types/fieldColor';
 import { ThresholdsMode } from '../types/thresholds';
 
-import { getScaleCalculator } from './scale';
+import { findNumericFieldMinMax, getScaleCalculator } from './scale';
 import { sortThresholds } from './thresholds';
 
 describe('getScaleCalculator', () => {
@@ -63,5 +65,67 @@ describe('getScaleCalculator', () => {
     const calc = getScaleCalculator(field, theme);
 
     expect(calc(1).color).toEqual('rgb(115, 191, 105)');
+  });
+});
+
+describe('findNumericFieldMinMax', () => {
+  it('find global min max', () => {
+    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
+      { title: 'AAA', value: 100, value2: 1234 },
+      { title: 'BBB', value: -20, value2: null },
+      { title: 'CCC', value: 200, value2: 1000 },
+    ]);
+
+    const minmax = findNumericFieldMinMax([f0]);
+    expect(minmax.min).toEqual(-20);
+    expect(minmax.max).toEqual(1234);
+  });
+
+  it('find global min max when all values are zero', () => {
+    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
+      { title: 'AAA', value: 0, value2: 0 },
+      { title: 'CCC', value: 0, value2: 0 },
+    ]);
+
+    const minmax = findNumericFieldMinMax([f0]);
+    expect(minmax.min).toEqual(0);
+    expect(minmax.max).toEqual(0);
+  });
+
+  describe('when value is null', () => {
+    it('then global min max should be null', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1] },
+          { name: 'Value', type: FieldType.number, values: [null] },
+        ],
+      });
+      const { min, max } = findNumericFieldMinMax([frame]);
+
+      expect(min).toBe(null);
+      expect(max).toBe(null);
+    });
+  });
+
+  describe('when values are zero', () => {
+    it('then global min max should be correct', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [1, 2] },
+        ],
+      });
+      const frame2 = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [0, 0] },
+        ],
+      });
+
+      const { min, max } = findNumericFieldMinMax([frame, frame2]);
+
+      expect(min).toBe(0);
+      expect(max).toBe(2);
+    });
   });
 });

--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -115,20 +115,22 @@ export function getMinMaxAndDelta(field: Field): NumericRange {
 
   // Calculate min/max if required
   if (!isNumber(min) || !isNumber(max)) {
+    let calculatedMin = 0;
+    let calculatedMax = 100;
     if (field.values && field.values.length) {
       if (field.type === FieldType.frame) {
         const result = findNumericFieldMinMax(field.values);
-        min = isNumber(min) ? min : result.min;
-        max = isNumber(max) ? max : result.max;
+        calculatedMin = result.min != null ? result.min : calculatedMin;
+        calculatedMax = result.max != null ? result.max : calculatedMax;
       } else if (field.type === FieldType.number) {
         const stats = reduceField({ field, reducers: [ReducerID.min, ReducerID.max] });
-        min = isNumber(min) ? min : stats[ReducerID.min];
-        max = isNumber(max) ? max : stats[ReducerID.max];
+        calculatedMin = stats[ReducerID.min];
+        calculatedMax = stats[ReducerID.max];
       }
-    } else {
-      min = 0;
-      max = 100;
     }
+
+    min = isNumber(min) ? min : calculatedMin;
+    max = isNumber(max) ? max : calculatedMax;
   }
 
   return {

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -100,7 +100,7 @@ export { type PluginAddedLinksConfigureFunc, type PluginExtensionEventHelpers } 
 export { getStreamingFrameOptions } from '../dataframe/StreamingDataFrame';
 export { fieldIndexComparer } from '../field/fieldComparers';
 export { decoupleHideFromState } from '../field/fieldState';
-export { findNumericFieldMinMax } from '../field/fieldOverrides';
+export { findNumericFieldMinMax } from '../field/scale';
 export { type PanelOptionsSupplier } from '../panel/PanelPlugin';
 export { sanitize, sanitizeUrl } from '../text/sanitize';
 export { type NestedValueAccess, type NestedPanelOptions, isNestedPanelOptions } from '../utils/OptionsUIBuilders';

--- a/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import {
   FieldType,
   FieldConfig,
-  getMinMaxAndDelta,
   FieldSparkline,
   isDataFrame,
   Field,
   isDataFrameWithValue,
   formattedValueToString,
+  getFieldConfigWithMinMax,
 } from '@grafana/data';
 import {
   BarAlignment,
@@ -54,6 +54,8 @@ export const SparklineCell = (props: TableCellProps) => {
     );
   }
 
+  const fieldConfig: FieldConfig<GraphFieldConfig> = getFieldConfigWithMinMax(field, true);
+
   // Get the step from the first two values to null-fill the x-axis based on timerange
   if (sparkline.x && !sparkline.x.config.interval && sparkline.x.values.length > 1) {
     sparkline.x.config.interval = sparkline.x.values[1] - sparkline.x.values[0];
@@ -68,16 +70,16 @@ export const SparklineCell = (props: TableCellProps) => {
     }
   });
 
-  const range = getMinMaxAndDelta(sparkline.y);
-  sparkline.y.config.min = range.min;
-  sparkline.y.config.max = range.max;
-  sparkline.y.state = { range };
+  sparkline.y.config.min = fieldConfig.min;
+  sparkline.y.config.max = fieldConfig.max;
+  sparkline.y.state = { range: field.state?.range };
   sparkline.timeRange = timeRange;
 
   const cellOptions = getTableSparklineCellOptions(field);
 
   const config: FieldConfig<GraphFieldConfig> = {
-    color: field.config.color,
+    ...fieldConfig,
+    color: fieldConfig.color,
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -5,13 +5,14 @@ import * as React from 'react';
 import {
   FieldType,
   FieldConfig,
-  getMinMaxAndDelta,
   FieldSparkline,
   isDataFrame,
   Field,
   isDataFrameWithValue,
   GrafanaTheme2,
+  getFieldConfigWithMinMax,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import {
   BarAlignment,
   GraphDrawStyle,
@@ -49,8 +50,10 @@ export const SparklineCell = (props: SparklineCellProps) => {
   const sparkline = getSparkline(value);
 
   if (!sparkline) {
-    return <>{field.config.noValue || 'no data'}</>;
+    return <>{field.config.noValue || t('grafana-ui.table.sparkline-cell.no-data', 'no data')}</>;
   }
+
+  const fieldConfig = getFieldConfigWithMinMax(field, true);
 
   // Get the step from the first two values to null-fill the x-axis based on timerange
   if (sparkline.x && !sparkline.x.config.interval && sparkline.x.values.length > 1) {
@@ -66,16 +69,16 @@ export const SparklineCell = (props: SparklineCellProps) => {
     }
   });
 
-  const range = getMinMaxAndDelta(sparkline.y);
-  sparkline.y.config.min = range.min;
-  sparkline.y.config.max = range.max;
-  sparkline.y.state = { range };
+  sparkline.y.config.min = fieldConfig.min;
+  sparkline.y.config.max = fieldConfig.max;
+  sparkline.y.state = { range: field.state?.range };
   sparkline.timeRange = timeRange;
 
   const cellOptions = getTableSparklineCellOptions(field);
 
   const config: FieldConfig<GraphFieldConfig> = {
-    color: field.config.color,
+    ...fieldConfig,
+    color: fieldConfig.color,
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -274,7 +274,7 @@ export const getAllStandardFieldConfigs = () => {
     override: standardEditorsRegistry.get('boolean').editor,
     process: booleanOverrideProcessor,
 
-    shouldApply: (field) => field.type === FieldType.number,
+    shouldApply: (field) => field.type === FieldType.number || field.type === FieldType.frame,
     showIf: (options) => {
       return options.min === undefined || options.max === undefined;
     },
@@ -297,7 +297,7 @@ export const getAllStandardFieldConfigs = () => {
     settings: {
       placeholder: t('options-ui.registry.standard-field-configs.placeholder-min', 'auto'),
     },
-    shouldApply: (field) => field.type === FieldType.number,
+    shouldApply: (field) => field.type === FieldType.number || field.type === FieldType.frame,
     category,
   };
 
@@ -318,7 +318,7 @@ export const getAllStandardFieldConfigs = () => {
       placeholder: t('options-ui.registry.standard-field-configs.placeholder-max', 'auto'),
     },
 
-    shouldApply: (field) => field.type === FieldType.number,
+    shouldApply: (field) => field.type === FieldType.number || field.type === FieldType.frame,
     category,
   };
 
@@ -338,7 +338,7 @@ export const getAllStandardFieldConfigs = () => {
       integer: true,
     },
 
-    shouldApply: (field) => field.type === FieldType.number,
+    shouldApply: (field) => field.type === FieldType.number || field.type === FieldType.frame,
     category,
   };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8012,7 +8012,10 @@
       "inspect-drawer-title": "Inspect value",
       "inspect-menu-label": "Inspect value",
       "no-values-label": "No values",
-      "pagination-summary": "{{itemsRangeStart}} - {{displayedEnd}} of {{numRows}} rows"
+      "pagination-summary": "{{itemsRangeStart}} - {{displayedEnd}} of {{numRows}} rows",
+      "sparkline-cell": {
+        "no-data": "no data"
+      }
     },
     "tags": {
       "list-label": "Tags"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

WIP

**What is this feature?**

Currently, ranges (mins and maxes) are only applied from settings to numeric fields. This means that SparklineCell on Table is never going to get these settings, and thus behaves weirdly, because the fields on a SparklineCell are Frames. This PR updates min and max to also apply to frames, and repurposes some utilities to get min and max calculation working on SparklineCell.

**Why do we need this feature?**

SparklineCells currently are hard to use because the min and max ranges can give an unclear picture of what's going on for a given dataset if their ranges are inconsistent with other data on a dashboard.

SparklineCells expect fields which either contain array of numbers or dataframes as their values (https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx#L120-L142).

**Who is this feature for?**

Users of SparklineCell.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/79334
Relates to https://github.com/grafana/support-escalations/issues/17223

*There is one kind of janky thing I want to point out which does not work about this.* 

When doing a min/max via fieldOverrides rather than the standard settings, targeting the frame field won't apply the min and max. I'm not sure there's a clean way to achieve it, but it would definitely require a deeper dive into the `applyFieldOverrides` method.

https://github.com/user-attachments/assets/0a21f4d5-77a9-41f7-9999-788c84d69c2d

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
