### PR TITLE
SCIM: Add is provisioned field to update command

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -133,7 +133,6 @@ func (s *UserSync) ValidateUserProvisioningHook(ctx context.Context, currentIden
 	log := s.log.FromContext(ctx).New("auth_module", currentIdentity.AuthenticatedBy, "auth_id", currentIdentity.AuthID)
 
 	if !currentIdentity.ClientParams.SyncUser {
-		log.Debug("Skipping user provisioning validation, syncUser is disabled")
 		return nil
 	}
 

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -95,8 +95,9 @@ type UpdateUserCommand struct {
 	// If old password is included it will be validated against users current password.
 	OldPassword *Password `json:"-"`
 	// If OrgID is included update current org for user
-	OrgID      *int64      `json:"-"`
-	HelpFlags1 *HelpFlags1 `json:"-"`
+	OrgID         *int64      `json:"-"`
+	HelpFlags1    *HelpFlags1 `json:"-"`
+	IsProvisioned *bool       `json:"-"`
 }
 
 type UpdateUserLastSeenAtCommand struct {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -278,6 +278,10 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 			q = q.MustCols("help_flags1")
 			usr.HelpFlags1 = *cmd.HelpFlags1
 		})
+		setOptional(cmd.IsProvisioned, func(v bool) {
+			q = q.UseBool("is_provisioned")
+			usr.IsProvisioned = v
+		})
 
 		if _, err := q.Update(&usr); err != nil {
 			return err

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -739,6 +739,47 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		require.True(t, usr.IsDisabled)
 	})
 
+	t.Run("Update IsProvisioned", func(t *testing.T) {
+		// Create a user with IsProvisioned set to false (default)
+		id, err := userStore.Insert(context.Background(), &user.User{
+			Name:    "provisioned_user",
+			Email:   "provisioned@test.com",
+			Login:   "provisioned_user",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		require.NoError(t, err)
+
+		// Verify initial state
+		usr, err := userStore.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		require.False(t, usr.IsProvisioned)
+
+		// Update user to set IsProvisioned to true
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID:        id,
+			IsProvisioned: boolPtr(true),
+		})
+		require.NoError(t, err)
+
+		// Verify IsProvisioned is now true
+		usr, err = userStore.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		require.True(t, usr.IsProvisioned)
+
+		// Update user to set IsProvisioned to false
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID:        id,
+			IsProvisioned: boolPtr(false),
+		})
+		require.NoError(t, err)
+
+		// Verify IsProvisioned is now false
+		usr, err = userStore.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		require.False(t, usr.IsProvisioned)
+	})
+
 	t.Run("Testing DB - multiple users", func(t *testing.T) {
 		ss = db.InitTestDB(t)
 


### PR DESCRIPTION
**What is this feature?**

This feature adds a new field to the Update User Command.

**Why do we need this feature?**

The new `IsProvisioned` field allows for updating the provisioning when merging existing users to provisioned users with SCIM.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

This is a two part fix for https://github.com/grafana/identity-access-team/issues/1548