### PR TITLE
Plugin Extensions: Update extension-point ID validation

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2535,6 +2535,9 @@ exports[`better eslint`] = {
     "public/app/features/plugins/extensions/usePluginFunctions.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "public/app/features/plugins/extensions/validators.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2535,9 +2535,6 @@ exports[`better eslint`] = {
     "public/app/features/plugins/extensions/usePluginFunctions.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/plugins/extensions/validators.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -195,6 +195,7 @@ export enum PluginExtensionPoints {
   TraceViewResourceAttributes = 'grafana/traceview/resource-attributes',
   LogsViewResourceAttributes = 'grafana/logsview/resource-attributes',
   AppChrome = 'grafana/app/chrome/v1',
+  ExtensionSidebar = 'grafana/extension-sidebar/v0-alpha',
 }
 
 export type PluginExtensionPanelContext = {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -1,14 +1,10 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, PluginExtensionPoints } from '@grafana/data';
 import { usePluginComponents } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 
-import {
-  EXTENSION_SIDEBAR_EXTENSION_POINT_ID,
-  getComponentMetaFromComponentId,
-  useExtensionSidebarContext,
-} from './ExtensionSidebarProvider';
+import { getComponentMetaFromComponentId, useExtensionSidebarContext } from './ExtensionSidebarProvider';
 
 export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = 300;
 export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
@@ -22,7 +18,7 @@ export function ExtensionSidebar() {
   const styles = getStyles(useTheme2());
   const { dockedComponentId, isEnabled, props = {} } = useExtensionSidebarContext();
   const { components, isLoading } = usePluginComponents<ExtensionSidebarComponentProps>({
-    extensionPointId: EXTENSION_SIDEBAR_EXTENSION_POINT_ID,
+    extensionPointId: PluginExtensionPoints.ExtensionSidebar,
   });
 
   if (isLoading || !dockedComponentId || !isEnabled) {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -1,14 +1,13 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import { useLocalStorage } from 'react-use';
 
-import { store, type ExtensionInfo } from '@grafana/data';
+import { PluginExtensionPoints, store, type ExtensionInfo } from '@grafana/data';
 import { config, getAppEvents, reportInteraction, usePluginLinks, locationService } from '@grafana/runtime';
 import { ExtensionPointPluginMeta, getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 import { OpenExtensionSidebarEvent } from 'app/types/events';
 
 import { DEFAULT_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar';
 
-export const EXTENSION_SIDEBAR_EXTENSION_POINT_ID = 'grafana/extension-sidebar/v0-alpha';
 export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarDocked';
 export const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
 const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
@@ -94,7 +93,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
   // `grafana/extension-sidebar/v0-alpha` and the link's `configure` method would control
   // whether the component is rendered or not
   const { links, isLoading } = usePluginLinks({
-    extensionPointId: EXTENSION_SIDEBAR_EXTENSION_POINT_ID,
+    extensionPointId: PluginExtensionPoints.ExtensionSidebar,
     context: {
       path: currentPath,
     },
@@ -107,7 +106,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
     () =>
       isEnabled
         ? new Map(
-            Array.from(getExtensionPointPluginMeta(EXTENSION_SIDEBAR_EXTENSION_POINT_ID).entries()).filter(
+            Array.from(getExtensionPointPluginMeta(PluginExtensionPoints.ExtensionSidebar).entries()).filter(
               ([pluginId, pluginMeta]) =>
                 PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(pluginId) &&
                 links.some(

--- a/public/app/features/plugins/extensions/errors.ts
+++ b/public/app/features/plugins/extensions/errors.ts
@@ -1,5 +1,5 @@
 export const INVALID_EXTENSION_POINT_ID =
-  'Invalid usage of extension point. Reason: Extension point id should be prefixed with your plugin id, e.g "myorg-foo-app/toolbar/v1".';
+  'Invalid usage of extension point. Reason: Extension point id should be prefixed with your plugin id, e.g "myorg-foo-app/toolbar/v1". Returning an empty array of extensions.';
 
 export const EXTENSION_POINT_META_INFO_MISSING =
   'Invalid usage of extension point. Reason: The extension point is not recorded in the "plugin.json" file. Extension points must be listed in the section "extensions.extensionPoints[]". Returning an empty array of extensions.';

--- a/public/app/features/plugins/extensions/errors.ts
+++ b/public/app/features/plugins/extensions/errors.ts
@@ -1,6 +1,14 @@
 export const INVALID_EXTENSION_POINT_ID =
   'Invalid usage of extension point. Reason: Extension point id should be prefixed with your plugin id, e.g "myorg-foo-app/toolbar/v1". Returning an empty array of extensions.';
 
+export const INVALID_EXTENSION_POINT_ID_PLUGIN = (pluginId: string, extensionPointId: string) =>
+  `Invalid usage of extension point. Reason: Extension point id should be prefixed with your plugin id, e.g "${pluginId}/${extensionPointId}".`;
+
+export const INVALID_EXTENSION_POINT_ID_GRAFANA_PREFIX = (extensionPointId: string) =>
+  `Invalid usage of extension point. Reason: Core Grafana extension point id should be prefixed with "grafana/", e.g "grafana/${extensionPointId}".`;
+
+export const INVALID_EXTENSION_POINT_ID_GRAFANA_EXPOSED = `Invalid usage of extension point. Reason: Core Grafana extension point id should be exposed to plugins via the "PluginExtensionPoints" enum in the "grafana-data" package (/packages/grafana-data/src/types/pluginExtensions.ts).`;
+
 export const EXTENSION_POINT_META_INFO_MISSING =
   'Invalid usage of extension point. Reason: The extension point is not recorded in the "plugin.json" file. Extension points must be listed in the section "extensions.extensionPoints[]". Returning an empty array of extensions.';
 

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -513,22 +513,6 @@ describe('usePluginComponents()', () => {
     expect(log.error).not.toHaveBeenCalled();
   });
 
-  it('should not validate the extension point id if used in Grafana core (no plugin context)', () => {
-    // Imitate running in dev mode
-    jest.mocked(isGrafanaDevMode).mockReturnValue(true);
-
-    // No plugin context -> used in Grafana core
-    wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ExtensionRegistriesProvider registries={registries}>{children}</ExtensionRegistriesProvider>
-    );
-
-    let { result } = renderHook(() => usePluginComponents({ extensionPointId: 'invalid-extension-point-id' }), {
-      wrapper,
-    });
-    expect(result.current.components.length).toBe(0);
-    expect(log.error).not.toHaveBeenCalled();
-  });
-
   it('should validate if the extension point meta-info is correct if in dev-mode and used by a plugin', () => {
     // Imitate running in dev mode
     jest.mocked(isGrafanaDevMode).mockReturnValue(true);

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -37,9 +37,8 @@ export function usePluginComponents<Props extends object = {}>({
       extensionPointId,
     });
 
-    // Only log error for an invalid `extensionPointId` in DEV mode
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin })) {
-      pointLog.error(errors.INVALID_EXTENSION_POINT_ID);
+    // Don't show extensions if the extension-point id is invalid in DEV mode
+    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
       return {
         isLoading: false,
         components: [],

--- a/public/app/features/plugins/extensions/usePluginFunctions.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.tsx
@@ -23,8 +23,7 @@ export function usePluginFunctions<Signature>({
   const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(deps);
 
   return useMemo(() => {
-    // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
-    const enableRestrictions = isGrafanaDevMode() && pluginContext;
+    const isInsidePlugin = Boolean(pluginContext);
     const results: Array<PluginExtensionFunction<Signature>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
@@ -32,11 +31,16 @@ export function usePluginFunctions<Signature>({
       pluginId,
       extensionPointId,
     });
-    if (enableRestrictions && !isExtensionPointIdValid({ extensionPointId, pluginId })) {
+
+    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin })) {
       pointLog.error(errors.INVALID_EXTENSION_POINT_ID);
+      return {
+        isLoading: false,
+        functions: [],
+      };
     }
 
-    if (enableRestrictions && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
+    if (isGrafanaDevMode() && pluginContext && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,

--- a/public/app/features/plugins/extensions/usePluginFunctions.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.tsx
@@ -32,8 +32,7 @@ export function usePluginFunctions<Signature>({
       extensionPointId,
     });
 
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin })) {
-      pointLog.error(errors.INVALID_EXTENSION_POINT_ID);
+    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
       return {
         isLoading: false,
         functions: [],

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -39,8 +39,7 @@ export function usePluginLinks({
       extensionPointId,
     });
 
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin })) {
-      pointLog.error(errors.INVALID_EXTENSION_POINT_ID);
+    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
       return {
         isLoading: false,
         links: [],

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -32,15 +32,14 @@ export function usePluginLinks({
   const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExtensionPointPluginDependencies(extensionPointId));
 
   return useMemo(() => {
-    // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
-    const enableRestrictions = isGrafanaDevMode() && pluginContext !== null;
+    const isInsidePlugin = Boolean(pluginContext);
     const pluginId = pluginContext?.meta.id ?? '';
     const pointLog = log.child({
       pluginId,
       extensionPointId,
     });
 
-    if (enableRestrictions && !isExtensionPointIdValid({ extensionPointId, pluginId })) {
+    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin })) {
       pointLog.error(errors.INVALID_EXTENSION_POINT_ID);
       return {
         isLoading: false,
@@ -48,7 +47,7 @@ export function usePluginLinks({
       };
     }
 
-    if (enableRestrictions && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
+    if (isGrafanaDevMode() && pluginContext && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,

--- a/public/app/features/plugins/extensions/validators.test.tsx
+++ b/public/app/features/plugins/extensions/validators.test.tsx
@@ -198,7 +198,6 @@ describe('Plugin Extension Validators', () => {
 
   describe('isExtensionPointIdValid()', () => {
     test.each([
-      // We (for now allow core Grafana extension points to run without a version)
       ['grafana/extension-point', ''],
       ['grafana/extension-point', 'grafana'],
       ['myorg-extensions-app/extension-point', 'myorg-extensions-app'],
@@ -217,6 +216,7 @@ describe('Plugin Extension Validators', () => {
         isExtensionPointIdValid({
           extensionPointId,
           pluginId,
+          isInsidePlugin: pluginId !== 'grafana' && pluginId !== '',
         })
       ).toBe(true);
     });
@@ -237,6 +237,7 @@ describe('Plugin Extension Validators', () => {
         isExtensionPointIdValid({
           extensionPointId,
           pluginId,
+          isInsidePlugin: true,
         })
       ).toBe(false);
     });

--- a/public/app/features/plugins/extensions/validators.test.tsx
+++ b/public/app/features/plugins/extensions/validators.test.tsx
@@ -198,8 +198,8 @@ describe('Plugin Extension Validators', () => {
 
   describe('isExtensionPointIdValid()', () => {
     test.each([
-      ['grafana/extension-point', ''],
-      ['grafana/extension-point', 'grafana'],
+      [PluginExtensionPoints.DashboardPanelMenu, ''],
+      [PluginExtensionPoints.DashboardPanelMenu, 'grafana'],
       ['myorg-extensions-app/extension-point', 'myorg-extensions-app'],
       ['myorg-extensions-app/extension-point/v1', 'myorg-extensions-app'],
       ['plugins/myorg-extensions-app/extension-point/v1', 'myorg-extensions-app'],
@@ -217,6 +217,7 @@ describe('Plugin Extension Validators', () => {
           extensionPointId,
           pluginId,
           isInsidePlugin: pluginId !== 'grafana' && pluginId !== '',
+          log: createLogMock(),
         })
       ).toBe(true);
     });
@@ -232,12 +233,18 @@ describe('Plugin Extension Validators', () => {
         'extension-point/v1',
         'myorgs-extensions-app',
       ],
+      [
+        // Not exposed to plugins
+        'grafana/not-exposed-extension-point/v1',
+        'grafana',
+      ],
     ])('should return FALSE if the extension point id is invalid ("%s", "%s")', (extensionPointId, pluginId) => {
       expect(
         isExtensionPointIdValid({
           extensionPointId,
           pluginId,
-          isInsidePlugin: true,
+          isInsidePlugin: pluginId !== 'grafana' && pluginId !== '',
+          log: createLogMock(),
         })
       ).toBe(false);
     });

--- a/public/app/features/plugins/extensions/validators.ts
+++ b/public/app/features/plugins/extensions/validators.ts
@@ -68,15 +68,20 @@ export function isLinkPathValid(pluginId: string, path: string) {
 export function isExtensionPointIdValid({
   extensionPointId,
   pluginId,
+  isInsidePlugin,
 }: {
   extensionPointId: string;
   pluginId: string;
+  isInsidePlugin: boolean;
 }) {
-  if (extensionPointId.startsWith('grafana/')) {
-    return true;
+  if (isInsidePlugin) {
+    return (
+      Boolean(extensionPointId.startsWith(`plugins/${pluginId}/`)) ||
+      Boolean(extensionPointId.startsWith(`${pluginId}/`))
+    );
   }
 
-  return Boolean(extensionPointId.startsWith(`plugins/${pluginId}/`) || extensionPointId.startsWith(`${pluginId}/`));
+  return Boolean(extensionPointId.startsWith('grafana/'));
 }
 
 export function extensionPointEndsWithVersion(extensionPointId: string) {

--- a/public/app/features/plugins/extensions/validators.ts
+++ b/public/app/features/plugins/extensions/validators.ts
@@ -89,7 +89,7 @@ export function isExtensionPointIdValid({
     return false;
   }
 
-  if (!isInsidePlugin && !Object.values(PluginExtensionPoints).includes(extensionPointId as PluginExtensionPoints)) {
+  if (!isInsidePlugin && !Object.values<string>(PluginExtensionPoints).includes(extensionPointId)) {
     log.error(errors.INVALID_EXTENSION_POINT_ID_GRAFANA_EXPOSED);
     return false;
   }


### PR DESCRIPTION
### Background
We have started to see scenarios where plugins are trying to access extensions registered to core Grafana extension points (starting with `grafana/`), and we also would like to restrict plugins more to only be able to access their own extensions (extension-point ids starting with `<plugin-id>/`).

### What changed?
- Logging more detailed error messages for any extension point id issues
- Not allowing plugins to create an extension point with an id that isn't prefixed with the plugin id (**in DEV**)
- Requiring core Grafana extension points to be prefixed with `grafana/` (**in DEV**)
- Requiring core Grafana extension points to be exposed by [the `PluginExtensionPoints` enum](https://github.com/grafana/grafana/blob/6d4c70854228bd2fbcab50e76f593c2ed790a3dc/packages/grafana-data/src/types/pluginExtensions.ts#L183) (**in DEV**)

**The changes are only intended to be applied during DEV mode, should not affect PROD.**