### PR TITLE
Fix: Showing raw prometheus table result

### DIFF
--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -32,12 +32,11 @@ interface PrometheusContainerState {
 function mapStateToProps(state: StoreState, { exploreId }: RawPrometheusContainerProps) {
   const explore = state.explore;
   const item: ExploreItemState = explore.panes[exploreId]!;
-  const { tableResult, rawPrometheusResult, range, queryResponse } = item;
+  const { rawPrometheusResult, range, queryResponse } = item;
   const rawPrometheusFrame: DataFrame[] = rawPrometheusResult ? [rawPrometheusResult] : [];
-  const result = (tableResult?.length ?? 0) > 0 && rawPrometheusResult ? tableResult : rawPrometheusFrame;
   const loading = queryResponse.state;
 
-  return { loading, tableResult: result, range };
+  return { loading, tableResult: rawPrometheusFrame, range };
 }
 
 const connector = connect(mapStateToProps, {});


### PR DESCRIPTION
**What is this feature?**

When we are using `Mixed` datasource, if we have two queries, one for prometheus and one for some other datasource, we they both produce table result, prometheus result gets overriden. This PR is fixing this issue.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/75036

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
