### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2866,7 +2866,7 @@ Set this to `false` to disable expressions and hide them in the Grafana UI. Defa
 
 Set the maximum number of cells that can be passed to a SQL expression. Default is `100000`.
 
-#### `sql_expression_cell_output_limit`
+#### `sql_expression_output_cell_limit`
 
 Set the maximum number of cells that can be returned from a SQL expression. Default is `100000`.
 


### PR DESCRIPTION
**What is this feature?**

docs fix for sql expressions

**Why do we need this feature?**

Our [docs](https://github.com/grafana/grafana/blob/main/docs/sources/setup-grafana/configure-grafana/_index.md?plain=1#L2869) refer to sql_expression_cell_output_limit but in the [code](https://github.com/grafana/grafana/blob/ff8a9fa4620c186d0c75706ff5da0e3312a0027d/pkg/setting/setting.go#L824) we're using sql_expression_output_cell_limit

**Who is this feature for?**

internal grafana devs and external admins interested in sql expressions and ensuring cell limits

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
