### PR TITLE
BackendSrv: Validate newline and tabs in validatePath

### DIFF
--- a/packages/grafana-data/src/text/sanitize.test.ts
+++ b/packages/grafana-data/src/text/sanitize.test.ts
@@ -78,6 +78,27 @@ describe('validatePath', () => {
       expect(() => validatePath('/api/%/admin')).toThrow(PathValidationError);
       expect(() => validatePath('/api/%2/admin')).toThrow(PathValidationError);
     });
+
+    it('should block paths with tab characters', () => {
+      expect(() => validatePath('/api/\tadmin')).toThrow(PathValidationError);
+      expect(() => validatePath('/api/users\t/123')).toThrow(PathValidationError);
+    });
+
+    it('should block paths with newline characters', () => {
+      expect(() => validatePath('/api/\nadmin')).toThrow(PathValidationError);
+      expect(() => validatePath('/api/users\n/123')).toThrow(PathValidationError);
+    });
+
+    it('should block paths with carriage return characters', () => {
+      expect(() => validatePath('/api/\radmin')).toThrow(PathValidationError);
+      expect(() => validatePath('/api/users\r/123')).toThrow(PathValidationError);
+    });
+
+    it('should block URL encoded tab and newline characters', () => {
+      expect(() => validatePath('/api/%09admin')).toThrow(PathValidationError); // tab
+      expect(() => validatePath('/api/%0Aadmin')).toThrow(PathValidationError); // newline
+      expect(() => validatePath('/api/%0Dadmin')).toThrow(PathValidationError); // carriage return
+    });
   });
 
   describe('safe paths', () => {

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -151,7 +151,7 @@ export function validatePath<OriginalPath extends string>(path: OriginalPath): O
     originalDecoded = cleaned;
 
     // If the original string contains traversal attempts, block it
-    if (originalDecoded.includes('..') || originalDecoded.includes('/\\')) {
+    if (/\.\.|\/\\|[\t\n\r]/.test(originalDecoded)) {
       throw new PathValidationError();
     }
 


### PR DESCRIPTION
1. Enhanced validatePath function to block `\t`, `\n`, and `\r` characters
2. Simplified code from multiple includes() calls to a single regex: `/\.\.|\/\\|[\t\n\r]/`
3. Added test cases for direct and URL-encoded variants of these characters

According to WHATWG standards. 