### PR TITLE
Dashboard: Fix issue with V2 to V1 annotations

### DIFF
--- a/public/app/features/dashboard-scene/serialization/annotations.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.ts
@@ -84,7 +84,7 @@ export function transformV2ToV1AnnotationQuery(annotation: AnnotationQueryKind):
     // TOOO: mappings
   };
 
-  if (Object.keys(dataQuery.spec).length > 0) {
+  if (dataQuery.spec && Object.keys(dataQuery.spec).length > 0) {
     // @ts-expect-error DataQueryKind spec should be typed as DataQuery interface
     annoQuerySpec.target = {
       ...dataQuery?.spec,


### PR DESCRIPTION
**What is this feature?**

Fix `transformV2ToV1AnnotationQuery` for a null annotation `spec`.

**Why do we need this feature?**

Stop crashes?

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1752140525159179

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
