### PR TITLE
Alertmanager: Add methods to merge nflog and silences

### DIFF
--- a/pkg/services/ngalert/notifier/alerts.go
+++ b/pkg/services/ngalert/notifier/alerts.go
@@ -13,3 +13,7 @@ func (am *alertmanager) GetAlerts(_ context.Context, active, silenced, inhibited
 func (am *alertmanager) GetAlertGroups(_ context.Context, active, silenced, inhibited bool, filter []string, receivers string) (alertingNotify.AlertGroups, error) {
 	return am.Base.GetAlertGroups(active, silenced, inhibited, filter, receivers)
 }
+
+func (am *alertmanager) MergeNflog(b []byte) error {
+	return am.Base.MergeNflog(b)
+}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -77,6 +77,12 @@ type Alertmanager interface {
 	Ready() bool
 }
 
+// StateMerger describes a type that is able to merge external state (nflog, silences) with its own.
+type StateMerger interface {
+	MergeNflog([]byte) error
+	MergeSilences([]byte) error
+}
+
 type MultiOrgAlertmanager struct {
 	Crypto    Crypto
 	ProvStore provisioningStore

--- a/pkg/services/ngalert/notifier/silences.go
+++ b/pkg/services/ngalert/notifier/silences.go
@@ -21,3 +21,7 @@ func (am *alertmanager) CreateSilence(_ context.Context, ps *alertingNotify.Post
 func (am *alertmanager) DeleteSilence(_ context.Context, silenceID string) error {
 	return am.Base.DeleteSilence(silenceID)
 }
+
+func (am *alertmanager) MergeSilences(b []byte) error {
+	return am.Base.MergeSilences(b)
+}


### PR DESCRIPTION
This PR adds methods to merge nflog entries and silences to the internal Alertmanager's state.

Part of https://github.com/grafana/grafana/pull/107710

#### Note for reviewers

Adding them to the `Alertmanager` interface without errors would require:
1. Adding no-op (or panic) implementations for the remote Alertmanager struct
2. Updating our mocks

Also, these methods are not describing a general Alertmanager, but a specific implementation. That's why these two methods are described in a new `StateMerger` interface.