### PR TITLE
New Logs Panel: Parse JSON by default and show highlighted log in details

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,6 +355,7 @@
     "leven": "^4.0.0",
     "lodash": "4.17.21",
     "logfmt": "^1.3.2",
+    "lossless-json": "^4.1.1",
     "lru-cache": "11.1.0",
     "lru-memoize": "^1.1.0",
     "lucene": "^2.1.1",

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -154,6 +154,7 @@ export const InfiniteScroll = ({
           displayedFields={displayedFields}
           index={index}
           log={logs[index]}
+          logs={logs}
           onClick={onClick}
           showTime={showTime}
           style={style}

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -45,6 +45,7 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
       displayedFields: [],
       index: 0,
       log,
+      logs: [log],
       onClick: jest.fn(),
       showTime: true,
       style: {},

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -101,7 +101,6 @@ const LogLineComponent = memo(
       hasSampledLogs,
       onLogLineHover,
     } = useLogListContext();
-    console.log('render')
     const [collapsed, setCollapsed] = useState<boolean | undefined>(
       wrapLogMessage && log.collapsed !== undefined ? log.collapsed : undefined
     );

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -27,6 +27,7 @@ export interface Props {
   displayedFields: string[];
   index: number;
   log: LogListModel;
+  logs: LogListModel[];
   showTime: boolean;
   style: CSSProperties;
   styles: LogLineStyles;
@@ -41,6 +42,7 @@ export const LogLine = ({
   displayedFields,
   index,
   log,
+  logs,
   style,
   styles,
   onClick,
@@ -57,6 +59,7 @@ export const LogLine = ({
         height={style.height}
         index={index}
         log={log}
+        logs={logs}
         styles={styles}
         onClick={onClick}
         onOverflow={onOverflow}
@@ -79,6 +82,7 @@ const LogLineComponent = memo(
     height,
     index,
     log,
+    logs,
     styles,
     onClick,
     onOverflow,
@@ -97,6 +101,7 @@ const LogLineComponent = memo(
       hasSampledLogs,
       onLogLineHover,
     } = useLogListContext();
+    console.log('render')
     const [collapsed, setCollapsed] = useState<boolean | undefined>(
       wrapLogMessage && log.collapsed !== undefined ? log.collapsed : undefined
     );
@@ -237,7 +242,7 @@ const LogLineComponent = memo(
             </Button>
           </div>
         )}
-        {detailsMode === 'inline' && detailsShown && <InlineLogLineDetails logs={[]} />}
+        {detailsMode === 'inline' && detailsShown && <InlineLogLineDetails logs={logs} />}
       </>
     );
   }

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -13,9 +13,9 @@ import { createLogLineLinks } from '../logParser';
 import { LogLineDetailsDisplayedFields } from './LogLineDetailsDisplayedFields';
 import { LabelWithLinks, LogLineDetailsFields, LogLineDetailsLabelFields } from './LogLineDetailsFields';
 import { LogLineDetailsHeader } from './LogLineDetailsHeader';
+import { LogLineDetailsLog } from './LogLineDetailsLog';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
-import { LogLineDetailsLog } from './LogLineDetailsLog';
 
 interface LogLineDetailsComponentProps {
   log: LogListModel;

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -15,6 +15,7 @@ import { LabelWithLinks, LogLineDetailsFields, LogLineDetailsLabelFields } from 
 import { LogLineDetailsHeader } from './LogLineDetailsHeader';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
+import { LogLineDetailsLog } from './LogLineDetailsLog';
 
 interface LogLineDetailsComponentProps {
   log: LogListModel;
@@ -102,7 +103,7 @@ export const LogLineDetailsComponent = ({ log, logs }: LogLineDetailsComponentPr
           isOpen={logLineOpen}
           onToggle={(isOpen: boolean) => handleToggle('logLineOpen', isOpen)}
         >
-          <div className={styles.logLineWrapper}>{log.raw}</div>
+          <LogLineDetailsLog log={log} />
         </ControlledCollapse>
         {displayedFields.length > 0 && setDisplayedFields && (
           <ControlledCollapse
@@ -188,9 +189,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   componentWrapper: css({
     padding: theme.spacing(0, 1, 1, 1),
-  }),
-  logLineWrapper: css({
-    maxHeight: '50vh',
-    overflow: 'auto',
   }),
 });

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -1,0 +1,43 @@
+import { css } from "@emotion/css";
+import { LogListModel } from "./processing";
+import { memo, useMemo } from "react";
+import { useLogListContext } from "./LogListContext";
+import { useStyles2 } from "@grafana/ui";
+import { getStyles } from "./LogLine";
+
+interface Props {
+  log: LogListModel;
+}
+
+export const LogLineDetailsLog = memo(({ log: originalLog }: Props) => {
+  const { syntaxHighlighting } = useLogListContext();
+  const logStyles = useStyles2(getStyles);
+  const log = useMemo(() => {
+    const log = originalLog.clone();
+    log.setCollapsedState(undefined);
+    return log;
+  }, []);
+
+  return (
+    <div className={styles.logLineWrapper}>
+      {!syntaxHighlighting ? (
+        <div className="field no-highlighting">{log.body}</div>
+      ) : (
+        <div className={logStyles.logLine}>
+          <div className={logStyles.wrappedLogLine}>
+            <div className="field log-syntax-highlight" dangerouslySetInnerHTML={{ __html: log.highlightedBody }} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+});
+
+LogLineDetailsLog.displayName = 'LogLineDetailsLog';
+
+const styles = {
+  logLineWrapper: css({
+    maxHeight: '50vh',
+    overflow: 'auto',
+  }),
+};

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -1,9 +1,11 @@
-import { css } from "@emotion/css";
-import { LogListModel } from "./processing";
-import { memo, useMemo } from "react";
-import { useLogListContext } from "./LogListContext";
-import { useStyles2 } from "@grafana/ui";
-import { getStyles } from "./LogLine";
+import { css } from '@emotion/css';
+import { memo, useMemo } from 'react';
+
+import { useStyles2 } from '@grafana/ui';
+
+import { getStyles } from './LogLine';
+import { useLogListContext } from './LogListContext';
+import { LogListModel } from './processing';
 
 interface Props {
   log: LogListModel;
@@ -16,7 +18,7 @@ export const LogLineDetailsLog = memo(({ log: originalLog }: Props) => {
     const log = originalLog.clone();
     log.setCollapsedState(undefined);
     return log;
-  }, []);
+  }, [originalLog]);
 
   return (
     <div className={styles.logLineWrapper}>
@@ -30,7 +32,7 @@ export const LogLineDetailsLog = memo(({ log: originalLog }: Props) => {
         </div>
       )}
     </div>
-  )
+  );
 });
 
 LogLineDetailsLog.displayName = 'LogLineDetailsLog';

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -16,7 +16,6 @@ export const LogLineDetailsLog = memo(({ log: originalLog }: Props) => {
   const logStyles = useStyles2(getStyles);
   const log = useMemo(() => {
     const log = originalLog.clone();
-    log.setCollapsedState(undefined);
     return log;
   }, [originalLog]);
 

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -243,6 +243,35 @@ describe('preProcessLogs', () => {
       expect(entry).toContain(longLog.body);
     });
 
+    test('Sets the collapsed state based on the new lines count', () => {
+      const entry = new Array(virtualization.getTruncationLineCount()).fill('test\n').join('');
+      const multilineLog = createLogLine(
+        { entry, labels: { field: 'value' } },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization, wrapLogMessage: true }
+      );
+
+      expect(multilineLog.collapsed).toBeUndefined();
+
+      multilineLog.updateCollapsedState([], container);
+
+      expect(multilineLog.collapsed).toBe(true);
+      expect(entry).toContain(multilineLog.body);
+    });
+
+    test('Correctly counts new lines', () => {
+      const entry = new Array(virtualization.getTruncationLineCount()-1).fill('test\n').join('');
+      const multilineLog = createLogLine(
+        { entry, labels: { field: 'value' } },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization, wrapLogMessage: true }
+      );
+
+      expect(multilineLog.collapsed).toBeUndefined();
+
+      multilineLog.updateCollapsedState([], container);
+
+      expect(multilineLog.collapsed).toBeUndefined();
+    });
+
     test('Considers the displayed fields to set the collapsed state', () => {
       // Make container half of the size
       jest.spyOn(container, 'clientWidth', 'get').mockReturnValue(100);
@@ -253,6 +282,22 @@ describe('preProcessLogs', () => {
       longLog.updateCollapsedState(['field'], container);
 
       expect(longLog.collapsed).toBeUndefined();
+    });
+
+    test('Considers new lines in displayed fields to set the collapsed state', () => {
+      const entry = new Array(virtualization.getTruncationLineCount() - 1).fill('test\n').join('');
+      const field = 'test\n';
+      const multilineLog = createLogLine(
+        { entry, labels: { field } },
+        { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization, wrapLogMessage: true }
+      );
+
+      expect(multilineLog.collapsed).toBeUndefined();
+
+      multilineLog.updateCollapsedState(['field', LOG_LINE_BODY_FIELD_NAME], container);
+
+      expect(multilineLog.collapsed).toBe(true);
+      expect(entry).toContain(multilineLog.body);
     });
 
     test('Updates the body based on the collapsed state', () => {

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -155,6 +155,21 @@ describe('preProcessLogs', () => {
       expect(logListModel.entry).toBe(entry);
       expect(logListModel.body).not.toBe(entry);
     });
+
+    test('Uses lossless parsing', () => {
+      const entry = '{"number": 90071992547409911}';
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: false, // unwrapped
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).toContain('90071992547409911');
+    });
   });
 
   test('Orders logs', () => {

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -259,7 +259,7 @@ describe('preProcessLogs', () => {
     });
 
     test('Correctly counts new lines', () => {
-      const entry = new Array(virtualization.getTruncationLineCount()-1).fill('test\n').join('');
+      const entry = new Array(virtualization.getTruncationLineCount() - 1).fill('test\n').join('');
       const multilineLog = createLogLine(
         { entry, labels: { field: 'value' } },
         { escape: false, order: LogsSortOrder.Descending, timeZone: 'browser', virtualization, wrapLogMessage: true }

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -140,6 +140,21 @@ describe('preProcessLogs', () => {
       );
       expect(logListModel.getDisplayedFieldValue(LOG_LINE_BODY_FIELD_NAME, true)).toBe('log message 1');
     });
+
+    test('Prettifies JSON', () => {
+      const entry = '{"key": "value", "otherKey": "otherValue"}';
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: false, // unwrapped
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).not.toBe(entry);
+    });
   });
 
   test('Orders logs', () => {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -168,7 +168,7 @@ export class LogListModel implements LogRowModel {
     const line =
       displayedFields.length > 0
         ? displayedFields.map((field) => this.getDisplayedFieldValue(field, true)).join('')
-        : this.entry;
+        : this.body;
 
     // Length truncation
     let collapsed =

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -179,7 +179,7 @@ export class LogListModel implements LogRowModel {
     // Newlines truncation
     if (!collapsed && this._virtualization) {
       const truncationLimit = this._virtualization.getTruncationLineCount();
-      collapsed = countNewLines(this.raw, truncationLimit) >= truncationLimit ? true : collapsed;
+      collapsed = countNewLines(line, truncationLimit) >= truncationLimit ? true : collapsed;
     }
 
     if (this.collapsed === undefined || collapsed === undefined) {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -99,7 +99,12 @@ export class LogListModel implements LogRowModel {
   }
 
   clone() {
-    return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+    const clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+    // Unless this function is required outside of <LogLineDetailsLog />, we create a wrapped clone, so new lines are not stripped.
+    clone._wrapLogMessage = true;
+    clone._body = undefined;
+    clone._highlightedBody = undefined;
+    return clone;
   }
 
   get body(): string {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -1,4 +1,5 @@
 import ansicolor from 'ansicolor';
+import { parse, stringify } from 'lossless-json';
 import Prism, { Grammar } from 'prismjs';
 
 import { DataFrame, dateTimeFormat, Labels, LogLevel, LogRowModel, LogsSortOrder, textUtil } from '@grafana/data';
@@ -104,7 +105,10 @@ export class LogListModel implements LogRowModel {
   get body(): string {
     if (this._body === undefined) {
       try {
-        this.raw = JSON.stringify(JSON.parse(this.raw), undefined, 2);
+        const parsed = stringify(parse(this.raw), undefined, 2);
+        if (parsed) {
+          this.raw = parsed;
+        }
       } catch (error) {}
       this._body = this.collapsed
         ? this.raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -1,7 +1,7 @@
 import ansicolor from 'ansicolor';
 import Prism, { Grammar } from 'prismjs';
 
-import { DataFrame, dateTimeFormat, Labels, LogLevel, LogRowModel, LogsSortOrder } from '@grafana/data';
+import { DataFrame, dateTimeFormat, Labels, LogLevel, LogRowModel, LogsSortOrder, textUtil } from '@grafana/data';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { checkLogsError, checkLogsSampled, escapeUnescapedString, sortLogRows } from '../../utils';
@@ -124,7 +124,11 @@ export class LogListModel implements LogRowModel {
     if (this._highlightedBody === undefined) {
       this._grammar = this._grammar ?? generateLogGrammar(this);
       const extraGrammar = generateTextMatchGrammar(this.searchWords, this._currentSearch);
-      this._highlightedBody = Prism.highlight(this.body, { ...extraGrammar, ...this._grammar }, 'lokiql');
+      this._highlightedBody = Prism.highlight(
+        textUtil.sanitize(this.body),
+        { ...extraGrammar, ...this._grammar },
+        'lokiql'
+      );
     }
     return this._highlightedBody;
   }

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -184,6 +184,8 @@ export class LogListModel implements LogRowModel {
 
     if (this.collapsed === undefined || collapsed === undefined) {
       this.collapsed = collapsed;
+      this._body = undefined;
+      this._highlightedBody = undefined;
     }
     return this.collapsed;
   }

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -259,7 +259,9 @@ function countNewLines(log: string, limit = Infinity) {
     } else if (log[i] === '\r') {
       count += 1;
       // skip LF in CRLF
-      if (log[i] === '\n') i += 1;
+      if (log[i] === '\n') {
+        i += 1;
+      }
     }
   }
   return count;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -179,7 +179,6 @@ export class LogListModel implements LogRowModel {
     // Newlines truncation
     if (!collapsed && this._virtualization) {
       const truncationLimit = this._virtualization.getTruncationLineCount();
-      console.log(truncationLimit);
       collapsed = countNewLines(this.raw, truncationLimit) >= truncationLimit ? true : collapsed;
     }
 

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -97,8 +97,15 @@ export class LogListModel implements LogRowModel {
     this.raw = raw;
   }
 
+  clone() {
+    return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+  }
+
   get body(): string {
     if (this._body === undefined) {
+      try {
+        this.raw = JSON.stringify(JSON.parse(this.raw), undefined, 2);
+      } catch (error) {}
       this._body = this.collapsed
         ? this.raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
         : this.raw;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -55,7 +55,6 @@ export class LogLineVirtualization {
   getGridSize = () => this.gridSize;
   getPaddingBottom = () => this.paddingBottom;
 
-  // 2/3 of the viewport height
   getTruncationLineCount = () => Math.round(window.innerHeight / this.getLineHeight() / 1.5);
 
   getTruncationLength = (container: HTMLDivElement | null) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18355,6 +18355,7 @@ __metadata:
     leven: "npm:^4.0.0"
     lodash: "npm:4.17.21"
     logfmt: "npm:^1.3.2"
+    lossless-json: "npm:^4.1.1"
     lru-cache: "npm:11.1.0"
     lru-memoize: "npm:^1.1.0"
     lucene: "npm:^2.1.1"
@@ -22157,6 +22158,13 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 10/6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
+  languageName: node
+  linkType: hard
+
+"lossless-json@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "lossless-json@npm:4.1.1"
+  checksum: 10/1e22e9e4ad8ebf169567a8c24553403bfd7abc33c141f4918f1b9626417f80477b849e6175a315a224e0c68072759c69a0e332a925de80269a7f9720af3a7fbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075
Fixes https://github.com/grafana/grafana/issues/55856

This PR introduces a few improvements related with the display of JSON log lines, and log lines within the new Log Details panel.

Changes:
- JSON is "prettified" like it was in the current panel https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/LogRowMessage.tsx#L130 . This happends on-demand when a line is about to be displayed.
- The log line displayed  within Log Details is shown with highlighting if the option is enabled
- Added truncation based on new lines, complementing the current truncation based on line length.
- Using lossless-json to pretty print JSON without losing number precision.

### Demo

https://github.com/user-attachments/assets/9cf735bf-d939-4530-8b8c-ccf46fed4ef5

### How to test

This requires some XL json log lines to trigger. We currently allow close to 1 viewport height before collapsing multi-line logs. 