### PR TITLE
TableNG: Scrollbar width handling

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,11 +1,12 @@
 import 'react-data-grid/lib/styles.css';
 import { css, cx } from '@emotion/css';
 import { Property } from 'csstype';
-import { Key, ReactNode, useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { Key, ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Cell,
   CellRendererProps,
   DataGrid,
+  DataGridHandle,
   DataGridProps,
   RenderCellProps,
   RenderRowProps,
@@ -39,6 +40,7 @@ import {
   useHeaderHeight,
   usePaginatedRows,
   useRowHeight,
+  useScrollbarWidth,
   useSortedRows,
   useTypographyCtx,
 } from './hooks';
@@ -151,9 +153,11 @@ export function TableNG(props: TableNGProps) {
 
   // vt scrollbar accounting for column auto-sizing
   const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
+  const gridRef = useRef<DataGridHandle>();
+  const scrollbarWidth = useScrollbarWidth(gridRef, height, sortedRows);
   const availableWidth = useMemo(
-    () => (hasNestedFrames ? width - COLUMN.EXPANDER_WIDTH : width),
-    [width, hasNestedFrames]
+    () => (hasNestedFrames ? width - COLUMN.EXPANDER_WIDTH : width) - scrollbarWidth,
+    [width, hasNestedFrames, scrollbarWidth]
   );
   const typographyCtx = useTypographyCtx();
   const widths = useMemo(() => computeColWidths(visibleFields, availableWidth), [visibleFields, availableWidth]);
@@ -549,6 +553,7 @@ export function TableNG(props: TableNGProps) {
     <>
       <DataGrid<TableRow, TableSummaryRow>
         {...commonDataGridProps}
+        ref={gridRef}
         className={styles.grid}
         columns={structureRevColumns}
         rows={paginatedRows}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -153,7 +153,7 @@ export function TableNG(props: TableNGProps) {
 
   // vt scrollbar accounting for column auto-sizing
   const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
-  const gridRef = useRef<DataGridHandle | null>(null);
+  const gridRef = useRef<DataGridHandle>(null);
   const scrollbarWidth = useScrollbarWidth(gridRef, height, sortedRows);
   const availableWidth = useMemo(
     () => (hasNestedFrames ? width - COLUMN.EXPANDER_WIDTH : width) - scrollbarWidth,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -153,7 +153,7 @@ export function TableNG(props: TableNGProps) {
 
   // vt scrollbar accounting for column auto-sizing
   const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
-  const gridRef = useRef<DataGridHandle>();
+  const gridRef = useRef<DataGridHandle | null>(null);
   const scrollbarWidth = useScrollbarWidth(gridRef, height, sortedRows);
   const availableWidth = useMemo(
     () => (hasNestedFrames ? width - COLUMN.EXPANDER_WIDTH : width) - scrollbarWidth,

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect, RefObject, MutableRefObject } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect, MutableRefObject } from 'react';
 import { Column, DataGridHandle, DataGridProps, SortColumn } from 'react-data-grid';
 import { varPreLine } from 'uwrap';
 
@@ -610,7 +610,7 @@ export function useSingleLink(field: Field, rowIdx: number): LinkModel | undefin
 }
 
 export function useScrollbarWidth(
-  ref: MutableRefObject<DataGridHandle | undefined>,
+  ref: MutableRefObject<DataGridHandle | null>,
   height: number,
   renderedRows: TableRow[]
 ) {

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -1,5 +1,5 @@
-import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect } from 'react';
-import { Column, DataGridProps, SortColumn } from 'react-data-grid';
+import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect, RefObject, MutableRefObject } from 'react';
+import { Column, DataGridHandle, DataGridProps, SortColumn } from 'react-data-grid';
 import { varPreLine } from 'uwrap';
 
 import { Field, fieldReducers, FieldType, formattedValueToString, LinkModel, reduceField } from '@grafana/data';
@@ -607,4 +607,26 @@ export function useSingleLink(field: Field, rowIdx: number): LinkModel | undefin
   const actionsCount = field.config.actions?.length ?? 0;
   const shouldShowLink = linksCount === 1 && actionsCount === 0;
   return useMemo(() => (shouldShowLink ? (getCellLinks(field, rowIdx) ?? []) : [])[0], [field, shouldShowLink, rowIdx]);
+}
+
+export function useScrollbarWidth(
+  ref: MutableRefObject<DataGridHandle | undefined>,
+  height: number,
+  renderedRows: TableRow[]
+) {
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+
+  useLayoutEffect(
+    () => {
+      let el = ref.current?.element;
+      if (el) {
+        setScrollbarWidth(el.offsetWidth - el.clientWidth);
+      }
+    },
+    // todo: account for pagination, subtable expansion, default row height changes, height changes, data length
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [height, renderedRows]
+  );
+
+  return scrollbarWidth;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -615,18 +615,13 @@ export function useScrollbarWidth(
   renderedRows: TableRow[]
 ) {
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const el = ref.current?.element;
 
-  useLayoutEffect(
-    () => {
-      let el = ref.current?.element;
-      if (el) {
-        setScrollbarWidth(el.offsetWidth - el.clientWidth);
-      }
-    },
-    // todo: account for pagination, subtable expansion, default row height changes, height changes, data length
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [height, renderedRows]
-  );
+  useLayoutEffect(() => {
+    if (el) {
+      setScrollbarWidth(el.offsetWidth - el.clientWidth);
+    }
+  }, [el, height, renderedRows]);
 
   return scrollbarWidth;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect, MutableRefObject } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef, useLayoutEffect, RefObject } from 'react';
 import { Column, DataGridHandle, DataGridProps, SortColumn } from 'react-data-grid';
 import { varPreLine } from 'uwrap';
 
@@ -609,19 +609,16 @@ export function useSingleLink(field: Field, rowIdx: number): LinkModel | undefin
   return useMemo(() => (shouldShowLink ? (getCellLinks(field, rowIdx) ?? []) : [])[0], [field, shouldShowLink, rowIdx]);
 }
 
-export function useScrollbarWidth(
-  ref: MutableRefObject<DataGridHandle | null>,
-  height: number,
-  renderedRows: TableRow[]
-) {
+export function useScrollbarWidth(ref: RefObject<DataGridHandle>, height: number, renderedRows: TableRow[]) {
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
-  const el = ref.current?.element;
 
   useLayoutEffect(() => {
+    const el = ref.current?.element;
+
     if (el) {
       setScrollbarWidth(el.offsetWidth - el.clientWidth);
     }
-  }, [el, height, renderedRows]);
+  }, [ref, height, renderedRows]);
 
   return scrollbarWidth;
 }


### PR DESCRIPTION
Restores the `useScrollbarWidth` calculation which was on the OG table-back-to-basics branch.

### Before
<img width="2534" height="880" alt="Screenshot 2025-07-10 at 4 29 06 PM" src="https://github.com/user-attachments/assets/d40b3df4-9134-41ad-bb19-db317ebfcb61" />

### After
<img width="2515" height="742" alt="Screenshot 2025-07-10 at 4 28 51 PM" src="https://github.com/user-attachments/assets/5ed0954b-6c2e-4eec-8180-ad0837323d9f" />

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
