### PR TITLE
DeleteProvisionedFolderForm: navigate user to dashboard page with open PR banner when push to branch

### DIFF
--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
@@ -16,6 +16,11 @@ jest.mock('@grafana/runtime', () => ({
   })),
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
 jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   useDeleteRepositoryFilesWithPathMutation: jest.fn(),
   provisioningAPI: {
@@ -140,6 +145,7 @@ function setup(
     ...renderResult,
     onDismiss,
     mockDeleteRepoFile,
+    mockNavigate,
     clickDeleteButton,
   };
 }
@@ -147,6 +153,7 @@ function setup(
 describe('DeleteProvisionedFolderForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigate.mockClear();
     jest.spyOn(console, 'error').mockImplementation(() => {});
     // Mock window.location.href
     Object.defineProperty(window, 'location', {

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
@@ -279,13 +279,21 @@ describe('DeleteProvisionedFolderForm', () => {
       });
     });
 
-    it('should handle branch workflow success without navigation', async () => {
+    it('should handle branch workflow success with navigation', async () => {
       const branchFormData = { ...mockFormData, workflow: 'branch' } as unknown as typeof mockFormData;
-      const successState = { isLoading: false, isSuccess: true, isError: false, error: null };
-      setup({}, { ...defaultHookData, initialValues: branchFormData }, successState);
+      const successState = {
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+        error: null,
+        data: { urls: { newPullRequestURL: 'https://github.com/test/repo/pull/new' } },
+      };
+      const { mockNavigate } = setup({}, { ...defaultHookData, initialValues: branchFormData }, successState);
 
       await waitFor(() => {
-        expect(window.location.href).toBe('');
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/dashboards?new_pull_request_url=https://github.com/test/repo/pull/new'
+        );
       });
     });
   });

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { AppEvents } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -42,6 +43,7 @@ function FormContent({
   const resourceId = parentFolder?.uid || '';
 
   const [deleteRepoFile, request] = useDeleteRepositoryFilesWithPathMutation();
+  const navigate = useNavigate();
 
   const methods = useForm<BaseProvisionedFormData>({ defaultValues: initialValues });
   const { handleSubmit, watch } = methods;
@@ -67,8 +69,8 @@ function FormContent({
   useEffect(() => {
     if (request.isSuccess && repository) {
       if (workflow === 'branch') {
-        // TODO: handle display banner https://github.com/grafana/git-ui-sync-project/issues/300
-        // TODO: implement when BE is ready
+        const prUrl = request.data?.urls?.newPullRequestURL;
+        navigate(`/dashboards?new_pull_request_url=${prUrl}`);
         return;
       }
 
@@ -101,7 +103,7 @@ function FormContent({
       });
       return;
     }
-  }, [request, repository, workflow, parentFolder]);
+  }, [request, repository, workflow, parentFolder, navigate]);
 
   return (
     <FormProvider {...methods}>

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -68,8 +68,8 @@ function FormContent({
   // TODO: move to a hook if this useEffect shared mostly the same logic as in NewProvisionedFolderForm
   useEffect(() => {
     if (request.isSuccess && repository) {
-      if (workflow === 'branch') {
-        const prUrl = request.data?.urls?.newPullRequestURL;
+      const prUrl = request.data?.urls?.newPullRequestURL;
+      if (workflow === 'branch' && prUrl) {
         navigate(`/dashboards?new_pull_request_url=${prUrl}`);
         return;
       }

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -103,8 +103,7 @@ export function FolderActionsButton({ folder }: Props) {
     <Menu>
       {canViewPermissions && <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />}
       {canMoveFolder && <MenuItem onClick={showMoveModal} label={moveLabel} />}
-      {/* TODO: remove isProvisionedFolder check once BE folder delete flow is complete */}
-      {canDeleteFolders && !isProvisionedFolder && (
+      {canDeleteFolders && (
         <MenuItem
           destructive
           onClick={isProvisionedFolder ? showDeleteProvisionedModal : showDeleteModal}

--- a/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
@@ -120,6 +120,8 @@ export function SaveProvisionedDashboardForm({
       ref = loadedFromRef;
     }
 
+    const message = comment || `Save dashboard: ${dashboard.state.title}`;
+
     const body = dashboard.getSaveResource({
       isNew,
       title,
@@ -130,7 +132,7 @@ export function SaveProvisionedDashboardForm({
       ref,
       name: repo,
       path,
-      message: comment,
+      message,
       body,
     });
   };


### PR DESCRIPTION
**What is this feature?**

When deleting folder to a new branch, add support to navigate user back to root page with new PR url. 
https://github.com/user-attachments/assets/90af1aa1-8053-4bb3-b8a4-d3c14210456e

**Why do we need this feature?**

To allow user delete folder to new branch and open PR.  


**Who is this feature for?**

All users 

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/git-ui-sync-project/issues/318

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
