### PR TITLE
virtualization: check for index

### DIFF
--- a/public/app/features/logs/components/panel/virtualization.test.ts
+++ b/public/app/features/logs/components/panel/virtualization.test.ts
@@ -67,6 +67,18 @@ describe('Virtualization', () => {
       expect(size).toBe(SINGLE_LINE_HEIGHT + DETAILS_HEIGHT);
     });
 
+    test('Should not throw when an undefined index is passed', () => {
+      const size = getLogLineSize(
+        virtualization,
+        [log],
+        container,
+        [],
+        { ...defaultOptions, showTime: true, showDetails: [log], detailsMode: 'inline' },
+        1 // Index out of bounds
+      );
+      expect(size).toBe(SINGLE_LINE_HEIGHT);
+    });
+
     test('Returns the a single line if the line is not loaded yet', () => {
       const logs = [log];
       const size = getLogLineSize(

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -255,7 +255,7 @@ export function getLogLineSize(
   }
   const gap = virtualization.getGridSize() * FIELD_GAP_MULTIPLIER;
   const detailsHeight =
-    detailsMode === 'inline' && showDetails.findIndex((log) => log.uid === logs[index].uid) >= 0
+    detailsMode === 'inline' && logs[index] && showDetails.findIndex((log) => log.uid === logs[index].uid) >= 0
       ? window.innerHeight * (LOG_LINE_DETAILS_HEIGHT / 100) + gap / 2
       : 0;
   // !logs[index] means the line is not yet loaded by infinite scrolling


### PR DESCRIPTION
When log[index] is not defined, it's a special row that we render for infinite scrolling.