### PR TITLE
Air: Stop running make gen-go

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,7 +7,6 @@ exclude_unchanged = true
 follow_symlink = true
 include_dir = ["apps", "conf", "devenv/dev-dashboards", "pkg", "public/views"]
 include_ext = ["go", "ini", "toml", "html", "json"]
-pre_cmd = ["make gen-go"]
 stop_on_error = true
 send_interrupt = true
 kill_delay = 500


### PR DESCRIPTION
Experimenting removing the `make gen-go` step on every rebuild, which speeds up the reload loop, since the wire files are now committed.