### PR TITLE
Provisioning: Fix usage reporting

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -37,6 +37,7 @@ import (
 	client "github.com/grafana/grafana/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 	informers "github.com/grafana/grafana/pkg/generated/informers/externalversions"
 	listers "github.com/grafana/grafana/pkg/generated/listers/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller"
@@ -75,6 +76,7 @@ var (
 type APIBuilder struct {
 	features featuremgmt.FeatureToggles
 
+	tracer              tracing.Tracer
 	getter              rest.Getter
 	localFileResolver   *repository.LocalFolderResolver
 	parsers             resources.ParserFactory
@@ -115,6 +117,7 @@ func NewAPIBuilder(
 	storageStatus dualwrite.Service,
 	secrets secrets.Service,
 	access authlib.AccessChecker,
+	tracer tracing.Tracer,
 	extraBuilders []ExtraBuilder,
 ) *APIBuilder {
 	clients := resources.NewClientFactory(configProvider)
@@ -122,6 +125,7 @@ func NewAPIBuilder(
 	resourceLister := resources.NewResourceLister(unified, unified, legacyMigrator, storageStatus)
 
 	b := &APIBuilder{
+		tracer:              tracer,
 		localFileResolver:   local,
 		features:            features,
 		ghFactory:           ghFactory,
@@ -162,6 +166,7 @@ func RegisterAPIService(
 	usageStatsService usagestats.Service,
 	// FIXME: use multi-tenant service when one exists. In this state, we can't make this a multi-tenant service!
 	secretsSvc grafanasecrets.Service,
+	tracer tracing.Tracer,
 	extraBuilders []ExtraBuilder,
 ) (*APIBuilder, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
@@ -185,6 +190,7 @@ func RegisterAPIService(
 		configProvider, ghFactory,
 		legacyMigrator, storageStatus,
 		secrets.NewSingleTenant(secretsSvc), access,
+		tracer,
 		extraBuilders,
 	)
 	apiregistration.RegisterAPI(builder)

--- a/pkg/registry/apis/provisioning/usage.go
+++ b/pkg/registry/apis/provisioning/usage.go
@@ -14,13 +14,8 @@ import (
 )
 
 func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (metrics map[string]any, err error) {
-	// TODO: tracer
 	ctx, span := b.tracer.Start(ctx, "Provisioning.Usage.collectProvisioningStats")
 	defer func() {
-		if err != nil {
-			// TODO: log it as warning
-		}
-
 		span.SetStatus(codes.Error, fmt.Sprintf("failed to fetch provisioning usage stats: %v", err))
 		span.End()
 	}()

--- a/pkg/registry/apis/provisioning/usage.go
+++ b/pkg/registry/apis/provisioning/usage.go
@@ -4,16 +4,42 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (map[string]any, error) {
+func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (metrics map[string]any, err error) {
+	// TODO: tracer
+	ctx, span := b.tracer.Start(ctx, "Provisioning.Usage.collectProvisioningStats")
+	defer func() {
+		if err != nil {
+			// TODO: log it as warning
+		}
+
+		span.SetStatus(codes.Error, fmt.Sprintf("failed to fetch provisioning usage stats: %v", err))
+		span.End()
+	}()
+
 	m := map[string]any{}
 	if b.unified == nil {
+		span.SetStatus(codes.Ok, "unified storage is not available")
 		return m, nil
 	}
+
+	// FIXME: hardcoded to "default" for now -- it works for single tenant deployments
+	// we could discover the set of valid namespaces, but that would count everything for
+	// each instance in cloud.
+	ns := "default"
+	ctx, _, err = identity.WithProvisioningIdentity(context.Background(), ns)
+	if err != nil {
+		return nil, err
+	}
+	ctx = request.WithNamespace(ctx, ns)
 
 	// FIXME: hardcoded to "default" for now -- it works for single tenant deployments
 	// we could discover the set of valid namespaces, but that would count everything for
@@ -21,17 +47,18 @@ func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (map[string]a
 	//
 	// We could get namespaces from the list of repos below, but that could be zero
 	// while we still have resources managed by terraform, etc
-	ns := "default"
 	count, err := b.unified.CountManagedObjects(ctx, &resourcepb.CountManagedObjectsRequest{
 		Namespace: ns,
 	})
 	if err != nil {
-		return m, err
+		return m, fmt.Errorf("count managed objects: %w", err)
 	}
 	counts := make(map[string]int, 10)
 	for _, v := range count.Items {
 		counts[v.Kind] = counts[v.Kind] + int(v.Count)
 	}
+
+	span.SetAttributes(attribute.Int("totalManagedObjectsCount", len(count.Items)))
 	for k, v := range counts {
 		m[fmt.Sprintf("stats.managed_by.%s.count", k)] = v
 	}
@@ -39,13 +66,14 @@ func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (map[string]a
 	// Inspect all configs
 	repos, err := b.repositoryLister.List(labels.Everything())
 	if err != nil {
-		return m, err
+		return m, fmt.Errorf("list repositories: %w", err)
 	}
 	clear(counts)
 	for _, repo := range repos {
 		counts[string(repo.Spec.Type)] = counts[string(repo.Spec.Type)] + 1
 	}
 
+	span.SetAttributes(attribute.Int("repositoryCount", len(repos)))
 	// Count how many items of each repository type
 	for k, v := range counts {
 		m[fmt.Sprintf("stats.repository.%s.count", k)] = v

--- a/pkg/registry/apis/provisioning/usage.go
+++ b/pkg/registry/apis/provisioning/usage.go
@@ -30,7 +30,7 @@ func (b *APIBuilder) collectProvisioningStats(ctx context.Context) (metrics map[
 	// we could discover the set of valid namespaces, but that would count everything for
 	// each instance in cloud.
 	ns := "default"
-	ctx, _, err = identity.WithProvisioningIdentity(context.Background(), ns)
+	ctx, _, err = identity.WithProvisioningIdentity(ctx, ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -739,7 +739,7 @@ func Initialize(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*Ser
 	legacyMigrator := legacy.ProvideLegacyMigrator(sqlStore, provisioningServiceImpl, libraryPanelService, accessControl)
 	webhookExtraBuilder := webhooks.ProvideWebhooks(cfg, featureToggles, secretsService, factory, renderingService, resourceClient, eventualRestConfigProvider)
 	v2 := apiregistry.MergeProvisioningExtras(webhookExtraBuilder)
-	apiBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, factory, accessClient, legacyMigrator, dualwriteService, usageStats, secretsService, v2)
+	apiBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, factory, accessClient, legacyMigrator, dualwriteService, usageStats, secretsService, tracingService, v2)
 	if err != nil {
 		return nil, err
 	}
@@ -1252,7 +1252,7 @@ func InitializeForTest(t sqlutil.ITestDB, testingT interface {
 	legacyMigrator := legacy.ProvideLegacyMigrator(sqlStore, provisioningServiceImpl, libraryPanelService, accessControl)
 	webhookExtraBuilder := webhooks.ProvideWebhooks(cfg, featureToggles, secretsService, factory, renderingService, resourceClient, eventualRestConfigProvider)
 	v2 := apiregistry.MergeProvisioningExtras(webhookExtraBuilder)
-	apiBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, factory, accessClient, legacyMigrator, dualwriteService, usageStats, secretsService, v2)
+	apiBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, factory, accessClient, legacyMigrator, dualwriteService, usageStats, secretsService, tracingService, v2)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the usage reporting for provisioning git sync and add some tracing.

**Why do we need this feature?**

It wasn't working as a background job due to missing claims in the context: 

<img width="1107" height="456" alt="image" src="https://github.com/user-attachments/assets/c17baf0e-da84-4d4a-aabb-8e555ad5e4e1" />


**Who is this feature for?**

Mostly future users of Provisioning / Git Sync in Cloud / Enterprise plus Grafana team to understand the interest on the feature and what people are trying out. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Not tracked

**Test Proof**: 

- I changed the hardcoded  interval to 2 minutes in the code. 
- Configured a repository and let it sync. 
- I could see the logs `Successfully fetched usage stats from provider`:
```
DEBUG[07-10|14:55:59] Successfully fetched usage stats from provider logger=infra.usagestats duration=4.801667ms function=github.com/grafana/grafana/pkg/infra/usagestats/statscollector.(*Service).collectSystemStats-fm
DEBUG[07-10|14:55:59] Successfully fetched usage stats from provider logger=infra.usagestats duration=8.409709ms function=github.com/grafana/grafana/pkg/registry/apis/provisioning.(*APIBuilder).collectProvisioningStats-fm
DEBUG[07-10|14:55:59] Collected usage stats                    logger=infra.usagestats metricCount=181 version=9_2_0 os=darwin arch=arm64 edition=oss duration=15.375584ms

```
- I could see the metric in the preview endpoint. http://localhost:3000/api/admin/usage-report-preview
```json
{
...
"stats.repository.github.count":1,
"stats.managed_by.repo.count":6,
...
}
```
- We could see it in big query. 
{
...
"stats.repository.github.count":1,
"stats.managed_by.repo.count":6,
...
}


**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
