### PR TITLE
Extensions: Add missing `description` field for exposed functions

### DIFF
--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -126,8 +126,9 @@ type AddedComponent struct {
 }
 
 type AddedFunction struct {
-	Targets []string `json:"targets"`
-	Title   string   `json:"title"`
+	Targets     []string `json:"targets"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
 }
 
 type ExposedComponent struct {


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/blob/de42b991e2aa4e5d68837ff3d6ace2faa9dddf88/public/app/features/plugins/extensions/usePluginFunctions.tsx#L39 is still checking against `description` and without it being set here in model.go, this check will almost always fail.