### PR TITLE
fix: enable mode3 and beyond for api validation integration tests

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
@@ -24,6 +24,7 @@ var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta
 var exampleObjNoRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", CreationTimestamp: metav1.Time{}, GenerateName: "foo"}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: now}}}
 var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2", GenerateName: "foo"}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: now}}}
 var failingObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "object-fail", ResourceVersion: "2", GenerateName: "object-fail"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var failingObjNoRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "object-fail", ResourceVersion: "", GenerateName: "object-fail"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
 var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListMeta: metav1.ListMeta{}, Items: []example.Pod{*exampleObj}}
 var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
@@ -29,32 +29,30 @@ func TestMode3_Create(t *testing.T) {
 			{
 				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
-				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
+				setupLegacyFn: func(m *mock.Mock, _ runtime.Object) {
 					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				},
+				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				setupLegacyFn: func(m *mock.Mock, _ runtime.Object) {
+					m.On("Create", mock.Anything, failingObjNoRV, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				},
+				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(failingObj, nil).Once()
+					m.On("Delete", mock.Anything, failingObj.GetName(), mock.Anything, mock.Anything).Return(failingObj, false, nil).Once()
 				},
 				wantErr: true,
 			},
 			{
-				name:  "should return an error when creating an object in the unified store fails and delete from LegacyStorage",
+				name:  "should return an error when creating an object in the unified store fails",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, true, nil).Once()
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
-				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
 				},
 				wantErr: true,
 			},

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -132,7 +132,6 @@ func TestIntegrationDashboardAPI(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// TODO: rest.Mode3 is failing on dashboard creation, so we skip it for now
 	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -61,7 +61,7 @@ func TestIntegrationValidation(t *testing.T) {
 		t.Skip("skipping integration test2")
 	}
 
-	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5}
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 			// Create a K8sTestHelper which will set up a real API server
@@ -82,35 +82,35 @@ func TestIntegrationValidation(t *testing.T) {
 		})
 	}
 
-	for _, dualWriterMode := range dualWriterModes {
-		t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
-			// Create a K8sTestHelper which will set up a real API server
-			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-				DisableAnonymous: true,
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
-				DisableFeatureToggles: []string{
-					featuremgmt.FlagKubernetesDashboards,
-				},
-				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-					"dashboards.dashboard.grafana.app": {
-						DualWriterMode: dualWriterMode,
-					},
-				}})
+	// for _, dualWriterMode := range dualWriterModes {
+	// 	t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
+	// 		// Create a K8sTestHelper which will set up a real API server
+	// 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+	// 			DisableAnonymous: true,
+	// 			EnableFeatureToggles: []string{
+	// 				featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
+	// 				featuremgmt.FlagUnifiedStorageSearch,
+	// 			},
+	// 			DisableFeatureToggles: []string{
+	// 				featuremgmt.FlagKubernetesDashboards,
+	// 			},
+	// 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+	// 				"dashboards.dashboard.grafana.app": {
+	// 					DualWriterMode: dualWriterMode,
+	// 				},
+	// 			}})
 
-			t.Cleanup(func() {
-				helper.Shutdown()
-			})
+	// 		t.Cleanup(func() {
+	// 			helper.Shutdown()
+	// 		})
 
-			org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
+	// 		org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 
-			t.Run("Dashboard permission tests", func(t *testing.T) {
-				runDashboardPermissionTests(t, org1Ctx, false)
-			})
-		})
-	}
+	// 		t.Run("Dashboard permission tests", func(t *testing.T) {
+	// 			runDashboardPermissionTests(t, org1Ctx, false)
+	// 		})
+	// 	})
+	// }
 }
 
 func testIntegrationValidationForServer(t *testing.T, helper *apis.K8sTestHelper, dualWriterMode rest.DualWriterMode) {
@@ -694,33 +694,6 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			require.NoError(t, err)
 		})
 	})
-}
-
-// skipIfMode skips the current test if running in any of the specified modes
-// Usage: skipIfMode(t, rest.Mode1, rest.Mode4)
-// or with a message: skipIfMode(t, "Known issue with conflict detection", rest.Mode1, rest.Mode4)
-// nolint:unused
-func (c *TestContext) skipIfMode(t *testing.T, args ...interface{}) {
-	t.Helper()
-
-	message := "Test not supported in this dual writer mode"
-	modes := []rest.DualWriterMode{}
-
-	// Parse args - first string is considered a message, all rest.DualWriterMode values are modes to skip
-	for _, arg := range args {
-		if msg, ok := arg.(string); ok {
-			message = msg
-		} else if mode, ok := arg.(rest.DualWriterMode); ok {
-			modes = append(modes, mode)
-		}
-	}
-
-	// Check if current mode is in the list of modes to skip
-	for _, mode := range modes {
-		if c.DualWriterMode == mode {
-			t.Skipf("%s (mode %d)", message, c.DualWriterMode)
-		}
-	}
 }
 
 // Run tests for quota validation

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -61,8 +61,7 @@ func TestIntegrationValidation(t *testing.T) {
 		t.Skip("skipping integration test2")
 	}
 
-	// TODO: Skip mode3 - borken due to race conditions while setting default permissions across storage backends
-	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
+	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 			// Create a K8sTestHelper which will set up a real API server
@@ -83,35 +82,35 @@ func TestIntegrationValidation(t *testing.T) {
 		})
 	}
 
-	for _, dualWriterMode := range dualWriterModes {
-		t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
-			// Create a K8sTestHelper which will set up a real API server
-			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-				DisableAnonymous: true,
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
-				DisableFeatureToggles: []string{
-					featuremgmt.FlagKubernetesDashboards,
-				},
-				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-					"dashboards.dashboard.grafana.app": {
-						DualWriterMode: dualWriterMode,
-					},
-				}})
+	// for _, dualWriterMode := range dualWriterModes {
+	// 	t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
+	// 		// Create a K8sTestHelper which will set up a real API server
+	// 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+	// 			DisableAnonymous: true,
+	// 			EnableFeatureToggles: []string{
+	// 				featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
+	// 				featuremgmt.FlagUnifiedStorageSearch,
+	// 			},
+	// 			DisableFeatureToggles: []string{
+	// 				featuremgmt.FlagKubernetesDashboards,
+	// 			},
+	// 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+	// 				"dashboards.dashboard.grafana.app": {
+	// 					DualWriterMode: dualWriterMode,
+	// 				},
+	// 			}})
 
-			t.Cleanup(func() {
-				helper.Shutdown()
-			})
+	// 		t.Cleanup(func() {
+	// 			helper.Shutdown()
+	// 		})
 
-			org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
+	// 		org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 
-			t.Run("Dashboard permission tests", func(t *testing.T) {
-				runDashboardPermissionTests(t, org1Ctx, false)
-			})
-		})
-	}
+	// 		t.Run("Dashboard permission tests", func(t *testing.T) {
+	// 			runDashboardPermissionTests(t, org1Ctx, false)
+	// 		})
+	// 	})
+	// }
 }
 
 func testIntegrationValidationForServer(t *testing.T, helper *apis.K8sTestHelper, dualWriterMode rest.DualWriterMode) {

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -82,35 +82,35 @@ func TestIntegrationValidation(t *testing.T) {
 		})
 	}
 
-	// for _, dualWriterMode := range dualWriterModes {
-	// 	t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
-	// 		// Create a K8sTestHelper which will set up a real API server
-	// 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-	// 			DisableAnonymous: true,
-	// 			EnableFeatureToggles: []string{
-	// 				featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
-	// 				featuremgmt.FlagUnifiedStorageSearch,
-	// 			},
-	// 			DisableFeatureToggles: []string{
-	// 				featuremgmt.FlagKubernetesDashboards,
-	// 			},
-	// 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-	// 				"dashboards.dashboard.grafana.app": {
-	// 					DualWriterMode: dualWriterMode,
-	// 				},
-	// 			}})
+	for _, dualWriterMode := range dualWriterModes {
+		t.Run(fmt.Sprintf("DualWriterMode %d - kubernetesDashboards disabled", dualWriterMode), func(t *testing.T) {
+			// Create a K8sTestHelper which will set up a real API server
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				DisableAnonymous: true,
+				EnableFeatureToggles: []string{
+					featuremgmt.FlagKubernetesClientDashboardsFolders, // Enable dashboard feature
+					featuremgmt.FlagUnifiedStorageSearch,
+				},
+				DisableFeatureToggles: []string{
+					featuremgmt.FlagKubernetesDashboards,
+				},
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"dashboards.dashboard.grafana.app": {
+						DualWriterMode: dualWriterMode,
+					},
+				}})
 
-	// 		t.Cleanup(func() {
-	// 			helper.Shutdown()
-	// 		})
+			t.Cleanup(func() {
+				helper.Shutdown()
+			})
 
-	// 		org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
+			org1Ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 
-	// 		t.Run("Dashboard permission tests", func(t *testing.T) {
-	// 			runDashboardPermissionTests(t, org1Ctx, false)
-	// 		})
-	// 	})
-	// }
+			t.Run("Dashboard permission tests", func(t *testing.T) {
+				runDashboardPermissionTests(t, org1Ctx, false)
+			})
+		})
+	}
 }
 
 func testIntegrationValidationForServer(t *testing.T, helper *apis.K8sTestHelper, dualWriterMode rest.DualWriterMode) {


### PR DESCRIPTION
This PR revisits the mode3 flow for the dual writer. 

Issue: The dual writer mode3 is read unified enabled, i.e. the operations are first done in unified storage. This triggers the issue on the creation path where the authorization hook is relying on the [dashboard service](https://github.com/grafana/grafana/blob/d37d0bbaca8ecfa5296cb73f438a64d3ce74cec2/pkg/services/dashboards/service/dashboard_service.go#L380) (`GetDashboard`) and **reading from unified while creating the resource in legacy**. [[ref](https://github.com/grafana/grafana/blob/d37d0bbaca8ecfa5296cb73f438a64d3ce74cec2/pkg/storage/unified/apistore/store.go#L236) and more specifically [here](https://github.com/grafana/grafana/blob/d37d0bbaca8ecfa5296cb73f438a64d3ce74cec2/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go#L103)].

ticket: https://github.com/grafana/search-and-storage-team/issues/377